### PR TITLE
fix: align session counts across header, stat card, and projects modal

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -263,6 +263,18 @@ export default function App() {
     return Object.keys(data.statsCache.modelUsage ?? {})
   }, [data])
 
+  // Session count per project from enriched sessions (have valid start_time).
+  // Used in the Projects modal so its count matches the card when "All" is selected.
+  const sessionCountByProject = useMemo(() => {
+    if (!data) return {}
+    const counts: Record<string, number> = {}
+    for (const s of data.sessions) {
+      if (!s.start_time || !s.project_path) continue
+      counts[s.project_path] = (counts[s.project_path] ?? 0) + 1
+    }
+    return counts
+  }, [data])
+
   // ── Info items for all 8 stat cards ──────────────────────────────────────────
   const infoItems = useMemo(() => {
     const projectFiltered = filters.projects.length > 0
@@ -820,7 +832,7 @@ export default function App() {
               <div style={{ fontSize: 11, color: 'var(--text-tertiary)', textAlign: 'right' }}>
                 <div>{lang === 'pt' ? 'Desde' : 'Since'} {format(parseISO(statsCache.firstSessionDate), 'MMM d, yyyy')}</div>
                 <div style={{ color: 'var(--text-secondary)' }}>
-                  {statsCache.totalSessions?.toLocaleString()} {lang === 'pt' ? 'sessões' : 'sessions'}
+                  {derived.allTimeTotalSessions.toLocaleString()} {lang === 'pt' ? 'sessões' : 'sessions'}
                 </div>
               </div>
             )}
@@ -1042,6 +1054,7 @@ export default function App() {
               filters={filters}
               onChange={setFilters}
               projects={data.projects}
+              sessionCountByProject={sessionCountByProject}
               models={models}
               lang={lang}
             />

--- a/src/components/FiltersBar.tsx
+++ b/src/components/FiltersBar.tsx
@@ -10,6 +10,7 @@ interface Props {
   filters: Filters
   onChange: (f: Filters) => void
   projects: Project[]
+  sessionCountByProject: Record<string, number>
   models: string[]
   lang: Lang
 }
@@ -36,7 +37,7 @@ const CTL: React.CSSProperties = {
   alignItems: 'center',
 }
 
-export function FiltersBar({ filters, onChange, projects, models, lang }: Props) {
+export function FiltersBar({ filters, onChange, projects, sessionCountByProject, models, lang }: Props) {
   const [showProjectsModal, setShowProjectsModal] = useState(false)
   const today = format(new Date(), 'yyyy-MM-dd')
   const hasCustomDates = !!(filters.customStart || filters.customEnd)
@@ -222,6 +223,7 @@ export function FiltersBar({ filters, onChange, projects, models, lang }: Props)
       {showProjectsModal && (
         <ProjectsModal
           projects={projects}
+          sessionCountByProject={sessionCountByProject}
           selected={filters.projects}
           onApply={paths => {
             onChange({ ...filters, projects: paths })

--- a/src/components/ProjectsModal.tsx
+++ b/src/components/ProjectsModal.tsx
@@ -5,6 +5,7 @@ import { formatProjectName } from '../lib/types'
 
 interface Props {
   projects: { path: string; sessions: { sessionId: string; created: string }[] }[]
+  sessionCountByProject: Record<string, number>
   selected: string[]
   onApply: (paths: string[]) => void
   onClose: () => void
@@ -43,7 +44,7 @@ const T = {
 
 const PER_PAGE_OPTIONS = [15, 25, 50]
 
-export function ProjectsModal({ projects, selected, onApply, onClose, lang }: Props) {
+export function ProjectsModal({ projects, sessionCountByProject, selected, onApply, onClose, lang }: Props) {
   const t = T[lang]
   const searchRef = useRef<HTMLInputElement>(null)
 
@@ -379,7 +380,7 @@ export function ProjectsModal({ projects, selected, onApply, onClose, lang }: Pr
                     color: 'var(--text-secondary)',
                     whiteSpace: 'nowrap',
                   }}>
-                    {project.sessions.length} {t.sessions}
+                    {sessionCountByProject[project.path] ?? project.sessions.length} {t.sessions}
                   </div>
                 </div>
               )

--- a/src/hooks/useData.ts
+++ b/src/hooks/useData.ts
@@ -161,6 +161,19 @@ export function useDerivedStats(data: AppData | null, filters: Filters) {
       ...Object.entries(supplementByDay).map(([date, v]) => ({ date, ...v })),
     ]
 
+    // ── All-time total sessions (no date/project filter) — used by the header ──
+    // Mirrors extendedDailyActivity logic but without any date restriction.
+    const allDailyDates = new Set((data.statsCache.dailyActivity ?? []).map(d => d.date))
+    const allTimeSupplementByDay: Record<string, number> = {}
+    for (const s of data.sessions) {
+      if (!s.start_time) continue
+      const day = format(parseISO(s.start_time), 'yyyy-MM-dd')
+      if (!allDailyDates.has(day)) allTimeSupplementByDay[day] = (allTimeSupplementByDay[day] ?? 0) + 1
+    }
+    const allTimeTotalSessions =
+      (data.statsCache.dailyActivity ?? []).reduce((s, d) => s + d.sessionCount, 0)
+      + Object.values(allTimeSupplementByDay).reduce((s, c) => s + c, 0)
+
     // ── Aggregate stats ──
     // When project filter active, rebuild from sessions (no per-project data in statsCache)
     const totalMessages = projectFiltered
@@ -383,6 +396,7 @@ export function useDerivedStats(data: AppData | null, filters: Filters) {
     return {
       totalMessages,
       totalSessions,
+      allTimeTotalSessions,
       totalToolCalls,
       totalCostUSD,
       streak,


### PR DESCRIPTION
## Summary

- **Header vs Card (315 vs 388):** Header was reading `statsCache.totalSessions` which is stale (last computed date). Now computes `allTimeTotalSessions` live using the same `dailyActivity + supplement sessions` logic as the stat card, but without any date/project filter applied.

- **Projects modal vs Card (10 vs 6):** Modal was counting raw session files from disk (`project.sessions.length`), which includes sessions without `start_time` metadata. Now uses `sessionCountByProject` — a map built from `data.sessions` filtered to entries with valid `start_time` — so the modal count matches what the card shows when that project is selected with "All" time range.

## Test plan

- [ ] With no filters active: header session count matches the stat card
- [ ] Select a project in the modal: count shown for the project matches the card after selecting it (with "All" range)
- [ ] Different date ranges: header count stays stable (not affected by date filter), card count changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)