### PR TITLE
fix: installer agentop.exe file-lock + Settings modal tab/toggle overflow

### DIFF
--- a/packages/desktop/installer-hooks.nsh
+++ b/packages/desktop/installer-hooks.nsh
@@ -1,0 +1,14 @@
+; Tauri NSIS installer hooks
+; The desktop app spawns `agentop.exe` as a sidecar process. Tauri's NSIS
+; installer kills the main app (Agentistics.exe) but does NOT know about the
+; sidecar, so if agentop.exe is still running the installer fails with
+; "Error opening file for writing: ...\agentop.exe". Kill it before installing
+; (and before uninstalling) so the file is never locked.
+
+!macro NSIS_HOOK_PREINSTALL
+  nsExec::Exec 'taskkill /F /IM agentop.exe /T'
+!macroend
+
+!macro NSIS_HOOK_PREUNINSTALL
+  nsExec::Exec 'taskkill /F /IM agentop.exe /T'
+!macroend

--- a/packages/desktop/tauri.conf.json
+++ b/packages/desktop/tauri.conf.json
@@ -53,6 +53,9 @@
       "webviewInstallMode": {
         "type": "downloadBootstrapper",
         "silent": false
+      },
+      "nsis": {
+        "installerHooks": "./installer-hooks.nsh"
       }
     }
   }

--- a/packages/web/src/components/PreferencesModal.tsx
+++ b/packages/web/src/components/PreferencesModal.tsx
@@ -106,7 +106,7 @@ function TabSelect<T extends string>({
   accent?: string
 }) {
   return (
-    <div style={{ display: 'flex', border: '1px solid var(--border)', borderRadius: 6, overflow: 'hidden' }}>
+    <div style={{ display: 'inline-flex', width: 'fit-content', border: '1px solid var(--border)', borderRadius: 6, overflow: 'hidden' }}>
       {options.map((opt, i) => {
         const active = opt.value === value
         return (
@@ -1261,11 +1261,11 @@ export function PreferencesModal({
             </button>
           </div>
 
-          {/* Tab bar — scrolls horizontally on mobile so tabs never overflow */}
-          <div style={{
+          {/* Tab bar — scrolls horizontally (desktop + mobile) so the tabs never
+              overflow the modal width; scrollbar hidden via .prefs-tabbar in css */}
+          <div className="prefs-tabbar" style={{
             display: 'flex', gap: 2, borderBottom: '1px solid var(--border)', marginBottom: 0,
-            overflowX: isMobile ? 'auto' : undefined,
-            ...(isMobile ? { scrollbarWidth: 'none' as const } : {}),
+            overflowX: 'auto', scrollbarWidth: 'none' as const,
           }}>
             {TABS.map(tab => {
               const active = activeTab === tab.id

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -155,6 +155,10 @@ html, body {
   scrollbar-color: rgba(255,255,255,0.1) transparent;
 }
 
+/* Settings modal tab bar: scrollable but no visible scrollbar (desktop + mobile) */
+.prefs-tabbar { scrollbar-width: none; }
+.prefs-tabbar::-webkit-scrollbar { display: none; }
+
 /* FiltersBar sticky shimmer scan */
 @keyframes filters-shimmer-scan {
   0%   { background-position: -100% 0; }


### PR DESCRIPTION
**Installer (the screenshot error):** Running the NSIS installer while the desktop app was open failed with `Error opening file for writing: ...\agentop.exe` — the running sidecar locks the exe and Tauri's NSIS only kills the main app. Added an NSIS PREINSTALL/PREUNINSTALL hook (`installer-hooks.nsh`, wired via `bundle.windows.nsis.installerHooks`) that `taskkill`s agentop.exe before copying files.

**Settings modal (web + desktop):**
- Tab bar overflowed the 560px modal on desktop (only mobile had overflow handling). Now scrolls horizontally on all viewports with a hidden scrollbar.
- `TabSelect` toggle groups (Theme/Currency/etc.) used a block `display:flex` so the bordered box stretched to the full grid-cell width, leaving dead space to the right. Switched to `inline-flex` + `fit-content`.

bun test 142/142, tsc clean. Verified the modal on a 1440px desktop viewport (tab bar contained, toggles hug their buttons). Also confirmed the in-app update banner now correctly shows 1.6.3→1.6.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)