### PR TITLE
feat(sessions): "only active", the one switch that narrows

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -892,6 +892,10 @@ packages/tui/scripts/preview.tsx   dev tool: render ONE control-center frame to 
   section part-way was the middle ground and the worst of the three — a block cut to two rows says
   no more than its heading did. The leftover goes to the open section so the column ends flush with
   the list: air under a pane is a fault, air inside one is a pane.
+- **`onlyActive` is the one switch that OVERRIDES the named-row rule**, and the only one on that
+  block that narrows rather than widens — which is why it is listed first: a switch that appears to
+  do nothing is one people conclude is broken. The named rule is right by default (it is what stops
+  a reboot emptying the list), but on a machine with months of named work it shows all of it.
 - **A row the user NAMED is never withheld by the history switches** (`sessionNamed`). A machine
   restart makes every managed session `lost`, and with those switches off — which is how they ship —
   the list came back EMPTY, taking the session you had renamed and filed under a task with it.

--- a/docs/session-manager.md
+++ b/docs/session-manager.md
@@ -84,6 +84,11 @@ history switches. A machine restart makes every managed session `lost`, and with
 list came back empty after a reboot — with the session you had renamed and filed under a task gone,
 and the name with it.
 
+**`only active` (`l`) is the one switch that overrides that**, and it is why it leads the *show*
+block. The rule above is right by default, but on a machine with months of named work it shows all
+of it; this is how you ask for the four things you are actually doing and nothing else. Everything
+else in that block can only ever widen.
+
 `/` searches all of it, including a closed conversation's opening prompt, which is what a person
 actually remembers about work they put down. `esc` drops the search, then the project scope, then the
 task scope — the summary row states what is narrowing the list and which key clears it.

--- a/packages/server/server/preferences.ts
+++ b/packages/server/server/preferences.ts
@@ -58,6 +58,7 @@ export interface Preferences {
     showExited: boolean
     showUnfiled: boolean
     showDone?: boolean
+    onlyActive?: boolean
   }
   /**
    * The session TASKS the user has marked finished.

--- a/packages/tui/src/control/i18n.ts
+++ b/packages/tui/src/control/i18n.ts
@@ -226,6 +226,8 @@ export interface ControlStrings {
   asidePreset: string
   asideAllProjects: string
   toggleDone: string
+  /** The strict switch: only what is running. Overrides the other three. */
+  toggleActive: string
   /** States the active search on the summary row, and how to drop it. */
   sessionsSearching: (query: string) => string
   /** How long ago, from a whole number of SECONDS — the caller does the clock arithmetic so this
@@ -273,6 +275,7 @@ export interface ControlStrings {
   viewTitle: string
   viewGroupBy: string
   viewShow: string
+  viewActiveOn: string
   viewClosedOn: string
   viewClosedOff: string
   viewUnfiledOn: string
@@ -293,6 +296,7 @@ export interface ControlStrings {
   manageHint: string
   promptHint: string
   sessionsHideClosed: string
+  keySessionsActive: string
   keySessionsClosed: string
   keySessionsNoTask: string
   /** How to change screen where the arrows belong to the screen itself. */
