### PR TITLE
fix(chat): detach UX, dynamic header, thinking toggle, and TUI fixes

### DIFF
--- a/server/data.ts
+++ b/server/data.ts
@@ -246,7 +246,14 @@ async function scanProjectDir(
   // Normalize all extra sessions to the canonical project path
   for (const s of extraSessions) s.project_path = projectPath
 
-  const git_stats = await getProjectGitStats(projectPath)
+  // Scope git stats to the period of Claude usage (earliest session date)
+  const sessionDates = projectSessions
+    .map(s => s.created || metaMap.get(s.sessionId)?.start_time || '')
+    .filter(Boolean)
+  const earliestSession = sessionDates.length > 0
+    ? sessionDates.reduce((a, b) => a < b ? a : b)
+    : undefined
+  const git_stats = await getProjectGitStats(projectPath, earliestSession)
 
   return {
     project: {

--- a/server/git.ts
+++ b/server/git.ts
@@ -49,17 +49,17 @@ export async function getGitFileStats(
   }
 }
 
-export async function getProjectGitStats(projectPath: string): Promise<ProjectGitStats | undefined> {
+export async function getProjectGitStats(projectPath: string, sinceIso?: string): Promise<ProjectGitStats | undefined> {
   const gitEnv = { ...process.env, GIT_TERMINAL_PROMPT: '0', GIT_ASKPASS: 'echo' }
   try {
-    // Check if it's a git repo
     await execAsync(`git -C "${projectPath}" rev-parse --git-dir`, { timeout: 3000, env: gitEnv })
   } catch {
     return undefined
   }
   try {
+    const sinceArg = sinceIso ? ` --since="${sinceIso}"` : ''
     const { stdout } = await execAsync(
-      `git -C "${projectPath}" log --numstat --format="COMMIT %H %ai" HEAD`,
+      `git -C "${projectPath}" log --numstat --format="COMMIT %H %ai"${sinceArg} HEAD`,
       { timeout: 10000, env: gitEnv }
     )
     let commits = 0, linesAdded = 0, linesRemoved = 0

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,13 +1,14 @@
 // embeddedDist is loaded inside server/sse.ts (conditional on SERVE_STATIC=1)
 
+import { readFile } from 'node:fs/promises'
 import { PORT } from './config'
 import { getRates } from './rates'
 import { getVersionInfo } from './version'
 import { buildApiResponse, buildApiResponseStream } from './data'
 import { readPreferences, writePreferences, type Preferences } from './preferences'
-import { streamViaClaude, execCommand, ensureNayChat, ensureClaudeChat, CLAUDE_CHAT_DIR, NAY_CHAT_DIR, type ChatMessage, type ChatModelId, type ChatAttachment } from './chat-tty'
+import { streamViaClaude, execCommand, ensureNayChat, ensureClaudeChat, CLAUDE_CHAT_DIR, type ChatMessage, type ChatModelId, type ChatAttachment } from './chat-tty'
 import { listMcpServers, removeMcpServer } from './mcp-list'
-import { listNaySessions, getNaySessionMessages, getNayChatProjectDir } from './nay-sessions'
+import { listNaySessions, getNaySessionMessages } from './nay-sessions'
 import { listClaudeSessions, getClaudeSessionMessages, type ClaudeSessionSummary, type ClaudeSessionMessage } from './claude-sessions'
 import { PROJECTS_DIR } from './config'
 import { safeReadDir } from './utils'
@@ -27,6 +28,25 @@ import {
   serveStatic,
   SERVE_STATIC,
 } from './sse'
+
+// ---------------------------------------------------------------------------
+// Reads the first `cwd` field found in a JSONL session file.
+// Used by /api/projects-list to get the real project path without ambiguous decoding.
+// ---------------------------------------------------------------------------
+async function readCwdFromJsonl(filePath: string): Promise<string | null> {
+  try {
+    const content = await readFile(filePath, 'utf-8')
+    for (const raw of content.split('\n').slice(0, 100)) {
+      const line = raw.trim()
+      if (!line) continue
+      try {
+        const e = JSON.parse(line)
+        if (typeof e.cwd === 'string' && e.cwd) return e.cwd
+      } catch { /* skip */ }
+    }
+  } catch { /* file unreadable */ }
+  return null
+}
 
 // ---------------------------------------------------------------------------
 // Start file watching and optionally spawn the OTel watcher daemon
@@ -203,15 +223,20 @@ Bun.serve({
       try {
         const dirs = await safeReadDir(PROJECTS_DIR)
         const entries: { name: string; path: string; encodedDir: string; sessionCount: number }[] = []
-        const nayChatEncodedDir = getNayChatProjectDir().split('/').pop() ?? ''
-        for (const dir of dirs) {
-          const projectPath = dir === nayChatEncodedDir ? NAY_CHAT_DIR : decodeProjectDir(dir)
-          const files = await safeReadDir(`${PROJECTS_DIR}/${dir}`)
-          const sessionCount = files.filter(f => f.endsWith('.jsonl')).length
-          if (sessionCount === 0) continue
+        await Promise.all(dirs.map(async dir => {
+          const dirPath = `${PROJECTS_DIR}/${dir}`
+          const files = await safeReadDir(dirPath)
+          const jsonlFiles = files.filter(f => f.endsWith('.jsonl'))
+          if (jsonlFiles.length === 0) return
+          const fallbackPath = decodeProjectDir(dir)
+          let projectPath = fallbackPath
+          for (const f of jsonlFiles) {
+            const cwd = await readCwdFromJsonl(`${dirPath}/${f}`)
+            if (cwd) { projectPath = cwd; break }
+          }
           const name = projectPath.split('/').filter(Boolean).pop() ?? dir
-          entries.push({ name, path: projectPath, encodedDir: dir, sessionCount })
-        }
+          entries.push({ name, path: projectPath, encodedDir: dir, sessionCount: jsonlFiles.length })
+        }))
         entries.sort((a, b) => b.sessionCount - a.sessionCount)
         return new Response(JSON.stringify(entries), {
           headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
@@ -299,8 +324,8 @@ Bun.serve({
 
     if (url.pathname === '/api/chat-tty' && req.method === 'POST') {
       try {
-        const body = await req.json() as { message: string; history?: ChatMessage[]; model?: ChatModelId; sessionId?: string | null; attachments?: ChatAttachment[] }
-        const { message, history = [], model = 'claude-sonnet-4-6', sessionId = null, attachments } = body
+        const body = await req.json() as { message: string; history?: ChatMessage[]; model?: ChatModelId; sessionId?: string | null; thinkingBudget?: number; attachments?: ChatAttachment[] }
+        const { message, history = [], model = 'claude-sonnet-4-6', sessionId = null, thinkingBudget, attachments } = body
         const enc = new TextEncoder()
         const stream = new ReadableStream<Uint8Array>({
           start(ctrl) {
@@ -326,7 +351,7 @@ Bun.serve({
                 ctrl.enqueue(enc.encode(`data: ${JSON.stringify({ sessionId: id })}\n\n`))
               },
               sessionId,
-              { attachments, signal: req.signal },
+              { thinkingBudget, attachments, signal: req.signal },
             )
           },
         })

--- a/server/index.ts
+++ b/server/index.ts
@@ -5,9 +5,9 @@ import { getRates } from './rates'
 import { getVersionInfo } from './version'
 import { buildApiResponse, buildApiResponseStream } from './data'
 import { readPreferences, writePreferences, type Preferences } from './preferences'
-import { streamViaClaude, execCommand, ensureNayChat, ensureClaudeChat, CLAUDE_CHAT_DIR, type ChatMessage, type ChatModelId, type ChatAttachment } from './chat-tty'
+import { streamViaClaude, execCommand, ensureNayChat, ensureClaudeChat, CLAUDE_CHAT_DIR, NAY_CHAT_DIR, type ChatMessage, type ChatModelId, type ChatAttachment } from './chat-tty'
 import { listMcpServers, removeMcpServer } from './mcp-list'
-import { listNaySessions, getNaySessionMessages } from './nay-sessions'
+import { listNaySessions, getNaySessionMessages, getNayChatProjectDir } from './nay-sessions'
 import { listClaudeSessions, getClaudeSessionMessages, type ClaudeSessionSummary, type ClaudeSessionMessage } from './claude-sessions'
 import { PROJECTS_DIR } from './config'
 import { safeReadDir } from './utils'
@@ -203,8 +203,9 @@ Bun.serve({
       try {
         const dirs = await safeReadDir(PROJECTS_DIR)
         const entries: { name: string; path: string; encodedDir: string; sessionCount: number }[] = []
+        const nayChatEncodedDir = getNayChatProjectDir().split('/').pop() ?? ''
         for (const dir of dirs) {
-          const projectPath = decodeProjectDir(dir)
+          const projectPath = dir === nayChatEncodedDir ? NAY_CHAT_DIR : decodeProjectDir(dir)
           const files = await safeReadDir(`${PROJECTS_DIR}/${dir}`)
           const sessionCount = files.filter(f => f.endsWith('.jsonl')).length
           if (sessionCount === 0) continue

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -789,6 +789,7 @@ export default function AppLayout() {
   const [claudeSharedState, setClaudeSharedState] = useState<{
     projectPath: string | null; projectName: string | null; projectEncodedDir: string | null
     sessionId: string | null; messages: import('./components/ClaudeChat').ChatMessage[]
+    model?: import('./lib/chatModels').ChatModelId
   }>({ projectPath: null, projectName: null, projectEncodedDir: null, sessionId: null, messages: [] })
 
   const [cardPrecision, setCardPrecisionState] = useState<Record<string, boolean>>({})

--- a/src/components/ClaudeChat.tsx
+++ b/src/components/ClaudeChat.tsx
@@ -1007,7 +1007,7 @@ interface ClaudeChatProps {
   initialProject?: { path: string; name: string; encodedDir: string } | null
   initialSessionId?: string | null
   initialMessages?: ChatMessage[]
-  onStateChange?: (state: { projectPath: string | null; projectName: string | null; projectEncodedDir: string | null; sessionId: string | null; messages: ChatMessage[] }) => void
+  onStateChange?: (state: { projectPath: string | null; projectName: string | null; projectEncodedDir: string | null; sessionId: string | null; messages: ChatMessage[]; model?: ChatModelId }) => void
 }
 
 export function ClaudeChat({ lang, onOpen, embedded, onDetach, onAttach, initialProject, initialSessionId, initialMessages, onStateChange }: ClaudeChatProps) {
@@ -1068,7 +1068,7 @@ export function ClaudeChat({ lang, onOpen, embedded, onDetach, onAttach, initial
 
   // Propagate state changes upward so parent can preserve when toggling float mode
   useEffect(() => {
-    onStateChange?.({ projectPath, projectName, projectEncodedDir, sessionId, messages })
+    onStateChange?.({ projectPath, projectName, projectEncodedDir, sessionId, messages, model })
   }, [projectPath, projectName, projectEncodedDir, sessionId, messages]) // eslint-disable-line react-hooks/exhaustive-deps
 
   // Poll for new messages written externally (e.g. from VS Code Claude extension)

--- a/src/components/ClaudeChat.tsx
+++ b/src/components/ClaudeChat.tsx
@@ -1608,15 +1608,17 @@ export function ClaudeChat({ lang, onOpen, embedded, onDetach, onAttach, initial
               )}
             </div>
 
-            {/* Decouple button */}
-            <button
-              className="claude-icon-btn"
-              onClick={onDetach}
-              title={lang === 'pt' ? 'Destacar janela' : 'Detach window'}
-              style={iconBtnStyle}
-            >
-              <ExternalLink size={11} />
-            </button>
+            {/* Decouple button — only shown in standalone mode; embedded mode uses TtyChat header */}
+            {onDetach && !embedded && (
+              <button
+                className="claude-icon-btn"
+                onClick={onDetach}
+                title={lang === 'pt' ? 'Destacar janela' : 'Detach window'}
+                style={iconBtnStyle}
+              >
+                <ExternalLink size={11} />
+              </button>
+            )}
           </div>
 
           {/* Messages */}

--- a/src/components/TtyChat.tsx
+++ b/src/components/TtyChat.tsx
@@ -1512,7 +1512,6 @@ export function TtyChat({ lang, chatModel, chatSoundEnabled, onModelSet, filters
                   onClick={() => {
                     setNayDetached(true)
                     setNayMinimized(false)
-                    setOpen(false)
                     setActiveTab('claude')
                   }}
                   title={pt ? 'Destacar janela Nay' : 'Detach Nay window'}
@@ -1614,7 +1613,7 @@ export function TtyChat({ lang, chatModel, chatSoundEnabled, onModelSet, filters
             ))}
           </div>}
 
-          {activeTab === 'nay' && <>
+          {!(nayDetached && claudeDetached) && activeTab === 'nay' && <>
 
           {/* History panel */}
           {showHistory && (
@@ -1891,7 +1890,7 @@ export function TtyChat({ lang, chatModel, chatSoundEnabled, onModelSet, filters
 
           </>}
 
-          {activeTab === 'claude' && (
+          {!(nayDetached && claudeDetached) && activeTab === 'claude' && (
             <ClaudeChat
               key={claudeResetKey}
               embedded

--- a/src/components/TtyChat.tsx
+++ b/src/components/TtyChat.tsx
@@ -826,8 +826,8 @@ export function TtyChat({ lang, chatModel, chatSoundEnabled, onModelSet, filters
 
   useEffect(() => { openRef.current = open }, [open])
   useEffect(() => { soundRef.current = chatSoundEnabled }, [chatSoundEnabled])
-  // When Nay is detached, the embedded panel should show Claude tab
   useEffect(() => { if (nayDetached) setActiveTab('claude') }, [nayDetached])
+  useEffect(() => { if (claudeDetached) setActiveTab('nay') }, [claudeDetached])
   useEffect(() => { nayPosRef.current = nayPos }, [nayPos])
   useEffect(() => { naySizeRef.current = naySize }, [naySize])
   useEffect(() => { nayFabPosRef.current = nayFabPos }, [nayFabPos])
@@ -1466,47 +1466,53 @@ export function TtyChat({ lang, chatModel, chatSoundEnabled, onModelSet, filters
                 background: 'var(--bg-elevated)', border: '1px solid var(--border)',
                 display: 'flex', alignItems: 'center', justifyContent: 'center',
               }}>
-                <img src="/minimalistLogo.png" alt="Nay" style={{ width: 22, height: 22, objectFit: 'contain' }} />
+                <img
+                  src={activeTab === 'claude' ? '/claudeLogo.png' : '/minimalistLogo.png'}
+                  alt={activeTab === 'claude' ? 'Claude' : 'Nay'}
+                  style={{ width: 22, height: 22, objectFit: 'contain' }}
+                />
               </div>
               <div>
                 <div style={{ fontSize: 13, fontWeight: 700, color: 'var(--text-primary)', lineHeight: 1.2 }}>
-                  Nay
+                  {activeTab === 'claude' ? 'Claude' : 'Nay'}
                 </div>
-                <div style={{ fontSize: 10, color: 'var(--text-tertiary)', display: 'flex', alignItems: 'center', gap: 4 }}>
-                  {streaming ? (
-                    <span style={{ color: 'var(--accent-purple)', display: 'flex', alignItems: 'center', gap: 4 }}>
-                      <Loader size={8} style={{ animation: 'ttyChatSpin 1s linear infinite' }} />
-                      {currentTools.length > 0
-                        ? formatToolName(currentTools[currentTools.length - 1]!)
-                        : (pt ? 'pensando...' : 'thinking...')}
-                    </span>
-                  ) : (
-                    <>
-                      <span>{modelInfo?.label ?? effectiveModel}</span>
-                      {modelInfo && (
-                        <span style={{
-                          fontSize: 9, fontWeight: 700,
-                          color: BADGE_COLORS[modelInfo.badge] ?? 'var(--text-tertiary)',
-                          background: `color-mix(in srgb, ${BADGE_COLORS[modelInfo.badge] ?? 'var(--text-tertiary)'} 12%, transparent)`,
-                          border: `1px solid color-mix(in srgb, ${BADGE_COLORS[modelInfo.badge] ?? 'var(--text-tertiary)'} 25%, transparent)`,
-                          padding: '0px 4px', borderRadius: 3,
-                        }}>
-                          {modelInfo.badge}
-                        </span>
-                      )}
-                    </>
-                  )}
-                </div>
+                {activeTab === 'nay' && (
+                  <div style={{ fontSize: 10, color: 'var(--text-tertiary)', display: 'flex', alignItems: 'center', gap: 4 }}>
+                    {streaming ? (
+                      <span style={{ color: 'var(--accent-purple)', display: 'flex', alignItems: 'center', gap: 4 }}>
+                        <Loader size={8} style={{ animation: 'ttyChatSpin 1s linear infinite' }} />
+                        {currentTools.length > 0
+                          ? formatToolName(currentTools[currentTools.length - 1]!)
+                          : (pt ? 'pensando...' : 'thinking...')}
+                      </span>
+                    ) : (
+                      <>
+                        <span>{modelInfo?.label ?? effectiveModel}</span>
+                        {modelInfo && (
+                          <span style={{
+                            fontSize: 9, fontWeight: 700,
+                            color: BADGE_COLORS[modelInfo.badge] ?? 'var(--text-tertiary)',
+                            background: `color-mix(in srgb, ${BADGE_COLORS[modelInfo.badge] ?? 'var(--text-tertiary)'} 12%, transparent)`,
+                            border: `1px solid color-mix(in srgb, ${BADGE_COLORS[modelInfo.badge] ?? 'var(--text-tertiary)'} 25%, transparent)`,
+                            padding: '0px 4px', borderRadius: 3,
+                          }}>
+                            {modelInfo.badge}
+                          </span>
+                        )}
+                      </>
+                    )}
+                  </div>
+                )}
               </div>
             </div>
 
             <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
-              {messages.length > 0 && (
+              {activeTab === 'nay' && messages.length > 0 && (
                 <button className="tty-icon-btn" onClick={clearChat} title={pt ? 'Nova conversa' : 'New conversation'} style={iconBtnStyle}>
                   <Plus size={12} />
                 </button>
               )}
-              {activeTab === 'nay' && !isMobile && (
+              {activeTab === 'nay' && !nayDetached && !isMobile && (
                 <button
                   className="tty-icon-btn"
                   onClick={() => {
@@ -1520,14 +1526,26 @@ export function TtyChat({ lang, chatModel, chatSoundEnabled, onModelSet, filters
                   <ExternalLink size={12} />
                 </button>
               )}
-              <button
-                className="tty-icon-btn"
-                onClick={openHistory}
-                title={pt ? 'Histórico de conversas' : 'Conversation history'}
-                style={{ ...iconBtnStyle, color: showHistory ? 'var(--accent-purple)' : 'var(--text-secondary)' }}
-              >
-                <History size={12} />
-              </button>
+              {activeTab === 'claude' && !claudeDetached && !isMobile && (
+                <button
+                  className="tty-icon-btn"
+                  onClick={() => { onDetachClaude?.(); setActiveTab('nay') }}
+                  title={pt ? 'Destacar janela Claude' : 'Detach Claude window'}
+                  style={iconBtnStyle}
+                >
+                  <ExternalLink size={12} />
+                </button>
+              )}
+              {activeTab === 'nay' && (
+                <button
+                  className="tty-icon-btn"
+                  onClick={openHistory}
+                  title={pt ? 'Histórico de conversas' : 'Conversation history'}
+                  style={{ ...iconBtnStyle, color: showHistory ? 'var(--accent-purple)' : 'var(--text-secondary)' }}
+                >
+                  <History size={12} />
+                </button>
+              )}
               <button
                 className="tty-icon-btn"
                 onClick={() => setFullscreen(v => !v)}
@@ -1588,7 +1606,7 @@ export function TtyChat({ lang, chatModel, chatSoundEnabled, onModelSet, filters
             display: 'flex', borderBottom: '1px solid var(--border)',
             background: 'var(--bg-card)', flexShrink: 0,
           }}>
-            {(['nay', 'claude'] as const).filter(tab => !(tab === 'nay' && nayDetached)).map(tab => (
+            {(['nay', 'claude'] as const).filter(tab => !(tab === 'nay' && nayDetached) && !(tab === 'claude' && claudeDetached)).map(tab => (
               <button
                 key={tab}
                 onClick={() => setActiveTab(tab)}
@@ -1613,7 +1631,7 @@ export function TtyChat({ lang, chatModel, chatSoundEnabled, onModelSet, filters
             ))}
           </div>}
 
-          {!(nayDetached && claudeDetached) && activeTab === 'nay' && <>
+          {!nayDetached && activeTab === 'nay' && <>
 
           {/* History panel */}
           {showHistory && (
@@ -1742,12 +1760,12 @@ export function TtyChat({ lang, chatModel, chatSoundEnabled, onModelSet, filters
               }}>
                 <img src="/minimalistLogo.png" alt="Nay" style={{ width: 36, height: 36, objectFit: 'contain', opacity: 0.3 }} />
                 <div style={{ fontSize: 13, fontWeight: 600 }}>
-                  {pt ? 'Olá! Sou o Nay' : 'Hi! I\'m Nay'}
+                  {pt ? 'Olá! Sou a Nay' : 'Hi! I\'m Nay'}
                 </div>
-                <div style={{ fontSize: 11, lineHeight: 1.65, opacity: 0.7 }}>
+                <div style={{ fontSize: 11, lineHeight: 1.65, opacity: 0.7, maxWidth: 220 }}>
                   {pt
-                    ? 'Analiso custos, sessões, projetos e crio layouts personalizados.'
-                    : 'I can analyze costs, sessions, projects and build custom layouts.'}
+                    ? 'Agente de analytics com acesso direto ao dashboard — custos, sessões, projetos e layouts personalizados.'
+                    : 'Analytics agent with direct dashboard access — costs, sessions, projects and custom layouts.'}
                 </div>
                 <div style={{
                   marginTop: 4, background: 'var(--bg-elevated)',
@@ -1890,7 +1908,7 @@ export function TtyChat({ lang, chatModel, chatSoundEnabled, onModelSet, filters
 
           </>}
 
-          {!(nayDetached && claudeDetached) && activeTab === 'claude' && (
+          {!claudeDetached && activeTab === 'claude' && (
             <ClaudeChat
               key={claudeResetKey}
               embedded
@@ -2181,12 +2199,12 @@ export function TtyChat({ lang, chatModel, chatSoundEnabled, onModelSet, filters
               }}>
                 <img src="/minimalistLogo.png" alt="Nay" style={{ width: 36, height: 36, objectFit: 'contain', opacity: 0.3 }} />
                 <div style={{ fontSize: 13, fontWeight: 600 }}>
-                  {pt ? 'Olá! Sou o Nay' : 'Hi! I\'m Nay'}
+                  {pt ? 'Olá! Sou a Nay' : 'Hi! I\'m Nay'}
                 </div>
-                <div style={{ fontSize: 11, lineHeight: 1.65, opacity: 0.7 }}>
+                <div style={{ fontSize: 11, lineHeight: 1.65, opacity: 0.7, maxWidth: 220 }}>
                   {pt
-                    ? 'Analiso custos, sessões, projetos e crio layouts personalizados.'
-                    : 'I can analyze costs, sessions, projects and build custom layouts.'}
+                    ? 'Agente de analytics com acesso direto ao dashboard — custos, sessões, projetos e layouts personalizados.'
+                    : 'Analytics agent with direct dashboard access — costs, sessions, projects and custom layouts.'}
                 </div>
                 <div style={{
                   marginTop: 4, background: 'var(--bg-elevated)',

--- a/src/components/TtyChat.tsx
+++ b/src/components/TtyChat.tsx
@@ -6,7 +6,7 @@ import {
   MessageSquare, X, Send, Loader, AlertCircle, Trash2,
   Maximize2, Minimize2, Terminal, Play, ChevronRight,
   Wrench, ChevronDown, ChevronUp, ArrowRight, Filter, History, Plus,
-  ShieldAlert, Check, ExternalLink, Paperclip, FileText as FileTextIcon, Minus,
+  ShieldAlert, Check, ExternalLink, Paperclip, FileText as FileTextIcon, Minus, Brain,
 } from 'lucide-react'
 
 // ── Attachment type (Nay only handles images + text files) ────────────────────
@@ -25,6 +25,18 @@ import { t } from '../lib/i18n'
 import type { Filters } from '../lib/types'
 
 type Lang = 'pt' | 'en'
+
+type ThinkingBudget = false | 8000 | 16000 | 32000
+const THINKING_CYCLE: ThinkingBudget[] = [false, 8000, 16000, 32000]
+function nextThinkingBudget(cur: ThinkingBudget): ThinkingBudget {
+  return THINKING_CYCLE[(THINKING_CYCLE.indexOf(cur) + 1) % THINKING_CYCLE.length]!
+}
+function thinkingLabel(b: ThinkingBudget): string {
+  if (!b) return ''
+  if (b === 8000) return '8K'
+  if (b === 16000) return '16K'
+  return '32K'
+}
 
 type ChatMessage = {
   role: 'user' | 'assistant'
@@ -711,11 +723,11 @@ interface TtyChatProps {
   onReattachClaude?: () => void
   claudeSharedState?: {
     projectPath: string | null; projectName: string | null; projectEncodedDir: string | null
-    sessionId: string | null; messages: ClaudeChatMessage[]
+    sessionId: string | null; messages: ClaudeChatMessage[]; model?: ChatModelId
   }
   onClaudeStateChange?: (s: {
     projectPath: string | null; projectName: string | null; projectEncodedDir: string | null
-    sessionId: string | null; messages: ClaudeChatMessage[]
+    sessionId: string | null; messages: ClaudeChatMessage[]; model?: ChatModelId
   }) => void
 }
 
@@ -784,6 +796,9 @@ export function TtyChat({ lang, chatModel, chatSoundEnabled, onModelSet, filters
   const [historyList, setHistoryList] = useState<NaySessionSummary[]>([])
   const [historyLoading, setHistoryLoading] = useState(false)
   const [sessionId, setSessionId] = useState<string | null>(null)
+  const [nayThinking, setNayThinking] = useState<ThinkingBudget>(false)
+  const [showNayModelPicker, setShowNayModelPicker] = useState(false)
+  const [claudeCurrentModel, setClaudeCurrentModel] = useState<ChatModelId>(DEFAULT_CHAT_MODEL)
   // Track which historical Nay session is being viewed (for live polling)
   const [viewedNaySessionId, setViewedNaySessionId] = useState<string | null>(null)
 
@@ -828,6 +843,7 @@ export function TtyChat({ lang, chatModel, chatSoundEnabled, onModelSet, filters
   useEffect(() => { soundRef.current = chatSoundEnabled }, [chatSoundEnabled])
   useEffect(() => { if (nayDetached) setActiveTab('claude') }, [nayDetached])
   useEffect(() => { if (claudeDetached) setActiveTab('nay') }, [claudeDetached])
+  useEffect(() => { if (claudeSharedState?.model) setClaudeCurrentModel(claudeSharedState.model) }, [claudeSharedState?.model])
   useEffect(() => { nayPosRef.current = nayPos }, [nayPos])
   useEffect(() => { naySizeRef.current = naySize }, [naySize])
   useEffect(() => { nayFabPosRef.current = nayFabPos }, [nayFabPos])
@@ -1259,6 +1275,7 @@ export function TtyChat({ lang, chatModel, chatSoundEnabled, onModelSet, filters
         signal: abortCtrl.signal,
         body: JSON.stringify({
           message: text, history, model, sessionId,
+          thinkingBudget: nayThinking || undefined,
           attachments: pendingAttachments.length > 0
             ? pendingAttachments.map(a => ({ name: a.name, mimeType: a.mimeType, data: a.data, isImage: a.isImage }))
             : undefined,
@@ -1476,33 +1493,54 @@ export function TtyChat({ lang, chatModel, chatSoundEnabled, onModelSet, filters
                 <div style={{ fontSize: 13, fontWeight: 700, color: 'var(--text-primary)', lineHeight: 1.2 }}>
                   {activeTab === 'claude' ? 'Claude' : 'Nay'}
                 </div>
-                {activeTab === 'nay' && (
-                  <div style={{ fontSize: 10, color: 'var(--text-tertiary)', display: 'flex', alignItems: 'center', gap: 4 }}>
-                    {streaming ? (
-                      <span style={{ color: 'var(--accent-purple)', display: 'flex', alignItems: 'center', gap: 4 }}>
-                        <Loader size={8} style={{ animation: 'ttyChatSpin 1s linear infinite' }} />
-                        {currentTools.length > 0
-                          ? formatToolName(currentTools[currentTools.length - 1]!)
-                          : (pt ? 'pensando...' : 'thinking...')}
-                      </span>
-                    ) : (
-                      <>
-                        <span>{modelInfo?.label ?? effectiveModel}</span>
-                        {modelInfo && (
-                          <span style={{
-                            fontSize: 9, fontWeight: 700,
-                            color: BADGE_COLORS[modelInfo.badge] ?? 'var(--text-tertiary)',
-                            background: `color-mix(in srgb, ${BADGE_COLORS[modelInfo.badge] ?? 'var(--text-tertiary)'} 12%, transparent)`,
-                            border: `1px solid color-mix(in srgb, ${BADGE_COLORS[modelInfo.badge] ?? 'var(--text-tertiary)'} 25%, transparent)`,
-                            padding: '0px 4px', borderRadius: 3,
-                          }}>
-                            {modelInfo.badge}
+                {(() => {
+                  if (activeTab === 'nay') {
+                    return (
+                      <div style={{ fontSize: 10, color: 'var(--text-tertiary)', display: 'flex', alignItems: 'center', gap: 4 }}>
+                        {streaming ? (
+                          <span style={{ color: 'var(--accent-purple)', display: 'flex', alignItems: 'center', gap: 4 }}>
+                            <Loader size={8} style={{ animation: 'ttyChatSpin 1s linear infinite' }} />
+                            {currentTools.length > 0
+                              ? formatToolName(currentTools[currentTools.length - 1]!)
+                              : (pt ? 'pensando...' : 'thinking...')}
                           </span>
+                        ) : (
+                          <>
+                            <span>{modelInfo?.label ?? effectiveModel}</span>
+                            {modelInfo && (
+                              <span style={{
+                                fontSize: 9, fontWeight: 700,
+                                color: BADGE_COLORS[modelInfo.badge] ?? 'var(--text-tertiary)',
+                                background: `color-mix(in srgb, ${BADGE_COLORS[modelInfo.badge] ?? 'var(--text-tertiary)'} 12%, transparent)`,
+                                border: `1px solid color-mix(in srgb, ${BADGE_COLORS[modelInfo.badge] ?? 'var(--text-tertiary)'} 25%, transparent)`,
+                                padding: '0px 4px', borderRadius: 3,
+                              }}>
+                                {modelInfo.badge}
+                              </span>
+                            )}
+                          </>
                         )}
-                      </>
-                    )}
-                  </div>
-                )}
+                      </div>
+                    )
+                  }
+                  const claudeModelInfo = CHAT_MODELS.find(m => m.id === claudeCurrentModel)
+                  return (
+                    <div style={{ fontSize: 10, color: 'var(--text-tertiary)', display: 'flex', alignItems: 'center', gap: 4 }}>
+                      <span>{claudeModelInfo?.label ?? claudeCurrentModel}</span>
+                      {claudeModelInfo && (
+                        <span style={{
+                          fontSize: 9, fontWeight: 700,
+                          color: BADGE_COLORS[claudeModelInfo.badge] ?? 'var(--text-tertiary)',
+                          background: `color-mix(in srgb, ${BADGE_COLORS[claudeModelInfo.badge] ?? 'var(--text-tertiary)'} 12%, transparent)`,
+                          border: `1px solid color-mix(in srgb, ${BADGE_COLORS[claudeModelInfo.badge] ?? 'var(--text-tertiary)'} 25%, transparent)`,
+                          padding: '0px 4px', borderRadius: 3,
+                        }}>
+                          {claudeModelInfo.badge}
+                        </span>
+                      )}
+                    </div>
+                  )
+                })()}
               </div>
             </div>
 
@@ -1841,6 +1879,69 @@ export function TtyChat({ lang, chatModel, chatSoundEnabled, onModelSet, filters
               </div>
             )}
             <input ref={nayFileInputRef} type="file" multiple accept="image/*,text/*,.md,.json,.ts,.js,.py,.txt,.csv" onChange={handleNayFileSelect} style={{ display: 'none' }} />
+
+          {/* Nay toolbar: thinking + model picker */}
+          <div style={{ display: 'flex', alignItems: 'center', gap: 4, padding: '4px 12px 0', justifyContent: 'flex-end' }}>
+            {/* Thinking toggle */}
+            <button
+              className="tty-icon-btn"
+              onClick={() => setNayThinking(prev => nextThinkingBudget(prev))}
+              title={nayThinking ? `Extended thinking: ${thinkingLabel(nayThinking)} tokens` : 'Enable extended thinking'}
+              style={{
+                ...iconBtnStyle,
+                color: nayThinking ? 'var(--accent-purple)' : 'var(--text-tertiary)',
+                borderColor: nayThinking ? 'color-mix(in srgb, var(--accent-purple) 40%, transparent)' : 'var(--border)',
+                background: nayThinking ? 'color-mix(in srgb, var(--accent-purple) 10%, transparent)' : 'transparent',
+                width: nayThinking ? 'auto' : 28, padding: nayThinking ? '0 6px' : 0, gap: 4, minWidth: 28,
+              }}
+            >
+              <Brain size={11} />
+              {nayThinking && <span style={{ fontSize: 9, fontWeight: 700 }}>{thinkingLabel(nayThinking)}</span>}
+            </button>
+
+            {/* Model picker */}
+            <div style={{ position: 'relative' }}>
+              <button
+                className="tty-icon-btn"
+                onClick={() => setShowNayModelPicker(v => !v)}
+                title="Change model"
+                style={{ ...iconBtnStyle, width: 'auto', padding: '0 6px', gap: 4, fontSize: 10 }}
+              >
+                <span>{modelInfo?.label ?? effectiveModel}</span>
+                <ChevronDown size={9} />
+              </button>
+              {showNayModelPicker && (
+                <div style={{
+                  position: 'absolute', bottom: 'calc(100% + 4px)', right: 0, zIndex: 10, minWidth: 180,
+                  background: 'var(--bg-card)', border: '1px solid var(--border)', borderRadius: 10,
+                  boxShadow: '0 8px 24px rgba(0,0,0,0.3)', overflow: 'hidden',
+                }}>
+                  {CHAT_MODELS.map(m => {
+                    const active = effectiveModel === m.id
+                    const badgeColor = BADGE_COLORS[m.badge] ?? 'var(--text-tertiary)'
+                    return (
+                      <button key={m.id} className="tty-icon-btn"
+                        onClick={() => { onModelSet(m.id); setShowNayModelPicker(false) }}
+                        style={{
+                          width: '100%', display: 'flex', alignItems: 'center', gap: 8, padding: '8px 12px',
+                          background: active ? 'var(--bg-elevated)' : 'transparent', border: 'none',
+                          cursor: 'pointer', fontFamily: 'inherit', textAlign: 'left',
+                          borderBottom: '1px solid var(--border)', transition: 'background 0.1s',
+                          borderRadius: 0,
+                        }}>
+                        <span style={{ flex: 1, fontSize: 12, fontWeight: active ? 700 : 400, color: active ? 'var(--text-primary)' : 'var(--text-secondary)' }}>{m.label}</span>
+                        <span style={{ fontSize: 9, fontWeight: 700, color: badgeColor,
+                          background: `color-mix(in srgb, ${badgeColor} 12%, transparent)`,
+                          border: `1px solid color-mix(in srgb, ${badgeColor} 30%, transparent)`,
+                          padding: '1px 5px', borderRadius: 3 }}>{m.badge}</span>
+                      </button>
+                    )
+                  })}
+                </div>
+              )}
+            </div>
+          </div>
+
           <div style={{ padding: '10px 12px', display: 'flex', alignItems: 'flex-end', gap: 6 }}>
             <button className="tty-icon-btn" onClick={() => nayFileInputRef.current?.click()} title={pt ? 'Anexar arquivo' : 'Attach file'} style={{ ...iconBtnStyle, flexShrink: 0, width: 30, height: 30, alignSelf: 'flex-end', marginBottom: 1 }}>
               <Paperclip size={12} />
@@ -1921,7 +2022,7 @@ export function TtyChat({ lang, chatModel, chatSoundEnabled, onModelSet, filters
               } : null}
               initialSessionId={claudeSharedState?.sessionId ?? null}
               initialMessages={claudeSharedState?.messages ?? []}
-              onStateChange={onClaudeStateChange}
+              onStateChange={(s) => { if (s.model) setClaudeCurrentModel(s.model); onClaudeStateChange?.(s) }}
             />
           )}
 

--- a/src/tui/index.ts
+++ b/src/tui/index.ts
@@ -214,7 +214,8 @@ function computeSnapshot(
     const supplementByDay: Record<string, { messageCount: number; sessionCount: number }> = {}
     for (const s of sessions) {
       if (!s.start_time) continue
-      const day = s.start_time.slice(0, 10)
+      const dt = new Date(s.start_time)
+      const day = `${dt.getFullYear()}-${String(dt.getMonth()+1).padStart(2,'0')}-${String(dt.getDate()).padStart(2,'0')}`
       if (dailyDates.has(day)) continue
       if (!supplementByDay[day]) supplementByDay[day] = { messageCount: 0, sessionCount: 0 }
       supplementByDay[day].messageCount += (s.user_message_count ?? 0) + (s.assistant_message_count ?? 0)
@@ -238,22 +239,42 @@ function computeSnapshot(
     cost = Object.entries(mu).reduce((s, [id, u]) => s + calcCost(u, id), 0)
   } else {
     const b = blendedCost(mu)
-    cost = (inTok / 1_000_000) * b.input + (outTok / 1_000_000) * b.output
+    for (const sess of filt) {
+      const m = sess.model
+      if (m) {
+        cost += calcCost({
+          inputTokens: sess.input_tokens ?? 0,
+          outputTokens: sess.output_tokens ?? 0,
+          cacheReadInputTokens: sess.cache_read_input_tokens ?? 0,
+          cacheCreationInputTokens: sess.cache_creation_input_tokens ?? 0,
+          webSearchRequests: 0, costUSD: 0,
+        }, m)
+      } else {
+        cost += ((sess.input_tokens ?? 0) / 1_000_000) * b.input
+             + ((sess.output_tokens ?? 0) / 1_000_000) * b.output
+      }
+    }
   }
 
   // ── Streak — mirrors useDerivedStats exactly ──
   //   with filter    → active dates from filtered sessions only
   //   without filter → union of dailyActivity dates + ALL session dates (covers stale statsCache)
+  // Use local dates consistently (YYYY-MM-DD in local timezone) to avoid UTC boundary issues.
+  const toLocalDate = (iso: string) => {
+    const d = new Date(iso)
+    return `${d.getFullYear()}-${String(d.getMonth()+1).padStart(2,'0')}-${String(d.getDate()).padStart(2,'0')}`
+  }
   const activeDates = isF
-    ? new Set(filt.filter(s => s.start_time).map(s => s.start_time.slice(0, 10)))
+    ? new Set(filt.filter(s => s.start_time).map(s => toLocalDate(s.start_time)))
     : new Set([
         ...daily.map(d => d.date),
-        ...sessions.filter(s => s.start_time).map(s => s.start_time.slice(0, 10)),
+        ...sessions.filter(s => s.start_time).map(s => toLocalDate(s.start_time)),
       ])
   let streak = 0
   for (let i = 0; i <= 365; i++) {
     const d = new Date(); d.setDate(d.getDate() - i)
-    if (activeDates.has(d.toISOString().slice(0, 10))) streak++
+    const dateStr = `${d.getFullYear()}-${String(d.getMonth()+1).padStart(2,'0')}-${String(d.getDate()).padStart(2,'0')}`
+    if (activeDates.has(dateStr)) streak++
     else if (i > 0) break
   }
 


### PR DESCRIPTION
## Summary

Follow-up fixes made after the main mobile/chat PR was merged:

- **Detach/re-attach UX**: Panel stays open (switches to Claude tab) when Nay is detached. Tab bar and content correctly hide each chat when detached individually — not just when both are detached. Auto-switches tab when either chat is detached/re-attached.
- **Dynamic header**: Logo and title reflect the active tab (Claude logo/name when Claude tab is selected, Nay otherwise). Claude model badge shown in header when Claude tab is active.
- **Thinking toggle + model picker for Nay**: Mirrors Claude's UX — cycling budget (off → 8K → 16K → 32K) and inline model dropdown in the Nay toolbar. Budget passed to `/api/chat-tty` server endpoint.
- **Nay welcome copy**: Updated description to "Analytics agent with direct dashboard access".
- **TUI fixes** (cherry-picked from closed PR #26):
  - Streak timezone bug: uses local dates consistently instead of mixing UTC/local
  - Git stats scoped to Claude usage period (not entire repo history)
  - Per-session cost uses `calcCost()` with session model (includes cache tokens)

## Test plan
- [x] Detach Nay → panel stays open on Claude tab
- [x] Detach Claude → Claude tab disappears, Nay content shown
- [x] Detach both → re-attach panel shown, no chat content visible
- [x] Header shows "Claude / Sonnet 4.6 Balanced" when Claude tab active
- [x] Nay toolbar has thinking toggle and model picker
- [x] Streak in TUI matches web UI value

🤖 Generated with [Claude Code](https://claude.com/claude-code)