### PR TITLE
fix(tags): stop offering a machine source on a machine

### DIFF
--- a/packages/web/src/lib/tagSourceTypes.test.ts
+++ b/packages/web/src/lib/tagSourceTypes.test.ts
@@ -1,0 +1,15 @@
+import { test, expect } from 'bun:test'
+import { tagSourceTypes } from './tagSourceTypes'
+
+test('a machine offers only the dimensions that exist on it', () => {
+  expect(tagSourceTypes(false)).toEqual(['repo', 'project'])
+})
+
+test('a central offers every dimension', () => {
+  expect(tagSourceTypes(true)).toEqual(['repo', 'project', 'machine', 'team', 'account'])
+})
+
+test('repo and project lead, on both — they are the ones anyone actually picks', () => {
+  expect(tagSourceTypes(true).slice(0, 2)).toEqual(['repo', 'project'])
+  expect(tagSourceTypes(false).slice(0, 2)).toEqual(['repo', 'project'])
+})

--- a/packages/web/src/lib/tagSourceTypes.ts
+++ b/packages/web/src/lib/tagSourceTypes.ts
@@ -1,0 +1,20 @@
+/** PURE: which source dimensions a tag may be built from, here.
+ *
+ *  `team` and `account` need IAM, which only a central has — they were already hidden off one.
+ *  `machine` is the same kind of thing and was not: off a central there is exactly ONE machine, so
+ *  the picker offered a single entry, "This machine", whose tag would cover every session on it.
+ *  That is not a tag, it is "everything", asked for in a way that reads like a real choice — and it
+ *  invited the question "why am I picking a machine while I AM the machine?".
+ *
+ *  Hiding it from the PICKER does not hide it from a tag that already carries it: a machine source
+ *  written on a central still resolves and still renders its label. This is about what can be
+ *  built here, not about what can be read here. */
+export type TagSourceType = 'repo' | 'project' | 'machine' | 'team' | 'account'
+
+/** Repo and project lead because they are what anyone actually reaches for. */
+const MACHINE_TYPES: TagSourceType[] = ['repo', 'project']
+const CENTRAL_TYPES: TagSourceType[] = ['repo', 'project', 'machine', 'team', 'account']
+
+export function tagSourceTypes(isCentral: boolean): TagSourceType[] {
+  return isCentral ? CENTRAL_TYPES : MACHINE_TYPES
+}

--- a/packages/web/src/pages/TagsPage.tsx
+++ b/packages/web/src/pages/TagsPage.tsx
@@ -11,7 +11,7 @@ import { DatePicker } from '../components/DatePicker'
 
 // /api/tags response shapes. Aggregate-only by design (spec rule 2): the server never sends the
 // session rows behind a tag, so everything rendered here is a number the server already computed.
-type TagSourceType = 'repo' | 'project' | 'machine' | 'team' | 'account'
+import { tagSourceTypes, type TagSourceType } from '../lib/tagSourceTypes'
 interface TagSource { type: TagSourceType; value: string }
 interface TagAggregate {
   sessions: number
@@ -51,7 +51,6 @@ const DEFAULT_COLOR = '#f59e0b'
  *  non-central instance knows about, which every local session is attributed to. */
 const LOCAL_MACHINE_ID = 'local'
 /** Source types that only exist where there is IAM. Hidden off a central, and refused there too. */
-const CENTRAL_ONLY_TYPES: TagSourceType[] = ['team', 'account']
 
 /** A label/value pair inside a grid card. */
 function MiniStat({ label, value }: { label: string; value: string }) {
@@ -244,11 +243,8 @@ export default function TagsPage() {
     }
   }, [teamName, accountName, machineName])
 
-  /** Team and account need IAM, which only a central has. */
-  const sourceTypes = useMemo<TagSourceType[]>(() => (
-    (['repo', 'project', 'machine', 'team', 'account'] as TagSourceType[])
-      .filter(t => isCentral || !CENTRAL_ONLY_TYPES.includes(t))
-  ), [isCentral])
+  /** Which dimensions can be picked here — see `tagSourceTypes`. */
+  const sourceTypes = useMemo<TagSourceType[]>(() => tagSourceTypes(isCentral), [isCentral])
 
   const optionsForType = useCallback((t: TagSourceType) => {
     switch (t) {


### PR DESCRIPTION
Half of the tag report — the half I could prove.

## What this fixes

Off a central there is exactly **one** machine, so the tag source picker offered a single entry, `This machine` / `Esta máquina`, whose tag would cover every session on it. That is not a tag, it is "everything", asked for in a way that reads like a real choice — and it invites the obvious question: *why am I picking a machine while I am the machine?*

`machine` is now central-only, like `team` and `account`, which are hidden off a central for the same structural reason (they need IAM). The rule lives in the pure, tested `lib/tagSourceTypes.ts`.

It hides the dimension from the **picker**, not from a tag that already carries it: a machine source written on a central still resolves and still renders its label. The question is what can be *built* here, not what can be *read* here.

## What this does NOT fix

The other half of the report — **sources cannot be selected at all, on central and machine** — is still open. I could not reproduce it from the code, and I will not guess at a fix for a symptom I cannot see fail.

What I ruled out with real data from the reporting machine:

- **Not missing options.** `/api/data` returns 196 sessions, 190 with a `project_path` and 97 with a `git_remote`, so `repoOptions` / `projectOptions` are non-empty.
- **Not a failing endpoint.** `GET /api/tags` answers `200 {"tags":[]}`.
- **Not the section collapsing shut.** `Section` with `hideActions` renders no Edit button, so a section that fell to `editing: false` would be stuck — but `openCreate`/`openEdit` set every one of them to `true`, and nothing sets them back.

Next step is the browser console on an affected instance; the failure is almost certainly a runtime error the server cannot see.

`bun tsc --noEmit` clean, 2760 tests pass (3 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M4zBaHSDnMiVpEwCfXtpqE