### PR TITLE
feat(central): agentop status + central-UI fixes (presence, DeployCentral, PDF selectors) + WSL2/Tailscale docs

### DIFF
--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -14,6 +14,11 @@ This guide covers running **agentistics Team Mode** as a central aggregator usin
 
 ## Quick Start
 
+> **No repo? Use the binary.** If you have the `agentop` binary installed, you can skip cloning
+> entirely: `agentop central up` pulls the published image and runs the central from any
+> directory (see [`agentop central`](#the-same-thing-from-the-cli--agentop-central)). The steps
+> below are the repo-based flow (builds the image from source).
+
 ### 1. Clone the repository and enter the project root
 
 ```bash
@@ -104,20 +109,27 @@ Override the defaults with env vars: `PROJECT=... ENV_FILE=... ./central.sh up`.
 
 ### The same thing from the cli — `agentop central`
 
-If you have the `agentop` binary installed, `agentop central <action>` is a thin wrapper
-that shells out to the repo's `central.sh` (it locates the script in the checkout it was
-run from, inheriting stdio so `init`'s prompts and `logs` streaming work). The actions map
-one-to-one:
+`agentop central <action>` manages the central via Docker. It picks its path automatically:
+
+- **In a repo checkout** — it shells out to the repo's `central.sh` (locating it in the
+  checkout, inheriting stdio so `init`'s prompts and `logs` streaming work). The image is
+  built from source (`build: .`).
+- **From the standalone binary (no repo)** — it materializes a Compose file that **pulls**
+  the published image `ghcr.io/blpsoares/agentistics:<version>` into `~/.agentistics/central/`,
+  generates `central.env` interactively on first `up`, and drives `docker compose` directly.
+  No clone required — run it from any directory.
+
+The actions map one-to-one:
 
 | central.sh | agentop equivalent | What it does |
 |---|---|---|
 | `./central.sh init` | `agentop central init` | (Re)generate `central.env` interactively |
-| `./central.sh up` | `agentop central up` | Build + `--force-recreate` the containers |
+| `./central.sh up` | `agentop central up` | Deploy: build (repo) or pull (standalone) + `--force-recreate` |
 | `./central.sh restart` | `agentop central restart` | Restart the `app` container without rebuilding |
 | `./central.sh logs` | `agentop central logs` | Follow the `app` logs |
 | `./central.sh status` | `agentop central status` | Show container + health status |
 | `./central.sh down` | `agentop central down` | Stop + remove containers (keeps the data volume) |
-| `./central.sh pull` | `agentop central pull` | Rebuild from a fresh base image |
+| `./central.sh pull` | `agentop central pull` | Pull a fresh image and recreate |
 
 ```bash
 agentop central up        # first time offers the interactive init, then deploys
@@ -125,8 +137,12 @@ agentop central status
 agentop central logs
 ```
 
-> `agentop central` needs the agentistics repo (it runs `central.sh`), so run it from
-> inside a checkout. On a machine that only has the binary, clone the repo first.
+> **Standalone requirements:** the published image must be reachable. It's public on GHCR by
+> default (no auth needed); if the package is private, run `docker login ghcr.io` first. Pin a
+> specific build with `AGENTISTICS_IMAGE=ghcr.io/blpsoares/agentistics:<tag>` (defaults to the
+> binary's own version). The standalone Compose runs a dedicated central and does **not** mount
+> the host harness dirs — for a self-contributing central (one machine = central + member), use
+> the repo `central.sh` with `AGENTISTICS_CENTRAL_USER` set.
 
 ---
 
@@ -165,6 +181,32 @@ expose the dashboard **outside** Tailscale.
 > **WSL2 note:** binding to a specific non-loopback IP (e.g. Tailscale) means Windows'
 > `localhost` forwarding no longer reaches the app — browse via that IP instead. The default
 > `0.0.0.0` keeps `http://localhost:<APP_PORT>` working.
+
+### WSL2 + Tailscale: use `tailscale serve` (recommended)
+
+Running the central in **Docker inside WSL2** and exposing it over Tailscale is flaky with a
+raw published port: `http://localhost:<APP_PORT>` works, but hitting the machine's Tailscale
+IP (`http://100.x.y.z:<APP_PORT>`) often hangs or "works, then stops". The cause is packets
+arriving on the `tailscale0` interface having to traverse Docker's DNAT/FORWARD inside WSL2 —
+that path is unreliable in WSL2's NAT networking. It is **not** an agentistics or container
+problem (localhost proves the app is fine).
+
+The robust fix is to let `tailscaled` proxy the port instead of relying on the Docker/interface
+path — `tailscale serve` accepts the tailnet connection in-process and forwards to
+`127.0.0.1:<APP_PORT>` (which always works):
+
+```bash
+sudo tailscale set --operator=$USER      # once — lets you run serve without sudo afterwards
+tailscale serve --bg <APP_PORT>          # e.g. 48080
+tailscale serve status                   # confirm: https://<host>.<tailnet>.ts.net → 127.0.0.1:<APP_PORT>
+```
+
+Everyone then uses the **HTTPS MagicDNS URL with no port** — e.g.
+`https://your-host.your-tailnet.ts.net` — both in the browser and as the member endpoint
+(`agentop member connect --endpoint https://your-host.your-tailnet.ts.net …`). `serve` proxies
+the reverse-channel WebSocket (`/api/team/agent`) too, so presence and on-demand chat keep
+working. Undo with `tailscale serve reset`. (Requires HTTPS certificates enabled for your
+tailnet — the default on modern Tailscale.)
 
 ---
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -29,6 +29,7 @@ agentop --version    # print version (and a notice if an update exists)
 | [`setup`](#setup) | Interactive first-run wizard (solo / central / member) |
 | [`server`](#server) | Start the web dashboard + api + Nay + background daemon (non-interactive) |
 | [`restart`](#restart) | Restart a running mode so it picks up new code / config |
+| [`status`](#status) | At-a-glance: mode, services (server/central/machine) + health |
 | [`tui`](#tui) | Live terminal dashboard (no browser) |
 | [`watch`](#watch) | OpenTelemetry metrics daemon only (headless) |
 | [`central`](#central) | Manage the Team Mode central (wraps `central.sh`) |
@@ -121,6 +122,24 @@ agentop restart central    # rebuild + restart the central's Docker container
 tells you to run it in the foreground or enable autostart first. `central` delegates to
 `central.sh restart`; to also pick up **code** changes on a central, use `agentop central up`
 (rebuilds the image) instead.
+
+---
+
+## `status`
+
+Non-interactive, at-a-glance report of this machine. Prints three blocks:
+
+- **CONFIG** — the team mode (`solo` / `central` / `member`) and, for a member, the
+  central endpoint (from preferences).
+- **SERVICES** — detected live: the local server (`http://localhost:47291/api/health`;
+  shows the dashboard URL when up), the central container, and the machine container.
+- **HEALTH** — a one-line summary from `/api/health` when the server is up, else `n/a`.
+
+```bash
+agentop status
+```
+
+Handy for a quick "is everything up and healthy?" without opening the dashboard.
 
 ---
 

--- a/packages/server/bin/cli.ts
+++ b/packages/server/bin/cli.ts
@@ -16,6 +16,7 @@ Commands:
   setup         Interactive first-run wizard (solo / central / member)
   server        Start the web dashboard + background daemon (non-interactive)
   restart       Restart a running mode's service so it picks up new code/config
+  status        Show services (server/central/member) + health
   tui           Start the live terminal dashboard (standalone)
   watch         Start the background metrics daemon only
   central       Manage the team central (Docker; runs from anywhere)
@@ -276,6 +277,11 @@ if (command === 'autostart') {
 
   process.stdout.write(res.message + '\n')
   process.exit(res.ok ? 0 : 1)
+}
+
+if (command === 'status') {
+  const { runStatus } = await import('../server/cli-status.ts')
+  process.exit(await runStatus())
 }
 
 if (command === 'restart') {

--- a/packages/server/server/cli-status.ts
+++ b/packages/server/server/cli-status.ts
@@ -1,0 +1,126 @@
+/**
+ * cli-status.ts — `agentop status`, a one-shot at-a-glance report.
+ *
+ * Non-interactive: prints CONFIG (team mode + endpoint from preferences), SERVICES (local server,
+ * central container, machine container — detected live) and HEALTH (a one-line summary from the
+ * local server's /api/health when it's up). Mirrors the detection helpers in cli-start.ts, but
+ * reimplements the tiny shell/docker helpers locally rather than importing private members.
+ */
+
+import { PORT, WEB_PORT } from './config'
+import { readPreferences } from './preferences'
+
+// ── ANSI (same palette as cli-start.ts) ──────────────────────────────────────
+const ESC = '\x1b'
+const R = `${ESC}[0m`
+const B = `${ESC}[1m`
+const D = `${ESC}[2m`
+const O = `${ESC}[38;5;208m`
+const CY = `${ESC}[96m`
+const GR = `${ESC}[92m`
+const YE = `${ESC}[33m`
+const WH = `${ESC}[97m`
+
+const CENTRAL_PROJECT = 'team-mode'      // central.sh: PROJECT=${PROJECT:-team-mode}
+const MACHINE_IMAGE = 'agentistics-machine' // docker-compose.machine.yml: image
+
+// ── shell helpers (local copy of cli-start.ts's pattern) ──────────────────────
+async function sh(cmd: string[]): Promise<{ code: number; out: string }> {
+  try {
+    const p = Bun.spawn(cmd, { stdout: 'pipe', stderr: 'ignore' })
+    const out = await new Response(p.stdout).text()
+    return { code: await p.exited, out: out.trim() }
+  } catch {
+    return { code: 127, out: '' }
+  }
+}
+
+async function dockerIds(filter: string): Promise<string[]> {
+  const r = await sh(['docker', 'ps', '-q', '-f', filter])
+  return r.out.split(/\s+/).filter(Boolean)
+}
+
+// ── detection ─────────────────────────────────────────────────────────────────
+async function isServerRunning(): Promise<boolean> {
+  try {
+    const res = await fetch(`http://localhost:${PORT}/api/health`, { signal: AbortSignal.timeout(600) })
+    return res.ok
+  } catch {
+    return false
+  }
+}
+
+/** Green dot for a live service, dim circle for a down one. */
+function dot(up: boolean): string {
+  return up ? `${GR}●${R}` : `${D}○${R}`
+}
+
+/** One-line health summary from /api/health. Counts passing checks when the shape allows. */
+async function healthLine(): Promise<string> {
+  try {
+    const res = await fetch(`http://localhost:${PORT}/api/health`, { signal: AbortSignal.timeout(600) })
+    if (!res.ok) return `${D}health: unreachable (HTTP ${res.status})${R}`
+    const data: unknown = await res.json().catch(() => null)
+    const checks = (data as { checks?: unknown } | null)?.checks
+    if (Array.isArray(checks) && checks.length > 0) {
+      const ok = checks.filter((c) => (c as { ok?: boolean; healthy?: boolean })?.ok ?? (c as { healthy?: boolean })?.healthy).length
+      const total = checks.length
+      const label = ok === total ? `${GR}healthy${R}` : `${YE}degraded${R}`
+      return `${label} ${D}(${ok}/${total} checks passing)${R}`
+    }
+    return `${GR}reachable${R}`
+  } catch {
+    return `${D}health: n/a (server down)${R}`
+  }
+}
+
+const RULE = `  ${D}────────────────────────────────────────${R}`
+
+type Mode = 'solo' | 'central' | 'member'
+
+async function loadConfig(): Promise<{ mode: Mode; endpoint?: string }> {
+  try {
+    const prefs = await readPreferences()
+    return { mode: prefs.team?.mode ?? 'solo', endpoint: prefs.team?.endpoint }
+  } catch {
+    return { mode: 'solo' }
+  }
+}
+
+export async function runStatus(): Promise<number> {
+  // CONFIG
+  const { mode, endpoint } = await loadConfig()
+
+  // SERVICES (detected live)
+  const [local, central, machine] = await Promise.all([
+    isServerRunning(),
+    dockerIds(`label=com.docker.compose.project=${CENTRAL_PROJECT}`).then((i) => i.length > 0),
+    dockerIds(`ancestor=${MACHINE_IMAGE}`).then((i) => i.length > 0),
+  ])
+
+  const configValue =
+    mode === 'member' ? `${CY}member${R} ${D}→${R} ${WH}${endpoint ?? '(?)'}${R}`
+    : mode === 'central' ? `${CY}central${R}`
+    : `${CY}solo${R}`
+
+  process.stdout.write('\n')
+  process.stdout.write(`  ${O}${B}agentop status${R}\n`)
+  process.stdout.write(`${RULE}\n`)
+  process.stdout.write(`  ${D}CONFIG${R}\n`)
+  process.stdout.write(`    ${D}mode${R}      ${configValue}\n`)
+  process.stdout.write(`${RULE}\n`)
+  process.stdout.write(`  ${D}SERVICES${R}\n`)
+  const localLine = local
+    ? `${dot(true)} ${WH}local server${R}   ${D}http://localhost:${WEB_PORT}${R}`
+    : `${dot(false)} ${D}local server${R}   ${D}offline${R}`
+  process.stdout.write(`    ${localLine}\n`)
+  process.stdout.write(`    ${dot(central)} ${central ? WH : D}central container${R} ${D}${central ? 'running' : 'stopped'}${R}\n`)
+  process.stdout.write(`    ${dot(machine)} ${machine ? WH : D}machine container${R} ${D}${machine ? 'running' : 'stopped'}${R}\n`)
+  process.stdout.write(`${RULE}\n`)
+  process.stdout.write(`  ${D}HEALTH${R}\n`)
+  const health = local ? await healthLine() : `${D}health: n/a (server down)${R}`
+  process.stdout.write(`    ${health}\n`)
+  process.stdout.write(`${RULE}\n\n`)
+
+  return 0
+}

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -2078,6 +2078,7 @@ export default function AppLayout() {
           highlightUpdates={highlightUpdates}
           setHighlightUpdates={setHighlightUpdates}
           harnesses={data.harnesses}
+          presence={data?.presence}
           />
       )}
 

--- a/packages/web/src/components/DeployCentral.tsx
+++ b/packages/web/src/components/DeployCentral.tsx
@@ -178,7 +178,7 @@ function InputField({
 
 export function DeployCentral({ pt }: { pt: boolean }) {
   const [org, setOrg] = useState('default')
-  const [port, setPort] = useState('47291')
+  const [port, setPort] = useState('48080')
   const [loading, setLoading] = useState(false)
   const [result, setResult] = useState<DeployResult | null>(null)
   const [error, setError] = useState<string | null>(null)
@@ -192,7 +192,7 @@ export function DeployCentral({ pt }: { pt: boolean }) {
 
   async function generate() {
     const trimmedOrg = org.trim() || 'default'
-    const trimmedPort = port.trim() || '47291'
+    const trimmedPort = port.trim() || '48080'
     setLoading(true)
     setError(null)
     // Do NOT clear result here — keep previous credentials visible until the

--- a/packages/web/src/components/PreferencesModal.tsx
+++ b/packages/web/src/components/PreferencesModal.tsx
@@ -5,7 +5,7 @@ import {
   Archive, Check, HardDrive, FolderClock, ExternalLink, DatabaseZap,
   Cpu, Copy, CheckCheck, AlertCircle, CircleDot, Users, Database,
 } from 'lucide-react'
-import type { Lang, Theme, HarnessId } from '@agentistics/core'
+import type { Lang, Theme, HarnessId, MemberPresence } from '@agentistics/core'
 import { HARNESS_LABELS, HARNESS_COLORS } from '../lib/harness'
 import { HarnessInfoPanel } from './HarnessInfoPanel'
 import type { ArchiveMode } from './ArchiveConsentModal'
@@ -76,6 +76,9 @@ interface Props {
   defaultTab?: SettingsTab
   /** Harnesses present in the data — drives the "Data & sources" tab content. */
   harnesses?: HarnessId[]
+  /** Shared dashboard presence (/api/data), threaded to the team members panel so it stays in
+   *  sync with the FiltersBar presence pill. */
+  presence?: Record<string, MemberPresence>
 }
 
 // ── Shared primitives ──────────────────────────────────────────────────────
@@ -557,9 +560,9 @@ function InstallTab({ pt, pwaPrompt, onPwaInstalled, onClose, central }: {
           : 'The Web App is faster to install and works on any platform. The Desktop App offers native Windows integration with a taskbar icon.'}
       </div>
 
-      {central === true && (
+      {central === false && (
         <>
-          {/* Deploy a team central — only shown on the central instance */}
+          {/* Deploy a team central — only shown on non-central instances */}
           <div style={{ height: 1, background: 'var(--border)', margin: '4px 0 4px' }} />
           <div style={{
             fontSize: 11, fontWeight: 700, color: 'var(--text-tertiary)',
@@ -1075,7 +1078,7 @@ const DEFAULT_TEAM_CONFIG: TeamConfig = {
   token: '',
 }
 
-function TeamTab({ pt, central }: { pt: boolean; central: boolean | null }) {
+function TeamTab({ pt, central, presence }: { pt: boolean; central: boolean | null; presence?: Record<string, MemberPresence> }) {
   const lang: 'pt' | 'en' = pt ? 'pt' : 'en'
   const [team, setTeam] = useState<TeamConfig>(DEFAULT_TEAM_CONFIG)
   const [loadErr, setLoadErr] = useState<string | null>(null)
@@ -1108,7 +1111,7 @@ function TeamTab({ pt, central }: { pt: boolean; central: boolean | null }) {
     <div>
       {/* TeamSettings handles saving explicitly via its Save button (member mode)
           or its own interval control (central mode). onChange just syncs local state. */}
-      <TeamSettings team={team} onChange={setTeam} lang={lang} central={central} />
+      <TeamSettings team={team} onChange={setTeam} lang={lang} central={central} presence={presence} />
     </div>
   )
 }
@@ -1133,6 +1136,7 @@ export function PreferencesModal({
   liveUpdates, setLiveUpdates, updateInterval, setUpdateInterval,
   riskyMode, setRiskyMode, highlightUpdates, setHighlightUpdates,
   defaultTab = 'preferences', harnesses = [],
+  presence,
 }: Props) {
   const isMobile = useIsMobile()
   const [activeTab, setActiveTab] = useState<SettingsTab>(defaultTab)
@@ -1286,7 +1290,7 @@ export function PreferencesModal({
           )}
           {activeTab === 'harnesses' && <HarnessesTab pt={pt} />}
           {activeTab === 'datasources' && <DataSourcesTab pt={pt} harnesses={harnesses} />}
-          {activeTab === 'team' && <TeamTab pt={pt} central={central} />}
+          {activeTab === 'team' && <TeamTab pt={pt} central={central} presence={presence} />}
         </div>
 
         {/* Footer — only for Preferences tab */}

--- a/packages/web/src/components/TeamMembers.tsx
+++ b/packages/web/src/components/TeamMembers.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useCallback, useRef } from 'react'
 import { Users, Plus, Trash2, Copy, CheckCheck, RefreshCw, AlertCircle, Pencil, Check, X, RotateCw } from 'lucide-react'
+import type { MemberPresence } from '@agentistics/core'
 import { copyText } from '../lib/clipboard'
 
 // ── Types ──────────────────────────────────────────────────────────────────
@@ -90,9 +91,13 @@ function relativeTime(isoStr: string, lang: 'en' | 'pt'): string {
 
 interface Props {
   lang: 'en' | 'pt'
+  /** Shared presence from the dashboard's /api/data (SSE-refreshed), keyed by member user.
+   *  When present it overrides this component's own /api/team/members online/latency so the
+   *  members panel and the FiltersBar presence pill can never diverge. */
+  presence?: Record<string, MemberPresence>
 }
 
-export function TeamMembers({ lang }: Props) {
+export function TeamMembers({ lang, presence }: Props) {
   const [members, setMembers] = useState<TeamMember[]>([])
   const [loading, setLoading] = useState(true)
   const [loadErr, setLoadErr] = useState<string | null>(null)
@@ -445,7 +450,13 @@ export function TeamMembers({ lang }: Props) {
               {t('noMembers', lang)}
             </div>
           ) : (
-            members.map((m, i) => (
+            members.map((m, i) => {
+              // Prefer the shared dashboard presence (SSE-refreshed) so this panel and the
+              // FiltersBar pill can never disagree; fall back to this component's own fetch.
+              const p = presence?.[m.user]
+              const online = p ? p.online : m.online
+              const latencyMs = p ? p.latencyMs : m.latencyMs
+              return (
               <div
                 key={m.id}
                 style={{
@@ -458,7 +469,7 @@ export function TeamMembers({ lang }: Props) {
                   background: 'var(--bg-card)',
                   transition: 'background 0.1s',
                   // Offline rows are dimmed so the eye jumps to who's actually connected.
-                  opacity: m.online ? 1 : 0.5,
+                  opacity: online ? 1 : 0.5,
                 }}
                 onMouseEnter={e => { (e.currentTarget as HTMLElement).style.background = 'var(--bg-elevated)' }}
                 onMouseLeave={e => { (e.currentTarget as HTMLElement).style.background = 'var(--bg-card)' }}
@@ -467,11 +478,11 @@ export function TeamMembers({ lang }: Props) {
                 <div style={{ display: 'flex', alignItems: 'center', gap: 6, paddingRight: 12, whiteSpace: 'nowrap' }}>
                   <span style={{
                     width: 8, height: 8, borderRadius: '50%', flexShrink: 0,
-                    background: m.online ? '#22c55e' : '#ef4444',
-                    boxShadow: m.online ? '0 0 6px rgba(34,197,94,0.6)' : 'none',
+                    background: online ? '#22c55e' : '#ef4444',
+                    boxShadow: online ? '0 0 6px rgba(34,197,94,0.6)' : 'none',
                   }} />
-                  <span style={{ fontSize: 11, color: m.online ? 'var(--accent-green, #22c55e)' : 'var(--text-tertiary)', fontWeight: 500 }}>
-                    {m.online ? (m.latencyMs != null ? `${m.latencyMs}ms` : t('online', lang)) : t('offline', lang)}
+                  <span style={{ fontSize: 11, color: online ? 'var(--accent-green, #22c55e)' : 'var(--text-tertiary)', fontWeight: 500 }}>
+                    {online ? (latencyMs != null ? `${latencyMs}ms` : t('online', lang)) : t('offline', lang)}
                   </span>
                 </div>
 
@@ -624,7 +635,8 @@ export function TeamMembers({ lang }: Props) {
                   </button>
                 </div>
               </div>
-            ))
+              )
+            })
           )}
         </div>
       )}

--- a/packages/web/src/components/TeamSettings.tsx
+++ b/packages/web/src/components/TeamSettings.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react'
 import { Loader2, CheckCircle, XCircle, Users, User, Server, LogOut } from 'lucide-react'
 import { TeamMembers } from './TeamMembers'
-import { PUSH_INTERVAL, type TeamConfig } from '@agentistics/core'
+import { PUSH_INTERVAL, type TeamConfig, type MemberPresence } from '@agentistics/core'
 import { pushNotification } from '../lib/notifications'
 import { MemberConnectionStatus } from './MemberConnectionStatus'
 
@@ -28,6 +28,9 @@ export interface Props {
   lang: 'pt' | 'en'
   /** When true, this instance is the team central — show admin panel, hide member connect fields */
   central: boolean | null
+  /** Shared dashboard presence (/api/data), threaded to the members panel so it can't diverge
+   *  from the FiltersBar presence pill. */
+  presence?: Record<string, MemberPresence>
 }
 
 interface TestResult {
@@ -259,7 +262,7 @@ interface SaveResult {
   error?: string
 }
 
-export function TeamSettings({ team, onChange, lang, central }: Props) {
+export function TeamSettings({ team, onChange, lang, central, presence }: Props) {
   const pt = lang === 'pt'
   const [testResult, setTestResult] = useState<TestResult | null>(null)
   const [testing, setTesting] = useState(false)
@@ -530,7 +533,7 @@ export function TeamSettings({ team, onChange, lang, central }: Props) {
 
         <Divider />
 
-        <TeamMembers lang={lang} />
+        <TeamMembers lang={lang} presence={presence} />
 
         {/* Inline keyframe for spinner */}
         <style>{`@keyframes spin { to { transform: rotate(360deg); } }`}</style>

--- a/packages/web/src/pages/ExportPage.tsx
+++ b/packages/web/src/pages/ExportPage.tsx
@@ -1,10 +1,10 @@
 import React, { useState, useMemo, useRef, useEffect } from 'react'
 import { useOutletContext } from 'react-router-dom'
-import { FileDown, Download, Sun, Moon, Check, Calendar, Cpu } from 'lucide-react'
+import { FileDown, Download, Sun, Moon, Check, Calendar, Cpu, FolderOpen, Users } from 'lucide-react'
 import { format } from 'date-fns'
 import type { AppContext } from '../lib/app-context'
 import type { HarnessId, Filters, Lang } from '@agentistics/core'
-import { t, formatModel } from '@agentistics/core'
+import { t, formatModel, formatProjectName, distinctUsers } from '@agentistics/core'
 import { useDerivedStats, blendedCostPerToken, computeHarnessSummaries } from '../hooks/useData'
 import { useIsMobile } from '../hooks/useIsMobile'
 import {
@@ -475,6 +475,8 @@ export default function ExportPage() {
   const [chartOverlayAll, setChartOverlayAll] = useState(false)
   const [dateRange, setDateRange] = useState<Filters['dateRange']>(appFilters.dateRange)
   const [selectedModels, setSelectedModels] = useState<string[]>([])
+  const [selectedProjects, setSelectedProjects] = useState<string[]>([])
+  const [selectedUsers, setSelectedUsers] = useState<string[]>([])
 
   // Export state
   const [exporting, setExporting] = useState(false)
@@ -508,12 +510,13 @@ export default function ExportPage() {
       dateRange,
       customStart: '',
       customEnd: '',
-      projects: [],
+      projects: selectedProjects,
+      users: selectedUsers,
       models: selectedModels,
     }
     if (scope === 'all' || scope === 'compare') return base
     return { ...base, harness: scope as HarnessId }
-  }, [scope, dateRange, selectedModels])
+  }, [scope, dateRange, selectedModels, selectedProjects, selectedUsers])
 
   // Derive stats for All/harness scopes (unused for Compare scope, but harmless)
   const derived = useDerivedStats(data, pdfFilters)
@@ -540,6 +543,38 @@ export default function ExportPage() {
       .filter(h => byH[h] && byH[h]!.size > 0)
       .map(h => ({ harness: h, models: Array.from(byH[h]!).sort() }))
   }, [data, scope])
+
+  // Members available to scope the export by — only populated on a central (solo
+  // sessions carry no `user` tag). Sourced the same way the dashboard filter is.
+  const availableUsers = useMemo(() => distinctUsers(data.sessions), [data])
+
+  // Session count per project, used to order the project list (busiest first).
+  const projectCounts = useMemo(() => {
+    const m: Record<string, number> = {}
+    for (const s of data.sessions) {
+      if (s.project_path) m[s.project_path] = (m[s.project_path] ?? 0) + 1
+    }
+    return m
+  }, [data])
+
+  // Projects offered in the picker, scoped to the SELECTED members (empty = all
+  // members) so on a central picking member X only lists X's projects, then sorted
+  // by session count. Mirrors App.tsx's availableProjects.
+  const availableProjects = useMemo(() => {
+    const base = selectedUsers.length === 0
+      ? data.projects
+      : data.projects.filter(p => (p.users ?? []).some(u => selectedUsers.includes(u)))
+    return [...base].sort((a, b) => (projectCounts[b.path] ?? 0) - (projectCounts[a.path] ?? 0))
+  }, [data, selectedUsers, projectCounts])
+
+  // Prune any selected project no longer available after a member-selection change.
+  useEffect(() => {
+    if (selectedProjects.length === 0) return
+    const allowed = new Set(availableProjects.map(p => p.path))
+    const pruned = selectedProjects.filter(p => allowed.has(p))
+    if (pruned.length !== selectedProjects.length) setSelectedProjects(pruned)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [availableProjects])
 
   // Filename based on scope
   const pdfFilename = useMemo(() => {
@@ -753,6 +788,84 @@ export default function ExportPage() {
                 ))}
                 {selectedModels.length > 0 && (
                   <button onClick={() => setSelectedModels([])} style={{
+                    fontSize: 10, color: 'var(--text-tertiary)', background: 'transparent',
+                    border: 'none', cursor: 'pointer', fontFamily: 'inherit', padding: '3px 0', textAlign: 'left',
+                  }}>
+                    {t('export.clearSelection', lang)}
+                  </button>
+                )}
+              </div>
+            </div>
+          )}
+
+          {/* Member filter — central only (solo sessions carry no user tag); hidden for Compare */}
+          {scope !== 'compare' && availableUsers.length > 0 && (
+            <div>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 8 }}>
+                <Users size={11} color="var(--text-tertiary)" />
+                <ConfigLabel text={pt ? 'Membros' : 'Members'} />
+              </div>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 3, maxHeight: 180, overflowY: 'auto' }}>
+                {availableUsers.map(u => {
+                  const sel = selectedUsers.includes(u)
+                  return (
+                    <button key={u} onClick={() => setSelectedUsers(prev =>
+                      prev.includes(u) ? prev.filter(x => x !== u) : [...prev, u]
+                    )} style={{
+                      display: 'flex', alignItems: 'center', gap: 8,
+                      padding: '5px 8px', borderRadius: 6, cursor: 'pointer',
+                      fontFamily: 'inherit', fontSize: 11, textAlign: 'left',
+                      background: sel ? 'var(--anthropic-orange-dim)' : 'transparent',
+                      border: sel ? '1px solid var(--anthropic-orange)30' : '1px solid transparent',
+                      color: sel ? 'var(--text-primary)' : 'var(--text-secondary)',
+                      fontWeight: sel ? 600 : 400, transition: 'all 0.12s',
+                    }}>
+                      <div style={{ width: 7, height: 7, borderRadius: '50%', background: sel ? 'var(--anthropic-orange)' : 'var(--border)', flexShrink: 0 }} />
+                      <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{u}</span>
+                    </button>
+                  )
+                })}
+                {selectedUsers.length > 0 && (
+                  <button onClick={() => setSelectedUsers([])} style={{
+                    fontSize: 10, color: 'var(--text-tertiary)', background: 'transparent',
+                    border: 'none', cursor: 'pointer', fontFamily: 'inherit', padding: '3px 0', textAlign: 'left',
+                  }}>
+                    {t('export.clearSelection', lang)}
+                  </button>
+                )}
+              </div>
+            </div>
+          )}
+
+          {/* Project filter — scope the report to specific projects; hidden for Compare */}
+          {scope !== 'compare' && availableProjects.length > 0 && (
+            <div>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 8 }}>
+                <FolderOpen size={11} color="var(--text-tertiary)" />
+                <ConfigLabel text={t('filter.project', lang)} />
+              </div>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 3, maxHeight: 200, overflowY: 'auto' }}>
+                {availableProjects.map(p => {
+                  const sel = selectedProjects.includes(p.path)
+                  return (
+                    <button key={p.path} onClick={() => setSelectedProjects(prev =>
+                      prev.includes(p.path) ? prev.filter(x => x !== p.path) : [...prev, p.path]
+                    )} style={{
+                      display: 'flex', alignItems: 'center', gap: 8,
+                      padding: '5px 8px', borderRadius: 6, cursor: 'pointer',
+                      fontFamily: 'inherit', fontSize: 11, textAlign: 'left',
+                      background: sel ? 'var(--anthropic-orange-dim)' : 'transparent',
+                      border: sel ? '1px solid var(--anthropic-orange)30' : '1px solid transparent',
+                      color: sel ? 'var(--text-primary)' : 'var(--text-secondary)',
+                      fontWeight: sel ? 600 : 400, transition: 'all 0.12s',
+                    }} title={p.path}>
+                      <div style={{ width: 7, height: 7, borderRadius: '50%', background: sel ? 'var(--anthropic-orange)' : 'var(--border)', flexShrink: 0 }} />
+                      <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{formatProjectName(p.path)}</span>
+                    </button>
+                  )
+                })}
+                {selectedProjects.length > 0 && (
+                  <button onClick={() => setSelectedProjects([])} style={{
                     fontSize: 10, color: 'var(--text-tertiary)', background: 'transparent',
                     border: 'none', cursor: 'pointer', fontFamily: 'inherit', padding: '3px 0', textAlign: 'left',
                   }}>


### PR DESCRIPTION
Batch of central/team-mode fixes raised during live testing.

## `agentop status` (new)
At-a-glance CLI report: **CONFIG** (mode/endpoint), **SERVICES** (local server / central / machine, detected live), **HEALTH** (`/api/health` summary). New `server/cli-status.ts` + `bin/cli.ts` wiring. Verified against a live member+central here.

## Presence single-source (fix)
The FiltersBar presence pill counts `data.presence` (SSE-refreshed) while the members panel fetched `/api/team/members` independently — so they could momentarily disagree (filter "1 online/1 offline" vs settings "2 online"; dot flips before the row appears). Thread `data.presence` App → PreferencesModal → TeamSettings → TeamMembers and override the row's online/latency from it, so the two can never diverge.

## DeployCentral gating + port (fix)
The "Deploy a team central" helper showed **only on a central** (pointless — you're already one). Gate inverted to non-central instances; default host port corrected `47291 → 48080`.

## PDF/export scope selectors (fix)
`ExportPage` hardcoded `projects: []` and had no member selector. Restored a **project** multi-select (from `data.projects`, default all) and added a **member** multi-select shown only when team data is present (central), both wired through `useDerivedStats` via `pdfFilters`.

## Docs
- `cli.md`: document `agentop status`.
- `DEPLOY.md`: **WSL2 + Tailscale** section recommending `tailscale serve` (a raw published Docker port on `tailscale0` is flaky in WSL2 NAT — `serve` proxies via `tailscaled` to `127.0.0.1` reliably). Re-applied the standalone (no-repo) `agentop central` flow a prior merge dropped.

## Verification
`bun tsc --noEmit` clean · **249 tests pass** · `agentop status` exercised live (member→central over Tailscale, server/central up).

## Related (not code — resolved live)
The central was unreachable over Tailscale from WSL2; root cause was the WSL2+Docker `tailscale0` DNAT path, fixed at runtime with `tailscale serve --bg 48080` → `https://<host>.<tailnet>.ts.net`. Documented in DEPLOY.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)