### PR TITLE
fix: green CI (claude adapter) + MCP per-harness tools + working Tauri auto-updater

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -310,7 +310,7 @@ jobs:
             echo "has_sig=true" >> $GITHUB_OUTPUT
           else
             echo "has_sig=false" >> $GITHUB_OUTPUT
-            echo "No .sig file — TAURI_SIGNING_PRIVATE_KEY is not set. Auto-updater disabled for this build."
+            echo "::warning title=Auto-updater disabled::No .exe.sig produced — the TAURI_SIGNING_PRIVATE_KEY secret is not set, so latest.json will not be generated and the in-app Tauri updater cannot detect this release. Add the signing secret to enable auto-update. (The in-app update banner still works.)"
           fi
 
       - name: Generate latest.json for auto-updater

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Versions follow [Semantic Versioning](https://semver.org/).
 - "Data & sources" tab per harness (`HarnessInfoPanel`) explaining each harness's data source, what's captured, and what's missing
 - Archive modes (`off` / `consolidate` / `full`) that survive Claude's 30-day transcript cleanup, gated by a first-run consent modal
 - **Full mobile/responsive support** — responsive layouts gated on `useIsMobile()`, a bottom nav with a square-tile "More" sheet (hosting settings/live/refresh/warnings), a collapsible sticky filter bar, full-screen modals on mobile, and iOS-aware PWA install guidance
+- **MCP multi-harness support** — `agentistics_summary` / `agentistics_projects` / `agentistics_sessions` / `agentistics_costs` accept an optional `harness` filter, plus a new `agentistics_harnesses` tool for side-by-side harness comparison
 
 ### Fixed
 - iOS `position: sticky` broke under `overflow-x: hidden`; switched mobile `html/body/#root` to `overflow-x: clip`
@@ -25,7 +26,7 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ### Changed
 - `stats-cache.json` is treated as Claude-only; non-Claude harnesses are aggregated purely from per-session data so Claude totals are never corrupted
-- README now describes agentistics as a multi-harness dashboard; `docs/mcp.md` documents the MCP's unified (all-harness) scope
+- README now describes agentistics as a multi-harness dashboard; `docs/mcp.md` documents the MCP's per-harness filtering and comparison tool
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -156,10 +156,11 @@ claude mcp list   # verify: should show "agentistics"
 
 | Tool | What it returns |
 |------|----------------|
-| `agentistics_summary` | All-time totals: tokens, cost, sessions, streak, cache hit rate |
-| `agentistics_projects` | Per-project token and cost breakdown |
-| `agentistics_sessions` | Recent sessions with duration, model, cost |
-| `agentistics_costs` | Model pricing breakdown and cache savings |
+| `agentistics_summary` | All-time totals: tokens, cost, sessions, streak — unified or per-harness |
+| `agentistics_harnesses` | Side-by-side comparison of every tracked harness |
+| `agentistics_projects` | Per-project token and cost breakdown (optionally per-harness) |
+| `agentistics_sessions` | Recent sessions with harness, duration, model, cost |
+| `agentistics_costs` | Model pricing breakdown and cache savings (optionally per-harness) |
 | `agentistics_component_catalog` | Available dashboard components |
 | `agentistics_get_layouts` | Current custom page layouts |
 | `agentistics_build_layout` | Create a full layout from a component list |

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -37,31 +37,62 @@ claude mcp list
 
 ## Multi-harness scope
 
-agentistics now tracks multiple coding harnesses (Claude Code, Codex CLI, Gemini CLI, Copilot CLI). The MCP server reads the same `/api/data` endpoint, so its numbers reflect the **unified (all-harness)** view — totals, projects, sessions, and costs are summed across every enabled harness.
+agentistics tracks multiple coding harnesses (Claude Code, Codex CLI, Gemini CLI, Copilot CLI). The MCP server reads the same `/api/data` endpoint, so by default its numbers reflect the **unified (all-harness)** view.
 
-The MCP tools do **not** yet expose a per-harness filter parameter: there is no way (via MCP) to scope a query to e.g. only Codex sessions. Per-harness slicing is available in the web UI (the harness selector, the `/h/:harness` pages, and the `/compare` page) but is a known follow-up for the MCP surface. Cost/token accuracy caveats still apply per harness — non-Claude harnesses that don't emit token usage (e.g. Gemini's local files) contribute 0 tokens/cost, matching the dashboard.
+- **Per-harness filtering:** `agentistics_summary`, `agentistics_projects`, `agentistics_sessions`, and `agentistics_costs` accept an optional `harness` parameter (`claude` | `codex` | `gemini` | `copilot`, or `all` — the default). When set, the tool scopes its result to that harness only.
+- **Comparison:** `agentistics_harnesses` lists every harness present in the data with its sessions, messages, tokens, estimated cost, and last-active date — the quickest way to answer "which harness do I use most / costs most".
+- **Caveats** match the dashboard: `currentStreak` is Claude-only (returned as `null` when scoping to a single non-Claude harness); harnesses that don't emit token usage (e.g. Gemini's local files) contribute 0 tokens/cost; the unified/`claude` cost breakdown comes from the Claude-complete stats-cache, while a specific non-Claude harness's cost breakdown is aggregated per-model from its sessions.
 
 ## Available tools
 
 ### `agentistics_summary`
 
