### PR TITLE
feat(desktop): "Change source" button to re-pick Windows/WSL after install

### DIFF
--- a/packages/desktop/src/main.rs
+++ b/packages/desktop/src/main.rs
@@ -338,6 +338,14 @@ fn reset_config(state: State<AppState>) -> Result<(), String> {
     Ok(())
 }
 
+/// Forget the saved data source and restart, so the onboarding source picker
+/// (Windows / WSL) shows again. Invoked from the dashboard's Settings.
+#[tauri::command]
+fn change_source(state: State<AppState>, app: AppHandle) {
+    let _ = std::fs::remove_file(&state.config_path);
+    app.restart();
+}
+
 // ── Auto-update ───────────────────────────────────────────────────────────────
 
 async fn check_for_update(app: AppHandle) {
@@ -422,6 +430,7 @@ fn main() {
             get_setup_state,
             launch_with_config,
             reset_config,
+            change_source,
         ])
         .setup(move |app| {
             let handle = app.handle().clone();

--- a/packages/web/src/components/PreferencesModal.tsx
+++ b/packages/web/src/components/PreferencesModal.tsx
@@ -697,8 +697,44 @@ function EnvironmentTab({ pt }: { pt: boolean }) {
     ? CONFIG_FIELDS.map(f => `${f.key}=${configData.backup?.[f.key] ?? f.default}`).join(', ')
     : ''
 
+  const isTauri = typeof window !== 'undefined' &&
+    ('__TAURI_INTERNALS__' in window || '__TAURI__' in window)
+  const changeSource = async () => {
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const invoke = (window as any).__TAURI__?.core?.invoke
+      if (invoke) await invoke('change_source')
+    } catch { /* ignore */ }
+  }
+
   return (
     <>
+      {isTauri && (
+        <div style={{
+          marginBottom: 20, padding: '12px 14px', borderRadius: 8,
+          border: '1px solid var(--border)', background: 'var(--bg-elevated)',
+        }}>
+          <div style={{ fontSize: 12, fontWeight: 600, color: 'var(--text-primary)', marginBottom: 4 }}>
+            {pt ? 'Fonte de dados (Windows / WSL)' : 'Data source (Windows / WSL)'}
+          </div>
+          <div style={{ fontSize: 11, color: 'var(--text-tertiary)', marginBottom: 10, lineHeight: 1.5 }}>
+            {pt
+              ? 'Escolha de qual ~/.claude ler. Os harnesses Codex/Gemini/Copilot são lidos da mesma pasta. Trocar reinicia o app e mostra o seletor de fontes.'
+              : 'Choose which ~/.claude to read from. Codex/Gemini/Copilot are read from the same folder. Switching restarts the app and shows the source picker.'}
+          </div>
+          <button
+            onClick={changeSource}
+            style={{
+              height: 32, padding: '0 14px', borderRadius: 8, cursor: 'pointer',
+              border: '1px solid var(--anthropic-orange)', background: 'var(--anthropic-orange-dim)',
+              color: 'var(--anthropic-orange)', fontSize: 12, fontWeight: 600, fontFamily: 'inherit',
+            }}
+          >
+            {pt ? 'Trocar fonte…' : 'Change source…'}
+          </button>
+        </div>
+      )}
+
       <div style={{ fontSize: 12, color: 'var(--text-tertiary)', marginBottom: 20, lineHeight: 1.6 }}>
         {pt
           ? 'Alterações entram em vigor após reiniciar o servidor.'


### PR DESCRIPTION
Reported: after updating, the WSL harnesses (Codex/Gemini/Copilot) dont appear and theres nowhere to choose Windows vs WSL.

Cause: the first-run onboarding source picker only shows when no config.json exists. After the first install (and across updates) the saved source persists, so the picker never returns and the user is stuck on whatever was first selected.

Fix: a `change_source` Tauri command (deletes the saved config + restarts → onboarding shows again) plus a Tauri-only "Change source (Windows/WSL)" button in Settings → Environment. Combined with the earlier sibling-dir fix (#39), picking the WSL source makes Codex/Gemini/Copilot show up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)