### PR TITLE
feat(tags): pin a tag to a date window

### DIFF
--- a/packages/server/server/tags-handlers.test.ts
+++ b/packages/server/server/tags-handlers.test.ts
@@ -38,3 +38,41 @@ test('stamping copies — the sessions /api/data serves are never mutated', () =
   expect(copy!.memberId).toBe(LOCAL_MACHINE_ID)
   expect(copy!.project_path).toBe(original.project_path)
 })
+
+// --- the tag's period: what the API accepts ----------------------------------------------------
+
+import { parseWindow } from './tags-handlers'
+
+test('parseWindow distinguishes absent, cleared and set', () => {
+  // Absent = leave whatever is stored alone; null = the caller explicitly removed the period.
+  expect(parseWindow(undefined)).toEqual({ ok: true, value: undefined })
+  expect(parseWindow(null)).toEqual({ ok: true, value: null })
+  // Blank ends are how the UI drops one side without sending a different body shape; with both
+  // blank there is no period left, which must collapse to null rather than a `{}` that reads as one.
+  expect(parseWindow({})).toEqual({ ok: true, value: null })
+  expect(parseWindow({ start: '', end: '' })).toEqual({ ok: true, value: null })
+  expect(parseWindow({ start: '2026-07-04', end: '' })).toEqual({ ok: true, value: { start: '2026-07-04' } })
+  expect(parseWindow({ end: '2026-07-18' })).toEqual({ ok: true, value: { end: '2026-07-18' } })
+  expect(parseWindow({ start: '2026-07-04', end: '2026-07-18' }))
+    .toEqual({ ok: true, value: { start: '2026-07-04', end: '2026-07-18' } })
+})
+
+test('parseWindow rejects a day that is not a real calendar day', () => {
+  // The regex alone accepts this; `new Date` then rolls it to 3 March, silently widening the
+  // period by up to three days against what was written.
+  expect(parseWindow({ start: '2026-02-31' }).ok).toBe(false)
+  expect(parseWindow({ start: '2026-13-01' }).ok).toBe(false)
+  expect(parseWindow({ start: '04/07/2026' }).ok).toBe(false)
+  expect(parseWindow({ start: '2026-7-4' }).ok).toBe(false)
+  expect(parseWindow({ start: 20260704 }).ok).toBe(false)
+  expect(parseWindow('2026-07-04').ok).toBe(false)
+  expect(parseWindow(['2026-07-04']).ok).toBe(false)
+  // A leap day that DOES exist must survive the same check.
+  expect(parseWindow({ start: '2028-02-29' })).toEqual({ ok: true, value: { start: '2028-02-29' } })
+})
+
+test('parseWindow rejects an inverted period', () => {
+  expect(parseWindow({ start: '2026-07-18', end: '2026-07-04' }).ok).toBe(false)
+  // Same day at both ends is a one-day period, not an error.
+  expect(parseWindow({ start: '2026-07-04', end: '2026-07-04' }).ok).toBe(true)
+})

--- a/packages/server/server/tags-handlers.ts
+++ b/packages/server/server/tags-handlers.ts
@@ -22,7 +22,7 @@ import { TEAM_CENTRAL } from './config'
 import { can } from './iam-caps'
 import { accountVisibleTo } from './iam-view'
 import { localTagStore, type TagStore } from './tags-local-store'
