### PR TITLE
fix: watch:cli color palette, loading state and goodbye screen

### DIFF
--- a/src/components/PDFExportModal.tsx
+++ b/src/components/PDFExportModal.tsx
@@ -6,7 +6,7 @@ import {
 import { format, parseISO, subDays } from 'date-fns'
 import type { AppData, Filters, Lang, ModelUsage, SessionMeta } from '../lib/types'
 import { formatModel, formatProjectName, calcCost } from '../lib/types'
-import { useDerivedStats } from '../hooks/useData'
+import { useDerivedStats, blendedCostPerToken } from '../hooks/useData'
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -348,8 +348,9 @@ function MiniProjectsList({ projectStats, c, lang }: {
   )
 }
 
-function MiniSessionsTable({ sessions, c, lang, currency, brlRate }: {
+function MiniSessionsTable({ sessions, c, lang, currency, brlRate, blendedRates }: {
   sessions: SessionMeta[]; c: Colors; lang: Lang; currency: 'USD' | 'BRL'; brlRate: number
+  blendedRates: { input: number; output: number }
 }) {
   const cols = '90px 1fr 48px 40px 40px 62px'
   const headers = [lang === 'pt' ? 'Data' : 'Date', lang === 'pt' ? 'Projeto' : 'Project',
@@ -362,7 +363,7 @@ function MiniSessionsTable({ sessions, c, lang, currency, brlRate }: {
       {sessions.slice(0, 12).map((s, i) => {
         const msgs = (s.user_message_count ?? 0) + (s.assistant_message_count ?? 0)
         const tools = Object.values(s.tool_counts ?? {}).reduce((a, b) => a + b, 0)
-        const costUSD = ((s.input_tokens ?? 0) / 1_000_000) * 3 + ((s.output_tokens ?? 0) / 1_000_000) * 15
+        const costUSD = ((s.input_tokens ?? 0) / 1_000_000) * blendedRates.input + ((s.output_tokens ?? 0) / 1_000_000) * blendedRates.output
         return (
           <div key={i} style={{ display: 'grid', gridTemplateColumns: cols, gap: 6, padding: '4px 0', borderBottom: `1px solid ${c.border}40`, alignItems: 'center' }}>
             <div style={{ color: c.textSec }}>{s.start_time ? format(parseISO(s.start_time), 'MM/dd HH:mm') : '—'}</div>
@@ -534,15 +535,16 @@ function MiniHighlightsSection({ sessions, c, lang }: {
 
 interface PDFContentProps {
   pdfTheme: PDFTheme
-  enabledSections: Set<SectionId>
+  sectionOrder: SectionId[]
   derived: ReturnType<typeof useDerivedStats>
   pdfFilters: Filters
   lang: Lang
   currency: 'USD' | 'BRL'
   brlRate: number
+  blendedRates: { input: number; output: number }
 }
 
-function PDFContent({ pdfTheme, enabledSections, derived, pdfFilters, lang, currency, brlRate }: PDFContentProps) {
+function PDFContent({ pdfTheme, sectionOrder, derived, pdfFilters, lang, currency, brlRate, blendedRates }: PDFContentProps) {
   if (!derived) return null
   const c = COLORS[pdfTheme]
   const pt = lang === 'pt'
@@ -588,92 +590,89 @@ function PDFContent({ pdfTheme, enabledSections, derived, pdfFilters, lang, curr
         </div>
       </div>
 
-      {/* Summary */}
-      {enabledSections.has('summary') && (
-        <div style={{ marginBottom: 28 }}>
-          <SectionTitle title={pt ? 'Resumo' : 'Summary'} c={c} />
-          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: 10, marginBottom: 10 }}>
-            <KPICard label={pt ? 'Mensagens' : 'Messages'} value={fmtN(derived.totalMessages)} sub={pt ? 'no período' : 'in period'} accent={c.orange} c={c} />
-            <KPICard label={pt ? 'Sessões' : 'Sessions'} value={fmtN(derived.totalSessions)} sub={`avg ${derived.totalSessions > 0 ? Math.round(derived.totalMessages / derived.totalSessions) : 0} msgs`} accent={c.blue} c={c} />
-            <KPICard label="Tool calls" value={fmtN(derived.totalToolCalls)} sub={pt ? 'execuções' : 'executions'} accent={c.green} c={c} />
-            <KPICard label={pt ? 'Custo est.' : 'Est. cost'} value={fmtCostStr(derived.totalCostUSD, currency, brlRate)} sub="Anthropic pricing" accent={c.orange} c={c} />
-          </div>
-          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: 10 }}>
-            <KPICard label={pt ? 'Sequência' : 'Streak'} value={`${derived.streak}d`} sub={pt ? 'dias consec.' : 'consecutive'} accent={c.red} c={c} />
-            <KPICard label={pt ? 'Sessão mais longa' : 'Longest session'} value={derived.longestSession?.duration_minutes ? fmtDur(derived.longestSession.duration_minutes) : '—'} sub="" accent={c.purple} c={c} />
-            <KPICard label="Commits" value={String(derived.gitCommits)} sub={derived.gitPushes > 0 ? `${derived.gitPushes} pushes` : pt ? 'via Claude' : 'via Claude'} accent={c.cyan} c={c} />
-            <KPICard label={pt ? 'Arquivos' : 'Files'} value={String(derived.filesModified)} sub={`+${fmtN(derived.linesAdded)} / -${fmtN(derived.linesRemoved)}`} accent={c.green} c={c} />
-          </div>
-        </div>
-      )}
-
-      {enabledSections.has('activity') && (
-        <div style={{ marginBottom: 28 }}>
-          <SectionTitle title={pt ? 'Atividade ao longo do tempo' : 'Activity over time'} c={c} />
-          <MiniLineChart data={derived.heatmapData} c={c} />
-        </div>
-      )}
-
-      {enabledSections.has('heatmap') && (
-        <div style={{ marginBottom: 28 }}>
-          <SectionTitle title={pt ? 'Mapa de calor (26 semanas)' : 'Activity heatmap (26 weeks)'} c={c} />
-          <MiniHeatmap data={derived.heatmapData} c={c} />
-        </div>
-      )}
-
-      {enabledSections.has('hours') && (
-        <div style={{ marginBottom: 28 }}>
-          <SectionTitle title={pt ? 'Uso por hora do dia' : 'Usage by hour of day'} c={c} />
-          <MiniBarChart hourCounts={derived.hourCounts} c={c} />
-        </div>
-      )}
-
-      {enabledSections.has('models') && (
-        <div style={{ marginBottom: 28 }}>
-          <SectionTitle title={pt ? 'Uso por modelo' : 'Model usage & cost'} c={c} />
-          <MiniModelBars modelUsage={derived.modelUsage} c={c} currency={currency} brlRate={brlRate} />
-        </div>
-      )}
-
-      {enabledSections.has('projects') && (
-        <div style={{ marginBottom: 28 }}>
-          <SectionTitle title={pt ? 'Principais projetos' : 'Top projects'} c={c} />
-          <MiniProjectsList projectStats={derived.projectStats} c={c} lang={lang} />
-        </div>
-      )}
-
-      {enabledSections.has('tools') && (
-        <div style={{ marginBottom: 28 }}>
-          <SectionTitle title={pt ? 'Ferramentas e linguagens' : 'Tools & languages'} c={c} />
-          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 20 }}>
-            <div>
-              <div style={{ fontSize: 10, fontWeight: 600, color: c.textSec, marginBottom: 8 }}>{pt ? 'Ferramentas mais usadas' : 'Most used tools'}</div>
-              <MiniTagCloud data={derived.toolCounts} color={c.green} c={c} />
+      {sectionOrder.map(id => {
+        switch (id) {
+          case 'summary': return (
+            <div key="summary" style={{ marginBottom: 28 }}>
+              <SectionTitle title={pt ? 'Resumo' : 'Summary'} c={c} />
+              <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: 10, marginBottom: 10 }}>
+                <KPICard label={pt ? 'Mensagens' : 'Messages'} value={fmtN(derived.totalMessages)} sub={pt ? 'no período' : 'in period'} accent={c.orange} c={c} />
+                <KPICard label={pt ? 'Sessões' : 'Sessions'} value={fmtN(derived.totalSessions)} sub={`avg ${derived.totalSessions > 0 ? Math.round(derived.totalMessages / derived.totalSessions) : 0} msgs`} accent={c.blue} c={c} />
+                <KPICard label="Tool calls" value={fmtN(derived.totalToolCalls)} sub={pt ? 'execuções' : 'executions'} accent={c.green} c={c} />
+                <KPICard label={pt ? 'Custo est.' : 'Est. cost'} value={fmtCostStr(derived.totalCostUSD, currency, brlRate)} sub="Anthropic pricing" accent={c.orange} c={c} />
+              </div>
+              <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: 10 }}>
+                <KPICard label={pt ? 'Sequência' : 'Streak'} value={`${derived.streak}d`} sub={pt ? 'dias consec.' : 'consecutive'} accent={c.red} c={c} />
+                <KPICard label={pt ? 'Sessão mais longa' : 'Longest session'} value={derived.longestSession?.duration_minutes ? fmtDur(derived.longestSession.duration_minutes) : '—'} sub="" accent={c.purple} c={c} />
+                <KPICard label="Commits" value={String(derived.gitCommits)} sub={derived.gitPushes > 0 ? `${derived.gitPushes} pushes` : pt ? 'via Claude' : 'via Claude'} accent={c.cyan} c={c} />
+                <KPICard label={pt ? 'Arquivos' : 'Files'} value={String(derived.filesModified)} sub={`+${fmtN(derived.linesAdded)} / -${fmtN(derived.linesRemoved)}`} accent={c.green} c={c} />
+              </div>
             </div>
-            <div>
-              <div style={{ fontSize: 10, fontWeight: 600, color: c.textSec, marginBottom: 8 }}>{pt ? 'Linguagens' : 'Languages'}</div>
-              <MiniTagCloud data={derived.langCounts} color={c.blue} c={c} />
+          )
+          case 'activity': return (
+            <div key="activity" style={{ marginBottom: 28 }}>
+              <SectionTitle title={pt ? 'Atividade ao longo do tempo' : 'Activity over time'} c={c} />
+              <MiniLineChart data={derived.heatmapData} c={c} />
             </div>
-          </div>
-        </div>
-      )}
-
-      {enabledSections.has('sessions') && (
-        <div style={{ marginBottom: 28 }}>
-          <SectionTitle title={pt ? 'Sessões recentes (top 12)' : 'Recent sessions (top 12)'} c={c} />
-          <MiniSessionsTable
-            sessions={[...derived.filteredSessions].sort((a, b) => (b.start_time ?? '').localeCompare(a.start_time ?? '')).slice(0, 12)}
-            c={c} lang={lang} currency={currency} brlRate={brlRate}
-          />
-        </div>
-      )}
-
-      {enabledSections.has('highlights') && (
-        <div style={{ marginBottom: 28 }}>
-          <SectionTitle title={pt ? 'Recordes do período' : 'Period highlights'} c={c} />
-          <MiniHighlightsSection sessions={derived.filteredSessions} c={c} lang={lang} />
-        </div>
-      )}
+          )
+          case 'heatmap': return (
+            <div key="heatmap" style={{ marginBottom: 28 }}>
+              <SectionTitle title={pt ? 'Mapa de calor (26 semanas)' : 'Activity heatmap (26 weeks)'} c={c} />
+              <MiniHeatmap data={derived.heatmapData} c={c} />
+            </div>
+          )
+          case 'hours': return (
+            <div key="hours" style={{ marginBottom: 28 }}>
+              <SectionTitle title={pt ? 'Uso por hora do dia' : 'Usage by hour of day'} c={c} />
+              <MiniBarChart hourCounts={derived.hourCounts} c={c} />
+            </div>
+          )
+          case 'models': return (
+            <div key="models" style={{ marginBottom: 28 }}>
+              <SectionTitle title={pt ? 'Uso por modelo' : 'Model usage & cost'} c={c} />
+              <MiniModelBars modelUsage={derived.modelUsage} c={c} currency={currency} brlRate={brlRate} />
+            </div>
+          )
+          case 'projects': return (
+            <div key="projects" style={{ marginBottom: 28 }}>
+              <SectionTitle title={pt ? 'Principais projetos' : 'Top projects'} c={c} />
+              <MiniProjectsList projectStats={derived.projectStats} c={c} lang={lang} />
+            </div>
+          )
+          case 'tools': return (
+            <div key="tools" style={{ marginBottom: 28 }}>
+              <SectionTitle title={pt ? 'Ferramentas e linguagens' : 'Tools & languages'} c={c} />
+              <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 20 }}>
+                <div>
+                  <div style={{ fontSize: 10, fontWeight: 600, color: c.textSec, marginBottom: 8 }}>{pt ? 'Ferramentas mais usadas' : 'Most used tools'}</div>
+                  <MiniTagCloud data={derived.toolCounts} color={c.green} c={c} />
+                </div>
+                <div>
+                  <div style={{ fontSize: 10, fontWeight: 600, color: c.textSec, marginBottom: 8 }}>{pt ? 'Linguagens' : 'Languages'}</div>
+                  <MiniTagCloud data={derived.langCounts} color={c.blue} c={c} />
+                </div>
+              </div>
+            </div>
+          )
+          case 'sessions': return (
+            <div key="sessions" style={{ marginBottom: 28 }}>
+              <SectionTitle title={pt ? 'Sessões recentes (top 12)' : 'Recent sessions (top 12)'} c={c} />
+              <MiniSessionsTable
+                sessions={[...derived.filteredSessions].sort((a, b) => (b.start_time ?? '').localeCompare(a.start_time ?? '')).slice(0, 12)}
+                c={c} lang={lang} currency={currency} brlRate={brlRate}
+                blendedRates={blendedRates}
+              />
+            </div>
+          )
+          case 'highlights': return (
+            <div key="highlights" style={{ marginBottom: 28 }}>
+              <SectionTitle title={pt ? 'Recordes do período' : 'Period highlights'} c={c} />
+              <MiniHighlightsSection sessions={derived.filteredSessions} c={c} lang={lang} />
+            </div>
+          )
+          default: return null
+        }
+      })}
 
       <div style={{ marginTop: 24, paddingTop: 14, borderTop: `1px solid ${c.border}`, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
         <div style={{ fontSize: 8, color: c.textTer }}>Claude Stats · Gerado automaticamente</div>
@@ -702,8 +701,8 @@ export function PDFExportModal({ data, filters, lang, currency, brlRate, onClose
   const [pdfTheme, setPdfTheme] = useState<PDFTheme>(
     () => window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
   )
-  const [enabledSections, setEnabledSections] = useState<Set<SectionId>>(
-    new Set<SectionId>(['summary', 'activity', 'heatmap', 'hours', 'models', 'projects', 'tools'])
+  const [sectionOrder, setSectionOrder] = useState<SectionId[]>(
+    ['summary', 'activity', 'heatmap', 'hours', 'models', 'projects', 'tools']
   )
   const [exporting, setExporting] = useState(false)
   const [exportSuccess, setExportSuccess] = useState(false)
@@ -731,19 +730,21 @@ export function PDFExportModal({ data, filters, lang, currency, brlRate, onClose
   }
 
   const toggleSection = (id: SectionId) => {
-    setEnabledSections(prev => {
-      const next = new Set(prev)
-      if (next.has(id)) next.delete(id)
-      else next.add(id)
-      return next
-    })
+    setSectionOrder(prev =>
+      prev.includes(id) ? prev.filter(s => s !== id) : [...prev, id]
+    )
   }
 
-  const allSelected = enabledSections.size === SECTIONS.length
+  const allSelected = sectionOrder.length === SECTIONS.length
   const toggleAll = () => {
-    if (allSelected) setEnabledSections(new Set())
-    else setEnabledSections(new Set(SECTION_IDS))
+    if (allSelected) setSectionOrder([])
+    else setSectionOrder([...SECTION_IDS])
   }
+
+  const blendedRates = useMemo(
+    () => blendedCostPerToken(data.statsCache.modelUsage ?? {}),
+    [data.statsCache.modelUsage]
+  )
 
   const handleExport = async () => {
     if (!contentRef.current || exporting) return
@@ -1070,7 +1071,7 @@ export function PDFExportModal({ data, filters, lang, currency, brlRate, onClose
               </div>
               <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 6 }}>
                 {SECTIONS.map(({ id, labelPt, labelEn, Icon }) => {
-                  const on = enabledSections.has(id)
+                  const on = sectionOrder.includes(id)
                   return (
                     <button key={id} onClick={() => toggleSection(id)} style={{
                       display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center',
@@ -1104,13 +1105,13 @@ export function PDFExportModal({ data, filters, lang, currency, brlRate, onClose
             {/* Export button */}
             <button
               onClick={handleExport}
-              disabled={exporting || enabledSections.size === 0}
+              disabled={exporting || sectionOrder.length === 0}
               style={{
                 display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 8,
                 padding: '11px 16px', borderRadius: 10, border: 'none',
-                cursor: enabledSections.size === 0 ? 'not-allowed' : 'pointer',
-                background: exportSuccess ? '#10b981' : enabledSections.size === 0 ? 'var(--bg-elevated)' : 'var(--anthropic-orange)',
-                color: exportSuccess || enabledSections.size > 0 ? '#fff' : 'var(--text-tertiary)',
+                cursor: sectionOrder.length === 0 ? 'not-allowed' : 'pointer',
+                background: exportSuccess ? '#10b981' : sectionOrder.length === 0 ? 'var(--bg-elevated)' : 'var(--anthropic-orange)',
+                color: exportSuccess || sectionOrder.length > 0 ? '#fff' : 'var(--text-tertiary)',
                 fontSize: 13, fontWeight: 700, fontFamily: 'inherit',
                 transition: 'all 0.2s', opacity: exporting ? 0.8 : 1,
               }}
@@ -1126,7 +1127,7 @@ export function PDFExportModal({ data, filters, lang, currency, brlRate, onClose
                 <><Download size={14} /> {pt ? 'Exportar PDF' : 'Export PDF'}</>
               )}
             </button>
-            {enabledSections.size === 0 && (
+            {sectionOrder.length === 0 && (
               <div style={{ fontSize: 10, color: 'var(--text-tertiary)', textAlign: 'center', marginTop: -12 }}>
                 {pt ? 'Selecione pelo menos uma seção' : 'Select at least one section'}
               </div>
@@ -1142,7 +1143,7 @@ export function PDFExportModal({ data, filters, lang, currency, brlRate, onClose
                 {pt ? 'Prévia em tempo real' : 'Live preview'} · 794px (A4)
               </div>
               <div style={{ fontSize: 10, color: 'var(--text-tertiary)', marginLeft: 'auto' }}>
-                {enabledSections.size} {pt ? 'seção(ões)' : 'section(s)'}
+                {sectionOrder.length} {pt ? 'seção(ões)' : 'section(s)'}
               </div>
             </div>
 
@@ -1151,12 +1152,13 @@ export function PDFExportModal({ data, filters, lang, currency, brlRate, onClose
               <div ref={contentRef} style={{ boxShadow: '0 4px 32px rgba(0,0,0,0.3)', borderRadius: 4, overflow: 'hidden', flexShrink: 0, alignSelf: 'flex-start', background: COLORS[pdfTheme].bg }}>
                 <PDFContent
                   pdfTheme={pdfTheme}
-                  enabledSections={enabledSections}
+                  sectionOrder={sectionOrder}
                   derived={derived}
                   pdfFilters={pdfFilters}
                   lang={lang}
                   currency={currency}
                   brlRate={brlRate}
+                  blendedRates={blendedRates}
                 />
               </div>
             </div>

--- a/watch-cli.ts
+++ b/watch-cli.ts
@@ -28,18 +28,24 @@ const CLAUDE_DIR  = join(HOME_DIR, '.claude')
 const API_BASE    = 'http://localhost:3001'
 const SESSION_START = Date.now()
 
-function showGoodbye(lastSnap?: { messages: number; streak: number; costUsd: number }): void {
-  const secs    = Math.floor((Date.now() - SESSION_START) / 1000)
-  const dur     = secs >= 60 ? `${Math.floor(secs/60)}m ${secs%60}s` : `${secs}s`
+function showGoodbye(opts?: {
+  messages: number; streak: number; costUsd: number
+  projects: string[]
+}): void {
+  const secs = Math.floor((Date.now() - SESSION_START) / 1000)
+  const dur  = secs >= 60 ? `${Math.floor(secs/60)}m ${secs%60}s` : `${secs}s`
+  const fmtN = (n: number) => n >= 1000 ? (n/1000).toFixed(1)+'k' : String(n)
   const lines: string[] = []
   lines.push('')
   lines.push(`  ${AM}${B}claude-stats${R}  ${D}·  watch mode${R}`)
   lines.push('')
-  lines.push(`  ${D}sessão:  ${R}${WH}${dur}${R}`)
-  if (lastSnap) {
-    lines.push(`  ${D}streak:  ${R}${WH}${lastSnap.streak}d${R}`)
-    lines.push(`  ${D}msgs:    ${R}${WH}${lastSnap.messages >= 1000 ? (lastSnap.messages/1000).toFixed(1)+'k' : lastSnap.messages}${R}`)
-    lines.push(`  ${D}custo:   ${R}${WH}$${lastSnap.costUsd.toFixed(2)}${R}`)
+  lines.push(`  ${D}sessão:   ${R}${WH}${dur}${R}`)
+  if (opts) {
+    const proj = opts.projects.length > 0 ? opts.projects.join(', ') : 'todos'
+    lines.push(`  ${D}projeto:  ${R}${WH}${proj}${R}`)
+    lines.push(`  ${D}streak:   ${R}${WH}${opts.streak}d${R}`)
+    lines.push(`  ${D}msgs:     ${R}${WH}${fmtN(opts.messages)}${R}`)
+    lines.push(`  ${D}custo:    ${R}${WH}$${opts.costUsd.toFixed(2)}${R}`)
   }
   lines.push('')
   lines.push(`  ${D}até logo  ${AM}✦${R}`)
@@ -297,12 +303,9 @@ async function reloadData(config: WatchConfig): Promise<{
 async function withLoader<T>(msg: string, fn: () => Promise<T>): Promise<T> {
   if (!process.stdout.isTTY) return fn()
 
-  const H     = 7
+  const H     = 8
   const W     = Math.min((process.stdout.columns || 80) - 2, 94)
   const BAR_W = W - 2
-
-  // Braille dots — cycling at ~12fps produces a perfectly smooth spin
-  const SPIN = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏']
 
   // Gradient wave: trough → peak → trough, repeated twice for seamless wrap
   const WAVE = '░░░▒▒▓▓███▓▓▒▒░░░░░▒▒▓▓███▓▓▒▒░░░'
@@ -310,8 +313,6 @@ async function withLoader<T>(msg: string, fn: () => Promise<T>): Promise<T> {
   let frame = 0
 
   const draw = () => {
-    const spin = SPIN[frame % SPIN.length]!
-
     // Scroll wave left — offset grows each frame
     const off  = (frame * 1) % WAVE.length
     const raw  = (WAVE + WAVE + WAVE).slice(off, off + BAR_W)
@@ -329,11 +330,12 @@ async function withLoader<T>(msg: string, fn: () => Promise<T>): Promise<T> {
     out(`\x1b[${H}A`)
     out(`\n`)
     out(`  ${sep}\n`)
-    out(`  ${AM}${B}${spin}${R}  ${B}claude-stats${R}  ${D}·  session pipeline${R}\n`)
+    out(`  ${B}claude-stats${R}  ${D}·  session pipeline${R}\n`)
+    out(`\n`)
     out(`  ${bar}\n`)
+    out(`\n`)
     out(`  ${D}▸${R}  ${D}${msg}${R}\n`)
     out(`  ${sep}\n`)
-    out(`\n`)
   }
 
   out('\n'.repeat(H))
@@ -469,24 +471,13 @@ function buildPanel(cfg: WatchConfig, st: AppState): string {
   lines.push(`  ${D}OTLP:${R}       ${cfg.otlpEndpoint ? `${WH}${cfg.otlpEndpoint}${R}` : `${D}(disabled)${R}`}`)
   lines.push('')
 
-  // Loading spinner — wave bar (same gradient as loader) + braille spinner
-  const WAVE_STR = '░░░▒▒▓▓███▓▓▒▒░░░░░▒▒▓▓███▓▓▒▒░░░'
-  const WAVE_W   = 36
-  const wOff  = st.animFrame % WAVE_STR.length
-  const wRaw  = (WAVE_STR + WAVE_STR + WAVE_STR).slice(wOff, wOff + WAVE_W)
-  const wBar  = wRaw.split('').map(c =>
-    c === '█' ? `${B}${AM}█${R}`
-    : c === '▓' ? `${AM}▓${R}`
-    : c === '▒' ? `${D}${AM}▒${R}`
-    : `${D}░${R}`
-  ).join('')
-  const MINI_SPIN = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏']
-  const mSpin = MINI_SPIN[st.animFrame % MINI_SPIN.length]!
-
   // Tabela
   const solo = cfg.selectedProjects.length <= 1
   const all  = st.snapshots.get('')
-  const ldg  = `  ${AM}${mSpin}${R}  ${wBar}`
+  // Enquanto não há dados: exibe zeros em cada coluna + mensagem discreta
+  const zeroSnap = { messages:0, sessions:0, inputTokens:0, outputTokens:0,
+    costUsd:0, streak:0, gitCommits:0, linesAdded:0, linesRemoved:0 }
+  const ldg = `${tRow(zeroSnap)}  ${D}obtendo dados...${R}`
 
   if (solo || cfg.viewMode === 'junto') {
     lines.push(sepLine(W))
@@ -538,7 +529,10 @@ async function watchLoop(cfg: WatchConfig): Promise<void> {
   const cleanup = () => {
     out(SHOW + ALT_OFF + CLR)
     const snap = st.snapshots.get('')
-    showGoodbye(snap ? { messages: snap.messages, streak: snap.streak, costUsd: snap.costUsd } : undefined)
+    showGoodbye(snap ? {
+      messages: snap.messages, streak: snap.streak, costUsd: snap.costUsd,
+      projects: cfg.selectedProjects.map(p => p.name),
+    } : undefined)
     if (spawnedServer) { spawnedServer.kill(); spawnedServer = null }
     process.exit(0)
   }

--- a/watch-cli.ts
+++ b/watch-cli.ts
@@ -298,9 +298,9 @@ async function withLoader<T>(msg: string, fn: () => Promise<T>): Promise<T> {
 
     // Apply color gradient: bright at peaks, dim at troughs
     const bar = raw.split('').map(c =>
-      c === '█' ? `${B}${BC}█${R}`
-      : c === '▓' ? `${CY}▓${R}`
-      : c === '▒' ? `${D}${CY}▒${R}`
+      c === '█' ? `${B}${AM}█${R}`
+      : c === '▓' ? `${AM}▓${R}`
+      : c === '▒' ? `${D}${AM}▒${R}`
       : `${D}░${R}`
     ).join('')
 
@@ -408,7 +408,7 @@ const tRow = (s: CliSnapshot, name?: string) => {
     fmtC(s.costUsd), `${s.streak}d`, fmtN(s.gitCommits),
     `+${fmtN(s.linesAdded)}`, `-${fmtN(s.linesRemoved)}`,
   ]
-  const c = v.map((x, i) => padStr(x, COLS[i]!.w))
+  const c = v.map((x, i) => padStr(`${AM}${x}${R}`, COLS[i]!.w))
   if (name !== undefined) {
     const n = name.length > PW-1 ? name.slice(0, PW-2)+'…' : name
     return padStr(`${AM}${n}${R}`, PW, 'l')+'  '+c.join('  ')
@@ -449,10 +449,17 @@ function buildPanel(cfg: WatchConfig, st: AppState): string {
   lines.push(`  ${D}OTLP:${R}       ${cfg.otlpEndpoint ? `${WH}${cfg.otlpEndpoint}${R}` : `${D}(disabled)${R}`}`)
   lines.push('')
 
+  // Binary spinner — 90% zeros, 1 (orange) moves like a cursor
+  const SPIN_W = 48
+  const spinPos = st.animFrame % SPIN_W
+  const spinLine = Array.from({ length: SPIN_W }, (_, i) =>
+    i === spinPos ? `${AM}${B}1${R}` : `${D}0${R}`
+  ).join('')
+
   // Tabela
   const solo = cfg.selectedProjects.length <= 1
   const all  = st.snapshots.get('')
-  const ldg  = `  ${D}(carregando...)${R}`
+  const ldg  = `  ${spinLine}`
 
   if (solo || cfg.viewMode === 'junto') {
     lines.push(sepLine(W))
@@ -501,10 +508,13 @@ async function watchLoop(cfg: WatchConfig): Promise<void> {
     animFrame: 0, showAnim: cfg.showAnim, isLoading: true, dataSource: 'api' as DataSrc,
   }
 
-  const cleanup = () => { out(SHOW + ALT_OFF); if (spawnedServer) { spawnedServer.kill(); spawnedServer = null } process.exit(0) }
+  const cleanup = () => { out(SHOW + ALT_OFF + CLR); if (spawnedServer) { spawnedServer.kill(); spawnedServer = null } process.exit(0) }
   out(ALT_ON + HIDE)
 
   const render = () => { out(CLR + buildPanel(cfg, st)) }
+
+  // Render imediato — mostra painel de loading antes de qualquer fetch
+  render()
 
   let reloading = false
   const refresh = async () => {

--- a/watch-cli.ts
+++ b/watch-cli.ts
@@ -23,9 +23,29 @@ import type { ModelUsage, SessionMeta } from './src/lib/types'
 
 // ── Paths ──────────────────────────────────────────────────────────────────
 
-const HOME_DIR   = process.env.HOME ?? process.env.USERPROFILE ?? ''
-const CLAUDE_DIR = join(HOME_DIR, '.claude')
-const API_BASE   = 'http://localhost:3001'
+const HOME_DIR    = process.env.HOME ?? process.env.USERPROFILE ?? ''
+const CLAUDE_DIR  = join(HOME_DIR, '.claude')
+const API_BASE    = 'http://localhost:3001'
+const SESSION_START = Date.now()
+
+function showGoodbye(lastSnap?: { messages: number; streak: number; costUsd: number }): void {
+  const secs    = Math.floor((Date.now() - SESSION_START) / 1000)
+  const dur     = secs >= 60 ? `${Math.floor(secs/60)}m ${secs%60}s` : `${secs}s`
+  const lines: string[] = []
+  lines.push('')
+  lines.push(`  ${AM}${B}claude-stats${R}  ${D}·  watch mode${R}`)
+  lines.push('')
+  lines.push(`  ${D}sessão:  ${R}${WH}${dur}${R}`)
+  if (lastSnap) {
+    lines.push(`  ${D}streak:  ${R}${WH}${lastSnap.streak}d${R}`)
+    lines.push(`  ${D}msgs:    ${R}${WH}${lastSnap.messages >= 1000 ? (lastSnap.messages/1000).toFixed(1)+'k' : lastSnap.messages}${R}`)
+    lines.push(`  ${D}custo:   ${R}${WH}$${lastSnap.costUsd.toFixed(2)}${R}`)
+  }
+  lines.push('')
+  lines.push(`  ${D}até logo  ${AM}✦${R}`)
+  lines.push('')
+  process.stdout.write(lines.join('\n') + '\n')
+}
 
 // ── ANSI ───────────────────────────────────────────────────────────────────
 
@@ -449,17 +469,24 @@ function buildPanel(cfg: WatchConfig, st: AppState): string {
   lines.push(`  ${D}OTLP:${R}       ${cfg.otlpEndpoint ? `${WH}${cfg.otlpEndpoint}${R}` : `${D}(disabled)${R}`}`)
   lines.push('')
 
-  // Binary spinner — 90% zeros, 1 (orange) moves like a cursor
-  const SPIN_W = 48
-  const spinPos = st.animFrame % SPIN_W
-  const spinLine = Array.from({ length: SPIN_W }, (_, i) =>
-    i === spinPos ? `${AM}${B}1${R}` : `${D}0${R}`
+  // Loading spinner — wave bar (same gradient as loader) + braille spinner
+  const WAVE_STR = '░░░▒▒▓▓███▓▓▒▒░░░░░▒▒▓▓███▓▓▒▒░░░'
+  const WAVE_W   = 36
+  const wOff  = st.animFrame % WAVE_STR.length
+  const wRaw  = (WAVE_STR + WAVE_STR + WAVE_STR).slice(wOff, wOff + WAVE_W)
+  const wBar  = wRaw.split('').map(c =>
+    c === '█' ? `${B}${AM}█${R}`
+    : c === '▓' ? `${AM}▓${R}`
+    : c === '▒' ? `${D}${AM}▒${R}`
+    : `${D}░${R}`
   ).join('')
+  const MINI_SPIN = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏']
+  const mSpin = MINI_SPIN[st.animFrame % MINI_SPIN.length]!
 
   // Tabela
   const solo = cfg.selectedProjects.length <= 1
   const all  = st.snapshots.get('')
-  const ldg  = `  ${spinLine}`
+  const ldg  = `  ${AM}${mSpin}${R}  ${wBar}`
 
   if (solo || cfg.viewMode === 'junto') {
     lines.push(sepLine(W))
@@ -508,7 +535,13 @@ async function watchLoop(cfg: WatchConfig): Promise<void> {
     animFrame: 0, showAnim: cfg.showAnim, isLoading: true, dataSource: 'api' as DataSrc,
   }
 
-  const cleanup = () => { out(SHOW + ALT_OFF + CLR); if (spawnedServer) { spawnedServer.kill(); spawnedServer = null } process.exit(0) }
+  const cleanup = () => {
+    out(SHOW + ALT_OFF + CLR)
+    const snap = st.snapshots.get('')
+    showGoodbye(snap ? { messages: snap.messages, streak: snap.streak, costUsd: snap.costUsd } : undefined)
+    if (spawnedServer) { spawnedServer.kill(); spawnedServer = null }
+    process.exit(0)
+  }
   out(ALT_ON + HIDE)
 
   const render = () => { out(CLR + buildPanel(cfg, st)) }
@@ -759,6 +792,11 @@ async function main() {
 }
 
 main().catch(err => {
+  // ExitPromptError = Ctrl+C during an inquirer prompt (expected exit)
+  if (err?.name === 'ExitPromptError' || err?.code === 'ERR_USE_AFTER_CLOSE') {
+    showGoodbye()
+    process.exit(0)
+  }
   out(SHOW + ALT_OFF)
   console.error('Erro fatal:', err)
   process.exit(1)

--- a/watch-cli.ts
+++ b/watch-cli.ts
@@ -309,7 +309,7 @@ async function withLoader<T>(msg: string, fn: () => Promise<T>): Promise<T> {
     out(`\x1b[${H}A`)
     out(`\n`)
     out(`  ${sep}\n`)
-    out(`  ${BC}${B}${spin}${R}  ${B}claude-stats${R}  ${D}·  session pipeline${R}\n`)
+    out(`  ${AM}${B}${spin}${R}  ${B}claude-stats${R}  ${D}·  session pipeline${R}\n`)
     out(`  ${bar}\n`)
     out(`  ${D}▸${R}  ${D}${msg}${R}\n`)
     out(`  ${sep}\n`)
@@ -366,9 +366,9 @@ function renderAnim(frame: number): string[] {
     const w = wPos + off
     const nodes = Array.from({ length: ANIM_N }, (_, i) => {
       if (i > w)       return `${D}·${R}`               // not reached
-      if (i === w)     return `${B}${AM}◉${R}`          // active front (violet)
-      if (i === w - 1) return `${CY}◌${R}`              // trailing edge (cyan)
-      return `${EM}○${R}`                               // processed (emerald)
+      if (i === w)     return `${B}${AM}◉${R}`          // active front (orange)
+      if (i === w - 1) return `${VI}◌${R}`              // trailing edge (violet)
+      return `${D}○${R}`                                // processed (dim)
     }).join(' ')
     return fp(`  ${nodes}`)
   })
@@ -444,9 +444,9 @@ function buildPanel(cfg: WatchConfig, st: AppState): string {
   } else {
     lines.push(`  ${D}Projetos:${R}   ${AM}${cfg.selectedProjects.map(p=>p.name).join(', ')}${R}`)
   }
-  if (cfg.selectedProjects.length > 1) lines.push(`  ${D}Modo:${R}       ${EM}${mode}${R}`)
+  if (cfg.selectedProjects.length > 1) lines.push(`  ${D}Modo:${R}       ${WH}${mode}${R}`)
   lines.push(`  ${D}Interval:${R}   ${WH}${cfg.intervalSec}s${R}`)
-  lines.push(`  ${D}OTLP:${R}       ${cfg.otlpEndpoint ? `${EM}${cfg.otlpEndpoint}${R}` : `${D}(disabled)${R}`}`)
+  lines.push(`  ${D}OTLP:${R}       ${cfg.otlpEndpoint ? `${WH}${cfg.otlpEndpoint}${R}` : `${D}(disabled)${R}`}`)
   lines.push('')
 
   // Tabela
@@ -459,7 +459,7 @@ function buildPanel(cfg: WatchConfig, st: AppState): string {
     if (!solo) lines.push(`  ${B}${AM}UNIFICADO${R}`)
     lines.push('')
     lines.push('  ' + tHdr(false))
-    lines.push(`  ${EM}${B}${all ? tRow(all) : ldg}${R}`)
+    lines.push(`  ${WH}${all ? tRow(all) : ldg}${R}`)
     lines.push(sepLine(W))
   } else if (cfg.viewMode === 'separado') {
     lines.push(sepLine(W))
@@ -476,7 +476,7 @@ function buildPanel(cfg: WatchConfig, st: AppState): string {
     lines.push(`  ${B}${AM}UNIFICADO${R}`)
     lines.push('')
     lines.push('  ' + tHdr(false))
-    lines.push(`  ${EM}${B}${all ? tRow(all) : ldg}${R}`)
+    lines.push(`  ${WH}${all ? tRow(all) : ldg}${R}`)
     lines.push('')
     lines.push(`  ${B}${AM}POR PROJETO${R}`)
     lines.push('')
@@ -604,10 +604,10 @@ const checkboxSearch = createPrompt<string[], {
     items: filtered as CbChoice[], active, pageSize: config.pageSize ?? 14, loop: false,
     renderItem: ({ item, isActive }) => {
       const sel = cs.has(item.value)
-      const bullet = sel ? `${EM}${B}●${R}` : `${D}○${R}`
+      const bullet = sel ? `${AM}${B}●${R}` : `${D}○${R}`
       const arrow  = isActive ? `${AM}▸${R}` : ` `
       const label  = sel
-        ? `${EM}${B}${item.name}${R}`
+        ? `${AM}${B}${item.name}${R}`
         : isActive
           ? `${B}${item.name}${R}`
           : `${D}${item.name}${R}`
@@ -619,7 +619,7 @@ const checkboxSearch = createPrompt<string[], {
   const selCount = checked.length
   const selNames = checked.map(v => config.choices.find(c => c.value === v)?.name ?? v).join(', ')
   const selLine  = selCount > 0
-    ? `\n  ${EM}${B}${selCount}${R}${EM} selecionado${selCount > 1 ? 's' : ''}${R}  ${D}${selNames}${R}`
+    ? `\n  ${AM}${B}${selCount}${R}${AM} selecionado${selCount > 1 ? 's' : ''}${R}  ${D}${selNames}${R}`
     : `\n  ${D}nenhum selecionado = todos os projetos${R}`
 
   return [
@@ -707,7 +707,7 @@ async function ensureApiRunning(): Promise<void> {
     console.error(`\n${RD}Nao foi possivel iniciar o servidor API (porta 3001).${R}`)
     process.exit(1)
   }
-  console.log(`${GR}Servidor iniciado (pid ${spawnedServer?.pid}).${R}`)
+  console.log(`${AM}Servidor iniciado (pid ${spawnedServer?.pid}).${R}`)
 }
 
 function registerServerCleanup() {
@@ -722,7 +722,7 @@ function registerServerCleanup() {
 // ── Entry point ────────────────────────────────────────────────────────────
 
 async function main() {
-  console.log(`\n${B}${BC}Claude Stats - Watch CLI${R}\n`)
+  console.log(`\n${B}${AM}Claude Stats${R}${D} · ${R}${B}Watch CLI${R}\n`)
 
   registerServerCleanup()
   await ensureApiRunning()
@@ -742,7 +742,7 @@ async function main() {
     console.error('Nenhum projeto encontrado.')
     process.exit(1)
   }
-  console.log(`${GR}${allProjects.length} projetos encontrados.${R}\n`)
+  console.log(`${AM}${allProjects.length} projetos encontrados.${R}\n`)
 
   const cfg = await askConfig(allProjects)
   await watchLoop(cfg)


### PR DESCRIPTION
## Summary

- Substitui todas as cores verdes/cyan (`EM`, `CY`, `BC`) por laranja (`AM`) e violeta (`VI`) em toda a CLI — checkbox, animação de nós, onda do loader
- Loading state exibe zeros em todas as colunas + mensagem "obtendo dados..." em vez de spinner
- Goodbye screen exibe projetos selecionados na saída
- Remove spinner braille `⠏` do loader; adiciona espaçadores `\n` para conforto visual
- Fix PDF: crash em `PDFContent`, custo com `blendedRates`, ordem dinâmica das seções

## Test plan

- [x] `bun watch:cli` — cores laranja/violeta, sem verde
- [x] Aguardar dados: deve mostrar zeros + "obtendo dados..."
- [x] Ctrl+C: goodbye screen com projetos selecionados listados
- [x] Loader inicial: sem spinner, só onda laranja com espaços

🤖 Generated with [Claude Code](https://claude.com/claude-code)