### PR TITLE
fix(control): ask the history question when the control center opens

### DIFF
--- a/packages/tui/src/control/ArchiveChoice.tsx
+++ b/packages/tui/src/control/ArchiveChoice.tsx
@@ -25,11 +25,20 @@ const ORDER: readonly ArchiveMode[] = ['consolidate', 'full', 'off'] as const
 /** The reason, the blank row under it, and the three options. */
 const ASIDE_ROWS = 2
 
-export function ArchiveChoice({ strings: s, suggested, onPick, onCancel, width, height, isActive, origin }: {
+/** The skip is a menu ROW, not an `esc` the user has to guess at. This question is the one the
+ *  opening gate asks unprompted, so declining to answer it has to be as visible as answering it —
+ *  and the row states what the skip costs, since a silent skip is how a machine ends up preserving
+ *  nothing. `esc` still cancels; the row is what makes the option discoverable. */
+const SKIP = '__later__'
+
+export function ArchiveChoice({ strings: s, suggested, onPick, onSkip, onCancel, width, height, isActive, origin }: {
   strings: ControlStrings
   /** The recommended answer, preselected. */
   suggested: ArchiveMode
   onPick: (mode: ArchiveMode) => void
+  /** Offered only where declining is legitimate — the opening gate. Absent elsewhere, and then the
+   *  menu has no such row: a start that needs the consent must not be able to proceed without it. */
+  onSkip?: () => void
   onCancel: () => void
   width: number
   height: number
@@ -52,9 +61,10 @@ export function ArchiveChoice({ strings: s, suggested, onPick, onCancel, width, 
           { label: s.archiveConsolidate, value: 'consolidate', hint: s.archiveConsolidateHint },
           { label: s.archiveFull, value: 'full', hint: s.archiveFullHint },
           { label: s.archiveOff, value: 'off', hint: s.archiveOffHint },
+          ...(onSkip ? [{ label: s.archiveLater, value: SKIP, hint: s.archiveLaterHint }] : []),
         ]}
         initialIndex={Math.max(0, ORDER.indexOf(suggested))}
-        onSelect={value => onPick(value as ArchiveMode)}
+        onSelect={value => (value === SKIP ? onSkip?.() : onPick(value as ArchiveMode))}
         // Ctrl-C out of `cli-setup.ts` is non-destructive; esc is its equivalent here — the
         // question comes back the next time the host says it is still unanswered.
         onCancel={onCancel}

--- a/packages/tui/src/control/archive-gate.test.ts
+++ b/packages/tui/src/control/archive-gate.test.ts
@@ -1,0 +1,19 @@
+import { test, expect } from 'bun:test'
+import { archiveGateOnOpen } from './archive-gate'
+
+test('asks when the machine has never answered, preselecting what the host recommends', () => {
+  expect(archiveGateOnOpen('consolidate', false)).toEqual({ ask: true, suggested: 'consolidate' })
+})
+
+test('never asks once the choice is on record — a machine coming back up is not asked again', () => {
+  expect(archiveGateOnOpen(null, false)).toEqual({ ask: false })
+  expect(archiveGateOnOpen(null, true)).toEqual({ ask: false })
+})
+
+test('a skip is honoured for the rest of this run — the gate does not re-open behind the user', () => {
+  expect(archiveGateOnOpen('consolidate', true)).toEqual({ ask: false })
+})
+
+test('carries the recommendation through, whatever it is', () => {
+  expect(archiveGateOnOpen('full', false)).toEqual({ ask: true, suggested: 'full' })
+})

--- a/packages/tui/src/control/archive-gate.ts
+++ b/packages/tui/src/control/archive-gate.ts
@@ -1,0 +1,28 @@
+/** PURE: should the control center ask the history question the moment it opens?
+ *
+ *  The consent used to be asked only on the path that STARTS a service from the cockpit. A machine
+ *  enabled at boot — the one people actually set up and forget — never crosses that path, so it ran
+ *  for weeks preserving nothing while its owner had never been asked anything. The dashboard would
+ *  eventually ask, but only when someone opened it; the CLI is where that machine was configured,
+ *  so the CLI is where the question belongs.
+ *
+ *  Two rules, and they are the whole module:
+ *  - `pending === null` means the answer is already on record. Never ask again — a machine coming
+ *    back up must not re-litigate a decision its owner already made.
+ *  - a skip holds for the rest of this run. The user is allowed to decline to decide now; re-opening
+ *    the gate behind them would make the skip a lie and the question a nag. The next launch asks
+ *    again, and the dashboard still gates on it, so nothing is silently left unanswered. */
+import type { ArchiveMode } from './types'
+
+export type ArchiveGate = { ask: false } | { ask: true; suggested: ArchiveMode }
+
+const NO: ArchiveGate = { ask: false }
+
+export function archiveGateOnOpen(
+  /** The host's answer: the recommended mode when the question is open, `null` when it is settled. */
+  pending: ArchiveMode | null,
+  askedThisSession: boolean,
+): ArchiveGate {
+  if (pending === null || askedThisSession) return NO
+  return { ask: true, suggested: pending }
+}

--- a/packages/tui/src/control/i18n.ts
+++ b/packages/tui/src/control/i18n.ts
@@ -169,6 +169,10 @@ export interface ControlStrings {
   archiveFullHint: string
   archiveOff: string
   archiveOffHint: string
+  /** The opening gate's fourth option, and what it costs. Absent from the other callers' menus. */
+  archiveLater: string
+  archiveLaterHint: string
+  archiveLaterMessage: string
   bootQuestion: string
 
   /** Logs tab. */
@@ -297,6 +301,9 @@ const EN: ControlStrings = {
   archiveFullHint: 'archivist — also mirror raw transcripts so you can re-read chats (heavy)',
   archiveOff: 'off',
   archiveOffHint: "do nothing — use Claude's default 30-day cleanup",
+  archiveLater: 'decide later',
+  archiveLaterHint: 'the dashboard will require an answer before it opens',
+  archiveLaterMessage: 'History left unset — the dashboard will ask before it opens.',
   bootQuestion: 'Start it on every boot (systemd user service)?',
 
   logSource: 'SOURCE',
@@ -420,6 +427,9 @@ const PT: ControlStrings = {
   archiveFullHint: 'arquivista — também espelha as transcrições cruas para reler os chats (pesado)',
   archiveOff: 'off',
   archiveOffHint: 'não fazer nada — usar a limpeza padrão de 30 dias do Claude',
+  archiveLater: 'decidir depois',
+  archiveLaterHint: 'a interface vai exigir a resposta antes de abrir',
+  archiveLaterMessage: 'Histórico sem definição — a interface vai perguntar antes de abrir.',
   bootQuestion: 'Iniciar também no boot (serviço systemd de usuário)?',
 
   logSource: 'FONTE',

--- a/packages/tui/src/control/tabs/Services.tsx
+++ b/packages/tui/src/control/tabs/Services.tsx
@@ -35,7 +35,7 @@
  * action DOES: every choice becomes one `host` call.
  */
 
-import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Box, Text, useInput } from 'ink'
 import { truncate } from '../../components/Primitives'
 import { COLORS } from '../../theme'
@@ -81,6 +81,7 @@ import {
 import { Menu } from '../Menu'
 import { OutputView } from '../Output'
 import { ArchiveChoice } from '../ArchiveChoice'
+import { archiveGateOnOpen } from '../archive-gate'
 import { ConfirmPrompt, TextPrompt } from '../Prompt'
 import type { ControlStrings } from '../i18n'
 import type { CliLang } from '../lang'
@@ -173,7 +174,10 @@ type View =
   | { kind: 'kill'; option: StartOption }
   /** `then` is why it was asked: the gate in front of a detached start still has a server to
    *  start afterwards, while the config row was only ever changing a setting. */
-  | { kind: 'archive'; suggested: ArchiveMode; then: StartOption | null }
+  /** `gate` marks the one nobody asked for: the question raised on OPEN, because a machine enabled
+   *  at boot never crosses the start path that used to be the only place it was asked. Only that
+   *  one may be skipped — see `archive-gate.ts`. */
+  | { kind: 'archive'; suggested: ArchiveMode; then: StartOption | null; gate?: boolean }
   | { kind: 'connect'; step: ConnectStep; endpoint: string; token: string }
   | { kind: 'disconnect' }
   /** `runtime` is the one that just started, when this came from a fresh start's boot question —
@@ -305,6 +309,29 @@ export function Services({
   const conflicted = Boolean(selected?.conflict)
 
   const back = useCallback(() => setView({ kind: 'cockpit' }), [])
+
+  /**
+   * The history question, asked on OPEN when it has never been answered.
+   *
+   * `pendingArchiveMode()` is the host's record, so a machine whose owner already chose is never
+   * asked again — including across restarts, which is the whole point. The ref is the second half of
+   * `archiveGateOnOpen`: a skip has to hold for the rest of this run, or declining would re-open the
+   * question on the next repaint and the skip would be a lie.
+   *
+   * It runs once, on mount, and only ever REPLACES the cockpit — never a question already up.
+   */
+  const archiveAsked = useRef(false)
+  useEffect(() => {
+    let alive = true
+    void (async () => {
+      const pending = await host.pendingArchiveMode().catch(() => null)
+      const gate = archiveGateOnOpen(pending, archiveAsked.current)
+      if (!alive || !gate.ask) return
+      archiveAsked.current = true
+      setView(v => (v.kind === 'cockpit' ? { kind: 'archive', suggested: gate.suggested, then: null, gate: true } : v))
+    })()
+    return () => { alive = false }
+  }, [host])
 
   // -------------------------------------------------------------------------
   // actions — every one of them a single host call, none of them decided here
@@ -1155,7 +1182,8 @@ export function Services({
               strings={s}
               suggested={view.suggested}
               onPick={mode => onArchive(mode, view.then)}
-              onCancel={back}
+              onSkip={view.gate ? onArchiveSkip : undefined}
+              onCancel={view.gate ? onArchiveSkip : back}
               width={body}
               height={rows}
               isActive={questionsLive}
@@ -1236,6 +1264,13 @@ export function Services({
 
   function onArchive(mode: ArchiveMode, then: StartOption | null) {
     void run(() => host.setArchiveMode(mode)).then(() => (then ? startNow(then) : back()))
+  }
+
+  /** Skipping the opening gate. It writes NOTHING — the setting stays unanswered on purpose — and
+   *  says so, because a question that vanishes silently reads as one that was answered. */
+  function onArchiveSkip() {
+    back()
+    void run(async () => ({ ok: true, message: s.archiveLaterMessage }))
   }
 
   function onConnect(step: ConnectStep, endpoint: string, token: string, value: string) {


### PR DESCRIPTION
## The problem

The archive/history consent was only ever asked on the path that **starts a service from the cockpit** (`Services.tsx`'s `archiveThen`). A machine enabled at boot — the one people actually set up and forget — never crosses that path. It ran preserving nothing while its owner had never been asked anything. The dashboard does gate on it, but only when somebody opens the dashboard, and that machine had been set up from the CLI.

## The change

The control center raises the question **on open** when it has never been answered. The two rules live in a new pure `control/archive-gate.ts`:

- **`pendingArchiveMode()` is the host's record**, so a machine coming back up is never asked again. Asked once, ever — not once per launch.
- **A skip holds for the rest of the run.** Re-opening the gate behind the user would make the skip a lie and the question a nag. The next launch asks again, and the dashboard still gates, so nothing is left silently unanswered.

Skipping is a menu **row** ("decide later" / "decidir depois"), not an `esc` to guess at, and it states what it costs. It writes nothing — the setting stays unanswered on purpose — and says so in the status line, because a question that vanishes silently reads as one that was answered.

The row is offered **only on the opening gate**. A start that needs the consent must still not be able to proceed without it, so `onSkip` is absent there and the menu has no such row.

## Verification

`scripts/preview.tsx`, EN and PT:

```
╭─ history ──────────────────────────────────────────────────────────╮
│ Preserve session history?                                          │
│ Claude deletes session transcripts older than 30 days.             │
│                                                                    │
│ ❯ 1. consolidate   recommended — store computed per-session metrics│
│   2. full          archivist — also mirror raw transcripts (heavy) │
│   3. off           do nothing — use Claude's 30-day cleanup        │
│   4. decide later  the dashboard will require an answer            │
╰────────────────────────────────────────────────────────────────────╯
```

- pending → question opens by itself, recommendation preselected
- "decide later" → back to the cockpit with `✓ History left unset — the dashboard will ask before it opens.`
- settled machine → not asked at all
- every row fits its column at 100 and 110 cols

`bun tsc --noEmit` clean, **2738 tests pass** (4 new, written failing first). Built and ran the compiled binary, per the TUI rule in CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M4zBaHSDnMiVpEwCfXtpqE