-All-time totals aggregated from all sessions. Token counts and cost are computed directly from session records (not from the stats-cache snapshot), so they are always accurate even if the cache is stale.
+All-time totals aggregated from sessions. Token counts and cost are computed directly from session records (not from the stats-cache snapshot), so they are always accurate even if the cache is stale.
+
+**Parameters:** `harness` *(optional)* — `claude` | `codex` | `gemini` | `copilot` | `all` (default `all`).
 
 **Returns:**
 ```json
 {
+  "harness": "all",
   "totalInputTokens": 12500000,
   "totalOutputTokens": 890000,
   "totalCacheReadTokens": 45000000,
   "totalCacheWriteTokens": 1200000,
   "estimatedCostUSD": 18.42,
   "totalSessions": 142,
-  "totalProjects": 44,
-  "topModel": "claude-sonnet-4-6",
+  "topModel": "claude-opus-4-8",
   "topProject": "my-app",
   "activeDays": 38,
   "currentStreak": 7
 }
+```
+
+`currentStreak` is `null` when scoped to a single non-Claude harness (streak is Claude-only).
+
+---
+
+### `agentistics_harnesses`
+
+Side-by-side comparison of every harness present in the data, sorted by total tokens. No parameters.
+
+**Returns:**
+```json
+[
+  {
+    "harness": "claude",
+    "sessions": 157,
+    "messages": 38664,
+    "inputTokens": 2467133,
+    "outputTokens": 29339498,
+    "cacheReadTokens": 5981874127,
+    "cacheWriteTokens": 208186404,
+    "totalTokens": 6221867162,
+    "estimatedCostUSD": 3031.51,
+    "lastActive": "2026-06-29T13:52:24.823Z"
+  },
+  { "harness": "codex", "sessions": 20, "estimatedCostUSD": 0.20, "...": "..." }
+]
 ```
 
 ---
@@ -69,6 +100,8 @@ All-time totals aggregated from all sessions. Token counts and cost are computed
 ### `agentistics_projects`
 
 Per-project breakdown with aggregated token and cost data, sorted by total tokens descending.
