### PR TITLE
feat: watch:cli — live terminal dashboard for Claude Stats

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "claude-stats",
       "dependencies": {
+        "@inquirer/prompts": "^8.4.1",
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/exporter-metrics-otlp-http": "^0.57.2",
         "@opentelemetry/sdk-metrics": "^1.30.1",
@@ -39,6 +40,38 @@
     "@emnapi/runtime": ["@emnapi/runtime@1.9.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA=="],
 
     "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg=="],
+
+    "@inquirer/ansi": ["@inquirer/ansi@2.0.5", "", {}, "sha512-doc2sWgJpbFQ64UflSVd17ibMGDuxO1yKgOgLMwavzESnXjFWJqUeG8saYosqKpHp4kWiM5x1nXvEjbpx90gzw=="],
+
+    "@inquirer/checkbox": ["@inquirer/checkbox@5.1.3", "", { "dependencies": { "@inquirer/ansi": "^2.0.5", "@inquirer/core": "^11.1.8", "@inquirer/figures": "^2.0.5", "@inquirer/type": "^4.0.5" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-+G7I8CT+EHv/hasNfUl3P37DVoMoZfpA+2FXmM54dA8MxYle1YqucxbacxHalw1iAFSdKNEDTGNV7F+j1Ldqcg=="],
+
+    "@inquirer/confirm": ["@inquirer/confirm@6.0.11", "", { "dependencies": { "@inquirer/core": "^11.1.8", "@inquirer/type": "^4.0.5" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-pTpHjg0iEIRMYV/7oCZUMf27/383E6Wyhfc/MY+AVQGEoUobffIYWOK9YLP2XFRGz/9i6WlTQh1CkFVIo2Y7XA=="],
+
+    "@inquirer/core": ["@inquirer/core@11.1.8", "", { "dependencies": { "@inquirer/ansi": "^2.0.5", "@inquirer/figures": "^2.0.5", "@inquirer/type": "^4.0.5", "cli-width": "^4.1.0", "fast-wrap-ansi": "^0.2.0", "mute-stream": "^3.0.0", "signal-exit": "^4.1.0" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-/u+yJk2pOKNDOh1ZgdUH2RQaRx6OOH4I0uwL95qPvTFTIL38YBsuSC4r1yXBB3Q6JvNqFFc202gk0Ew79rrcjA=="],
+
+    "@inquirer/editor": ["@inquirer/editor@5.1.0", "", { "dependencies": { "@inquirer/core": "^11.1.8", "@inquirer/external-editor": "^3.0.0", "@inquirer/type": "^4.0.5" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-6wlkYl65Qfayy48gPCfU4D7li6KCAGN79mLXa/tYHZH99OfZ820yY+HA+DgE88r8YwwgeuY6PQgNqMeK6LuMmw=="],
+
+    "@inquirer/expand": ["@inquirer/expand@5.0.12", "", { "dependencies": { "@inquirer/core": "^11.1.8", "@inquirer/type": "^4.0.5" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-vOfrB33b7YIZfDauXS8vNNz2Z86FozTZLIt7e+7/dCaPJ1RXZsHCuI9TlcERzEUq57vkM+UdnBgxP0rFd23JYQ=="],
+
+    "@inquirer/external-editor": ["@inquirer/external-editor@3.0.0", "", { "dependencies": { "chardet": "^2.1.1", "iconv-lite": "^0.7.2" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-lDSwMgg+M5rq6JKBYaJwSX6T9e/HK2qqZ1oxmOwn4AQoJE5D+7TumsxLGC02PWS//rkIVqbZv3XA3ejsc9FYvg=="],
+
+    "@inquirer/figures": ["@inquirer/figures@2.0.5", "", {}, "sha512-NsSs4kzfm12lNetHwAn3GEuH317IzpwrMCbOuMIVytpjnJ90YYHNwdRgYGuKmVxwuIqSgqk3M5qqQt1cDk0tGQ=="],
+
+    "@inquirer/input": ["@inquirer/input@5.0.11", "", { "dependencies": { "@inquirer/core": "^11.1.8", "@inquirer/type": "^4.0.5" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-twUWidn4ocPO8qi6fRM7tNWt7W1FOnOZqQ+/+PsfLUacMR5rFLDPK9ql0nBPwxi0oELbo8T5NhRs8B2+qQEqFQ=="],
+
+    "@inquirer/number": ["@inquirer/number@4.0.11", "", { "dependencies": { "@inquirer/core": "^11.1.8", "@inquirer/type": "^4.0.5" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-Vscmim9TCksQsfjPtka/JwPUcbLhqWYrgfPf1cHrCm24X/F2joFwnageD50yMKsaX14oNGOyKf/RNXAFkNjWpA=="],
+
+    "@inquirer/password": ["@inquirer/password@5.0.11", "", { "dependencies": { "@inquirer/ansi": "^2.0.5", "@inquirer/core": "^11.1.8", "@inquirer/type": "^4.0.5" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-9KZFeRaNHIcejtPb0wN4ddFc7EvobVoAFa049eS3LrDZFxI8O7xUXiITEOinBzkZFAIwY5V4yzQae/QfO9cbbg=="],
+
+    "@inquirer/prompts": ["@inquirer/prompts@8.4.1", "", { "dependencies": { "@inquirer/checkbox": "^5.1.3", "@inquirer/confirm": "^6.0.11", "@inquirer/editor": "^5.1.0", "@inquirer/expand": "^5.0.12", "@inquirer/input": "^5.0.11", "@inquirer/number": "^4.0.11", "@inquirer/password": "^5.0.11", "@inquirer/rawlist": "^5.2.7", "@inquirer/search": "^4.1.7", "@inquirer/select": "^5.1.3" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-AH5xPQ997K7e0F0vulPlteIHke2awMkFi8F0dBemrDfmvtPmHJo82mdHbONC4F/t8d1NHwrbI5cGVI+RbLWdoQ=="],
+
+    "@inquirer/rawlist": ["@inquirer/rawlist@5.2.7", "", { "dependencies": { "@inquirer/core": "^11.1.8", "@inquirer/type": "^4.0.5" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-AqRMiD9+uE1lskDPrdqHwrV/EUmxKEBLX44SR7uxK3vD2413AmVfE5EQaPeNzYf5Pq5SitHJDYUFVF0poIr09w=="],
+
+    "@inquirer/search": ["@inquirer/search@4.1.7", "", { "dependencies": { "@inquirer/core": "^11.1.8", "@inquirer/figures": "^2.0.5", "@inquirer/type": "^4.0.5" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-1y7+0N65AWk5RdlXH/Kn13txf3IjIQ7OEfhCEkDTU+h5wKMLq8DUF3P6z+/kLSxDGDtQT1dRBWEUC3o/VvImsQ=="],
+
+    "@inquirer/select": ["@inquirer/select@5.1.3", "", { "dependencies": { "@inquirer/ansi": "^2.0.5", "@inquirer/core": "^11.1.8", "@inquirer/figures": "^2.0.5", "@inquirer/type": "^4.0.5" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-zYyqWgGQi3NhBcNq4Isc5rB3oEdQEh1Q/EcAnOW0FK4MpnXWkvSBYgA4cYrTM4A9UB573omouZbnL9JJ74Mq3A=="],
+
+    "@inquirer/type": ["@inquirer/type@4.0.5", "", { "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.3", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ=="],
 
@@ -176,7 +209,11 @@
 
     "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
+    "chardet": ["chardet@2.1.1", "", {}, "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ=="],
+
     "chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
+
+    "cli-width": ["cli-width@4.1.0", "", {}, "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ=="],
 
     "cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
 
@@ -234,6 +271,12 @@
 
     "fast-png": ["fast-png@6.4.0", "", { "dependencies": { "@types/pako": "^2.0.3", "iobuffer": "^5.3.2", "pako": "^2.1.0" } }, "sha512-kAqZq1TlgBjZcLr5mcN6NP5Rv4V2f22z00c3g8vRrwkcqjerx7BEhPbOnWCPqaHUl2XWQBJQvOT/FQhdMT7X/Q=="],
 
+    "fast-string-truncated-width": ["fast-string-truncated-width@3.0.3", "", {}, "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g=="],
+
+    "fast-string-width": ["fast-string-width@3.0.2", "", { "dependencies": { "fast-string-truncated-width": "^3.0.2" } }, "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg=="],
+
+    "fast-wrap-ansi": ["fast-wrap-ansi@0.2.0", "", { "dependencies": { "fast-string-width": "^3.0.2" } }, "sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w=="],
+
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
     "fflate": ["fflate@0.8.2", "", {}, "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A=="],
@@ -245,6 +288,8 @@
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
     "html2canvas": ["html2canvas@1.4.1", "", { "dependencies": { "css-line-break": "^2.1.0", "text-segmentation": "^1.0.3" } }, "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA=="],
+
+    "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
     "immer": ["immer@10.2.0", "", {}, "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw=="],
 
@@ -283,6 +328,8 @@
     "long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
 
     "lucide-react": ["lucide-react@1.7.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-yI7BeItCLZJTXikmK4KNUGCKoGzSvbKlfCvw44bU4fXAL6v3gYS4uHD1jzsLkfwODYwI6Drw5Tu9Z5ulDe0TSg=="],
+
+    "mute-stream": ["mute-stream@3.0.0", "", {}, "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw=="],
 
     "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
@@ -328,9 +375,13 @@
 
     "rxjs": ["rxjs@7.8.2", "", { "dependencies": { "tslib": "^2.1.0" } }, "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA=="],
 
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
     "shell-quote": ["shell-quote@1.8.3", "", {}, "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw=="],
+
+    "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "watch": "bun run watcher.ts",
+    "watch:cli": "bun run watch-cli.ts",
     "test": "bun test"
   },
   "devDependencies": {
@@ -24,6 +25,7 @@
     "typescript": "^5"
   },
   "dependencies": {
+    "@inquirer/prompts": "^8.4.1",
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/exporter-metrics-otlp-http": "^0.57.2",
     "@opentelemetry/sdk-metrics": "^1.30.1",

--- a/server.ts
+++ b/server.ts
@@ -1271,6 +1271,13 @@ Bun.serve({
       })
     }
 
+    if (url.pathname === '/api/health' && req.method === 'GET') {
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
+      })
+    }
+
     if (url.pathname === '/api/rates' && req.method === 'GET') {
       try {
         const rates = await getRates()

--- a/server.ts
+++ b/server.ts
@@ -1236,6 +1236,7 @@ function maybeSpawnWatcher() {
 setupFileWatcher()
 maybeSpawnWatcher()
 
+try {
 Bun.serve({
   port: PORT,
   async fetch(req) {
@@ -1314,5 +1315,12 @@ Bun.serve({
     })
   },
 })
-
 console.log(`Claude Stats API running at http://localhost:${PORT}`)
+} catch (err: unknown) {
+  const msg = err instanceof Error ? err.message : String(err)
+  if (msg.includes('EADDRINUSE') || msg.includes('already in use')) {
+    console.log(`[server] Port ${PORT} already in use — reusing existing instance.`)
+    process.exit(0)
+  }
+  throw err
+}

--- a/watch-cli.ts
+++ b/watch-cli.ts
@@ -2,76 +2,80 @@
 /**
  * Claude Stats — Watch CLI
  *
- * TUI interativa para monitorar métricas Claude em tempo real.
- * Selecione projetos e visualize dados agregados no terminal.
+ * TUI interativa que monitora métricas Claude em tempo real, atualizando o painel
+ * no lugar (como `watch` do Linux) sem duplicar a saída.
  *
  * Usage:
  *   bun run watch:cli
  *
- * Variáveis de ambiente:
- *   CLAUDE_STATS_WATCH_INTERVAL  — Intervalo de polling em segundos (padrão: 30, mín: 5)
+ * Controles durante o watch:
+ *   Ctrl+O  — ocultar/mostrar animação de batalha
+ *   Ctrl+C  — sair
  */
 
 import { readdir, readFile } from 'fs/promises'
 import { join } from 'path'
 import chokidar from 'chokidar'
-import { checkbox, select } from '@inquirer/prompts'
-import { calcCost } from './src/lib/types'
+import {
+  createPrompt,
+  useState,
+  useMemo,
+  useKeypress,
+  usePagination,
+  isUpKey,
+  isDownKey,
+  isEnterKey,
+  isSpaceKey,
+  isBackspaceKey,
+  type KeypressEvent,
+} from '@inquirer/core'
+import { select, input } from '@inquirer/prompts'
+import { calcCost, getModelPrice } from './src/lib/types'
 import type { ModelUsage } from './src/lib/types'
 
 // ── Configuração ───────────────────────────────────────────────────────────
 
-const HOME_DIR = process.env.HOME ?? process.env.USERPROFILE ?? ''
+const HOME_DIR   = process.env.HOME ?? process.env.USERPROFILE ?? ''
 const CLAUDE_DIR = join(HOME_DIR, '.claude')
-const SESSION_META_DIR = join(CLAUDE_DIR, 'usage-data', 'session-meta')
-const STATS_CACHE_FILE = join(CLAUDE_DIR, 'stats-cache.json')
+const PROJECTS_DIR       = join(CLAUDE_DIR, 'projects')
+const SESSION_META_DIR   = join(CLAUDE_DIR, 'usage-data', 'session-meta')
+const STATS_CACHE_FILE   = join(CLAUDE_DIR, 'stats-cache.json')
 
-const MIN_INTERVAL_SEC = 5
-const rawInterval = parseInt(process.env.CLAUDE_STATS_WATCH_INTERVAL ?? '30', 10)
-const WATCH_INTERVAL_SEC = !Number.isFinite(rawInterval) || rawInterval < MIN_INTERVAL_SEC ? 30 : rawInterval
+// ── ANSI ───────────────────────────────────────────────────────────────────
 
-// ── ANSI helpers ───────────────────────────────────────────────────────────
-
-const ESC = '\x1b'
+const ESC   = '\x1b'
 const RESET = `${ESC}[0m`
-const BOLD = `${ESC}[1m`
-const DIM = `${ESC}[2m`
-const CYAN = `${ESC}[36m`
+const BOLD  = `${ESC}[1m`
+const DIM   = `${ESC}[2m`
+const CYAN  = `${ESC}[36m`
 const GREEN = `${ESC}[32m`
 const YELLOW = `${ESC}[33m`
+const RED   = `${ESC}[31m`
 const WHITE = `${ESC}[37m`
 const BRIGHT_CYAN = `${ESC}[96m`
 
-function clearScreen() {
-  process.stdout.write(`${ESC}[2J${ESC}[H`)
+function clearScreen()  { process.stdout.write(`${ESC}[2J${ESC}[H`) }
+function hideCursor()   { process.stdout.write(`${ESC}[?25l`) }
+function showCursor()   { process.stdout.write(`${ESC}[?25h`) }
+function visLen(s: string) { return s.replace(/\x1b\[[0-9;]*m/g, '').length }
+function col(s: string, w: number, align: 'l' | 'r' = 'r') {
+  const p = ' '.repeat(Math.max(0, w - visLen(s)))
+  return align === 'l' ? s + p : p + s
 }
-function hideCursor() {
-  process.stdout.write(`${ESC}[?25l`)
-}
-function showCursor() {
-  process.stdout.write(`${ESC}[?25h`)
-}
+function hr(w: number, ch = '─') { return `${DIM}${ch.repeat(w)}${RESET}` }
 
 // ── Tipos ──────────────────────────────────────────────────────────────────
 
 type ViewMode = 'separado' | 'junto' | 'ambos'
 
-interface ProjectInfo {
-  name: string
-  path: string
-}
+interface ProjectInfo { name: string; path: string }
 
 interface CliSnapshot {
-  messages: number
-  sessions: number
-  inputTokens: number
-  outputTokens: number
-  costUsd: number
-  streak: number
-  gitCommits: number
-  gitPushes: number
-  linesAdded: number
-  linesRemoved: number
+  messages: number; sessions: number
+  inputTokens: number; outputTokens: number
+  costUsd: number; streak: number
+  gitCommits: number; gitPushes: number
+  linesAdded: number; linesRemoved: number
 }
 
 interface StatsCache {
@@ -79,266 +83,330 @@ interface StatsCache {
   modelUsage?: Record<string, ModelUsage>
 }
 
-interface SessionMetaLight {
-  session_id: string
-  project_path: string
-  input_tokens: number
-  output_tokens: number
-  user_message_count: number
-  assistant_message_count: number
-  git_commits: number
-  git_pushes: number
-  lines_added: number
-  lines_removed: number
-  start_time: string
+interface SessionMeta {
+  session_id: string; project_path: string; start_time: string
+  user_message_count: number; assistant_message_count: number
+  git_commits: number; git_pushes: number
+  input_tokens: number; output_tokens: number
+  lines_added: number; lines_removed: number
 }
 
 interface WatchConfig {
-  selectedProjects: ProjectInfo[]  // empty = todos
+  selectedProjects: ProjectInfo[]
   allProjects: ProjectInfo[]
   viewMode: ViewMode
   intervalSec: number
+  otlpEndpoint: string
+}
+
+interface AppState {
+  snapshots: Map<string, CliSnapshot>   // chave '' = all, ou project_path
+  lastUpdated: Date
+  animFrame: number
+  showAnimation: boolean
+  isLoadingData: boolean
 }
 
 // ── I/O helpers ────────────────────────────────────────────────────────────
 
-async function safeReadJson<T>(filePath: string): Promise<T | null> {
-  try {
-    return JSON.parse(await readFile(filePath, 'utf-8')) as T
-  } catch {
-    return null
-  }
+async function safeReadJson<T>(f: string): Promise<T | null> {
+  try { return JSON.parse(await readFile(f, 'utf-8')) as T } catch { return null }
+}
+async function safeReadDir(d: string): Promise<string[]> {
+  try { return await readdir(d) } catch { return [] }
 }
 
-async function safeReadDir(dirPath: string): Promise<string[]> {
-  try {
-    return await readdir(dirPath)
-  } catch {
-    return []
-  }
-}
+// ── Descoberta de projetos (mesma lógica do server.ts) ─────────────────────
 
-// ── Descoberta de projetos ─────────────────────────────────────────────────
-// Lê os project_path únicos dos arquivos session-meta (caminhos canônicos reais).
+function decodeProjectDir(dirName: string): string {
+  if (dirName.startsWith('-')) return dirName.replace(/-/g, '/')
+  return '/' + dirName.replace(/-/g, '/')
+}
 
 async function discoverProjects(): Promise<ProjectInfo[]> {
+  // 1. Caminhos canônicos dos session-meta
   const metaFiles = (await safeReadDir(SESSION_META_DIR)).filter(f => f.endsWith('.json'))
-
-  const projectPaths = new Set<string>()
-
-  // Lê em lotes para não abrir muitos file descriptors de uma vez
+  const metaPaths = new Set<string>()
   const BATCH = 30
   for (let i = 0; i < metaFiles.length; i += BATCH) {
-    const batch = metaFiles.slice(i, i + BATCH)
-    const results = await Promise.all(
-      batch.map(f => safeReadJson<{ project_path?: string }>(join(SESSION_META_DIR, f)))
+    const res = await Promise.all(
+      metaFiles.slice(i, i + BATCH).map(f =>
+        safeReadJson<{ project_path?: string }>(join(SESSION_META_DIR, f))
+      )
     )
-    for (const s of results) {
-      if (s?.project_path) projectPaths.add(s.project_path)
+    for (const s of res) if (s?.project_path) metaPaths.add(s.project_path)
+  }
+
+  // 2. Dirs em ~/.claude/projects/ como fallback (projetos sem session-meta)
+  for (const dir of await safeReadDir(PROJECTS_DIR)) {
+    if (!dir.startsWith('.')) {
+      const decoded = decodeProjectDir(dir)
+      if (!metaPaths.has(decoded)) metaPaths.add(decoded)
     }
   }
 
-  return Array.from(projectPaths)
-    .sort()
-    .map(path => ({
-      path,
-      name: path.split('/').filter(Boolean).pop() ?? path,
-    }))
+  return Array.from(metaPaths).sort().map(path => ({
+    path,
+    name: path.split('/').filter(Boolean).pop() ?? path,
+  }))
 }
 
-// ── Cálculo de snapshot ────────────────────────────────────────────────────
+// ── Cálculo de snapshot (espelha useDerivedStats) ──────────────────────────
 
-async function buildCliSnapshot(projectPaths?: string[]): Promise<CliSnapshot> {
-  const isFiltered = projectPaths !== undefined && projectPaths.length > 0
-  const metaFiles = (await safeReadDir(SESSION_META_DIR)).filter(f => f.endsWith('.json'))
-  const sessions: SessionMetaLight[] = []
+function blendedCostPerToken(modelUsage: Record<string, ModelUsage>) {
+  let tIn = 0, tOut = 0, tCR = 0, tCW = 0
+  let wIn = 0, wOut = 0, wCR = 0, wCW = 0
+  for (const [id, u] of Object.entries(modelUsage)) {
+    const p = getModelPrice(id)
+    tIn += u.inputTokens; tOut += u.outputTokens
+    tCR += u.cacheReadInputTokens; tCW += u.cacheCreationInputTokens
+    wIn += u.inputTokens * p.input; wOut += u.outputTokens * p.output
+    wCR += u.cacheReadInputTokens * p.cacheRead; wCW += u.cacheCreationInputTokens * p.cacheWrite
+  }
+  return {
+    input:      tIn  > 0 ? wIn  / tIn  : 3,
+    output:     tOut > 0 ? wOut / tOut : 15,
+    cacheRead:  tCR  > 0 ? wCR  / tCR  : 0.3,
+    cacheWrite: tCW  > 0 ? wCW  / tCW  : 3.75,
+  }
+}
 
+async function loadSessions(): Promise<SessionMeta[]> {
+  const files = (await safeReadDir(SESSION_META_DIR)).filter(f => f.endsWith('.json'))
+  const result: SessionMeta[] = []
   const BATCH = 30
-  for (let i = 0; i < metaFiles.length; i += BATCH) {
-    const batch = metaFiles.slice(i, i + BATCH)
-    const results = await Promise.all(
-      batch.map(f => safeReadJson<SessionMetaLight>(join(SESSION_META_DIR, f)))
+  for (let i = 0; i < files.length; i += BATCH) {
+    const res = await Promise.all(
+      files.slice(i, i + BATCH).map(f => safeReadJson<SessionMeta>(join(SESSION_META_DIR, f)))
     )
-    for (const s of results) {
-      if (s) sessions.push(s)
-    }
+    for (const s of res) if (s?.session_id) result.push(s)
   }
+  return result
+}
 
-  const filtered = isFiltered
-    ? sessions.filter(s => projectPaths!.includes(s.project_path))
-    : sessions
+function computeSnapshot(
+  allSessions: SessionMeta[],
+  statsCache: StatsCache,
+  projectFilter?: string[]
+): CliSnapshot {
+  const isFiltered = projectFilter !== undefined && projectFilter.length > 0
+  const filtered   = isFiltered
+    ? allSessions.filter(s => projectFilter!.includes(s.project_path))
+    : allSessions
 
-  let inputTokens = 0
-  let outputTokens = 0
-  let gitCommits = 0
-  let gitPushes = 0
-  let linesAdded = 0
-  let linesRemoved = 0
-  let messages = 0
-  const activeDates = new Set<string>()
-  const sessionIds = new Set<string>()
+  const messages = isFiltered
+    ? filtered.reduce((s, x) => s + (x.user_message_count ?? 0) + (x.assistant_message_count ?? 0), 0)
+    : (statsCache.dailyActivity ?? []).reduce((s, d) => s + d.messageCount, 0)
 
-  for (const s of filtered) {
-    inputTokens += s.input_tokens ?? 0
-    outputTokens += s.output_tokens ?? 0
-    gitCommits += s.git_commits ?? 0
-    gitPushes += s.git_pushes ?? 0
-    linesAdded += s.lines_added ?? 0
-    linesRemoved += s.lines_removed ?? 0
-    messages += (s.user_message_count ?? 0) + (s.assistant_message_count ?? 0)
-    if (s.session_id) sessionIds.add(s.session_id)
-    if (s.start_time) activeDates.add(s.start_time.slice(0, 10))
-  }
+  const sessions = isFiltered
+    ? filtered.length
+    : (statsCache.dailyActivity ?? []).reduce((s, d) => s + d.sessionCount, 0)
 
-  // Custo: usa stats-cache para global (preciso); aproximação proporcional para filtros
+  const inputTokens  = filtered.reduce((s, x) => s + (x.input_tokens  ?? 0), 0)
+  const outputTokens = filtered.reduce((s, x) => s + (x.output_tokens ?? 0), 0)
+  const gitCommits   = filtered.reduce((s, x) => s + (x.git_commits   ?? 0), 0)
+  const gitPushes    = filtered.reduce((s, x) => s + (x.git_pushes    ?? 0), 0)
+  const linesAdded   = filtered.reduce((s, x) => s + (x.lines_added   ?? 0), 0)
+  const linesRemoved = filtered.reduce((s, x) => s + (x.lines_removed ?? 0), 0)
+
+  const modelUsage = statsCache.modelUsage ?? {}
   let costUsd = 0
-  const cache = await safeReadJson<StatsCache>(STATS_CACHE_FILE)
-
   if (!isFiltered) {
-    if (cache?.modelUsage) {
-      for (const [modelId, u] of Object.entries(cache.modelUsage)) {
-        costUsd += calcCost(u, modelId)
-      }
-    }
+    costUsd = Object.entries(modelUsage).reduce((s, [id, u]) => s + calcCost(u, id), 0)
   } else {
-    // Taxa combinada global → aplica ao volume de tokens do subconjunto
-    let globalInput = 0
-    let globalOutput = 0
-    let globalCost = 0
-    if (cache?.modelUsage) {
-      for (const [modelId, u] of Object.entries(cache.modelUsage)) {
-        globalInput += u.inputTokens + (u.cacheReadInputTokens ?? 0) + (u.cacheCreationInputTokens ?? 0)
-        globalOutput += u.outputTokens
-        globalCost += calcCost(u, modelId)
-      }
-    }
-    const totalTokens = globalInput + globalOutput
-    if (totalTokens > 0) {
-      costUsd = ((inputTokens + outputTokens) / totalTokens) * globalCost
-    }
+    const b = blendedCostPerToken(modelUsage)
+    costUsd = (inputTokens / 1_000_000) * b.input + (outputTokens / 1_000_000) * b.output
   }
 
-  // Streak: conta dias consecutivos para trás a partir de hoje
+  const activeDates = new Set((statsCache.dailyActivity ?? []).map(d => d.date))
   let streak = 0
   for (let i = 0; i <= 365; i++) {
-    const d = new Date()
-    d.setDate(d.getDate() - i)
-    const dateStr = d.toISOString().slice(0, 10)
-    if (activeDates.has(dateStr)) {
-      streak++
-    } else if (i > 0) {
-      break
+    const d = new Date(); d.setDate(d.getDate() - i)
+    const ds = d.toISOString().slice(0, 10)
+    if (activeDates.has(ds)) streak++
+    else if (i > 0) break
+  }
+
+  return { messages, sessions, inputTokens, outputTokens, costUsd, streak, gitCommits, gitPushes, linesAdded, linesRemoved }
+}
+
+async function reloadAllSnapshots(config: WatchConfig): Promise<{
+  snapshots: Map<string, CliSnapshot>
+  lastUpdated: Date
+}> {
+  const [allSessions, statsCache] = await Promise.all([
+    loadSessions(),
+    safeReadJson<StatsCache>(STATS_CACHE_FILE).then(v => v ?? {}),
+  ])
+
+  const snapshots = new Map<string, CliSnapshot>()
+
+  if (config.selectedProjects.length === 0) {
+    // Todos os projetos
+    snapshots.set('', computeSnapshot(allSessions, statsCache))
+  } else {
+    // Snapshot unificado dos selecionados
+    snapshots.set('', computeSnapshot(allSessions, statsCache,
+      config.selectedProjects.map(p => p.path)))
+    // Snapshot individual por projeto
+    for (const proj of config.selectedProjects) {
+      snapshots.set(proj.path, computeSnapshot(allSessions, statsCache, [proj.path]))
     }
   }
 
-  return {
-    messages,
-    sessions: sessionIds.size,
-    inputTokens,
-    outputTokens,
-    costUsd,
-    streak,
-    gitCommits,
-    gitPushes,
-    linesAdded,
-    linesRemoved,
-  }
+  return { snapshots, lastUpdated: new Date() }
 }
 
-// ── Formatação ─────────────────────────────────────────────────────────────
+// ── Animação de batalha: Claude vs Cursor ──────────────────────────────────
+
+const BATTLE_FRAMES: string[][] = [
+  // 0 — idle (ambos de pé)
+  [
+    `   ${YELLOW}o${RESET}                     ${RED}o${RESET}   `,
+    `  ${YELLOW}/|\\${RESET}   ${DIM}~ vs ~${RESET}     ${RED}/|\\${RESET}  `,
+    `  ${YELLOW}/ \\${RESET}                   ${RED}/ \\${RESET}  `,
+  ],
+  // 1 — Claude carrega golpe
+  [
+    `  ${YELLOW}\\o/${RESET}                    ${RED}o${RESET}   `,
+    `   ${YELLOW}|${RESET}    ${DIM}~ vs ~${RESET}      ${RED}/|\\${RESET}  `,
+    `  ${YELLOW}/ \\${RESET}                   ${RED}/ \\${RESET}  `,
+  ],
+  // 2 — Claude lança golpe →
+  [
+    `   ${YELLOW}o${RESET}${BOLD}─────────────→${RESET}  ${RED}o${RESET}   `,
+    `  ${YELLOW}─|─${RESET}                   ${RED}|${RESET}   `,
+    `  ${YELLOW}/ \\${RESET}                  ${RED}/\\${RESET}   `,
+  ],
+  // 3 — Impacto! Cursor apanha
+  [
+    `   ${YELLOW}o${RESET}            ${GREEN}✦${RESET}  ${RED}*${RESET}    `,
+    `  ${YELLOW}/|\\${RESET}               ${RED}\\${RESET}    `,
+    `  ${YELLOW}/ \\${RESET}               ${RED}/${RESET}    `,
+  ],
+  // 4 — Cursor se recupera
+  [
+    `   ${YELLOW}o${RESET}                    ${RED}o${RESET}   `,
+    `  ${YELLOW}/|\\${RESET}   ${DIM}~ vs ~${RESET}    ${RED}\\|/${RESET}   `,
+    `  ${YELLOW}/ \\${RESET}                  ${RED}/\\${RESET}   `,
+  ],
+  // 5 — Cursor carrega contra-ataque
+  [
+    `   ${YELLOW}o${RESET}                   ${RED}\\o/${RESET}  `,
+    `  ${YELLOW}/|\\${RESET}   ${DIM}~ vs ~${RESET}    ${RED}|${RESET}    `,
+    `  ${YELLOW}/ \\${RESET}                  ${RED}/ \\${RESET}  `,
+  ],
+  // 6 — Cursor lança golpe ←
+  [
+    `   ${YELLOW}o${RESET}  ${RED}←─────────────${RESET}${RED}─|─${RESET}  `,
+    `   ${YELLOW}|${RESET}                    ${RED}|${RESET}    `,
+    `  ${YELLOW}/\\${RESET}                   ${RED}/ \\${RESET}  `,
+  ],
+  // 7 — Claude apanha
+  [
+    `  ${GREEN}✦${RESET} ${YELLOW}*${RESET}                   ${RED}o${RESET}    `,
+    `    ${YELLOW}\\${RESET}                   ${RED}/|\\${RESET}  `,
+    `    ${YELLOW}/                   ${RED}/ \\${RESET}  `,
+  ],
+]
+
+const BATTLE_LABELS = [
+  `${YELLOW}CLAUDE${RESET}              ${RED}CURSOR${RESET}`,
+  `${YELLOW}CLAUDE${RESET}  ${DIM}se prepara...${RESET}  ${RED}CURSOR${RESET}`,
+  `${YELLOW}CLAUDE${RESET}  ${GREEN}ATAQUE!${RESET}        ${RED}CURSOR${RESET}`,
+  `${YELLOW}CLAUDE${RESET}  ${GREEN}CRÍTICO!${RESET}       ${RED}CURSOR${RESET}`,
+  `${YELLOW}CLAUDE${RESET}              ${RED}CURSOR${RESET}`,
+  `${YELLOW}CLAUDE${RESET}          ${DIM}se prepara...${RESET} ${RED}CURSOR${RESET}`,
+  `${YELLOW}CLAUDE${RESET}       ${RED}CONTRA-ATAQUE!${RESET} ${RED}CURSOR${RESET}`,
+  `${YELLOW}CLAUDE${RESET}  ${RED}LEVOU!${RESET}           ${RED}CURSOR${RESET}`,
+]
+
+function renderBattle(frame: number): string[] {
+  const f = frame % BATTLE_FRAMES.length
+  const lines = [
+    `  ${DIM}┌───────────────────────────────────────────┐${RESET}`,
+    `  ${DIM}│${RESET}${BATTLE_LABELS[f].padEnd(43)}${DIM}│${RESET}`,
+    ...BATTLE_FRAMES[f].map(l => `  ${DIM}│${RESET}  ${l}${DIM}│${RESET}`),
+    `  ${DIM}│${RESET}  ${DIM}[Ctrl+O para ocultar]${RESET}               ${DIM}│${RESET}`,
+    `  ${DIM}└───────────────────────────────────────────┘${RESET}`,
+  ]
+  return lines
+}
+
+// ── Formatação de métricas ─────────────────────────────────────────────────
 
 function fmtNum(n: number): string {
   if (n >= 1_000_000) return (n / 1_000_000).toFixed(1) + 'M'
-  if (n >= 1_000) return (n / 1_000).toFixed(1) + 'k'
+  if (n >= 1_000)     return (n / 1_000).toFixed(1) + 'k'
   return n.toString()
 }
-
 function fmtCost(usd: number): string {
   if (usd >= 1000) return `$${(usd / 1000).toFixed(1)}k`
-  if (usd >= 1) return `$${usd.toFixed(2)}`
+  if (usd >= 1)    return `$${usd.toFixed(2)}`
   return `$${usd.toFixed(3)}`
 }
 
-/** Alinha string considerando que ela pode ter escape codes ANSI. */
-function col(s: string, width: number, align: 'l' | 'r' = 'r'): string {
-  const visLen = s.replace(/\x1b\[[0-9;]*m/g, '').length
-  const pad = ' '.repeat(Math.max(0, width - visLen))
-  return align === 'l' ? s + pad : pad + s
-}
-
-function hr(width: number, char = '─'): string {
-  return `${DIM}${char.repeat(width)}${RESET}`
-}
-
-// Colunas da tabela de métricas (label, largura, alinhamento)
-const METRIC_COLS: Array<{ label: string; width: number }> = [
-  { label: 'Msgs',    width: 8  },
-  { label: 'Sessões', width: 8  },
-  { label: 'Tok↑',   width: 9  },
-  { label: 'Tok↓',   width: 9  },
-  { label: 'Custo',  width: 10 },
-  { label: 'Streak', width: 7  },
-  { label: 'Commits',width: 8  },
-  { label: '+Linhas',width: 9  },
-  { label: '-Linhas',width: 9  },
+const METRIC_COLS = [
+  { label: 'Msgs',     w: 8  },
+  { label: 'Sessões',  w: 8  },
+  { label: 'Tok↑',    w: 9  },
+  { label: 'Tok↓',    w: 9  },
+  { label: 'Custo',   w: 10 },
+  { label: 'Streak',  w: 7  },
+  { label: 'Commits', w: 8  },
+  { label: '+Linhas', w: 9  },
+  { label: '-Linhas', w: 9  },
 ]
+const PROJECT_COL_W = 24
 
-const PROJECT_COL_WIDTH = 24
-
-function renderTableHeader(includeProjectCol: boolean): string {
-  const cells = METRIC_COLS.map(c => col(`${DIM}${c.label}${RESET}`, c.width))
-  if (includeProjectCol) {
-    return col(`${DIM}Projeto${RESET}`, PROJECT_COL_WIDTH, 'l') + '  ' + cells.join('  ')
-  }
+function tableHeader(withProject: boolean): string {
+  const cells = METRIC_COLS.map(c => col(`${DIM}${c.label}${RESET}`, c.w))
+  if (withProject) return col(`${DIM}Projeto${RESET}`, PROJECT_COL_W, 'l') + '  ' + cells.join('  ')
   return cells.join('  ')
 }
-
-function renderSnapshotRow(snap: CliSnapshot, projectName?: string): string {
-  const values = [
-    fmtNum(snap.messages),
-    fmtNum(snap.sessions),
-    fmtNum(snap.inputTokens),
-    fmtNum(snap.outputTokens),
-    fmtCost(snap.costUsd),
-    `${snap.streak}d`,
+function tableRow(snap: CliSnapshot, projectName?: string): string {
+  const vals = [
+    fmtNum(snap.messages), fmtNum(snap.sessions),
+    fmtNum(snap.inputTokens), fmtNum(snap.outputTokens),
+    fmtCost(snap.costUsd), `${snap.streak}d`,
     fmtNum(snap.gitCommits),
-    `+${fmtNum(snap.linesAdded)}`,
-    `-${fmtNum(snap.linesRemoved)}`,
+    `+${fmtNum(snap.linesAdded)}`, `-${fmtNum(snap.linesRemoved)}`,
   ]
-  const cells = values.map((v, i) => col(v, METRIC_COLS[i].width))
-
+  const cells = vals.map((v, i) => col(v, METRIC_COLS[i].w))
   if (projectName !== undefined) {
-    const name = projectName.length > PROJECT_COL_WIDTH - 1
-      ? projectName.slice(0, PROJECT_COL_WIDTH - 2) + '…'
+    const name = projectName.length > PROJECT_COL_W - 1
+      ? projectName.slice(0, PROJECT_COL_W - 2) + '…'
       : projectName
-    return col(`${CYAN}${name}${RESET}`, PROJECT_COL_WIDTH, 'l') + '  ' + cells.join('  ')
+    return col(`${CYAN}${name}${RESET}`, PROJECT_COL_W, 'l') + '  ' + cells.join('  ')
   }
   return cells.join('  ')
 }
 
 // ── Renderização do painel ─────────────────────────────────────────────────
 
-function buildHeaderLines(config: WatchConfig, updatedAt: Date): string[] {
-  const width = process.stdout.columns || 100
-  const now = updatedAt.toLocaleTimeString('pt-BR')
-  const refresh = `⟳ ${config.intervalSec}s`
-  const rightSide = `${DIM}${now}  ${refresh}${RESET}`
-  const leftSide = `${BOLD}${BRIGHT_CYAN}Claude Stats — Watch Mode${RESET}`
-
-  const visLeft = 'Claude Stats — Watch Mode'
-  const visRight = `${now}  ${refresh}`
-  const gap = Math.max(1, width - visLeft.length - visRight.length)
-
+function buildPanel(config: WatchConfig, state: AppState): string {
+  const w = process.stdout.columns || 100
   const lines: string[] = []
-  lines.push(leftSide + ' '.repeat(gap) + rightSide)
-  lines.push(hr(width))
+
+  // Título
+  const now    = state.lastUpdated.toLocaleTimeString('pt-BR')
+  const loader = state.isLoadingData ? `${DIM} ⟳${RESET}` : ''
+  const left   = `${BOLD}${BRIGHT_CYAN}Claude Stats — Watch Mode${RESET}`
+  const right  = `${DIM}${now}  ⟳ ${config.intervalSec}s${loader}${RESET}`
+  const gap    = Math.max(1, w - visLen(left.replace(/\x1b\[[0-9;]*m/g, '')) - visLen(right.replace(/\x1b\[[0-9;]*m/g, '')))
+  lines.push(left + ' '.repeat(gap) + right)
+  lines.push(hr(w))
   lines.push('')
 
-  // Info block
-  const modeDesc =
-    config.viewMode === 'junto'    ? 'unificado'
-    : config.viewMode === 'separado' ? 'separado'
-    : 'ambos'
+  // Animação (se visível)
+  if (state.showAnimation) {
+    lines.push(...renderBattle(state.animFrame))
+    lines.push('')
+  }
+
+  // Bloco de info
+  const modeDesc = config.viewMode === 'junto' ? 'unificado'
+    : config.viewMode === 'separado' ? 'separado' : 'ambos'
 
   lines.push(`  ${DIM}Home:${RESET}       ${WHITE}${HOME_DIR}${RESET}`)
   lines.push(`  ${DIM}Claude dir:${RESET} ${WHITE}${CLAUDE_DIR}${RESET}`)
@@ -355,221 +423,282 @@ function buildHeaderLines(config: WatchConfig, updatedAt: Date): string[] {
   }
 
   lines.push(`  ${DIM}Interval:${RESET}   ${WHITE}${config.intervalSec}s${RESET}`)
-  lines.push(`  ${DIM}OTLP:${RESET}       ${DIM}(disabled)${RESET}`)
+  lines.push(`  ${DIM}OTLP:${RESET}       ${config.otlpEndpoint ? `${GREEN}${config.otlpEndpoint}${RESET}` : `${DIM}(disabled)${RESET}`}`)
   lines.push('')
 
-  return lines
-}
-
-async function renderPanel(config: WatchConfig): Promise<void> {
-  const updatedAt = new Date()
-  const width = process.stdout.columns || 100
-  const lines: string[] = []
-
-  lines.push(...buildHeaderLines(config, updatedAt))
-
-  const selectedPaths =
-    config.selectedProjects.length > 0
-      ? config.selectedProjects.map(p => p.path)
-      : undefined
-
-  // Modo 'todos' ou único projeto selecionado → sem perguntar view mode
+  // Tabela de métricas
   const singleView = config.selectedProjects.length <= 1
+  const allSnap    = state.snapshots.get('')
 
   if (singleView || config.viewMode === 'junto') {
-    // ── Linha unificada ───────────────────────────────────────────────────
-    const snap = await buildCliSnapshot(selectedPaths)
-    lines.push(hr(width))
-    lines.push(`  ${BOLD}${CYAN}UNIFICADO${RESET}`)
+    lines.push(hr(w))
+    if (!singleView) lines.push(`  ${BOLD}${CYAN}UNIFICADO${RESET}`)
     lines.push('')
-    lines.push('  ' + renderTableHeader(false))
-    lines.push(`  ${GREEN}${BOLD}${renderSnapshotRow(snap)}${RESET}`)
-    lines.push(hr(width))
+    lines.push('  ' + tableHeader(false))
+    lines.push(`  ${GREEN}${BOLD}${allSnap ? tableRow(allSnap) : '  (carregando...)'}${RESET}`)
+    lines.push(hr(w))
   } else if (config.viewMode === 'separado') {
-    // ── Uma linha por projeto ─────────────────────────────────────────────
-    lines.push(hr(width))
+    lines.push(hr(w))
     lines.push(`  ${BOLD}${CYAN}POR PROJETO${RESET}`)
     lines.push('')
-    lines.push('  ' + renderTableHeader(true))
-
+    lines.push('  ' + tableHeader(true))
     for (const proj of config.selectedProjects) {
-      const snap = await buildCliSnapshot([proj.path])
-      lines.push('  ' + renderSnapshotRow(snap, proj.name))
+      const snap = state.snapshots.get(proj.path)
+      lines.push('  ' + (snap ? tableRow(snap, proj.name) : `  ${DIM}${proj.name}  (carregando...)${RESET}`))
     }
-    lines.push(hr(width))
+    lines.push(hr(w))
   } else {
-    // ── Ambos: total no topo + um por projeto ──────────────────────────────
-    const allSnap = await buildCliSnapshot(selectedPaths)
-    lines.push(hr(width))
+    // ambos
+    lines.push(hr(w))
     lines.push(`  ${BOLD}${CYAN}UNIFICADO${RESET}`)
     lines.push('')
-    lines.push('  ' + renderTableHeader(false))
-    lines.push(`  ${GREEN}${BOLD}${renderSnapshotRow(allSnap)}${RESET}`)
+    lines.push('  ' + tableHeader(false))
+    lines.push(`  ${GREEN}${BOLD}${allSnap ? tableRow(allSnap) : '  (carregando...)'}${RESET}`)
     lines.push('')
     lines.push(`  ${BOLD}${CYAN}POR PROJETO${RESET}`)
     lines.push('')
-    lines.push('  ' + renderTableHeader(true))
-
+    lines.push('  ' + tableHeader(true))
     for (const proj of config.selectedProjects) {
-      const snap = await buildCliSnapshot([proj.path])
-      lines.push('  ' + renderSnapshotRow(snap, proj.name))
+      const snap = state.snapshots.get(proj.path)
+      lines.push('  ' + (snap ? tableRow(snap, proj.name) : `  ${DIM}${proj.name}  (carregando...)${RESET}`))
     }
-    lines.push(hr(width))
+    lines.push(hr(w))
   }
 
   lines.push('')
-  lines.push(`  ${DIM}Pressione Ctrl+C para sair${RESET}`)
+  lines.push(`  ${DIM}Ctrl+C sair  |  Ctrl+O ${state.showAnimation ? 'ocultar' : 'mostrar'} batalha${RESET}`)
 
-  clearScreen()
-  process.stdout.write(lines.join('\n') + '\n')
+  return lines.join('\n') + '\n'
 }
 
-// ── Seleção interativa ─────────────────────────────────────────────────────
-
-async function promptProjects(projects: ProjectInfo[]): Promise<ProjectInfo[]> {
-  const ALL_VALUE = '__all__'
-
-  const choices = [
-    {
-      name: `${BOLD}(todos os projetos)${RESET}`,
-      value: ALL_VALUE,
-      short: 'todos',
-    },
-    ...projects.map(p => ({
-      name: `${p.name}  ${DIM}${p.path}${RESET}`,
-      value: p.path,
-      short: p.name,
-    })),
-  ]
-
-  const selected = await checkbox({
-    message: 'Selecione os projetos para monitorar (⎵ seleciona, ↑↓ navega, Enter confirma):',
-    choices,
-    pageSize: Math.min(20, projects.length + 3),
-    loop: false,
-  })
-
-  if (selected.length === 0 || selected.includes(ALL_VALUE)) {
-    return []
-  }
-
-  return projects.filter(p => selected.includes(p.path))
-}
-
-async function promptViewMode(): Promise<ViewMode> {
-  return select<ViewMode>({
-    message: 'Como deseja visualizar os dados?',
-    choices: [
-      {
-        name: `${BOLD}Separado${RESET}  — uma linha por projeto`,
-        value: 'separado',
-        short: 'separado',
-      },
-      {
-        name: `${BOLD}Unificado${RESET} — total dos projetos selecionados`,
-        value: 'junto',
-        short: 'unificado',
-      },
-      {
-        name: `${BOLD}Ambos${RESET}     — total no topo + uma linha por projeto`,
-        value: 'ambos',
-        short: 'ambos',
-      },
-    ],
-  })
-}
-
-// ── Loop principal ─────────────────────────────────────────────────────────
+// ── Watch loop ─────────────────────────────────────────────────────────────
 
 async function watchLoop(config: WatchConfig): Promise<void> {
   hideCursor()
 
-  process.on('SIGINT', () => {
-    showCursor()
-    clearScreen()
-    process.exit(0)
-  })
-  process.on('SIGTERM', () => {
-    showCursor()
-    clearScreen()
-    process.exit(0)
-  })
+  const state: AppState = {
+    snapshots: new Map(),
+    lastUpdated: new Date(),
+    animFrame: 0,
+    showAnimation: true,
+    isLoadingData: true,
+  }
 
-  let isRendering = false
-  let pendingRender = false
+  // Limpa + redesenha no lugar (sem append)
+  const render = () => {
+    clearScreen()
+    process.stdout.write(buildPanel(config, state))
+  }
 
-  const render = async () => {
-    if (isRendering) {
-      pendingRender = true
-      return
-    }
-    isRendering = true
+  // Reload pesado de dados do disco
+  let reloading = false
+  const reloadData = async () => {
+    if (reloading) return
+    reloading = true
+    state.isLoadingData = true
     try {
-      await renderPanel(config)
-    } catch (err) {
-      // Não falha silenciosamente em erros de renderização
-      clearScreen()
-      console.error(`${RESET}Erro ao renderizar painel:`, err)
-    } finally {
-      isRendering = false
-      if (pendingRender) {
-        pendingRender = false
+      const { snapshots, lastUpdated } = await reloadAllSnapshots(config)
+      state.snapshots   = snapshots
+      state.lastUpdated = lastUpdated
+    } catch { /* mantém snapshot anterior */ }
+    finally {
+      state.isLoadingData = false
+      reloading = false
+    }
+    render()
+  }
+
+  // Carregamento inicial
+  await reloadData()
+
+  // Teclado: Ctrl+O toggle animação, Ctrl+C sair
+  if (process.stdin.isTTY) {
+    process.stdin.setRawMode(true)
+    process.stdin.resume()
+    process.stdin.on('data', (buf: Buffer) => {
+      const ch = buf[0]
+      if (ch === 3) {                      // Ctrl+C
+        showCursor()
+        clearScreen()
+        process.exit(0)
+      } else if (ch === 15) {              // Ctrl+O
+        state.showAnimation = !state.showAnimation
         render()
       }
-    }
-  }
-
-  // Renderização inicial
-  await render()
-
-  // Debounce para eventos de filesystem
-  let debounceTimer: ReturnType<typeof setTimeout> | null = null
-  const debouncedRender = () => {
-    if (debounceTimer) clearTimeout(debounceTimer)
-    debounceTimer = setTimeout(render, 1500)
-  }
-
-  chokidar
-    .watch([SESSION_META_DIR, STATS_CACHE_FILE], {
-      persistent: true,
-      ignoreInitial: true,
     })
-    .on('all', debouncedRender)
+  } else {
+    process.on('SIGINT',  () => { showCursor(); clearScreen(); process.exit(0) })
+    process.on('SIGTERM', () => { showCursor(); clearScreen(); process.exit(0) })
+  }
 
-  // Poll periódico como fallback
-  setInterval(render, WATCH_INTERVAL_SEC * 1000)
+  // Timer de animação (200ms) — só redesenha, não relê disco
+  const ANIM_INTERVAL = 200
+  setInterval(() => {
+    state.animFrame++
+    render()
+  }, ANIM_INTERVAL)
+
+  // Timer de dados (configurable)
+  setInterval(reloadData, config.intervalSec * 1000)
+
+  // Chokidar: reload imediato em mudanças de arquivo (debounce 1.5s)
+  let debounceTimer: ReturnType<typeof setTimeout> | null = null
+  chokidar
+    .watch([SESSION_META_DIR, STATS_CACHE_FILE], { persistent: true, ignoreInitial: true })
+    .on('all', () => {
+      if (debounceTimer) clearTimeout(debounceTimer)
+      debounceTimer = setTimeout(reloadData, 1500)
+    })
+}
+
+// ── Custom prompt: checkbox com busca reativa ──────────────────────────────
+
+interface CheckboxChoice { name: string; value: string; path: string }
+
+/** KeypressEvent estendido com os campos extras do readline de Node.js */
+type RlKeypress = KeypressEvent & { meta?: boolean; sequence?: string }
+
+const checkboxWithSearch = createPrompt<string[], {
+  message: string
+  choices: ReadonlyArray<CheckboxChoice>
+  pageSize?: number
+}>((config, done) => {
+  const [searchTerm, setSearchTerm] = useState('')
+  const [active, setActive]         = useState(0)
+  const [checked, setChecked]       = useState<ReadonlyArray<string>>([])
+
+  const filtered = useMemo(
+    () => {
+      const t = searchTerm.toLowerCase()
+      if (!t) return config.choices
+      return config.choices.filter(c =>
+        c.name.toLowerCase().includes(t) || c.path.toLowerCase().includes(t)
+      )
+    },
+    [searchTerm]
+  )
+
+  useKeypress((key) => {
+    const k = key as RlKeypress
+    if (isEnterKey(k)) { done([...checked]); return }
+
+    const len = filtered.length
+    if (isUpKey(k)) {
+      setActive(active === 0 ? Math.max(0, len - 1) : active - 1)
+    } else if (isDownKey(k)) {
+      setActive(active >= len - 1 ? 0 : active + 1)
+    } else if (isSpaceKey(k)) {
+      const item = filtered[active]
+      if (!item) return
+      const s = new Set(checked)
+      if (s.has(item.value)) s.delete(item.value)
+      else s.add(item.value)
+      setChecked(Array.from(s))
+    } else if (isBackspaceKey(k)) {
+      setSearchTerm(searchTerm.slice(0, -1))
+      setActive(0)
+    } else if (!k.ctrl && !k.meta && k.sequence?.length === 1 && k.sequence.charCodeAt(0) >= 32) {
+      setSearchTerm(searchTerm + k.sequence)
+      setActive(0)
+    }
+  })
+
+  const checkedSet = new Set(checked)
+
+  const pageView = usePagination({
+    items:    filtered as CheckboxChoice[],
+    active,
+    pageSize: config.pageSize ?? 16,
+    loop:     false,
+    renderItem: ({ item, isActive }) => {
+      const cursor  = isActive ? `${CYAN}❯${RESET}` : ' '
+      const box     = checkedSet.has(item.value) ? `${GREEN}◉${RESET}` : `${DIM}◯${RESET}`
+      const nameStr = checkedSet.has(item.value) ? `${GREEN}${item.name}${RESET}` : item.name
+      return ` ${cursor} ${box}  ${nameStr}  ${DIM}${item.path}${RESET}`
+    },
+  })
+
+  const cursorBlock   = `${ESC}[7m ${RESET}`
+  const searchDisplay = `${DIM}[Buscar]${RESET} ${BOLD}${searchTerm}${RESET}${cursorBlock}`
+
+  const checkedNames = checked
+    .map(v => config.choices.find(c => c.value === v)?.name ?? v)
+    .join(', ')
+
+  const selectedLine = checked.length > 0
+    ? `\n  ${DIM}Selecionados: ${RESET}${GREEN}${checkedNames}${RESET}`
+    : `\n  ${DIM}(nenhum = todos os projetos)${RESET}`
+
+  return (
+    `${BOLD}${config.message}${RESET}\n  ${searchDisplay}\n\n` +
+    pageView +
+    selectedLine +
+    `\n  ${DIM}↑↓ navegar  ⎵ selecionar  ⏎ confirmar  Backspace apaga busca${RESET}`
+  )
+})
+
+// ── Configuração inicial via prompts ───────────────────────────────────────
+
+async function askConfig(allProjects: ProjectInfo[]): Promise<WatchConfig> {
+  // 1. Intervalo
+  const intervalStr = await input({
+    message: `Intervalo de atualização (segundos):`,
+    default: '30',
+    validate: (v) => {
+      const n = parseInt(v, 10)
+      if (!Number.isFinite(n) || n < 5) return 'Mínimo 5 segundos'
+      return true
+    },
+  })
+  const intervalSec = parseInt(intervalStr, 10)
+
+  // 2. OTLP endpoint
+  const otlpEndpoint = await input({
+    message: 'OTLP endpoint (vazio para desativar):',
+    default: process.env.OTEL_EXPORTER_OTLP_ENDPOINT ?? '',
+  })
+
+  // 3. Seleção de projetos com busca
+  const selectedPaths = await checkboxWithSearch({
+    message: 'Selecione os projetos para monitorar:',
+    choices: allProjects.map(p => ({ name: p.name, value: p.path, path: p.path })),
+    pageSize: Math.min(20, allProjects.length),
+  })
+
+  const selectedProjects = selectedPaths.length === 0
+    ? []
+    : allProjects.filter(p => selectedPaths.includes(p.path))
+
+  // 4. Modo de visualização (só se múltiplos selecionados)
+  let viewMode: ViewMode = 'junto'
+  if (selectedProjects.length > 1) {
+    viewMode = await select<ViewMode>({
+      message: 'Como deseja visualizar os dados?',
+      choices: [
+        { name: `${BOLD}Separado${RESET}  — uma linha por projeto`,             value: 'separado', short: 'separado'  },
+        { name: `${BOLD}Unificado${RESET} — total dos projetos selecionados`,   value: 'junto',    short: 'unificado' },
+        { name: `${BOLD}Ambos${RESET}     — total no topo + uma linha/projeto`, value: 'ambos',    short: 'ambos'     },
+      ],
+    })
+  }
+
+  return { selectedProjects, allProjects, viewMode, intervalSec, otlpEndpoint }
 }
 
 // ── Entry point ────────────────────────────────────────────────────────────
 
 async function main() {
-  console.log(`${CYAN}${BOLD}Claude Stats — Watch CLI${RESET}\n`)
-  console.log(`${DIM}Descobrindo projetos em ${SESSION_META_DIR}...${RESET}`)
+  console.log(`\n${BOLD}${BRIGHT_CYAN}Claude Stats — Watch CLI${RESET}\n`)
+  console.log(`${DIM}Descobrindo projetos...${RESET}`)
 
-  const projects = await discoverProjects()
-
-  if (projects.length === 0) {
-    console.error(`\nNenhum projeto encontrado. Verifique se o diretório existe:\n  ${SESSION_META_DIR}`)
+  const allProjects = await discoverProjects()
+  if (allProjects.length === 0) {
+    console.error(`\nNenhum projeto encontrado em:\n  ${SESSION_META_DIR}\n  ${PROJECTS_DIR}`)
     process.exit(1)
   }
+  console.log(`${GREEN}${allProjects.length} projetos encontrados.${RESET}\n`)
 
-  console.log(`${GREEN}${projects.length} projetos encontrados.${RESET}\n`)
-
-  // Seleção interativa
-  const selectedProjects = await promptProjects(projects)
-
-  let viewMode: ViewMode = 'junto'
-  if (selectedProjects.length > 1) {
-    viewMode = await promptViewMode()
-  }
-
-  const config: WatchConfig = {
-    selectedProjects,
-    allProjects: projects,
-    viewMode,
-    intervalSec: WATCH_INTERVAL_SEC,
-  }
-
+  const config = await askConfig(allProjects)
   await watchLoop(config)
 }
 

--- a/watch-cli.ts
+++ b/watch-cli.ts
@@ -127,6 +127,19 @@ async function fetchApi(timeout = 3000): Promise<ApiResponse | null> {
   }
 }
 
+/** Probe leve — apenas verifica se o servidor está aceitando conexões. */
+async function probeApi(timeout = 1000): Promise<boolean> {
+  try {
+    const ac  = new AbortController()
+    const tid = setTimeout(() => ac.abort(), timeout)
+    const res = await fetch(`${API_BASE}/api/health`, { signal: ac.signal })
+    clearTimeout(tid)
+    return res.ok
+  } catch {
+    return false
+  }
+}
+
 // ── Fonte 2: Leitura direta de arquivos (fallback) ─────────────────────────
 
 /** Lê primeiras linhas de um JSONL até encontrar campo `cwd`. */
@@ -670,8 +683,7 @@ let spawnedServer: ReturnType<typeof Bun.spawn> | null = null
 
 async function ensureApiRunning(): Promise<boolean> {
   // Já está rodando?
-  const probe = await fetchApi(2000)
-  if (probe) return false // já estava rodando, não precisamos subir
+  if (await probeApi(2000)) return false // já estava rodando, não precisamos subir
 
   // Sobe server.ts em background
   const serverPath = join(import.meta.dir, 'server.ts')
@@ -683,10 +695,10 @@ async function ensureApiRunning(): Promise<boolean> {
     env: { ...process.env },
   })
 
-  // Aguarda até 10s (polling a cada 300ms)
+  // Aguarda até 10s (polling a cada 300ms) usando probe leve
   for (let i = 0; i < 33; i++) {
     await new Promise(r => setTimeout(r, 300))
-    const ok = await fetchApi(1000)
+    const ok = await probeApi(1000)
     if (ok) {
       console.log(`${GR}Servidor iniciado (pid ${spawnedServer.pid}).${R}`)
       return true

--- a/watch-cli.ts
+++ b/watch-cli.ts
@@ -210,45 +210,55 @@ async function reloadData(config: WatchConfig): Promise<{
   return { snapshots, dataSource: 'api' }
 }
 
-// ── Loader: Claude caçando tokens ─────────────────────────────────────────
+// ── Loader ─────────────────────────────────────────────────────────────────
+// Braille spinner + gradient wave bar scrolling.
+// 7 linhas fixas, reescritas via cursor-up a cada 80ms.
 
 async function withLoader<T>(msg: string, fn: () => Promise<T>): Promise<T> {
-  const H   = 5
-  const W   = Math.min(process.stdout.columns || 80, 100)
-  const fld = W - 4
-  // Tokens fogem para a esquerda (offset cresce = conteudo desliza para esquerda)
-  const PAT = '  $   $$  $    $$$   $  $$    $   $  $$$  '
-  // Frames de corrida: [cabeca, torso, pernas]
-  const RF: [string, string, string][] = [
-    ['\\o/', ' |  ', '/ \\ '],
-    [' o/', '/|\\ ', '/ \\ '],
-    [' o ', ' |/ ', '\\ / '],
-    ['\\o ', ' |  ', '\\ / '],
-  ]
-  const cp = Math.floor(fld * 0.35)
+  if (!process.stdout.isTTY) return fn()
+
+  const H     = 7
+  const W     = Math.min((process.stdout.columns || 80) - 2, 94)
+  const BAR_W = W - 2
+
+  // Braille dots — cycling at ~12fps produces a perfectly smooth spin
+  const SPIN = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏']
+
+  // Gradient wave: trough → peak → trough, repeated twice for seamless wrap
+  const WAVE = '░░░▒▒▓▓███▓▓▒▒░░░░░▒▒▓▓███▓▓▒▒░░░'
 
   let frame = 0
 
   const draw = () => {
-    const off   = (frame * 2) % PAT.length
-    const river = (PAT + PAT + PAT).slice(off, off + fld)
-    // apaga zona do Claude para nao sobrepor tokens
-    const rArr = river.split('')
-    for (let i = Math.max(0, cp - 1); i < Math.min(rArr.length, cp + 5); i++) rArr[i] = ' '
-    const rLine = rArr.join('')
-    const rf = RF[frame % RF.length]!
+    const spin = SPIN[frame % SPIN.length]!
+
+    // Scroll wave left — offset grows each frame
+    const off  = (frame * 1) % WAVE.length
+    const raw  = (WAVE + WAVE + WAVE).slice(off, off + BAR_W)
+
+    // Apply color gradient: bright at peaks, dim at troughs
+    const bar = raw.split('').map(c =>
+      c === '█' ? `${B}${BC}█${R}`
+      : c === '▓' ? `${CY}▓${R}`
+      : c === '▒' ? `${D}${CY}▒${R}`
+      : `${D}░${R}`
+    ).join('')
+
+    const sep = `${D}${'─'.repeat(BAR_W)}${R}`
 
     out(`\x1b[${H}A`)
-    out(`  ${YL}${rLine}${R}\n`)
-    out(`  ${' '.repeat(cp)}${YL}${rf[0]}${R}${GR}~~>${R}\n`)
-    out(`  ${' '.repeat(cp)}${D}${rf[1]}${R}\n`)
-    out(`  ${' '.repeat(cp)}${YL}${rf[2]}${R}\n`)
-    out(`  ${D}${msg}${R}\n`)
+    out(`\n`)
+    out(`  ${sep}\n`)
+    out(`  ${BC}${B}${spin}${R}  ${B}claude-stats${R}  ${D}·  session pipeline${R}\n`)
+    out(`  ${bar}\n`)
+    out(`  ${D}▸${R}  ${D}${msg}${R}\n`)
+    out(`  ${sep}\n`)
+    out(`\n`)
   }
 
   out('\n'.repeat(H))
   draw()
-  const timer = setInterval(() => { frame++; draw() }, 120)
+  const timer = setInterval(() => { frame++; draw() }, 80)
 
   try {
     return await fn()

--- a/watch-cli.ts
+++ b/watch-cli.ts
@@ -2,14 +2,11 @@
 /**
  * Claude Stats — Watch CLI
  *
- * TUI interativa que monitora métricas Claude em tempo real, atualizando o painel
- * no lugar (como `watch` do Linux) sem duplicar a saída.
- *
- * Usage:
- *   bun run watch:cli
+ * TUI interativa que monitora métricas Claude em tempo real.
+ * Usa alternate screen buffer (como vim/less) — sai limpo ao encerrar.
  *
  * Controles durante o watch:
- *   Ctrl+O  — ocultar/mostrar animação de batalha
+ *   Ctrl+O  — ocultar/mostrar batalha
  *   Ctrl+C  — sair
  */
 
@@ -29,47 +26,59 @@ import {
   isBackspaceKey,
   type KeypressEvent,
 } from '@inquirer/core'
-import { select, input } from '@inquirer/prompts'
+import { select, input, confirm } from '@inquirer/prompts'
 import { calcCost, getModelPrice } from './src/lib/types'
 import type { ModelUsage } from './src/lib/types'
 
-// ── Configuração ───────────────────────────────────────────────────────────
+// ── Constantes ─────────────────────────────────────────────────────────────
 
-const HOME_DIR   = process.env.HOME ?? process.env.USERPROFILE ?? ''
-const CLAUDE_DIR = join(HOME_DIR, '.claude')
-const PROJECTS_DIR       = join(CLAUDE_DIR, 'projects')
-const SESSION_META_DIR   = join(CLAUDE_DIR, 'usage-data', 'session-meta')
-const STATS_CACHE_FILE   = join(CLAUDE_DIR, 'stats-cache.json')
+const HOME_DIR         = process.env.HOME ?? process.env.USERPROFILE ?? ''
+const CLAUDE_DIR       = join(HOME_DIR, '.claude')
+const PROJECTS_DIR     = join(CLAUDE_DIR, 'projects')
+const SESSION_META_DIR = join(CLAUDE_DIR, 'usage-data', 'session-meta')
+const STATS_CACHE_FILE = join(CLAUDE_DIR, 'stats-cache.json')
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
 // ── ANSI ───────────────────────────────────────────────────────────────────
 
-const ESC   = '\x1b'
-const RESET = `${ESC}[0m`
-const BOLD  = `${ESC}[1m`
-const DIM   = `${ESC}[2m`
-const CYAN  = `${ESC}[36m`
-const GREEN = `${ESC}[32m`
-const YELLOW = `${ESC}[33m`
-const RED   = `${ESC}[31m`
-const WHITE = `${ESC}[37m`
-const BRIGHT_CYAN = `${ESC}[96m`
+const E     = '\x1b'
+const R     = `${E}[0m`      // reset
+const B     = `${E}[1m`      // bold
+const D     = `${E}[2m`      // dim
+const CY    = `${E}[36m`     // cyan
+const GR    = `${E}[32m`     // green
+const YL    = `${E}[33m`     // yellow
+const RD    = `${E}[31m`     // red
+const WH    = `${E}[37m`     // white
+const BCY   = `${E}[96m`     // bright cyan
 
-function clearScreen()  { process.stdout.write(`${ESC}[2J${ESC}[H`) }
-function hideCursor()   { process.stdout.write(`${ESC}[?25l`) }
-function showCursor()   { process.stdout.write(`${ESC}[?25h`) }
-function visLen(s: string) { return s.replace(/\x1b\[[0-9;]*m/g, '').length }
-function col(s: string, w: number, align: 'l' | 'r' = 'r') {
+// Terminal control
+const ALT_ON    = `${E}[?1049h`   // entra no alternate screen buffer
+const ALT_OFF   = `${E}[?1049l`   // sai do alternate screen buffer
+const CLEAR_SCR = `${E}[2J${E}[H` // limpa e vai pro topo
+const HIDE_CUR  = `${E}[?25l`
+const SHOW_CUR  = `${E}[?25h`
+
+const write = (s: string) => process.stdout.write(s)
+const visLen = (s: string) => s.replace(/\x1b\[[0-9;]*m/g, '').length
+const pad = (s: string, w: number, align: 'l' | 'r' = 'r') => {
   const p = ' '.repeat(Math.max(0, w - visLen(s)))
   return align === 'l' ? s + p : p + s
 }
-function hr(w: number, ch = '─') { return `${DIM}${ch.repeat(w)}${RESET}` }
+const hr = (w: number, ch = '─') => `${D}${ch.repeat(w)}${R}`
 
 // ── Tipos ──────────────────────────────────────────────────────────────────
 
 type ViewMode = 'separado' | 'junto' | 'ambos'
-
 interface ProjectInfo { name: string; path: string }
-
+interface WatchConfig {
+  selectedProjects: ProjectInfo[]
+  allProjects: ProjectInfo[]
+  viewMode: ViewMode
+  intervalSec: number
+  otlpEndpoint: string
+  showBattle: boolean
+}
 interface CliSnapshot {
   messages: number; sessions: number
   inputTokens: number; outputTokens: number
@@ -77,34 +86,23 @@ interface CliSnapshot {
   gitCommits: number; gitPushes: number
   linesAdded: number; linesRemoved: number
 }
-
 interface StatsCache {
   dailyActivity?: Array<{ date: string; messageCount: number; sessionCount: number }>
   modelUsage?: Record<string, ModelUsage>
 }
-
-interface SessionMeta {
+interface SessionMetaMin {
   session_id: string; project_path: string; start_time: string
   user_message_count: number; assistant_message_count: number
   git_commits: number; git_pushes: number
   input_tokens: number; output_tokens: number
   lines_added: number; lines_removed: number
 }
-
-interface WatchConfig {
-  selectedProjects: ProjectInfo[]
-  allProjects: ProjectInfo[]
-  viewMode: ViewMode
-  intervalSec: number
-  otlpEndpoint: string
-}
-
 interface AppState {
-  snapshots: Map<string, CliSnapshot>   // chave '' = all, ou project_path
+  snapshots: Map<string, CliSnapshot>
   lastUpdated: Date
   animFrame: number
-  showAnimation: boolean
-  isLoadingData: boolean
+  showBattle: boolean
+  isLoading: boolean
 }
 
 // ── I/O helpers ────────────────────────────────────────────────────────────
@@ -116,470 +114,457 @@ async function safeReadDir(d: string): Promise<string[]> {
   try { return await readdir(d) } catch { return [] }
 }
 
-// ── Descoberta de projetos (mesma lógica do server.ts) ─────────────────────
+// ── Descoberta de projetos — mesma lógica do server.ts ─────────────────────
+// 1. Carrega session-meta → Map<sessionId, project_path>
+// 2. Para cada dir em ~/.claude/projects/, lista entries e vota no project_path
+//    canônico via majority-vote (igual ao scanProjects/scanProjectDir do server.ts)
+// 3. Sem votos → usa fallback decodificado do nome do dir
 
-function decodeProjectDir(dirName: string): string {
-  if (dirName.startsWith('-')) return dirName.replace(/-/g, '/')
-  return '/' + dirName.replace(/-/g, '/')
+function decodeProjectDir(name: string): string {
+  // Claude codifica paths substituindo '/' por '-'; leading '-' = leading '/'
+  return name.startsWith('-') ? name.replace(/-/g, '/') : '/' + name.replace(/-/g, '/')
 }
 
 async function discoverProjects(): Promise<ProjectInfo[]> {
-  // 1. Caminhos canônicos dos session-meta
+  // Passo 1: mapa sessionId → project_path
   const metaFiles = (await safeReadDir(SESSION_META_DIR)).filter(f => f.endsWith('.json'))
-  const metaPaths = new Set<string>()
-  const BATCH = 30
+  const metaMap   = new Map<string, string>()
+
+  const BATCH = 40
   for (let i = 0; i < metaFiles.length; i += BATCH) {
     const res = await Promise.all(
       metaFiles.slice(i, i + BATCH).map(f =>
-        safeReadJson<{ project_path?: string }>(join(SESSION_META_DIR, f))
+        safeReadJson<{ session_id?: string; project_path?: string }>(join(SESSION_META_DIR, f))
       )
     )
-    for (const s of res) if (s?.project_path) metaPaths.add(s.project_path)
+    for (const s of res) if (s?.session_id && s.project_path) metaMap.set(s.session_id, s.project_path)
   }
 
-  // 2. Dirs em ~/.claude/projects/ como fallback (projetos sem session-meta)
-  for (const dir of await safeReadDir(PROJECTS_DIR)) {
-    if (!dir.startsWith('.')) {
-      const decoded = decodeProjectDir(dir)
-      if (!metaPaths.has(decoded)) metaPaths.add(decoded)
+  // Passo 2: varre dirs de projeto
+  const projectDirs = await safeReadDir(PROJECTS_DIR)
+  const seen        = new Map<string, ProjectInfo>()
+
+  await Promise.all(projectDirs.map(async dir => {
+    if (dir.startsWith('.')) return
+    const fallback = decodeProjectDir(dir)
+    const entries  = await safeReadDir(join(PROJECTS_DIR, dir))
+
+    const votes: Record<string, number> = {}
+
+    for (const entry of entries) {
+      // Formato A: <uuid>.jsonl
+      const sessionId = entry.endsWith('.jsonl') ? entry.slice(0, -6)
+        : UUID_RE.test(entry) ? entry       // Formato B: <uuid>/ subdir
+        : null
+      if (!sessionId) continue
+
+      const path = metaMap.get(sessionId)
+      if (path) votes[path] = (votes[path] ?? 0) + 1
     }
-  }
 
-  return Array.from(metaPaths).sort().map(path => ({
-    path,
-    name: path.split('/').filter(Boolean).pop() ?? path,
+    // Canonical path = mais votado; fallback se sem votos
+    const canonical = Object.keys(votes).length > 0
+      ? Object.entries(votes).sort((a, b) => b[1] - a[1])[0][0]
+      : fallback
+
+    if (!seen.has(canonical)) {
+      seen.set(canonical, {
+        path: canonical,
+        name: canonical.split('/').filter(Boolean).pop() ?? dir,
+      })
+    }
   }))
+
+  return Array.from(seen.values()).sort((a, b) => a.path.localeCompare(b.path))
 }
 
-// ── Cálculo de snapshot (espelha useDerivedStats) ──────────────────────────
+// ── Cálculo de snapshot — espelha useDerivedStats ─────────────────────────
 
-function blendedCostPerToken(modelUsage: Record<string, ModelUsage>) {
+function blendedCostPerToken(mu: Record<string, ModelUsage>) {
   let tIn = 0, tOut = 0, tCR = 0, tCW = 0
   let wIn = 0, wOut = 0, wCR = 0, wCW = 0
-  for (const [id, u] of Object.entries(modelUsage)) {
+  for (const [id, u] of Object.entries(mu)) {
     const p = getModelPrice(id)
-    tIn += u.inputTokens; tOut += u.outputTokens
+    tIn += u.inputTokens;  tOut += u.outputTokens
     tCR += u.cacheReadInputTokens; tCW += u.cacheCreationInputTokens
-    wIn += u.inputTokens * p.input; wOut += u.outputTokens * p.output
+    wIn += u.inputTokens * p.input;         wOut += u.outputTokens * p.output
     wCR += u.cacheReadInputTokens * p.cacheRead; wCW += u.cacheCreationInputTokens * p.cacheWrite
   }
   return {
-    input:      tIn  > 0 ? wIn  / tIn  : 3,
-    output:     tOut > 0 ? wOut / tOut : 15,
-    cacheRead:  tCR  > 0 ? wCR  / tCR  : 0.3,
-    cacheWrite: tCW  > 0 ? wCW  / tCW  : 3.75,
+    input:  tIn  > 0 ? wIn  / tIn  : 3,
+    output: tOut > 0 ? wOut / tOut : 15,
   }
 }
 
-async function loadSessions(): Promise<SessionMeta[]> {
+async function loadSessions(): Promise<SessionMetaMin[]> {
   const files = (await safeReadDir(SESSION_META_DIR)).filter(f => f.endsWith('.json'))
-  const result: SessionMeta[] = []
-  const BATCH = 30
+  const out: SessionMetaMin[] = []
+  const BATCH = 40
   for (let i = 0; i < files.length; i += BATCH) {
     const res = await Promise.all(
-      files.slice(i, i + BATCH).map(f => safeReadJson<SessionMeta>(join(SESSION_META_DIR, f)))
+      files.slice(i, i + BATCH).map(f => safeReadJson<SessionMetaMin>(join(SESSION_META_DIR, f)))
     )
-    for (const s of res) if (s?.session_id) result.push(s)
+    for (const s of res) if (s?.session_id) out.push(s)
   }
-  return result
+  return out
 }
 
 function computeSnapshot(
-  allSessions: SessionMeta[],
-  statsCache: StatsCache,
-  projectFilter?: string[]
+  sessions: SessionMetaMin[],
+  cache: StatsCache,
+  filter?: string[]
 ): CliSnapshot {
-  const isFiltered = projectFilter !== undefined && projectFilter.length > 0
-  const filtered   = isFiltered
-    ? allSessions.filter(s => projectFilter!.includes(s.project_path))
-    : allSessions
+  const filtered = filter?.length ? sessions.filter(s => filter.includes(s.project_path)) : sessions
+  const isF      = !!(filter?.length)
 
-  const messages = isFiltered
+  const messages = isF
     ? filtered.reduce((s, x) => s + (x.user_message_count ?? 0) + (x.assistant_message_count ?? 0), 0)
-    : (statsCache.dailyActivity ?? []).reduce((s, d) => s + d.messageCount, 0)
+    : (cache.dailyActivity ?? []).reduce((s, d) => s + d.messageCount, 0)
 
-  const sessions = isFiltered
+  const sessions_ = isF
     ? filtered.length
-    : (statsCache.dailyActivity ?? []).reduce((s, d) => s + d.sessionCount, 0)
+    : (cache.dailyActivity ?? []).reduce((s, d) => s + d.sessionCount, 0)
 
-  const inputTokens  = filtered.reduce((s, x) => s + (x.input_tokens  ?? 0), 0)
-  const outputTokens = filtered.reduce((s, x) => s + (x.output_tokens ?? 0), 0)
-  const gitCommits   = filtered.reduce((s, x) => s + (x.git_commits   ?? 0), 0)
-  const gitPushes    = filtered.reduce((s, x) => s + (x.git_pushes    ?? 0), 0)
-  const linesAdded   = filtered.reduce((s, x) => s + (x.lines_added   ?? 0), 0)
-  const linesRemoved = filtered.reduce((s, x) => s + (x.lines_removed ?? 0), 0)
+  const inTok  = filtered.reduce((s, x) => s + (x.input_tokens  ?? 0), 0)
+  const outTok = filtered.reduce((s, x) => s + (x.output_tokens ?? 0), 0)
+  const gC     = filtered.reduce((s, x) => s + (x.git_commits   ?? 0), 0)
+  const gP     = filtered.reduce((s, x) => s + (x.git_pushes    ?? 0), 0)
+  const lA     = filtered.reduce((s, x) => s + (x.lines_added   ?? 0), 0)
+  const lR     = filtered.reduce((s, x) => s + (x.lines_removed ?? 0), 0)
 
-  const modelUsage = statsCache.modelUsage ?? {}
-  let costUsd = 0
-  if (!isFiltered) {
-    costUsd = Object.entries(modelUsage).reduce((s, [id, u]) => s + calcCost(u, id), 0)
+  const mu = cache.modelUsage ?? {}
+  let cost = 0
+  if (!isF) {
+    cost = Object.entries(mu).reduce((s, [id, u]) => s + calcCost(u, id), 0)
   } else {
-    const b = blendedCostPerToken(modelUsage)
-    costUsd = (inputTokens / 1_000_000) * b.input + (outputTokens / 1_000_000) * b.output
+    const b = blendedCostPerToken(mu)
+    cost = (inTok / 1_000_000) * b.input + (outTok / 1_000_000) * b.output
   }
 
-  const activeDates = new Set((statsCache.dailyActivity ?? []).map(d => d.date))
+  const acts = new Set((cache.dailyActivity ?? []).map(d => d.date))
   let streak = 0
   for (let i = 0; i <= 365; i++) {
     const d = new Date(); d.setDate(d.getDate() - i)
-    const ds = d.toISOString().slice(0, 10)
-    if (activeDates.has(ds)) streak++
+    if (acts.has(d.toISOString().slice(0, 10))) streak++
     else if (i > 0) break
   }
 
-  return { messages, sessions, inputTokens, outputTokens, costUsd, streak, gitCommits, gitPushes, linesAdded, linesRemoved }
+  return { messages, sessions: sessions_, inputTokens: inTok, outputTokens: outTok,
+    costUsd: cost, streak, gitCommits: gC, gitPushes: gP, linesAdded: lA, linesRemoved: lR }
 }
 
-async function reloadAllSnapshots(config: WatchConfig): Promise<{
-  snapshots: Map<string, CliSnapshot>
-  lastUpdated: Date
-}> {
-  const [allSessions, statsCache] = await Promise.all([
+async function reloadSnapshots(config: WatchConfig): Promise<Map<string, CliSnapshot>> {
+  const [sessions, cache] = await Promise.all([
     loadSessions(),
     safeReadJson<StatsCache>(STATS_CACHE_FILE).then(v => v ?? {}),
   ])
+  const map = new Map<string, CliSnapshot>()
+  const paths = config.selectedProjects.length > 0
+    ? config.selectedProjects.map(p => p.path)
+    : undefined
 
-  const snapshots = new Map<string, CliSnapshot>()
-
-  if (config.selectedProjects.length === 0) {
-    // Todos os projetos
-    snapshots.set('', computeSnapshot(allSessions, statsCache))
-  } else {
-    // Snapshot unificado dos selecionados
-    snapshots.set('', computeSnapshot(allSessions, statsCache,
-      config.selectedProjects.map(p => p.path)))
-    // Snapshot individual por projeto
-    for (const proj of config.selectedProjects) {
-      snapshots.set(proj.path, computeSnapshot(allSessions, statsCache, [proj.path]))
-    }
+  map.set('', computeSnapshot(sessions, cache, paths))
+  for (const p of config.selectedProjects) {
+    map.set(p.path, computeSnapshot(sessions, cache, [p.path]))
   }
-
-  return { snapshots, lastUpdated: new Date() }
+  return map
 }
 
 // ── Animação de batalha: Claude vs Cursor ──────────────────────────────────
+// Cada frame = 4 linhas de conteúdo com largura visível fixa (FW caracteres).
+// Padded com espaços para garantir que não varia de tamanho entre frames.
 
-const BATTLE_FRAMES: string[][] = [
-  // 0 — idle (ambos de pé)
-  [
-    `   ${YELLOW}o${RESET}                     ${RED}o${RESET}   `,
-    `  ${YELLOW}/|\\${RESET}   ${DIM}~ vs ~${RESET}     ${RED}/|\\${RESET}  `,
-    `  ${YELLOW}/ \\${RESET}                   ${RED}/ \\${RESET}  `,
-  ],
-  // 1 — Claude carrega golpe
-  [
-    `  ${YELLOW}\\o/${RESET}                    ${RED}o${RESET}   `,
-    `   ${YELLOW}|${RESET}    ${DIM}~ vs ~${RESET}      ${RED}/|\\${RESET}  `,
-    `  ${YELLOW}/ \\${RESET}                   ${RED}/ \\${RESET}  `,
-  ],
-  // 2 — Claude lança golpe →
-  [
-    `   ${YELLOW}o${RESET}${BOLD}─────────────→${RESET}  ${RED}o${RESET}   `,
-    `  ${YELLOW}─|─${RESET}                   ${RED}|${RESET}   `,
-    `  ${YELLOW}/ \\${RESET}                  ${RED}/\\${RESET}   `,
-  ],
-  // 3 — Impacto! Cursor apanha
-  [
-    `   ${YELLOW}o${RESET}            ${GREEN}✦${RESET}  ${RED}*${RESET}    `,
-    `  ${YELLOW}/|\\${RESET}               ${RED}\\${RESET}    `,
-    `  ${YELLOW}/ \\${RESET}               ${RED}/${RESET}    `,
-  ],
+const FW = 46 // largura visível do frame
+
+function fp(line: string): string {
+  // Preenche linha até FW caracteres visíveis
+  return line + ' '.repeat(Math.max(0, FW - visLen(line)))
+}
+
+// Cada frame: [linha1, linha2, linha3, linha4, statusLabel]
+// Linha 1-3: figuras; linha 4: nomes fixos
+const FRAMES: [string, string, string, string][] = [
+  // 0 — idle
+  [ fp(`  ${YL}o${R}                         ${RD}o${R}`),
+    fp(`  ${YL}/|\\${R}      ${D}~ VS ~${R}       ${RD}/|\\${R}`),
+    fp(`  ${YL}/ \\${R}                       ${RD}/ \\${R}`),
+    fp(`  ${YL}CLAUDE${R}               ${RD}CURSOR${R}`) ],
+
+  // 1 — Claude carrega
+  [ fp(`  ${YL}\\o/${R}                        ${RD}o${R}`),
+    fp(`   ${YL}|${R}       ${D}~ VS ~${R}       ${RD}/|\\${R}`),
+    fp(`  ${YL}/ \\${R}                       ${RD}/ \\${R}`),
+    fp(`  ${YL}CLAUDE${R} ${D}carrega...${R}    ${RD}CURSOR${R}`) ],
+
+  // 2 — Claude ataca →
+  [ fp(`  ${YL}o${R}${B}─────────────────────→${R}  ${RD}o${R}`),
+    fp(` ${YL}─|─${R}                        ${RD}|${R}`),
+    fp(`  ${YL}/ \\${R}                      ${RD}/\\${R}`),
+    fp(`  ${YL}CLAUDE${R} ${GR}ATAQUE!${R}         ${RD}CURSOR${R}`) ],
+
+  // 3 — Impacto!
+  [ fp(`  ${YL}o${R}               ${GR}✦${R}  ${B}${RD}*${R}`),
+    fp(`  ${YL}/|\\${R}                    ${RD}\\${R}`),
+    fp(`  ${YL}/ \\${R}                    ${RD}/\\${R}`),
+    fp(`  ${YL}CLAUDE${R} ${GR}CRÍTICO!${R}        ${RD}CURSOR${R}`) ],
+
   // 4 — Cursor se recupera
-  [
-    `   ${YELLOW}o${RESET}                    ${RED}o${RESET}   `,
-    `  ${YELLOW}/|\\${RESET}   ${DIM}~ vs ~${RESET}    ${RED}\\|/${RESET}   `,
-    `  ${YELLOW}/ \\${RESET}                  ${RED}/\\${RESET}   `,
-  ],
-  // 5 — Cursor carrega contra-ataque
-  [
-    `   ${YELLOW}o${RESET}                   ${RED}\\o/${RESET}  `,
-    `  ${YELLOW}/|\\${RESET}   ${DIM}~ vs ~${RESET}    ${RED}|${RESET}    `,
-    `  ${YELLOW}/ \\${RESET}                  ${RED}/ \\${RESET}  `,
-  ],
-  // 6 — Cursor lança golpe ←
-  [
-    `   ${YELLOW}o${RESET}  ${RED}←─────────────${RESET}${RED}─|─${RESET}  `,
-    `   ${YELLOW}|${RESET}                    ${RED}|${RESET}    `,
-    `  ${YELLOW}/\\${RESET}                   ${RED}/ \\${RESET}  `,
-  ],
-  // 7 — Claude apanha
-  [
-    `  ${GREEN}✦${RESET} ${YELLOW}*${RESET}                   ${RED}o${RESET}    `,
-    `    ${YELLOW}\\${RESET}                   ${RED}/|\\${RESET}  `,
-    `    ${YELLOW}/                   ${RED}/ \\${RESET}  `,
-  ],
-]
+  [ fp(`  ${YL}o${R}                         ${RD}o${R}`),
+    fp(`  ${YL}/|\\${R}      ${D}~ VS ~${R}      ${RD}\\|/${R}`),
+    fp(`  ${YL}/ \\${R}                      ${RD}/\\${R}`),
+    fp(`  ${YL}CLAUDE${R}               ${RD}CURSOR${R}`) ],
 
-const BATTLE_LABELS = [
-  `${YELLOW}CLAUDE${RESET}              ${RED}CURSOR${RESET}`,
-  `${YELLOW}CLAUDE${RESET}  ${DIM}se prepara...${RESET}  ${RED}CURSOR${RESET}`,
-  `${YELLOW}CLAUDE${RESET}  ${GREEN}ATAQUE!${RESET}        ${RED}CURSOR${RESET}`,
-  `${YELLOW}CLAUDE${RESET}  ${GREEN}CRÍTICO!${RESET}       ${RED}CURSOR${RESET}`,
-  `${YELLOW}CLAUDE${RESET}              ${RED}CURSOR${RESET}`,
-  `${YELLOW}CLAUDE${RESET}          ${DIM}se prepara...${RESET} ${RED}CURSOR${RESET}`,
-  `${YELLOW}CLAUDE${RESET}       ${RED}CONTRA-ATAQUE!${RESET} ${RED}CURSOR${RESET}`,
-  `${YELLOW}CLAUDE${RESET}  ${RED}LEVOU!${RESET}           ${RED}CURSOR${RESET}`,
+  // 5 — Cursor carrega
+  [ fp(`  ${YL}o${R}                        ${RD}\\o/${R}`),
+    fp(`  ${YL}/|\\${R}      ${D}~ VS ~${R}         ${RD}|${R}`),
+    fp(`  ${YL}/ \\${R}                       ${RD}/ \\${R}`),
+    fp(`  ${YL}CLAUDE${R}      ${RD}CURSOR ${D}carrega...${R}`) ],
+
+  // 6 — Cursor ataca ←
+  [ fp(`  ${YL}o${R}${B}←─────────────────────${R}${RD}─|─${R}`),
+    fp(`   ${YL}|${R}                           ${RD}|${R}`),
+    fp(`  ${YL}/\\${R}                          ${RD}/ \\${R}`),
+    fp(`  ${YL}CLAUDE${R}       ${RD}CURSOR CONTRA-ATACA!${R}`) ],
+
+  // 7 — Claude apanha
+  [ fp(`  ${B}${YL}*${R}  ${GR}✦${R}                     ${RD}o${R}`),
+    fp(`   ${YL}\\${R}                          ${RD}/|\\${R}`),
+    fp(`   ${YL}/                          ${RD}/ \\${R}`),
+    fp(`  ${YL}CLAUDE${R} ${D}levou!${R}          ${RD}CURSOR${R}`) ],
 ]
 
 function renderBattle(frame: number): string[] {
-  const f = frame % BATTLE_FRAMES.length
-  const lines = [
-    `  ${DIM}┌───────────────────────────────────────────┐${RESET}`,
-    `  ${DIM}│${RESET}${BATTLE_LABELS[f].padEnd(43)}${DIM}│${RESET}`,
-    ...BATTLE_FRAMES[f].map(l => `  ${DIM}│${RESET}  ${l}${DIM}│${RESET}`),
-    `  ${DIM}│${RESET}  ${DIM}[Ctrl+O para ocultar]${RESET}               ${DIM}│${RESET}`,
-    `  ${DIM}└───────────────────────────────────────────┘${RESET}`,
+  const f = FRAMES[frame % FRAMES.length]
+  return [
+    `  ${D}${'─'.repeat(FW + 6)}${R}`,
+    `  ${D}│${R}  ${f[0]}  ${D}│${R}`,
+    `  ${D}│${R}  ${f[1]}  ${D}│${R}`,
+    `  ${D}│${R}  ${f[2]}  ${D}│${R}`,
+    `  ${D}│${R}  ${f[3]}  ${D}│${R}`,
+    `  ${D}│${R}  ${D}Ctrl+O para ocultar${' '.repeat(FW - 19)}${R}  ${D}│${R}`,
+    `  ${D}${'─'.repeat(FW + 6)}${R}`,
   ]
-  return lines
 }
 
 // ── Formatação de métricas ─────────────────────────────────────────────────
 
-function fmtNum(n: number): string {
-  if (n >= 1_000_000) return (n / 1_000_000).toFixed(1) + 'M'
-  if (n >= 1_000)     return (n / 1_000).toFixed(1) + 'k'
-  return n.toString()
-}
-function fmtCost(usd: number): string {
-  if (usd >= 1000) return `$${(usd / 1000).toFixed(1)}k`
-  if (usd >= 1)    return `$${usd.toFixed(2)}`
-  return `$${usd.toFixed(3)}`
-}
+const fmtN = (n: number) =>
+  n >= 1_000_000 ? (n / 1_000_000).toFixed(1) + 'M'
+  : n >= 1_000   ? (n / 1_000).toFixed(1) + 'k'
+  : n.toString()
 
-const METRIC_COLS = [
-  { label: 'Msgs',     w: 8  },
-  { label: 'Sessões',  w: 8  },
-  { label: 'Tok↑',    w: 9  },
-  { label: 'Tok↓',    w: 9  },
-  { label: 'Custo',   w: 10 },
-  { label: 'Streak',  w: 7  },
-  { label: 'Commits', w: 8  },
-  { label: '+Linhas', w: 9  },
-  { label: '-Linhas', w: 9  },
+const fmtC = (u: number) =>
+  u >= 1000 ? `$${(u / 1000).toFixed(1)}k`
+  : u >= 1  ? `$${u.toFixed(2)}`
+  : `$${u.toFixed(3)}`
+
+const COLS = [
+  { h: 'Msgs',     w: 8  }, { h: 'Sessões',  w: 8  },
+  { h: 'Tok↑',    w: 9  }, { h: 'Tok↓',    w: 9  },
+  { h: 'Custo',   w: 10 }, { h: 'Streak',  w: 7  },
+  { h: 'Commits', w: 8  }, { h: '+Linhas', w: 9  }, { h: '-Linhas', w: 9  },
 ]
-const PROJECT_COL_W = 24
+const PW = 24
 
-function tableHeader(withProject: boolean): string {
-  const cells = METRIC_COLS.map(c => col(`${DIM}${c.label}${RESET}`, c.w))
-  if (withProject) return col(`${DIM}Projeto${RESET}`, PROJECT_COL_W, 'l') + '  ' + cells.join('  ')
-  return cells.join('  ')
+const tblHdr = (proj: boolean) => {
+  const cells = COLS.map(c => pad(`${D}${c.h}${R}`, c.w))
+  return (proj ? pad(`${D}Projeto${R}`, PW, 'l') + '  ' : '') + cells.join('  ')
 }
-function tableRow(snap: CliSnapshot, projectName?: string): string {
+const tblRow = (s: CliSnapshot, name?: string) => {
   const vals = [
-    fmtNum(snap.messages), fmtNum(snap.sessions),
-    fmtNum(snap.inputTokens), fmtNum(snap.outputTokens),
-    fmtCost(snap.costUsd), `${snap.streak}d`,
-    fmtNum(snap.gitCommits),
-    `+${fmtNum(snap.linesAdded)}`, `-${fmtNum(snap.linesRemoved)}`,
+    fmtN(s.messages), fmtN(s.sessions), fmtN(s.inputTokens), fmtN(s.outputTokens),
+    fmtC(s.costUsd), `${s.streak}d`, fmtN(s.gitCommits),
+    `+${fmtN(s.linesAdded)}`, `-${fmtN(s.linesRemoved)}`,
   ]
-  const cells = vals.map((v, i) => col(v, METRIC_COLS[i].w))
-  if (projectName !== undefined) {
-    const name = projectName.length > PROJECT_COL_W - 1
-      ? projectName.slice(0, PROJECT_COL_W - 2) + '…'
-      : projectName
-    return col(`${CYAN}${name}${RESET}`, PROJECT_COL_W, 'l') + '  ' + cells.join('  ')
+  const cells = vals.map((v, i) => pad(v, COLS[i].w))
+  if (name !== undefined) {
+    const n = name.length > PW - 1 ? name.slice(0, PW - 2) + '…' : name
+    return pad(`${CY}${n}${R}`, PW, 'l') + '  ' + cells.join('  ')
   }
   return cells.join('  ')
 }
 
-// ── Renderização do painel ─────────────────────────────────────────────────
+// ── Construção do painel ───────────────────────────────────────────────────
 
-function buildPanel(config: WatchConfig, state: AppState): string {
-  const w = process.stdout.columns || 100
+function buildPanel(cfg: WatchConfig, st: AppState): string {
+  const W = process.stdout.columns || 100
   const lines: string[] = []
 
-  // Título
-  const now    = state.lastUpdated.toLocaleTimeString('pt-BR')
-  const loader = state.isLoadingData ? `${DIM} ⟳${RESET}` : ''
-  const left   = `${BOLD}${BRIGHT_CYAN}Claude Stats — Watch Mode${RESET}`
-  const right  = `${DIM}${now}  ⟳ ${config.intervalSec}s${loader}${RESET}`
-  const gap    = Math.max(1, w - visLen(left.replace(/\x1b\[[0-9;]*m/g, '')) - visLen(right.replace(/\x1b\[[0-9;]*m/g, '')))
+  // Cabeçalho
+  const now   = st.lastUpdated.toLocaleTimeString('pt-BR')
+  const right = `${D}${now}  ⟳ ${cfg.intervalSec}s${st.isLoading ? ' …' : ''}${R}`
+  const left  = `${B}${BCY}Claude Stats — Watch Mode${R}`
+  const gap   = Math.max(1, W - visLen(left.replace(/\x1b\[[0-9;]*m/g,'')) - visLen(right.replace(/\x1b\[[0-9;]*m/g,'')))
   lines.push(left + ' '.repeat(gap) + right)
-  lines.push(hr(w))
+  lines.push(hr(W))
   lines.push('')
 
-  // Animação (se visível)
-  if (state.showAnimation) {
-    lines.push(...renderBattle(state.animFrame))
+  // Batalha
+  if (st.showBattle) {
+    lines.push(...renderBattle(st.animFrame))
     lines.push('')
   }
 
   // Bloco de info
-  const modeDesc = config.viewMode === 'junto' ? 'unificado'
-    : config.viewMode === 'separado' ? 'separado' : 'ambos'
+  const mode = cfg.viewMode === 'junto' ? 'unificado'
+    : cfg.viewMode === 'separado' ? 'separado' : 'ambos'
 
-  lines.push(`  ${DIM}Home:${RESET}       ${WHITE}${HOME_DIR}${RESET}`)
-  lines.push(`  ${DIM}Claude dir:${RESET} ${WHITE}${CLAUDE_DIR}${RESET}`)
+  lines.push(`  ${D}Home:${R}       ${WH}${HOME_DIR}${R}`)
+  lines.push(`  ${D}Claude dir:${R} ${WH}${CLAUDE_DIR}${R}`)
 
-  if (config.selectedProjects.length === 0) {
-    lines.push(`  ${DIM}Projetos:${RESET}   ${YELLOW}todos (${config.allProjects.length})${RESET}`)
+  if (cfg.selectedProjects.length === 0) {
+    lines.push(`  ${D}Projetos:${R}   ${YL}todos (${cfg.allProjects.length})${R}`)
   } else {
-    const names = config.selectedProjects.map(p => p.name).join(', ')
-    lines.push(`  ${DIM}Projetos:${RESET}   ${CYAN}${names}${RESET}`)
+    lines.push(`  ${D}Projetos:${R}   ${CY}${cfg.selectedProjects.map(p => p.name).join(', ')}${R}`)
   }
-
-  if (config.selectedProjects.length > 1) {
-    lines.push(`  ${DIM}Modo:${RESET}       ${GREEN}${modeDesc}${RESET}`)
-  }
-
-  lines.push(`  ${DIM}Interval:${RESET}   ${WHITE}${config.intervalSec}s${RESET}`)
-  lines.push(`  ${DIM}OTLP:${RESET}       ${config.otlpEndpoint ? `${GREEN}${config.otlpEndpoint}${RESET}` : `${DIM}(disabled)${RESET}`}`)
+  if (cfg.selectedProjects.length > 1) lines.push(`  ${D}Modo:${R}       ${GR}${mode}${R}`)
+  lines.push(`  ${D}Interval:${R}   ${WH}${cfg.intervalSec}s${R}`)
+  lines.push(`  ${D}OTLP:${R}       ${cfg.otlpEndpoint ? `${GR}${cfg.otlpEndpoint}${R}` : `${D}(disabled)${R}`}`)
   lines.push('')
 
-  // Tabela de métricas
-  const singleView = config.selectedProjects.length <= 1
-  const allSnap    = state.snapshots.get('')
+  // Tabela
+  const solo = cfg.selectedProjects.length <= 1
+  const all  = st.snapshots.get('')
+  const loading = `  ${D}(carregando...)${R}`
 
-  if (singleView || config.viewMode === 'junto') {
-    lines.push(hr(w))
-    if (!singleView) lines.push(`  ${BOLD}${CYAN}UNIFICADO${RESET}`)
+  if (solo || cfg.viewMode === 'junto') {
+    lines.push(hr(W))
+    if (!solo) lines.push(`  ${B}${CY}UNIFICADO${R}`)
     lines.push('')
-    lines.push('  ' + tableHeader(false))
-    lines.push(`  ${GREEN}${BOLD}${allSnap ? tableRow(allSnap) : '  (carregando...)'}${RESET}`)
-    lines.push(hr(w))
-  } else if (config.viewMode === 'separado') {
-    lines.push(hr(w))
-    lines.push(`  ${BOLD}${CYAN}POR PROJETO${RESET}`)
+    lines.push('  ' + tblHdr(false))
+    lines.push(`  ${GR}${B}${all ? tblRow(all) : loading}${R}`)
+    lines.push(hr(W))
+
+  } else if (cfg.viewMode === 'separado') {
+    lines.push(hr(W))
+    lines.push(`  ${B}${CY}POR PROJETO${R}`)
     lines.push('')
-    lines.push('  ' + tableHeader(true))
-    for (const proj of config.selectedProjects) {
-      const snap = state.snapshots.get(proj.path)
-      lines.push('  ' + (snap ? tableRow(snap, proj.name) : `  ${DIM}${proj.name}  (carregando...)${RESET}`))
+    lines.push('  ' + tblHdr(true))
+    for (const p of cfg.selectedProjects) {
+      const s = st.snapshots.get(p.path)
+      lines.push('  ' + (s ? tblRow(s, p.name) : `  ${D}${p.name} (carregando...)${R}`))
     }
-    lines.push(hr(w))
+    lines.push(hr(W))
+
   } else {
-    // ambos
-    lines.push(hr(w))
-    lines.push(`  ${BOLD}${CYAN}UNIFICADO${RESET}`)
+    lines.push(hr(W))
+    lines.push(`  ${B}${CY}UNIFICADO${R}`)
     lines.push('')
-    lines.push('  ' + tableHeader(false))
-    lines.push(`  ${GREEN}${BOLD}${allSnap ? tableRow(allSnap) : '  (carregando...)'}${RESET}`)
+    lines.push('  ' + tblHdr(false))
+    lines.push(`  ${GR}${B}${all ? tblRow(all) : loading}${R}`)
     lines.push('')
-    lines.push(`  ${BOLD}${CYAN}POR PROJETO${RESET}`)
+    lines.push(`  ${B}${CY}POR PROJETO${R}`)
     lines.push('')
-    lines.push('  ' + tableHeader(true))
-    for (const proj of config.selectedProjects) {
-      const snap = state.snapshots.get(proj.path)
-      lines.push('  ' + (snap ? tableRow(snap, proj.name) : `  ${DIM}${proj.name}  (carregando...)${RESET}`))
+    lines.push('  ' + tblHdr(true))
+    for (const p of cfg.selectedProjects) {
+      const s = st.snapshots.get(p.path)
+      lines.push('  ' + (s ? tblRow(s, p.name) : `  ${D}${p.name} (carregando...)${R}`))
     }
-    lines.push(hr(w))
+    lines.push(hr(W))
   }
 
   lines.push('')
-  lines.push(`  ${DIM}Ctrl+C sair  |  Ctrl+O ${state.showAnimation ? 'ocultar' : 'mostrar'} batalha${RESET}`)
-
+  lines.push(`  ${D}Ctrl+C sair  │  Ctrl+O ${st.showBattle ? 'ocultar' : 'mostrar'} batalha${R}`)
   return lines.join('\n') + '\n'
 }
 
 // ── Watch loop ─────────────────────────────────────────────────────────────
 
-async function watchLoop(config: WatchConfig): Promise<void> {
-  hideCursor()
-
-  const state: AppState = {
+async function watchLoop(cfg: WatchConfig): Promise<void> {
+  const st: AppState = {
     snapshots: new Map(),
     lastUpdated: new Date(),
     animFrame: 0,
-    showAnimation: true,
-    isLoadingData: true,
+    showBattle: cfg.showBattle,
+    isLoading: true,
   }
 
-  // Limpa + redesenha no lugar (sem append)
+  // Cleanup centralizado
+  const cleanup = () => {
+    write(SHOW_CUR + ALT_OFF)
+    process.exit(0)
+  }
+
+  // Alternate screen: entra limpo, sai limpo
+  write(ALT_ON + HIDE_CUR)
+
   const render = () => {
-    clearScreen()
-    process.stdout.write(buildPanel(config, state))
+    write(CLEAR_SCR + buildPanel(cfg, st))
   }
 
-  // Reload pesado de dados do disco
+  // Reload pesado de disco
   let reloading = false
   const reloadData = async () => {
     if (reloading) return
     reloading = true
-    state.isLoadingData = true
+    st.isLoading = true
     try {
-      const { snapshots, lastUpdated } = await reloadAllSnapshots(config)
-      state.snapshots   = snapshots
-      state.lastUpdated = lastUpdated
-    } catch { /* mantém snapshot anterior */ }
-    finally {
-      state.isLoadingData = false
-      reloading = false
-    }
+      st.snapshots   = await reloadSnapshots(cfg)
+      st.lastUpdated = new Date()
+    } catch { /* mantém anterior */ }
+    finally { st.isLoading = false; reloading = false }
     render()
   }
 
-  // Carregamento inicial
+  // Carga inicial
   await reloadData()
 
-  // Teclado: Ctrl+O toggle animação, Ctrl+C sair
+  // Teclado: Ctrl+C e Ctrl+O
   if (process.stdin.isTTY) {
     process.stdin.setRawMode(true)
     process.stdin.resume()
     process.stdin.on('data', (buf: Buffer) => {
-      const ch = buf[0]
-      if (ch === 3) {                      // Ctrl+C
-        showCursor()
-        clearScreen()
-        process.exit(0)
-      } else if (ch === 15) {              // Ctrl+O
-        state.showAnimation = !state.showAnimation
+      if (buf[0] === 3)  { cleanup() }           // Ctrl+C
+      if (buf[0] === 15) {                        // Ctrl+O
+        st.showBattle = !st.showBattle
         render()
       }
     })
   } else {
-    process.on('SIGINT',  () => { showCursor(); clearScreen(); process.exit(0) })
-    process.on('SIGTERM', () => { showCursor(); clearScreen(); process.exit(0) })
+    process.on('SIGINT',  cleanup)
+    process.on('SIGTERM', cleanup)
   }
 
-  // Timer de animação (200ms) — só redesenha, não relê disco
-  const ANIM_INTERVAL = 200
-  setInterval(() => {
-    state.animFrame++
-    render()
-  }, ANIM_INTERVAL)
+  // Timer de animação — só re-renderiza com cache, sem I/O
+  setInterval(() => { st.animFrame++; render() }, 200)
 
-  // Timer de dados (configurable)
-  setInterval(reloadData, config.intervalSec * 1000)
+  // Timer de dados
+  setInterval(reloadData, cfg.intervalSec * 1000)
 
-  // Chokidar: reload imediato em mudanças de arquivo (debounce 1.5s)
-  let debounceTimer: ReturnType<typeof setTimeout> | null = null
+  // Chokidar
+  let dbt: ReturnType<typeof setTimeout> | null = null
   chokidar
     .watch([SESSION_META_DIR, STATS_CACHE_FILE], { persistent: true, ignoreInitial: true })
-    .on('all', () => {
-      if (debounceTimer) clearTimeout(debounceTimer)
-      debounceTimer = setTimeout(reloadData, 1500)
-    })
+    .on('all', () => { if (dbt) clearTimeout(dbt); dbt = setTimeout(reloadData, 1500) })
 }
 
 // ── Custom prompt: checkbox com busca reativa ──────────────────────────────
 
-interface CheckboxChoice { name: string; value: string; path: string }
+type RlKey = KeypressEvent & { meta?: boolean; sequence?: string }
 
-/** KeypressEvent estendido com os campos extras do readline de Node.js */
-type RlKeypress = KeypressEvent & { meta?: boolean; sequence?: string }
+interface CbChoice { name: string; value: string; path: string }
 
-const checkboxWithSearch = createPrompt<string[], {
+const checkboxSearch = createPrompt<string[], {
   message: string
-  choices: ReadonlyArray<CheckboxChoice>
+  choices: ReadonlyArray<CbChoice>
   pageSize?: number
 }>((config, done) => {
-  const [searchTerm, setSearchTerm] = useState('')
-  const [active, setActive]         = useState(0)
-  const [checked, setChecked]       = useState<ReadonlyArray<string>>([])
+  const [term,    setTerm]    = useState('')
+  const [active,  setActive]  = useState(0)
+  const [checked, setChecked] = useState<ReadonlyArray<string>>([])
 
   const filtered = useMemo(
     () => {
-      const t = searchTerm.toLowerCase()
-      if (!t) return config.choices
-      return config.choices.filter(c =>
+      const t = term.toLowerCase()
+      return t ? config.choices.filter(c =>
         c.name.toLowerCase().includes(t) || c.path.toLowerCase().includes(t)
-      )
+      ) : config.choices
     },
-    [searchTerm]
+    [term]
   )
 
   useKeypress((key) => {
-    const k = key as RlKeypress
+    const k = key as RlKey
     if (isEnterKey(k)) { done([...checked]); return }
 
     const len = filtered.length
@@ -591,119 +576,113 @@ const checkboxWithSearch = createPrompt<string[], {
       const item = filtered[active]
       if (!item) return
       const s = new Set(checked)
-      if (s.has(item.value)) s.delete(item.value)
-      else s.add(item.value)
+      s.has(item.value) ? s.delete(item.value) : s.add(item.value)
       setChecked(Array.from(s))
     } else if (isBackspaceKey(k)) {
-      setSearchTerm(searchTerm.slice(0, -1))
-      setActive(0)
+      setTerm(term.slice(0, -1)); setActive(0)
     } else if (!k.ctrl && !k.meta && k.sequence?.length === 1 && k.sequence.charCodeAt(0) >= 32) {
-      setSearchTerm(searchTerm + k.sequence)
-      setActive(0)
+      setTerm(term + k.sequence); setActive(0)
     }
   })
 
-  const checkedSet = new Set(checked)
+  const cs = new Set(checked)
 
-  const pageView = usePagination({
-    items:    filtered as CheckboxChoice[],
+  const page = usePagination({
+    items:    filtered as CbChoice[],
     active,
     pageSize: config.pageSize ?? 16,
     loop:     false,
     renderItem: ({ item, isActive }) => {
-      const cursor  = isActive ? `${CYAN}❯${RESET}` : ' '
-      const box     = checkedSet.has(item.value) ? `${GREEN}◉${RESET}` : `${DIM}◯${RESET}`
-      const nameStr = checkedSet.has(item.value) ? `${GREEN}${item.name}${RESET}` : item.name
-      return ` ${cursor} ${box}  ${nameStr}  ${DIM}${item.path}${RESET}`
+      const cur  = isActive ? `${CY}❯${R}` : ' '
+      const box  = cs.has(item.value) ? `${GR}◉${R}` : `${D}◯${R}`
+      const name = cs.has(item.value) ? `${GR}${item.name}${R}` : item.name
+      return ` ${cur} ${box}  ${name}  ${D}${item.path}${R}`
     },
   })
 
-  const cursorBlock   = `${ESC}[7m ${RESET}`
-  const searchDisplay = `${DIM}[Buscar]${RESET} ${BOLD}${searchTerm}${RESET}${cursorBlock}`
+  const cursor   = `\x1b[7m \x1b[0m`
+  const search   = `${D}[Buscar]${R} ${B}${term}${R}${cursor}`
+  const selNames = checked.map(v => config.choices.find(c => c.value === v)?.name ?? v).join(', ')
+  const selLine  = checked.length > 0
+    ? `\n  ${D}Selecionados: ${R}${GR}${selNames}${R}`
+    : `\n  ${D}(nenhum = todos os projetos)${R}`
 
-  const checkedNames = checked
-    .map(v => config.choices.find(c => c.value === v)?.name ?? v)
-    .join(', ')
-
-  const selectedLine = checked.length > 0
-    ? `\n  ${DIM}Selecionados: ${RESET}${GREEN}${checkedNames}${RESET}`
-    : `\n  ${DIM}(nenhum = todos os projetos)${RESET}`
-
-  return (
-    `${BOLD}${config.message}${RESET}\n  ${searchDisplay}\n\n` +
-    pageView +
-    selectedLine +
-    `\n  ${DIM}↑↓ navegar  ⎵ selecionar  ⏎ confirmar  Backspace apaga busca${RESET}`
-  )
+  return `${B}${config.message}${R}\n  ${search}\n\n${page}${selLine}\n  ${D}↑↓ navegar  ⎵ selecionar  ⏎ confirmar  Backspace apaga busca${R}`
 })
 
-// ── Configuração inicial via prompts ───────────────────────────────────────
+// ── Configuração via prompts ───────────────────────────────────────────────
 
-async function askConfig(allProjects: ProjectInfo[]): Promise<WatchConfig> {
-  // 1. Intervalo
-  const intervalStr = await input({
-    message: `Intervalo de atualização (segundos):`,
+async function askConfig(all: ProjectInfo[]): Promise<WatchConfig> {
+  // Intervalo
+  const intStr = await input({
+    message: 'Intervalo de atualização (segundos):',
     default: '30',
-    validate: (v) => {
-      const n = parseInt(v, 10)
-      if (!Number.isFinite(n) || n < 5) return 'Mínimo 5 segundos'
-      return true
-    },
+    validate: v => { const n = parseInt(v, 10); return Number.isFinite(n) && n >= 5 ? true : 'Mínimo 5s' },
   })
-  const intervalSec = parseInt(intervalStr, 10)
 
-  // 2. OTLP endpoint
-  const otlpEndpoint = await input({
-    message: 'OTLP endpoint (vazio para desativar):',
+  // OTLP
+  const otlp = await input({
+    message: 'OTLP endpoint (vazio = desativado):',
     default: process.env.OTEL_EXPORTER_OTLP_ENDPOINT ?? '',
   })
 
-  // 3. Seleção de projetos com busca
-  const selectedPaths = await checkboxWithSearch({
-    message: 'Selecione os projetos para monitorar:',
-    choices: allProjects.map(p => ({ name: p.name, value: p.path, path: p.path })),
-    pageSize: Math.min(20, allProjects.length),
+  // Animação
+  const showBattle = await confirm({
+    message: 'Mostrar batalha Claude vs Cursor no painel?',
+    default: true,
   })
 
-  const selectedProjects = selectedPaths.length === 0
-    ? []
-    : allProjects.filter(p => selectedPaths.includes(p.path))
+  // Projetos
+  const paths = await checkboxSearch({
+    message: 'Selecione os projetos para monitorar:',
+    choices: all.map(p => ({ name: p.name, value: p.path, path: p.path })),
+    pageSize: Math.min(20, all.length),
+  })
 
-  // 4. Modo de visualização (só se múltiplos selecionados)
+  const selected = paths.length === 0 ? [] : all.filter(p => paths.includes(p.path))
+
+  // Modo
   let viewMode: ViewMode = 'junto'
-  if (selectedProjects.length > 1) {
+  if (selected.length > 1) {
     viewMode = await select<ViewMode>({
       message: 'Como deseja visualizar os dados?',
       choices: [
-        { name: `${BOLD}Separado${RESET}  — uma linha por projeto`,             value: 'separado', short: 'separado'  },
-        { name: `${BOLD}Unificado${RESET} — total dos projetos selecionados`,   value: 'junto',    short: 'unificado' },
-        { name: `${BOLD}Ambos${RESET}     — total no topo + uma linha/projeto`, value: 'ambos',    short: 'ambos'     },
+        { name: `${B}Separado${R}  — uma linha por projeto`,             value: 'separado', short: 'separado'  },
+        { name: `${B}Unificado${R} — total dos projetos selecionados`,   value: 'junto',    short: 'unificado' },
+        { name: `${B}Ambos${R}     — total no topo + uma linha/projeto`, value: 'ambos',    short: 'ambos'     },
       ],
     })
   }
 
-  return { selectedProjects, allProjects, viewMode, intervalSec, otlpEndpoint }
+  return {
+    selectedProjects: selected,
+    allProjects: all,
+    viewMode,
+    intervalSec: parseInt(intStr, 10),
+    otlpEndpoint: otlp,
+    showBattle,
+  }
 }
 
 // ── Entry point ────────────────────────────────────────────────────────────
 
 async function main() {
-  console.log(`\n${BOLD}${BRIGHT_CYAN}Claude Stats — Watch CLI${RESET}\n`)
-  console.log(`${DIM}Descobrindo projetos...${RESET}`)
+  console.log(`\n${B}${BCY}Claude Stats — Watch CLI${R}\n`)
+  console.log(`${D}Descobrindo projetos...${R}`)
 
-  const allProjects = await discoverProjects()
-  if (allProjects.length === 0) {
+  const all = await discoverProjects()
+  if (all.length === 0) {
     console.error(`\nNenhum projeto encontrado em:\n  ${SESSION_META_DIR}\n  ${PROJECTS_DIR}`)
     process.exit(1)
   }
-  console.log(`${GREEN}${allProjects.length} projetos encontrados.${RESET}\n`)
+  console.log(`${GR}${all.length} projetos encontrados.${R}\n`)
 
-  const config = await askConfig(allProjects)
-  await watchLoop(config)
+  const cfg = await askConfig(all)
+  await watchLoop(cfg)
 }
 
 main().catch(err => {
-  showCursor()
+  write(SHOW_CUR + ALT_OFF)
   console.error('Erro fatal:', err)
   process.exit(1)
 })

--- a/watch-cli.ts
+++ b/watch-cli.ts
@@ -344,8 +344,7 @@ async function reloadData(config: WatchConfig): Promise<{
   return { snapshots, dataSource: 'files' }
 }
 
-// ── Animação de batalha ────────────────────────────────────────────────────
-// Apenas ASCII básico (a-z, /, \, -, |, >, <, *, =, o) + ANSI cores.
+// ── Animação: Claude resolve um incidente de produção ────────────────────
 // Cada frame = 4 linhas com largura visível exatamente igual a FW.
 
 const FW = 44
@@ -354,53 +353,53 @@ const fp = (s: string) => s + ' '.repeat(Math.max(0, FW - visLen(s)))
 
 // Cada elemento: [linha1, linha2, linha3, label]
 const FRAMES: Array<[string, string, string, string]> = [
-  [ // 0 — idle
-    fp(`  ${YL}o${R}                        ${RD}o${R}`),
-    fp(`  ${YL}|${R}         - vs -         ${RD}|${R}`),
-    fp(` ${YL}/ \\${R}                      ${RD}/ \\${R}`),
-    fp(`  ${YL}CLAUDE${R}               ${RD}CURSOR${R}`),
+  [ // 0 — tudo ok
+    fp(`  ${GR}.-----------.${R}  status: ${GR}[OK]${R}`),
+    fp(`  ${GR}| PROD SYS  |${R}  uptime: 99.9%`),
+    fp(`  ${GR}'-----------'${R}  errors:  ${GR}0${R}`),
+    fp(`  ${D}all systems normal${R}`),
   ],
-  [ // 1 — Claude carrega
-    fp(` ${YL}\\o/${R}                       ${RD}o${R}`),
-    fp(`  ${YL}|${R}         - vs -         ${RD}|${R}`),
-    fp(` ${YL}/ \\${R}                      ${RD}/ \\${R}`),
-    fp(`  ${YL}CLAUDE${R} ${D}carrega...${R}  ${RD}CURSOR${R}`),
+  [ // 1 — alerta dispara
+    fp(`  ${RD}.-----------.${R}  ${B}${RD}[!]${R} Error spike!`),
+    fp(`  ${RD}|  ALERT!!  |${R}  ${B}${RD}[!]${R} P0 incident`),
+    fp(`  ${RD}'-----------'${R}  errors: 500/min`),
+    fp(`  ${YL}waking up claude...${R}`),
   ],
-  [ // 2 — Claude ataca →
-    fp(`  ${YL}o${R} ${B}=======${R}${GR}>${R}           ${RD}o${R}`),
-    fp(`  ${YL}|${R}                         ${RD}|${R}`),
-    fp(` ${YL}/ \\${R}                      ${RD}/ \\${R}`),
-    fp(`  ${YL}CLAUDE${R} ${GR}ATAQUE!${R}      ${RD}CURSOR${R}`),
+  [ // 2 — claude lendo logs
+    fp(`   ${YL}o${R}   ${D}$ tail -f /var/log/app.log${R}`),
+    fp(`  ${YL}/|\\${R}  ${RD}> ERROR line 42: null ref${R}`),
+    fp(`  ${YL}/ \\${R}  ${RD}> ERROR line 42: null ref${R}`),
+    fp(`  ${D}investigating...${R}`),
   ],
-  [ // 3 — impacto no Cursor
-    fp(`  ${YL}o${R}         ${GR}*${R}      ${B}${RD}(o)${R}`),
-    fp(`  ${YL}|${R}                      ${RD}\\${R}`),
-    fp(` ${YL}/ \\${R}                     ${RD}/\\${R}`),
-    fp(`  ${YL}CLAUDE${R} ${GR}CRITICO!${R}    ${RD}CURSOR${R}`),
+  [ // 3 — achou o bug
+    fp(`   ${YL}o${R}   ${B}${GR}AHA!${R} found it - ${RD}line 42${R}`),
+    fp(`  ${YL}/|\\${R}  ${RD}> if (obj.get() == null)${R}`),
+    fp(`  ${YL}/ \\${R}  ${GR}> fix: obj?.get() ?? ''${R}`),
+    fp(`  ${GR}got the bug!${R}`),
   ],
-  [ // 4 — Cursor se recupera
-    fp(`  ${YL}o${R}                        ${RD}o${R}`),
-    fp(`  ${YL}|${R}         - vs -        ${RD}\\|/${R}`),
-    fp(` ${YL}/ \\${R}                      ${RD}/\\${R}`),
-    fp(`  ${YL}CLAUDE${R}               ${RD}CURSOR${R}`),
+  [ // 4 — digitando a correcao
+    fp(`   ${YL}o${R}   ${D}$ vim src/handler.ts:42${R}`),
+    fp(`  ${YL}\\|/${R}  ${RD}[-]${R} ${D}if (obj.get() == null)${R}`),
+    fp(`   ${YL}|${R}   ${GR}[+]${R} ${GR}if (obj?.get() == null)${R}`),
+    fp(`  ${D}patching...${R}`),
   ],
-  [ // 5 — Cursor carrega
-    fp(`  ${YL}o${R}                       ${RD}\\o/${R}`),
-    fp(`  ${YL}|${R}         - vs -         ${RD}|${R}`),
-    fp(` ${YL}/ \\${R}                      ${RD}/ \\${R}`),
-    fp(`  ${YL}CLAUDE${R}   ${RD}CURSOR ${D}carrega...${R}`),
+  [ // 5 — commit
+    fp(`   ${YL}o${R}   ${D}$ git commit -m "fix: ..."${R}`),
+    fp(`  ${YL}/|\\${R}  ${GR}[main a1b2c3] fix: null ref${R}`),
+    fp(`  ${YL}/ \\${R}  ${D}1 file changed, +1 -1${R}`),
+    fp(`  ${GR}committed!${R}`),
   ],
-  [ // 6 — Cursor ataca ←
-    fp(`  ${YL}o${R}           ${GR}<${R}${B}=======${R}  ${RD}o${R}`),
-    fp(`  ${YL}|${R}                         ${RD}|${R}`),
-    fp(` ${YL}/ \\${R}                      ${RD}/ \\${R}`),
-    fp(`  ${YL}CLAUDE${R}    ${RD}CURSOR ATAQUE!${R}`),
+  [ // 6 — deploy
+    fp(`   ${YL}o${R}   ${D}$ git push && ./deploy.sh${R}`),
+    fp(`  ${YL}/|\\${R}  ${YL}Deploying... ${GR}[========]${R}`),
+    fp(`  ${YL}/ \\${R}  ${GR}Build: OK    Tests: PASS${R}`),
+    fp(`  ${YL}deploying fix...${R}`),
   ],
-  [ // 7 — Claude leva
-    fp(`${GR}*${R} ${B}${YL}(o)${R}                       ${RD}o${R}`),
-    fp(`   ${YL}/\\${R}                        ${RD}|${R}`),
-    fp(`  ${YL}/  \\${R}                     ${RD}/ \\${R}`),
-    fp(`  ${YL}CLAUDE${R} ${D}levou!${R}       ${RD}CURSOR${R}`),
+  [ // 7 — resolvido, heroi
+    fp(`  ${GR}.-----------.${R}  status: ${GR}[OK]${R}`),
+    fp(`  ${GR}| INCIDENT  |${R}  errors: ${GR}0${R}`),
+    fp(`  ${GR}| RESOLVED  |${R}  fixed in ${B}4m32s${R}`),
+    fp(`  ${BC}${B}hero mode: activated${R}`),
   ],
 ]
 
@@ -524,7 +523,7 @@ function buildPanel(cfg: WatchConfig, st: AppState): string {
   }
 
   lines.push('')
-  lines.push(`  ${D}Ctrl+C sair  |  Ctrl+O ${st.showBattle ? 'ocultar' : 'mostrar'} batalha${R}`)
+  lines.push(`  ${D}Ctrl+C sair  |  Ctrl+O ${st.showBattle ? 'ocultar' : 'mostrar'} animacao${R}`)
   return lines.join('\n') + '\n'
 }
 
@@ -649,7 +648,7 @@ async function askConfig(all: ProjectInfo[]): Promise<WatchConfig> {
   })
 
   const showBattle = await confirm({
-    message: 'Mostrar batalha Claude vs Cursor no painel?',
+    message: 'Mostrar animacao "Claude resolve incidente" no painel?',
     default: true,
   })
 

--- a/watch-cli.ts
+++ b/watch-cli.ts
@@ -1,0 +1,580 @@
+#!/usr/bin/env bun
+/**
+ * Claude Stats — Watch CLI
+ *
+ * TUI interativa para monitorar métricas Claude em tempo real.
+ * Selecione projetos e visualize dados agregados no terminal.
+ *
+ * Usage:
+ *   bun run watch:cli
+ *
+ * Variáveis de ambiente:
+ *   CLAUDE_STATS_WATCH_INTERVAL  — Intervalo de polling em segundos (padrão: 30, mín: 5)
+ */
+
+import { readdir, readFile } from 'fs/promises'
+import { join } from 'path'
+import chokidar from 'chokidar'
+import { checkbox, select } from '@inquirer/prompts'
+import { calcCost } from './src/lib/types'
+import type { ModelUsage } from './src/lib/types'
+
+// ── Configuração ───────────────────────────────────────────────────────────
+
+const HOME_DIR = process.env.HOME ?? process.env.USERPROFILE ?? ''
+const CLAUDE_DIR = join(HOME_DIR, '.claude')
+const SESSION_META_DIR = join(CLAUDE_DIR, 'usage-data', 'session-meta')
+const STATS_CACHE_FILE = join(CLAUDE_DIR, 'stats-cache.json')
+
+const MIN_INTERVAL_SEC = 5
+const rawInterval = parseInt(process.env.CLAUDE_STATS_WATCH_INTERVAL ?? '30', 10)
+const WATCH_INTERVAL_SEC = !Number.isFinite(rawInterval) || rawInterval < MIN_INTERVAL_SEC ? 30 : rawInterval
+
+// ── ANSI helpers ───────────────────────────────────────────────────────────
+
+const ESC = '\x1b'
+const RESET = `${ESC}[0m`
+const BOLD = `${ESC}[1m`
+const DIM = `${ESC}[2m`
+const CYAN = `${ESC}[36m`
+const GREEN = `${ESC}[32m`
+const YELLOW = `${ESC}[33m`
+const WHITE = `${ESC}[37m`
+const BRIGHT_CYAN = `${ESC}[96m`
+
+function clearScreen() {
+  process.stdout.write(`${ESC}[2J${ESC}[H`)
+}
+function hideCursor() {
+  process.stdout.write(`${ESC}[?25l`)
+}
+function showCursor() {
+  process.stdout.write(`${ESC}[?25h`)
+}
+
+// ── Tipos ──────────────────────────────────────────────────────────────────
+
+type ViewMode = 'separado' | 'junto' | 'ambos'
+
+interface ProjectInfo {
+  name: string
+  path: string
+}
+
+interface CliSnapshot {
+  messages: number
+  sessions: number
+  inputTokens: number
+  outputTokens: number
+  costUsd: number
+  streak: number
+  gitCommits: number
+  gitPushes: number
+  linesAdded: number
+  linesRemoved: number
+}
+
+interface StatsCache {
+  dailyActivity?: Array<{ date: string; messageCount: number; sessionCount: number }>
+  modelUsage?: Record<string, ModelUsage>
+}
+
+interface SessionMetaLight {
+  session_id: string
+  project_path: string
+  input_tokens: number
+  output_tokens: number
+  user_message_count: number
+  assistant_message_count: number
+  git_commits: number
+  git_pushes: number
+  lines_added: number
+  lines_removed: number
+  start_time: string
+}
+
+interface WatchConfig {
+  selectedProjects: ProjectInfo[]  // empty = todos
+  allProjects: ProjectInfo[]
+  viewMode: ViewMode
+  intervalSec: number
+}
+
+// ── I/O helpers ────────────────────────────────────────────────────────────
+
+async function safeReadJson<T>(filePath: string): Promise<T | null> {
+  try {
+    return JSON.parse(await readFile(filePath, 'utf-8')) as T
+  } catch {
+    return null
+  }
+}
+
+async function safeReadDir(dirPath: string): Promise<string[]> {
+  try {
+    return await readdir(dirPath)
+  } catch {
+    return []
+  }
+}
+
+// ── Descoberta de projetos ─────────────────────────────────────────────────
+// Lê os project_path únicos dos arquivos session-meta (caminhos canônicos reais).
+
+async function discoverProjects(): Promise<ProjectInfo[]> {
+  const metaFiles = (await safeReadDir(SESSION_META_DIR)).filter(f => f.endsWith('.json'))
+
+  const projectPaths = new Set<string>()
+
+  // Lê em lotes para não abrir muitos file descriptors de uma vez
+  const BATCH = 30
+  for (let i = 0; i < metaFiles.length; i += BATCH) {
+    const batch = metaFiles.slice(i, i + BATCH)
+    const results = await Promise.all(
+      batch.map(f => safeReadJson<{ project_path?: string }>(join(SESSION_META_DIR, f)))
+    )
+    for (const s of results) {
+      if (s?.project_path) projectPaths.add(s.project_path)
+    }
+  }
+
+  return Array.from(projectPaths)
+    .sort()
+    .map(path => ({
+      path,
+      name: path.split('/').filter(Boolean).pop() ?? path,
+    }))
+}
+
+// ── Cálculo de snapshot ────────────────────────────────────────────────────
+
+async function buildCliSnapshot(projectPaths?: string[]): Promise<CliSnapshot> {
+  const isFiltered = projectPaths !== undefined && projectPaths.length > 0
+  const metaFiles = (await safeReadDir(SESSION_META_DIR)).filter(f => f.endsWith('.json'))
+  const sessions: SessionMetaLight[] = []
+
+  const BATCH = 30
+  for (let i = 0; i < metaFiles.length; i += BATCH) {
+    const batch = metaFiles.slice(i, i + BATCH)
+    const results = await Promise.all(
+      batch.map(f => safeReadJson<SessionMetaLight>(join(SESSION_META_DIR, f)))
+    )
+    for (const s of results) {
+      if (s) sessions.push(s)
+    }
+  }
+
+  const filtered = isFiltered
+    ? sessions.filter(s => projectPaths!.includes(s.project_path))
+    : sessions
+
+  let inputTokens = 0
+  let outputTokens = 0
+  let gitCommits = 0
+  let gitPushes = 0
+  let linesAdded = 0
+  let linesRemoved = 0
+  let messages = 0
+  const activeDates = new Set<string>()
+  const sessionIds = new Set<string>()
+
+  for (const s of filtered) {
+    inputTokens += s.input_tokens ?? 0
+    outputTokens += s.output_tokens ?? 0
+    gitCommits += s.git_commits ?? 0
+    gitPushes += s.git_pushes ?? 0
+    linesAdded += s.lines_added ?? 0
+    linesRemoved += s.lines_removed ?? 0
+    messages += (s.user_message_count ?? 0) + (s.assistant_message_count ?? 0)
+    if (s.session_id) sessionIds.add(s.session_id)
+    if (s.start_time) activeDates.add(s.start_time.slice(0, 10))
+  }
+
+  // Custo: usa stats-cache para global (preciso); aproximação proporcional para filtros
+  let costUsd = 0
+  const cache = await safeReadJson<StatsCache>(STATS_CACHE_FILE)
+
+  if (!isFiltered) {
+    if (cache?.modelUsage) {
+      for (const [modelId, u] of Object.entries(cache.modelUsage)) {
+        costUsd += calcCost(u, modelId)
+      }
+    }
+  } else {
+    // Taxa combinada global → aplica ao volume de tokens do subconjunto
+    let globalInput = 0
+    let globalOutput = 0
+    let globalCost = 0
+    if (cache?.modelUsage) {
+      for (const [modelId, u] of Object.entries(cache.modelUsage)) {
+        globalInput += u.inputTokens + (u.cacheReadInputTokens ?? 0) + (u.cacheCreationInputTokens ?? 0)
+        globalOutput += u.outputTokens
+        globalCost += calcCost(u, modelId)
+      }
+    }
+    const totalTokens = globalInput + globalOutput
+    if (totalTokens > 0) {
+      costUsd = ((inputTokens + outputTokens) / totalTokens) * globalCost
+    }
+  }
+
+  // Streak: conta dias consecutivos para trás a partir de hoje
+  let streak = 0
+  for (let i = 0; i <= 365; i++) {
+    const d = new Date()
+    d.setDate(d.getDate() - i)
+    const dateStr = d.toISOString().slice(0, 10)
+    if (activeDates.has(dateStr)) {
+      streak++
+    } else if (i > 0) {
+      break
+    }
+  }
+
+  return {
+    messages,
+    sessions: sessionIds.size,
+    inputTokens,
+    outputTokens,
+    costUsd,
+    streak,
+    gitCommits,
+    gitPushes,
+    linesAdded,
+    linesRemoved,
+  }
+}
+
+// ── Formatação ─────────────────────────────────────────────────────────────
+
+function fmtNum(n: number): string {
+  if (n >= 1_000_000) return (n / 1_000_000).toFixed(1) + 'M'
+  if (n >= 1_000) return (n / 1_000).toFixed(1) + 'k'
+  return n.toString()
+}
+
+function fmtCost(usd: number): string {
+  if (usd >= 1000) return `$${(usd / 1000).toFixed(1)}k`
+  if (usd >= 1) return `$${usd.toFixed(2)}`
+  return `$${usd.toFixed(3)}`
+}
+
+/** Alinha string considerando que ela pode ter escape codes ANSI. */
+function col(s: string, width: number, align: 'l' | 'r' = 'r'): string {
+  const visLen = s.replace(/\x1b\[[0-9;]*m/g, '').length
+  const pad = ' '.repeat(Math.max(0, width - visLen))
+  return align === 'l' ? s + pad : pad + s
+}
+
+function hr(width: number, char = '─'): string {
+  return `${DIM}${char.repeat(width)}${RESET}`
+}
+
+// Colunas da tabela de métricas (label, largura, alinhamento)
+const METRIC_COLS: Array<{ label: string; width: number }> = [
+  { label: 'Msgs',    width: 8  },
+  { label: 'Sessões', width: 8  },
+  { label: 'Tok↑',   width: 9  },
+  { label: 'Tok↓',   width: 9  },
+  { label: 'Custo',  width: 10 },
+  { label: 'Streak', width: 7  },
+  { label: 'Commits',width: 8  },
+  { label: '+Linhas',width: 9  },
+  { label: '-Linhas',width: 9  },
+]
+
+const PROJECT_COL_WIDTH = 24
+
+function renderTableHeader(includeProjectCol: boolean): string {
+  const cells = METRIC_COLS.map(c => col(`${DIM}${c.label}${RESET}`, c.width))
+  if (includeProjectCol) {
+    return col(`${DIM}Projeto${RESET}`, PROJECT_COL_WIDTH, 'l') + '  ' + cells.join('  ')
+  }
+  return cells.join('  ')
+}
+
+function renderSnapshotRow(snap: CliSnapshot, projectName?: string): string {
+  const values = [
+    fmtNum(snap.messages),
+    fmtNum(snap.sessions),
+    fmtNum(snap.inputTokens),
+    fmtNum(snap.outputTokens),
+    fmtCost(snap.costUsd),
+    `${snap.streak}d`,
+    fmtNum(snap.gitCommits),
+    `+${fmtNum(snap.linesAdded)}`,
+    `-${fmtNum(snap.linesRemoved)}`,
+  ]
+  const cells = values.map((v, i) => col(v, METRIC_COLS[i].width))
+
+  if (projectName !== undefined) {
+    const name = projectName.length > PROJECT_COL_WIDTH - 1
+      ? projectName.slice(0, PROJECT_COL_WIDTH - 2) + '…'
+      : projectName
+    return col(`${CYAN}${name}${RESET}`, PROJECT_COL_WIDTH, 'l') + '  ' + cells.join('  ')
+  }
+  return cells.join('  ')
+}
+
+// ── Renderização do painel ─────────────────────────────────────────────────
+
+function buildHeaderLines(config: WatchConfig, updatedAt: Date): string[] {
+  const width = process.stdout.columns || 100
+  const now = updatedAt.toLocaleTimeString('pt-BR')
+  const refresh = `⟳ ${config.intervalSec}s`
+  const rightSide = `${DIM}${now}  ${refresh}${RESET}`
+  const leftSide = `${BOLD}${BRIGHT_CYAN}Claude Stats — Watch Mode${RESET}`
+
+  const visLeft = 'Claude Stats — Watch Mode'
+  const visRight = `${now}  ${refresh}`
+  const gap = Math.max(1, width - visLeft.length - visRight.length)
+
+  const lines: string[] = []
+  lines.push(leftSide + ' '.repeat(gap) + rightSide)
+  lines.push(hr(width))
+  lines.push('')
+
+  // Info block
+  const modeDesc =
+    config.viewMode === 'junto'    ? 'unificado'
+    : config.viewMode === 'separado' ? 'separado'
+    : 'ambos'
+
+  lines.push(`  ${DIM}Home:${RESET}       ${WHITE}${HOME_DIR}${RESET}`)
+  lines.push(`  ${DIM}Claude dir:${RESET} ${WHITE}${CLAUDE_DIR}${RESET}`)
+
+  if (config.selectedProjects.length === 0) {
+    lines.push(`  ${DIM}Projetos:${RESET}   ${YELLOW}todos (${config.allProjects.length})${RESET}`)
+  } else {
+    const names = config.selectedProjects.map(p => p.name).join(', ')
+    lines.push(`  ${DIM}Projetos:${RESET}   ${CYAN}${names}${RESET}`)
+  }
+
+  if (config.selectedProjects.length > 1) {
+    lines.push(`  ${DIM}Modo:${RESET}       ${GREEN}${modeDesc}${RESET}`)
+  }
+
+  lines.push(`  ${DIM}Interval:${RESET}   ${WHITE}${config.intervalSec}s${RESET}`)
+  lines.push(`  ${DIM}OTLP:${RESET}       ${DIM}(disabled)${RESET}`)
+  lines.push('')
+
+  return lines
+}
+
+async function renderPanel(config: WatchConfig): Promise<void> {
+  const updatedAt = new Date()
+  const width = process.stdout.columns || 100
+  const lines: string[] = []
+
+  lines.push(...buildHeaderLines(config, updatedAt))
+
+  const selectedPaths =
+    config.selectedProjects.length > 0
+      ? config.selectedProjects.map(p => p.path)
+      : undefined
+
+  // Modo 'todos' ou único projeto selecionado → sem perguntar view mode
+  const singleView = config.selectedProjects.length <= 1
+
+  if (singleView || config.viewMode === 'junto') {
+    // ── Linha unificada ───────────────────────────────────────────────────
+    const snap = await buildCliSnapshot(selectedPaths)
+    lines.push(hr(width))
+    lines.push(`  ${BOLD}${CYAN}UNIFICADO${RESET}`)
+    lines.push('')
+    lines.push('  ' + renderTableHeader(false))
+    lines.push(`  ${GREEN}${BOLD}${renderSnapshotRow(snap)}${RESET}`)
+    lines.push(hr(width))
+  } else if (config.viewMode === 'separado') {
+    // ── Uma linha por projeto ─────────────────────────────────────────────
+    lines.push(hr(width))
+    lines.push(`  ${BOLD}${CYAN}POR PROJETO${RESET}`)
+    lines.push('')
+    lines.push('  ' + renderTableHeader(true))
+
+    for (const proj of config.selectedProjects) {
+      const snap = await buildCliSnapshot([proj.path])
+      lines.push('  ' + renderSnapshotRow(snap, proj.name))
+    }
+    lines.push(hr(width))
+  } else {
+    // ── Ambos: total no topo + um por projeto ──────────────────────────────
+    const allSnap = await buildCliSnapshot(selectedPaths)
+    lines.push(hr(width))
+    lines.push(`  ${BOLD}${CYAN}UNIFICADO${RESET}`)
+    lines.push('')
+    lines.push('  ' + renderTableHeader(false))
+    lines.push(`  ${GREEN}${BOLD}${renderSnapshotRow(allSnap)}${RESET}`)
+    lines.push('')
+    lines.push(`  ${BOLD}${CYAN}POR PROJETO${RESET}`)
+    lines.push('')
+    lines.push('  ' + renderTableHeader(true))
+
+    for (const proj of config.selectedProjects) {
+      const snap = await buildCliSnapshot([proj.path])
+      lines.push('  ' + renderSnapshotRow(snap, proj.name))
+    }
+    lines.push(hr(width))
+  }
+
+  lines.push('')
+  lines.push(`  ${DIM}Pressione Ctrl+C para sair${RESET}`)
+
+  clearScreen()
+  process.stdout.write(lines.join('\n') + '\n')
+}
+
+// ── Seleção interativa ─────────────────────────────────────────────────────
+
+async function promptProjects(projects: ProjectInfo[]): Promise<ProjectInfo[]> {
+  const ALL_VALUE = '__all__'
+
+  const choices = [
+    {
+      name: `${BOLD}(todos os projetos)${RESET}`,
+      value: ALL_VALUE,
+      short: 'todos',
+    },
+    ...projects.map(p => ({
+      name: `${p.name}  ${DIM}${p.path}${RESET}`,
+      value: p.path,
+      short: p.name,
+    })),
+  ]
+
+  const selected = await checkbox({
+    message: 'Selecione os projetos para monitorar (⎵ seleciona, ↑↓ navega, Enter confirma):',
+    choices,
+    pageSize: Math.min(20, projects.length + 3),
+    loop: false,
+  })
+
+  if (selected.length === 0 || selected.includes(ALL_VALUE)) {
+    return []
+  }
+
+  return projects.filter(p => selected.includes(p.path))
+}
+
+async function promptViewMode(): Promise<ViewMode> {
+  return select<ViewMode>({
+    message: 'Como deseja visualizar os dados?',
+    choices: [
+      {
+        name: `${BOLD}Separado${RESET}  — uma linha por projeto`,
+        value: 'separado',
+        short: 'separado',
+      },
+      {
+        name: `${BOLD}Unificado${RESET} — total dos projetos selecionados`,
+        value: 'junto',
+        short: 'unificado',
+      },
+      {
+        name: `${BOLD}Ambos${RESET}     — total no topo + uma linha por projeto`,
+        value: 'ambos',
+        short: 'ambos',
+      },
+    ],
+  })
+}
+
+// ── Loop principal ─────────────────────────────────────────────────────────
+
+async function watchLoop(config: WatchConfig): Promise<void> {
+  hideCursor()
+
+  process.on('SIGINT', () => {
+    showCursor()
+    clearScreen()
+    process.exit(0)
+  })
+  process.on('SIGTERM', () => {
+    showCursor()
+    clearScreen()
+    process.exit(0)
+  })
+
+  let isRendering = false
+  let pendingRender = false
+
+  const render = async () => {
+    if (isRendering) {
+      pendingRender = true
+      return
+    }
+    isRendering = true
+    try {
+      await renderPanel(config)
+    } catch (err) {
+      // Não falha silenciosamente em erros de renderização
+      clearScreen()
+      console.error(`${RESET}Erro ao renderizar painel:`, err)
+    } finally {
+      isRendering = false
+      if (pendingRender) {
+        pendingRender = false
+        render()
+      }
+    }
+  }
+
+  // Renderização inicial
+  await render()
+
+  // Debounce para eventos de filesystem
+  let debounceTimer: ReturnType<typeof setTimeout> | null = null
+  const debouncedRender = () => {
+    if (debounceTimer) clearTimeout(debounceTimer)
+    debounceTimer = setTimeout(render, 1500)
+  }
+
+  chokidar
+    .watch([SESSION_META_DIR, STATS_CACHE_FILE], {
+      persistent: true,
+      ignoreInitial: true,
+    })
+    .on('all', debouncedRender)
+
+  // Poll periódico como fallback
+  setInterval(render, WATCH_INTERVAL_SEC * 1000)
+}
+
+// ── Entry point ────────────────────────────────────────────────────────────
+
+async function main() {
+  console.log(`${CYAN}${BOLD}Claude Stats — Watch CLI${RESET}\n`)
+  console.log(`${DIM}Descobrindo projetos em ${SESSION_META_DIR}...${RESET}`)
+
+  const projects = await discoverProjects()
+
+  if (projects.length === 0) {
+    console.error(`\nNenhum projeto encontrado. Verifique se o diretório existe:\n  ${SESSION_META_DIR}`)
+    process.exit(1)
+  }
+
+  console.log(`${GREEN}${projects.length} projetos encontrados.${RESET}\n`)
+
+  // Seleção interativa
+  const selectedProjects = await promptProjects(projects)
+
+  let viewMode: ViewMode = 'junto'
+  if (selectedProjects.length > 1) {
+    viewMode = await promptViewMode()
+  }
+
+  const config: WatchConfig = {
+    selectedProjects,
+    allProjects: projects,
+    viewMode,
+    intervalSec: WATCH_INTERVAL_SEC,
+  }
+
+  await watchLoop(config)
+}
+
+main().catch(err => {
+  showCursor()
+  console.error('Erro fatal:', err)
+  process.exit(1)
+})

--- a/watch-cli.ts
+++ b/watch-cli.ts
@@ -10,7 +10,6 @@
  *   Ctrl+C  — sair
  */
 
-import { readFile, readdir } from 'fs/promises'
 import { join } from 'path'
 import chokidar from 'chokidar'
 import {
@@ -24,13 +23,9 @@ import type { ModelUsage, SessionMeta } from './src/lib/types'
 
 // ── Paths ──────────────────────────────────────────────────────────────────
 
-const HOME_DIR         = process.env.HOME ?? process.env.USERPROFILE ?? ''
-const CLAUDE_DIR       = join(HOME_DIR, '.claude')
-const PROJECTS_DIR     = join(CLAUDE_DIR, 'projects')
-const SESSION_META_DIR = join(CLAUDE_DIR, 'usage-data', 'session-meta')
-const STATS_CACHE_FILE = join(CLAUDE_DIR, 'stats-cache.json')
-const API_BASE         = 'http://localhost:3001'
-const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+const HOME_DIR   = process.env.HOME ?? process.env.USERPROFILE ?? ''
+const CLAUDE_DIR = join(HOME_DIR, '.claude')
+const API_BASE   = 'http://localhost:3001'
 
 // ── ANSI ───────────────────────────────────────────────────────────────────
 
@@ -96,16 +91,7 @@ interface AppState {
   dataSource:  DataSrc
 }
 
-// ── I/O helpers ────────────────────────────────────────────────────────────
-
-async function safeJson<T>(p: string): Promise<T | null> {
-  try { return JSON.parse(await readFile(p, 'utf-8')) as T } catch { return null }
-}
-async function safeDir(d: string): Promise<string[]> {
-  try { return await readdir(d) } catch { return [] }
-}
-
-// ── Fonte 1: API (dados idênticos ao frontend) ─────────────────────────────
+// ── API ────────────────────────────────────────────────────────────────────
 
 interface ApiProject { path: string; name: string }
 interface ApiResponse {
@@ -127,124 +113,20 @@ async function fetchApi(timeout = 3000): Promise<ApiResponse | null> {
   }
 }
 
-/** Probe leve — apenas verifica se o servidor está aceitando conexões. */
+/** Probe leve — verifica se o servidor está aceitando conexões.
+ *  Aceita qualquer resposta HTTP (incluindo 404 de versões antigas sem /api/health). */
 async function probeApi(timeout = 1000): Promise<boolean> {
   try {
     const ac  = new AbortController()
     const tid = setTimeout(() => ac.abort(), timeout)
     const res = await fetch(`${API_BASE}/api/health`, { signal: ac.signal })
     clearTimeout(tid)
-    return res.ok
+    return res.status < 500 // 200 (novo) ou 404 (versao sem endpoint) = servidor on
   } catch {
     return false
   }
 }
 
-// ── Fonte 2: Leitura direta de arquivos (fallback) ─────────────────────────
-
-/** Lê primeiras linhas de um JSONL até encontrar campo `cwd`. */
-async function readJsonlCwd(filePath: string): Promise<string | null> {
-  try {
-    const text  = await readFile(filePath, 'utf-8')
-    const lines = text.split('\n').filter(Boolean).slice(0, 30)
-    for (const line of lines) {
-      try {
-        const obj = JSON.parse(line)
-        if (typeof obj?.cwd === 'string' && obj.cwd) return obj.cwd
-      } catch { /* skip */ }
-    }
-  } catch { /* skip */ }
-  return null
-}
-
-function decodeDir(name: string): string {
-  return name.startsWith('-') ? name.replace(/-/g, '/') : '/' + name.replace(/-/g, '/')
-}
-
-/**
- * Descobre projetos da mesma forma que server.ts/scanProjects:
- * - Carrega metaMap (sessionId → project_path)
- * - Para cada project dir, vota no project_path usando sessões com meta
- * - Se sem votos, lê CWD do primeiro arquivo JSONL disponível
- * - Fallback final: path decodificado do nome do dir
- */
-async function discoverProjectsFromFiles(): Promise<{ projects: ProjectInfo[]; metaMap: Map<string, string> }> {
-  // 1. session-meta → metaMap
-  const metaFiles = (await safeDir(SESSION_META_DIR)).filter(f => f.endsWith('.json'))
-  const metaMap   = new Map<string, string>()
-  const BATCH     = 40
-
-  for (let i = 0; i < metaFiles.length; i += BATCH) {
-    const res = await Promise.all(
-      metaFiles.slice(i, i + BATCH).map(f =>
-        safeJson<{ session_id?: string; project_path?: string }>(join(SESSION_META_DIR, f))
-      )
-    )
-    for (const s of res) if (s?.session_id && s.project_path) metaMap.set(s.session_id, s.project_path)
-  }
-
-  // 2. Varrer project dirs
-  const dirs  = await safeDir(PROJECTS_DIR)
-  const seen  = new Map<string, ProjectInfo>()
-
-  await Promise.all(dirs.map(async dir => {
-    if (dir.startsWith('.')) return
-    const fallback = decodeDir(dir)
-    const entries  = await safeDir(join(PROJECTS_DIR, dir))
-
-    const votes: Record<string, number> = {}
-    let firstJsonl: string | null = null
-
-    for (const entry of entries) {
-      const sid = entry.endsWith('.jsonl') ? entry.slice(0, -6)
-        : UUID_RE.test(entry) ? entry : null
-      if (!sid) continue
-
-      const p = metaMap.get(sid)
-      if (p) {
-        votes[p] = (votes[p] ?? 0) + 1
-      } else if (!firstJsonl && entry.endsWith('.jsonl')) {
-        firstJsonl = join(PROJECTS_DIR, dir, entry)
-      }
-    }
-
-    // Canonical path: majority-vote → JSONL cwd → fallback decoded
-    let canonical: string
-    if (Object.keys(votes).length > 0) {
-      canonical = Object.entries(votes).sort((a, b) => b[1] - a[1])[0][0]
-    } else if (firstJsonl) {
-      canonical = (await readJsonlCwd(firstJsonl)) ?? fallback
-    } else {
-      canonical = fallback
-    }
-
-    if (!seen.has(canonical)) {
-      seen.set(canonical, {
-        path: canonical,
-        name: canonical.split('/').filter(Boolean).pop() ?? dir,
-      })
-    }
-  }))
-
-  return {
-    projects: Array.from(seen.values()).sort((a, b) => a.path.localeCompare(b.path)),
-    metaMap,
-  }
-}
-
-async function loadSessionsFromFiles(metaMap: Map<string, string>): Promise<SessionMeta[]> {
-  const files = (await safeDir(SESSION_META_DIR)).filter(f => f.endsWith('.json'))
-  const out: SessionMeta[] = []
-  const BATCH = 40
-
-  for (let i = 0; i < files.length; i += BATCH) {
-    const res = await Promise.all(
-      files.slice(i, i + BATCH).map(f => safeJson<SessionMeta>(join(SESSION_META_DIR, f)))
-    )
-    for (const s of res) if (s?.session_id) out.push(s)
-  }
-  return out
-}
 
 // ── Cálculo de snapshot — espelha useDerivedStats ─────────────────────────
 
@@ -308,40 +190,74 @@ function computeSnapshot(
     costUsd: cost, streak, gitCommits: gC, linesAdded: lA, linesRemoved: lR }
 }
 
-// ── Reload de dados ────────────────────────────────────────────────────────
+// ── Reload de dados (apenas via API) ──────────────────────────────────────
 
 async function reloadData(config: WatchConfig): Promise<{
   snapshots: Map<string, CliSnapshot>
   dataSource: DataSrc
-  allProjects?: ProjectInfo[]
 }> {
-  const paths   = config.selectedProjects.length > 0 ? config.selectedProjects.map(p => p.path) : undefined
+  const paths     = config.selectedProjects.length > 0 ? config.selectedProjects.map(p => p.path) : undefined
   const snapshots = new Map<string, CliSnapshot>()
 
-  // Tenta API primeiro (dados idênticos ao frontend)
-  const apiData = await fetchApi()
+  const apiData = await fetchApi(30_000)
+  if (!apiData) throw new Error('API indisponivel')
 
-  if (apiData) {
-    const { sessions, statsCache } = apiData
-    snapshots.set('', computeSnapshot(sessions, statsCache, paths))
-    for (const p of config.selectedProjects) {
-      snapshots.set(p.path, computeSnapshot(sessions, statsCache, [p.path]))
-    }
-    return { snapshots, dataSource: 'api' }
-  }
-
-  // Fallback: leitura direta
-  const { metaMap } = await discoverProjectsFromFiles()
-  const [sessions, statsCache] = await Promise.all([
-    loadSessionsFromFiles(metaMap),
-    safeJson<StatsCache>(STATS_CACHE_FILE).then(v => v ?? {}),
-  ])
-
+  const { sessions, statsCache } = apiData
   snapshots.set('', computeSnapshot(sessions, statsCache, paths))
   for (const p of config.selectedProjects) {
     snapshots.set(p.path, computeSnapshot(sessions, statsCache, [p.path]))
   }
-  return { snapshots, dataSource: 'files' }
+  return { snapshots, dataSource: 'api' }
+}
+
+// ── Loader: Claude caçando tokens ─────────────────────────────────────────
+
+async function withLoader<T>(msg: string, fn: () => Promise<T>): Promise<T> {
+  const H   = 5
+  const W   = Math.min(process.stdout.columns || 80, 100)
+  const fld = W - 4
+  // Tokens fogem para a esquerda (offset cresce = conteudo desliza para esquerda)
+  const PAT = '  $   $$  $    $$$   $  $$    $   $  $$$  '
+  // Frames de corrida: [cabeca, torso, pernas]
+  const RF: [string, string, string][] = [
+    ['\\o/', ' |  ', '/ \\ '],
+    [' o/', '/|\\ ', '/ \\ '],
+    [' o ', ' |/ ', '\\ / '],
+    ['\\o ', ' |  ', '\\ / '],
+  ]
+  const cp = Math.floor(fld * 0.35)
+
+  let frame = 0
+
+  const draw = () => {
+    const off   = (frame * 2) % PAT.length
+    const river = (PAT + PAT + PAT).slice(off, off + fld)
+    // apaga zona do Claude para nao sobrepor tokens
+    const rArr = river.split('')
+    for (let i = Math.max(0, cp - 1); i < Math.min(rArr.length, cp + 5); i++) rArr[i] = ' '
+    const rLine = rArr.join('')
+    const rf = RF[frame % RF.length]!
+
+    out(`\x1b[${H}A`)
+    out(`  ${YL}${rLine}${R}\n`)
+    out(`  ${' '.repeat(cp)}${YL}${rf[0]}${R}${GR}~~>${R}\n`)
+    out(`  ${' '.repeat(cp)}${D}${rf[1]}${R}\n`)
+    out(`  ${' '.repeat(cp)}${YL}${rf[2]}${R}\n`)
+    out(`  ${D}${msg}${R}\n`)
+  }
+
+  out('\n'.repeat(H))
+  draw()
+  const timer = setInterval(() => { frame++; draw() }, 120)
+
+  try {
+    return await fn()
+  } finally {
+    clearInterval(timer)
+    out(`\x1b[${H}A`)
+    for (let i = 0; i < H; i++) out('\x1b[2K\n')
+    out(`\x1b[${H}A`)
+  }
 }
 
 // ── Animação: Claude resolve um incidente de produção ────────────────────
@@ -404,7 +320,7 @@ const FRAMES: Array<[string, string, string, string]> = [
 ]
 
 function renderBattle(frame: number): string[] {
-  const f = FRAMES[frame % FRAMES.length]
+  const f = FRAMES[frame % FRAMES.length]!
   const sep = sepLine(FW + 4)
   return [
     sep,
@@ -442,7 +358,7 @@ const tRow = (s: CliSnapshot, name?: string) => {
     fmtC(s.costUsd), `${s.streak}d`, fmtN(s.gitCommits),
     `+${fmtN(s.linesAdded)}`, `-${fmtN(s.linesRemoved)}`,
   ]
-  const c = v.map((x, i) => padStr(x, COLS[i].w))
+  const c = v.map((x, i) => padStr(x, COLS[i]!.w))
   if (name !== undefined) {
     const n = name.length > PW-1 ? name.slice(0, PW-2)+'…' : name
     return padStr(`${CY}${n}${R}`, PW, 'l')+'  '+c.join('  ')
@@ -532,7 +448,7 @@ function buildPanel(cfg: WatchConfig, st: AppState): string {
 async function watchLoop(cfg: WatchConfig): Promise<void> {
   const st: AppState = {
     snapshots: new Map(), lastUpdated: new Date(),
-    animFrame: 0, showBattle: cfg.showBattle, isLoading: true, dataSource: 'files',
+    animFrame: 0, showBattle: cfg.showBattle, isLoading: true, dataSource: 'api' as DataSrc,
   }
 
   const cleanup = () => { out(SHOW + ALT_OFF); if (spawnedServer) { spawnedServer.kill(); spawnedServer = null } process.exit(0) }
@@ -573,8 +489,10 @@ async function watchLoop(cfg: WatchConfig): Promise<void> {
 
   // Chokidar para atualizações imediatas
   let dbt: ReturnType<typeof setTimeout> | null = null
+  const sessionMetaDir = join(HOME_DIR, '.claude', 'usage-data', 'session-meta')
+  const statsCacheFile = join(HOME_DIR, '.claude', 'stats-cache.json')
   chokidar
-    .watch([SESSION_META_DIR, STATS_CACHE_FILE], { persistent: true, ignoreInitial: true })
+    .watch([sessionMetaDir, statsCacheFile], { persistent: true, ignoreInitial: true })
     .on('all', () => { if (dbt) clearTimeout(dbt); dbt = setTimeout(refresh, 1500) })
 }
 
@@ -680,9 +598,9 @@ async function askConfig(all: ProjectInfo[]): Promise<WatchConfig> {
 
 let spawnedServer: ReturnType<typeof Bun.spawn> | null = null
 
-async function ensureApiRunning(): Promise<boolean> {
+async function ensureApiRunning(): Promise<void> {
   // Já está rodando?
-  if (await probeApi(2000)) return false // já estava rodando, não precisamos subir
+  if (await probeApi(2000)) return
 
   // Sobe server.ts em background
   const serverPath = join(import.meta.dir, 'server.ts')
@@ -694,20 +612,20 @@ async function ensureApiRunning(): Promise<boolean> {
     env: { ...process.env },
   })
 
-  // Aguarda até 10s (polling a cada 300ms) usando probe leve
-  for (let i = 0; i < 33; i++) {
-    await new Promise(r => setTimeout(r, 300))
-    const ok = await probeApi(1000)
-    if (ok) {
-      console.log(`${GR}Servidor iniciado (pid ${spawnedServer.pid}).${R}`)
-      return true
+  const ok = await withLoader('Aguardando servidor API iniciar...', async () => {
+    for (let i = 0; i < 40; i++) {
+      await new Promise(r => setTimeout(r, 300))
+      if (await probeApi(800)) return true
     }
-  }
+    return false
+  })
 
-  console.log(`${RD}Nao foi possivel iniciar o servidor. Usando leitura direta de arquivos.${R}`)
-  spawnedServer?.kill()
-  spawnedServer = null
-  return false
+  if (!ok) {
+    if (spawnedServer) { spawnedServer.kill(); spawnedServer = null }
+    console.error(`\n${RD}Nao foi possivel iniciar o servidor API (porta 3001).${R}`)
+    process.exit(1)
+  }
+  console.log(`${GR}Servidor iniciado (pid ${spawnedServer?.pid}).${R}`)
 }
 
 function registerServerCleanup() {
@@ -725,22 +643,18 @@ async function main() {
   console.log(`\n${B}${BC}Claude Stats - Watch CLI${R}\n`)
 
   registerServerCleanup()
-
   await ensureApiRunning()
 
-  // Agora tenta a API (pode estar recém-subida ou já existente)
-  const apiData = await fetchApi(2000)
-  let allProjects: ProjectInfo[]
+  const apiData = await withLoader('Carregando dados da API...', () => fetchApi(60_000))
 
-  if (apiData) {
-    console.log(`${GR}Usando dados da API em ${API_BASE}${R}\n`)
-    allProjects = apiData.projects.map(p => ({ name: p.name, path: p.path }))
-      .sort((a, b) => a.path.localeCompare(b.path))
-  } else {
-    console.log(`${YL}Usando leitura direta de arquivos (fallback).${R}\n`)
-    const { projects } = await discoverProjectsFromFiles()
-    allProjects = projects
+  if (!apiData) {
+    console.error(`\n${RD}Falha ao carregar dados da API. O servidor respondeu mas retornou erro.${R}`)
+    process.exit(1)
   }
+
+  const allProjects = apiData.projects
+    .map(p => ({ name: p.name, path: p.path }))
+    .sort((a, b) => a.path.localeCompare(b.path))
 
   if (allProjects.length === 0) {
     console.error('Nenhum projeto encontrado.')

--- a/watch-cli.ts
+++ b/watch-cli.ts
@@ -2,75 +2,70 @@
 /**
  * Claude Stats — Watch CLI
  *
- * TUI interativa que monitora métricas Claude em tempo real.
- * Usa alternate screen buffer (como vim/less) — sai limpo ao encerrar.
+ * Usa os mesmos dados que o frontend (via /api/data quando o servidor está rodando,
+ * ou leitura direta de arquivos como fallback).
  *
- * Controles durante o watch:
- *   Ctrl+O  — ocultar/mostrar batalha
+ * Controles:
+ *   Ctrl+O  — batalha on/off
  *   Ctrl+C  — sair
  */
 
-import { readdir, readFile } from 'fs/promises'
+import { readFile, readdir } from 'fs/promises'
 import { join } from 'path'
 import chokidar from 'chokidar'
 import {
-  createPrompt,
-  useState,
-  useMemo,
-  useKeypress,
-  usePagination,
-  isUpKey,
-  isDownKey,
-  isEnterKey,
-  isSpaceKey,
-  isBackspaceKey,
+  createPrompt, useState, useMemo, useKeypress, usePagination,
+  isUpKey, isDownKey, isEnterKey, isSpaceKey, isBackspaceKey,
   type KeypressEvent,
 } from '@inquirer/core'
 import { select, input, confirm } from '@inquirer/prompts'
 import { calcCost, getModelPrice } from './src/lib/types'
-import type { ModelUsage } from './src/lib/types'
+import type { ModelUsage, SessionMeta } from './src/lib/types'
 
-// ── Constantes ─────────────────────────────────────────────────────────────
+// ── Paths ──────────────────────────────────────────────────────────────────
 
 const HOME_DIR         = process.env.HOME ?? process.env.USERPROFILE ?? ''
 const CLAUDE_DIR       = join(HOME_DIR, '.claude')
 const PROJECTS_DIR     = join(CLAUDE_DIR, 'projects')
 const SESSION_META_DIR = join(CLAUDE_DIR, 'usage-data', 'session-meta')
 const STATS_CACHE_FILE = join(CLAUDE_DIR, 'stats-cache.json')
+const API_BASE         = 'http://localhost:3001'
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
 // ── ANSI ───────────────────────────────────────────────────────────────────
 
-const E     = '\x1b'
-const R     = `${E}[0m`      // reset
-const B     = `${E}[1m`      // bold
-const D     = `${E}[2m`      // dim
-const CY    = `${E}[36m`     // cyan
-const GR    = `${E}[32m`     // green
-const YL    = `${E}[33m`     // yellow
-const RD    = `${E}[31m`     // red
-const WH    = `${E}[37m`     // white
-const BCY   = `${E}[96m`     // bright cyan
+const E = '\x1b'
+const R  = `${E}[0m`
+const B  = `${E}[1m`
+const D  = `${E}[2m`
+const CY = `${E}[36m`
+const GR = `${E}[32m`
+const YL = `${E}[33m`
+const RD = `${E}[31m`
+const WH = `${E}[37m`
+const BC = `${E}[96m`
 
-// Terminal control
-const ALT_ON    = `${E}[?1049h`   // entra no alternate screen buffer
-const ALT_OFF   = `${E}[?1049l`   // sai do alternate screen buffer
-const CLEAR_SCR = `${E}[2J${E}[H` // limpa e vai pro topo
-const HIDE_CUR  = `${E}[?25l`
-const SHOW_CUR  = `${E}[?25h`
+const ALT_ON  = `${E}[?1049h`
+const ALT_OFF = `${E}[?1049l`
+const CLR     = `${E}[2J${E}[H`
+const HIDE    = `${E}[?25l`
+const SHOW    = `${E}[?25h`
 
-const write = (s: string) => process.stdout.write(s)
-const visLen = (s: string) => s.replace(/\x1b\[[0-9;]*m/g, '').length
-const pad = (s: string, w: number, align: 'l' | 'r' = 'r') => {
+const out     = (s: string) => process.stdout.write(s)
+const visLen  = (s: string) => s.replace(/\x1b\[[0-9;]*m/g, '').length
+const padStr  = (s: string, w: number, align: 'l'|'r' = 'r') => {
   const p = ' '.repeat(Math.max(0, w - visLen(s)))
   return align === 'l' ? s + p : p + s
 }
-const hr = (w: number, ch = '─') => `${D}${ch.repeat(w)}${R}`
+const sepLine = (w: number) => `${D}${'-'.repeat(w)}${R}`
 
 // ── Tipos ──────────────────────────────────────────────────────────────────
 
 type ViewMode = 'separado' | 'junto' | 'ambos'
+type DataSrc  = 'api' | 'files'
+
 interface ProjectInfo { name: string; path: string }
+
 interface WatchConfig {
   selectedProjects: ProjectInfo[]
   allProjects: ProjectInfo[]
@@ -79,93 +74,136 @@ interface WatchConfig {
   otlpEndpoint: string
   showBattle: boolean
 }
+
 interface CliSnapshot {
   messages: number; sessions: number
   inputTokens: number; outputTokens: number
   costUsd: number; streak: number
-  gitCommits: number; gitPushes: number
-  linesAdded: number; linesRemoved: number
+  gitCommits: number; linesAdded: number; linesRemoved: number
 }
+
 interface StatsCache {
   dailyActivity?: Array<{ date: string; messageCount: number; sessionCount: number }>
   modelUsage?: Record<string, ModelUsage>
 }
-interface SessionMetaMin {
-  session_id: string; project_path: string; start_time: string
-  user_message_count: number; assistant_message_count: number
-  git_commits: number; git_pushes: number
-  input_tokens: number; output_tokens: number
-  lines_added: number; lines_removed: number
-}
+
 interface AppState {
-  snapshots: Map<string, CliSnapshot>
+  snapshots:   Map<string, CliSnapshot>
   lastUpdated: Date
-  animFrame: number
-  showBattle: boolean
-  isLoading: boolean
+  animFrame:   number
+  showBattle:  boolean
+  isLoading:   boolean
+  dataSource:  DataSrc
 }
 
 // ── I/O helpers ────────────────────────────────────────────────────────────
 
-async function safeReadJson<T>(f: string): Promise<T | null> {
-  try { return JSON.parse(await readFile(f, 'utf-8')) as T } catch { return null }
+async function safeJson<T>(p: string): Promise<T | null> {
+  try { return JSON.parse(await readFile(p, 'utf-8')) as T } catch { return null }
 }
-async function safeReadDir(d: string): Promise<string[]> {
+async function safeDir(d: string): Promise<string[]> {
   try { return await readdir(d) } catch { return [] }
 }
 
-// ── Descoberta de projetos — mesma lógica do server.ts ─────────────────────
-// 1. Carrega session-meta → Map<sessionId, project_path>
-// 2. Para cada dir em ~/.claude/projects/, lista entries e vota no project_path
-//    canônico via majority-vote (igual ao scanProjects/scanProjectDir do server.ts)
-// 3. Sem votos → usa fallback decodificado do nome do dir
+// ── Fonte 1: API (dados idênticos ao frontend) ─────────────────────────────
 
-function decodeProjectDir(name: string): string {
-  // Claude codifica paths substituindo '/' por '-'; leading '-' = leading '/'
+interface ApiProject { path: string; name: string }
+interface ApiResponse {
+  statsCache: StatsCache
+  projects:   ApiProject[]
+  sessions:   SessionMeta[]
+}
+
+async function fetchApi(timeout = 3000): Promise<ApiResponse | null> {
+  try {
+    const ac  = new AbortController()
+    const tid = setTimeout(() => ac.abort(), timeout)
+    const res = await fetch(`${API_BASE}/api/data`, { signal: ac.signal })
+    clearTimeout(tid)
+    if (!res.ok) return null
+    return await res.json() as ApiResponse
+  } catch {
+    return null
+  }
+}
+
+// ── Fonte 2: Leitura direta de arquivos (fallback) ─────────────────────────
+
+/** Lê primeiras linhas de um JSONL até encontrar campo `cwd`. */
+async function readJsonlCwd(filePath: string): Promise<string | null> {
+  try {
+    const text  = await readFile(filePath, 'utf-8')
+    const lines = text.split('\n').filter(Boolean).slice(0, 30)
+    for (const line of lines) {
+      try {
+        const obj = JSON.parse(line)
+        if (typeof obj?.cwd === 'string' && obj.cwd) return obj.cwd
+      } catch { /* skip */ }
+    }
+  } catch { /* skip */ }
+  return null
+}
+
+function decodeDir(name: string): string {
   return name.startsWith('-') ? name.replace(/-/g, '/') : '/' + name.replace(/-/g, '/')
 }
 
-async function discoverProjects(): Promise<ProjectInfo[]> {
-  // Passo 1: mapa sessionId → project_path
-  const metaFiles = (await safeReadDir(SESSION_META_DIR)).filter(f => f.endsWith('.json'))
+/**
+ * Descobre projetos da mesma forma que server.ts/scanProjects:
+ * - Carrega metaMap (sessionId → project_path)
+ * - Para cada project dir, vota no project_path usando sessões com meta
+ * - Se sem votos, lê CWD do primeiro arquivo JSONL disponível
+ * - Fallback final: path decodificado do nome do dir
+ */
+async function discoverProjectsFromFiles(): Promise<{ projects: ProjectInfo[]; metaMap: Map<string, string> }> {
+  // 1. session-meta → metaMap
+  const metaFiles = (await safeDir(SESSION_META_DIR)).filter(f => f.endsWith('.json'))
   const metaMap   = new Map<string, string>()
+  const BATCH     = 40
 
-  const BATCH = 40
   for (let i = 0; i < metaFiles.length; i += BATCH) {
     const res = await Promise.all(
       metaFiles.slice(i, i + BATCH).map(f =>
-        safeReadJson<{ session_id?: string; project_path?: string }>(join(SESSION_META_DIR, f))
+        safeJson<{ session_id?: string; project_path?: string }>(join(SESSION_META_DIR, f))
       )
     )
     for (const s of res) if (s?.session_id && s.project_path) metaMap.set(s.session_id, s.project_path)
   }
 
-  // Passo 2: varre dirs de projeto
-  const projectDirs = await safeReadDir(PROJECTS_DIR)
-  const seen        = new Map<string, ProjectInfo>()
+  // 2. Varrer project dirs
+  const dirs  = await safeDir(PROJECTS_DIR)
+  const seen  = new Map<string, ProjectInfo>()
 
-  await Promise.all(projectDirs.map(async dir => {
+  await Promise.all(dirs.map(async dir => {
     if (dir.startsWith('.')) return
-    const fallback = decodeProjectDir(dir)
-    const entries  = await safeReadDir(join(PROJECTS_DIR, dir))
+    const fallback = decodeDir(dir)
+    const entries  = await safeDir(join(PROJECTS_DIR, dir))
 
     const votes: Record<string, number> = {}
+    let firstJsonl: string | null = null
 
     for (const entry of entries) {
-      // Formato A: <uuid>.jsonl
-      const sessionId = entry.endsWith('.jsonl') ? entry.slice(0, -6)
-        : UUID_RE.test(entry) ? entry       // Formato B: <uuid>/ subdir
-        : null
-      if (!sessionId) continue
+      const sid = entry.endsWith('.jsonl') ? entry.slice(0, -6)
+        : UUID_RE.test(entry) ? entry : null
+      if (!sid) continue
 
-      const path = metaMap.get(sessionId)
-      if (path) votes[path] = (votes[path] ?? 0) + 1
+      const p = metaMap.get(sid)
+      if (p) {
+        votes[p] = (votes[p] ?? 0) + 1
+      } else if (!firstJsonl && entry.endsWith('.jsonl')) {
+        firstJsonl = join(PROJECTS_DIR, dir, entry)
+      }
     }
 
-    // Canonical path = mais votado; fallback se sem votos
-    const canonical = Object.keys(votes).length > 0
-      ? Object.entries(votes).sort((a, b) => b[1] - a[1])[0][0]
-      : fallback
+    // Canonical path: majority-vote → JSONL cwd → fallback decoded
+    let canonical: string
+    if (Object.keys(votes).length > 0) {
+      canonical = Object.entries(votes).sort((a, b) => b[1] - a[1])[0][0]
+    } else if (firstJsonl) {
+      canonical = (await readJsonlCwd(firstJsonl)) ?? fallback
+    } else {
+      canonical = fallback
+    }
 
     if (!seen.has(canonical)) {
       seen.set(canonical, {
@@ -175,73 +213,77 @@ async function discoverProjects(): Promise<ProjectInfo[]> {
     }
   }))
 
-  return Array.from(seen.values()).sort((a, b) => a.path.localeCompare(b.path))
-}
-
-// ── Cálculo de snapshot — espelha useDerivedStats ─────────────────────────
-
-function blendedCostPerToken(mu: Record<string, ModelUsage>) {
-  let tIn = 0, tOut = 0, tCR = 0, tCW = 0
-  let wIn = 0, wOut = 0, wCR = 0, wCW = 0
-  for (const [id, u] of Object.entries(mu)) {
-    const p = getModelPrice(id)
-    tIn += u.inputTokens;  tOut += u.outputTokens
-    tCR += u.cacheReadInputTokens; tCW += u.cacheCreationInputTokens
-    wIn += u.inputTokens * p.input;         wOut += u.outputTokens * p.output
-    wCR += u.cacheReadInputTokens * p.cacheRead; wCW += u.cacheCreationInputTokens * p.cacheWrite
-  }
   return {
-    input:  tIn  > 0 ? wIn  / tIn  : 3,
-    output: tOut > 0 ? wOut / tOut : 15,
+    projects: Array.from(seen.values()).sort((a, b) => a.path.localeCompare(b.path)),
+    metaMap,
   }
 }
 
-async function loadSessions(): Promise<SessionMetaMin[]> {
-  const files = (await safeReadDir(SESSION_META_DIR)).filter(f => f.endsWith('.json'))
-  const out: SessionMetaMin[] = []
+async function loadSessionsFromFiles(metaMap: Map<string, string>): Promise<SessionMeta[]> {
+  const files = (await safeDir(SESSION_META_DIR)).filter(f => f.endsWith('.json'))
+  const out: SessionMeta[] = []
   const BATCH = 40
+
   for (let i = 0; i < files.length; i += BATCH) {
     const res = await Promise.all(
-      files.slice(i, i + BATCH).map(f => safeReadJson<SessionMetaMin>(join(SESSION_META_DIR, f)))
+      files.slice(i, i + BATCH).map(f => safeJson<SessionMeta>(join(SESSION_META_DIR, f)))
     )
     for (const s of res) if (s?.session_id) out.push(s)
   }
   return out
 }
 
+// ── Cálculo de snapshot — espelha useDerivedStats ─────────────────────────
+
+function blendedCost(mu: Record<string, ModelUsage>) {
+  let tIn = 0, tOut = 0, wIn = 0, wOut = 0
+  for (const [id, u] of Object.entries(mu)) {
+    const p = getModelPrice(id)
+    tIn  += u.inputTokens;   tOut += u.outputTokens
+    wIn  += u.inputTokens * p.input; wOut += u.outputTokens * p.output
+  }
+  return { input: tIn > 0 ? wIn / tIn : 3, output: tOut > 0 ? wOut / tOut : 15 }
+}
+
 function computeSnapshot(
-  sessions: SessionMetaMin[],
-  cache: StatsCache,
-  filter?: string[]
+  sessions:    SessionMeta[],
+  statsCache:  StatsCache,
+  filter?:     string[]
 ): CliSnapshot {
-  const filtered = filter?.length ? sessions.filter(s => filter.includes(s.project_path)) : sessions
-  const isF      = !!(filter?.length)
+  const isF     = !!(filter?.length)
+  const filt    = isF ? sessions.filter(s => filter!.includes(s.project_path)) : sessions
+  const daily   = statsCache.dailyActivity ?? []
+  const mu      = statsCache.modelUsage ?? {}
 
+  // Mensagens/sessões — idêntico ao useDerivedStats:
+  //   sem filtro → statsCache.dailyActivity (mais preciso, inclui sessões sem meta)
+  //   com filtro → soma das sessões filtradas
   const messages = isF
-    ? filtered.reduce((s, x) => s + (x.user_message_count ?? 0) + (x.assistant_message_count ?? 0), 0)
-    : (cache.dailyActivity ?? []).reduce((s, d) => s + d.messageCount, 0)
+    ? filt.reduce((s, x) => s + (x.user_message_count ?? 0) + (x.assistant_message_count ?? 0), 0)
+    : daily.reduce((s, d) => s + d.messageCount, 0)
 
-  const sessions_ = isF
-    ? filtered.length
-    : (cache.dailyActivity ?? []).reduce((s, d) => s + d.sessionCount, 0)
+  const sessCnt = isF
+    ? filt.length
+    : daily.reduce((s, d) => s + d.sessionCount, 0)
 
-  const inTok  = filtered.reduce((s, x) => s + (x.input_tokens  ?? 0), 0)
-  const outTok = filtered.reduce((s, x) => s + (x.output_tokens ?? 0), 0)
-  const gC     = filtered.reduce((s, x) => s + (x.git_commits   ?? 0), 0)
-  const gP     = filtered.reduce((s, x) => s + (x.git_pushes    ?? 0), 0)
-  const lA     = filtered.reduce((s, x) => s + (x.lines_added   ?? 0), 0)
-  const lR     = filtered.reduce((s, x) => s + (x.lines_removed ?? 0), 0)
+  // Tokens sempre das sessões filtradas (como no frontend)
+  const inTok  = filt.reduce((s, x) => s + (x.input_tokens  ?? 0), 0)
+  const outTok = filt.reduce((s, x) => s + (x.output_tokens ?? 0), 0)
+  const gC     = filt.reduce((s, x) => s + (x.git_commits   ?? 0), 0)
+  const lA     = filt.reduce((s, x) => s + (x.lines_added   ?? 0), 0)
+  const lR     = filt.reduce((s, x) => s + (x.lines_removed ?? 0), 0)
 
-  const mu = cache.modelUsage ?? {}
+  // Custo — idêntico ao useDerivedStats
   let cost = 0
   if (!isF) {
     cost = Object.entries(mu).reduce((s, [id, u]) => s + calcCost(u, id), 0)
   } else {
-    const b = blendedCostPerToken(mu)
+    const b = blendedCost(mu)
     cost = (inTok / 1_000_000) * b.input + (outTok / 1_000_000) * b.output
   }
 
-  const acts = new Set((cache.dailyActivity ?? []).map(d => d.date))
+  // Streak — sempre global (dailyActivity), igual ao frontend
+  const acts = new Set(daily.map(d => d.date))
   let streak = 0
   for (let i = 0; i <= 365; i++) {
     const d = new Date(); d.setDate(d.getDate() - i)
@@ -249,173 +291,180 @@ function computeSnapshot(
     else if (i > 0) break
   }
 
-  return { messages, sessions: sessions_, inputTokens: inTok, outputTokens: outTok,
-    costUsd: cost, streak, gitCommits: gC, gitPushes: gP, linesAdded: lA, linesRemoved: lR }
+  return { messages, sessions: sessCnt, inputTokens: inTok, outputTokens: outTok,
+    costUsd: cost, streak, gitCommits: gC, linesAdded: lA, linesRemoved: lR }
 }
 
-async function reloadSnapshots(config: WatchConfig): Promise<Map<string, CliSnapshot>> {
-  const [sessions, cache] = await Promise.all([
-    loadSessions(),
-    safeReadJson<StatsCache>(STATS_CACHE_FILE).then(v => v ?? {}),
-  ])
-  const map = new Map<string, CliSnapshot>()
-  const paths = config.selectedProjects.length > 0
-    ? config.selectedProjects.map(p => p.path)
-    : undefined
+// ── Reload de dados ────────────────────────────────────────────────────────
 
-  map.set('', computeSnapshot(sessions, cache, paths))
-  for (const p of config.selectedProjects) {
-    map.set(p.path, computeSnapshot(sessions, cache, [p.path]))
+async function reloadData(config: WatchConfig): Promise<{
+  snapshots: Map<string, CliSnapshot>
+  dataSource: DataSrc
+  allProjects?: ProjectInfo[]
+}> {
+  const paths   = config.selectedProjects.length > 0 ? config.selectedProjects.map(p => p.path) : undefined
+  const snapshots = new Map<string, CliSnapshot>()
+
+  // Tenta API primeiro (dados idênticos ao frontend)
+  const apiData = await fetchApi()
+
+  if (apiData) {
+    const { sessions, statsCache } = apiData
+    snapshots.set('', computeSnapshot(sessions, statsCache, paths))
+    for (const p of config.selectedProjects) {
+      snapshots.set(p.path, computeSnapshot(sessions, statsCache, [p.path]))
+    }
+    return { snapshots, dataSource: 'api' }
   }
-  return map
+
+  // Fallback: leitura direta
+  const { metaMap } = await discoverProjectsFromFiles()
+  const [sessions, statsCache] = await Promise.all([
+    loadSessionsFromFiles(metaMap),
+    safeJson<StatsCache>(STATS_CACHE_FILE).then(v => v ?? {}),
+  ])
+
+  snapshots.set('', computeSnapshot(sessions, statsCache, paths))
+  for (const p of config.selectedProjects) {
+    snapshots.set(p.path, computeSnapshot(sessions, statsCache, [p.path]))
+  }
+  return { snapshots, dataSource: 'files' }
 }
 
-// ── Animação de batalha: Claude vs Cursor ──────────────────────────────────
-// Cada frame = 4 linhas de conteúdo com largura visível fixa (FW caracteres).
-// Padded com espaços para garantir que não varia de tamanho entre frames.
+// ── Animação de batalha ────────────────────────────────────────────────────
+// Apenas ASCII básico (a-z, /, \, -, |, >, <, *, =, o) + ANSI cores.
+// Cada frame = 4 linhas com largura visível exatamente igual a FW.
 
-const FW = 46 // largura visível do frame
+const FW = 44
 
-function fp(line: string): string {
-  // Preenche linha até FW caracteres visíveis
-  return line + ' '.repeat(Math.max(0, FW - visLen(line)))
-}
+const fp = (s: string) => s + ' '.repeat(Math.max(0, FW - visLen(s)))
 
-// Cada frame: [linha1, linha2, linha3, linha4, statusLabel]
-// Linha 1-3: figuras; linha 4: nomes fixos
-const FRAMES: [string, string, string, string][] = [
-  // 0 — idle
-  [ fp(`  ${YL}o${R}                         ${RD}o${R}`),
-    fp(`  ${YL}/|\\${R}      ${D}~ VS ~${R}       ${RD}/|\\${R}`),
-    fp(`  ${YL}/ \\${R}                       ${RD}/ \\${R}`),
-    fp(`  ${YL}CLAUDE${R}               ${RD}CURSOR${R}`) ],
-
-  // 1 — Claude carrega
-  [ fp(`  ${YL}\\o/${R}                        ${RD}o${R}`),
-    fp(`   ${YL}|${R}       ${D}~ VS ~${R}       ${RD}/|\\${R}`),
-    fp(`  ${YL}/ \\${R}                       ${RD}/ \\${R}`),
-    fp(`  ${YL}CLAUDE${R} ${D}carrega...${R}    ${RD}CURSOR${R}`) ],
-
-  // 2 — Claude ataca →
-  [ fp(`  ${YL}o${R}${B}─────────────────────→${R}  ${RD}o${R}`),
-    fp(` ${YL}─|─${R}                        ${RD}|${R}`),
-    fp(`  ${YL}/ \\${R}                      ${RD}/\\${R}`),
-    fp(`  ${YL}CLAUDE${R} ${GR}ATAQUE!${R}         ${RD}CURSOR${R}`) ],
-
-  // 3 — Impacto!
-  [ fp(`  ${YL}o${R}               ${GR}✦${R}  ${B}${RD}*${R}`),
-    fp(`  ${YL}/|\\${R}                    ${RD}\\${R}`),
-    fp(`  ${YL}/ \\${R}                    ${RD}/\\${R}`),
-    fp(`  ${YL}CLAUDE${R} ${GR}CRÍTICO!${R}        ${RD}CURSOR${R}`) ],
-
-  // 4 — Cursor se recupera
-  [ fp(`  ${YL}o${R}                         ${RD}o${R}`),
-    fp(`  ${YL}/|\\${R}      ${D}~ VS ~${R}      ${RD}\\|/${R}`),
-    fp(`  ${YL}/ \\${R}                      ${RD}/\\${R}`),
-    fp(`  ${YL}CLAUDE${R}               ${RD}CURSOR${R}`) ],
-
-  // 5 — Cursor carrega
-  [ fp(`  ${YL}o${R}                        ${RD}\\o/${R}`),
-    fp(`  ${YL}/|\\${R}      ${D}~ VS ~${R}         ${RD}|${R}`),
-    fp(`  ${YL}/ \\${R}                       ${RD}/ \\${R}`),
-    fp(`  ${YL}CLAUDE${R}      ${RD}CURSOR ${D}carrega...${R}`) ],
-
-  // 6 — Cursor ataca ←
-  [ fp(`  ${YL}o${R}${B}←─────────────────────${R}${RD}─|─${R}`),
-    fp(`   ${YL}|${R}                           ${RD}|${R}`),
-    fp(`  ${YL}/\\${R}                          ${RD}/ \\${R}`),
-    fp(`  ${YL}CLAUDE${R}       ${RD}CURSOR CONTRA-ATACA!${R}`) ],
-
-  // 7 — Claude apanha
-  [ fp(`  ${B}${YL}*${R}  ${GR}✦${R}                     ${RD}o${R}`),
-    fp(`   ${YL}\\${R}                          ${RD}/|\\${R}`),
-    fp(`   ${YL}/                          ${RD}/ \\${R}`),
-    fp(`  ${YL}CLAUDE${R} ${D}levou!${R}          ${RD}CURSOR${R}`) ],
+// Cada elemento: [linha1, linha2, linha3, label]
+const FRAMES: Array<[string, string, string, string]> = [
+  [ // 0 — idle
+    fp(`  ${YL}o${R}                        ${RD}o${R}`),
+    fp(`  ${YL}|${R}         - vs -         ${RD}|${R}`),
+    fp(` ${YL}/ \\${R}                      ${RD}/ \\${R}`),
+    fp(`  ${YL}CLAUDE${R}               ${RD}CURSOR${R}`),
+  ],
+  [ // 1 — Claude carrega
+    fp(` ${YL}\\o/${R}                       ${RD}o${R}`),
+    fp(`  ${YL}|${R}         - vs -         ${RD}|${R}`),
+    fp(` ${YL}/ \\${R}                      ${RD}/ \\${R}`),
+    fp(`  ${YL}CLAUDE${R} ${D}carrega...${R}  ${RD}CURSOR${R}`),
+  ],
+  [ // 2 — Claude ataca →
+    fp(`  ${YL}o${R} ${B}=======${R}${GR}>${R}           ${RD}o${R}`),
+    fp(`  ${YL}|${R}                         ${RD}|${R}`),
+    fp(` ${YL}/ \\${R}                      ${RD}/ \\${R}`),
+    fp(`  ${YL}CLAUDE${R} ${GR}ATAQUE!${R}      ${RD}CURSOR${R}`),
+  ],
+  [ // 3 — impacto no Cursor
+    fp(`  ${YL}o${R}         ${GR}*${R}      ${B}${RD}(o)${R}`),
+    fp(`  ${YL}|${R}                      ${RD}\\${R}`),
+    fp(` ${YL}/ \\${R}                     ${RD}/\\${R}`),
+    fp(`  ${YL}CLAUDE${R} ${GR}CRITICO!${R}    ${RD}CURSOR${R}`),
+  ],
+  [ // 4 — Cursor se recupera
+    fp(`  ${YL}o${R}                        ${RD}o${R}`),
+    fp(`  ${YL}|${R}         - vs -        ${RD}\\|/${R}`),
+    fp(` ${YL}/ \\${R}                      ${RD}/\\${R}`),
+    fp(`  ${YL}CLAUDE${R}               ${RD}CURSOR${R}`),
+  ],
+  [ // 5 — Cursor carrega
+    fp(`  ${YL}o${R}                       ${RD}\\o/${R}`),
+    fp(`  ${YL}|${R}         - vs -         ${RD}|${R}`),
+    fp(` ${YL}/ \\${R}                      ${RD}/ \\${R}`),
+    fp(`  ${YL}CLAUDE${R}   ${RD}CURSOR ${D}carrega...${R}`),
+  ],
+  [ // 6 — Cursor ataca ←
+    fp(`  ${YL}o${R}           ${GR}<${R}${B}=======${R}  ${RD}o${R}`),
+    fp(`  ${YL}|${R}                         ${RD}|${R}`),
+    fp(` ${YL}/ \\${R}                      ${RD}/ \\${R}`),
+    fp(`  ${YL}CLAUDE${R}    ${RD}CURSOR ATAQUE!${R}`),
+  ],
+  [ // 7 — Claude leva
+    fp(`${GR}*${R} ${B}${YL}(o)${R}                       ${RD}o${R}`),
+    fp(`   ${YL}/\\${R}                        ${RD}|${R}`),
+    fp(`  ${YL}/  \\${R}                     ${RD}/ \\${R}`),
+    fp(`  ${YL}CLAUDE${R} ${D}levou!${R}       ${RD}CURSOR${R}`),
+  ],
 ]
 
 function renderBattle(frame: number): string[] {
   const f = FRAMES[frame % FRAMES.length]
+  const sep = sepLine(FW + 4)
   return [
-    `  ${D}${'─'.repeat(FW + 6)}${R}`,
-    `  ${D}│${R}  ${f[0]}  ${D}│${R}`,
-    `  ${D}│${R}  ${f[1]}  ${D}│${R}`,
-    `  ${D}│${R}  ${f[2]}  ${D}│${R}`,
-    `  ${D}│${R}  ${f[3]}  ${D}│${R}`,
-    `  ${D}│${R}  ${D}Ctrl+O para ocultar${' '.repeat(FW - 19)}${R}  ${D}│${R}`,
-    `  ${D}${'─'.repeat(FW + 6)}${R}`,
+    sep,
+    `  ${f[0]}`,
+    `  ${f[1]}`,
+    `  ${f[2]}`,
+    `  ${f[3]}`,
+    `  ${D}[Ctrl+O para ocultar]${R}`,
+    sep,
   ]
 }
 
-// ── Formatação de métricas ─────────────────────────────────────────────────
+// ── Tabela de métricas ─────────────────────────────────────────────────────
 
 const fmtN = (n: number) =>
-  n >= 1_000_000 ? (n / 1_000_000).toFixed(1) + 'M'
-  : n >= 1_000   ? (n / 1_000).toFixed(1) + 'k'
-  : n.toString()
-
+  n >= 1_000_000 ? (n/1e6).toFixed(1)+'M' : n >= 1_000 ? (n/1e3).toFixed(1)+'k' : String(n)
 const fmtC = (u: number) =>
-  u >= 1000 ? `$${(u / 1000).toFixed(1)}k`
-  : u >= 1  ? `$${u.toFixed(2)}`
-  : `$${u.toFixed(3)}`
+  u >= 1000 ? `$${(u/1000).toFixed(1)}k` : u >= 1 ? `$${u.toFixed(2)}` : `$${u.toFixed(3)}`
 
 const COLS = [
-  { h: 'Msgs',     w: 8  }, { h: 'Sessões',  w: 8  },
-  { h: 'Tok↑',    w: 9  }, { h: 'Tok↓',    w: 9  },
-  { h: 'Custo',   w: 10 }, { h: 'Streak',  w: 7  },
-  { h: 'Commits', w: 8  }, { h: '+Linhas', w: 9  }, { h: '-Linhas', w: 9  },
+  {h:'Msgs',    w:8}, {h:'Sessoes', w:8},
+  {h:'Tok-In',  w:9}, {h:'Tok-Out', w:9},
+  {h:'Custo',  w:10}, {h:'Streak',  w:7},
+  {h:'Commits', w:8}, {h:'+Linhas', w:9}, {h:'-Linhas', w:9},
 ]
 const PW = 24
 
-const tblHdr = (proj: boolean) => {
-  const cells = COLS.map(c => pad(`${D}${c.h}${R}`, c.w))
-  return (proj ? pad(`${D}Projeto${R}`, PW, 'l') + '  ' : '') + cells.join('  ')
+const tHdr = (proj: boolean) => {
+  const c = COLS.map(c => padStr(`${D}${c.h}${R}`, c.w))
+  return (proj ? padStr(`${D}Projeto${R}`, PW, 'l')+'  ' : '') + c.join('  ')
 }
-const tblRow = (s: CliSnapshot, name?: string) => {
-  const vals = [
+const tRow = (s: CliSnapshot, name?: string) => {
+  const v = [
     fmtN(s.messages), fmtN(s.sessions), fmtN(s.inputTokens), fmtN(s.outputTokens),
     fmtC(s.costUsd), `${s.streak}d`, fmtN(s.gitCommits),
     `+${fmtN(s.linesAdded)}`, `-${fmtN(s.linesRemoved)}`,
   ]
-  const cells = vals.map((v, i) => pad(v, COLS[i].w))
+  const c = v.map((x, i) => padStr(x, COLS[i].w))
   if (name !== undefined) {
-    const n = name.length > PW - 1 ? name.slice(0, PW - 2) + '…' : name
-    return pad(`${CY}${n}${R}`, PW, 'l') + '  ' + cells.join('  ')
+    const n = name.length > PW-1 ? name.slice(0, PW-2)+'…' : name
+    return padStr(`${CY}${n}${R}`, PW, 'l')+'  '+c.join('  ')
   }
-  return cells.join('  ')
+  return c.join('  ')
 }
 
-// ── Construção do painel ───────────────────────────────────────────────────
+// ── Painel ─────────────────────────────────────────────────────────────────
 
 function buildPanel(cfg: WatchConfig, st: AppState): string {
   const W = process.stdout.columns || 100
   const lines: string[] = []
 
   // Cabeçalho
-  const now   = st.lastUpdated.toLocaleTimeString('pt-BR')
-  const right = `${D}${now}  ⟳ ${cfg.intervalSec}s${st.isLoading ? ' …' : ''}${R}`
-  const left  = `${B}${BCY}Claude Stats — Watch Mode${R}`
-  const gap   = Math.max(1, W - visLen(left.replace(/\x1b\[[0-9;]*m/g,'')) - visLen(right.replace(/\x1b\[[0-9;]*m/g,'')))
+  const ts     = st.lastUpdated.toLocaleTimeString('pt-BR')
+  const src    = st.dataSource === 'api' ? `${D}api${R}` : `${YL}files${R}`
+  const right  = `${D}${ts}  ${R}${src}${D}  refresh: ${cfg.intervalSec}s${R}`
+  const left   = `${B}${BC}Claude Stats - Watch Mode${R}`
+  const gap    = Math.max(1, W - visLen('Claude Stats - Watch Mode') - visLen(ts) - visLen('  api  refresh: XXs'))
   lines.push(left + ' '.repeat(gap) + right)
-  lines.push(hr(W))
+  lines.push(sepLine(W))
   lines.push('')
 
-  // Batalha
-  if (st.showBattle) {
-    lines.push(...renderBattle(st.animFrame))
-    lines.push('')
-  }
+  // Batalha (se ativa)
+  if (st.showBattle) { lines.push(...renderBattle(st.animFrame)); lines.push('') }
 
-  // Bloco de info
-  const mode = cfg.viewMode === 'junto' ? 'unificado'
-    : cfg.viewMode === 'separado' ? 'separado' : 'ambos'
-
+  // Bloco info
+  const mode = cfg.viewMode === 'junto' ? 'unificado' : cfg.viewMode === 'separado' ? 'separado' : 'ambos'
   lines.push(`  ${D}Home:${R}       ${WH}${HOME_DIR}${R}`)
   lines.push(`  ${D}Claude dir:${R} ${WH}${CLAUDE_DIR}${R}`)
-
   if (cfg.selectedProjects.length === 0) {
     lines.push(`  ${D}Projetos:${R}   ${YL}todos (${cfg.allProjects.length})${R}`)
   } else {
-    lines.push(`  ${D}Projetos:${R}   ${CY}${cfg.selectedProjects.map(p => p.name).join(', ')}${R}`)
+    lines.push(`  ${D}Projetos:${R}   ${CY}${cfg.selectedProjects.map(p=>p.name).join(', ')}${R}`)
   }
   if (cfg.selectedProjects.length > 1) lines.push(`  ${D}Modo:${R}       ${GR}${mode}${R}`)
   lines.push(`  ${D}Interval:${R}   ${WH}${cfg.intervalSec}s${R}`)
@@ -425,46 +474,44 @@ function buildPanel(cfg: WatchConfig, st: AppState): string {
   // Tabela
   const solo = cfg.selectedProjects.length <= 1
   const all  = st.snapshots.get('')
-  const loading = `  ${D}(carregando...)${R}`
+  const ldg  = `  ${D}(carregando...)${R}`
 
   if (solo || cfg.viewMode === 'junto') {
-    lines.push(hr(W))
+    lines.push(sepLine(W))
     if (!solo) lines.push(`  ${B}${CY}UNIFICADO${R}`)
     lines.push('')
-    lines.push('  ' + tblHdr(false))
-    lines.push(`  ${GR}${B}${all ? tblRow(all) : loading}${R}`)
-    lines.push(hr(W))
-
+    lines.push('  ' + tHdr(false))
+    lines.push(`  ${GR}${B}${all ? tRow(all) : ldg}${R}`)
+    lines.push(sepLine(W))
   } else if (cfg.viewMode === 'separado') {
-    lines.push(hr(W))
+    lines.push(sepLine(W))
     lines.push(`  ${B}${CY}POR PROJETO${R}`)
     lines.push('')
-    lines.push('  ' + tblHdr(true))
+    lines.push('  ' + tHdr(true))
     for (const p of cfg.selectedProjects) {
       const s = st.snapshots.get(p.path)
-      lines.push('  ' + (s ? tblRow(s, p.name) : `  ${D}${p.name} (carregando...)${R}`))
+      lines.push('  ' + (s ? tRow(s, p.name) : ldg))
     }
-    lines.push(hr(W))
-
+    lines.push(sepLine(W))
   } else {
-    lines.push(hr(W))
+    lines.push(sepLine(W))
     lines.push(`  ${B}${CY}UNIFICADO${R}`)
     lines.push('')
-    lines.push('  ' + tblHdr(false))
-    lines.push(`  ${GR}${B}${all ? tblRow(all) : loading}${R}`)
+    lines.push('  ' + tHdr(false))
+    lines.push(`  ${GR}${B}${all ? tRow(all) : ldg}${R}`)
     lines.push('')
     lines.push(`  ${B}${CY}POR PROJETO${R}`)
     lines.push('')
-    lines.push('  ' + tblHdr(true))
+    lines.push('  ' + tHdr(true))
     for (const p of cfg.selectedProjects) {
       const s = st.snapshots.get(p.path)
-      lines.push('  ' + (s ? tblRow(s, p.name) : `  ${D}${p.name} (carregando...)${R}`))
+      lines.push('  ' + (s ? tRow(s, p.name) : ldg))
     }
-    lines.push(hr(W))
+    lines.push(sepLine(W))
   }
 
   lines.push('')
-  lines.push(`  ${D}Ctrl+C sair  │  Ctrl+O ${st.showBattle ? 'ocultar' : 'mostrar'} batalha${R}`)
+  lines.push(`  ${D}Ctrl+C sair  |  Ctrl+O ${st.showBattle ? 'ocultar' : 'mostrar'} batalha${R}`)
   return lines.join('\n') + '\n'
 }
 
@@ -472,76 +519,56 @@ function buildPanel(cfg: WatchConfig, st: AppState): string {
 
 async function watchLoop(cfg: WatchConfig): Promise<void> {
   const st: AppState = {
-    snapshots: new Map(),
-    lastUpdated: new Date(),
-    animFrame: 0,
-    showBattle: cfg.showBattle,
-    isLoading: true,
+    snapshots: new Map(), lastUpdated: new Date(),
+    animFrame: 0, showBattle: cfg.showBattle, isLoading: true, dataSource: 'files',
   }
 
-  // Cleanup centralizado
-  const cleanup = () => {
-    write(SHOW_CUR + ALT_OFF)
-    process.exit(0)
-  }
+  const cleanup = () => { out(SHOW + ALT_OFF); if (spawnedServer) { spawnedServer.kill(); spawnedServer = null } process.exit(0) }
+  out(ALT_ON + HIDE)
 
-  // Alternate screen: entra limpo, sai limpo
-  write(ALT_ON + HIDE_CUR)
+  const render = () => { out(CLR + buildPanel(cfg, st)) }
 
-  const render = () => {
-    write(CLEAR_SCR + buildPanel(cfg, st))
-  }
-
-  // Reload pesado de disco
   let reloading = false
-  const reloadData = async () => {
+  const refresh = async () => {
     if (reloading) return
-    reloading = true
-    st.isLoading = true
+    reloading = true; st.isLoading = true
     try {
-      st.snapshots   = await reloadSnapshots(cfg)
+      const { snapshots, dataSource } = await reloadData(cfg)
+      st.snapshots = snapshots; st.dataSource = dataSource
       st.lastUpdated = new Date()
     } catch { /* mantém anterior */ }
     finally { st.isLoading = false; reloading = false }
     render()
   }
 
-  // Carga inicial
-  await reloadData()
+  await refresh()
 
-  // Teclado: Ctrl+C e Ctrl+O
   if (process.stdin.isTTY) {
-    process.stdin.setRawMode(true)
-    process.stdin.resume()
+    process.stdin.setRawMode(true); process.stdin.resume()
     process.stdin.on('data', (buf: Buffer) => {
-      if (buf[0] === 3)  { cleanup() }           // Ctrl+C
-      if (buf[0] === 15) {                        // Ctrl+O
-        st.showBattle = !st.showBattle
-        render()
-      }
+      if (buf[0] === 3)  cleanup()
+      if (buf[0] === 15) { st.showBattle = !st.showBattle; render() }
     })
   } else {
-    process.on('SIGINT',  cleanup)
-    process.on('SIGTERM', cleanup)
+    process.on('SIGINT', cleanup); process.on('SIGTERM', cleanup)
   }
 
-  // Timer de animação — só re-renderiza com cache, sem I/O
+  // Timer de animação (200ms, sem I/O)
   setInterval(() => { st.animFrame++; render() }, 200)
 
   // Timer de dados
-  setInterval(reloadData, cfg.intervalSec * 1000)
+  setInterval(refresh, cfg.intervalSec * 1000)
 
-  // Chokidar
+  // Chokidar para atualizações imediatas
   let dbt: ReturnType<typeof setTimeout> | null = null
   chokidar
     .watch([SESSION_META_DIR, STATS_CACHE_FILE], { persistent: true, ignoreInitial: true })
-    .on('all', () => { if (dbt) clearTimeout(dbt); dbt = setTimeout(reloadData, 1500) })
+    .on('all', () => { if (dbt) clearTimeout(dbt); dbt = setTimeout(refresh, 1500) })
 }
 
 // ── Custom prompt: checkbox com busca reativa ──────────────────────────────
 
 type RlKey = KeypressEvent & { meta?: boolean; sequence?: string }
-
 interface CbChoice { name: string; value: string; path: string }
 
 const checkboxSearch = createPrompt<string[], {
@@ -566,123 +593,156 @@ const checkboxSearch = createPrompt<string[], {
   useKeypress((key) => {
     const k = key as RlKey
     if (isEnterKey(k)) { done([...checked]); return }
-
     const len = filtered.length
-    if (isUpKey(k)) {
-      setActive(active === 0 ? Math.max(0, len - 1) : active - 1)
-    } else if (isDownKey(k)) {
-      setActive(active >= len - 1 ? 0 : active + 1)
-    } else if (isSpaceKey(k)) {
-      const item = filtered[active]
-      if (!item) return
+    if (isUpKey(k))        { setActive(active === 0 ? Math.max(0, len-1) : active-1) }
+    else if (isDownKey(k)) { setActive(active >= len-1 ? 0 : active+1) }
+    else if (isSpaceKey(k)) {
+      const item = filtered[active]; if (!item) return
       const s = new Set(checked)
       s.has(item.value) ? s.delete(item.value) : s.add(item.value)
       setChecked(Array.from(s))
-    } else if (isBackspaceKey(k)) {
-      setTerm(term.slice(0, -1)); setActive(0)
-    } else if (!k.ctrl && !k.meta && k.sequence?.length === 1 && k.sequence.charCodeAt(0) >= 32) {
+    } else if (isBackspaceKey(k)) { setTerm(term.slice(0,-1)); setActive(0) }
+    else if (!k.ctrl && !k.meta && k.sequence?.length === 1 && k.sequence.charCodeAt(0) >= 32) {
       setTerm(term + k.sequence); setActive(0)
     }
   })
 
   const cs = new Set(checked)
-
   const page = usePagination({
-    items:    filtered as CbChoice[],
-    active,
-    pageSize: config.pageSize ?? 16,
-    loop:     false,
-    renderItem: ({ item, isActive }) => {
-      const cur  = isActive ? `${CY}❯${R}` : ' '
-      const box  = cs.has(item.value) ? `${GR}◉${R}` : `${D}◯${R}`
-      const name = cs.has(item.value) ? `${GR}${item.name}${R}` : item.name
-      return ` ${cur} ${box}  ${name}  ${D}${item.path}${R}`
-    },
+    items: filtered as CbChoice[], active, pageSize: config.pageSize ?? 16, loop: false,
+    renderItem: ({ item, isActive }) =>
+      ` ${isActive ? `${CY}>` : ' '}${R} ${cs.has(item.value) ? `${GR}[x]` : `${D}[ ]`}${R}  ${cs.has(item.value) ? GR : ''}${item.name}${R}  ${D}${item.path}${R}`,
   })
 
-  const cursor   = `\x1b[7m \x1b[0m`
-  const search   = `${D}[Buscar]${R} ${B}${term}${R}${cursor}`
-  const selNames = checked.map(v => config.choices.find(c => c.value === v)?.name ?? v).join(', ')
-  const selLine  = checked.length > 0
-    ? `\n  ${D}Selecionados: ${R}${GR}${selNames}${R}`
-    : `\n  ${D}(nenhum = todos os projetos)${R}`
+  const cur      = `${E}[7m ${R}`
+  const selNames = checked.map(v => config.choices.find(c => c.value===v)?.name ?? v).join(', ')
+  const selLine  = checked.length > 0 ? `\n  ${D}Sel: ${R}${GR}${selNames}${R}` : `\n  ${D}(nenhum = todos)${R}`
 
-  return `${B}${config.message}${R}\n  ${search}\n\n${page}${selLine}\n  ${D}↑↓ navegar  ⎵ selecionar  ⏎ confirmar  Backspace apaga busca${R}`
+  return `${B}${config.message}${R}\n  ${D}[Buscar]${R} ${B}${term}${R}${cur}\n\n${page}${selLine}\n  ${D}↑↓ navegar  Espaco selecionar  Enter confirmar  Backspace apagar busca${R}`
 })
 
-// ── Configuração via prompts ───────────────────────────────────────────────
+// ── Prompts de configuração ────────────────────────────────────────────────
 
 async function askConfig(all: ProjectInfo[]): Promise<WatchConfig> {
-  // Intervalo
   const intStr = await input({
-    message: 'Intervalo de atualização (segundos):',
+    message: 'Intervalo de refresh (segundos):',
     default: '30',
-    validate: v => { const n = parseInt(v, 10); return Number.isFinite(n) && n >= 5 ? true : 'Mínimo 5s' },
+    validate: v => { const n = parseInt(v,10); return Number.isFinite(n) && n >= 5 ? true : 'Min 5s' },
   })
 
-  // OTLP
   const otlp = await input({
     message: 'OTLP endpoint (vazio = desativado):',
     default: process.env.OTEL_EXPORTER_OTLP_ENDPOINT ?? '',
   })
 
-  // Animação
   const showBattle = await confirm({
     message: 'Mostrar batalha Claude vs Cursor no painel?',
     default: true,
   })
 
-  // Projetos
   const paths = await checkboxSearch({
-    message: 'Selecione os projetos para monitorar:',
+    message: 'Selecione os projetos:',
     choices: all.map(p => ({ name: p.name, value: p.path, path: p.path })),
     pageSize: Math.min(20, all.length),
   })
 
   const selected = paths.length === 0 ? [] : all.filter(p => paths.includes(p.path))
 
-  // Modo
   let viewMode: ViewMode = 'junto'
   if (selected.length > 1) {
     viewMode = await select<ViewMode>({
-      message: 'Como deseja visualizar os dados?',
+      message: 'Como visualizar?',
       choices: [
-        { name: `${B}Separado${R}  — uma linha por projeto`,             value: 'separado', short: 'separado'  },
-        { name: `${B}Unificado${R} — total dos projetos selecionados`,   value: 'junto',    short: 'unificado' },
-        { name: `${B}Ambos${R}     — total no topo + uma linha/projeto`, value: 'ambos',    short: 'ambos'     },
+        { name: `${B}Separado${R}  — uma linha por projeto`,          value: 'separado', short: 'separado' },
+        { name: `${B}Unificado${R} — total dos selecionados`,          value: 'junto',    short: 'unificado' },
+        { name: `${B}Ambos${R}     — total no topo + linha/projeto`,   value: 'ambos',    short: 'ambos' },
       ],
     })
   }
 
-  return {
-    selectedProjects: selected,
-    allProjects: all,
-    viewMode,
-    intervalSec: parseInt(intStr, 10),
-    otlpEndpoint: otlp,
-    showBattle,
+  return { selectedProjects: selected, allProjects: all, viewMode,
+    intervalSec: parseInt(intStr, 10), otlpEndpoint: otlp, showBattle }
+}
+
+// ── Auto-start do servidor API ────────────────────────────────────────────
+
+let spawnedServer: ReturnType<typeof Bun.spawn> | null = null
+
+async function ensureApiRunning(): Promise<boolean> {
+  // Já está rodando?
+  const probe = await fetchApi(2000)
+  if (probe) return false // já estava rodando, não precisamos subir
+
+  // Sobe server.ts em background
+  const serverPath = join(import.meta.dir, 'server.ts')
+  console.log(`${YL}Servidor API nao detectado — iniciando automaticamente...${R}`)
+
+  spawnedServer = Bun.spawn(['bun', 'run', serverPath], {
+    stdout: 'ignore',
+    stderr: 'ignore',
+    env: { ...process.env },
+  })
+
+  // Aguarda até 10s (polling a cada 300ms)
+  for (let i = 0; i < 33; i++) {
+    await new Promise(r => setTimeout(r, 300))
+    const ok = await fetchApi(1000)
+    if (ok) {
+      console.log(`${GR}Servidor iniciado (pid ${spawnedServer.pid}).${R}`)
+      return true
+    }
   }
+
+  console.log(`${RD}Nao foi possivel iniciar o servidor. Usando leitura direta de arquivos.${R}`)
+  spawnedServer?.kill()
+  spawnedServer = null
+  return false
+}
+
+function registerServerCleanup() {
+  const killServer = () => {
+    if (spawnedServer) { spawnedServer.kill(); spawnedServer = null }
+  }
+  process.on('exit',    killServer)
+  process.on('SIGINT',  () => { killServer(); process.exit(0) })
+  process.on('SIGTERM', () => { killServer(); process.exit(0) })
 }
 
 // ── Entry point ────────────────────────────────────────────────────────────
 
 async function main() {
-  console.log(`\n${B}${BCY}Claude Stats — Watch CLI${R}\n`)
-  console.log(`${D}Descobrindo projetos...${R}`)
+  console.log(`\n${B}${BC}Claude Stats - Watch CLI${R}\n`)
 
-  const all = await discoverProjects()
-  if (all.length === 0) {
-    console.error(`\nNenhum projeto encontrado em:\n  ${SESSION_META_DIR}\n  ${PROJECTS_DIR}`)
+  registerServerCleanup()
+
+  await ensureApiRunning()
+
+  // Agora tenta a API (pode estar recém-subida ou já existente)
+  const apiData = await fetchApi(2000)
+  let allProjects: ProjectInfo[]
+
+  if (apiData) {
+    console.log(`${GR}Usando dados da API em ${API_BASE}${R}\n`)
+    allProjects = apiData.projects.map(p => ({ name: p.name, path: p.path }))
+      .sort((a, b) => a.path.localeCompare(b.path))
+  } else {
+    console.log(`${YL}Usando leitura direta de arquivos (fallback).${R}\n`)
+    const { projects } = await discoverProjectsFromFiles()
+    allProjects = projects
+  }
+
+  if (allProjects.length === 0) {
+    console.error('Nenhum projeto encontrado.')
     process.exit(1)
   }
-  console.log(`${GR}${all.length} projetos encontrados.${R}\n`)
+  console.log(`${GR}${allProjects.length} projetos encontrados.${R}\n`)
 
-  const cfg = await askConfig(all)
+  const cfg = await askConfig(allProjects)
   await watchLoop(cfg)
 }
 
 main().catch(err => {
-  write(SHOW_CUR + ALT_OFF)
+  out(SHOW + ALT_OFF)
   console.error('Erro fatal:', err)
   process.exit(1)
 })

--- a/watch-cli.ts
+++ b/watch-cli.ts
@@ -33,12 +33,17 @@ const E = '\x1b'
 const R  = `${E}[0m`
 const B  = `${E}[1m`
 const D  = `${E}[2m`
-const CY = `${E}[36m`
-const GR = `${E}[32m`
-const YL = `${E}[33m`
-const RD = `${E}[31m`
-const WH = `${E}[37m`
-const BC = `${E}[96m`
+// Web dark-mode palette mapped to terminal
+const AM = `${E}[38;5;208m`  // orange/amber   — PRIMARY accent (#f59e0b / Anthropic brand)
+const VI = `${E}[38;5;135m`  // violet/indigo  — secondary accent (#6366f1)
+const EM = `${E}[92m`        // emerald green  — success/active (#10b981)
+const RS = `${E}[38;5;204m`  // rose           — error (#f43f5e)
+const CY = `${E}[36m`        // cyan            — tertiary accent
+const GR = `${E}[32m`        // green           — kept for compat
+const YL = `${E}[33m`        // yellow          — kept for compat
+const RD = `${E}[31m`        // red             — kept for compat
+const WH = `${E}[97m`        // bright white    — primary text
+const BC = `${E}[96m`        // bright cyan     — highlights
 
 const ALT_ON  = `${E}[?1049h`
 const ALT_OFF = `${E}[?1049l`
@@ -67,7 +72,7 @@ interface WatchConfig {
   viewMode: ViewMode
   intervalSec: number
   otlpEndpoint: string
-  showBattle: boolean
+  showAnim: boolean
 }
 
 interface CliSnapshot {
@@ -86,14 +91,24 @@ interface AppState {
   snapshots:   Map<string, CliSnapshot>
   lastUpdated: Date
   animFrame:   number
-  showBattle:  boolean
+  showAnim:    boolean
   isLoading:   boolean
   dataSource:  DataSrc
 }
 
 // ── API ────────────────────────────────────────────────────────────────────
 
-interface ApiProject { path: string; name: string }
+interface ApiProject {
+  path: string
+  name: string
+  git_stats?: {
+    commits: number
+    lines_added: number
+    lines_removed: number
+    files_modified: number
+    since: string
+  }
+}
 interface ApiResponse {
   statsCache: StatsCache
   projects:   ApiProject[]
@@ -131,44 +146,67 @@ async function probeApi(timeout = 1000): Promise<boolean> {
 // ── Cálculo de snapshot — espelha useDerivedStats ─────────────────────────
 
 function blendedCost(mu: Record<string, ModelUsage>) {
-  let tIn = 0, tOut = 0, wIn = 0, wOut = 0
+  let tIn = 0, tOut = 0, tCR = 0, tCW = 0
+  let wIn = 0, wOut = 0, wCR = 0, wCW = 0
   for (const [id, u] of Object.entries(mu)) {
     const p = getModelPrice(id)
-    tIn  += u.inputTokens;   tOut += u.outputTokens
-    wIn  += u.inputTokens * p.input; wOut += u.outputTokens * p.output
+    tIn  += u.inputTokens;               tOut += u.outputTokens
+    tCR  += u.cacheReadInputTokens;      tCW  += u.cacheCreationInputTokens
+    wIn  += u.inputTokens * p.input;     wOut += u.outputTokens * p.output
+    wCR  += u.cacheReadInputTokens * p.cacheRead
+    wCW  += u.cacheCreationInputTokens  * p.cacheWrite
   }
-  return { input: tIn > 0 ? wIn / tIn : 3, output: tOut > 0 ? wOut / tOut : 15 }
+  return {
+    input:      tIn  > 0 ? wIn  / tIn  : 3,
+    output:     tOut > 0 ? wOut / tOut : 15,
+    cacheRead:  tCR  > 0 ? wCR  / tCR  : 0.3,
+    cacheWrite: tCW  > 0 ? wCW  / tCW  : 3.75,
+  }
 }
 
 function computeSnapshot(
-  sessions:    SessionMeta[],
-  statsCache:  StatsCache,
-  filter?:     string[]
+  sessions:   SessionMeta[],
+  statsCache: StatsCache,
+  projects:   ApiProject[],
+  filter?:    string[]
 ): CliSnapshot {
-  const isF     = !!(filter?.length)
-  const filt    = isF ? sessions.filter(s => filter!.includes(s.project_path)) : sessions
-  const daily   = statsCache.dailyActivity ?? []
-  const mu      = statsCache.modelUsage ?? {}
+  const isF  = !!(filter?.length)
+  const filt = isF ? sessions.filter(s => filter!.includes(s.project_path)) : sessions
+  const daily = statsCache.dailyActivity ?? []
+  const mu    = statsCache.modelUsage ?? {}
 
-  // Mensagens/sessões — idêntico ao useDerivedStats:
-  //   sem filtro → statsCache.dailyActivity (mais preciso, inclui sessões sem meta)
-  //   com filtro → soma das sessões filtradas
-  const messages = isF
-    ? filt.reduce((s, x) => s + (x.user_message_count ?? 0) + (x.assistant_message_count ?? 0), 0)
-    : daily.reduce((s, d) => s + d.messageCount, 0)
+  // ── Messages/sessions — mirrors useDerivedStats exactly ──
+  //   with filter    → sum filtered sessions
+  //   without filter → extendedDailyActivity (statsCache + sessions on days not yet cached)
+  let messages: number
+  let sessCnt:  number
+  if (isF) {
+    messages = filt.reduce((s, x) => s + (x.user_message_count ?? 0) + (x.assistant_message_count ?? 0), 0)
+    sessCnt  = filt.length
+  } else {
+    const dailyDates = new Set(daily.map(d => d.date))
+    const supplementByDay: Record<string, { messageCount: number; sessionCount: number }> = {}
+    for (const s of sessions) {
+      if (!s.start_time) continue
+      const day = s.start_time.slice(0, 10)
+      if (dailyDates.has(day)) continue
+      if (!supplementByDay[day]) supplementByDay[day] = { messageCount: 0, sessionCount: 0 }
+      supplementByDay[day].messageCount += (s.user_message_count ?? 0) + (s.assistant_message_count ?? 0)
+      supplementByDay[day].sessionCount += 1
+    }
+    const extended = [
+      ...daily,
+      ...Object.entries(supplementByDay).map(([date, v]) => ({ date, ...v })),
+    ]
+    messages = extended.reduce((s, d) => s + d.messageCount, 0)
+    sessCnt  = extended.reduce((s, d) => s + d.sessionCount, 0)
+  }
 
-  const sessCnt = isF
-    ? filt.length
-    : daily.reduce((s, d) => s + d.sessionCount, 0)
-
-  // Tokens sempre das sessões filtradas (como no frontend)
+  // ── Tokens — always from filtered sessions ──
   const inTok  = filt.reduce((s, x) => s + (x.input_tokens  ?? 0), 0)
   const outTok = filt.reduce((s, x) => s + (x.output_tokens ?? 0), 0)
-  const gC     = filt.reduce((s, x) => s + (x.git_commits   ?? 0), 0)
-  const lA     = filt.reduce((s, x) => s + (x.lines_added   ?? 0), 0)
-  const lR     = filt.reduce((s, x) => s + (x.lines_removed ?? 0), 0)
 
-  // Custo — idêntico ao useDerivedStats
+  // ── Cost — mirrors useDerivedStats ──
   let cost = 0
   if (!isF) {
     cost = Object.entries(mu).reduce((s, [id, u]) => s + calcCost(u, id), 0)
@@ -177,14 +215,36 @@ function computeSnapshot(
     cost = (inTok / 1_000_000) * b.input + (outTok / 1_000_000) * b.output
   }
 
-  // Streak — sempre global (dailyActivity), igual ao frontend
-  const acts = new Set(daily.map(d => d.date))
+  // ── Streak — mirrors useDerivedStats exactly ──
+  //   with filter    → active dates from filtered sessions only
+  //   without filter → union of dailyActivity dates + ALL session dates (covers stale statsCache)
+  const activeDates = isF
+    ? new Set(filt.filter(s => s.start_time).map(s => s.start_time.slice(0, 10)))
+    : new Set([
+        ...daily.map(d => d.date),
+        ...sessions.filter(s => s.start_time).map(s => s.start_time.slice(0, 10)),
+      ])
   let streak = 0
   for (let i = 0; i <= 365; i++) {
     const d = new Date(); d.setDate(d.getDate() - i)
-    if (acts.has(d.toISOString().slice(0, 10))) streak++
+    if (activeDates.has(d.toISOString().slice(0, 10))) streak++
     else if (i > 0) break
   }
+
+  // ── Git stats — mirrors useDerivedStats: use project git_stats when exactly 1 project ──
+  //   (project-level git counts are more accurate than summing session fields)
+  const singleProjectGitStats = isF && filter!.length === 1
+    ? projects.find(p => p.path === filter![0])?.git_stats
+    : undefined
+  const gC = singleProjectGitStats
+    ? singleProjectGitStats.commits
+    : filt.reduce((s, x) => s + (x.git_commits   ?? 0), 0)
+  const lA = singleProjectGitStats
+    ? singleProjectGitStats.lines_added
+    : filt.reduce((s, x) => s + (x.lines_added   ?? 0), 0)
+  const lR = singleProjectGitStats
+    ? singleProjectGitStats.lines_removed
+    : filt.reduce((s, x) => s + (x.lines_removed ?? 0), 0)
 
   return { messages, sessions: sessCnt, inputTokens: inTok, outputTokens: outTok,
     costUsd: cost, streak, gitCommits: gC, linesAdded: lA, linesRemoved: lR }
@@ -202,10 +262,10 @@ async function reloadData(config: WatchConfig): Promise<{
   const apiData = await fetchApi(30_000)
   if (!apiData) throw new Error('API indisponivel')
 
-  const { sessions, statsCache } = apiData
-  snapshots.set('', computeSnapshot(sessions, statsCache, paths))
+  const { sessions, statsCache, projects } = apiData
+  snapshots.set('', computeSnapshot(sessions, statsCache, projects, paths))
   for (const p of config.selectedProjects) {
-    snapshots.set(p.path, computeSnapshot(sessions, statsCache, [p.path]))
+    snapshots.set(p.path, computeSnapshot(sessions, statsCache, projects, [p.path]))
   }
   return { snapshots, dataSource: 'api' }
 }
@@ -270,75 +330,55 @@ async function withLoader<T>(msg: string, fn: () => Promise<T>): Promise<T> {
   }
 }
 
-// ── Animação: Claude resolve um incidente de produção ────────────────────
-// Cada frame = 4 linhas com largura visível exatamente igual a FW.
+// ── Animação: Neural Wave ─────────────────────────────────────────────────
+// Visualiza um forward-pass num transformer: onda de ativação atravessando
+// 3 "camadas de atenção" em paralelo, da esquerda (input) para a direita (output).
+// Dinâmica — calculada a partir de `frame` sem array estático.
 
 const FW = 44
 
 const fp = (s: string) => s + ' '.repeat(Math.max(0, FW - visLen(s)))
 
-// Cada elemento: [linha1, linha2, linha3, label]
-const FRAMES: Array<[string, string, string, string]> = [
-  [ // 0 — tudo ok
-    fp(`  ${GR}.-----------.${R}  status: ${GR}[OK]${R}`),
-    fp(`  ${GR}| PROD SYS  |${R}  uptime: 99.9%`),
-    fp(`  ${GR}'-----------'${R}  errors:  ${GR}0${R}`),
-    fp(`  ${D}all systems normal${R}`),
-  ],
-  [ // 1 — alerta dispara
-    fp(`  ${RD}.-----------.${R}  ${B}${RD}[!]${R} Error spike!`),
-    fp(`  ${RD}|  ALERT!!  |${R}  ${B}${RD}[!]${R} P0 incident`),
-    fp(`  ${RD}'-----------'${R}  errors: 500/min`),
-    fp(`  ${YL}waking up claude...${R}`),
-  ],
-  [ // 2 — claude lendo logs
-    fp(`   ${YL}o${R}   ${D}$ tail -f /var/log/app.log${R}`),
-    fp(`  ${YL}/|\\${R}  ${RD}> ERROR line 42: null ref${R}`),
-    fp(`  ${YL}/ \\${R}  ${RD}> ERROR line 42: null ref${R}`),
-    fp(`  ${D}investigating...${R}`),
-  ],
-  [ // 3 — achou o bug
-    fp(`   ${YL}o${R}   ${B}${GR}AHA!${R} found it - ${RD}line 42${R}`),
-    fp(`  ${YL}/|\\${R}  ${RD}> if (obj.get() == null)${R}`),
-    fp(`  ${YL}/ \\${R}  ${GR}> fix: obj?.get() ?? ''${R}`),
-    fp(`  ${GR}got the bug!${R}`),
-  ],
-  [ // 4 — digitando a correcao
-    fp(`   ${YL}o${R}   ${D}$ vim src/handler.ts:42${R}`),
-    fp(`  ${YL}\\|/${R}  ${RD}[-]${R} ${D}if (obj.get() == null)${R}`),
-    fp(`   ${YL}|${R}   ${GR}[+]${R} ${GR}if (obj?.get() == null)${R}`),
-    fp(`  ${D}patching...${R}`),
-  ],
-  [ // 5 — commit
-    fp(`   ${YL}o${R}   ${D}$ git commit -m "fix: ..."${R}`),
-    fp(`  ${YL}/|\\${R}  ${GR}[main a1b2c3] fix: null ref${R}`),
-    fp(`  ${YL}/ \\${R}  ${D}1 file changed, +1 -1${R}`),
-    fp(`  ${GR}committed!${R}`),
-  ],
-  [ // 6 — deploy
-    fp(`   ${YL}o${R}   ${D}$ git push && ./deploy.sh${R}`),
-    fp(`  ${YL}/|\\${R}  ${YL}Deploying... ${GR}[========]${R}`),
-    fp(`  ${YL}/ \\${R}  ${GR}Build: OK    Tests: PASS${R}`),
-    fp(`  ${YL}deploying fix...${R}`),
-  ],
-  [ // 7 — resolvido, heroi
-    fp(`  ${GR}.-----------.${R}  status: ${GR}[OK]${R}`),
-    fp(`  ${GR}| INCIDENT  |${R}  errors: ${GR}0${R}`),
-    fp(`  ${GR}| RESOLVED  |${R}  fixed in ${B}4m32s${R}`),
-    fp(`  ${BC}${B}hero mode: activated${R}`),
-  ],
-]
+const ANIM_N     = 12  // nós por linha
+const ANIM_CYCLE = ANIM_N + 4  // frames por ciclo (2 hold + N + 2 hold)
 
-function renderBattle(frame: number): string[] {
-  const f = FRAMES[frame % FRAMES.length]!
-  const sep = sepLine(FW + 4)
+// Offset de fase por linha — simula attention heads independentes
+const ROW_OFFSETS = [0, -1, 1]
+
+// Labels por posição da onda (t = posição no ciclo 0..ANIM_CYCLE-1)
+const ANIM_LABELS: Record<number, string> = {
+  0: 'awaiting input…',    1: 'awaiting input…',
+  2: 'encoding context…',  3: 'encoding context…',
+  4: 'computing attention…', 5: 'computing attention…',
+  6: 'generating tokens…', 7: 'generating tokens…',
+  8: 'decoding output…',   9: 'decoding output…',
+  10: 'response ready  ✦', 11: 'response ready  ✦',
+  12: 'response ready  ✦', 13: 'response ready  ✦',
+  14: 'response ready  ✦', 15: 'response ready  ✦',
+}
+
+function renderAnim(frame: number): string[] {
+  const sep   = sepLine(FW + 4)
+  const t     = frame % ANIM_CYCLE                      // 0 … ANIM_CYCLE-1
+  const wPos  = t - 2                                   // wave front: -2 … N+1
+
+  const rows = ROW_OFFSETS.map(off => {
+    const w = wPos + off
+    const nodes = Array.from({ length: ANIM_N }, (_, i) => {
+      if (i > w)       return `${D}·${R}`               // not reached
+      if (i === w)     return `${B}${AM}◉${R}`          // active front (violet)
+      if (i === w - 1) return `${CY}◌${R}`              // trailing edge (cyan)
+      return `${EM}○${R}`                               // processed (emerald)
+    }).join(' ')
+    return fp(`  ${nodes}`)
+  })
+
+  const label = ANIM_LABELS[t] ?? '…'
   return [
     sep,
-    `  ${f[0]}`,
-    `  ${f[1]}`,
-    `  ${f[2]}`,
-    `  ${f[3]}`,
-    `  ${D}[Ctrl+O para ocultar]${R}`,
+    ...rows,
+    fp(`  ${D}${label}${R}`),
+    `  ${D}[Ctrl+O ocultar]${R}`,
     sep,
   ]
 }
@@ -371,7 +411,7 @@ const tRow = (s: CliSnapshot, name?: string) => {
   const c = v.map((x, i) => padStr(x, COLS[i]!.w))
   if (name !== undefined) {
     const n = name.length > PW-1 ? name.slice(0, PW-2)+'…' : name
-    return padStr(`${CY}${n}${R}`, PW, 'l')+'  '+c.join('  ')
+    return padStr(`${AM}${n}${R}`, PW, 'l')+'  '+c.join('  ')
   }
   return c.join('  ')
 }
@@ -386,27 +426,27 @@ function buildPanel(cfg: WatchConfig, st: AppState): string {
   const ts     = st.lastUpdated.toLocaleTimeString('pt-BR')
   const src    = st.dataSource === 'api' ? `${D}api${R}` : `${YL}files${R}`
   const right  = `${D}${ts}  ${R}${src}${D}  refresh: ${cfg.intervalSec}s${R}`
-  const left   = `${B}${BC}Claude Stats - Watch Mode${R}`
+  const left   = `${B}${AM}Claude Stats${R}${D} · ${R}${B}Watch Mode${R}`
   const gap    = Math.max(1, W - visLen('Claude Stats - Watch Mode') - visLen(ts) - visLen('  api  refresh: XXs'))
   lines.push(left + ' '.repeat(gap) + right)
   lines.push(sepLine(W))
   lines.push('')
 
-  // Batalha (se ativa)
-  if (st.showBattle) { lines.push(...renderBattle(st.animFrame)); lines.push('') }
+  // Animação (se ativa)
+  if (st.showAnim) { lines.push(...renderAnim(st.animFrame)); lines.push('') }
 
   // Bloco info
   const mode = cfg.viewMode === 'junto' ? 'unificado' : cfg.viewMode === 'separado' ? 'separado' : 'ambos'
   lines.push(`  ${D}Home:${R}       ${WH}${HOME_DIR}${R}`)
   lines.push(`  ${D}Claude dir:${R} ${WH}${CLAUDE_DIR}${R}`)
   if (cfg.selectedProjects.length === 0) {
-    lines.push(`  ${D}Projetos:${R}   ${YL}todos (${cfg.allProjects.length})${R}`)
+    lines.push(`  ${D}Projetos:${R}   ${AM}todos (${cfg.allProjects.length})${R}`)
   } else {
-    lines.push(`  ${D}Projetos:${R}   ${CY}${cfg.selectedProjects.map(p=>p.name).join(', ')}${R}`)
+    lines.push(`  ${D}Projetos:${R}   ${AM}${cfg.selectedProjects.map(p=>p.name).join(', ')}${R}`)
   }
-  if (cfg.selectedProjects.length > 1) lines.push(`  ${D}Modo:${R}       ${GR}${mode}${R}`)
+  if (cfg.selectedProjects.length > 1) lines.push(`  ${D}Modo:${R}       ${EM}${mode}${R}`)
   lines.push(`  ${D}Interval:${R}   ${WH}${cfg.intervalSec}s${R}`)
-  lines.push(`  ${D}OTLP:${R}       ${cfg.otlpEndpoint ? `${GR}${cfg.otlpEndpoint}${R}` : `${D}(disabled)${R}`}`)
+  lines.push(`  ${D}OTLP:${R}       ${cfg.otlpEndpoint ? `${EM}${cfg.otlpEndpoint}${R}` : `${D}(disabled)${R}`}`)
   lines.push('')
 
   // Tabela
@@ -416,14 +456,14 @@ function buildPanel(cfg: WatchConfig, st: AppState): string {
 
   if (solo || cfg.viewMode === 'junto') {
     lines.push(sepLine(W))
-    if (!solo) lines.push(`  ${B}${CY}UNIFICADO${R}`)
+    if (!solo) lines.push(`  ${B}${AM}UNIFICADO${R}`)
     lines.push('')
     lines.push('  ' + tHdr(false))
-    lines.push(`  ${GR}${B}${all ? tRow(all) : ldg}${R}`)
+    lines.push(`  ${EM}${B}${all ? tRow(all) : ldg}${R}`)
     lines.push(sepLine(W))
   } else if (cfg.viewMode === 'separado') {
     lines.push(sepLine(W))
-    lines.push(`  ${B}${CY}POR PROJETO${R}`)
+    lines.push(`  ${B}${AM}POR PROJETO${R}`)
     lines.push('')
     lines.push('  ' + tHdr(true))
     for (const p of cfg.selectedProjects) {
@@ -433,12 +473,12 @@ function buildPanel(cfg: WatchConfig, st: AppState): string {
     lines.push(sepLine(W))
   } else {
     lines.push(sepLine(W))
-    lines.push(`  ${B}${CY}UNIFICADO${R}`)
+    lines.push(`  ${B}${AM}UNIFICADO${R}`)
     lines.push('')
     lines.push('  ' + tHdr(false))
-    lines.push(`  ${GR}${B}${all ? tRow(all) : ldg}${R}`)
+    lines.push(`  ${EM}${B}${all ? tRow(all) : ldg}${R}`)
     lines.push('')
-    lines.push(`  ${B}${CY}POR PROJETO${R}`)
+    lines.push(`  ${B}${AM}POR PROJETO${R}`)
     lines.push('')
     lines.push('  ' + tHdr(true))
     for (const p of cfg.selectedProjects) {
@@ -449,7 +489,7 @@ function buildPanel(cfg: WatchConfig, st: AppState): string {
   }
 
   lines.push('')
-  lines.push(`  ${D}Ctrl+C sair  |  Ctrl+O ${st.showBattle ? 'ocultar' : 'mostrar'} animacao${R}`)
+  lines.push(`  ${D}Ctrl+C sair  |  Ctrl+O ${st.showAnim ? 'ocultar' : 'mostrar'} animação${R}`)
   return lines.join('\n') + '\n'
 }
 
@@ -458,7 +498,7 @@ function buildPanel(cfg: WatchConfig, st: AppState): string {
 async function watchLoop(cfg: WatchConfig): Promise<void> {
   const st: AppState = {
     snapshots: new Map(), lastUpdated: new Date(),
-    animFrame: 0, showBattle: cfg.showBattle, isLoading: true, dataSource: 'api' as DataSrc,
+    animFrame: 0, showAnim: cfg.showAnim, isLoading: true, dataSource: 'api' as DataSrc,
   }
 
   const cleanup = () => { out(SHOW + ALT_OFF); if (spawnedServer) { spawnedServer.kill(); spawnedServer = null } process.exit(0) }
@@ -485,7 +525,7 @@ async function watchLoop(cfg: WatchConfig): Promise<void> {
     process.stdin.setRawMode(true); process.stdin.resume()
     process.stdin.on('data', (buf: Buffer) => {
       if (buf[0] === 3)  cleanup()
-      if (buf[0] === 15) { st.showBattle = !st.showBattle; render() }
+      if (buf[0] === 15) { st.showAnim = !st.showAnim; render() }
     })
   } else {
     process.on('SIGINT', cleanup); process.on('SIGTERM', cleanup)
@@ -548,17 +588,49 @@ const checkboxSearch = createPrompt<string[], {
   })
 
   const cs = new Set(checked)
+
+  // Search bar — styled like an input box
+  const COL = process.stdout.columns || 80
+  const BOX = Math.min(56, COL - 6)
+  const cur = `${E}[7m ${R}`  // blinking-cursor block
+  const termPad = ' '.repeat(Math.max(0, BOX - 4 - visLen(term)))
+  const searchBar = [
+    `  ${D}┌${'─'.repeat(BOX)}┐${R}`,
+    `  ${D}│${R}  ${AM}${B}❯${R}  ${B}${term}${R}${cur}${termPad}${D}│${R}`,
+    `  ${D}└${'─'.repeat(BOX)}┘${R}`,
+  ].join('\n')
+
   const page = usePagination({
-    items: filtered as CbChoice[], active, pageSize: config.pageSize ?? 16, loop: false,
-    renderItem: ({ item, isActive }) =>
-      ` ${isActive ? `${CY}>` : ' '}${R} ${cs.has(item.value) ? `${GR}[x]` : `${D}[ ]`}${R}  ${cs.has(item.value) ? GR : ''}${item.name}${R}  ${D}${item.path}${R}`,
+    items: filtered as CbChoice[], active, pageSize: config.pageSize ?? 14, loop: false,
+    renderItem: ({ item, isActive }) => {
+      const sel = cs.has(item.value)
+      const bullet = sel ? `${EM}${B}●${R}` : `${D}○${R}`
+      const arrow  = isActive ? `${AM}▸${R}` : ` `
+      const label  = sel
+        ? `${EM}${B}${item.name}${R}`
+        : isActive
+          ? `${B}${item.name}${R}`
+          : `${D}${item.name}${R}`
+      const path   = `${D}${item.path}${R}`
+      return `  ${arrow} ${bullet}  ${label}  ${path}`
+    },
   })
 
-  const cur      = `${E}[7m ${R}`
-  const selNames = checked.map(v => config.choices.find(c => c.value===v)?.name ?? v).join(', ')
-  const selLine  = checked.length > 0 ? `\n  ${D}Sel: ${R}${GR}${selNames}${R}` : `\n  ${D}(nenhum = todos)${R}`
+  const selCount = checked.length
+  const selNames = checked.map(v => config.choices.find(c => c.value === v)?.name ?? v).join(', ')
+  const selLine  = selCount > 0
+    ? `\n  ${EM}${B}${selCount}${R}${EM} selecionado${selCount > 1 ? 's' : ''}${R}  ${D}${selNames}${R}`
+    : `\n  ${D}nenhum selecionado = todos os projetos${R}`
 
-  return `${B}${config.message}${R}\n  ${D}[Buscar]${R} ${B}${term}${R}${cur}\n\n${page}${selLine}\n  ${D}↑↓ navegar  Espaco selecionar  Enter confirmar  Backspace apagar busca${R}`
+  return [
+    `\n  ${AM}${B}${config.message}${R}`,
+    '',
+    searchBar,
+    '',
+    page,
+    selLine,
+    `\n  ${D}↑↓ navegar  ·  Espaço selecionar  ·  Enter confirmar  ·  Backspace apagar${R}`,
+  ].join('\n')
 })
 
 // ── Prompts de configuração ────────────────────────────────────────────────
@@ -575,8 +647,8 @@ async function askConfig(all: ProjectInfo[]): Promise<WatchConfig> {
     default: process.env.OTEL_EXPORTER_OTLP_ENDPOINT ?? '',
   })
 
-  const showBattle = await confirm({
-    message: 'Mostrar animacao "Claude resolve incidente" no painel?',
+  const showAnim = await confirm({
+    message: 'Mostrar animação neural no painel?',
     default: true,
   })
 
@@ -601,7 +673,7 @@ async function askConfig(all: ProjectInfo[]): Promise<WatchConfig> {
   }
 
   return { selectedProjects: selected, allProjects: all, viewMode,
-    intervalSec: parseInt(intStr, 10), otlpEndpoint: otlp, showBattle }
+    intervalSec: parseInt(intStr, 10), otlpEndpoint: otlp, showAnim }
 }
 
 // ── Auto-start do servidor API ────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Adds `bun run watch` — a full-screen TUI that mirrors the web dashboard in the terminal, updating in real-time via chokidar + SSE
- Auto-starts the API server (`server.ts`) if not already running
- Interactive project selector with reactive search, `●/○` checkboxes, and box-drawing input bar
- **Neural Wave animation** — 3 attention heads (rows) showing a token activation wave propagating from input → encoding → attention → output
- Color palette matched to the web dark mode (orange/amber as primary accent)

## What changed

| File | Why |
|------|-----|
| `watch-cli.ts` | New TUI — full-screen panel, metrics table, animation, project filter |
| `server.ts` | Add `/api/health` probe endpoint; graceful exit if port 3001 is already in use |
| `package.json` | Add `watch` and `watch:cli` scripts |

## Metrics correctness

All calculations mirror `useDerivedStats` exactly:

- **Streak** — union of `dailyActivity` dates + all session dates (covers stale stats-cache)
- **Git stats** — uses `project.git_stats` for single-project view (direct git counts, same as frontend)
- **Blended cost** — includes cache read/write tokens in weighted rate
- **Messages (no filter)** — supplements `dailyActivity` with sessions on days not yet cached

## Test plan

- [ ] `bun run watch` starts without API running → auto-starts server, shows loader
- [ ] `bun run watch` with API already running → skips start
- [ ] Select 1 project → metrics match web dashboard exactly (sessions, tokens, cost, streak, commits, lines)
- [ ] Select 0 projects (all) → global metrics match web
- [ ] Select 2+ projects → unified + per-project views work
- [ ] Ctrl+O toggles neural wave animation
- [ ] Ctrl+C exits cleanly and kills spawned server

🤖 Generated with [Claude Code](https://claude.com/claude-code)