### PR TITLE
fix(cli): doctor reads the deployment's config; document bringing a central up

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -58,7 +58,7 @@ If you run a central reachable by anyone other than yourself, read
 [docs/exposure.md](docs/exposure.md) and run:
 
 ```bash
-agentop doctor --exposed
+./central.sh doctor --exposed        # or: agentop central doctor --exposed
 ```
 
 It exits non-zero until every control is configured. A check it could not verify is reported as

--- a/central.sh
+++ b/central.sh
@@ -15,6 +15,9 @@
 #   restart   Restart the app container WITHOUT rebuilding
 #   logs      Follow the app container logs (Ctrl-C to stop)
 #   status    Show container + health status
+#   doctor    Run the exposure preflight INSIDE the container, where central.env is
+#             the live environment and the database is reachable. Add --exposed to
+#             check against the strict public bar before opening a tunnel.
 #   down      Stop and remove the containers (KEEPS the data volume)
 #   pull      Rebuild from a fresh base image (git pull first, then this)
 #   help      Show this message
@@ -275,6 +278,13 @@ case "$cmd" in
     ;;
   status)
     docker compose -p "$PROJECT" ps
+    ;;
+
+  doctor)
+    # Run it inside the container on purpose: that is where central.env is the live
+    # environment AND where MongoDB is reachable, so the owner-MFA and token checks
+    # can actually run instead of reporting "could not verify".
+    compose exec -T app bun run packages/server/bin/cli.ts doctor "${@:2}"
     ;;
   down)
     # Note: no `-v` — the Mongo data volume is preserved. Add it manually only

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -298,10 +298,12 @@ the deployment runbook and go-live checklist are **[docs/exposure.md](exposure.m
 | **Error hygiene** — clients get a code plus a correlation ref; the real message goes to the log only | `server/errors.ts` |
 | **Container** — uid 10001, read-only root filesystem, `cap_drop: ALL`, `no-new-privileges`, loopback bind, Mongo unpublished. Host harness dirs are mounted only when `AGENTISTICS_CENTRAL_USER` is set | `Dockerfile`, `docker-compose*.yml` |
 
-Before exposing anything, run:
+Before exposing anything, run the preflight **inside the container**, where `central.env` is the
+live environment and the database is reachable:
 
 ```bash
-agentop doctor --exposed
+./central.sh doctor --exposed        # repo checkout
+agentop central doctor --exposed     # standalone binary
 ```
 
 It prints the nine-point checklist and exits non-zero on any failure. A check that could not be

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -406,7 +406,16 @@ remembering nine environment variables.
 ```bash
 agentop doctor              # check against the current profile
 agentop doctor --exposed    # check against the strict public bar
+
+./central.sh doctor --exposed        # from a repo checkout, INSIDE the container
+agentop central doctor --exposed     # same, from the standalone binary
 ```
+
+**On a Docker central, prefer the `central.sh` / `agentop central` form.** The command
+evaluates the configuration the deployment will actually run with — it reads `central.env` when
+present and prints which file it used — but the owner-MFA and machine-token checks also need
+MongoDB, which is reachable only from inside the compose network. Run on the host, those two
+report as unverified, which counts as a failure by design.
 
 `--exposed` evaluates as if `AGENTISTICS_EXPOSURE=public` were already set, which is how you
 verify readiness **before** flipping it.

--- a/docs/exposure.md
+++ b/docs/exposure.md
@@ -92,7 +92,48 @@ Two notes on the secrets:
 
 Then `chmod 600 central.env` — it holds secrets.
 
-## 4. The tunnel
+## 4. Bringing it up
+
+From a repo checkout:
+
+```sh
+./central.sh up          # builds, migrates the data volume, (re)creates the containers
+./central.sh status      # containers + health
+./central.sh logs        # follow the app log
+```
+
+From the standalone binary, with no checkout (materialises a compose + `central.env` under
+`~/.agentistics/central/` and pulls the published image):
+
+```sh
+agentop central up
+agentop central status
+agentop central logs
+```
+
+The first boot with no owner account prints a **one-time setup token** to the log. Capture it —
+it is shown once:
+
+```sh
+./central.sh logs | grep -A 6 "OWNER SETUP REQUIRED"
+```
+
+Then check the deployment before anything is reachable from outside:
+
+```sh
+./central.sh doctor --exposed
+```
+
+Run it through `central.sh` rather than as bare `agentop doctor`: inside the container
+`central.env` is the live environment **and** MongoDB is reachable, so the owner-MFA and
+machine-token checks actually run. On the host, `agentop doctor --exposed` still reads
+`central.env` (it says which file it used) but cannot reach the database, so those two checks
+report as unverified — which counts as a failure, deliberately.
+
+Nothing above opens a port. The container binds `127.0.0.1`, so at this point the central is
+reachable only from the host itself. The tunnel below is what publishes it.
+
+## 5. The tunnel
 
 ```sh
 cloudflared tunnel login
@@ -118,7 +159,7 @@ sudo cloudflared service install     # run it as a service, not in a shell
 Rotate the tunnel token periodically. If it leaks, delete the tunnel and create a new one — that
 invalidates the old credentials immediately.
 
-## 5. At the edge (Cloudflare)
+## 6. At the edge (Cloudflare)
 
 The in-app limiter is the backstop, not the front line. Configure:
 
@@ -134,7 +175,7 @@ Access login. Either bypass those paths, give them a service token, or (cleanest
 hostname pointed at a separate instance with `AGENTISTICS_INGEST_ONLY=1` sharing the same Mongo:
 that instance serves only the token-gated ingest endpoint and 404s everything else.
 
-## 6. Onboarding a person
+## 7. Onboarding a person
 
 1. On first boot with no owner, the central prints a one-time setup token. Use it once to create
    the owner account.
@@ -150,7 +191,7 @@ Roles: `owner` reaches everything; a team `manager` manages their own teams' mac
 and `user` accounts; a plain `user` sees only the teams they belong to plus machines they own.
 That scoping is enforced server-side in `team-scope.ts` and asserted in `authz-gate.test.ts`.
 
-## 7. Incident response
+## 8. Incident response
 
 | Situation | Action |
 |---|---|
@@ -160,9 +201,10 @@ That scoping is enforced server-side in `team-scope.ts` and asserted in `authz-g
 | Something looks wrong | `GET /api/iam/audit` (owner only) — logins, failures, lockouts, MFA events, password changes, account/team/token changes and every gate denial, kept 180 days. |
 | The tunnel token leaked | Delete the tunnel, create a new one. |
 
-## 8. Go-live checklist
+## 9. Go-live checklist
 
-Run `agentop doctor --exposed`. It must print no `✗`.
+Run `./central.sh doctor --exposed` (or `agentop central doctor --exposed`). It must print
+no `✗`.
 
 Then verify from outside, against the real hostname:
 

--- a/packages/server/server/cli-doctor.ts
+++ b/packages/server/server/cli-doctor.ts
@@ -4,20 +4,17 @@
  * Prints the go-live checklist and exits non-zero on any failure, so exposing an instance can
  * be gated on a single command instead of on remembering nine environment variables.
  * `--exposed` evaluates against the strict (public) bar even when the profile is not yet set,
- * which is how you check readiness BEFORE flipping AGENTISTICS_EXPOSURE.
+ * which is how you check readiness BEFORE flipping it.
+ *
+ * It evaluates the configuration the central will actually RUN with: on a Docker deployment
+ * that is `central.env`, not the shell you typed the command in (see deployment-config.ts).
+ * The source is always printed, so the verdict is never about an ambiguous machine.
  */
-import { PROFILE, CAPS } from './exposure'
+import { existsSync, readFileSync } from 'node:fs'
+import * as path from 'node:path'
+import { capabilitiesFor, resolveProfile } from './exposure'
 import { runPreflight, allPassed } from './preflight'
-import {
-  TEAM_SESSION_SECRET,
-  TEAM_SESSION_SECRET_ENV,
-  TEAM_PASSWORD,
-  TEAM_TLS,
-  TRUST_PROXY,
-  ALLOWED_ORIGINS,
-  MONGO_URL,
-  TEAM_CENTRAL,
-} from './config'
+import { resolveDeploymentConfig } from './deployment-config'
 
 const GREEN = '\x1b[92m'
 const RED = '\x1b[91m'
@@ -25,15 +22,43 @@ const YELLOW = '\x1b[93m'
 const DIM = '\x1b[2m'
 const RESET = '\x1b[0m'
 
+/** `central.env` beside the compose files, or next to the binary's working directory. */
+function findEnvFile(): string | null {
+  const candidates = [
+    process.env.ENV_FILE,
+    path.join(process.cwd(), 'central.env'),
+    path.join(process.env.HOME ?? '', '.agentistics', 'central', 'central.env'),
+  ].filter((p): p is string => !!p)
+  for (const c of candidates) if (existsSync(c)) return c
+  return null
+}
+
 export async function runDoctor(argv: string[]): Promise<never> {
   const exposed = argv.includes('--exposed')
+
+  const envPath = findEnvFile()
+  const cfg = resolveDeploymentConfig(
+    envPath ? readFileSync(envPath, 'utf8') : null,
+    process.env as Record<string, string | undefined>,
+  )
+
+  // Derive the profile and capabilities from the DEPLOYMENT's config, not from this process's
+  // singletons — the container is what will serve traffic.
+  const env = {
+    central: cfg.central,
+    exposure: cfg.exposure,
+    allowLocalShell: cfg.allowLocalShell,
+    tls: cfg.tls,
+  }
+  const profile = resolveProfile(env)
+  const caps = capabilitiesFor(profile, env)
 
   // Owner MFA + token counts need the database; a central that cannot reach it cannot be
   // declared ready either, so a lookup failure is surfaced rather than silently passed.
   let ownersWithoutMfa: string[] = []
   let machineTokenCount = 0
   let dbError: string | null = null
-  if (TEAM_CENTRAL) {
+  if (cfg.central) {
     try {
       const [{ listAccounts }, { accountsWithoutMfa }, { listMachines }] = await Promise.all([
         import('./accounts'),
@@ -51,22 +76,24 @@ export async function runDoctor(argv: string[]): Promise<never> {
   }
 
   const checks = runPreflight({
-    profile: exposed ? 'public' : PROFILE,
-    caps: CAPS,
-    sessionSecret: TEAM_SESSION_SECRET_ENV ?? TEAM_SESSION_SECRET ?? undefined,
-    password: TEAM_PASSWORD,
-    tls: TEAM_TLS,
-    trustProxy: TRUST_PROXY,
-    bindIp: process.env.BIND_IP ?? '127.0.0.1',
-    allowedOrigins: ALLOWED_ORIGINS,
+    profile: exposed ? 'public' : profile,
+    caps,
+    sessionSecret: cfg.sessionSecret,
+    password: cfg.password,
+    tls: cfg.tls,
+    trustProxy: cfg.trustProxy,
+    bindIp: cfg.bindIp,
+    allowedOrigins: cfg.allowedOrigins,
     ownersWithoutMfa,
-    // A credentialed URI carries `user:pass@`.
-    mongoAuthenticated: /\/\/[^/@]+@/.test(MONGO_URL),
+    mongoAuthenticated: cfg.mongoAuthenticated,
     machineTokenCount,
     dbUnavailable: !!dbError,
   })
 
-  console.log(`\n  agentistics — exposure preflight ${DIM}(profile: ${exposed ? 'public (forced)' : PROFILE})${RESET}\n`)
+  const readFrom = cfg.source === 'file' ? envPath : 'this process environment'
+  console.log(`\n  agentistics — exposure preflight ${DIM}(profile: ${exposed ? 'public (forced)' : profile})${RESET}`)
+  console.log(`  ${DIM}config read from: ${readFrom}${RESET}\n`)
+
   for (const c of checks) {
     const icon = c.status === 'pass' ? `${GREEN}✓${RESET}` : c.status === 'warn' ? `${YELLOW}!${RESET}` : `${RED}✗${RESET}`
     console.log(`  ${icon} ${c.label}`)
@@ -76,6 +103,10 @@ export async function runDoctor(argv: string[]): Promise<never> {
   if (dbError) {
     console.log(`\n  ${YELLOW}!${RESET} Database unreachable — owner-MFA and machine-token checks could not run.`)
     console.log(`    ${DIM}${dbError}${RESET}`)
+    if (cfg.source === 'file') {
+      console.log(`    ${DIM}Expected when the database is only reachable from inside the compose network;${RESET}`)
+      console.log(`    ${DIM}re-run inside the container: ./central.sh doctor${RESET}`)
+    }
   }
 
   const ok = allPassed(checks) && !dbError

--- a/packages/server/server/deployment-config.test.ts
+++ b/packages/server/server/deployment-config.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'bun:test'
+import { parseEnvFile, resolveDeploymentConfig } from './deployment-config'
+
+describe('parseEnvFile', () => {
+  it('reads simple assignments and ignores comments and blanks', () => {
+    expect(parseEnvFile('# comment\nA=1\n\nB=two\n')).toEqual({ A: '1', B: 'two' })
+  })
+
+  it('keeps everything after the first = , so a URI survives intact', () => {
+    expect(parseEnvFile('MONGO_URL=mongodb://u:p@h:27017/?replicaSet=rs0').MONGO_URL)
+      .toBe('mongodb://u:p@h:27017/?replicaSet=rs0')
+  })
+
+  it('strips surrounding quotes and whitespace', () => {
+    expect(parseEnvFile('A = "x" \nB=\'y\'')).toEqual({ A: 'x', B: 'y' })
+  })
+
+  it('ignores malformed lines rather than throwing', () => {
+    expect(parseEnvFile('no-equals-here\nA=1')).toEqual({ A: '1' })
+  })
+})
+
+describe('resolveDeploymentConfig', () => {
+  const proc = {
+    AGENTISTICS_TEAM_CENTRAL: '1',
+    AGENTISTICS_TEAM_TLS: '1',
+    BIND_IP: '127.0.0.1',
+  }
+
+  it('uses the process environment when there is no env file', () => {
+    const r = resolveDeploymentConfig(null, proc)
+    expect(r.source).toBe('process')
+    expect(r.bindIp).toBe('127.0.0.1')
+    expect(r.tls).toBe(true)
+  })
+
+  it('prefers the deployment file, because that is what the container will run with', () => {
+    const r = resolveDeploymentConfig('BIND_IP=0.0.0.0\nAGENTISTICS_TEAM_CENTRAL=1\n', proc)
+    expect(r.source).toBe('file')
+    expect(r.bindIp).toBe('0.0.0.0')
+    // Absent from the file means absent from the deployment — the host's own env must not
+    // paper over it, or the check reports on the wrong machine.
+    expect(r.tls).toBe(false)
+  })
+
+  it('reports the documented defaults for keys the file omits', () => {
+    const r = resolveDeploymentConfig('AGENTISTICS_TEAM_CENTRAL=1\n', {})
+    expect(r.bindIp).toBe('127.0.0.1')
+    expect(r.exposure).toBeUndefined()
+    expect(r.allowLocalShell).toBe(false)
+  })
+
+  it('carries every field the preflight needs', () => {
+    const r = resolveDeploymentConfig(
+      [
+        'AGENTISTICS_TEAM_CENTRAL=1',
+        'AGENTISTICS_EXPOSURE=public',
+        'AGENTISTICS_TEAM_TLS=1',
+        'AGENTISTICS_TRUST_PROXY=1',
+        'AGENTISTICS_ALLOW_LOCAL_SHELL=1',
+        'AGENTISTICS_TEAM_SESSION_SECRET=' + 'f'.repeat(64),
+        'AGENTISTICS_TEAM_PASSWORD=hunter2hunter2',
+        'AGENTISTICS_ALLOWED_ORIGINS=https://a.example, https://b.example',
+        'BIND_IP=127.0.0.1',
+        'MONGO_URL=mongodb://user:pass@mongo:27017/',
+      ].join('\n'),
+      {},
+    )
+    expect(r).toMatchObject({
+      central: true,
+      exposure: 'public',
+      tls: true,
+      trustProxy: true,
+      allowLocalShell: true,
+      bindIp: '127.0.0.1',
+      mongoAuthenticated: true,
+      source: 'file',
+    })
+    expect(r.allowedOrigins).toEqual(['https://a.example', 'https://b.example'])
+    expect(r.password).toBe('hunter2hunter2')
+  })
+
+  it('detects an unauthenticated mongo URI', () => {
+    expect(resolveDeploymentConfig('MONGO_URL=mongodb://mongo:27017/', {}).mongoAuthenticated).toBe(false)
+  })
+})

--- a/packages/server/server/deployment-config.ts
+++ b/packages/server/server/deployment-config.ts
@@ -1,0 +1,82 @@
+/**
+ * deployment-config.ts — resolve the configuration a central will actually RUN with.
+ *
+ * `agentop doctor` is usually typed on the host, while the central runs in a container whose
+ * environment comes from `central.env`. Reading `process.env` there describes the operator's
+ * shell, not the deployment: on a real machine that produced a preflight reporting
+ * `BIND_IP=127.0.0.1` while `central.env` said `0.0.0.0` — a false pass on the one check that
+ * decides whether the instance is reachable from the internet.
+ *
+ * So when a deployment file exists it is the authority, whole: a key absent from it is absent
+ * from the deployment, and the host's own environment must not paper over it. Inside the
+ * container there is no such file and `process.env` is correct.
+ *
+ * Pure — the caller reads the file and passes its text (or null).
+ */
+
+export interface DeploymentConfig {
+  central: boolean
+  exposure: string | undefined
+  allowLocalShell: boolean
+  tls: boolean
+  trustProxy: boolean
+  bindIp: string
+  allowedOrigins: string[]
+  sessionSecret: string | undefined
+  password: string | undefined
+  mongoAuthenticated: boolean
+  /** Which source the values came from — reported to the operator so it is never ambiguous. */
+  source: 'file' | 'process'
+}
+
+/** Minimal `KEY=value` reader: comments, blanks and malformed lines are skipped. */
+export function parseEnvFile(text: string): Record<string, string> {
+  const out: Record<string, string> = {}
+  for (const raw of text.split('\n')) {
+    const line = raw.trim()
+    if (!line || line.startsWith('#')) continue
+    const eq = line.indexOf('=')
+    if (eq === -1) continue
+    const key = line.slice(0, eq).trim()
+    let value = line.slice(eq + 1).trim()
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1)
+    }
+    if (key) out[key] = value
+  }
+  return out
+}
+
+export function resolveDeploymentConfig(
+  envFileText: string | null,
+  processEnv: Record<string, string | undefined>,
+): DeploymentConfig {
+  const fromFile = envFileText !== null
+  const env = fromFile ? parseEnvFile(envFileText) : processEnv
+  const get = (k: string): string | undefined => {
+    const v = env[k]
+    return v === undefined || v === '' ? undefined : v
+  }
+  const mongoUrl = get('MONGO_URL') ?? ''
+  return {
+    central: get('AGENTISTICS_TEAM_CENTRAL') === '1',
+    exposure: get('AGENTISTICS_EXPOSURE'),
+    allowLocalShell: get('AGENTISTICS_ALLOW_LOCAL_SHELL') === '1',
+    tls: get('AGENTISTICS_TEAM_TLS') === '1',
+    trustProxy: get('AGENTISTICS_TRUST_PROXY') === '1',
+    // Mirrors the compose default, so an omitted key reads as what will actually happen.
+    bindIp: get('BIND_IP') ?? '127.0.0.1',
+    allowedOrigins: (get('AGENTISTICS_ALLOWED_ORIGINS') ?? '')
+      .split(',')
+      .map(s => s.trim())
+      .filter(Boolean),
+    sessionSecret: get('AGENTISTICS_TEAM_SESSION_SECRET'),
+    password: get('AGENTISTICS_TEAM_PASSWORD'),
+    // A credentialed URI carries `user:pass@`.
+    mongoAuthenticated: /\/\/[^/@]+@/.test(mongoUrl),
+    source: fromFile ? 'file' : 'process',
+  }
+}


### PR DESCRIPTION
Follow-up to #51. Found by trying to follow `docs/exposure.md` from top to bottom as a new operator would.

## `doctor` was reporting on the wrong machine

`agentop doctor` read `process.env`. A Docker central runs with `central.env`, so on the host the two are unrelated. On this repo's own machine that produced:

```
central.env:  BIND_IP=0.0.0.0
doctor said:  BIND_IP=127.0.0.1 ✓
```

A **false pass on the single check that decides whether the instance is reachable from the internet** — precisely the failure mode the preflight exists to prevent.

It now resolves the deployment's configuration through the new pure `deployment-config.ts`. When `central.env` exists it is the authority *whole*: a key absent from the file is absent from the deployment, and the host's own environment must not paper over it. Inside the container there is no such file and `process.env` is correct. Either way the source is printed:

```
config read from: /home/…/agentistics/central.env
```

## `central.sh doctor`

The owner-MFA and machine-token checks need MongoDB, which is reachable only from inside the compose network. Run on the host those report "could not verify" — which counts as a failure by design, but is unhelpful as the normal path. `./central.sh doctor --exposed` runs the preflight inside the container, where `central.env` is the live environment and the database is reachable.

## exposure.md never said how to start it

The runbook configured `central.env`, set up the tunnel, and described the edge — with no `up` anywhere. New section 4 covers both paths (`./central.sh up` and `agentop central up`), where the one-time owner setup token appears and how to capture it, and the preflight to run *before* anything is published. It also states the property that makes the ordering safe: nothing in that section opens a port, because the container binds `127.0.0.1` — the tunnel is what publishes it.

`cli.md`, `DEPLOY.md` and `SECURITY.md` now point at the container form of the command instead of the bare one.

## Verified

`tsc --noEmit` clean, **871 tests** pass (9 new for `deployment-config`). Against this machine's real `central.env`, `doctor --exposed` now correctly fails on `BIND_IP=0.0.0.0` and names the file it read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U6fb6XXiqmSYZBDF9GPQBF
