### PR TITLE
feat(sessions): order, filter by state, hide the detail pane, mark a row

### DIFF
--- a/docs/session-manager.md
+++ b/docs/session-manager.md
@@ -84,6 +84,21 @@ history switches. A machine restart makes every managed session `lost`, and with
 list came back empty after a reboot — with the session you had renamed and filed under a task gone,
 and the name with it.
 
+The **state** block is the finer answer: one row per state — needs approval, waiting, working,
+exited, lost, closed, external — each with how many sessions wear it, ticked or not. Ticking any of
+them replaces the two switches entirely; unticking the last one falls back to them rather than
+showing nothing, which is never what unticking a box means.
+
+The **order** block sorts by urgency (the default — what is blocked on you, first), name, start
+time, usage or project. Picking the order already in force flips its direction, which is the gesture
+every table has and the only one that does not need a second control. Every key keeps state as its
+tiebreak: a screen sorted by name that buries a session waiting on approval among nine idle ones has
+lost the thing it is for.
+
+The detail pane has its own switch (`d`). It is a pane, not a fact, and a screen is allowed to be a
+list — but a QUESTION still takes the region whatever the switch says, because a prompt with nowhere
+to draw cannot be answered.
+
 **`only active` (`l`) is the one switch that overrides that**, and it is why it leads the *show*
 block. The rule above is right by default, but on a machine with months of named work it shows all
 of it; this is how you ask for the four things you are actually doing and nothing else. Everything

--- a/docs/session-manager.md
+++ b/docs/session-manager.md
@@ -95,6 +95,13 @@ every table has and the only one that does not need a second control. Every key 
 tiebreak: a screen sorted by name that buries a session waiting on approval among nine idle ones has
 lost the thing it is for.
 
+`space` **marks a row** — a highlighter, not a selection. The mark is a bar in the gutter beside the
+cursor caret, in a different colour from the accent (which means *focus* everywhere else in this
+app, so a highlight wearing it would read as "this is selected" on four rows at once), plus the name
+in that colour. It is kept by session id, because the list re-sorts under it every five seconds and
+a mark meaning "the third row" would be on someone else's session by the next poll — and it survives
+detaching, which is exactly when you needed it.
+
 The detail pane has its own switch (`d`). It is a pane, not a fact, and a screen is allowed to be a
 list — but a QUESTION still takes the region whatever the switch says, because a prompt with nowhere
 to draw cannot be answered.

--- a/packages/server/server/preferences.ts
+++ b/packages/server/server/preferences.ts
@@ -62,6 +62,7 @@ export interface Preferences {
     states?: string[]
     sort?: { by: string; dir: 'asc' | 'desc' }
     hideDetail?: boolean
+    marked?: string[]
   }
   /**
    * The session TASKS the user has marked finished.

--- a/packages/server/server/preferences.ts
+++ b/packages/server/server/preferences.ts
@@ -59,6 +59,9 @@ export interface Preferences {
     showUnfiled: boolean
     showDone?: boolean
     onlyActive?: boolean
+    states?: string[]
+    sort?: { by: string; dir: 'asc' | 'desc' }
+    hideDetail?: boolean
   }
   /**
    * The session TASKS the user has marked finished.

--- a/packages/tui/src/control/i18n.ts
+++ b/packages/tui/src/control/i18n.ts
@@ -308,6 +308,7 @@ export interface ControlStrings {
   sessionsHideClosed: string
   keySessionsActive: string
   keySessionsDetail: string
+  keySessionsMark: string
   keySessionsClosed: string
   keySessionsNoTask: string
   /** How to change screen where the arrows belong to the screen itself. */
