### PR TITLE
fix(desktop): enable createUpdaterArtifacts so the Tauri updater publishes latest.json

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -310,7 +310,7 @@ jobs:
             echo "has_sig=true" >> $GITHUB_OUTPUT
           else
             echo "has_sig=false" >> $GITHUB_OUTPUT
-            echo "::warning title=Auto-updater disabled::No .exe.sig produced — the TAURI_SIGNING_PRIVATE_KEY secret is not set, so latest.json will not be generated and the in-app Tauri updater cannot detect this release. Add the signing secret to enable auto-update. (The in-app update banner still works.)"
+            echo "::warning title=Auto-updater disabled::No .exe.sig produced — latest.json will not be generated and the native Tauri updater cannot detect this release. Check that the TAURI_SIGNING_PRIVATE_KEY secret is set AND that bundle.createUpdaterArtifacts is true in tauri.conf.json. (The in-app update banner still works.)"
           fi
 
       - name: Generate latest.json for auto-updater

--- a/packages/desktop/tauri.conf.json
+++ b/packages/desktop/tauri.conf.json
@@ -34,6 +34,7 @@
   },
   "bundle": {
     "active": true,
+    "createUpdaterArtifacts": true,
     "targets": [
       "msi",
       "nsis"


### PR DESCRIPTION
## Why

The release triggered by merging #36 built the desktop installer with `TAURI_SIGNING_PRIVATE_KEY` set, but produced **no `.exe.sig`** → `latest.json` was skipped → the native Tauri updater still can't see releases (`latest.json` 404s).

Root cause: in **Tauri v2, `tauri build` only emits updater signature artifacts when `bundle.createUpdaterArtifacts: true`** — it defaults to `false`. The config didn't have it.

## Fix
- `tauri.conf.json`: `bundle.createUpdaterArtifacts: true`.
- `release.yml`: corrected the "no signature" warning to name both causes (missing secret OR `createUpdaterArtifacts` off).

After this merges, the next `main` release will emit `<installer>.exe.sig`, generate and publish `latest.json`, and the native updater goes fully live.

## Testing
`bun test` — 142/142. (Desktop signing itself can only be verified on the Windows release runner.)
