### PR TITLE
fix(desktop): detect Codex/Gemini/Copilot + stop PWA install modal in the desktop app

### DIFF
--- a/packages/desktop/src/main.rs
+++ b/packages/desktop/src/main.rs
@@ -244,6 +244,16 @@ fn spawn_sidecar(
     let mut cmd = std::process::Command::new(&binary);
     cmd.arg("server").env("CLAUDE_DIR", claude_dir);
 
+    // Multi-harness: the other CLIs (Codex/Gemini/Copilot) live next to ~/.claude
+    // in the same home directory. The selected claude_dir is "<home>/.claude", so
+    // point each adapter at its sibling. Without this the server derives them from
+    // the Windows HOME and never finds the user's WSL data → only Claude shows up.
+    if let Some(home) = Path::new(claude_dir).parent() {
+        cmd.env("CODEX_DIR", home.join(".codex"));
+        cmd.env("GEMINI_DIR", home.join(".gemini"));
+        cmd.env("COPILOT_DIR", home.join(".copilot"));
+    }
+
     // Suppress the console window that would otherwise flash on Windows
     #[cfg(windows)]
     {

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -1085,8 +1085,12 @@ export default function AppLayout() {
 
   type PwaPrompt = Event & { prompt(): Promise<void>; userChoice: Promise<{ outcome: string }> }
   const [pwaPrompt, setPwaPrompt] = useState<PwaPrompt | null>(null)
+  // Treat the Tauri desktop app as "already installed" — it must never show the
+  // PWA install prompt (it IS the app). Tauri v2 exposes these globals.
+  const isTauri = typeof window !== 'undefined' &&
+    ('__TAURI_INTERNALS__' in window || '__TAURI__' in window)
   const [pwaInstalled, setPwaInstalled] = useState(() =>
-    typeof window !== 'undefined' && window.matchMedia('(display-mode: standalone)').matches
+    isTauri || (typeof window !== 'undefined' && window.matchMedia('(display-mode: standalone)').matches)
   )
   useEffect(() => {
     const handler = (e: Event) => { e.preventDefault(); setPwaPrompt(e as PwaPrompt) }


### PR DESCRIPTION
Reported on the installed desktop app: no multi-harness (looked identical to the old version) and a "install this app?" modal showing inside the desktop app.

**1. Multi-harness never detected.** `spawn_sidecar` only passed `CLAUDE_DIR`; the Codex/Gemini/Copilot adapters then derived their dirs from the Windows HOME and found nothing (the user's data is under the same home as the selected `~/.claude`, e.g. in WSL). Now main.rs sets `CODEX_DIR`/`GEMINI_DIR`/`COPILOT_DIR` as siblings of the selected claude dir → harness selector and /compare appear when that data exists.

**2. PWA install modal inside Tauri.** The webview isn't `display-mode: standalone`, so the "install this app" prompt fired in the desktop app. Now we detect Tauri (`__TAURI_INTERNALS__`/`__TAURI__`) and treat it as already installed → no install prompt.

Note: the double initial loading is the Tauri shell → served-app handoff; cosmetic, tracked separately.

bun test 142/142, tsc clean. Needs a release + reinstall to take effect on the desktop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)