### PR TITLE
fix(live): report every open session, not the ones the filters happen to show

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -107,6 +107,11 @@ export const HARNESS_ORDER: HarnessId[] = (Object.keys(HARNESS_SORT) as HarnessI
 export interface SessionMeta {
   session_id: string
   project_path: string
+  /** The directory the session is in NOW, when it differs from `project_path` — a session that
+   *  moved into a git worktree (or any subdirectory) keeps `project_path` at the directory it was
+   *  opened in, so that it stays grouped under the same project. Live-session detection matches a
+   *  running process by its cwd, and without this the moved session looks closed while it is open. */
+  current_cwd?: string
   start_time: string
   end_time?: string
   /** WALL CLOCK: last event − first event. A session reopened over three weeks reports ~500h here,

--- a/packages/server/server/jsonl.ts
+++ b/packages/server/server/jsonl.ts
@@ -156,7 +156,7 @@ export async function parseSessionJsonl(
     return makeEmptySession(sessionId, fallbackPath, '', '', source)
   }
 
-  let cwd = '', startTime = '', lastTime = '', firstPrompt = '', modelId = '', sessionTitle = ''
+  let cwd = '', lastCwd = '', startTime = '', lastTime = '', firstPrompt = '', modelId = '', sessionTitle = ''
   let userMsgs = 0, assistantMsgs = 0, inputTokens = 0, outputTokens = 0
   let cacheReadTokens = 0, cacheCreationTokens = 0
   let gitCommits = 0, gitPushes = 0
@@ -185,7 +185,12 @@ export async function parseSessionJsonl(
     let e: Record<string, unknown>
     try { e = JSON.parse(line) } catch { continue }
 
-    if (!cwd && e.cwd) cwd = e.cwd as string
+    // First cwd = the project the session belongs to; last cwd = where it is now. They differ when
+    // the session moved (a git worktree), and the live-session detector needs the latter.
+    if (e.cwd && typeof e.cwd === 'string') {
+      if (!cwd) cwd = e.cwd
+      lastCwd = e.cwd
+    }
     const ts = e.timestamp as string | undefined
     let turnEvent: TurnEvent | null = null
     if (ts) {
@@ -358,6 +363,7 @@ export async function parseSessionJsonl(
   return {
     session_id: sessionId,
     project_path: projectPath,
+    ...(lastCwd && lastCwd !== projectPath ? { current_cwd: lastCwd } : {}),
     start_time: startTime,
     end_time: lastTime || undefined,
     duration_minutes: durationMinutes,

--- a/packages/server/server/live-sessions.test.ts
+++ b/packages/server/server/live-sessions.test.ts
@@ -49,6 +49,28 @@ test('no processes → nothing open; process with no matching project → nothin
   expect(resolveOpenSessionIds(['/proj/zzz'], sessions, NOW).size).toBe(0)
 })
 
+// --- the directory the session is actually in ---------------------------------------------------
+
+test('a session whose cwd moved (git worktree) is matched on its current_cwd, not project_path', () => {
+  // Real shape: a session opened at the repo root and then moved into a worktree keeps
+  // project_path = the repo (so it stays in the same project) while its process runs in the
+  // worktree. Matching on project_path alone reported it closed while it was plainly open.
+  const wt = '/repo/.claude/worktrees/feature'
+  const moved = { ...s('moved', '/repo', minsAgo(1)), current_cwd: wt }
+  const atRoot = s('root', '/repo', minsAgo(2))
+  const procs = [
+    { harness: 'claude' as HarnessId, cwd: wt, startedMs: 0 },
+    { harness: 'claude' as HarnessId, cwd: '/repo', startedMs: 0 },
+  ]
+  expect(resolveOpenSessionIds(procs, [moved, atRoot], NOW)).toEqual(new Set(['moved', 'root']))
+})
+
+test('current_cwd does not let a session be claimed by a process in an unrelated directory', () => {
+  const moved = { ...s('moved', '/repo', minsAgo(1)), current_cwd: '/repo/wt' }
+  const open = resolveOpenSessionIds([{ harness: 'claude' as HarnessId, cwd: '/elsewhere', startedMs: 0 }], [moved], NOW)
+  expect(open.size).toBe(0)
+})
+
 // --- identity from argv ------------------------------------------------------------------------
 
 const UUID_A = '1f9f48c3-6e75-4009-addd-fba4c3a53877'

--- a/packages/server/server/live-sessions.ts
+++ b/packages/server/server/live-sessions.ts
@@ -29,6 +29,14 @@ function lastActivityMs(s: SessionMeta): number {
   return 0
 }
 
+/** Where a session IS, which is not always the project it belongs to: a session that moved into a
+ *  git worktree keeps `project_path` at the directory it was opened in (so the worktree's work
+ *  still counts as the same project) while its process runs in the worktree. The process cwd is
+ *  matched against this, and against this alone — a moved session is in one place, not two. */
+export function sessionCwd(s: SessionMeta): string {
+  return s.current_cwd || s.project_path
+}
+
 /** Process name (`/proc/<pid>/comm`) → the harness it belongs to. `comm` is truncated to 15 chars
  *  by the kernel, which none of these reach. A session is only ever matched to a process of its own
  *  harness, so a `gemini` process can never mark an `antigravity` session open (they share a home
@@ -249,7 +257,7 @@ export function resolveOpenSessionIds(
   for (const group of groups.values()) {
     const { harness, cwd } = group[0]!
     const candidates = sessions
-      .filter(s => s.harness === harness && s.project_path === cwd && !open.has(s.session_id))
+      .filter(s => s.harness === harness && sessionCwd(s) === cwd && !open.has(s.session_id))
       .filter(isFresh)
       .sort((a, b) => lastActivityMs(b) - lastActivityMs(a))
     // Strictest bound first, so the newest process claims the newest session it could be driving
@@ -307,7 +315,10 @@ export function resolveLiveSnapshot(
   const remaining = new Map<string, number>()
   for (const id of open) {
     const s = sessions.find(x => x.session_id === id)
-    if (s) remaining.set(`${s.harness} ${s.project_path}`, (remaining.get(`${s.harness} ${s.project_path}`) ?? 0) + 1)
+    if (s) {
+      const key = `${s.harness} ${sessionCwd(s)}`
+      remaining.set(key, (remaining.get(key) ?? 0) + 1)
+    }
   }
 
   const known = new Set(sessions.map(s => s.session_id))

--- a/packages/web/src/pages/SessionsPage.tsx
+++ b/packages/web/src/pages/SessionsPage.tsx
@@ -42,11 +42,15 @@ export default function SessionsPage() {
   }, [isCentral])
 
   const liveIds = useMemo(() => new Set(liveIdList), [liveIdList])
-  const sorted = useMemo(
-    () => [...derived.filteredSessions].sort((a, b) => lastActivityMs(b) - lastActivityMs(a)),
-    [derived.filteredSessions],
+  // Deliberately NOT the filtered set: "open now" is a fact about this machine right now, not a
+  // slice of the dashboard. A long-running session that started outside the active date range (or
+  // sits in a project the filter excludes) is still open, and dropping it here reported one open
+  // session while three were on screen.
+  const live = useMemo(
+    () => data.sessions.filter(s => liveIds.has(s.session_id))
+      .sort((a, b) => lastActivityMs(b) - lastActivityMs(a)),
+    [data.sessions, liveIds],
   )
-  const live = useMemo(() => sorted.filter(s => liveIds.has(s.session_id)), [sorted, liveIds])
   const liveCount = live.length + liveProcs.length
 
   return (


### PR DESCRIPTION
Four Claude Code sessions were open on this machine and **"Open now" listed one**. Two independent causes, both reproduced against the host's own `/proc` and transcripts.

## 1. A session that moved directory never matched its process

`SessionMeta.project_path` is the **first** `cwd` of the transcript — that is what keeps work done inside a git worktree counted under the project it belongs to. `resolveOpenSessionIds` matches an anonymous process by comparing its cwd to that path, so the two sessions living in `.claude/worktrees/*` matched nothing. They did not show up as "starting" either: that fallback only covers a process still inside the 30-minute startup grace.

- `SessionMeta.current_cwd` (new, optional): the **last** `cwd` of the transcript, written only when it differs from `project_path`, so project grouping is untouched.
- `sessionCwd(s) = current_cwd || project_path` — where the session *is*, not where it belongs — is what the process cwd is compared against, in the pass-2 candidate filter and in the unmatched-process accounting alike. A moved session is in one place, so it can be claimed there and only there.

## 2. The "Open now" list was filtered by the dashboard filters

It was built from `derived.filteredSessions`. A session started before the active date range dropped out of the list while being plainly open — with a short date filter, exactly the "1 of 4" on screen. What is open is a fact about this machine, not a slice of the dashboard, so it now reads `data.sessions`.

## Verification

Against the live host, four `claude` processes:

```
processos claude: 4  →  sessoes vivas: 4  (processos sem sessao: 0)
  5f6bd343 → .../worktrees/session-active-time
  75502c2b → .../worktrees/members-statscache
  a07b0da2, b594ea85 → /home/mithrandir/agentistics
```

And through the rebuilt binary's own endpoint, `GET /api/live-sessions` returns all four ids.

Two new tests in `live-sessions.test.ts`: a worktree session is matched via `current_cwd`, and `current_cwd` never lets a process in an unrelated directory claim a session. `bun test` is green in the main checkout (862/862); the 11 failures in the scratch worktree are a missing `mongodb` package there and are identical on unmodified `dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016eyrdnVnCKGEicsWJRRHkD