@@ -617,6 +618,7 @@ const EN: ControlStrings = {
   sessionsHideClosed: 'closed: hidden',
   keySessionsActive: 'l only active',
   keySessionsDetail: 'd detail',
+  keySessionsMark: 'space mark',
   keySessionsClosed: 'c closed',
   keySessionsNoTask: 'u unfiled',
   keyTabsAlt: '[ ] screens',
@@ -914,6 +916,7 @@ const PT: ControlStrings = {
   sessionsHideClosed: 'fechadas: ocultas',
   keySessionsActive: 'l só ativas',
   keySessionsDetail: 'd detalhe',
+  keySessionsMark: 'space marcar',
   keySessionsClosed: 'c fechadas',
   keySessionsNoTask: 'u sem tarefa',
   keyTabsAlt: '[ ] telas',

--- a/packages/tui/src/control/i18n.ts
+++ b/packages/tui/src/control/i18n.ts
@@ -230,6 +230,14 @@ export interface ControlStrings {
   toggleDone: string
   /** The strict switch: only what is running. Overrides the other three. */
   toggleActive: string
+  /** The detail pane's own switch: it is a pane, not a fact, and a screen is allowed to be a list. */
+  toggleDetail: string
+  asideSort: string
+  asideStates: string
+  sessionsSorts: Record<'state' | 'name' | 'started' | 'usage' | 'project', string>
+  sessionsStates: Record<
+    'working' | 'waiting' | 'waiting-approval' | 'exited' | 'lost' | 'closed' | 'unknown', string
+  >
   /** States the active search on the summary row, and how to drop it. */
   sessionsSearching: (query: string) => string
   /** How long ago, from a whole number of SECONDS — the caller does the clock arithmetic so this
@@ -299,6 +307,7 @@ export interface ControlStrings {
   promptHint: string
   sessionsHideClosed: string
   keySessionsActive: string
+  keySessionsDetail: string
   keySessionsClosed: string
   keySessionsNoTask: string
   /** How to change screen where the arrows belong to the screen itself. */
@@ -525,6 +534,21 @@ const EN: ControlStrings = {
   asideAllProjects: 'every project',
   toggleDone: 'finished tasks',
   toggleActive: 'only active',
+  toggleDetail: 'detail pane',
+  asideSort: 'ORDER',
+  asideStates: 'STATE',
+  sessionsSorts: {
+    state: 'urgency', name: 'name', started: 'started', usage: 'usage', project: 'project',
+  },
+  sessionsStates: {
+    'waiting-approval': 'needs approval',
+    waiting: 'waiting',
+    working: 'working',
+    exited: 'exited',
+    lost: 'lost',
+    closed: 'closed',
+    unknown: 'external',
+  },
   sessionsSearching: q => `search: ${q} · esc clears`,
   sessionsAgo: (sec: number) => {
     if (sec < 60) return `${sec}s ago`
@@ -592,6 +616,7 @@ const EN: ControlStrings = {
   promptHint: 'enter saves · esc cancels',
   sessionsHideClosed: 'closed: hidden',
   keySessionsActive: 'l only active',
+  keySessionsDetail: 'd detail',
   keySessionsClosed: 'c closed',
   keySessionsNoTask: 'u unfiled',
   keyTabsAlt: '[ ] screens',
@@ -806,6 +831,21 @@ const PT: ControlStrings = {
   asideAllProjects: 'todos os projetos',
   toggleDone: 'tarefas finalizadas',
   toggleActive: 'apenas ativas',
+  toggleDetail: 'painel de detalhe',
+  asideSort: 'ORDENAR',
+  asideStates: 'ESTADO',
+  sessionsSorts: {
+    state: 'urgência', name: 'nome', started: 'início', usage: 'uso', project: 'projeto',
+  },
+  sessionsStates: {
+    'waiting-approval': 'precisa aprovação',
+    waiting: 'aguardando',
+    working: 'trabalhando',
+    exited: 'encerrada',
+    lost: 'perdida',
+    closed: 'fechada',
+    unknown: 'externa',
+  },
   sessionsSearching: q => `busca: ${q} · esc limpa`,
   sessionsAgo: (sec: number) => {
     if (sec < 60) return `há ${sec}s`
@@ -873,6 +913,7 @@ const PT: ControlStrings = {
   promptHint: 'enter salva · esc cancela',
   sessionsHideClosed: 'fechadas: ocultas',
   keySessionsActive: 'l só ativas',
+  keySessionsDetail: 'd detalhe',
   keySessionsClosed: 'c fechadas',
   keySessionsNoTask: 'u sem tarefa',
   keyTabsAlt: '[ ] telas',

--- a/packages/tui/src/control/sessions.test.ts
+++ b/packages/tui/src/control/sessions.test.ts
@@ -5,6 +5,7 @@ import {
   sessionColumns, sessionsCockpit, asideRows, asideSelectable, projectCounts, projectColumns,
   projectPickRows, groupProjects, asideSections, asideFold, scrollBar, THUMB, TRACK, sessionNamed,
   sessionHandle, worktreeName, sessionRunning, asideRowKey, resolveAsideCursor,
+  DEFAULT_ORDER, usageOf,
 } from './sessions'
 import type { ControlSession, SessionState } from './types'
 
@@ -514,7 +515,7 @@ describe('asideRows', () => {
     new: 'New', search: 'Search', group: 'Group',
   }
   const groupWords = { repo: 'repo', none: 'flat', task: 'tasks', harness: 'harness', model: 'model', project: 'project' }
-  const toggleWords = { closed: 'closed', exited: 'finished', unfiled: 'no task', done: 'done tasks', active: 'only active' }
+  const toggleWords = { closed: 'closed', exited: 'finished', unfiled: 'no task', done: 'done tasks', active: 'only active', detail: 'detail' }
   const headings = { actions: 'ACTIONS', view: 'VIEW', show: 'SHOW' }
 
   const build = (o: Partial<Parameters<typeof asideRows>[0]> = {}) => asideRows({
@@ -522,7 +523,7 @@ describe('asideRows', () => {
     actionWords: words,
     grouping: 'none',
     groupWords,
-    toggles: { closed: false, exited: false, unfiled: false, done: false, active: false },
+    toggles: { closed: false, exited: false, unfiled: false, done: false, active: false, detail: false },
     toggleWords,
     headings,
     showUnfiled: false,
@@ -539,7 +540,7 @@ describe('asideRows', () => {
   })
 
   it('states every row own state, so nothing must be pressed to be discovered', () => {
-    const rows = build({ grouping: 'task', toggles: { closed: true, exited: false, unfiled: false, done: false, active: false } })
+    const rows = build({ grouping: 'task', toggles: { closed: true, exited: false, unfiled: false, done: false, active: false, detail: false } })
     expect(rows.find(r => r.kind === 'group' && r.value === 'task')).toMatchObject({ on: true })
     expect(rows.find(r => r.kind === 'group' && r.value === 'none')).toMatchObject({ on: false })
     expect(rows.find(r => r.kind === 'toggle' && r.toggle === 'closed')).toMatchObject({ on: true })
@@ -1007,10 +1008,10 @@ describe('the only-active toggle', () => {
       repo: 'repository', none: 'flat', task: 'task', harness: 'harness', model: 'model',
       project: 'project',
     },
-    toggles: { closed: false, exited: false, unfiled: false, done: false, active: true },
+    toggles: { closed: false, exited: false, unfiled: false, done: false, active: true, detail: false },
     toggleWords: {
       closed: 'closed', exited: 'finished', unfiled: 'no task', done: 'done tasks',
-      active: 'only active',
+      active: 'only active', detail: 'detail',
     },
     headings: { actions: 'ACTIONS', view: 'VIEW', show: 'SHOW' },
     showUnfiled,
@@ -1076,5 +1077,55 @@ describe('resolveAsideCursor', () => {
 
   it('reports -1 when there is nothing to land on at all', () => {
     expect(resolveAsideCursor([{ kind: 'heading', label: 'X' }], 'action:attach')).toBe(-1)
+  })
+})
+
+describe('sortSessions', () => {
+  const rows = [
+    session('a', { title: 'zebra', state: 'exited' as SessionState, startedAt: 300, tokens: '1.2M' }),
+    session('b', { title: 'alpha', state: 'waiting' as SessionState, startedAt: 100, tokens: '9.9k' }),
+    session('c', { title: 'mango', state: 'waiting-approval' as SessionState, startedAt: 200, tokens: '5' }),
+  ]
+  const ids = (o: Parameters<typeof sortSessions>[1]) => sortSessions(rows, o).map(s => s.id)
+
+  it('puts what is blocked on you first by default', () => {
+    expect(ids(DEFAULT_ORDER)).toEqual(['c', 'b', 'a'])
+  })
+
+  it('reads the SUFFIX when ordering by usage', () => {
+    // `9.9k` above `1.2M` would point the column that exists to show what is expensive at the
+    // cheapest row on the screen.
+    expect(usageOf(session('x', { tokens: '1.2M' }))).toBe(1_200_000)
+    expect(usageOf(session('x', { tokens: '9.9k' }))).toBe(9_900)
+    expect(usageOf(session('x'))).toBe(0)
+    expect(ids({ by: 'usage', dir: 'desc' })).toEqual(['a', 'b', 'c'])
+  })
+
+  it('orders by name in the direction the key is USEFUL in, and flips', () => {
+    // `desc` names the useful direction for every key — most urgent, A to Z, largest, newest — so
+    // there is one convention rather than a per-key argument about which way its "descending" runs.
+    expect(ids({ by: 'name', dir: 'desc' })).toEqual(['b', 'c', 'a'])
+    expect(ids({ by: 'name', dir: 'asc' })).toEqual(['a', 'c', 'b'])
+  })
+
+  it('orders by start time, newest first', () => {
+    expect(ids({ by: 'started', dir: 'desc' })).toEqual(['a', 'c', 'b'])
+    expect(ids({ by: 'started', dir: 'asc' })).toEqual(['b', 'c', 'a'])
+  })
+
+  it('keeps STATE as the tiebreak of every other key', () => {
+    // A screen sorted by name that buries a session waiting on approval among nine idle ones has
+    // lost the thing it is for.
+    const tied = [
+      session('x', { title: 'same', state: 'exited' as SessionState }),
+      session('y', { title: 'same', state: 'waiting-approval' as SessionState }),
+    ]
+    expect(sortSessions(tied, { by: 'name', dir: 'desc' }).map(s => s.id)).toEqual(['y', 'x'])
+  })
+
+  it('never mutates what it was given', () => {
+    const before = rows.map(s => s.id)
+    sortSessions(rows, { by: 'name', dir: 'asc' })
+    expect(rows.map(s => s.id)).toEqual(before)
   })
 })

--- a/packages/tui/src/control/sessions.ts
+++ b/packages/tui/src/control/sessions.ts
@@ -32,8 +32,68 @@ export function sessionRank(s: ControlSession): number {
   return RANK[s.state]
 }
 
-export function sortSessions(list: readonly ControlSession[]): ControlSession[] {
+/**
+ * What a list can be ordered BY.
+ *
+ * `state` is the default and is not merely one option among the others: it puts what is blocked on
+ * you at the top, which is the reason this screen exists. Every other order is a way of ANSWERING a
+ * question ("what is costing me", "where was I an hour ago"), and each keeps state as its tiebreak
+ * so a run of equal values still surfaces the blocked one first.
+ */
+export type SessionSort = 'state' | 'name' | 'started' | 'usage' | 'project'
+
+export const SESSION_SORTS: readonly SessionSort[] = ['state', 'name', 'started', 'usage', 'project'] as const
+
+export interface SessionOrder {
+  by: SessionSort
+  /** `desc` is newest / largest / most-urgent first — the direction each key is useful in. */
+  dir: 'asc' | 'desc'
+}
+
+export const DEFAULT_ORDER: SessionOrder = { by: 'state', dir: 'desc' }
+
+/**
+ * Tokens as a NUMBER for ordering, from the already-formatted string the host sent.
+ *
+ * The host formats `51.7k` because every other surface wants it formatted, and re-deriving the
+ * number here beats asking it to send both — but it must parse the SUFFIX, or `9.9k` sorts above
+ * `1.2M` and the column that exists to show what is expensive points at the cheapest row.
+ */
+export function usageOf(s: ControlSession): number {
+  const raw = (s.tokens ?? '').trim()
+  const n = Number.parseFloat(raw)
+  if (!Number.isFinite(n)) return 0
+  const unit = raw.replace(/[\d.,\s]/g, '').toUpperCase()
+  return n * (unit.startsWith('M') ? 1e6 : unit.startsWith('K') ? 1e3 : 1)
+}
+
+/**
+ * Order a list — PURE.
+ *
+ * STATE is every key's tiebreak, not only its own: a screen sorted by name that buries a session
+ * waiting on approval among nine idle ones has lost the thing it is for. The direction flips the
+ * primary key only, so `asc` by name still puts the blocked session first among equal names.
+ */
+export function sortSessions(
+  list: readonly ControlSession[],
+  order: SessionOrder = DEFAULT_ORDER,
+): ControlSession[] {
+  // `primary` returns negative when `a` belongs FIRST in the direction the key is useful in, which
+  // `desc` names: most urgent, A to Z, largest, newest. `asc` is that flipped. One convention for
+  // every key, rather than a per-key argument about which way round its "descending" runs.
+  const primary = (a: ControlSession, b: ControlSession): number => {
+    switch (order.by) {
+      case 'state': return sessionRank(a) - sessionRank(b)
+      case 'name': return a.title.localeCompare(b.title)
+      case 'project': return (a.projectGroup || a.project).localeCompare(b.projectGroup || b.project)
+      case 'usage': return usageOf(b) - usageOf(a)
+      case 'started': return (b.startedAt ?? 0) - (a.startedAt ?? 0)
+    }
+  }
+  const sign = order.dir === 'asc' ? -1 : 1
   return [...list].sort((a, b) => {
+    const byPrimary = primary(a, b) * sign
+    if (byPrimary !== 0) return byPrimary
     const byRank = sessionRank(a) - sessionRank(b)
     if (byRank !== 0) return byRank
     return (b.startedAt ?? 0) - (a.startedAt ?? 0)
@@ -106,8 +166,9 @@ export function groupSessions(
   unknownLabels: { harness: string; model: string; project: string; task: string; repo: string },
   /** The tasks the user marked finished — a statement about the WORK, not about any session. */
   doneTasks: readonly string[] = [],
+  order: SessionOrder = DEFAULT_ORDER,
 ): SessionGroup[] {
-  if (by === 'none') return [{ key: '', label: '', sessions: sortSessions(list) }]
+  if (by === 'none') return [{ key: '', label: '', sessions: sortSessions(list, order) }]
 
   const groups = new Map<string, SessionGroup>()
   for (const s of list) {
@@ -130,7 +191,7 @@ export function groupSessions(
   // Groups ordered by their most urgent member, so the box holding a blocked session is the one at
   // the top — grouping must not bury the thing the screen exists to surface.
   return [...groups.values()]
-    .map(g => ({ ...g, sessions: sortSessions(g.sessions) }))
+    .map(g => ({ ...g, sessions: sortSessions(g.sessions, order) }))
     .sort((a, b) => {
       const byRank = sessionRank(a.sessions[0]!) - sessionRank(b.sessions[0]!)
       return byRank !== 0 ? byRank : a.label.localeCompare(b.label)
@@ -784,10 +845,27 @@ export type AsideRow =
   | { kind: 'task'; name: string; count: number; on: boolean; done?: boolean }
   /** One project directory, with its session count. `name: ''` is "every project". */
   | { kind: 'project'; name: string; count: number; on: boolean }
+  /** One STATE the list may keep, with how many rows wear it. */
+  | { kind: 'state'; value: SessionState; label: string; count: number; on: boolean }
+  /** One ordering, and whether it is the one in force. */
+  | { kind: 'sort'; value: SessionSort; label: string; on: boolean; dir: 'asc' | 'desc' }
 
 
 /** The three things the list can be told to withhold. */
-export type SessionToggle = 'closed' | 'exited' | 'unfiled' | 'done' | 'active'
+export type SessionToggle = 'closed' | 'exited' | 'unfiled' | 'done' | 'active' | 'detail'
+
+/**
+ * Every state a row can wear, in the order the menu lists them: most urgent first, history last.
+ *
+ * The list is exhaustive on purpose — `Record`-shaped elsewhere, a plain array here — so a new
+ * state added to `SessionState` shows up as a missing row rather than as a filter that silently
+ * drops every session wearing it.
+ */
+export const SESSION_STATES: readonly SessionState[] =
+  ['waiting-approval', 'waiting', 'working', 'exited', 'lost', 'closed', 'unknown'] as const
+
+/** The three that mean something is alive on the other end — what `only active` keeps. */
+export const ACTIVE_STATES: readonly SessionState[] = ['working', 'waiting', 'waiting-approval'] as const
 
 /**
  * Is this session RUNNING right now — PURE.
@@ -816,6 +894,21 @@ export function asideRows(o: {
   toggles: Record<SessionToggle, boolean>
   toggleWords: Record<SessionToggle, string>
   headings: { actions: string; view: string; show: string }
+  /** The ordering block, when the menu should offer one. */
+  sort?: { heading: string; words: Record<SessionSort, string>; by: SessionSort; dir: 'asc' | 'desc' }
+  /**
+   * The per-STATE block: which states are kept, what each is called, and how many wear it.
+   *
+   * Counted over the fleet rather than over the filtered list, for the same reason the tasks are:
+   * the count is what says a state has anything in it, and counting after the filter would report
+   * the number the filter left — which for an unselected state is always zero.
+   */
+  states?: {
+    heading: string
+    words: Record<SessionState, string>
+    counts: Partial<Record<SessionState, number>>
+    kept: readonly SessionState[]
+  }
   /** `unfiled` only means anything while grouping by task, so it is ABSENT otherwise. */
   showUnfiled: boolean
   /**
@@ -858,14 +951,38 @@ export function asideRows(o: {
   // switch that appears to do nothing is one people conclude is broken. Listed first, it reads as
   // what it is — the strict answer, with the widening ones beneath.
   const toggles: SessionToggle[] = o.showUnfiled
-    ? ['active', 'closed', 'exited', 'done', 'unfiled']
-    : ['active', 'closed', 'exited', 'done']
+    ? ['active', 'closed', 'exited', 'done', 'unfiled', 'detail']
+    : ['active', 'closed', 'exited', 'done', 'detail']
   for (const t of toggles) {
     rows.push({ kind: 'toggle', toggle: t, label: o.toggleWords[t], on: o.toggles[t] })
   }
 
   // The tasks, last, and only when there are any: a heading over an empty section is a promise the
   // screen cannot keep.
+  // ORDER, then STATE: the first is how the list is arranged and belongs beside the grouping, the
+  // second is what it contains and belongs beside the switches that decide the same thing.
+  if (o.sort) {
+    rows.push({ kind: 'rule' }, { kind: 'heading', label: o.sort.heading })
+    for (const by of SESSION_SORTS) {
+      rows.push({
+        kind: 'sort', value: by, label: o.sort.words[by], on: by === o.sort.by, dir: o.sort.dir,
+      })
+    }
+  }
+
+  if (o.states) {
+    rows.push({ kind: 'rule' }, { kind: 'heading', label: o.states.heading })
+    for (const value of SESSION_STATES) {
+      const count = o.states.counts[value] ?? 0
+      // A state nothing on this machine wears is not a filter, it is a row that does nothing.
+      if (count === 0 && !o.states.kept.includes(value)) continue
+      rows.push({
+        kind: 'state', value, label: o.states.words[value], count,
+        on: o.states.kept.includes(value),
+      })
+    }
+  }
+
   if (o.tasks && o.tasks.counts.length > 0) {
     const done = o.tasks.done ?? []
     rows.push({ kind: 'rule' }, { kind: 'heading', label: o.tasks.heading })
@@ -939,6 +1056,8 @@ export function asideRowKey(row: AsideRow): string {
     case 'group': return `group:${row.value}`
     case 'toggle': return `toggle:${row.toggle}`
     case 'task': return `task:${row.name}`
+    case 'state': return `state:${row.value}`
+    case 'sort': return `sort:${row.value}`
     case 'project': return `project:${row.name}`
     case 'heading': return `heading:${row.label}`
     case 'rule': return 'rule'

--- a/packages/tui/src/control/tabs/Sessions.tsx
+++ b/packages/tui/src/control/tabs/Sessions.tsx
@@ -56,6 +56,7 @@ import {
   enabledActionIndexes, filterSessions,
   sessionActions, sessionsCockpit, summaryCells, sessionColumns, padCell,
   taskCounts, projectCounts, sessionMetric, sessionHandle, worktreeName, sessionRunning,
+  DEFAULT_ORDER, ACTIVE_STATES, type SessionOrder,
   asideSections, asideFold, scrollBar, THUMB,
   sessionNamed,
   type AsideRow, type OfferedAction, type SessionColumns, type SessionToggle,
@@ -141,6 +142,15 @@ export function Sessions({
   const [onlyActive, setOnlyActive] = useState(
     view?.onlyActive ?? DEFAULT_SESSION_VIEW.onlyActive ?? false,
   )
+  // `null` means "the two switches above decide", which is the ordinary case. A Set means the user
+  // narrowed it further, and then it is the whole answer.
+  const [states, setStates] = useState<ReadonlySet<SessionState> | null>(
+    view?.states ? new Set(view.states as SessionState[]) : null,
+  )
+  const [order, setOrder] = useState<SessionOrder>(
+    (view?.sort as SessionOrder | undefined) ?? DEFAULT_ORDER,
+  )
+  const [hideDetail, setHideDetail] = useState(view?.hideDetail ?? false)
   /**
    * Whether the visible action row has the keyboard.
    *
@@ -195,7 +205,11 @@ export function Sessions({
         // ONLY ACTIVE is absolute: it answers the whole question above on its own, named rows
         // included. Everything else here can only ever widen, and the point of this switch is that
         // there is finally one that does not.
-        (onlyActive
+        // An explicit STATE set is the whole answer, ahead of both switches: it is the more
+        // specific thing the user said, and letting a switch widen past it would make ticking a
+        // box add rows it does not name.
+        (states ? states.has(v.state)
+          : onlyActive
           ? sessionRunning(v)
           // What you NAMED, you keep seeing. A machine restart makes every managed session `lost`,
           // and with the history switches off — which is how they ship — the list came back empty:
@@ -227,9 +241,10 @@ export function Sessions({
       repo: s.sessionsUnknownRepo,
     },
     fleet?.finishedTasks ?? [],
+    order,
   ), s.sessionsClosedWord, s.sessionsDoneWord), [
     fleet?.sessions, fleet?.finishedTasks, done, grouping, query, showClosed, showExited,
-    hideEmptyTask, showDone, onlyActive, taskFilter, projectFilter, s,
+    hideEmptyTask, showDone, onlyActive, states, order, taskFilter, projectFilter, s,
   ])
 
   const selectable = useMemo(() => selectableIndexes(rows), [rows])
@@ -269,7 +284,9 @@ export function Sessions({
   // The action row is drawn from this screen's own budget, so it is subtracted BEFORE the split. A
   // row taken without being paid for is composited over the one under it, which reads as a corrupt
   // frame rather than a cramped one.
-  const detailWanted = ask ? Math.max(QUESTION_ROWS, detail.length) : detail.length
+  // A QUESTION always gets its rows, switch or no switch: it is a prompt, and one with nowhere to
+  // draw cannot be answered. Only the FACTS are what the switch withholds.
+  const detailWanted = ask ? Math.max(QUESTION_ROWS, detail.length) : hideDetail ? 0 : detail.length
 
   /**
    * Act on the selected row, or say why it cannot be acted on.
@@ -299,6 +316,13 @@ export function Sessions({
     group: s.actSessions.group,
   }), [actions, s])
 
+  /** How many sessions wear each state, over the WHOLE fleet — see the note in `asideRows`. */
+  const stateCounts = useMemo(() => {
+    const out: Partial<Record<SessionState, number>> = {}
+    for (const v of fleet?.sessions ?? []) out[v.state] = (out[v.state] ?? 0) + 1
+    return out
+  }, [fleet?.sessions])
+
   const asideList = useMemo(() => asideRows({
     actions,
     actionWords: {
@@ -312,11 +336,11 @@ export function Sessions({
     groupWords: s.sessionsGroupings,
     toggles: {
       closed: showClosed, exited: showExited, unfiled: !hideEmptyTask, done: showDone,
-      active: onlyActive,
+      active: onlyActive, detail: !hideDetail,
     },
     toggleWords: {
       closed: s.toggleClosed, exited: s.toggleExited, unfiled: s.toggleUnfiled, done: s.toggleDone,
-      active: s.toggleActive,
+      active: s.toggleActive, detail: s.toggleDetail,
     },
     headings: { actions: s.asideActions, view: s.asideView, show: s.asideShow },
     showUnfiled: grouping === 'task',
@@ -329,6 +353,15 @@ export function Sessions({
       allLabel: s.asideAllTasks,
       done: fleet?.finishedTasks ?? [],
     },
+    sort: { heading: s.asideSort, words: s.sessionsSorts, by: order.by, dir: order.dir },
+    states: {
+      heading: s.asideStates,
+      words: s.sessionsStates,
+      // Counted over the WHOLE fleet: counting after the filter reports the number the filter left,
+      // which for an unselected state is always zero — a row that can never be turned back on.
+      counts: stateCounts,
+      kept: [...(states ?? ACTIVE_STATES)],
+    },
     // The other half of the drill-down: a task is something you declared, a project is something
     // every session already has — which makes it the scope that can find a session you never filed.
     projects: {
@@ -338,7 +371,8 @@ export function Sessions({
       allLabel: s.asideAllProjects,
     },
   }), [
-    actions, grouping, showClosed, showExited, hideEmptyTask, showDone, onlyActive, taskFilter,
+    actions, grouping, showClosed, showExited, hideEmptyTask, showDone, onlyActive, hideDetail,
+    states, stateCounts, order, taskFilter,
     projectFilter, fleet?.sessions, fleet?.finishedTasks, s,
   ])
 
@@ -449,6 +483,9 @@ export function Sessions({
     setShowExited(DEFAULT_SESSION_VIEW.showExited)
     setShowDone(DEFAULT_SESSION_VIEW.showDone ?? false)
     setOnlyActive(DEFAULT_SESSION_VIEW.onlyActive ?? false)
+    setStates(null)
+    setOrder(DEFAULT_ORDER)
+    setHideDetail(false)
     setHideEmptyTask(!DEFAULT_SESSION_VIEW.showUnfiled)
     setTaskFilter(null)
     setProjectFilter(null)
@@ -464,12 +501,33 @@ export function Sessions({
     if (row.kind === 'group') { setGrouping(row.value); setCursor(0); return }
     if (row.kind === 'task') { setTaskFilter(row.name || null); setCursor(0); return }
     if (row.kind === 'project') { setProjectFilter(row.name || null); setCursor(0); return }
+    if (row.kind === 'sort') {
+      // Picking the order already in force FLIPS it, which is the gesture every table has and the
+      // only one that does not need a second control for the direction.
+      setOrder(o => (o.by === row.value
+        ? { by: o.by, dir: o.dir === 'desc' ? 'asc' : 'desc' }
+        : { by: row.value, dir: DEFAULT_ORDER.dir }))
+      setCursor(0)
+      return
+    }
+    if (row.kind === 'state') {
+      setStates(prev => {
+        const next = new Set(prev ?? ACTIVE_STATES)
+        if (next.has(row.value)) next.delete(row.value)
+        else next.add(row.value)
+        // Emptying it would show nothing at all, which is never what unticking the last box means.
+        return next.size === 0 ? null : next
+      })
+      setCursor(0)
+      return
+    }
     if (row.kind !== 'toggle') return
     setCursor(0)
     if (row.toggle === 'closed') return setShowClosed(v => !v)
     if (row.toggle === 'exited') return setShowExited(v => !v)
     if (row.toggle === 'done') return setShowDone(v => !v)
     if (row.toggle === 'active') return setOnlyActive(v => !v)
+    if (row.toggle === 'detail') return setHideDetail(v => !v)
     return setHideEmptyTask(v => !v)
   }, [asideList, runAction, resetView])
 
@@ -563,6 +621,7 @@ export function Sessions({
     if (input === 'c') { setShowClosed(v => !v); setCursor(0); return }
     if (input === 'e') { setShowExited(v => !v); setCursor(0); return }
     if (input === 'l') { setOnlyActive(v => !v); setCursor(0); return }
+    if (input === 'd') { setHideDetail(v => !v); return }
     if (input === 'u' && grouping === 'task') { setHideEmptyTask(v => !v); setCursor(0); return }
     if (input === 'a') return runAction('new')
     // Attaching has its OWN key because `enter` deliberately does not do it any more: enter opens
@@ -601,7 +660,14 @@ export function Sessions({
     // the stored `showClosed` follows, so a preferences file written before this existed opens with
     // finished work put away rather than with the switch inverted.
     setShowDone(view.showDone ?? false)
-    setOnlyActive(view.onlyActive ?? false)
+    // The DEFAULT, not `false`. `showDone` above defaults to false so its `?? false` is right; this
+    // one defaults to TRUE, and copying the rule across turned the strict filter off on every
+    // preferences file written before it existed — then the persist effect wrote that off to disk,
+    // making it permanent. Reported from a real machine.
+    setOnlyActive(view.onlyActive ?? DEFAULT_SESSION_VIEW.onlyActive ?? false)
+    setStates(view.states ? new Set(view.states as SessionState[]) : null)
+    setOrder((view.sort as SessionOrder | undefined) ?? DEFAULT_ORDER)
+    setHideDetail(view.hideDetail ?? false)
   }, [view])
 
   // Written whenever any part of the arrangement moves, rather than at each call site: four setters
@@ -615,8 +681,14 @@ export function Sessions({
     // stored arrangement was read, and the arrangement was gone. `sessionViewPref` now always
     // answers, so an absent `view` means "not loaded yet" and nothing else.
     if (!restored.current) return
-    onView({ grouping, showClosed, showExited, showUnfiled: !hideEmptyTask, showDone, onlyActive })
-  }, [grouping, showClosed, showExited, hideEmptyTask, showDone, onlyActive, onView, view])
+    onView({
+      grouping, showClosed, showExited, showUnfiled: !hideEmptyTask, showDone, onlyActive,
+      hideDetail,
+      ...(states ? { states: [...states] } : {}),
+      sort: order,
+    })
+  }, [grouping, showClosed, showExited, hideEmptyTask, showDone, onlyActive, hideDetail,
+      states, order, onView, view])
 
   useEffect(() => {
     if (!isActive) return
@@ -1036,7 +1108,7 @@ export function Sessions({
 
       {/* The third pane: what you selected, or the question you were just asked. A question owns the
           keyboard, so the frame says so — the accent is where the keys go, everywhere, always. */}
-      {cockpit.detail > 0 && (ask || detail.length > 0) ? (
+      {cockpit.detail > 0 && (ask || (!hideDetail && detail.length > 0)) ? (
         <Pane
           title={ask ? s.sessionsPaneAsk : s.sessionsPaneDetail}
           focused={Boolean(ask)}
@@ -1632,7 +1704,13 @@ function AsideMenu({
         // truncated around it rather than the count being dropped: a task named at its full length
         // with no number tells you nothing you did not already know from the grouping.
         const scoped = row.kind === 'task' || row.kind === 'project'
-        const count = scoped && row.name ? ` ${row.count}` : ''
+        // A STATE row carries its count for the same reason a task does — it is what says the
+        // filter has anything behind it. The ORDER row carries its direction instead, because
+        // picking the order already in force flips it and the arrow is what says which way.
+        const count = row.kind === 'state' ? ` ${row.count}`
+          : scoped && row.name ? ` ${row.count}`
+          : row.kind === 'sort' && row.on ? (row.dir === 'desc' ? ' ↓' : ' ↑')
+          : ''
         const allLabel = row.kind === 'project' ? allProjectsLabel : allTasksLabel
         // A finished task wears a tick, so the menu states what it already knows rather than making
         // someone select it to find out.

--- a/packages/tui/src/control/tabs/Sessions.tsx
+++ b/packages/tui/src/control/tabs/Sessions.tsx
@@ -152,6 +152,13 @@ export function Sessions({
   )
   const [hideDetail, setHideDetail] = useState(view?.hideDetail ?? false)
   /**
+   * The rows the user MARKED — a highlighter, not a selection.
+   *
+   * Kept by session id rather than by position, because the list re-sorts under it every five
+   * seconds: a mark that meant "the third row" would be on someone else's session by the next poll.
+   */
+  const [marked, setMarked] = useState<ReadonlySet<string>>(new Set(view?.marked ?? []))
+  /**
    * Whether the visible action row has the keyboard.
    *
    * The row is there so the screen can be used WITHOUT knowing any letters — every verb is spelled
@@ -486,6 +493,7 @@ export function Sessions({
     setStates(null)
     setOrder(DEFAULT_ORDER)
     setHideDetail(false)
+    setMarked(new Set())
     setHideEmptyTask(!DEFAULT_SESSION_VIEW.showUnfiled)
     setTaskFilter(null)
     setProjectFilter(null)
@@ -622,6 +630,18 @@ export function Sessions({
     if (input === 'e') { setShowExited(v => !v); setCursor(0); return }
     if (input === 'l') { setOnlyActive(v => !v); setCursor(0); return }
     if (input === 'd') { setHideDetail(v => !v); return }
+    // The HIGHLIGHTER. `space` because it is the mark key of every list that has one, and because
+    // it is the only unclaimed key on this screen that a person reaches for without being told.
+    if (input === ' ') {
+      if (!selected) return
+      setMarked(prev => {
+        const next = new Set(prev)
+        if (next.has(selected.id)) next.delete(selected.id)
+        else next.add(selected.id)
+        return next
+      })
+      return
+    }
     if (input === 'u' && grouping === 'task') { setHideEmptyTask(v => !v); setCursor(0); return }
     if (input === 'a') return runAction('new')
     // Attaching has its OWN key because `enter` deliberately does not do it any more: enter opens
@@ -668,6 +688,7 @@ export function Sessions({
     setStates(view.states ? new Set(view.states as SessionState[]) : null)
     setOrder((view.sort as SessionOrder | undefined) ?? DEFAULT_ORDER)
     setHideDetail(view.hideDetail ?? false)
+    setMarked(new Set(view.marked ?? []))
   }, [view])
 
   // Written whenever any part of the arrangement moves, rather than at each call site: four setters
@@ -684,11 +705,12 @@ export function Sessions({
     onView({
       grouping, showClosed, showExited, showUnfiled: !hideEmptyTask, showDone, onlyActive,
       hideDetail,
+      ...(marked.size > 0 ? { marked: [...marked] } : {}),
       ...(states ? { states: [...states] } : {}),
       sort: order,
     })
   }, [grouping, showClosed, showExited, hideEmptyTask, showDone, onlyActive, hideDetail,
-      states, order, onView, view])
+      states, order, marked, onView, view])
 
   useEffect(() => {
     if (!isActive) return
@@ -1079,6 +1101,7 @@ export function Sessions({
                 key={row.session.id}
                 session={row.session}
                 selected={selected?.id === row.session.id}
+                marked={marked.has(row.session.id)}
                 columns={columns}
                 width={listBody}
               />
@@ -1235,9 +1258,11 @@ function SummaryRow({
   )
 }
 
-function SessionRowView({ session, selected, columns, width }: {
+function SessionRowView({ session, selected, marked, columns, width }: {
   session: ControlSession
   selected: boolean
+  /** The user's own highlight. Survives re-sorting, and outlives the cursor moving away. */
+  marked: boolean
   columns: SessionColumns
   width: number
 }) {
@@ -1248,7 +1273,13 @@ function SessionRowView({ session, selected, columns, width }: {
 
   return (
     <Text wrap="truncate">
-      <Text color={selected ? COLORS.accent : undefined}>{selected ? '❯ ' : '  '}</Text>
+      {/* Two cells, and they answer different questions: the caret is WHERE THE CURSOR IS, the bar
+          is WHAT YOU MARKED. Sharing one cell would make a mark vanish under the cursor, which is
+          the one moment you are looking straight at it. The bar is `info` rather than the accent
+          on purpose — the accent means focus everywhere else in this app, and a highlight that
+          wore it would read as "this is selected" on four rows at once. */}
+      <Text color={selected ? COLORS.accent : undefined}>{selected ? '❯' : ' '}</Text>
+      <Text color={marked ? COLORS.info : undefined} bold={marked}>{marked ? '▌' : ' '}</Text>
       {/* Colour AND word, always paired — and PADDED, so every title starts in the same column.
           Two spaces between unpadded cells is what made this read as a jumble of words: the state
           words differ by ten characters, so nothing after them ever lined up. */}
@@ -1261,7 +1292,10 @@ function SessionRowView({ session, selected, columns, width }: {
         {padCell(session.stateLabel, columns.state)}
       </Text>
       {columns.title > 0 ? (
-        <Text color={selected ? COLORS.accent : undefined} bold={selected}>
+        <Text
+          color={selected ? COLORS.accent : marked ? COLORS.info : undefined}
+          bold={selected || marked}
+        >
           {gap + padCell(session.title, columns.title)}
         </Text>
       ) : null}

--- a/packages/tui/src/control/types.ts
+++ b/packages/tui/src/control/types.ts
@@ -409,6 +409,18 @@ export interface SessionViewPrefs {
    * the four things they are actually doing had no way to say so. This is that way.
    */
   onlyActive?: boolean
+  /**
+   * The exact states the list keeps, when the user narrowed it beyond "active or everything".
+   *
+   * Absent means the two switches above decide, which is the ordinary case. Present, it is the
+   * whole answer — and it is stored as the states to KEEP rather than the ones to hide, so a state
+   * added to the product later is not silently included in a filter written before it existed.
+   */
+  states?: string[]
+  /** How the rows are ordered. Absent is by state — what is blocked on you, first. */
+  sort?: { by: string; dir: 'asc' | 'desc' }
+  /** Whether the detail pane under the list is drawn at all. */
+  hideDetail?: boolean
 }
 
 /**

--- a/packages/tui/src/control/types.ts
+++ b/packages/tui/src/control/types.ts
@@ -421,6 +421,14 @@ export interface SessionViewPrefs {
   sort?: { by: string; dir: 'asc' | 'desc' }
   /** Whether the detail pane under the list is drawn at all. */
   hideDetail?: boolean
+  /**
+   * Session ids the user has MARKED, so a row can be found again without searching for it.
+   *
+   * Persisted for the same reason the arrangement is: detaching from a session remounts this
+   * screen, and a mark that did not survive that would be gone at exactly the moment it was most
+   * useful — you marked the row because you were about to go into it.
+   */
+  marked?: string[]
 }
 
 /**


### PR DESCRIPTION
Four controls the screen was missing, and one bug that would have undone the last release on every machine that already had a preferences file.

## The bug first

`setOnlyActive(view.onlyActive ?? false)` on the restore path fell back to `false` while the app's default is `true`. `showDone` above it defaults to false, so its `?? false` is right — and the rule was copied to a field whose default is the opposite.

Every `preferences.json` written before the switch existed (every machine that had ever run agentop) opened with the strict filter **off**, and the persist effect then wrote that off to disk, making it permanent. Reported from a real machine by a session running beside this one.

## Order

By urgency (the default — what is blocked on you, first), name, start time, usage or project. Picking the order already in force flips it: the gesture every table has, and the only one that does not need a second control for the direction.

`desc` names the direction each key is *useful* in — most urgent, A to Z, largest, newest — so there is one convention rather than a per-key argument about which way its "descending" runs. Every key keeps state as its tiebreak: a list sorted by name that buries a session waiting on approval among nine idle ones has lost the thing it is for. Usage parses the **suffix** of the formatted count, or `9.9k` sorts above `1.2M` and the column that shows what is expensive points at the cheapest row.

## State

One row per state with how many sessions wear it, counted over the whole fleet — counting after the filter reports the number the filter left, which for an unselected state is always zero: a row that can never be turned back on.

A state set is the whole answer, ahead of both history switches. It is the more specific thing the user said, and letting a switch widen past it would make ticking a box add rows it does not name. Unticking the last one falls back to the switches rather than showing nothing, which is never what unticking a box means.

## The detail pane has a switch (`d`)

It is a pane, not a fact, and a screen is allowed to be a list — but a **question** still takes the region whatever the switch says, because a prompt with nowhere to draw cannot be answered.

## `space` marks a row

A highlighter, not a selection. Two gutter cells rather than one, because they answer different questions: the caret is where the cursor **is**, the bar is what you **marked**. Sharing a cell would make a mark vanish under the cursor — the one moment you are looking straight at it.

The bar is `info`, not the accent: the accent means *focus* everywhere else in this app, and a highlight wearing it would read as "this is selected" on four rows at once. Kept by session id, because the list re-sorts every five seconds and a mark meaning "the third row" would be on someone else's session by the next poll — and persisted, because detaching remounts the screen and you marked the row precisely because you were about to go into it.

Tests: 3162 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019vBSuKQLuyLhWZS4zbiu2s