### PR TITLE
chore: adiciona CLAUDE.md, testes unitários (TDD) e extrai calcStreak

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,70 @@
+# Claude Stats — CLAUDE.md
+
+Painel local de analytics para Claude Code. Visualiza tokens, custos, atividade e projetos com base nos dados em `~/.claude/`.
+
+## Arquitetura
+
+Dois serviços independentes:
+
+```
+server.ts (Bun, porta 3001)
+  ├── Lê ~/.claude/usage-data/session-meta/ → sessões enriquecidas (fonte preferida)
+  ├── Fallback: parseia JSONL de ~/.claude/projects/*/**/*.jsonl
+  ├── Serve /api/data, /api/events (SSE), /api/rates
+  └── Monitorado por chokidar para atualizações em tempo real
+
+src/ (React + Vite, porta 5173)
+  ├── useData.ts → fetch de /api/data + subscrição SSE
+  ├── useDerivedStats() → toda lógica de filtro e agregação
+  └── components/ → UI (gráficos, cards, heatmap, exportação PDF)
+```
+
+## Lógica de negócio crítica
+
+| Função | Arquivo | O que faz |
+|--------|---------|-----------|
+| `calcCost()` | `src/lib/types.ts` | Custo USD por uso de modelo (preço por 1M tokens) |
+| `getModelPrice()` | `src/lib/types.ts` | Resolve preço para modelo por ID (com fallback para Sonnet) |
+| `MODEL_PRICING` | `src/lib/types.ts` | Tabela de preços — atualizar quando Anthropic alterar preços |
+| `calcStreak()` | `src/hooks/useData.ts` | Streak de dias consecutivos (hoje sem atividade não quebra) |
+| `getDateRangeFilter()` | `src/hooks/useData.ts` | Converte filtro de data em intervalo `{start, end}` |
+| `parseSessionJsonl()` | `server.ts` | Parser de sessão JSONL → `SessionMeta` completo |
+| `blendedCostPerToken()` | `src/hooks/useData.ts` | Custo combinado por token quando filtro de projeto está ativo |
+
+## Fluxo de dados
+
+```
+~/.claude/
+  ├── stats-cache.json          → dados agregados (tokens/dia, modelo, atividade)
+  ├── usage-data/session-meta/  → sessões enriquecidas (fonte preferida)
+  └── projects/**/*.jsonl       → arquivos brutos (fallback quando meta não existe)
+         ↓
+    server.ts (agrega e serve)
+         ↓
+    /api/data → useData() → useDerivedStats() → componentes React
+```
+
+## Regras importantes
+
+- **`stats-cache.json`** não tem granularidade por projeto — filtros de projeto recalculam somando sessões individuais
+- **Tokens por modelo/data**: `dailyModelTokens` só tem total; o split input/output usa proporções globais do statsCache como aproximação
+- **Streak**: conta de hoje para trás; se hoje não tiver atividade, começa de ontem — comportamento intencional para não penalizar quem ainda não trabalhou hoje
+- **Custos em BRL**: conversão via `/api/rates` (busca câmbio externo); fallback para taxa fixa se a API falhar
+- **Fonte das sessões**: `_source: 'meta'` são as mais completas; `'jsonl'` e `'subdir'` são fallbacks com dados parciais (sem git lines, sem cache tokens)
+
+## Desenvolvimento
+
+```bash
+bun run dev      # API (3001) + UI (5173) em paralelo
+bun run watch    # Daemon OpenTelemetry (opcional)
+bun test         # Testes unitários das funções puras
+```
+
+## Testes
+
+Testes unitários cobrem as funções puras críticas:
+
+- `src/lib/types.test.ts` → `calcCost()`, `getModelPrice()`
+- `src/hooks/useData.test.ts` → `calcStreak()`, `getDateRangeFilter()`
+
+Não mockar filesystem — as funções testadas são puras e não têm efeitos colaterais.

