### PR TITLE
fix(sessions): the menu cursor is a row, not a number

### DIFF
--- a/docs/session-manager.md
+++ b/docs/session-manager.md
@@ -101,9 +101,8 @@ remembered across runs.
 That default is strict on purpose, and has one consequence worth knowing: when nothing is running,
 it shows an empty list. The screen says *why* and names the key that lifts it — the sessions a
 reboot turned into `lost` rows are still there, still named and still reopenable, so "no sessions"
-would be false, and a blank pane under a strict filter is indistinguishable from a broken one. `ctrl+r` puts it back to that default, and so does the row at the top of the
-**view** block — every switch here is sticky, which is also how an arrangement you fiddled with weeks
-ago follows you around, and a key with no row is a feature only the footer knows about.
+would be false, and a blank pane under a strict filter is indistinguishable from a broken one. `ctrl+r` puts it back to that default — every switch here is sticky, which
+is also how an arrangement you fiddled with weeks ago follows you around.
 
 Grouping by **repository** is the other useful one: a session is opened in a directory, but the thing
 a person thinks in is the repository, and three worktrees of `agentistics` are three places to work

--- a/packages/tui/src/control/i18n.ts
+++ b/packages/tui/src/control/i18n.ts
@@ -226,8 +226,6 @@ export interface ControlStrings {
   sessionsFinishConfirm: (task: string, count: number) => string
   sessionsReopenConfirm: (task: string) => string
   asideProjects: string
-  /** The default arrangement, offered as one row: what the list opens as. */
-  asidePreset: string
   asideAllProjects: string
   toggleDone: string
   /** The strict switch: only what is running. Overrides the other three. */
@@ -524,7 +522,6 @@ const EN: ControlStrings = {
     `Mark "${task}" finished? Its ${count} session${count === 1 ? '' : 's'} stay listed behind the "finished tasks" switch.`,
   sessionsReopenConfirm: task => `Reopen "${task}"?`,
   asideProjects: 'PROJECTS',
-  asidePreset: 'active · project',
   asideAllProjects: 'every project',
   toggleDone: 'finished tasks',
   toggleActive: 'only active',
@@ -806,7 +803,6 @@ const PT: ControlStrings = {
     `Finalizar "${task}"? Suas ${count} sessõe${count === 1 ? '' : 's'} continuam listadas atrás do interruptor "tarefas finalizadas".`,
   sessionsReopenConfirm: task => `Reabrir "${task}"?`,
   asideProjects: 'PROJETOS',
-  asidePreset: 'ativos · projeto',
   asideAllProjects: 'todos os projetos',
   toggleDone: 'tarefas finalizadas',
   toggleActive: 'apenas ativas',

--- a/packages/tui/src/control/sessions.test.ts
+++ b/packages/tui/src/control/sessions.test.ts
@@ -4,7 +4,7 @@ import {
   sessionRows, sortSessions, summaryCells, actionLabels, enabledActionIndexes,
   sessionColumns, sessionsCockpit, asideRows, asideSelectable, projectCounts, projectColumns,
   projectPickRows, groupProjects, asideSections, asideFold, scrollBar, THUMB, TRACK, sessionNamed,
-  sessionHandle, worktreeName, sessionRunning,
+  sessionHandle, worktreeName, sessionRunning, asideRowKey, resolveAsideCursor,
 } from './sessions'
 import type { ControlSession, SessionState } from './types'
 
@@ -960,55 +960,6 @@ describe('sessionNamed', () => {
   })
 })
 
-describe('the default-arrangement row', () => {
-  const verbs = {
-    attach: 'Attach', resume: 'Reopen', rename: 'Rename', note: 'Note', task: 'Task',
-    kill: 'Stop', openTask: 'Open whole task', finishTask: 'Finish task',
-    new: 'New', search: 'Search', group: 'Group',
-  }
-  const groups = {
-    repo: 'repository', none: 'flat', task: 'task', harness: 'harness', model: 'model',
-    project: 'project',
-  }
-  const toggles = { closed: 'closed', exited: 'finished', unfiled: 'no task', done: 'done tasks', active: 'only active' }
-  const heads = { actions: 'ACTIONS', view: 'VIEW', show: 'SHOW' }
-
-  it('is offered at the head of the VIEW section, and states whether it is on', () => {
-    // A key with no row is a feature only the footer knows about — and this menu exists precisely
-    // so that nothing on the screen is reachable by keystroke alone.
-    const rows = asideRows({
-      actions: sessionActions(session('m')),
-      actionWords: verbs,
-      grouping: 'project',
-      groupWords: groups,
-      toggles: { closed: false, exited: false, unfiled: false, done: false, active: false },
-      toggleWords: toggles,
-      headings: heads,
-      showUnfiled: false,
-      presetLabel: 'active · project',
-      presetOn: true,
-    })
-    const view = rows.findIndex(r => r.kind === 'heading' && r.label === 'VIEW')
-    const preset = rows[view + 1]
-    expect(preset?.kind).toBe('preset')
-    expect(preset).toMatchObject({ label: 'active · project', on: true })
-  })
-
-  it('is absent when the caller does not offer one', () => {
-    const rows = asideRows({
-      actions: sessionActions(session('m')),
-      actionWords: verbs,
-      grouping: 'project',
-      groupWords: groups,
-      toggles: { closed: false, exited: false, unfiled: false, done: false, active: false },
-      toggleWords: toggles,
-      headings: heads,
-      showUnfiled: false,
-    })
-    expect(rows.some(r => r.kind === 'preset')).toBe(false)
-  })
-})
-
 describe('grouping by project', () => {
   it('files a WORKTREE under the project it belongs to, not under its own folder', () => {
     // Three worktrees of one repository are three places to work on ONE project. Keying on the
@@ -1073,5 +1024,57 @@ describe('the only-active toggle', () => {
       const show = rows.findIndex(r => r.kind === 'heading' && r.label === 'SHOW')
       expect(rows[show + 1]).toMatchObject({ kind: 'toggle', toggle: 'active', on: true })
     }
+  })
+})
+
+describe('resolveAsideCursor', () => {
+  const rows: Parameters<typeof resolveAsideCursor>[0] = [
+    { kind: 'heading', label: 'ACTIONS' },
+    { kind: 'action', action: 'attach', label: 'Attach', enabled: true },
+    { kind: 'action', action: 'kill', label: 'Stop', enabled: true },
+    { kind: 'rule' },
+    { kind: 'heading', label: 'VIEW' },
+    { kind: 'group', value: 'project', label: 'project', on: true },
+    { kind: 'toggle', toggle: 'active', label: 'only active', on: true },
+  ]
+
+  it('keeps the cursor on the SAME row when the list is rebuilt around it', () => {
+    // The cursor used to be an index into the selectable rows, and which verbs are enabled depends
+    // on the selected session — so moving down the fleet renumbered every row beneath the actions
+    // block and the menu cursor jumped, usually into the first section, which then opened.
+    const shorter: typeof rows = [
+      { kind: 'heading', label: 'ACTIONS' },
+      { kind: 'action', action: 'resume', label: 'Reopen', enabled: true },
+      { kind: 'rule' },
+      { kind: 'heading', label: 'VIEW' },
+      { kind: 'group', value: 'project', label: 'project', on: true },
+      { kind: 'toggle', toggle: 'active', label: 'only active', on: true },
+    ]
+    expect(asideRowKey(rows[6]!)).toBe('toggle:active')
+    expect(resolveAsideCursor(shorter, 'toggle:active')).toBe(5)
+    expect(asideRowKey(shorter[5]!)).toBe('toggle:active')
+  })
+
+  it('lands on the NEAREST selectable row when its own row is gone', () => {
+    // A verb that becomes unavailable moves the cursor one place, never to the top of the menu —
+    // the top is in the first section, and landing there opens it.
+    const without: typeof rows = rows.filter(r => !(r.kind === 'action' && r.action === 'kill'))
+    const at = resolveAsideCursor(without, 'action:kill')
+    expect(at).toBeGreaterThan(0)
+    expect(without[at]!.kind).not.toBe('heading')
+  })
+
+  it('never lands on a heading, a rule, or a disabled verb', () => {
+    const disabled: typeof rows = rows.map(r =>
+      r.kind === 'action' && r.action === 'kill' ? { ...r, enabled: false } : r)
+    const at = resolveAsideCursor(disabled, 'action:kill')
+    const row = disabled[at]!
+    expect(row.kind).not.toBe('heading')
+    expect(row.kind).not.toBe('rule')
+    if (row.kind === 'action') expect(row.enabled).toBe(true)
+  })
+
+  it('reports -1 when there is nothing to land on at all', () => {
+    expect(resolveAsideCursor([{ kind: 'heading', label: 'X' }], 'action:attach')).toBe(-1)
   })
 })

--- a/packages/tui/src/control/sessions.ts
+++ b/packages/tui/src/control/sessions.ts
@@ -784,15 +784,7 @@ export type AsideRow =
   | { kind: 'task'; name: string; count: number; on: boolean; done?: boolean }
   /** One project directory, with its session count. `name: ''` is "every project". */
   | { kind: 'project'; name: string; count: number; on: boolean }
-  /**
-   * The DEFAULT arrangement, as one press.
-   *
-   * Every switch on this screen is remembered, which is what people asked for and also what makes
-   * an arrangement you fiddled with weeks ago follow you around. `ctrl+r` restores it, but a key
-   * with no row is a feature only the footer knows about — and this menu exists precisely so that
-   * nothing is reachable by keystroke alone.
-   */
-  | { kind: 'preset'; label: string; on: boolean }
+
 
 /** The three things the list can be told to withhold. */
 export type SessionToggle = 'closed' | 'exited' | 'unfiled' | 'done' | 'active'
@@ -824,10 +816,6 @@ export function asideRows(o: {
   toggles: Record<SessionToggle, boolean>
   toggleWords: Record<SessionToggle, string>
   headings: { actions: string; view: string; show: string }
-  /** Already-localized name of the default arrangement, when the menu should offer it. */
-  presetLabel?: string
-  /** Whether the list is currently arranged exactly that way. */
-  presetOn?: boolean
   /** `unfiled` only means anything while grouping by task, so it is ABSENT otherwise. */
   showUnfiled: boolean
   /**
@@ -860,9 +848,6 @@ export function asideRows(o: {
     rows.push({ kind: 'action', action: a.action, label: o.actionWords[a.action], enabled: a.enabled })
   }
   rows.push({ kind: 'rule' }, { kind: 'heading', label: o.headings.view })
-  if (o.presetLabel !== undefined) {
-    rows.push({ kind: 'preset', label: o.presetLabel, on: o.presetOn === true })
-  }
   for (const g of GROUPINGS) {
     rows.push({ kind: 'group', value: g, label: o.groupWords[g], on: g === o.grouping })
   }
@@ -936,6 +921,48 @@ export function taskCounts(list: readonly ControlSession[]): Array<{ name: strin
   return [...counts.entries()]
     .map(([name, count]) => ({ name, count }))
     .sort((a, b) => (b.count - a.count) || a.name.localeCompare(b.name))
+}
+
+/**
+ * A stable NAME for a menu row, so a cursor can survive the list being rebuilt — PURE.
+ *
+ * The cursor used to be an index into the SELECTABLE rows, and that list changes composition
+ * constantly: which verbs are enabled depends on the selected session, so moving down the fleet
+ * silently renumbered every row beneath the actions block and the menu cursor jumped — usually back
+ * into the first section, which then opened. An index is not an identity.
+ *
+ * Keyed by kind and by what the row acts on, never by position.
+ */
+export function asideRowKey(row: AsideRow): string {
+  switch (row.kind) {
+    case 'action': return `action:${row.action}`
+    case 'group': return `group:${row.value}`
+    case 'toggle': return `toggle:${row.toggle}`
+    case 'task': return `task:${row.name}`
+    case 'project': return `project:${row.name}`
+    case 'heading': return `heading:${row.label}`
+    case 'rule': return 'rule'
+  }
+}
+
+/**
+ * Where the cursor lands after the menu is rebuilt — PURE.
+ *
+ * The SAME row when it is still there and still selectable; otherwise the nearest selectable row to
+ * where it was, so a verb that becomes unavailable moves the cursor by one place rather than to the
+ * top of the menu.
+ */
+export function resolveAsideCursor(rows: readonly AsideRow[], wanted: string): number {
+  const picks = asideSelectable(rows)
+  if (picks.length === 0) return -1
+  const exact = picks.find(i => asideRowKey(rows[i]!) === wanted)
+  if (exact !== undefined) return exact
+  // Not there any more: fall back to where it WAS, which for a disabled verb is the row that took
+  // its place. Never the top — a cursor that jumps to the first section makes that section open.
+  const previous = rows.findIndex(r => asideRowKey(r) === wanted)
+  if (previous < 0) return picks[0]!
+  return picks.reduce((best, i) =>
+    Math.abs(i - previous) < Math.abs(best - previous) ? i : best, picks[0]!)
 }
 
 /** Index of the nth row the cursor may land on: never a heading, a rule, or a disabled action. */

--- a/packages/tui/src/control/tabs/Sessions.tsx
+++ b/packages/tui/src/control/tabs/Sessions.tsx
@@ -52,7 +52,8 @@ import { SessionWizard } from './SessionWizard'
 import { TaskChoice } from '../TaskChoice'
 import {
   GROUPINGS, detailLines, groupSessions, selectableIndexes, sessionCells, sessionRows,
-  QUESTION_ROWS, actionLabels, asideRows, asideSelectable, enabledActionIndexes, filterSessions,
+  QUESTION_ROWS, actionLabels, asideRows, asideSelectable, asideRowKey, resolveAsideCursor,
+  enabledActionIndexes, filterSessions,
   sessionActions, sessionsCockpit, summaryCells, sessionColumns, padCell,
   taskCounts, projectCounts, sessionMetric, sessionHandle, worktreeName, sessionRunning,
   asideSections, asideFold, scrollBar, THUMB,
@@ -177,7 +178,15 @@ export function Sessions({
   const [taskFilter, setTaskFilter] = useState<string | null>(null)
   /** Which pane has the keyboard. The aside is a real pane, not a strip of hints. */
   const [focus, setFocus] = useState<'list' | 'aside'>('list')
-  const [asideIndex, setAsideIndex] = useState(0)
+  /**
+   * WHICH ROW the menu cursor is on, by name rather than by position.
+   *
+   * It used to be an index into the selectable rows, and that list changes composition constantly —
+   * which verbs are enabled depends on the selected session — so moving down the fleet renumbered
+   * every row beneath the actions block and the menu cursor jumped, usually back into the first
+   * section, which then opened. An index is not an identity.
+   */
+  const [asideKey, setAsideKey] = useState('action:attach')
 
   const done = useMemo(() => new Set(fleet?.finishedTasks ?? []), [fleet?.finishedTasks])
   const rows = useMemo(() => sessionRows(groupSessions(
@@ -290,16 +299,6 @@ export function Sessions({
     group: s.actSessions.group,
   }), [actions, s])
 
-  // Whether the list is arranged exactly as the app opens. Compared against the ONE default rather
-  // than against a second copy of it, so the row cannot claim to be on while it is not.
-  const isDefaultView = grouping === DEFAULT_SESSION_VIEW.grouping
-    && showClosed === DEFAULT_SESSION_VIEW.showClosed
-    && showExited === DEFAULT_SESSION_VIEW.showExited
-    && showDone === (DEFAULT_SESSION_VIEW.showDone ?? false)
-    && onlyActive === (DEFAULT_SESSION_VIEW.onlyActive ?? false)
-    && hideEmptyTask === !DEFAULT_SESSION_VIEW.showUnfiled
-    && taskFilter === null && projectFilter === null && query === ''
-
   const asideList = useMemo(() => asideRows({
     actions,
     actionWords: {
@@ -320,8 +319,6 @@ export function Sessions({
       active: s.toggleActive,
     },
     headings: { actions: s.asideActions, view: s.asideView, show: s.asideShow },
-    presetLabel: s.asidePreset,
-    presetOn: isDefaultView,
     showUnfiled: grouping === 'task',
     tasks: {
       // Counted over the WHOLE fleet: the count is what says a task has work in it, and counting
@@ -342,15 +339,22 @@ export function Sessions({
     },
   }), [
     actions, grouping, showClosed, showExited, hideEmptyTask, showDone, onlyActive, taskFilter,
-    projectFilter, fleet?.sessions, fleet?.finishedTasks, isDefaultView, s,
+    projectFilter, fleet?.sessions, fleet?.finishedTasks, s,
   ])
 
   const asidePicks = useMemo(() => asideSelectable(asideList), [asideList])
+  // Re-resolved on every render against the list as it now is, so nothing has to remember to fix
+  // the cursor after a rebuild.
+  const asideRow = resolveAsideCursor(asideList, asideKey)
+  const asideAt = asidePicks.indexOf(asideRow)
+  /** Move the cursor by NAME — the one setter every key, click and jump goes through. */
+  const setAsideRow = useCallback((index: number) => {
+    const row = asideList[index]
+    if (row) setAsideKey(asideRowKey(row))
+  }, [asideList])
   // The menu's titled blocks, derived from the same flat list the cursor walks.
   const sections = useMemo(() => asideSections(asideList), [asideList])
 
-  const asideAt = asidePicks.length === 0 ? -1 : Math.min(asideIndex, asidePicks.length - 1)
-  const asideRow = asideAt < 0 ? -1 : asidePicks[asideAt]!
 
   const asideLabel = useMemo(
     () => asideList.reduce((n, r) => Math.max(n, 'label' in r ? r.label.length + 2 : 0), 0),
@@ -430,8 +434,8 @@ export function Sessions({
     if (target === undefined) return
     setFocus('aside')
     setActionsFocused(false)
-    setAsideIndex(Math.max(0, asidePicks.indexOf(target)))
-  }, [sections, asidePicks])
+    setAsideRow(target)
+  }, [sections, setAsideRow])
 
   /**
    * Put the arrangement back to how the app opens on a fresh machine.
@@ -460,7 +464,6 @@ export function Sessions({
     if (row.kind === 'group') { setGrouping(row.value); setCursor(0); return }
     if (row.kind === 'task') { setTaskFilter(row.name || null); setCursor(0); return }
     if (row.kind === 'project') { setProjectFilter(row.name || null); setCursor(0); return }
-    if (row.kind === 'preset') return resetView()
     if (row.kind !== 'toggle') return
     setCursor(0)
     if (row.toggle === 'closed') return setShowClosed(v => !v)
@@ -511,8 +514,8 @@ export function Sessions({
         const step = key.rightArrow ? 1 : -1
         return gotoSection((activeSection + step + sections.length) % sections.length)
       }
-      if (key.upArrow || input === 'k') return setAsideIndex(Math.max(0, asideAt - 1))
-      if (key.downArrow || input === 'j') return setAsideIndex(Math.min(asidePicks.length - 1, asideAt + 1))
+      if (key.upArrow || input === 'k') return setAsideRow(asidePicks[Math.max(0, asideAt - 1)] ?? asideRow)
+      if (key.downArrow || input === 'j') return setAsideRow(asidePicks[Math.min(asidePicks.length - 1, asideAt + 1)] ?? asideRow)
       return
     }
 
@@ -533,7 +536,10 @@ export function Sessions({
     if (key.return) {
       if (cockpit.aside > 0 && selected) {
         setFocus('aside')
-        setAsideIndex(0)
+        // The first verb this row can actually take, by name — the row-specific verb is `attach`
+        // on a running session and `resume` on everything else, so a fixed index would land on
+        // whichever happened to be first.
+        setAsideRow(asidePicks[0] ?? 0)
         return
       }
       // No menu to move to on a narrow terminal, so enter keeps its old meaning there.
@@ -699,7 +705,7 @@ export function Sessions({
       if (!row || row.kind === 'heading' || row.kind === 'rule') return
       if (row.kind === 'action' && !row.enabled) return
       setFocus('aside')
-      setAsideIndex(Math.max(0, asidePicks.indexOf(index)))
+      setAsideRow(index)
       runAside(index)
       return
     }


### PR DESCRIPTION
Flipping a switch jumped the menu cursor back into the first section, which then opened.

The cursor was an **index** into the selectable rows, and that list changes composition constantly — which verbs are enabled depends on the selected session, and a session that stops running trades `attach` for `resume` — so every row beneath the actions block was silently renumbered under it. An index is not an identity.

It is a **name** now (`asideRowKey`), re-resolved on every render against the list as it currently is, so nothing has to remember to fix the cursor after a rebuild. When the row it names is gone, `resolveAsideCursor` lands on the nearest selectable row to where it *was* rather than on the first one — the first row is in the first section, and landing there is exactly what opened it.

The combined "active · project" row is gone from the view block. Both halves of it are separate switches that now ship on by default, so the row was a third control for a state the other two already show, and one more thing that could disagree with them. `ctrl+r` still restores the default.

Tests: 3156 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019vBSuKQLuyLhWZS4zbiu2s