### PR TITLE
feat(sessions): the list opens strict — only active, by project

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -901,8 +901,12 @@ packages/tui/scripts/preview.tsx   dev tool: render ONE control-center frame to 
   the list came back EMPTY, taking the session you had renamed and filed under a task with it.
   `named` is its own flag rather than inferred from `title`, because `title` always has a value: the
   host derives one whenever there is no label.
-- **The default arrangement is stated ONCE** (`DEFAULT_SESSION_VIEW`): active conversations, grouped
-  by project. The host's fallback, the screen's initial state and the `ctrl+r` reset all read it —
+- **The default arrangement is stated ONCE** (`DEFAULT_SESSION_VIEW`): ONLY ACTIVE conversations,
+  grouped by project. It is strict, so when nothing is running it shows an empty list — and the
+  screen must therefore say WHY and name the key that lifts it, since the `lost` rows behind it are
+  still there and still reopenable. The reason is chosen by what actually emptied the list: blaming
+  the filter while a search removed the rows sends someone to the wrong switch, and blaming a search
+  while nothing is running at all would hide that the filter is on. The host's fallback, the screen's initial state and the `ctrl+r` reset all read it —
   three copies of a default is three chances for the app to open on one arrangement and reset to
   another. It is persisted by the HOST (`setSessionView`), and **nothing is written before the
   restore has happened**: `sessionViewPref` always answers, so an absent `view` means "not loaded

--- a/docs/session-manager.md
+++ b/docs/session-manager.md
@@ -95,8 +95,13 @@ task scope — the summary row states what is narrowing the list and which key c
 
 ### The view, and the default
 
-The list opens as **active conversations, grouped by project**, and every change you make is
-remembered across runs. `ctrl+r` puts it back to that default, and so does the row at the top of the
+The list opens as **only active conversations, grouped by project**, and every change you make is
+remembered across runs.
+
+That default is strict on purpose, and has one consequence worth knowing: when nothing is running,
+it shows an empty list. The screen says *why* and names the key that lifts it — the sessions a
+reboot turned into `lost` rows are still there, still named and still reopenable, so "no sessions"
+would be false, and a blank pane under a strict filter is indistinguishable from a broken one. `ctrl+r` puts it back to that default, and so does the row at the top of the
 **view** block — every switch here is sticky, which is also how an arrangement you fiddled with weeks
 ago follows you around, and a key with no row is a feature only the footer knows about.
 

