### PR TITLE
chore: add MIT license and improve README badges and install section

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 blpsoares
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -10,10 +10,21 @@
 </p>
 
 <p align="center">
+  <a href="https://github.com/blpsoares/agentistics/releases/latest">
+    <img src="https://img.shields.io/github/v/release/blpsoares/agentistics?label=release&color=f97316" alt="Latest release" />
+  </a>
+  <a href="https://github.com/blpsoares/agentistics/actions/workflows/release.yml">
+    <img src="https://img.shields.io/github/actions/workflow/status/blpsoares/agentistics/release.yml?label=build" alt="Build status" />
+  </a>
+  <a href="LICENSE">
+    <img src="https://img.shields.io/github/license/blpsoares/agentistics?color=green" alt="MIT License" />
+  </a>
+  <img src="https://img.shields.io/badge/platform-Linux%20x86__64-lightgrey" alt="Platform: Linux x86_64" />
   <img src="https://img.shields.io/badge/Bun-runtime-f9f1e1?logo=bun" alt="Bun" />
-  <img src="https://img.shields.io/badge/React-19-61dafb?logo=react" alt="React" />
-  <img src="https://img.shields.io/badge/TypeScript-5-3178c6?logo=typescript" alt="TypeScript" />
-  <img src="https://img.shields.io/badge/Vite-8-646cff?logo=vite" alt="Vite" />
+</p>
+
+<p align="center">
+  <a href="#install"><strong>Install in one line →</strong></a>
 </p>
 
 ---
@@ -38,21 +49,28 @@
 
 ## Install
 
-One-line install (Linux x86_64):
+> [!TIP]
+> Requires **Linux x86_64**. macOS and Windows support is planned.
+
+**One-line install** — downloads the latest binary to `~/.local/bin`:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/blpsoares/agentistics/main/install.sh | bash
 ```
 
-With `sudo` for a system-wide install (`/usr/local/bin`):
+System-wide install (`/usr/local/bin`):
 
 ```bash
 sudo curl -fsSL https://raw.githubusercontent.com/blpsoares/agentistics/main/install.sh | bash
 ```
 
-The script downloads the latest pre-built binary from [GitHub Releases](https://github.com/blpsoares/agentistics/releases/latest) and places it in `~/.local/bin` (or `/usr/local/bin` when run as root).
+Then start the dashboard:
 
-> **PATH note:** If `~/.local/bin` is not in your `$PATH`, the installer will print the command to add it.
+```bash
+agentop server   # opens http://localhost:3001
+```
+
+> **PATH note:** If `~/.local/bin` is not in your `$PATH`, the installer will print the command to add it. Pre-built binaries are available on the [Releases page](https://github.com/blpsoares/agentistics/releases/latest).
 
 ---
 


### PR DESCRIPTION
## Summary

- **LICENSE:** Adds MIT license — without this, the project is legally unusable by anyone else, which is a blocker for open-source adoption and GitHub stars.
- **Dynamic badges:** Replaces static tech stack badges with actionable ones — latest release version, CI build status (linked to the workflow), and license badge (linked to the file). These update automatically and show project health at a glance.
- **README install UX:** Adds a `[!TIP]` callout with platform note, a quick-start `agentop server` snippet right after install, and an "Install in one line →" anchor in the hero section so visitors can jump straight to the install without scrolling.

## Test plan

- [ ] LICENSE file renders correctly on GitHub repo page (shows "MIT" in sidebar)
- [ ] Release badge shows the latest version tag
- [ ] Build badge links to the release.yml workflow and shows current status
- [ ] License badge links to the LICENSE file
- [ ] `[!TIP]` callout renders as a GitHub-styled tip block

🤖 Generated with [Claude Code](https://claude.com/claude-code)