### PR TITLE
fix(server): robust Nay backend CLI detection (false 'not installed')

### DIFF
--- a/packages/server/server/chat-drivers/claude.ts
+++ b/packages/server/server/chat-drivers/claude.ts
@@ -1,17 +1,9 @@
-import { existsSync } from 'node:fs'
 import { CHAT_MODELS, registerMcpGlobally, streamViaClaude } from '../chat-tty'
 import type { ChatDriver } from './types'
+import { findCli } from './cli-detect'
 
 function claudeIsAvailable(): boolean {
-  // Try common binary paths; fall back to PATH via `which`
-  if (existsSync('/usr/local/bin/claude')) return true
-  if (existsSync('/usr/bin/claude')) return true
-  try {
-    const proc = Bun.spawnSync(['which', 'claude'], { stdout: 'pipe', stderr: 'pipe' })
-    return proc.exitCode === 0
-  } catch {
-    return false
-  }
+  return findCli('claude')
 }
 
 export const claudeDriver: ChatDriver = {

--- a/packages/server/server/chat-drivers/cli-detect.ts
+++ b/packages/server/server/chat-drivers/cli-detect.ts
@@ -1,0 +1,54 @@
+import { existsSync } from 'node:fs'
+import path from 'node:path'
+
+const HOME = process.env.HOME ?? process.env.USERPROFILE ?? ''
+
+/**
+ * Robustly detect whether a CLI binary is installed.
+ *
+ * The Nay backend spawns these CLIs to generate chat responses, so detection
+ * must not rely solely on the server process's PATH — when the server runs as a
+ * background/sidecar process the PATH is often stripped of user bin dirs
+ * (~/.local/bin, ~/.bun/bin, npm global prefix), which made installed CLIs read
+ * as "not installed". Check the common install locations directly, then fall
+ * back to `which` with an augmented PATH.
+ *
+ * Note: this only detects CLIs runnable by the *server process*. The desktop app
+ * runs its sidecar on Windows; CLIs installed inside WSL are not executable from
+ * Windows and will (correctly) read as unavailable there.
+ */
+export function findCli(name: string): boolean {
+  const candidates = [
+    `/usr/local/bin/${name}`,
+    `/usr/bin/${name}`,
+    path.join(HOME, '.local', 'bin', name),
+    path.join(HOME, '.bun', 'bin', name),
+    path.join(HOME, '.npm-global', 'bin', name),
+    path.join(HOME, '.npm', 'bin', name),
+    path.join(HOME, 'node_modules', '.bin', name),
+    // Windows global npm install location
+    path.join(process.env.APPDATA ?? '', 'npm', `${name}.cmd`),
+    path.join(process.env.APPDATA ?? '', 'npm', `${name}.exe`),
+  ]
+  if (candidates.some(p => p && existsSync(p))) return true
+
+  const augmentedPath = [
+    process.env.PATH ?? '',
+    path.join(HOME, '.local', 'bin'),
+    path.join(HOME, '.bun', 'bin'),
+    path.join(HOME, '.npm-global', 'bin'),
+  ].filter(Boolean).join(path.delimiter)
+
+  try {
+    // `which` on POSIX, `where` on Windows.
+    const cmd = process.platform === 'win32' ? ['where', name] : ['which', name]
+    const proc = Bun.spawnSync(cmd, {
+      stdout: 'pipe',
+      stderr: 'pipe',
+      env: { ...process.env, PATH: augmentedPath },
+    })
+    return proc.exitCode === 0
+  } catch {
+    return false
+  }
+}

--- a/packages/server/server/chat-drivers/codex.ts
+++ b/packages/server/server/chat-drivers/codex.ts
@@ -27,6 +27,7 @@ import { existsSync } from 'node:fs'
 import { HOME_DIR } from '../config'
 import type { ChatDriver } from './types'
 import type { ChatMessage } from '../chat-tty'
+import { findCli } from './cli-detect'
 
 // chat-drivers/ is one level deeper than chat-tty.ts, so 4 levels up to reach the repo root
 const AGENTISTICS_ROOT = path.resolve(import.meta.dir, '..', '..', '..', '..')
@@ -62,16 +63,7 @@ const CODEX_MODELS = [
 type CodexModelId = typeof CODEX_MODELS[number]['id']
 
 function codexIsAvailable(): boolean {
-  if (existsSync('/usr/local/bin/codex')) return true
-  if (existsSync('/usr/bin/codex')) return true
-  const home = HOME_DIR
-  if (existsSync(path.join(home, '.bun', 'bin', 'codex'))) return true
-  try {
-    const proc = Bun.spawnSync(['which', 'codex'], { stdout: 'pipe', stderr: 'pipe' })
-    return proc.exitCode === 0
-  } catch {
-    return false
-  }
+  return findCli('codex')
 }
 
 /**

--- a/packages/server/server/chat-drivers/copilot.ts
+++ b/packages/server/server/chat-drivers/copilot.ts
@@ -15,6 +15,7 @@ import { existsSync, readFileSync } from 'node:fs'
 import { readFile, writeFile, mkdir } from 'node:fs/promises'
 import { HOME_DIR } from '../config'
 import type { ChatDriver, ChatDriverModel } from './types'
+import { findCli } from './cli-detect'
 
 const AGENTISTICS_ROOT = path.resolve(import.meta.dir, '..', '..', '..', '..')
 
@@ -48,14 +49,7 @@ export const COPILOT_MODELS: ChatDriverModel[] = [
 ]
 
 function copilotIsAvailable(): boolean {
-  if (existsSync('/usr/local/bin/copilot')) return true
-  if (existsSync('/usr/bin/copilot')) return true
-  try {
-    const proc = Bun.spawnSync(['which', 'copilot'], { stdout: 'pipe', stderr: 'pipe' })
-    return proc.exitCode === 0
-  } catch {
-    return false
-  }
+  return findCli('copilot')
 }
 
 /**

--- a/packages/server/server/chat-drivers/gemini.ts
+++ b/packages/server/server/chat-drivers/gemini.ts
@@ -19,6 +19,7 @@ import { existsSync } from 'node:fs'
 import { HOME_DIR } from '../config'
 import type { ChatDriver } from './types'
 import type { ChatMessage } from '../chat-tty'
+import { findCli } from './cli-detect'
 
 // chat-drivers/ is one level deeper than chat-tty.ts, so 4 levels up to reach the repo root
 const AGENTISTICS_ROOT = path.resolve(import.meta.dir, '..', '..', '..', '..')
@@ -50,16 +51,7 @@ const GEMINI_MODELS = [
 type GeminiModelId = typeof GEMINI_MODELS[number]['id']
 
 function geminiIsAvailable(): boolean {
-  if (existsSync('/usr/local/bin/gemini')) return true
-  if (existsSync('/usr/bin/gemini')) return true
-  const home = HOME_DIR
-  if (existsSync(path.join(home, '.bun', 'bin', 'gemini'))) return true
-  try {
-    const proc = Bun.spawnSync(['which', 'gemini'], { stdout: 'pipe', stderr: 'pipe' })
-    return proc.exitCode === 0
-  } catch {
-    return false
-  }
+  return findCli('gemini')
 }
 
 /**


### PR DESCRIPTION
The Nay chat showed 'X is not installed' even though the CLIs were installed, because detection only checked `/usr/local/bin`+`/usr/bin`+bare `which`. When the server runs as a background/sidecar process the PATH often lacks `~/.local/bin`/`~/.bun/bin`/npm-global, so `which` failed.

Added a shared `findCli()` that checks the common install locations directly (incl. `~/.local/bin`, `~/.bun/bin`, npm global, Windows `%APPDATA%\npm`) and falls back to which/where with an augmented PATH. All 4 drivers use it.

Verified on the live server: `/api/chat-harnesses` now reports installed+ready for all four, and the Nay panel no longer shows the install block.

Caveat: detects CLIs runnable by the server process. The desktop sidecar runs on Windows, so CLIs installed only in WSL still can't be executed from Windows (separate limitation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)