+
+**Parameters:** `harness` *(optional)* — scope to one harness, or `all` (default). When scoped, projects with no sessions in that harness are omitted and `sessions` reflects that harness's count.
 
 **Returns:** array of projects
 ```json
@@ -100,12 +133,14 @@ Recent sessions with duration, model, and cost.
 | Name | Type | Default | Description |
 |------|------|---------|-------------|
 | `limit` | number | 20 | Max sessions to return (1–50) |
+| `harness` | string | `all` | Scope to one harness (`claude` \| `codex` \| `gemini` \| `copilot`) |
 
-**Returns:** array of sessions sorted by start time descending
+**Returns:** array of sessions sorted by start time descending (each row includes its `harness`)
 ```json
 [
   {
     "id": "abc123",
+    "harness": "claude",
     "project": "/home/user/projects/my-app",
     "startedAt": "2025-01-15T14:30:00Z",
     "durationMinutes": 47,
@@ -126,6 +161,8 @@ Recent sessions with duration, model, and cost.
 ### `agentistics_costs`
 
 Model pricing breakdown and cache analysis.
+
+**Parameters:** `harness` *(optional)* — `all`/`claude` (default) uses the Claude-complete stats-cache; a specific non-Claude harness is aggregated per-model from its sessions.
 
 **Returns:** array of models sorted by total tokens descending
 ```json

--- a/packages/desktop/.gitignore
+++ b/packages/desktop/.gitignore
@@ -1,3 +1,7 @@
 target/
 binaries/
 ui/logo.png
+
+# Tauri updater signing keys — never commit
+*.key
+*.key.pub

--- a/packages/desktop/capabilities/default.json
+++ b/packages/desktop/capabilities/default.json
@@ -4,6 +4,7 @@
   "description": "Default Agentistics capabilities",
   "windows": ["main"],
   "permissions": [
-    "core:default"
+    "core:default",
+    "updater:default"
   ]
 }

--- a/packages/desktop/src/main.rs
+++ b/packages/desktop/src/main.rs
@@ -335,15 +335,26 @@ async fn check_for_update(app: AppHandle) {
 
     let updater = match app.updater() {
         Ok(u) => u,
-        Err(_) => return,
+        Err(e) => {
+            log_error(&format!("updater init failed: {e}"));
+            return;
+        }
     };
 
     let update = match updater.check().await {
         Ok(Some(u)) => u,
-        _ => return,
+        Ok(None) => {
+            log_error("update check: already on the latest version");
+            return;
+        }
+        Err(e) => {
+            log_error(&format!("update check failed: {e}"));
+            return;
+        }
     };
 
     let version = update.version.clone();
+    log_error(&format!("update available: {} (current {})", version, update.current_version));
     let msg = format!(
         "Agentistics {} is available (you have {}).\n\nInstall now?",
         version,

--- a/packages/desktop/tauri.conf.json
+++ b/packages/desktop/tauri.conf.json
@@ -26,7 +26,7 @@
   },
   "plugins": {
     "updater": {
-      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDZGMTU0QTlCOUFBNDlGQUIKUldTcm42U2FtMG9WYjlSSlpCMzQwdWE5blkzUUQ0b0x3Zkc5SDNJY2cweGQ5VUNwRURIZ2NncWgK",
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDE3NzY3OTM4NzA5MjVCQQpSV1M2SlFtSGsyZDNBVTllbDdZV3VZWFpjeXlTeXZOcEtGa2d5ZUcvR3hzTHkxUjJFeEF5TUJyVAo=",
       "endpoints": [
         "https://github.com/blpsoares/agentistics/releases/latest/download/latest.json"
       ]
@@ -34,7 +34,10 @@
   },
   "bundle": {
     "active": true,
-    "targets": ["msi", "nsis"],
+    "targets": [
+      "msi",
+      "nsis"
+    ],
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -36,10 +36,11 @@ The `AGENTISTICS_API` env var must point to a running agentistics server.
 
 | Tool | Returns |
 |------|---------|
-| `agentistics_summary` | All-time totals: tokens, cost, sessions, streak, cache hit rate |
-| `agentistics_projects` | Per-project token and cost breakdown |
-| `agentistics_sessions` | Recent sessions with duration, model, cost |
-| `agentistics_costs` | Model pricing breakdown and cache savings |
+| `agentistics_summary` | All-time totals: tokens, cost, sessions, streak — unified or per-harness |
+| `agentistics_harnesses` | Side-by-side comparison of every tracked harness |
+| `agentistics_projects` | Per-project token and cost breakdown (optionally per-harness) |
+| `agentistics_sessions` | Recent sessions with harness, duration, model, cost |
+| `agentistics_costs` | Model pricing breakdown and cache savings (optionally per-harness) |
 | `agentistics_component_catalog` | Available dashboard components |
 | `agentistics_get_layouts` | Current custom page layouts |
 | `agentistics_build_layout` | Create a full layout from a component list |

--- a/packages/mcp/agentistics-mcp.ts
+++ b/packages/mcp/agentistics-mcp.ts
@@ -21,6 +21,42 @@ function calcCostUSD(input: number, output: number, cacheRead: number, cacheWrit
   }, model);
 }
 
+// ─── Multi-harness helpers ────────────────────────────────────────────────────
+// agentistics tracks several harnesses (Claude Code, Codex CLI, Gemini CLI,
+// Copilot CLI). Sessions carry a `harness` field; legacy/missing defaults to claude.
+
+const HARNESS_IDS = ["claude", "codex", "gemini", "copilot"] as const;
+const HARNESS_PARAM = {
+  type: "string",
+  enum: ["all", ...HARNESS_IDS],
+  description:
+    "Scope to one harness (claude | codex | gemini | copilot), or 'all' (default) for the unified view across every harness.",
+} as const;
+
+type AnySession = Record<string, any>;
+
+function sessionHarness(s: AnySession): string {
+  return (s.harness as string) ?? "claude";
+}
+
+/** Filter sessions to a single harness, or return all for undefined/'all'. */
+function filterSessions(sessions: AnySession[], harness?: string): AnySession[] {
+  if (!harness || harness === "all") return sessions;
+  return sessions.filter((s) => sessionHarness(s) === harness);
+}
+
+function sessionTokens(s: AnySession) {
+  const input = s.input_tokens ?? 0;
+  const output = s.output_tokens ?? 0;
+  const cacheRead = s.cache_read_input_tokens ?? 0;
+  const cacheWrite = s.cache_creation_input_tokens ?? 0;
+  return { input, output, cacheRead, cacheWrite, cost: calcCostUSD(input, output, cacheRead, cacheWrite, s.model ?? "") };
+}
+
+function sessionMessages(s: AnySession): number {
+  return (s.user_message_count ?? 0) + (s.assistant_message_count ?? 0);
+}
+
 // Static mirror of src/lib/componentCatalog.tsx — keep in sync when adding components
 const CATALOG = [
   // KPI cards
@@ -150,19 +186,25 @@ const TOOLS: Tool[] = [
   {
     name: "agentistics_summary",
     description:
-      "Get an overview of Claude Code usage metrics: total tokens, estimated cost, sessions, streak, most used model, and top project. Good starting point for any metrics question.",
+      "Get an overview of AI coding usage metrics (across all tracked harnesses — Claude Code, Codex, Gemini, Copilot — or scoped to one): total tokens, estimated cost, sessions, streak, most used model, and top project. Good starting point for any metrics question.",
+    inputSchema: { type: "object", properties: { harness: HARNESS_PARAM }, required: [] },
+  },
+  {
+    name: "agentistics_harnesses",
+    description:
+      "Compare the tracked AI coding harnesses side by side. Lists every harness present in the data with its sessions, messages, token usage, estimated cost, and last-active date. Use this to answer 'which harness do I use most / costs most' questions.",
     inputSchema: { type: "object", properties: {}, required: [] },
   },
   {
     name: "agentistics_projects",
     description:
-      "List all Claude Code projects with session counts, message counts, token usage, estimated cost, and last active date.",
-    inputSchema: { type: "object", properties: {}, required: [] },
+      "List projects with session counts, message counts, token usage, estimated cost, and last active date. Optionally scope to a single harness.",
+    inputSchema: { type: "object", properties: { harness: HARNESS_PARAM }, required: [] },
   },
   {
     name: "agentistics_sessions",
     description:
-      "Get the most recent Claude Code sessions with project path, duration, message count, token usage, and model.",
+      "Get the most recent sessions with harness, project path, duration, message count, token usage, and model. Optionally scope to a single harness.",
     inputSchema: {
       type: "object",
       properties: {
@@ -170,14 +212,15 @@ const TOOLS: Tool[] = [
           type: "number",
           description: "Max sessions to return (default 20, max 50)",
         },
+        harness: HARNESS_PARAM,
       },
     },
   },
   {
     name: "agentistics_costs",
     description:
-      "Get cost breakdown by model: token counts (input/output/cache read/write) and estimated USD cost per model.",
-    inputSchema: { type: "object", properties: {}, required: [] },
+      "Get cost breakdown by model: token counts (input/output/cache read/write) and estimated USD cost per model. Scope to a single harness, or 'all' (default) for the unified breakdown.",
+    inputSchema: { type: "object", properties: { harness: HARNESS_PARAM }, required: [] },
   },
   {
     name: "agentistics_component_catalog",
@@ -336,90 +379,119 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
   try {
     switch (name) {
       case "agentistics_summary": {
+        const harness = (args as any)?.harness as string | undefined;
+        const unified = !harness || harness === "all";
         const data = await apiGet("/api/data");
         const sc = data.statsCache ?? {};
         const totals = sc.allTimeTotals ?? {};
-        const models = sc.modelUsage ?? {};
-        const topModel =
-          Object.entries(models as Record<string, { totalTokens?: number }>)
-            .sort(([, a], [, b]) => (b.totalTokens ?? 0) - (a.totalTokens ?? 0))[0]?.[0] ?? "—";
-        const projects = (data.projects ?? []) as Array<{ name: string; sessions?: Array<unknown> }>;
-        const topProject =
-          [...projects]
-            .sort((a, b) => (b.sessions?.length ?? 0) - (a.sessions?.length ?? 0))[0]?.name ?? "—";
 
-        // Aggregate from sessions for accurate totals (statsCache may be stale or empty)
-        const allSessions = (data.sessions ?? []) as Array<any>;
+        // Aggregate from sessions (the only harness-aware source). statsCache is
+        // Claude-only, so it's used as a fallback ONLY for the unified/claude view.
+        const allSessions = filterSessions((data.sessions ?? []) as AnySession[], harness);
         let totalCostUSD = 0;
         let totalInput = 0, totalOutput = 0, totalCacheRead = 0, totalCacheWrite = 0;
+        const modelTokens: Record<string, number> = {};
+        const projectSessions: Record<string, number> = {};
+        const activeDates = new Set<string>();
         for (const s of allSessions) {
-          const inp = s.input_tokens ?? 0;
-          const out = s.output_tokens ?? 0;
-          const cr  = s.cache_read_input_tokens ?? 0;
-          const cw  = s.cache_creation_input_tokens ?? 0;
-          totalInput    += inp;
-          totalOutput   += out;
-          totalCacheRead  += cr;
-          totalCacheWrite += cw;
-          totalCostUSD  += calcCostUSD(inp, out, cr, cw, s.model ?? "");
+          const { input, output, cacheRead, cacheWrite, cost } = sessionTokens(s);
+          totalInput += input; totalOutput += output; totalCacheRead += cacheRead; totalCacheWrite += cacheWrite;
+          totalCostUSD += cost;
+          if (s.model) modelTokens[s.model] = (modelTokens[s.model] ?? 0) + input + output;
+          if (s.project_path) projectSessions[s.project_path] = (projectSessions[s.project_path] ?? 0) + 1;
+          if (s.start_time) activeDates.add(String(s.start_time).slice(0, 10));
         }
-        // Fall back to statsCache if sessions carry no token data
-        const finalInput       = totalInput    || (totals.inputTokens      ?? 0);
-        const finalOutput      = totalOutput   || (totals.outputTokens     ?? 0);
-        const finalCacheRead   = totalCacheRead  || (totals.cacheReadTokens  ?? 0);
-        const finalCacheWrite  = totalCacheWrite || (totals.cacheWriteTokens ?? 0);
+        const claudeFallback = unified || harness === "claude";
+        const topModel =
+          Object.entries(modelTokens).sort(([, a], [, b]) => b - a)[0]?.[0]
+          ?? (claudeFallback
+            ? Object.entries((sc.modelUsage ?? {}) as Record<string, { totalTokens?: number }>)
+                .sort(([, a], [, b]) => (b.totalTokens ?? 0) - (a.totalTokens ?? 0))[0]?.[0] ?? "—"
+            : "—");
+        const topProject = Object.entries(projectSessions).sort(([, a], [, b]) => b - a)[0]?.[0] ?? "—";
 
         return {
           content: [{
             type: "text",
             text: JSON.stringify({
-              totalInputTokens:      finalInput,
-              totalOutputTokens:     finalOutput,
-              totalCacheReadTokens:  finalCacheRead,
-              totalCacheWriteTokens: finalCacheWrite,
+              harness: unified ? "all" : harness,
+              totalInputTokens:      totalInput    || (claudeFallback ? totals.inputTokens      ?? 0 : 0),
+              totalOutputTokens:     totalOutput   || (claudeFallback ? totals.outputTokens     ?? 0 : 0),
+              totalCacheReadTokens:  totalCacheRead  || (claudeFallback ? totals.cacheReadTokens  ?? 0 : 0),
+              totalCacheWriteTokens: totalCacheWrite || (claudeFallback ? totals.cacheWriteTokens ?? 0 : 0),
               estimatedCostUSD:      Math.round(totalCostUSD * 100) / 100,
               totalSessions: allSessions.length,
-              totalProjects: projects.length,
               topModel,
               topProject,
-              activeDays: sc.activeDays ?? 0,
-              currentStreak: sc.currentStreak ?? 0,
+              activeDays: activeDates.size || (claudeFallback ? sc.activeDays ?? 0 : 0),
+              // Streak is Claude-only (derived from statsCache); N/A for a single non-claude harness.
+              currentStreak: claudeFallback ? sc.currentStreak ?? 0 : null,
             }, null, 2),
           }],
         };
       }
 
+      case "agentistics_harnesses": {
+        const data = await apiGet("/api/data");
+        const present = (data.harnesses ?? ["claude"]) as string[];
+        const sessions = (data.sessions ?? []) as AnySession[];
+        const rows = present.map((h) => {
+          const hs = sessions.filter((s) => sessionHarness(s) === h);
+          let input = 0, output = 0, cacheRead = 0, cacheWrite = 0, cost = 0, messages = 0, lastActive = "";
+          for (const s of hs) {
+            const t = sessionTokens(s);
+            input += t.input; output += t.output; cacheRead += t.cacheRead; cacheWrite += t.cacheWrite; cost += t.cost;
+            messages += sessionMessages(s);
+            if (s.start_time && String(s.start_time) > lastActive) lastActive = String(s.start_time);
+          }
+          return {
+            harness: h,
+            sessions: hs.length,
+            messages,
+            inputTokens: input,
+            outputTokens: output,
+            cacheReadTokens: cacheRead,
+            cacheWriteTokens: cacheWrite,
+            totalTokens: input + output + cacheRead + cacheWrite,
+            estimatedCostUSD: Math.round(cost * 100) / 100,
+            lastActive: lastActive || null,
+          };
+        }).sort((a, b) => b.totalTokens - a.totalTokens);
+        return { content: [{ type: "text", text: JSON.stringify(rows, null, 2) }] };
+      }
+
       case "agentistics_projects": {
+        const harness = (args as any)?.harness as string | undefined;
         const data = await apiGet("/api/data");
         // projects[] only has {name, path, sessions:[{sessionId}]} — aggregate tokens/cost from sessions
-        const allSessions = (data.sessions ?? []) as Array<any>;
-        const byPath: Record<string, { inputTokens: number; outputTokens: number; cacheRead: number; cacheWrite: number; costUSD: number; messages: number; lastActive: string; languages: string[] }> = {};
+        const allSessions = filterSessions((data.sessions ?? []) as AnySession[], harness);
+        const byPath: Record<string, { sessions: number; inputTokens: number; outputTokens: number; cacheRead: number; cacheWrite: number; costUSD: number; messages: number; lastActive: string; languages: string[] }> = {};
         for (const s of allSessions) {
           const key = s.project_path as string;
           if (!key) continue;
-          if (!byPath[key]) byPath[key] = { inputTokens: 0, outputTokens: 0, cacheRead: 0, cacheWrite: 0, costUSD: 0, messages: 0, lastActive: "", languages: [] };
+          if (!byPath[key]) byPath[key] = { sessions: 0, inputTokens: 0, outputTokens: 0, cacheRead: 0, cacheWrite: 0, costUSD: 0, messages: 0, lastActive: "", languages: [] };
           const agg = byPath[key]!;
-          const inp = s.input_tokens ?? 0;
-          const out = s.output_tokens ?? 0;
-          const cr  = s.cache_read_input_tokens ?? 0;
-          const cw  = s.cache_creation_input_tokens ?? 0;
-          agg.inputTokens  += inp;
-          agg.outputTokens += out;
-          agg.cacheRead    += cr;
-          agg.cacheWrite   += cw;
-          agg.costUSD      += calcCostUSD(inp, out, cr, cw, s.model ?? "");
-          agg.messages     += (s.user_message_count ?? 0) + (s.assistant_message_count ?? 0);
+          const { input, output, cacheRead, cacheWrite, cost } = sessionTokens(s);
+          agg.sessions     += 1;
+          agg.inputTokens  += input;
+          agg.outputTokens += output;
+          agg.cacheRead    += cacheRead;
+          agg.cacheWrite   += cacheWrite;
+          agg.costUSD      += cost;
+          agg.messages     += sessionMessages(s);
           if (!agg.lastActive || (s.start_time ?? "") > agg.lastActive) agg.lastActive = s.start_time ?? "";
           for (const lang of s.languages ?? []) if (!agg.languages.includes(lang)) agg.languages.push(lang);
         }
         const projects = (data.projects ?? []) as Array<any>;
         const summary = projects
+          // When scoped to a harness, drop projects with no sessions in that harness.
+          .filter((p: any) => !harness || harness === "all" || byPath[p.path])
           .map((p: any) => {
-            const agg = byPath[p.path] ?? { inputTokens: 0, outputTokens: 0, cacheRead: 0, cacheWrite: 0, costUSD: 0, messages: 0, lastActive: "", languages: [] };
+            const agg = byPath[p.path] ?? { sessions: 0, inputTokens: 0, outputTokens: 0, cacheRead: 0, cacheWrite: 0, costUSD: 0, messages: 0, lastActive: "", languages: [] };
             return {
               name: p.name,
               path: p.path,
-              sessions: (p.sessions ?? []).length,
+              sessions: (!harness || harness === "all") ? (p.sessions ?? []).length : agg.sessions,
               messages: agg.messages,
               inputTokens: agg.inputTokens,
               outputTokens: agg.outputTokens,
@@ -435,26 +507,25 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
 
       case "agentistics_sessions": {
         const limit = Math.min((args as any)?.limit ?? 20, 50);
+        const harness = (args as any)?.harness as string | undefined;
         const data = await apiGet("/api/data");
-        const rows = ((data.sessions ?? []) as Array<any>)
+        const rows = filterSessions((data.sessions ?? []) as AnySession[], harness)
           .slice(0, limit)
           .map((s: any) => {
-            const inp = s.input_tokens ?? 0;
-            const out = s.output_tokens ?? 0;
-            const cr  = s.cache_read_input_tokens ?? 0;
-            const cw  = s.cache_creation_input_tokens ?? 0;
+            const { input, output, cacheRead, cacheWrite, cost } = sessionTokens(s);
             return {
               id: s.session_id,
+              harness: sessionHarness(s),
               project: s.project_path,
               startedAt: s.start_time,
               durationMinutes: s.duration_minutes,
-              messages: (s.user_message_count ?? 0) + (s.assistant_message_count ?? 0),
-              inputTokens: inp,
-              outputTokens: out,
-              cacheReadTokens: cr,
-              cacheWriteTokens: cw,
-              totalTokens: inp + out + cr + cw,
-              estimatedCostUSD: Math.round(calcCostUSD(inp, out, cr, cw, s.model ?? "") * 10000) / 10000,
+              messages: sessionMessages(s),
+              inputTokens: input,
+              outputTokens: output,
+              cacheReadTokens: cacheRead,
+              cacheWriteTokens: cacheWrite,
+              totalTokens: input + output + cacheRead + cacheWrite,
+              estimatedCostUSD: Math.round(cost * 10000) / 10000,
               model: s.model ?? null,
             };
           });
@@ -462,17 +533,44 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
       }
 
       case "agentistics_costs": {
+        const harness = (args as any)?.harness as string | undefined;
         const data = await apiGet("/api/data");
-        const usage = (data.statsCache?.modelUsage ?? {}) as Record<string, any>;
-        const breakdown = Object.entries(usage)
-          .map(([model, u]: [string, any]) => ({
+        // The unified/claude view uses statsCache.modelUsage (Claude-complete, incl.
+        // meta-only sessions). A specific harness is aggregated per-model from its
+        // sessions, since statsCache is Claude-only.
+        if (!harness || harness === "all" || harness === "claude") {
+          const usage = (data.statsCache?.modelUsage ?? {}) as Record<string, any>;
+          const breakdown = Object.entries(usage)
+            .map(([model, u]: [string, any]) => ({
+              model,
+              inputTokens: u.inputTokens ?? 0,
+              outputTokens: u.outputTokens ?? 0,
+              cacheReadTokens: u.cacheReadTokens ?? 0,
+              cacheWriteTokens: u.cacheWriteTokens ?? 0,
+              totalTokens: u.totalTokens ?? 0,
+              estimatedCostUSD: u.costUSD ?? 0,
+            }))
+            .sort((a, b) => b.totalTokens - a.totalTokens);
+          return { content: [{ type: "text", text: JSON.stringify(breakdown, null, 2) }] };
+        }
+        const byModel: Record<string, { inputTokens: number; outputTokens: number; cacheReadTokens: number; cacheWriteTokens: number; estimatedCostUSD: number }> = {};
+        for (const s of filterSessions((data.sessions ?? []) as AnySession[], harness)) {
+          const model = (s.model as string) || "unknown";
+          if (!byModel[model]) byModel[model] = { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0, estimatedCostUSD: 0 };
+          const agg = byModel[model]!;
+          const { input, output, cacheRead, cacheWrite, cost } = sessionTokens(s);
+          agg.inputTokens += input; agg.outputTokens += output; agg.cacheReadTokens += cacheRead; agg.cacheWriteTokens += cacheWrite;
+          agg.estimatedCostUSD += cost;
+        }
+        const breakdown = Object.entries(byModel)
+          .map(([model, u]) => ({
             model,
-            inputTokens: u.inputTokens ?? 0,
-            outputTokens: u.outputTokens ?? 0,
-            cacheReadTokens: u.cacheReadTokens ?? 0,
-            cacheWriteTokens: u.cacheWriteTokens ?? 0,
-            totalTokens: u.totalTokens ?? 0,
-            estimatedCostUSD: u.costUSD ?? 0,
+            inputTokens: u.inputTokens,
+            outputTokens: u.outputTokens,
+            cacheReadTokens: u.cacheReadTokens,
+            cacheWriteTokens: u.cacheWriteTokens,
+            totalTokens: u.inputTokens + u.outputTokens + u.cacheReadTokens + u.cacheWriteTokens,
+            estimatedCostUSD: Math.round(u.estimatedCostUSD * 10000) / 10000,
           }))
           .sort((a, b) => b.totalTokens - a.totalTokens);
         return { content: [{ type: "text", text: JSON.stringify(breakdown, null, 2) }] };

--- a/packages/server/server/adapters/claude.ts
+++ b/packages/server/server/adapters/claude.ts
@@ -1,4 +1,3 @@
-import { existsSync } from 'fs'
 import type { SessionMeta } from '@agentistics/core'
 import type { HarnessAdapter } from './types'
 import { harnessEnabled } from './types'
@@ -8,8 +7,12 @@ import { loadSessionMetas, scanProjects } from '../data'
 export const claudeAdapter: HarnessAdapter = {
   id: 'claude',
   dataRoot: CLAUDE_DIR,
+  // Claude is the baseline harness: always present unless explicitly disabled,
+  // with no directory requirement (legacy/missing sessions default to claude,
+  // and stats-cache totals are claude). loadSessions() returns [] when ~/.claude
+  // is absent, so an empty environment (e.g. CI) is handled gracefully.
   isAvailable() {
-    return harnessEnabled('claude') && existsSync(CLAUDE_DIR)
+    return harnessEnabled('claude')
   },
   async loadSessions(): Promise<SessionMeta[]> {
     const metaMap = await loadSessionMetas()

--- a/packages/server/server/version.test.ts
+++ b/packages/server/server/version.test.ts
@@ -1,0 +1,25 @@
+import { test, expect } from 'bun:test'
+import { compareVersions } from './version'
+
+test('compareVersions orders semver correctly', () => {
+  expect(compareVersions('1.5.4', '1.5.3')).toBeGreaterThan(0)
+  expect(compareVersions('1.5.3', '1.5.4')).toBeLessThan(0)
+  expect(compareVersions('1.5.4', '1.5.4')).toBe(0)
+  expect(compareVersions('2.0.0', '1.9.9')).toBeGreaterThan(0)
+  expect(compareVersions('1.10.0', '1.9.0')).toBeGreaterThan(0)
+})
+
+// Picking the newest semver tag from a release list, ignoring the rolling
+// "latest" tag — this is the logic that drives the in-app update banner.
+const SEMVER_RE = /^\d+\.\d+\.\d+$/
+function pickLatest(tags: string[], current: string): string {
+  return tags
+    .map(t => t.replace(/^v/, '').trim())
+    .filter(v => SEMVER_RE.test(v))
+    .sort((a, b) => compareVersions(b, a))[0] ?? current
+}
+
+test('newest semver tag is chosen, rolling "latest" tag ignored', () => {
+  expect(pickLatest(['latest', 'v1.5.4', 'v1.5.3', 'v1.5.10'], '1.5.4')).toBe('1.5.10')
+  expect(pickLatest(['latest'], '1.5.4')).toBe('1.5.4') // no semver → fall back to current (no false update)
+})

--- a/packages/server/server/version.ts
+++ b/packages/server/server/version.ts
@@ -13,6 +13,16 @@ interface VersionCache {
 
 let _cache: VersionCache | null = null
 
+/** Strict semver pattern (major.minor.patch). Non-matching tags (e.g. the
+ *  rolling "latest" release tag) are ignored when resolving the newest version. */
+const SEMVER_RE = /^\d+\.\d+\.\d+$/
+
+/** Normalizes a tag to a bare semver string, or null if it isn't semver. */
+function toSemver(tag: string): string | null {
+  const v = tag.replace(/^v/, '').trim()
+  return SEMVER_RE.test(v) ? v : null
+}
+
 /** Compares two semver strings. Returns positive if a > b. */
 export function compareVersions(a: string, b: string): number {
   const pa = a.split('.').map(Number)
@@ -41,8 +51,12 @@ export async function getVersionInfo(): Promise<VersionInfo> {
   }
 
   try {
+    // List releases and pick the highest *semver* tag. We can't use
+    // /releases/latest because this repo also publishes a rolling "latest"
+    // tagged release, which /releases/latest returns (tag_name "latest" is not
+    // semver and would never compare as an update).
     const resp = await fetch(
-      `https://api.github.com/repos/${GITHUB_REPO}/releases/latest`,
+      `https://api.github.com/repos/${GITHUB_REPO}/releases?per_page=30`,
       {
         headers: {
           'Accept': 'application/vnd.github+json',
@@ -52,8 +66,13 @@ export async function getVersionInfo(): Promise<VersionInfo> {
       },
     )
     if (!resp.ok) throw new Error(`GitHub API ${resp.status}`)
-    const data = await resp.json() as { tag_name: string }
-    const latest = data.tag_name.replace(/^v/, '')
+    const releases = await resp.json() as Array<{ tag_name: string; draft?: boolean; prerelease?: boolean }>
+    const latest = releases
+      .filter(r => !r.draft && !r.prerelease)
+      .map(r => toSemver(r.tag_name))
+      .filter((v): v is string => v !== null)
+      .sort((a, b) => compareVersions(b, a))[0]
+      ?? CURRENT_VERSION
     const hasUpdate = compareVersions(latest, CURRENT_VERSION) > 0
     _cache = { latest, hasUpdate, fetchedAt: now }
     return { current: CURRENT_VERSION, latest, hasUpdate }


### PR DESCRIPTION
## 1. CI fix (main is red because of this)

After #35 merged, **Build & Release** on `main` failed at **Run tests**:

```
(fail) registry returns only known harness ids, always includes claude
```

`claudeAdapter.isAvailable()` gated on `existsSync(CLAUDE_DIR)`. CI runners have no `~/.claude`, so claude was filtered out and the "always includes claude" invariant broke (passed locally only because dev machines have `~/.claude`).

**Fix:** `isAvailable()` now returns `harnessEnabled('claude')` — no directory requirement. Claude is the baseline harness (legacy/missing sessions default to claude, stats-cache is claude, `data.ts` always seeds the harness set with claude). `loadSessions()` already returns `[]` gracefully. Verified the registry test passes with an empty `HOME`.

## 2. MCP multi-harness support

- `agentistics_summary` / `agentistics_projects` / `agentistics_sessions` / `agentistics_costs` accept an optional **`harness`** param (`claude|codex|gemini|copilot|all`). Aggregation is harness-aware; the Claude-only stats-cache is a fallback only for the unified/claude view. `currentStreak` is `null` for a single non-Claude harness.
- New **`agentistics_harnesses`** tool — side-by-side per-harness comparison.
- Docs updated (`docs/mcp.md`, README, `packages/mcp/README.md`, CHANGELOG). Verified end-to-end over the MCP stdio protocol.

## 3. Desktop (Tauri) auto-updater — made it work end-to-end

The desktop auto-update was non-functional. The Tauri window already loads the bundled `agentop.exe` sidecar (which serves the embedded frontend), so **all UI changes reflect once a release is published** — but updates weren't being delivered:

- **In-app update banner was broken:** `version.ts` queried `/releases/latest`, which returns this repo's rolling `latest`-tagged release (`tag_name: "latest"` isn't semver → `compareVersions` returned `NaN` → `hasUpdate` always false). Now it lists releases and picks the highest **semver** tag, ignoring the rolling tag. Added `version.test.ts`.
- **Native Tauri updater signing:** regenerated the updater keypair, set the matching `pubkey` in `tauri.conf.json`, and configured the `TAURI_SIGNING_PRIVATE_KEY` repo secret. CI now produces a **signed** installer + `latest.json`, so the native updater can detect releases. (Previous builds were unsigned → `latest.json` was never published → the endpoint 404'd.)
- Added `updater:default` to the Tauri capabilities.
- `main.rs` now logs every update-check outcome (init/none/error/available) instead of failing silently.
- `release.yml` emits a loud `::warning::` when a build is unsigned, so we never again silently ship an un-updatable release.
- `.gitignore` excludes `*.key` signing keys.

> Note: existing 1.5.3 desktop installs never had a working updater (no `latest.json` ever existed), so rotating the key has no downside — users do one manual reinstall of the next signed release, then auto-update works from there.

## Testing
- `bun tsc --noEmit` clean
- `bun test` — **142/142 pass** (registry test verified under empty `HOME`; new version tests)
- MCP verified live over stdio