-import { resolveTagSessions, type TagSource, type TagSourceType, type TagLookups } from './tags-resolve'
+import { resolveTagSessions, type TagSource, type TagSourceType, type TagLookups, type TagWindow } from './tags-resolve'
 import { aggregateSessions, type TagAggregate } from './tags-aggregate'
 import { aggregateTagDetail, type TagDetailStats } from './tags-detail'
 import {
@@ -265,7 +265,7 @@ function redactAggregate(p: Principal, agg: TagAggregate, ctx: TagAuthorityConte
 function withAggregate(p: Principal, tag: TagDoc, sessions: SessionMeta[], ctx: TagContext): TagDoc & { aggregate: TagAggregate } {
   // Resolve against the STORED sources (the real values) but ship the REDACTED list — otherwise the
   // response hands back the same identifying strings the bucket redaction just collapsed.
-  const resolved = resolveTagSessions(sessions, tag.sources, ctx.lookups, tag.filters ?? [])
+  const resolved = resolveTagSessions(sessions, tag.sources, ctx.lookups, tag.filters ?? [], tag.window)
   return {
     ...tag,
     sources: redactSources(p, tag.sources, ctx.authority),
@@ -342,6 +342,45 @@ function parseColor(raw: unknown): { ok: true; value: string | undefined } | { o
   return HEX_COLOR.test(v) ? { ok: true, value: v } : { ok: false }
 }
 
+const DAY_RE = /^\d{4}-\d{2}-\d{2}$/
+
+/** `yyyy-MM-dd` AND a real calendar day. The regex alone accepts 2026-02-31, which `Date` then
+ *  rolls forward to 3 March — a window silently one to three days wider than the one written. */
+function isCalendarDay(v: string): boolean {
+  if (!DAY_RE.test(v)) return false
+  const d = new Date(`${v}T00:00:00Z`)
+  return !Number.isNaN(d.getTime()) && d.toISOString().slice(0, 10) === v
+}
+
+/**
+ * Parse the optional period. `undefined` = field absent (leave alone); `null` = explicitly cleared.
+ *
+ * An empty string on either end clears THAT end, so the UI can drop one side without having to
+ * send a differently-shaped body, and a window that ends up with neither end set collapses to
+ * `null` rather than being stored as a `{}` that reads as "has a window" everywhere downstream.
+ */
+export function parseWindow(raw: unknown):
+  { ok: true; value: TagWindow | null | undefined } | { ok: false; error: string } {
+  if (raw === undefined) return { ok: true, value: undefined }
+  if (raw === null) return { ok: true, value: null }
+  if (typeof raw !== 'object' || Array.isArray(raw)) return { ok: false, error: 'window must be an object' }
+  const w = raw as Record<string, unknown>
+  const read = (k: 'start' | 'end'): string | undefined | false => {
+    const v = w[k]
+    if (v === undefined || v === null || v === '') return undefined
+    if (typeof v !== 'string' || !isCalendarDay(v.trim())) return false
+    return v.trim()
+  }
+  const start = read('start')
+  const end = read('end')
+  if (start === false || end === false) {
+    return { ok: false, error: 'window dates must be calendar days in YYYY-MM-DD' }
+  }
+  if (!start && !end) return { ok: true, value: null }
+  if (start && end && start > end) return { ok: false, error: 'window start must not be after end' }
+  return { ok: true, value: { ...(start ? { start } : {}), ...(end ? { end } : {}) } }
+}
+
 /** Every grantee must be a real account the caller can already see — otherwise `sharedWith` is a
  *  blind account-id oracle, and a manager could grant a tag to someone outside their scope. */
 function checkSharedWith(p: Principal, ids: string[], accounts: AccountDoc[]): Response | null {
@@ -385,12 +424,14 @@ export async function handleTags(req: Request): Promise<Response> {
     const sessions = await loadAllSessions()
     const ctx = await buildContext(principal, sessions)
     if (!canReadTag(principal, tag, ctx.authority)) return json({ error: 'tag not found' }, 404)
-    const resolved = resolveTagSessions(sessions, tag.sources, ctx.lookups, tag.filters ?? [])
+    // The period applies to the per-source breakdown too — otherwise the parts of a windowed tag
+    // add up to more than the whole it is shown next to.
+    const resolved = resolveTagSessions(sessions, tag.sources, ctx.lookups, tag.filters ?? [], tag.window)
     // Same rule as withAggregate: resolve on the real source, report the redacted one.
     const breakdown = tag.sources.map(src => ({
       source: redactSources(principal, [src], ctx.authority)[0]!,
       aggregate: redactAggregate(principal, aggregateSessions(
-        resolveTagSessions(sessions, [src], ctx.lookups, tag.filters ?? [])), ctx.authority),
+        resolveTagSessions(sessions, [src], ctx.lookups, tag.filters ?? [], tag.window)), ctx.authority),
     }))
     return json({
       // `resolved` is exactly what withAggregate would re-derive — reuse it rather than walking
@@ -432,6 +473,10 @@ export async function handleTags(req: Request): Promise<Response> {
     const filters = parseSources(body.filters)
     const badType = checkSourceTypes(sources) ?? checkSourceTypes(filters)
     if (badType) return badType
+    // The period only ever narrows, so it is NOT part of the Rule 1 source check below: it cannot
+    // reach anything the sources do not already cover, and it names nothing identifying.
+    const window = parseWindow(body.window)
+    if (!window.ok) return json({ error: window.error }, 400)
     // Sharing needs accounts to share WITH; a non-central instance has none, so the field is
     // ignored rather than validated (the UI does not offer it either).
     const sharedWith = TEAM_CENTRAL ? parseStringList(body.sharedWith) : []
@@ -449,6 +494,7 @@ export async function handleTags(req: Request): Promise<Response> {
       color: color.value,
       sources,
       filters,
+      window: window.value ?? undefined,
       sharedWith,
       createdBy: principal.accountId,
     })
@@ -480,6 +526,8 @@ export async function handleTags(req: Request): Promise<Response> {
     const nextFilters = body.filters !== undefined ? parseSources(body.filters) : (existing.filters ?? [])
     const badType = checkSourceTypes(nextSources) ?? checkSourceTypes(nextFilters)
     if (badType) return badType
+    const window = parseWindow(body.window)
+    if (!window.ok) return json({ error: window.error }, 400)
     if (!canWriteTagSources(principal, [...nextSources, ...nextFilters], ctx.authority)) {
       return json({ error: 'forbidden' }, 403)
     }
@@ -493,6 +541,7 @@ export async function handleTags(req: Request): Promise<Response> {
       color: color.value,
       sources: body.sources !== undefined ? nextSources : undefined,
       filters: body.filters !== undefined ? nextFilters : undefined,
+      window: window.value,
       sharedWith,
     })
     return json({ ok: true })

--- a/packages/server/server/tags-local-store.test.ts
+++ b/packages/server/server/tags-local-store.test.ts
@@ -187,3 +187,56 @@ test('visibleTagsFor applies the caller predicate', async () => {
   const visible = await store.visibleTagsFor(t => t.createdBy === 'local')
   expect(visible.map(t => t.name)).toEqual(['mine'])
 })
+
+// --- the tag's period -------------------------------------------------------------------------
+
+test('the period round-trips, is patchable, and is CLEARED rather than emptied', async () => {
+  const file = tmpFile()
+  const store = createLocalTagStore(file)
+  const doc = await store.createTag({
+    name: 'Experiment', sources: [{ type: 'repo', value: 'github.com/org/repo' }],
+    window: { start: '2026-07-04', end: '2026-07-18' },
+    sharedWith: [], createdBy: 'local',
+  })
+  expect(doc.window).toEqual({ start: '2026-07-04', end: '2026-07-18' })
+  expect((await createLocalTagStore(file).getTag(doc._id))?.window)
+    .toEqual({ start: '2026-07-04', end: '2026-07-18' })
+
+  // Narrowing one end only.
+  expect(await store.updateTag(doc._id, { window: { start: '2026-07-06' } })).toBe(true)
+  expect((await createLocalTagStore(file).getTag(doc._id))?.window).toEqual({ start: '2026-07-06' })
+
+  // `undefined` must LEAVE IT ALONE — otherwise editing a tag's name silently drops its period.
+  expect(await store.updateTag(doc._id, { name: 'Renamed' })).toBe(true)
+  const kept = await createLocalTagStore(file).getTag(doc._id)
+  expect(kept?.name).toBe('Renamed')
+  expect(kept?.window).toEqual({ start: '2026-07-06' })
+
+  // `null` removes the key entirely: a leftover `{}` would read as "has a period" downstream.
+  expect(await store.updateTag(doc._id, { window: null })).toBe(true)
+  const cleared = await createLocalTagStore(file).getTag(doc._id)
+  expect(cleared?.window).toBeUndefined()
+  expect(JSON.parse(await readFile(file, 'utf8')).tags[0]).not.toHaveProperty('window')
+})
+
+test('a hand-edited period survives only when it is well-formed and ordered', async () => {
+  const file = tmpFile()
+  await mkdir(join(file, '..'), { recursive: true })
+  const doc = (window: unknown) => ({
+    _id: 'a'.repeat(24), name: 'T', sources: [], sharedWith: [], createdBy: 'local',
+    createdAt: '2026-07-01T00:00:00.000Z', updatedAt: '2026-07-01T00:00:00.000Z', window,
+  })
+  const read = async (window: unknown) => {
+    await writeFile(file, JSON.stringify({ version: 1, tags: [doc(window)] }))
+    return (await createLocalTagStore(file).listAllTags())[0]?.window
+  }
+  expect(await read({ start: '2026-07-04', end: '2026-07-18' })).toEqual({ start: '2026-07-04', end: '2026-07-18' })
+  expect(await read({ start: '2026-07-04' })).toEqual({ start: '2026-07-04' })
+  // Anything malformed drops the whole period: a half-read window would shift the tag's numbers,
+  // which is worse than the tag falling back to all-time.
+  expect(await read({ start: 'yesterday' })).toBeUndefined()
+  expect(await read({ start: '2026-07-18', end: '2026-07-04' })).toBeUndefined()
+  expect(await read({})).toBeUndefined()
+  expect(await read('2026-07-04')).toBeUndefined()
+  expect(await read(null)).toBeUndefined()
+})

--- a/packages/server/server/tags-local-store.ts
+++ b/packages/server/server/tags-local-store.ts
@@ -28,7 +28,7 @@ import { rename, mkdir, readFile, writeFile } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 import { AGENTISTICS_DATA_DIR } from './config'
 import type { TagDoc } from './tags-store'
-import type { TagSource } from './tags-resolve'
+import type { TagSource, TagWindow } from './tags-resolve'
 
 export const LOCAL_TAGS_FILE = join(AGENTISTICS_DATA_DIR, 'tags.json')
 
@@ -42,10 +42,13 @@ export interface TagStore {
   listAllTags(): Promise<TagDoc[]>
   getTag(id: string): Promise<TagDoc | null>
   createTag(input: {
-    name: string; color?: string; sources: TagSource[]; filters?: TagSource[]; sharedWith: string[]; createdBy: string
+    name: string; color?: string; sources: TagSource[]; filters?: TagSource[]; window?: TagWindow
+    sharedWith: string[]; createdBy: string
   }): Promise<TagDoc>
   updateTag(id: string, patch: {
-    name?: string; color?: string; sources?: TagSource[]; filters?: TagSource[]; sharedWith?: string[]
+    name?: string; color?: string; sources?: TagSource[]; filters?: TagSource[]
+    /** `null` clears the period; `undefined` leaves it alone. */
+    window?: TagWindow | null; sharedWith?: string[]
   }): Promise<boolean>
   deleteTag(id: string): Promise<boolean>
   visibleTagsFor(canRead: (tag: TagDoc) => boolean): Promise<TagDoc[]>
@@ -64,6 +67,20 @@ function sanitizeSources(raw: unknown): TagSource[] {
     .map(s => ({ type: s.type, value: s.value }))
 }
 
+/** A hand-edited file can hold anything; keep the period only when BOTH ends are well-formed and
+ *  ordered, and drop it entirely otherwise. A half-parsed window would silently shift a tag's
+ *  numbers, which is worse than the tag reverting to all-time. */
+const DAY_RE = /^\d{4}-\d{2}-\d{2}$/
+function sanitizeWindow(raw: unknown): TagWindow | undefined {
+  if (!raw || typeof raw !== 'object') return undefined
+  const w = raw as Record<string, unknown>
+  const start = typeof w.start === 'string' && DAY_RE.test(w.start) ? w.start : undefined
+  const end = typeof w.end === 'string' && DAY_RE.test(w.end) ? w.end : undefined
+  if (!start && !end) return undefined
+  if (start && end && start > end) return undefined
+  return { ...(start ? { start } : {}), ...(end ? { end } : {}) }
+}
+
 function sanitize(raw: unknown): TagDoc | null {
   if (!raw || typeof raw !== 'object') return null
   const d = raw as Record<string, unknown>
@@ -71,6 +88,7 @@ function sanitize(raw: unknown): TagDoc | null {
   if (typeof d.name !== 'string' || !d.name) return null
   const sources = sanitizeSources(d.sources)
   const filters = sanitizeSources(d.filters)
+  const window = sanitizeWindow(d.window)
   const now = new Date().toISOString()
   return {
     _id: d._id,
@@ -78,6 +96,7 @@ function sanitize(raw: unknown): TagDoc | null {
     ...(typeof d.color === 'string' && d.color ? { color: d.color } : {}),
     sources,
     ...(filters.length ? { filters } : {}),
+    ...(window ? { window } : {}),
     sharedWith: Array.isArray(d.sharedWith) ? d.sharedWith.filter((x): x is string => typeof x === 'string') : [],
     createdBy: typeof d.createdBy === 'string' ? d.createdBy : 'local',
     createdAt: typeof d.createdAt === 'string' ? d.createdAt : now,
@@ -180,6 +199,7 @@ export function createLocalTagStore(file: string): TagStore {
         ...(input.color ? { color: input.color } : {}),
         sources: input.sources,
         ...(input.filters && input.filters.length ? { filters: input.filters } : {}),
+        ...(input.window ? { window: input.window } : {}),
         sharedWith: [...new Set(input.sharedWith.filter(Boolean))],
         createdBy: input.createdBy,
         createdAt: now,
@@ -192,12 +212,18 @@ export function createLocalTagStore(file: string): TagStore {
         const i = tags.findIndex(t => t._id === id)
         if (i < 0) return { tags, result: false, changed: false }
         const prev = tags[i]!
+        // `window: undefined` in a spread still CREATES the key (value undefined), which survives
+        // JSON.stringify as an absent key but not an in-memory `'window' in doc` check. Strip it
+        // explicitly when clearing so the cleared doc is indistinguishable from one never set.
+        const base = { ...prev }
+        if (patch.window === null) delete base.window
         const next: TagDoc = {
-          ...prev,
+          ...base,
           ...(patch.name !== undefined ? { name: patch.name } : {}),
           ...(patch.color !== undefined ? { color: patch.color } : {}),
           ...(patch.sources !== undefined ? { sources: patch.sources } : {}),
           ...(patch.filters !== undefined ? { filters: patch.filters } : {}),
+          ...(patch.window ? { window: patch.window } : {}),
           ...(patch.sharedWith !== undefined ? { sharedWith: [...new Set(patch.sharedWith.filter(Boolean))] } : {}),
           updatedAt: new Date().toISOString(),
         }

--- a/packages/server/server/tags-resolve.test.ts
+++ b/packages/server/server/tags-resolve.test.ts
@@ -115,3 +115,75 @@ test('an untouched type places no constraint even when other types are filtered'
     [{ type: 'project', value: '/c' }])
   expect(out.length).toBe(1)
 })
+
+// --- the tag's period -------------------------------------------------------------------------
+
+import { sessionInWindow, tagSessionDay, type TagWindow } from './tags-resolve'
+
+const repoSrc: TagSource[] = [{ type: 'repo', value: 'github.com/org/a' }]
+const inRepo = (day?: string) =>
+  s({ git_remote: 'github.com/org/a', ...(day ? { start_time: `${day}T12:00:00.000Z` } : {}) })
+
+test('sessionInWindow: absent or empty window accepts everything', () => {
+  expect(sessionInWindow(inRepo('2026-07-04'))).toBe(true)
+  expect(sessionInWindow(inRepo('2026-07-04'), {})).toBe(true)
+  // A session with no date passes only because there is no period to fail.
+  expect(sessionInWindow(inRepo())).toBe(true)
+})
+
+test('sessionInWindow: both ends are INCLUSIVE', () => {
+  const w: TagWindow = { start: '2026-07-04', end: '2026-07-18' }
+  expect(sessionInWindow(inRepo('2026-07-03'), w)).toBe(false)
+  expect(sessionInWindow(inRepo('2026-07-04'), w)).toBe(true)   // first day counts
+  expect(sessionInWindow(inRepo('2026-07-11'), w)).toBe(true)
+  expect(sessionInWindow(inRepo('2026-07-18'), w)).toBe(true)   // last day counts
+  expect(sessionInWindow(inRepo('2026-07-19'), w)).toBe(false)
+})
+
+test('sessionInWindow: each end is independently optional', () => {
+  expect(sessionInWindow(inRepo('2026-07-03'), { start: '2026-07-04' })).toBe(false)
+  expect(sessionInWindow(inRepo('2026-09-01'), { start: '2026-07-04' })).toBe(true)
+  expect(sessionInWindow(inRepo('2026-01-01'), { end: '2026-07-18' })).toBe(true)
+  expect(sessionInWindow(inRepo('2026-07-19'), { end: '2026-07-18' })).toBe(false)
+})
+
+test('sessionInWindow: an undated session belongs to NO period', () => {
+  // The alternative — admitting it — would place it in every window at once, so a frozen cost
+  // would silently include sessions nobody can date.
+  expect(sessionInWindow(inRepo(), { start: '2026-07-04' })).toBe(false)
+  expect(sessionInWindow(inRepo(), { end: '2026-07-18' })).toBe(false)
+  expect(sessionInWindow(s({ git_remote: 'x', start_time: 'garbage' }), { start: '2026-07-04' })).toBe(false)
+})
+
+test('tagSessionDay reads the leading day, matching tags-detail rather than the local clock', () => {
+  expect(tagSessionDay(s({ start_time: '2026-07-04T23:30:00.000Z' }))).toBe('2026-07-04')
+  expect(tagSessionDay(s({}))).toBeNull()
+  expect(tagSessionDay(s({ start_time: 'nope' }))).toBeNull()
+})
+
+test('the period is an AND over the source union, never a way to widen it', () => {
+  const w: TagWindow = { start: '2026-07-04', end: '2026-07-18' }
+  // Right source, wrong period.
+  expect(sessionMatchesTag(inRepo('2026-08-01'), repoSrc, noLookups, [], w)).toBe(false)
+  // Right period, wrong source — the window cannot pull in what the sources never covered.
+  expect(sessionMatchesTag(
+    s({ git_remote: 'github.com/org/other', start_time: '2026-07-10T00:00:00Z' }),
+    repoSrc, noLookups, [], w,
+  )).toBe(false)
+  expect(sessionMatchesTag(inRepo('2026-07-10'), repoSrc, noLookups, [], w)).toBe(true)
+})
+
+test('resolveTagSessions narrows to the period, and composes with filters', () => {
+  const sessions = [
+    s({ git_remote: 'github.com/org/a', project_path: '/keep', start_time: '2026-07-01T00:00:00Z' }),
+    s({ git_remote: 'github.com/org/a', project_path: '/keep', start_time: '2026-07-10T00:00:00Z' }),
+    s({ git_remote: 'github.com/org/a', project_path: '/drop', start_time: '2026-07-10T00:00:00Z' }),
+    s({ git_remote: 'github.com/org/a', project_path: '/keep', start_time: '2026-08-01T00:00:00Z' }),
+  ]
+  const w: TagWindow = { start: '2026-07-04', end: '2026-07-18' }
+  expect(resolveTagSessions(sessions, repoSrc, noLookups, [], w)).toHaveLength(2)
+  expect(resolveTagSessions(sessions, repoSrc, noLookups, [{ type: 'project', value: '/keep' }], w))
+    .toHaveLength(1)
+  // Without the period the same tag is the whole history — that is the number it must differ from.
+  expect(resolveTagSessions(sessions, repoSrc, noLookups)).toHaveLength(4)
+})

--- a/packages/server/server/tags-resolve.ts
+++ b/packages/server/server/tags-resolve.ts
@@ -28,6 +28,48 @@ export interface TagLookups {
   machinesByAccount: Record<string, string[]>
 }
 
+/**
+ * An optional period the tag is pinned to — `yyyy-MM-dd`, both ends INCLUSIVE, each side
+ * independently optional (`start` alone = "from then on", `end` alone = "up to then").
+ *
+ * This is what turns a tag from "these sources" into "these sources, during that experiment":
+ * "I ran harness X through the API on this project from the 4th to the 18th — how much did that
+ * cost?". Without it the same question needs the global date filter, which is transient and is not
+ * carried by the tag, so the number changes the moment someone else opens the page.
+ */
+export interface TagWindow {
+  start?: string
+  end?: string
+}
+
+/**
+ * Day a session is filed under.
+ *
+ * Deliberately the SAME rule as `dayOf` in tags-detail.ts (the leading 10 characters of the
+ * timestamp), because the window is read against that module's daily series and activity window.
+ * A local-clock day would be more correct in isolation and WRONG here: at UTC-3 a session started
+ * at 23:00 would fall inside the window while being plotted on the next day's bar of the tag's own
+ * chart. The two rules must be one rule; when tags-detail changes, this changes with it.
+ */
+export function tagSessionDay(s: SessionMeta): string | null {
+  const raw = s.start_time
+  if (!raw) return null
+  const d = raw.slice(0, 10)
+  return /^\d{4}-\d{2}-\d{2}$/.test(d) ? d : null
+}
+
+/** Is a session inside the tag's period? No window (or neither end set) accepts everything. */
+export function sessionInWindow(s: SessionMeta, window?: TagWindow): boolean {
+  if (!window || (!window.start && !window.end)) return true
+  const day = tagSessionDay(s)
+  // A session with no usable date cannot be shown to belong to the period. Admitting it would put
+  // undated rows in EVERY window, which is the one outcome a frozen cost must not have.
+  if (!day) return false
+  if (window.start && day < window.start) return false
+  if (window.end && day > window.end) return false
+  return true
+}
+
 /** All teams a session belongs to (multi-team machines), falling back to the legacy single id. */
 function teamsOf(s: SessionMeta): string[] {
   if (s.teamIds && s.teamIds.length) return s.teamIds
@@ -74,13 +116,22 @@ export function sessionPassesFilters(s: SessionMeta, filters: TagSource[], looku
   return true
 }
 
+/**
+ * The full rule, in one place so no caller can apply half of it: (ANY source) AND (all filter
+ * groups) AND (inside the period). The window is an AND on top of the union for the same reason
+ * the filters are — it narrows, never widens, so it can never turn a tag into a way of reaching
+ * something its sources did not already cover.
+ */
 export function sessionMatchesTag(
   s: SessionMeta,
   sources: TagSource[],
   lookups: TagLookups,
   filters: TagSource[] = [],
+  window?: TagWindow,
 ): boolean {
-  return sources.some(src => matchesSource(s, src, lookups)) && sessionPassesFilters(s, filters, lookups)
+  return sources.some(src => matchesSource(s, src, lookups))
+    && sessionPassesFilters(s, filters, lookups)
+    && sessionInWindow(s, window)
 }
 
 export function resolveTagSessions(
@@ -88,7 +139,8 @@ export function resolveTagSessions(
   sources: TagSource[],
   lookups: TagLookups,
   filters: TagSource[] = [],
+  window?: TagWindow,
 ): SessionMeta[] {
   if (sources.length === 0) return []
-  return sessions.filter(s => sessionMatchesTag(s, sources, lookups, filters))
+  return sessions.filter(s => sessionMatchesTag(s, sources, lookups, filters, window))
 }

--- a/packages/server/server/tags-store.ts
+++ b/packages/server/server/tags-store.ts
@@ -2,7 +2,7 @@
  * tags-store.ts — Mongo persistence for tags (B5).
  *
  * Collection: `tags`
- *   { _id, name, color?, sources[], filters[], sharedWith[], createdBy, createdAt, updatedAt }
+ *   { _id, name, color?, sources[], filters[], window?, sharedWith[], createdBy, createdAt, updatedAt }
  *
  * Visibility is an explicit account list — never derived from teams. The creator and every owner
  * always see a tag; everyone else must be in `sharedWith`.
@@ -10,7 +10,7 @@
 import { randomBytes } from 'node:crypto'
 import type { Collection } from 'mongodb'
 import { getMongoDb } from './mongo'
-import type { TagSource } from './tags-resolve'
+import type { TagSource, TagWindow } from './tags-resolve'
 
 export interface TagDoc {
   _id: string
@@ -19,6 +19,8 @@ export interface TagDoc {
   sources: TagSource[]
   /** Optional narrowing of the union: OR within a type, AND across types. Never widens. */
   filters?: TagSource[]
+  /** Optional period the tag is pinned to (inclusive `yyyy-MM-dd`). Absent = all time. */
+  window?: TagWindow
   /** accountIds granted read access. The creator and owners are implicit and not stored here. */
   sharedWith: string[]
   createdBy: string
@@ -42,7 +44,8 @@ export async function getTag(id: string): Promise<TagDoc | null> {
 }
 
 export async function createTag(input: {
-  name: string; color?: string; sources: TagSource[]; filters?: TagSource[]; sharedWith: string[]; createdBy: string
+  name: string; color?: string; sources: TagSource[]; filters?: TagSource[]; window?: TagWindow
+  sharedWith: string[]; createdBy: string
 }): Promise<TagDoc> {
   const now = new Date().toISOString()
   const doc: TagDoc = {
@@ -51,6 +54,7 @@ export async function createTag(input: {
     ...(input.color ? { color: input.color } : {}),
     sources: input.sources,
     ...(input.filters && input.filters.length ? { filters: input.filters } : {}),
+    ...(input.window ? { window: input.window } : {}),
     sharedWith: [...new Set(input.sharedWith.filter(Boolean))],
     createdBy: input.createdBy,
     createdAt: now,
@@ -62,7 +66,9 @@ export async function createTag(input: {
 }
 
 export async function updateTag(id: string, patch: {
-  name?: string; color?: string; sources?: TagSource[]; filters?: TagSource[]; sharedWith?: string[]
+  name?: string; color?: string; sources?: TagSource[]; filters?: TagSource[]
+  /** `null` clears the period; `undefined` leaves it alone. */
+  window?: TagWindow | null; sharedWith?: string[]
 }): Promise<boolean> {
   const col = await getTagsCollection()
   const $set: Partial<TagDoc> = { updatedAt: new Date().toISOString() }
@@ -70,8 +76,18 @@ export async function updateTag(id: string, patch: {
   if (patch.color !== undefined) $set.color = patch.color
   if (patch.sources !== undefined) $set.sources = patch.sources
   if (patch.filters !== undefined) $set.filters = patch.filters
+  // Clearing has to UNSET, not store an empty object: `{}` would read back as a window and every
+  // `tag.window &&` guard downstream would take the wrong branch.
+  const $unset: Record<string, ''> = {}
+  if (patch.window !== undefined) {
+    if (patch.window) $set.window = patch.window
+    else $unset.window = ''
+  }
   if (patch.sharedWith !== undefined) $set.sharedWith = [...new Set(patch.sharedWith.filter(Boolean))]
-  const res = await col.updateOne({ _id: id }, { $set })
+  const res = await col.updateOne(
+    { _id: id },
+    Object.keys($unset).length ? { $set, $unset } : { $set },
+  )
   return res.matchedCount > 0
 }
 

--- a/packages/web/src/lib/tagMatch.test.ts
+++ b/packages/web/src/lib/tagMatch.test.ts
@@ -93,3 +93,79 @@ test('makeTagFilter keeps sessions matching ANY source of ANY selected tag', () 
   ]
   expect(sessions.filter(keep).map(x => x.session_id)).toEqual(['1', '2'])
 })
+
+// --- the tag's period, and agreement with the server copy --------------------------------------
+
+import { sessionInTagWindow, type TagWindow } from './tagMatch'
+import { sessionInWindow, sessionMatchesTag } from '../../../server/server/tags-resolve'
+
+const dated = (day: string, over: Partial<SessionMeta> = {}) =>
+  s({ start_time: `${day}T12:00:00.000Z`, ...over })
+
+function windowed(id: string, sources: TagSource[], window?: TagWindow): TagDef {
+  return { _id: id, name: id, sources, ...(window ? { window } : {}) }
+}
+
+test('sessionInTagWindow: inclusive both ends, each side optional, undated belongs nowhere', () => {
+  const w: TagWindow = { start: '2026-07-04', end: '2026-07-18' }
+  expect(sessionInTagWindow(dated('2026-07-03'), w)).toBe(false)
+  expect(sessionInTagWindow(dated('2026-07-04'), w)).toBe(true)
+  expect(sessionInTagWindow(dated('2026-07-18'), w)).toBe(true)
+  expect(sessionInTagWindow(dated('2026-07-19'), w)).toBe(false)
+  expect(sessionInTagWindow(dated('2026-07-19'), { start: '2026-07-04' })).toBe(true)
+  expect(sessionInTagWindow(dated('2026-07-03'), { end: '2026-07-18' })).toBe(true)
+  expect(sessionInTagWindow(dated('2026-07-10'))).toBe(true)
+  expect(sessionInTagWindow(s({}), w)).toBe(false)
+})
+
+test('makeTagFilter applies EACH tag its own period, not one flattened union', () => {
+  // Two tags over the same repo, different months. A session in July belongs to the July tag only,
+  // and flattening the sources first would have let the August tag admit it.
+  const july = windowed('july', [{ type: 'repo', value: 'r1' }], { start: '2026-07-01', end: '2026-07-31' })
+  const august = windowed('aug', [{ type: 'repo', value: 'r1' }], { start: '2026-08-01', end: '2026-08-31' })
+
+  const inJuly = dated('2026-07-10', { git_remote: 'r1' })
+  const inAugust = dated('2026-08-10', { git_remote: 'r1' })
+  const inSeptember = dated('2026-09-10', { git_remote: 'r1' })
+
+  const onlyJuly = makeTagFilter(['july'], [july, august], noLookups)!
+  expect(onlyJuly(inJuly)).toBe(true)
+  expect(onlyJuly(inAugust)).toBe(false)
+
+  // Selecting both is a union of the two periods — and still excludes what neither covers.
+  const both = makeTagFilter(['july', 'aug'], [july, august], noLookups)!
+  expect(both(inJuly)).toBe(true)
+  expect(both(inAugust)).toBe(true)
+  expect(both(inSeptember)).toBe(false)
+})
+
+test('makeTagFilter: a tag with no period still covers everything from its sources', () => {
+  const allTime = windowed('all', [{ type: 'repo', value: 'r1' }])
+  const keep = makeTagFilter(['all'], [allTime], noLookups)!
+  expect(keep(dated('2020-01-01', { git_remote: 'r1' }))).toBe(true)
+  expect(keep(s({ git_remote: 'r1' }))).toBe(true)          // undated: no period to fail
+  expect(keep(dated('2026-07-10', { git_remote: 'other' }))).toBe(false)
+})
+
+test('the browser mirror and the server resolver agree, session for session', () => {
+  // The two copies are hand-kept in sync (the web bundle cannot import from packages/server at
+  // runtime). This is the test that fails when only one of them is updated.
+  const w: TagWindow = { start: '2026-07-04', end: '2026-07-18' }
+  const sources: TagSource[] = [{ type: 'repo', value: 'r1' }, { type: 'machine', value: 'm1' }]
+  const tagDef = windowed('t', sources, w)
+  const filter = makeTagFilter(['t'], [tagDef], noLookups)!
+
+  const corpus: SessionMeta[] = [
+    dated('2026-07-03', { git_remote: 'r1' }),
+    dated('2026-07-04', { git_remote: 'r1' }),
+    dated('2026-07-18', { memberId: 'm1' }),
+    dated('2026-07-19', { memberId: 'm1' }),
+    dated('2026-07-10', { git_remote: 'other' }),
+    s({ git_remote: 'r1' }),
+    s({ git_remote: 'r1', start_time: 'garbage' }),
+  ]
+  for (const session of corpus) {
+    expect(filter(session)).toBe(sessionMatchesTag(session, sources, noLookups, [], w))
+    expect(sessionInTagWindow(session, w)).toBe(sessionInWindow(session, w))
+  }
+})

--- a/packages/web/src/lib/tagMatch.ts
+++ b/packages/web/src/lib/tagMatch.ts
@@ -6,7 +6,8 @@
  * APIs), which is exactly why this tiny pure predicate is duplicated here instead of shared.
  * Any change to the server rule must be reflected here and in `tagMatch.test.ts`.
  *
- * A session belongs to a tag when it matches ANY of the tag's sources (OR union):
+ * A session belongs to a tag when it matches ANY of the tag's sources (OR union) AND falls inside
+ * the tag's optional period:
  *   repo → git_remote, project → project_path, machine → memberId, team → any of
  *   teamIds/teamId, account → any machine that account owns.
  *
@@ -23,12 +24,19 @@ export interface TagSource {
   value: string
 }
 
+/** Optional period a tag is pinned to — inclusive `yyyy-MM-dd`, each side independent. */
+export interface TagWindow {
+  start?: string
+  end?: string
+}
+
 /** Minimal shape of a tag needed to filter — matches what `GET /api/tags` returns. */
 export interface TagDef {
   _id: string
   name: string
   color?: string
   sources: TagSource[]
+  window?: TagWindow
 }
 
 export interface TagLookups {
@@ -66,8 +74,37 @@ export function sessionMatchesTagSources(
 }
 
 /**
+ * Day a session is filed under — the leading 10 characters of the timestamp.
+ *
+ * MUST match `tagSessionDay` in tags-resolve.ts, which in turn matches tags-detail's daily series.
+ * If this used the local clock and the server used the raw slice, a tag with a period would report
+ * one total on its own card (server) and a different one through the tag FILTER (here) — the same
+ * class of split-source disagreement the dashboard already paid for once.
+ */
+function sessionDay(s: SessionMeta): string | null {
+  const raw = s.start_time
+  if (!raw) return null
+  const d = raw.slice(0, 10)
+  return /^\d{4}-\d{2}-\d{2}$/.test(d) ? d : null
+}
+
+/** Is the session inside the tag's period? No window accepts everything. Mirrors the server. */
+export function sessionInTagWindow(s: SessionMeta, window?: TagWindow): boolean {
+  if (!window || (!window.start && !window.end)) return true
+  const day = sessionDay(s)
+  // Undated sessions belong to no period — admitting them would put them in every window.
+  if (!day) return false
+  if (window.start && day < window.start) return false
+  if (window.end && day > window.end) return false
+  return true
+}
+
+/**
  * Flatten the sources of the selected tags into one OR-union list.
  * Unknown ids (a tag the viewer can no longer see) contribute nothing.
+ *
+ * NOTE: flattening loses which tag each source came from, so it CANNOT express per-tag periods —
+ * `makeTagFilter` evaluates tag by tag instead. This stays for callers that only need the union.
  */
 export function selectedTagSources(selected: string[], tags: TagDef[]): TagSource[] {
   if (selected.length === 0 || tags.length === 0) return []
@@ -81,9 +118,13 @@ export function selectedTagSources(selected: string[], tags: TagDef[]): TagSourc
 }
 
 /**
- * Predicate for the `tags` filter dimension: keep a session when it matches ANY source of ANY
- * selected tag. Returns `null` when the filter is inert (nothing selected, or no selected tag
- * resolves to a known definition with sources) so callers can skip filtering entirely instead of
+ * Predicate for the `tags` filter dimension: keep a session when it belongs to ANY selected tag —
+ * that is, it matches one of that tag's sources AND falls inside that tag's own period.
+ *
+ * Evaluated per tag rather than over one flattened source list, because the period is per tag: a
+ * flattened union would let a session from tag A's period be admitted by tag B's sources, which is
+ * neither tag's answer. Returns `null` when the filter is inert (nothing selected, or no selected
+ * tag resolves to a known definition with sources) so callers skip filtering entirely instead of
  * blanking the dashboard.
  */
 export function makeTagFilter(
@@ -91,7 +132,10 @@ export function makeTagFilter(
   tags: TagDef[],
   lookups: TagLookups = EMPTY_TAG_LOOKUPS,
 ): ((s: SessionMeta) => boolean) | null {
-  const sources = selectedTagSources(selected, tags)
-  if (sources.length === 0) return null
-  return (s: SessionMeta) => sessionMatchesTagSources(s, sources, lookups)
+  if (selected.length === 0 || tags.length === 0) return null
+  const wanted = new Set(selected)
+  const active = tags.filter(t => wanted.has(t._id) && t.sources.length > 0)
+  if (active.length === 0) return null
+  return (s: SessionMeta) => active.some(t =>
+    sessionMatchesTagSources(s, t.sources, lookups) && sessionInTagWindow(s, t.window))
 }

--- a/packages/web/src/pages/TagDetailPage.tsx
+++ b/packages/web/src/pages/TagDetailPage.tsx
@@ -4,7 +4,7 @@ import {
   AreaChart, Area, XAxis, YAxis, Tooltip, ResponsiveContainer, CartesianGrid,
 } from 'recharts'
 import { format, parseISO } from 'date-fns'
-import { ArrowLeft, Pencil, Trash2 } from 'lucide-react'
+import { ArrowLeft, Pencil, Trash2, CalendarRange } from 'lucide-react'
 import { fmt, fmtCost, formatModel, formatProjectName, repoShortName } from '@agentistics/core'
 import type { AppContext } from '../lib/app-context'
 import { HARNESS_LABELS } from '../lib/harness'
@@ -24,12 +24,15 @@ interface TagAggregate {
   topModel: string | null
   topHarness: string | null
 }
+/** Optional period the tag is pinned to — inclusive `yyyy-MM-dd`, each side independent. */
+interface TagWindow { start?: string; end?: string }
 interface Tag {
   _id: string
   name: string
   color?: string
   sources: TagSource[]
   filters?: TagSource[]
+  window?: TagWindow
   sharedWith: string[]
   createdBy: string
   aggregate: TagAggregate
@@ -305,9 +308,20 @@ export default function TagDetailPage() {
     )
   }
 
-  const window_ = stats.firstSessionDate && stats.lastSessionDate
+  // Two different things, and conflating them would be the confusing part: `activity` is when work
+  // actually happened, `pinned` is the period the tag is fixed to. With a period set the first is
+  // necessarily inside the second — seeing both is how you tell "the run ended early" from "the
+  // period is wrong".
+  const activity = stats.firstSessionDate && stats.lastSessionDate
     ? `${niceDate(stats.firstSessionDate)} → ${niceDate(stats.lastSessionDate)}`
     : (pt ? 'Sem atividade registrada' : 'No recorded activity')
+  const pinned = tag.window && (tag.window.start || tag.window.end)
+    ? (tag.window.start && tag.window.end
+      ? `${niceDate(tag.window.start)} → ${niceDate(tag.window.end)}`
+      : tag.window.start
+        ? `${pt ? 'desde' : 'from'} ${niceDate(tag.window.start)}`
+        : `${pt ? 'até' : 'until'} ${niceDate(tag.window.end!)}`)
+    : null
 
   const totalTokens = tag.aggregate.inputTokens + tag.aggregate.outputTokens
   const empty = tag.aggregate.sessions === 0
@@ -337,8 +351,21 @@ export default function TagDetailPage() {
               minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis',
             }}>{tag.name}</h1>
           </div>
+          {pinned && (
+            <div style={{ marginTop: 7 }}>
+              <span style={{
+                display: 'inline-flex', alignItems: 'center', gap: 5,
+                padding: '3px 9px', borderRadius: 999, fontSize: 11.5, fontWeight: 600,
+                background: 'var(--anthropic-orange-dim)', border: '1px solid rgba(217,119,6,0.35)',
+                color: 'var(--anthropic-orange)', fontVariantNumeric: 'tabular-nums',
+              }}>
+                <CalendarRange size={12} />
+                {pt ? 'Período fixado' : 'Pinned period'}: {pinned}
+              </span>
+            </div>
+          )}
           <div style={{ fontSize: 12, color: 'var(--text-tertiary)', marginTop: 5 }}>
-            {window_}
+            {pinned ? `${pt ? 'Atividade' : 'Activity'}: ${activity}` : activity}
             {' · '}
             {tag.sources.length} {tag.sources.length === 1 ? (pt ? 'fonte' : 'source') : (pt ? 'fontes' : 'sources')}
             {(tag.filters?.length ?? 0) > 0 && (

--- a/packages/web/src/pages/TagsPage.tsx
+++ b/packages/web/src/pages/TagsPage.tsx
@@ -1,12 +1,13 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { useLocation, useNavigate, useOutletContext } from 'react-router-dom'
-import { Plus, Trash2, X } from 'lucide-react'
+import { Plus, Trash2, X, CalendarRange } from 'lucide-react'
 import { fmt, fmtCost, formatProjectName, canonicalProjectPath } from '@agentistics/core'
 import type { AppContext } from '../lib/app-context'
 import { HARNESS_LABELS } from '../lib/harness'
 import { Drawer } from './settings/Drawer'
 import { Section, Select, TabSelect, MultiPicker } from './settings/primitives'
 import { useIsMobile } from '../hooks/useIsMobile'
+import { DatePicker } from '../components/DatePicker'
 
 // /api/tags response shapes. Aggregate-only by design (spec rule 2): the server never sends the
 // session rows behind a tag, so everything rendered here is a number the server already computed.
@@ -21,12 +22,15 @@ interface TagAggregate {
   topModel: string | null
   topHarness: string | null
 }
+/** Optional period the tag is pinned to — inclusive `yyyy-MM-dd`, each side independent. */
+interface TagWindow { start?: string; end?: string }
 interface Tag {
   _id: string
   name: string
   color?: string
   sources: TagSource[]
   filters?: TagSource[]
+  window?: TagWindow
   sharedWith: string[]
   createdBy: string
   aggregate: TagAggregate
@@ -68,6 +72,19 @@ function Pill({ text }: { text: string }) {
       overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
     }}>{text}</span>
   )
+}
+
+/** Human-readable period, e.g. "04/07/26 → 18/07/26", "desde 04/07/26", "até 18/07/26".
+ *  Returns null when the tag has no period, which is what hides the chip entirely. */
+function windowLabel(w: TagWindow | undefined, pt: boolean): string | null {
+  if (!w || (!w.start && !w.end)) return null
+  const d = (iso: string) => {
+    const [y, m, day] = iso.split('-')
+    return pt ? `${day}/${m}/${y?.slice(2)}` : `${m}/${day}/${y?.slice(2)}`
+  }
+  if (w.start && w.end) return `${d(w.start)} → ${d(w.end)}`
+  if (w.start) return `${pt ? 'desde' : 'from'} ${d(w.start)}`
+  return `${pt ? 'até' : 'until'} ${d(w.end!)}`
 }
 
 /** One column of the list layout. The label is always rendered so the row stays readable when it
@@ -263,6 +280,10 @@ export default function TagsPage() {
   const [filters, setFilters] = useState<TagSource[]>([])
   const [filterType, setFilterType] = useState<TagSourceType>('project')
   const [filtersEditing, setFiltersEditing] = useState(true)
+  /** The period the tag is pinned to. Empty string = that end is open. */
+  const [winStart, setWinStart] = useState('')
+  const [winEnd, setWinEnd] = useState('')
+  const [windowEditing, setWindowEditing] = useState(true)
   // True when the chosen colour is not one of the presets — drives the custom circle's ring.
   const isCustomColor = !SWATCHES.some(c => c.toLowerCase() === color.toLowerCase())
   const [sharedWith, setSharedWith] = useState<string[]>([])
@@ -275,16 +296,18 @@ export default function TagsPage() {
 
   const openCreate = useCallback(() => {
     setEditingId(null); setName(''); setColor(DEFAULT_COLOR); setSources([]); setFilters([]); setSharedWith([])
+    setWinStart(''); setWinEnd('')
     setDraftType('repo'); setDraftValue(''); setSaveErr(null)
-    setSourcesEditing(true); setShareEditing(true)
+    setSourcesEditing(true); setShareEditing(true); setWindowEditing(true)
     setEditorOpen(true)
   }, [])
 
   const openEdit = useCallback((t: Tag) => {
     setEditingId(t._id); setName(t.name); setColor(t.color || DEFAULT_COLOR)
     setSources(t.sources); setFilters(t.filters ?? []); setSharedWith(t.sharedWith)
+    setWinStart(t.window?.start ?? ''); setWinEnd(t.window?.end ?? '')
     setDraftType('repo'); setDraftValue(''); setSaveErr(null)
-    setSourcesEditing(true); setShareEditing(true)
+    setSourcesEditing(true); setShareEditing(true); setWindowEditing(true)
     setEditorOpen(true)
   }, [])
 
@@ -296,9 +319,11 @@ export default function TagsPage() {
       || color !== (original.color || DEFAULT_COLOR)
       || JSON.stringify(sources) !== JSON.stringify(original.sources)
       || JSON.stringify(filters) !== JSON.stringify(original.filters ?? [])
+      || winStart !== (original.window?.start ?? '')
+      || winEnd !== (original.window?.end ?? '')
       || JSON.stringify([...sharedWith].sort()) !== JSON.stringify([...original.sharedWith].sort())
     )
-    : name.trim().length > 0 || sources.length > 0
+    : name.trim().length > 0 || sources.length > 0 || !!winStart || !!winEnd
 
   /** Commit a picked value as a source. Called straight from the value Select's onChange so a
    *  single click adds it — the old two-step (pick, then press "Add") silently dropped the pick
@@ -377,9 +402,20 @@ export default function TagsPage() {
 
   const save = async () => {
     if (!name.trim()) { setSaveErr(pt ? 'Informe um nome.' : 'A name is required.'); return }
+    // Caught here as well as server-side: an inverted period is the one mistake a date pair invites,
+    // and a 400 after pressing Save reads as a bug rather than as a correction.
+    if (winStart && winEnd && winStart > winEnd) {
+      setSaveErr(pt ? 'A data inicial não pode ser depois da final.' : 'The start date cannot be after the end date.')
+      return
+    }
     setSaving(true); setSaveErr(null)
     try {
-      const body = { id: editingId ?? undefined, name: name.trim(), color, sources, filters, sharedWith }
+      // Always SENT, even when empty: `null` is how the server is told the period was removed,
+      // whereas omitting the field means "leave whatever is stored alone".
+      const window = winStart || winEnd
+        ? { ...(winStart ? { start: winStart } : {}), ...(winEnd ? { end: winEnd } : {}) }
+        : null
+      const body = { id: editingId ?? undefined, name: name.trim(), color, sources, filters, window, sharedWith }
       const res = await fetch('/api/tags', {
         method: editingId ? 'PATCH' : 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -487,6 +523,19 @@ export default function TagsPage() {
                   {t.sources.length} {t.sources.length === 1 ? (pt ? 'fonte' : 'source') : (pt ? 'fontes' : 'sources')}
                 </span>
               </div>
+              {/* Without this the card is unexplainable: two tags over the same sources, one
+                  pinned to a period, are otherwise identical and show different money. */}
+              {windowLabel(t.window, pt) && (
+                <span style={{
+                  display: 'inline-flex', alignItems: 'center', gap: 4, alignSelf: 'flex-start',
+                  padding: '2px 8px', borderRadius: 999, fontSize: 10.5,
+                  background: 'var(--anthropic-orange-dim)', border: '1px solid rgba(217,119,6,0.35)',
+                  color: 'var(--anthropic-orange)', fontVariantNumeric: 'tabular-nums',
+                }}>
+                  <CalendarRange size={11} />
+                  {windowLabel(t.window, pt)}
+                </span>
+              )}
               <div style={{ fontSize: 20, fontWeight: 700, color: 'var(--anthropic-orange)', wordBreak: 'break-word' }}>
                 {fmtCost(t.aggregate.costUSD, currency, brlRate)}
               </div>
@@ -528,6 +577,17 @@ export default function TagsPage() {
               <span style={{ display: 'inline-flex', alignItems: 'center', gap: 8, minWidth: 0 }}>
                 <span style={{ width: 10, height: 10, borderRadius: '50%', background: t.color || 'var(--anthropic-orange)', flexShrink: 0 }} />
                 <span style={{ fontSize: 13, fontWeight: 700, color: 'var(--text-primary)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{t.name}</span>
+                {windowLabel(t.window, pt) && (
+                  <span
+                    title={windowLabel(t.window, pt)!}
+                    style={{
+                      display: 'inline-flex', alignItems: 'center', flexShrink: 0,
+                      color: 'var(--anthropic-orange)', opacity: 0.85,
+                    }}
+                  >
+                    <CalendarRange size={12} />
+                  </span>
+                )}
               </span>
               <Cell label={pt ? 'Custo' : 'Cost'} value={fmtCost(t.aggregate.costUSD, currency, brlRate)} accent />
               <Cell label={pt ? 'Sessões' : 'Sessions'} value={t.aggregate.sessions.toLocaleString()} />
@@ -749,6 +809,77 @@ export default function TagsPage() {
           />
         </Section>
         )}
+
+        {/* A period turns the tag from "these sources" into "these sources, during that run" —
+            the shape of question a tag is actually asked ("I tried harness X on this project from
+            the 4th to the 18th; what did it cost?"). Unlike the global date filter it belongs to
+            the tag, so the number is the same for everyone who opens it. */}
+        <Section
+          title={pt ? 'Período' : 'Period'}
+          editing={windowEditing}
+          onEdit={() => setWindowEditing(true)}
+          onCancel={() => setWindowEditing(false)}
+          onSave={() => setWindowEditing(false)}
+          labels={{ edit: pt ? 'Editar' : 'Edit', save: pt ? 'Pronto' : 'Done', cancel: pt ? 'Fechar' : 'Close' }}
+          editChildren={
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+              <div style={{ fontSize: 11.5, color: 'var(--text-tertiary)', lineHeight: 1.5 }}>
+                {pt
+                  ? 'Opcional. Prende a tag a um intervalo — as duas datas entram na conta. Deixe um lado em branco para "a partir de" ou "até". Sem período, a tag cobre todo o histórico.'
+                  : 'Optional. Pins the tag to a range — both dates are included. Leave one side blank for "from" or "until". With no period the tag covers the whole history.'}
+              </div>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+                <div style={{
+                  display: 'flex', alignItems: 'center', gap: 2, minHeight: 44, padding: '0 4px',
+                  background: 'var(--bg-elevated)', border: '1px solid var(--border)', borderRadius: 7,
+                }}>
+                  <DatePicker
+                    value={winStart}
+                    onChange={setWinStart}
+                    label={pt ? 'De' : 'From'}
+                    placeholder="DD/MM/YY"
+                    max={winEnd || undefined}
+                    rangeStart={winStart}
+                    rangeEnd={winEnd}
+                    lang={lang}
+                  />
+                  <div style={{ width: 14, height: 1, background: 'var(--border)', flexShrink: 0 }} />
+                  <DatePicker
+                    value={winEnd}
+                    onChange={setWinEnd}
+                    label={pt ? 'Até' : 'To'}
+                    placeholder="DD/MM/YY"
+                    min={winStart || undefined}
+                    rangeStart={winStart}
+                    rangeEnd={winEnd}
+                    lang={lang}
+                    align="right"
+                  />
+                </div>
+                {(winStart || winEnd) && (
+                  <button
+                    type="button"
+                    onClick={() => { setWinStart(''); setWinEnd('') }}
+                    style={{
+                      display: 'inline-flex', alignItems: 'center', justifyContent: 'center', gap: 5,
+                      minHeight: 44, padding: '0 12px', borderRadius: 7,
+                      border: '1px solid var(--border)', background: 'transparent',
+                      color: 'var(--text-tertiary)', fontSize: 12, fontFamily: 'inherit', cursor: 'pointer',
+                    }}
+                  >
+                    <X size={13} />
+                    {pt ? 'Limpar' : 'Clear'}
+                  </button>
+                )}
+              </div>
+            </div>
+          }
+        >
+          <div style={{ fontSize: 12.5, color: windowLabel({ start: winStart, end: winEnd }, pt) ? 'var(--text-secondary)' : 'var(--text-tertiary)' }}>
+            {windowLabel({ start: winStart, end: winEnd }, pt)
+              ?? (pt ? 'Todo o histórico.' : 'The whole history.')}
+          </div>
+        </Section>
 
         {/* Sharing is an IAM act — it grants a tag's numbers to another ACCOUNT. Off a central
             there are no other accounts, so the whole section is hidden (and the server ignores


### PR DESCRIPTION
Rescues the tag date-window feature from `10e1bc9`, a **local-only** docs commit that a concurrent session's broad `git add` had swept it into — the feature existed on no remote and the commit message described none of it. Extracted the 11 feature files onto `dev` and left `hardening/public-exposure` untouched (rebasing a branch a live session is committing to destroys work).

## What it does

A tag answered *"these sources"*; it could not answer *"these sources, during that experiment"* — "I ran harness X through the API on this project from the 4th to the 18th, what did it cost?". That needed the global date filter, which is transient and not carried by the tag, so the number changed the moment someone else opened the page.

`TagDoc.window` is `yyyy-MM-dd`, **both ends inclusive**, each side independently optional (`start` alone = from then on, `end` alone = up to then).

## Design notes

- **Narrows, never widens.** The window resolves as an AND on top of the union of sources, so it cannot turn a tag into a way of reaching something its sources did not already cover — which is why it stays out of the Rule 1 check and comes back unredacted.
- **One day rule.** Uses `tags-detail.ts`'s `start_time.slice(0, 10)`, not the local day. The local day is more correct in isolation and wrong here: at UTC-3 a session started at 23:00 would fall inside the window while being plotted on the next day's bar of the tag's own chart.
- **`makeTagFilter` no longer flattens** the selected tags into one source list — a flattened union cannot express a per-tag period, and would let a session inside tag A's window be admitted by tag B's sources. `tagMatch.test.ts` cross-checks the server module against the browser mirror session by session.
- **Three storage states**, because collapsing them loses data silently: absent leaves the period untouched (renaming no longer clears it), `null` removes it, and a window with neither end is stored as `null` rather than `{}`, which every `tag.window &&` guard would read as "has a period". Dates are validated as real calendar days — a regex alone accepts `2026-02-31`, which `Date` rolls to March 3rd, widening the period beyond what was written.

## Verification

`bun tsc --noEmit` clean, **678 tests / 0 failures** (662 + 16 new). Applied cleanly onto `dev`, confirming it carries no dependency on the hardening branch it was extracted from.

Behaviour spot-checked against the resolver directly, sessions at 23:30Z on each boundary:

| window | sessions kept |
|---|---|
| none | `a,b,c,d` |
| `2026-07-04` → `2026-07-18` | `b,c` |
| `start` only, `2026-07-18` | `c,d` |
| `end` only, `2026-07-04` | `a,b` |
| `{}` (neither end) | `a,b,c,d` |

Single-day window `04→04` keeps exactly `b`, confirming both bounds inclusive.

## Known limitation — "freeze" is not literal yet

Tag math is per-session by definition, so a window only sees what still exists as a session document. Measured on this central tonight: one person had **255 surviving sessions out of 783**. A window older than the retention horizon is therefore incomplete at birth and **shrinks over time**. Real freezing is a second feature (a `frozen` snapshot stored on the doc, shown beside the live number and labelled with its date) — deliberately not included here, since it raises "which of the two numbers is the true one?".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018rKoY6Ckd61FkFL2VfyP45