### PR TITLE
ci(release): stop deleting the rolling release before we can recreate it

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -224,12 +224,20 @@ jobs:
           TAG="${{ steps.version.outputs.tag }}"
           VERSION="${{ steps.version.outputs.next }}"
 
-          # Create the versioned release (Linux binary only; Windows installer added by build-desktop job)
-          gh release create "$TAG" \
-            --title "v${VERSION}" \
-            --notes-file /tmp/release-notes.md \
-            ./release/agentop \
-            ./release/agentop.exe
+          # Create the versioned release (Linux binary only; Windows installer added by build-desktop job).
+          # `gh release create` fails outright when the release already exists, which turns a
+          # re-run — the normal response to a later job in this workflow failing — into a second
+          # failure at the first step. Upload into it instead when it is already there.
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "release $TAG already exists — uploading the binaries into it"
+            gh release upload "$TAG" ./release/agentop ./release/agentop.exe --clobber
+          else
+            gh release create "$TAG" \
+              --title "v${VERSION}" \
+              --notes-file /tmp/release-notes.md \
+              ./release/agentop \
+              ./release/agentop.exe
+          fi
 
           # Update the rolling latest pointer
           gh release delete latest --yes 2>/dev/null || true
@@ -238,7 +246,15 @@ jobs:
           git tag latest
           git push origin latest
 
+          # `--target` is REQUIRED here. Without it `gh release create` refuses a tag it cannot
+          # yet see on the remote ("tag latest exists locally but has not been pushed"), and the
+          # push immediately above has not necessarily propagated by the time this runs. That is
+          # exactly how v1.7.4 failed: the old `latest` release had already been DELETED by the
+          # line above, so the repository was left with no rolling release at all, and every job
+          # after this one — the npm publish, the Windows installer, the GHCR image — was skipped.
+          # Naming the commit lets gh create the release without waiting on tag propagation.
           gh release create latest \
+            --target "$GITHUB_SHA" \
             --title "Latest build ($(date -u +'%Y-%m-%d %H:%M UTC'))" \
             --notes-file /tmp/release-notes.md \
             ./release/agentop \


### PR DESCRIPTION
`v1.7.4` published its binaries and then failed, skipping everything after it.

## What happened

The `Publish versioned release + update latest` step does this, in this order:

```bash
gh release delete latest --yes      # ← the old rolling release is gone here
git push origin :refs/tags/latest
git tag latest && git push origin latest
gh release create latest ...        # ← fails: "tag latest exists locally but
                                    #    has not been pushed to …"
```

`gh` verifies that the tag exists **on the remote** before creating a release
for it, and the push immediately above has not necessarily propagated by the
time it looks. Two consequences, and the order is what makes them serious:

1. The old `latest` release was **already deleted**, so the repository was left
   with **no rolling release at all**.
2. The step lives in the `build` job, so its failure **skipped every downstream
   job** — `Publish @agentistics/mcp to npm`, `Build Tauri Desktop (Windows)`
   and `Publish central image to GHCR`. `v1.7.4` has its two binaries and
   nothing else.

## The fix

- **`--target "$GITHUB_SHA"`** on `gh release create latest`. Naming the commit
  removes the reason gh waits on tag propagation at all.
- **The versioned release becomes idempotent** — created when missing, uploaded
  into when present. This is not defensive padding: `gh release create` fails
  when the release exists, which is exactly the state a re-run starts from, so
  the obvious response to this failure (re-run the job) would have failed again
  at the *first* step, before reaching any of the work it was meant to retry.

## What merging this does

It cuts **v1.7.5**, and that release is what finally exercises the two CI
changes that came in with #49 and never got to run:

- `@agentistics/mcp` publishes at the project's version. It is still on **1.3.3**
  (April), so the published version will jump straight to 1.7.5 — that is the
  correction, not a fault.
- The rolling `latest` release comes back.

The Windows installer and the GHCR image for 1.7.4 are not recovered by this;
they are simply produced for 1.7.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MqdJkLbNxC3gd9epkSpcLF
