### PR TITLE
fix(ci): build desktop installer at bumped version (fix updater re-prompt loop)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -293,6 +293,22 @@ jobs:
         shell: bash
         run: cp packages/web/public/minimalistLogo.png packages/desktop/ui/logo.png
 
+      # The desktop job checks out the pre-bump commit, so set the version to the
+      # same value the build job published. Otherwise the installer is built at the
+      # old version while latest.json advertises the bumped one, which makes the
+      # updater re-prompt forever (installed version never reaches the manifest one).
+      - name: Set version
+        shell: bash
+        run: |
+          VERSION="${{ needs.build.outputs.next }}"
+          bun -e "
+            const fs = require('fs');
+            const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+            pkg.version = '$VERSION';
+            fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
+          "
+          echo "Desktop build version set to $VERSION"
+
       - name: Build Tauri app
         working-directory: packages/desktop
         env:


### PR DESCRIPTION
The release after #37 published latest.json correctly (signed), but the manifest `version` (1.6.1) didn't match the installer filename (Agentistics_1.6.0). The desktop job checks out the pre-bump commit and never set the version, so the installer is built at the old version while latest.json advertises the bumped one — the updater would install and re-prompt forever. This adds a "Set version" step (mirroring the MCP publish job) so the installer version == manifest version.

After merge, the next release will have a matching installer/manifest and the native updater works cleanly end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)