--- a/packages/tui/src/control/i18n.ts
+++ b/packages/tui/src/control/i18n.ts
@@ -187,6 +187,10 @@ export interface ControlStrings {
 
   /** Sessions tab. */
   sessionsEmpty: string
+  /** The list is empty because `only active` is on, and this many sessions are being withheld. */
+  sessionsEmptyActive: (total: number) => string
+  /** The list is empty because a search or a scope is narrowing it. */
+  sessionsEmptyFiltered: string
   sessionsLoading: string
   /** Said when the host does not implement the fleet at all — not the same as an empty fleet. */
   sessionsUnsupported: string
@@ -471,6 +475,9 @@ const EN: ControlStrings = {
   logPaused: 'paused',
 
   sessionsEmpty: 'no sessions running.',
+  sessionsEmptyActive: (total: number) =>
+    `nothing running · ${total} session${total === 1 ? '' : 's'} withheld — l shows them`,
+  sessionsEmptyFiltered: 'nothing matches · esc clears the filter',
   sessionsLoading: 'reading…',
   sessionsUnsupported: 'session management is not available on this machine.',
   sessionsCount: (n: number) => (n === 1 ? '1 session' : `${n} sessions`),
@@ -751,6 +758,9 @@ const PT: ControlStrings = {
   logPaused: 'pausado',
 
   sessionsEmpty: 'nenhuma sessão em execução.',
+  sessionsEmptyActive: (total: number) =>
+    `nada rodando · ${total} ${total === 1 ? 'sessão retida' : 'sessões retidas'} — l mostra`,
+  sessionsEmptyFiltered: 'nada corresponde · esc limpa o filtro',
   sessionsLoading: 'lendo…',
   sessionsUnsupported: 'gerenciamento de sessões não está disponível nesta máquina.',
   sessionsCount: (n: number) => (n === 1 ? '1 sessão' : `${n} sessões`),

--- a/packages/tui/src/control/tabs/Sessions.tsx
+++ b/packages/tui/src/control/tabs/Sessions.tsx
@@ -739,6 +739,21 @@ export function Sessions({
 
   const offset = windowOffset(at < 0 ? 0 : selectable[at]!, rows.length, cockpit.listRows)
   const visible = rows.slice(offset, offset + cockpit.listRows)
+  /**
+   * WHY the list is empty, which is never simply "there is nothing".
+   *
+   * The strict filter is only named when it is genuinely the thing that emptied the list — nothing
+   * is running AND there is a fleet behind it. Blaming it while a search is what removed the rows
+   * sends someone to the wrong switch, and blaming a search while nothing is running at all would
+   * hide the fact that the filter is on. Everything else is the plain sentence.
+   */
+  const runningCount = (fleet?.sessions ?? []).filter(sessionRunning).length
+  const narrowed = Boolean(query || projectFilter !== null || taskFilter !== null)
+  const emptyReason = onlyActive && runningCount === 0 && (fleet?.sessions.length ?? 0) > 0
+    ? s.sessionsEmptyActive(fleet!.sessions.length)
+    : narrowed ? s.sessionsEmptyFiltered
+    : s.sessionsEmpty
+
   // The bar takes a column, so the rows are measured against what is left — a table sized to the
   // full pane and then drawn beside a bar is a table truncated by one character on every row.
   const listBar = scrollBar({ offset, total: rows.length, rows: cockpit.listRows })
@@ -949,8 +964,15 @@ export function Sessions({
         <Text dimColor>{s.sessionsLoading}</Text>
       ) : rows.length === 0 ? (
         // An empty fleet is only ever reported as empty when the poll actually worked. When it did
-        // not, the host's own sentence is what the summary row is already showing.
-        <Text dimColor>{fleet.unavailable ? '' : s.sessionsEmpty}</Text>
+        // not, the host's own sentence is what the summary row is already showing. And a list
+        // emptied by a FILTER says which filter and which key lifts it: the sessions a reboot
+        // turned into `lost` rows are still there, still named and still reopenable, so "no
+        // sessions" would be false — and a blank pane under a strict filter is indistinguishable
+        // from a broken one.
+        <Text dimColor wrap="truncate">
+          {fleet.unavailable ? ''
+            : truncate(emptyReason, listBody)}
+        </Text>
       ) : (
         // NO fixed height: the rows pack upward so nothing sits at the bottom of a tall pane with a
         // field of blank above it. The leftover space belongs at the very bottom of the frame.

--- a/packages/tui/src/control/types.ts
+++ b/packages/tui/src/control/types.ts
@@ -418,10 +418,15 @@ export interface SessionViewPrefs {
  * initial state, and the reset. Three copies of a default is three chances for the app to open on
  * one arrangement and reset to another.
  *
- * Active conversations, grouped by project: the grouping is the directory you are working in, and
- * the two history switches are off, so the list opens as what is happening rather than as
- * everything that ever has. A row the user NAMED is still shown whatever the switches say — see
- * `sessionNamed` — which is what brings a task back after the machine restarts.
+ * Only ACTIVE conversations, grouped by project. The list opens as what is happening rather than as
+ * everything that ever has — and `onlyActive` means that strictly, named rows included, which is
+ * the whole reason it exists.
+ *
+ * The consequence is deliberate and has to be stated somewhere the user can see it: when nothing is
+ * running, this default shows an EMPTY list. It is not empty because the fleet is — the sessions
+ * that a reboot turned into `lost` rows are still there, still named, still reopenable — so the
+ * screen says so in words and names the key that lifts the filter. A blank pane under a strict
+ * filter is indistinguishable from a broken one.
  */
 export const DEFAULT_SESSION_VIEW: SessionViewPrefs = {
   grouping: 'project',
@@ -429,6 +434,7 @@ export const DEFAULT_SESSION_VIEW: SessionViewPrefs = {
   showExited: false,
   showUnfiled: true,
   showDone: false,
+  onlyActive: true,
 }
 
 export interface ControlSessions {


### PR DESCRIPTION
`onlyActive` joins the default arrangement, so `agentop` opens on the sessions that are running and nothing else, grouped by project.

It is strict on purpose and it has one consequence: **when nothing is running, the list is empty.** That is not the fleet being empty — the sessions a reboot turned into `lost` rows are still there, still named, still reopenable — so the screen says *why* and names the key that lifts the filter. A blank pane under a strict filter is indistinguishable from a broken one.

The reason is chosen by what actually emptied the list. Naming the filter while a search is what removed the rows sends someone to the wrong switch; naming the search while nothing is running at all would hide that the filter is on.

Follows #87, which added the switch. Tests: 3154 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019vBSuKQLuyLhWZS4zbiu2s