--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,10 @@
     "": {
       "name": "claude-stats",
       "dependencies": {
+        "@opentelemetry/api": "^1.9.1",
+        "@opentelemetry/exporter-metrics-otlp-http": "^0.57.2",
+        "@opentelemetry/sdk-metrics": "^1.30.1",
+        "chokidar": "^5.0.0",
         "date-fns": "^4.1.0",
         "html2canvas": "^1.4.1",
         "jspdf": "^4.2.1",
@@ -38,7 +42,49 @@
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.3", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ=="],
 
+    "@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
+
+    "@opentelemetry/api-logs": ["@opentelemetry/api-logs@0.57.2", "", { "dependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A=="],
+
+    "@opentelemetry/core": ["@opentelemetry/core@1.30.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "1.28.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ=="],
+
+    "@opentelemetry/exporter-metrics-otlp-http": ["@opentelemetry/exporter-metrics-otlp-http@0.57.2", "", { "dependencies": { "@opentelemetry/core": "1.30.1", "@opentelemetry/otlp-exporter-base": "0.57.2", "@opentelemetry/otlp-transformer": "0.57.2", "@opentelemetry/resources": "1.30.1", "@opentelemetry/sdk-metrics": "1.30.1" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-ttb9+4iKw04IMubjm3t0EZsYRNWr3kg44uUuzfo9CaccYlOh8cDooe4QObDUkvx9d5qQUrbEckhrWKfJnKhemA=="],
+
+    "@opentelemetry/otlp-exporter-base": ["@opentelemetry/otlp-exporter-base@0.57.2", "", { "dependencies": { "@opentelemetry/core": "1.30.1", "@opentelemetry/otlp-transformer": "0.57.2" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-XdxEzL23Urhidyebg5E6jZoaiW5ygP/mRjxLHixogbqwDy2Faduzb5N0o/Oi+XTIJu+iyxXdVORjXax+Qgfxag=="],
+
+    "@opentelemetry/otlp-transformer": ["@opentelemetry/otlp-transformer@0.57.2", "", { "dependencies": { "@opentelemetry/api-logs": "0.57.2", "@opentelemetry/core": "1.30.1", "@opentelemetry/resources": "1.30.1", "@opentelemetry/sdk-logs": "0.57.2", "@opentelemetry/sdk-metrics": "1.30.1", "@opentelemetry/sdk-trace-base": "1.30.1", "protobufjs": "^7.3.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-48IIRj49gbQVK52jYsw70+Jv+JbahT8BqT2Th7C4H7RCM9d0gZ5sgNPoMpWldmfjvIsSgiGJtjfk9MeZvjhoig=="],
+
+    "@opentelemetry/resources": ["@opentelemetry/resources@1.30.1", "", { "dependencies": { "@opentelemetry/core": "1.30.1", "@opentelemetry/semantic-conventions": "1.28.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA=="],
+
+    "@opentelemetry/sdk-logs": ["@opentelemetry/sdk-logs@0.57.2", "", { "dependencies": { "@opentelemetry/api-logs": "0.57.2", "@opentelemetry/core": "1.30.1", "@opentelemetry/resources": "1.30.1" }, "peerDependencies": { "@opentelemetry/api": ">=1.4.0 <1.10.0" } }, "sha512-TXFHJ5c+BKggWbdEQ/inpgIzEmS2BGQowLE9UhsMd7YYlUfBQJ4uax0VF/B5NYigdM/75OoJGhAV3upEhK+3gg=="],
+
+    "@opentelemetry/sdk-metrics": ["@opentelemetry/sdk-metrics@1.30.1", "", { "dependencies": { "@opentelemetry/core": "1.30.1", "@opentelemetry/resources": "1.30.1" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-q9zcZ0Okl8jRgmy7eNW3Ku1XSgg3sDLa5evHZpCwjspw7E8Is4K/haRPDJrBcX3YSn/Y7gUvFnByNYEKQNbNog=="],
+
+    "@opentelemetry/sdk-trace-base": ["@opentelemetry/sdk-trace-base@1.30.1", "", { "dependencies": { "@opentelemetry/core": "1.30.1", "@opentelemetry/resources": "1.30.1", "@opentelemetry/semantic-conventions": "1.28.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-jVPgBbH1gCy2Lb7X0AVQ8XAfgg0pJ4nvl8/IiQA6nxOsPvS+0zMJaFSs2ltXe0J6C8dqjcnpyqINDJmU30+uOg=="],
+
+    "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.28.0", "", {}, "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA=="],
+
     "@oxc-project/types": ["@oxc-project/types@0.123.0", "", {}, "sha512-YtECP/y8Mj1lSHiUWGSRzy/C6teUKlS87dEfuVKT09LgQbUsBW1rNg+MiJ4buGu3yuADV60gbIvo9/HplA56Ew=="],
+
+    "@protobufjs/aspromise": ["@protobufjs/aspromise@1.1.2", "", {}, "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="],
+
+    "@protobufjs/base64": ["@protobufjs/base64@1.1.2", "", {}, "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="],
+
+    "@protobufjs/codegen": ["@protobufjs/codegen@2.0.4", "", {}, "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="],
+
+    "@protobufjs/eventemitter": ["@protobufjs/eventemitter@1.1.0", "", {}, "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="],
+
+    "@protobufjs/fetch": ["@protobufjs/fetch@1.1.0", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.1", "@protobufjs/inquire": "^1.1.0" } }, "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ=="],
+
+    "@protobufjs/float": ["@protobufjs/float@1.0.2", "", {}, "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="],
+
+    "@protobufjs/inquire": ["@protobufjs/inquire@1.1.0", "", {}, "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="],
+
+    "@protobufjs/path": ["@protobufjs/path@1.1.2", "", {}, "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="],
+
+    "@protobufjs/pool": ["@protobufjs/pool@1.1.0", "", {}, "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="],
+
+    "@protobufjs/utf8": ["@protobufjs/utf8@1.1.0", "", {}, "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="],
 
     "@reduxjs/toolkit": ["@reduxjs/toolkit@2.11.2", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@standard-schema/utils": "^0.3.0", "immer": "^11.0.0", "redux": "^5.0.1", "redux-thunk": "^3.1.0", "reselect": "^5.1.0" }, "peerDependencies": { "react": "^16.9.0 || ^17.0.0 || ^18 || ^19", "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0" }, "optionalPeers": ["react", "react-redux"] }, "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ=="],
 
@@ -129,6 +175,8 @@
     "canvg": ["canvg@3.0.11", "", { "dependencies": { "@babel/runtime": "^7.12.5", "@types/raf": "^3.4.0", "core-js": "^3.8.3", "raf": "^3.4.1", "regenerator-runtime": "^0.13.7", "rgbcolor": "^1.0.1", "stackblur-canvas": "^2.0.0", "svg-pathdata": "^6.0.3" } }, "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA=="],
 
     "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+
+    "chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
 
     "cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
 
@@ -232,6 +280,8 @@
 
     "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
 
+    "long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
+
     "lucide-react": ["lucide-react@1.7.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-yI7BeItCLZJTXikmK4KNUGCKoGzSvbKlfCvw44bU4fXAL6v3gYS4uHD1jzsLkfwODYwI6Drw5Tu9Z5ulDe0TSg=="],
 
     "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
@@ -246,6 +296,8 @@
 
     "postcss": ["postcss@8.5.9", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw=="],
 
+    "protobufjs": ["protobufjs@7.5.4", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.4", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.0", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.0", "@types/node": ">=13.7.0", "long": "^5.0.0" } }, "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg=="],
+
     "raf": ["raf@3.4.1", "", { "dependencies": { "performance-now": "^2.1.0" } }, "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA=="],
 
     "react": ["react@19.2.5", "", {}, "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA=="],
@@ -255,6 +307,8 @@
     "react-is": ["react-is@19.2.5", "", {}, "sha512-Dn0t8IQhCmeIT3wu+Apm1/YVsJXsGWi6k4sPdnBIdqMVtHtv0IGi6dcpNpNkNac0zB2uUAqNX3MHzN8c+z2rwQ=="],
 
     "react-redux": ["react-redux@9.2.0", "", { "dependencies": { "@types/use-sync-external-store": "^0.0.6", "use-sync-external-store": "^1.4.0" }, "peerDependencies": { "@types/react": "^18.2.25 || ^19", "react": "^18.0 || ^19", "redux": "^5.0.0" }, "optionalPeers": ["@types/react", "redux"] }, "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g=="],
+
+    "readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
 
     "recharts": ["recharts@3.8.1", "", { "dependencies": { "@reduxjs/toolkit": "^1.9.0 || 2.x.x", "clsx": "^2.1.1", "decimal.js-light": "^2.5.1", "es-toolkit": "^1.39.3", "eventemitter3": "^5.0.1", "immer": "^10.1.1", "react-redux": "8.x.x || 9.x.x", "reselect": "5.1.1", "tiny-invariant": "^1.3.3", "use-sync-external-store": "^1.2.2", "victory-vendor": "^37.0.2" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg=="],
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "dev": "bun run --bun concurrently \"bun run dev:api\" \"bun run dev:ui\"",
     "build": "vite build",
     "preview": "vite preview",
-    "watch": "bun run watcher.ts"
+    "watch": "bun run watcher.ts",
+    "test": "bun test"
   },
   "devDependencies": {
     "@types/bun": "latest",

--- a/src/hooks/useData.test.ts
+++ b/src/hooks/useData.test.ts
@@ -1,0 +1,105 @@
+import { describe, test, expect } from 'bun:test'
+import { calcStreak, getDateRangeFilter } from './useData'
+
+// ── calcStreak ────────────────────────────────────────────────────────────────
+
+describe('calcStreak', () => {
+  // Data de referência fixa para evitar flakiness
+  const TODAY = new Date('2026-04-10T12:00:00.000Z')
+
+  // Datas no formato UTC (slice do toISOString)
+  const d = (offset: number) =>
+    new Date(TODAY.getTime() - offset * 86_400_000).toISOString().slice(0, 10)
+
+  test('set vazio → streak 0', () => {
+    expect(calcStreak(new Set(), TODAY)).toBe(0)
+  })
+
+  test('somente hoje ativo → streak 1', () => {
+    expect(calcStreak(new Set([d(0)]), TODAY)).toBe(1)
+  })
+
+  test('hoje e ontem ativos → streak 2', () => {
+    expect(calcStreak(new Set([d(0), d(1)]), TODAY)).toBe(2)
+  })
+
+  test('3 dias consecutivos → streak 3', () => {
+    expect(calcStreak(new Set([d(0), d(1), d(2)]), TODAY)).toBe(3)
+  })
+
+  test('gap interrompe streak — conta apenas do início até o gap', () => {
+    // Hoje e anteontem ativos, ontem não → streak 1 (para em ontem)
+    expect(calcStreak(new Set([d(0), d(2)]), TODAY)).toBe(1)
+  })
+
+  test('hoje sem atividade, ontem e anteontem ativos → streak 2', () => {
+    // Comportamento intencional: hoje sem atividade não quebra o streak anterior
+    expect(calcStreak(new Set([d(1), d(2)]), TODAY)).toBe(2)
+  })
+
+  test('hoje e ontem sem atividade → streak 0', () => {
+    // Gap de dois dias: hoje não ativo (não quebra), ontem não ativo (quebra)
+    expect(calcStreak(new Set([d(2), d(3)]), TODAY)).toBe(0)
+  })
+
+  test('atividade antiga sem continuidade até hoje → streak 0', () => {
+    expect(calcStreak(new Set([d(10), d(11), d(12)]), TODAY)).toBe(0)
+  })
+
+  test('365 dias consecutivos → streak 365', () => {
+    const dates = new Set(Array.from({ length: 365 }, (_, i) => d(i)))
+    expect(calcStreak(dates, TODAY)).toBe(365)
+  })
+})
+
+// ── getDateRangeFilter ────────────────────────────────────────────────────────
+
+describe('getDateRangeFilter', () => {
+  test('"all" sem customização → início do epoch até agora', () => {
+    const { start, end } = getDateRangeFilter('all')
+    expect(start.getTime()).toBe(new Date(0).getTime())
+    expect(end.getTime()).toBeGreaterThan(Date.now() - 1000)
+  })
+
+  test('"7d" → start é startOfDay de 7 dias atrás, end é endOfDay de hoje', () => {
+    const { start, end } = getDateRangeFilter('7d')
+    // startOfDay(subDays) + endOfDay(hoje) = ~8 dias de diferença total
+    const diffDays = (end.getTime() - start.getTime()) / (1000 * 60 * 60 * 24)
+    expect(diffDays).toBeGreaterThan(7.9)
+    expect(diffDays).toBeLessThan(8.1)
+  })
+
+  test('"30d" → start é startOfDay de 30 dias atrás, end é endOfDay de hoje', () => {
+    const { start, end } = getDateRangeFilter('30d')
+    const diffDays = (end.getTime() - start.getTime()) / (1000 * 60 * 60 * 24)
+    expect(diffDays).toBeGreaterThan(30.9)
+    expect(diffDays).toBeLessThan(31.1)
+  })
+
+  test('"90d" → start é startOfDay de 90 dias atrás, end é endOfDay de hoje', () => {
+    const { start, end } = getDateRangeFilter('90d')
+    const diffDays = (end.getTime() - start.getTime()) / (1000 * 60 * 60 * 24)
+    expect(diffDays).toBeGreaterThan(90.9)
+    expect(diffDays).toBeLessThan(91.1)
+  })
+
+  test('"all" com datas customizadas → usa as datas fornecidas', () => {
+    const { start, end } = getDateRangeFilter('all', '2026-01-01', '2026-03-31')
+    expect(start.getFullYear()).toBe(2026)
+    expect(start.getMonth()).toBe(0) // janeiro
+    expect(end.getMonth()).toBe(2)   // março
+  })
+
+  test('customStart sem customEnd → end é agora', () => {
+    const { start, end } = getDateRangeFilter('all', '2025-01-01')
+    expect(start.getFullYear()).toBe(2025)
+    expect(end.getTime()).toBeGreaterThan(Date.now() - 1000)
+  })
+
+  test('start sempre antes de end', () => {
+    for (const range of ['7d', '30d', '90d', 'all'] as const) {
+      const { start, end } = getDateRangeFilter(range)
+      expect(start.getTime()).toBeLessThan(end.getTime())
+    }
+  })
+})

--- a/src/hooks/useData.ts
+++ b/src/hooks/useData.ts
@@ -59,6 +59,20 @@ function inRange(date: Date, start: Date, end: Date) {
   return !isBefore(date, start) && !isAfter(date, end)
 }
 
+/**
+ * Calcula streak de dias consecutivos de atividade.
+ * Se hoje não tiver atividade, conta a partir de ontem (não penaliza quem ainda não trabalhou hoje).
+ */
+export function calcStreak(activeDates: Set<string>, today: Date = new Date()): number {
+  let streak = 0
+  for (let i = 0; i <= 365; i++) {
+    const dateStr = subDays(today, i).toISOString().slice(0, 10)
+    if (activeDates.has(dateStr)) streak++
+    else if (i > 0) break
+  }
+  return streak
+}
+
 /** Blended cost per token using global model usage proportions */
 function blendedCostPerToken(modelUsage: Record<string, { inputTokens: number; outputTokens: number; cacheReadInputTokens: number; cacheCreationInputTokens: number }>) {
   let totalInput = 0, totalOutput = 0, totalCacheRead = 0, totalCacheWrite = 0
@@ -125,13 +139,7 @@ export function useDerivedStats(data: AppData | null, filters: Filters) {
 
     // ── Streak (always global) ──
     const activeDates = new Set((data.statsCache.dailyActivity ?? []).map(d => d.date))
-    const today = new Date()
-    let streak = 0
-    for (let i = 0; i <= 365; i++) {
-      const dateStr = subDays(today, i).toISOString().slice(0, 10)
-      if (activeDates.has(dateStr)) streak++
-      else if (i > 0) break
-    }
+    const streak = calcStreak(activeDates)
 
     // ── Heatmap data ──
     let heatmapData: { date: string; value: number; sessions: number; tools: number }[]

--- a/src/lib/types.test.ts
+++ b/src/lib/types.test.ts
@@ -1,0 +1,168 @@
+import { describe, test, expect } from 'bun:test'
+import { calcCost, getModelPrice, formatModel, getModelColor, formatProjectName, setHomeDir } from './types'
+import type { ModelUsage } from './types'
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function usage(overrides: Partial<ModelUsage> = {}): ModelUsage {
+  return {
+    inputTokens: 0,
+    outputTokens: 0,
+    cacheReadInputTokens: 0,
+    cacheCreationInputTokens: 0,
+    webSearchRequests: 0,
+    costUSD: 0,
+    ...overrides,
+  }
+}
+
+// ── getModelPrice ─────────────────────────────────────────────────────────────
+
+describe('getModelPrice', () => {
+  test('retorna preço exato para modelo conhecido', () => {
+    expect(getModelPrice('claude-sonnet-4-6')).toEqual({
+      input: 3,
+      output: 15,
+      cacheRead: 0.30,
+      cacheWrite: 3.75,
+    })
+  })
+
+  test('retorna preço exato para opus', () => {
+    expect(getModelPrice('claude-opus-4-6')).toEqual({
+      input: 5,
+      output: 25,
+      cacheRead: 0.50,
+      cacheWrite: 6.25,
+    })
+  })
+
+  test('retorna preço exato para haiku', () => {
+    const price = getModelPrice('claude-haiku-4-5-20251001')
+    expect(price.input).toBe(1)
+    expect(price.output).toBe(5)
+  })
+
+  test('fallback para sonnet quando modelo desconhecido', () => {
+    expect(getModelPrice('modelo-inexistente')).toEqual({
+      input: 3,
+      output: 15,
+      cacheRead: 0.3,
+      cacheWrite: 3.75,
+    })
+  })
+
+  test('match parcial por prefixo — modelId começa com chave conhecida', () => {
+    const price = getModelPrice('claude-opus-4-6-custom-suffix')
+    expect(price.input).toBe(5)
+  })
+})
+
+// ── calcCost ──────────────────────────────────────────────────────────────────
+
+describe('calcCost', () => {
+  test('zero tokens → custo zero', () => {
+    expect(calcCost(usage(), 'claude-sonnet-4-6')).toBe(0)
+  })
+
+  test('1M input tokens de sonnet → $3', () => {
+    const cost = calcCost(usage({ inputTokens: 1_000_000 }), 'claude-sonnet-4-6')
+    expect(cost).toBe(3)
+  })
+
+  test('1M output tokens de sonnet → $15', () => {
+    const cost = calcCost(usage({ outputTokens: 1_000_000 }), 'claude-sonnet-4-6')
+    expect(cost).toBe(15)
+  })
+
+  test('1M input + 1M output de sonnet → $18', () => {
+    const cost = calcCost(usage({ inputTokens: 1_000_000, outputTokens: 1_000_000 }), 'claude-sonnet-4-6')
+    expect(cost).toBe(18)
+  })
+
+  test('cache read tokens aplicam preço correto', () => {
+    // 1M cache read de sonnet → $0.30
+    const cost = calcCost(usage({ cacheReadInputTokens: 1_000_000 }), 'claude-sonnet-4-6')
+    expect(cost).toBeCloseTo(0.30)
+  })
+
+  test('cache write tokens aplicam preço correto', () => {
+    // 1M cache write de sonnet → $3.75
+    const cost = calcCost(usage({ cacheCreationInputTokens: 1_000_000 }), 'claude-sonnet-4-6')
+    expect(cost).toBeCloseTo(3.75)
+  })
+
+  test('opus custa mais que haiku para mesmo volume de tokens', () => {
+    const u = usage({ inputTokens: 100_000, outputTokens: 100_000 })
+    expect(calcCost(u, 'claude-opus-4-6')).toBeGreaterThan(calcCost(u, 'claude-haiku-4-5-20251001'))
+  })
+
+  test('modelo desconhecido usa preço de fallback (sonnet)', () => {
+    const u = usage({ inputTokens: 1_000_000 })
+    expect(calcCost(u, 'modelo-desconhecido')).toBe(calcCost(u, 'claude-sonnet-4-6'))
+  })
+
+  test('custo proporcional — dobrar tokens dobra custo', () => {
+    const base = calcCost(usage({ inputTokens: 500_000 }), 'claude-opus-4-6')
+    const double = calcCost(usage({ inputTokens: 1_000_000 }), 'claude-opus-4-6')
+    expect(double).toBeCloseTo(base * 2)
+  })
+})
+
+// ── formatModel ───────────────────────────────────────────────────────────────
+
+describe('formatModel', () => {
+  test('retorna nome legível para modelos conhecidos', () => {
+    expect(formatModel('claude-sonnet-4-6')).toBe('Sonnet 4.6')
+    expect(formatModel('claude-opus-4-6')).toBe('Opus 4.6')
+    expect(formatModel('claude-haiku-4-5-20251001')).toBe('Haiku 4.5')
+  })
+
+  test('retorna o próprio ID para modelos não mapeados', () => {
+    expect(formatModel('claude-qualquer-coisa')).toBe('claude-qualquer-coisa')
+  })
+})
+
+// ── getModelColor ─────────────────────────────────────────────────────────────
+
+describe('getModelColor', () => {
+  test('opus tem cor âmbar', () => {
+    expect(getModelColor('claude-opus-4-6')).toBe('#D97706')
+  })
+
+  test('sonnet tem cor índigo', () => {
+    expect(getModelColor('claude-sonnet-4-6')).toBe('#6366f1')
+  })
+
+  test('haiku tem cor verde', () => {
+    expect(getModelColor('claude-haiku-4-5-20251001')).toBe('#10b981')
+  })
+
+  test('modelo desconhecido tem cor padrão', () => {
+    expect(getModelColor('outro-modelo')).toBe('#8b5cf6')
+  })
+})
+
+// ── formatProjectName ─────────────────────────────────────────────────────────
+
+describe('formatProjectName', () => {
+  test('retorna "Unknown" para string vazia', () => {
+    setHomeDir('')
+    expect(formatProjectName('')).toBe('Unknown')
+  })
+
+  test('substitui homeDir por ~/', () => {
+    setHomeDir('/home/user')
+    expect(formatProjectName('/home/user/projetos/app')).toBe('~/projetos/app')
+  })
+
+  test('homeDir exato retorna "~ (home)"', () => {
+    setHomeDir('/home/user')
+    expect(formatProjectName('/home/user')).toBe('~ (home)')
+  })
+
+  test('caminho fora do home retorna caminho completo', () => {
+    setHomeDir('/home/user')
+    expect(formatProjectName('/opt/apps/servidor')).toBe('/opt/apps/servidor')
+  })
+})


### PR DESCRIPTION
## Resumo

Implementa a estratégia de qualidade leve discutida: **CLAUDE.md bem feito + TDD nas partes críticas**.

- **`CLAUDE.md`** — documenta arquitetura dual-service, fluxo de dados, tabela de funções críticas com localização, e regras de negócio não óbvias (comportamento do streak, aproximação de tokens por data, fontes de sessão)
- **Extração de `calcStreak()`** — função pura exportada com parâmetro `today` injetável, eliminando flakiness em testes
- **`src/lib/types.test.ts`** — 25 casos cobrindo `calcCost`, `getModelPrice`, `formatModel`, `getModelColor`, `formatProjectName`
- **`src/hooks/useData.test.ts`** — 15 casos cobrindo `calcStreak` e `getDateRangeFilter`
- **`bun test`** adicionado ao `package.json`

## Resultado dos testes

```
40 pass, 0 fail — 42ms
```

## Plano de teste

- [ ] `bun test` passa localmente
- [ ] `bun run dev` ainda funciona normalmente (nenhuma lógica de runtime alterada)
- [ ] Verificar que o streak no dashboard continua correto

🤖 Generated with [Claude Code](https://claude.com/claude-code)