### PR TITLE
fix: delete local git tag before recreating latest release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,6 +98,7 @@ jobs:
         run: |
           gh release delete latest --yes 2>/dev/null || true
           git push origin :refs/tags/latest 2>/dev/null || true
+          git tag -d latest 2>/dev/null || true
 
           gh release create latest \
             --title "Latest build ($(date -u +'%Y-%m-%d %H:%M UTC'))" \


### PR DESCRIPTION
## Summary

Com `fetch-depth: 0`, o `git fetch` baixa a tag `latest` do remote. O passo anterior deleta a tag do remote com `git push origin :refs/tags/latest`, mas a cópia local permanece. O `gh release create latest` encontra a tag local e falha:

```
tag latest exists locally but has not been pushed
```

**Fix:** adicionar `git tag -d latest 2>/dev/null || true` para deletar a cópia local também.

Testado localmente simulando o fluxo exato do CI.

## Test plan

- [ ] CI passa sem erro no step "Publish release"

🤖 Generated with [Claude Code](https://claude.com/claude-code)