@@ -516,6 +520,7 @@ const EN: ControlStrings = {
   asidePreset: 'active · project',
   asideAllProjects: 'every project',
   toggleDone: 'finished tasks',
+  toggleActive: 'only active',
   sessionsSearching: q => `search: ${q} · esc clears`,
   sessionsAgo: (sec: number) => {
     if (sec < 60) return `${sec}s ago`
@@ -563,6 +568,7 @@ const EN: ControlStrings = {
   viewTitle: 'What this list shows',
   viewGroupBy: 'Group by',
   viewShow: 'Show',
+  viewActiveOn: 'everything but active',
   viewClosedOn: 'closed conversations',
   viewClosedOff: 'closed conversations',
   viewUnfiledOn: 'sessions with no task',
@@ -581,6 +587,7 @@ const EN: ControlStrings = {
   manageHint: '↑↓ move · enter run · esc back to the list',
   promptHint: 'enter saves · esc cancels',
   sessionsHideClosed: 'closed: hidden',
+  keySessionsActive: 'l only active',
   keySessionsClosed: 'c closed',
   keySessionsNoTask: 'u unfiled',
   keyTabsAlt: '[ ] screens',
@@ -792,6 +799,7 @@ const PT: ControlStrings = {
   asidePreset: 'ativos · projeto',
   asideAllProjects: 'todos os projetos',
   toggleDone: 'tarefas finalizadas',
+  toggleActive: 'apenas ativas',
   sessionsSearching: q => `busca: ${q} · esc limpa`,
   sessionsAgo: (sec: number) => {
     if (sec < 60) return `há ${sec}s`
@@ -839,6 +847,7 @@ const PT: ControlStrings = {
   viewTitle: 'O que esta lista mostra',
   viewGroupBy: 'Agrupar por',
   viewShow: 'Mostrar',
+  viewActiveOn: 'tudo menos as ativas',
   viewClosedOn: 'conversas fechadas',
   viewClosedOff: 'conversas fechadas',
   viewUnfiledOn: 'sessões sem tarefa',
@@ -857,6 +866,7 @@ const PT: ControlStrings = {
   manageHint: '↑↓ mover · enter executar · esc voltar à lista',
   promptHint: 'enter salva · esc cancela',
   sessionsHideClosed: 'fechadas: ocultas',
+  keySessionsActive: 'l só ativas',
   keySessionsClosed: 'c fechadas',
   keySessionsNoTask: 'u sem tarefa',
   keyTabsAlt: '[ ] telas',

--- a/packages/tui/src/control/sessions.test.ts
+++ b/packages/tui/src/control/sessions.test.ts
@@ -4,7 +4,7 @@ import {
   sessionRows, sortSessions, summaryCells, actionLabels, enabledActionIndexes,
   sessionColumns, sessionsCockpit, asideRows, asideSelectable, projectCounts, projectColumns,
   projectPickRows, groupProjects, asideSections, asideFold, scrollBar, THUMB, TRACK, sessionNamed,
-  sessionHandle, worktreeName,
+  sessionHandle, worktreeName, sessionRunning,
 } from './sessions'
 import type { ControlSession, SessionState } from './types'
 
@@ -514,7 +514,7 @@ describe('asideRows', () => {
     new: 'New', search: 'Search', group: 'Group',
   }
   const groupWords = { repo: 'repo', none: 'flat', task: 'tasks', harness: 'harness', model: 'model', project: 'project' }
-  const toggleWords = { closed: 'closed', exited: 'finished', unfiled: 'no task', done: 'done tasks' }
+  const toggleWords = { closed: 'closed', exited: 'finished', unfiled: 'no task', done: 'done tasks', active: 'only active' }
   const headings = { actions: 'ACTIONS', view: 'VIEW', show: 'SHOW' }
 
   const build = (o: Partial<Parameters<typeof asideRows>[0]> = {}) => asideRows({
@@ -522,7 +522,7 @@ describe('asideRows', () => {
     actionWords: words,
     grouping: 'none',
     groupWords,
-    toggles: { closed: false, exited: false, unfiled: false, done: false },
+    toggles: { closed: false, exited: false, unfiled: false, done: false, active: false },
     toggleWords,
     headings,
     showUnfiled: false,
@@ -539,7 +539,7 @@ describe('asideRows', () => {
   })
 
   it('states every row own state, so nothing must be pressed to be discovered', () => {
-    const rows = build({ grouping: 'task', toggles: { closed: true, exited: false, unfiled: false, done: false } })
+    const rows = build({ grouping: 'task', toggles: { closed: true, exited: false, unfiled: false, done: false, active: false } })
     expect(rows.find(r => r.kind === 'group' && r.value === 'task')).toMatchObject({ on: true })
     expect(rows.find(r => r.kind === 'group' && r.value === 'none')).toMatchObject({ on: false })
     expect(rows.find(r => r.kind === 'toggle' && r.toggle === 'closed')).toMatchObject({ on: true })
@@ -970,7 +970,7 @@ describe('the default-arrangement row', () => {
     repo: 'repository', none: 'flat', task: 'task', harness: 'harness', model: 'model',
     project: 'project',
   }
-  const toggles = { closed: 'closed', exited: 'finished', unfiled: 'no task', done: 'done tasks' }
+  const toggles = { closed: 'closed', exited: 'finished', unfiled: 'no task', done: 'done tasks', active: 'only active' }
   const heads = { actions: 'ACTIONS', view: 'VIEW', show: 'SHOW' }
 
   it('is offered at the head of the VIEW section, and states whether it is on', () => {
@@ -981,7 +981,7 @@ describe('the default-arrangement row', () => {
       actionWords: verbs,
       grouping: 'project',
       groupWords: groups,
-      toggles: { closed: false, exited: false, unfiled: false, done: false },
+      toggles: { closed: false, exited: false, unfiled: false, done: false, active: false },
       toggleWords: toggles,
       headings: heads,
       showUnfiled: false,
@@ -1000,7 +1000,7 @@ describe('the default-arrangement row', () => {
       actionWords: verbs,
       grouping: 'project',
       groupWords: groups,
-      toggles: { closed: false, exited: false, unfiled: false, done: false },
+      toggles: { closed: false, exited: false, unfiled: false, done: false, active: false },
       toggleWords: toggles,
       headings: heads,
       showUnfiled: false,
@@ -1027,5 +1027,51 @@ describe('grouping by project', () => {
   it('falls back to the directory when the session belongs to no repository', () => {
     const g = groupSessions([session('a', { project: 'scratch' })], 'project', UNKNOWN)
     expect(g[0]!.key).toBe('scratch')
+  })
+})
+
+describe('sessionRunning', () => {
+  it('is the three states that mean something is alive on the other end', () => {
+    const at = (state: SessionState) => sessionRunning(session('a', { state }))
+    expect(at('working')).toBe(true)
+    expect(at('waiting')).toBe(true)
+    expect(at('waiting-approval')).toBe(true)
+    // An external process's state cannot be read at all, so it is not evidence of anything.
+    expect(at('unknown')).toBe(false)
+    expect(at('exited')).toBe(false)
+    expect(at('lost')).toBe(false)
+    expect(at('closed')).toBe(false)
+  })
+})
+
+describe('the only-active toggle', () => {
+  const build = (showUnfiled: boolean) => asideRows({
+    actions: sessionActions(session('m')),
+    actionWords: {
+      attach: 'A', resume: 'R', rename: 'N', note: 'O', task: 'T', kill: 'K',
+      openTask: 'OT', finishTask: 'FT', new: 'NW', search: 'S', group: 'G',
+    },
+    grouping: 'project',
+    groupWords: {
+      repo: 'repository', none: 'flat', task: 'task', harness: 'harness', model: 'model',
+      project: 'project',
+    },
+    toggles: { closed: false, exited: false, unfiled: false, done: false, active: true },
+    toggleWords: {
+      closed: 'closed', exited: 'finished', unfiled: 'no task', done: 'done tasks',
+      active: 'only active',
+    },
+    headings: { actions: 'ACTIONS', view: 'VIEW', show: 'SHOW' },
+    showUnfiled,
+  })
+
+  it('leads the SHOW block, because it overrides the three under it', () => {
+    // A switch that appears to do nothing is one people conclude is broken. Listed first it reads
+    // as what it is: the strict answer, with the widening ones beneath.
+    for (const unfiled of [false, true]) {
+      const rows = build(unfiled)
+      const show = rows.findIndex(r => r.kind === 'heading' && r.label === 'SHOW')
+      expect(rows[show + 1]).toMatchObject({ kind: 'toggle', toggle: 'active', on: true })
+    }
   })
 })

--- a/packages/tui/src/control/sessions.ts
+++ b/packages/tui/src/control/sessions.ts
@@ -795,7 +795,18 @@ export type AsideRow =
   | { kind: 'preset'; label: string; on: boolean }
 
 /** The three things the list can be told to withhold. */
-export type SessionToggle = 'closed' | 'exited' | 'unfiled' | 'done'
+export type SessionToggle = 'closed' | 'exited' | 'unfiled' | 'done' | 'active'
+
+/**
+ * Is this session RUNNING right now — PURE.
+ *
+ * The three states that mean something is alive on the other end. `exited`, `lost`, `closed` and
+ * `unknown` (an external process, whose state cannot be read at all) are not running, and the
+ * "only active" switch keeps none of them.
+ */
+export function sessionRunning(s: ControlSession): boolean {
+  return s.state === 'working' || s.state === 'waiting' || s.state === 'waiting-approval'
+}
 
 /**
  * The aside's rows, in reading order — PURE, so what is drawn and what a click resolves against are
@@ -858,9 +869,12 @@ export function asideRows(o: {
   rows.push({ kind: 'rule' }, { kind: 'heading', label: o.headings.show })
   // `done` sits with the other two because it is the same kind of thing — what the list withholds.
   // `unfiled` only means anything while grouping by task and is ABSENT otherwise.
+  // `active` leads because it OVERRIDES the three under it: with it on they change nothing, and a
+  // switch that appears to do nothing is one people conclude is broken. Listed first, it reads as
+  // what it is — the strict answer, with the widening ones beneath.
   const toggles: SessionToggle[] = o.showUnfiled
-    ? ['closed', 'exited', 'done', 'unfiled']
-    : ['closed', 'exited', 'done']
+    ? ['active', 'closed', 'exited', 'done', 'unfiled']
+    : ['active', 'closed', 'exited', 'done']
   for (const t of toggles) {
     rows.push({ kind: 'toggle', toggle: t, label: o.toggleWords[t], on: o.toggles[t] })
   }

--- a/packages/tui/src/control/tabs/Sessions.tsx
+++ b/packages/tui/src/control/tabs/Sessions.tsx
@@ -54,7 +54,7 @@ import {
   GROUPINGS, detailLines, groupSessions, selectableIndexes, sessionCells, sessionRows,
   QUESTION_ROWS, actionLabels, asideRows, asideSelectable, enabledActionIndexes, filterSessions,
   sessionActions, sessionsCockpit, summaryCells, sessionColumns, padCell,
-  taskCounts, projectCounts, sessionMetric, sessionHandle, worktreeName,
+  taskCounts, projectCounts, sessionMetric, sessionHandle, worktreeName, sessionRunning,
   asideSections, asideFold, scrollBar, THUMB,
   sessionNamed,
   type AsideRow, type OfferedAction, type SessionColumns, type SessionToggle,
@@ -133,6 +133,13 @@ export function Sessions({
   // "which project am I looking through right now" is not something a restart should remember.
   const [projectFilter, setProjectFilter] = useState<string | null>(null)
   const [showDone, setShowDone] = useState(view?.showDone ?? DEFAULT_SESSION_VIEW.showDone ?? false)
+  // The strict switch: only what is running, and it OVERRIDES the "a row you named is never hidden"
+  // rule rather than widening alongside the others. That rule is right by default — it is what
+  // stops a reboot emptying the list — but on a machine with months of named work it shows all of
+  // it, and someone who wants the four things they are actually doing had no way to say so.
+  const [onlyActive, setOnlyActive] = useState(
+    view?.onlyActive ?? DEFAULT_SESSION_VIEW.onlyActive ?? false,
+  )
   /**
    * Whether the visible action row has the keyboard.
    *
@@ -176,14 +183,19 @@ export function Sessions({
   const rows = useMemo(() => sessionRows(groupSessions(
     filterSessions(
       (fleet?.sessions ?? []).filter(v =>
-        // What you NAMED, you keep seeing. A machine restart makes every managed session `lost`,
-        // and with the history switches off — which is how they ship — the list came back empty:
-        // the session you had renamed and filed under a task was gone, and so was the name. A row
-        // someone deliberately marked is their work, not anonymous history, so the two switches
-        // withhold everything EXCEPT that.
-        (sessionNamed(v)
-          || ((showClosed || v.state !== 'closed')
-            && (showExited || (v.state !== 'exited' && v.state !== 'lost'))))
+        // ONLY ACTIVE is absolute: it answers the whole question above on its own, named rows
+        // included. Everything else here can only ever widen, and the point of this switch is that
+        // there is finally one that does not.
+        (onlyActive
+          ? sessionRunning(v)
+          // What you NAMED, you keep seeing. A machine restart makes every managed session `lost`,
+          // and with the history switches off — which is how they ship — the list came back empty:
+          // the session you had renamed and filed under a task was gone, and so was the name. A row
+          // someone deliberately marked is their work, not anonymous history, so the two switches
+          // withhold everything EXCEPT that.
+          : sessionNamed(v)
+            || ((showClosed || v.state !== 'closed')
+              && (showExited || (v.state !== 'exited' && v.state !== 'lost'))))
         // Scoped to one task: every verb still works, on the rows inside it.
         && (taskFilter === null || v.task === taskFilter)
         // The project drill-down. Exact, never a prefix — two projects can share a first word.
@@ -208,7 +220,7 @@ export function Sessions({
     fleet?.finishedTasks ?? [],
   ), s.sessionsClosedWord, s.sessionsDoneWord), [
     fleet?.sessions, fleet?.finishedTasks, done, grouping, query, showClosed, showExited,
-    hideEmptyTask, showDone, taskFilter, projectFilter, s,
+    hideEmptyTask, showDone, onlyActive, taskFilter, projectFilter, s,
   ])
 
   const selectable = useMemo(() => selectableIndexes(rows), [rows])
@@ -284,6 +296,7 @@ export function Sessions({
     && showClosed === DEFAULT_SESSION_VIEW.showClosed
     && showExited === DEFAULT_SESSION_VIEW.showExited
     && showDone === (DEFAULT_SESSION_VIEW.showDone ?? false)
+    && onlyActive === (DEFAULT_SESSION_VIEW.onlyActive ?? false)
     && hideEmptyTask === !DEFAULT_SESSION_VIEW.showUnfiled
     && taskFilter === null && projectFilter === null && query === ''
 
@@ -298,9 +311,13 @@ export function Sessions({
     },
     grouping,
     groupWords: s.sessionsGroupings,
-    toggles: { closed: showClosed, exited: showExited, unfiled: !hideEmptyTask, done: showDone },
+    toggles: {
+      closed: showClosed, exited: showExited, unfiled: !hideEmptyTask, done: showDone,
+      active: onlyActive,
+    },
     toggleWords: {
       closed: s.toggleClosed, exited: s.toggleExited, unfiled: s.toggleUnfiled, done: s.toggleDone,
+      active: s.toggleActive,
     },
     headings: { actions: s.asideActions, view: s.asideView, show: s.asideShow },
     presetLabel: s.asidePreset,
@@ -324,8 +341,8 @@ export function Sessions({
       allLabel: s.asideAllProjects,
     },
   }), [
-    actions, grouping, showClosed, showExited, hideEmptyTask, showDone, taskFilter, projectFilter,
-    fleet?.sessions, fleet?.finishedTasks, isDefaultView, s,
+    actions, grouping, showClosed, showExited, hideEmptyTask, showDone, onlyActive, taskFilter,
+    projectFilter, fleet?.sessions, fleet?.finishedTasks, isDefaultView, s,
   ])
 
   const asidePicks = useMemo(() => asideSelectable(asideList), [asideList])
@@ -427,6 +444,7 @@ export function Sessions({
     setShowClosed(DEFAULT_SESSION_VIEW.showClosed)
     setShowExited(DEFAULT_SESSION_VIEW.showExited)
     setShowDone(DEFAULT_SESSION_VIEW.showDone ?? false)
+    setOnlyActive(DEFAULT_SESSION_VIEW.onlyActive ?? false)
     setHideEmptyTask(!DEFAULT_SESSION_VIEW.showUnfiled)
     setTaskFilter(null)
     setProjectFilter(null)
@@ -448,6 +466,7 @@ export function Sessions({
     if (row.toggle === 'closed') return setShowClosed(v => !v)
     if (row.toggle === 'exited') return setShowExited(v => !v)
     if (row.toggle === 'done') return setShowDone(v => !v)
+    if (row.toggle === 'active') return setOnlyActive(v => !v)
     return setHideEmptyTask(v => !v)
   }, [asideList, runAction, resetView])
 
@@ -537,6 +556,7 @@ export function Sessions({
     if (input === 'v') return runAction('group')
     if (input === 'c') { setShowClosed(v => !v); setCursor(0); return }
     if (input === 'e') { setShowExited(v => !v); setCursor(0); return }
+    if (input === 'l') { setOnlyActive(v => !v); setCursor(0); return }
     if (input === 'u' && grouping === 'task') { setHideEmptyTask(v => !v); setCursor(0); return }
     if (input === 'a') return runAction('new')
     // Attaching has its OWN key because `enter` deliberately does not do it any more: enter opens
@@ -575,6 +595,7 @@ export function Sessions({
     // the stored `showClosed` follows, so a preferences file written before this existed opens with
     // finished work put away rather than with the switch inverted.
     setShowDone(view.showDone ?? false)
+    setOnlyActive(view.onlyActive ?? false)
   }, [view])
 
   // Written whenever any part of the arrangement moves, rather than at each call site: four setters
@@ -588,8 +609,8 @@ export function Sessions({
     // stored arrangement was read, and the arrangement was gone. `sessionViewPref` now always
     // answers, so an absent `view` means "not loaded yet" and nothing else.
     if (!restored.current) return
-    onView({ grouping, showClosed, showExited, showUnfiled: !hideEmptyTask, showDone })
-  }, [grouping, showClosed, showExited, hideEmptyTask, showDone, onView, view])
+    onView({ grouping, showClosed, showExited, showUnfiled: !hideEmptyTask, showDone, onlyActive })
+  }, [grouping, showClosed, showExited, hideEmptyTask, showDone, onlyActive, onView, view])
 
   useEffect(() => {
     if (!isActive) return
@@ -900,6 +921,7 @@ export function Sessions({
           width={listBody}
           showClosed={showClosed}
           hideEmptyTask={grouping === 'task' ? hideEmptyTask : null}
+          onlyActive={onlyActive}
           query={query}
           scope={projectFilter ?? taskFilter ?? ''}
         />
@@ -1041,7 +1063,9 @@ export function Sessions({
  * neither findable nor obviously switches. The controls moved to the view panel; this row's job is
  * to state the answer, so a glance tells you why the list looks the way it does.
  */
-function SummaryRow({ fleet, grouping, strings: s, width, showClosed, hideEmptyTask, query, scope }: {
+function SummaryRow({
+  fleet, grouping, strings: s, width, showClosed, hideEmptyTask, onlyActive, query, scope,
+}: {
   fleet: ControlSessions | null | undefined
   grouping: SessionGrouping
   strings: ControlStrings
@@ -1049,6 +1073,8 @@ function SummaryRow({ fleet, grouping, strings: s, width, showClosed, hideEmptyT
   showClosed: boolean
   /** `null` when the setting does not apply — grouping by anything but task. */
   hideEmptyTask: boolean | null
+  /** The strict switch, which withholds more than the other two together. */
+  onlyActive: boolean
   /** The active search, or `''`. Stated HERE because a list narrowed silently reads as an empty one. */
   query: string
   /** The active task or project scope, already localized, or `''`. */
@@ -1062,8 +1088,13 @@ function SummaryRow({ fleet, grouping, strings: s, width, showClosed, hideEmptyT
   // Only the filters that are actually HIDING something are named. A row that lists every setting
   // at its default is noise; one that names what is being withheld is an explanation.
   const hiding: string[] = []
-  if (!showClosed) hiding.push(s.viewClosedOn)
-  if (hideEmptyTask) hiding.push(s.viewUnfiledOn)
+  // The strict switch is stated FIRST and alone: it withholds everything the other two do and more,
+  // so listing them beside it would describe a filter that is not the one in force.
+  if (onlyActive) hiding.push(s.viewActiveOn)
+  else {
+    if (!showClosed) hiding.push(s.viewClosedOn)
+    if (hideEmptyTask) hiding.push(s.viewUnfiledOn)
+  }
 
   // MEASURED, never left to Yoga: a row that wraps takes two of the screen's rows while its budget
   // counted one, and everything below it — the action row, the detail pane, the footer — is pushed

--- a/packages/tui/src/control/types.ts
+++ b/packages/tui/src/control/types.ts
@@ -400,6 +400,15 @@ export interface SessionViewPrefs {
    * never a deletion — the sessions are still there, still attachable, one toggle away.
    */
   showDone?: boolean
+  /**
+   * Show ONLY what is running: working, waiting, waiting on approval. Nothing else, no exceptions.
+   *
+   * The one switch that OVERRIDES the "a row you named is never hidden" rule rather than widening
+   * alongside it. That rule exists so a reboot does not empty the list, and it is right by default —
+   * but it also means a machine with months of named work shows all of it, and someone who wants
+   * the four things they are actually doing had no way to say so. This is that way.
+   */
+  onlyActive?: boolean
 }
 
 /**


### PR DESCRIPTION
Every switch on the sessions screen's **show** block widened the list. There was no way to narrow it.

"A row you named is never withheld" is right by default — it is what stops a reboot emptying the
screen, since a restart takes tmux and leaves the registry, so every managed session comes back
`lost` with its name and task intact. But on a machine with months of named work it shows all of it,
and someone who wants the four things they are actually doing had no way to say so.

`onlyActive` is that way. It keeps **working**, **waiting** and **waiting on approval**, and nothing
else — it OVERRIDES the named-row rule rather than composing with the other switches.

It leads the block for the same reason: with it on, the three beneath it change nothing, and a
switch that appears to do nothing is one people conclude is broken. Listed first it reads as what it
is — the strict answer, with the widening ones underneath.

The summary row states it **alone** rather than beside the others. It withholds everything they do
and more, so listing them together would describe a filter that is not the one in force.

`l` toggles it, it is remembered across runs like every other part of the arrangement, and `ctrl+r`
clears it with the rest.

Tests: 3154 pass. Docs: `docs/session-manager.md`, `CLAUDE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019vBSuKQLuyLhWZS4zbiu2s
