### PR TITLE
fix(sessions): "only active" hid the sessions running outside agentop

### DIFF
--- a/docs/session-manager.md
+++ b/docs/session-manager.md
@@ -102,11 +102,14 @@ in that colour. It is kept by session id, because the list re-sorts under it eve
 a mark meaning "the third row" would be on someone else's session by the next poll — and it survives
 detaching, which is exactly when you needed it.
 
-The detail pane has its own switch (`d`). It is a pane, not a fact, and a screen is allowed to be a
+The detail pane has its own switch (`d`), written on the pane itself as well as offered in the
+*show* block — a control for a thing you are looking straight at belongs on the thing. It is a pane, not a fact, and a screen is allowed to be a
 list — but a QUESTION still takes the region whatever the switch says, because a prompt with nowhere
 to draw cannot be answered.
 
-**`only active` (`l`) is the one switch that overrides that**, and it is why it leads the *show*
+**`only active` (`l`) counts EXTERNAL sessions as active**, because an external row exists precisely
+because a live assistant process was found: what cannot be read there is its activity, never whether
+it is running. It is the one switch that overrides the rule above, and it is why it leads the *show*
 block. The rule above is right by default, but on a machine with months of named work it shows all
 of it; this is how you ask for the four things you are actually doing and nothing else. Everything
 else in that block can only ever widen.

--- a/packages/tui/src/control/i18n.ts
+++ b/packages/tui/src/control/i18n.ts
@@ -232,6 +232,8 @@ export interface ControlStrings {
   toggleActive: string
   /** The detail pane's own switch: it is a pane, not a fact, and a screen is allowed to be a list. */
   toggleDetail: string
+  /** Written on the detail pane itself: the key that puts it away. */
+  sessionsDetailHide: string
   asideSort: string
   asideStates: string
   sessionsSorts: Record<'state' | 'name' | 'started' | 'usage' | 'project', string>
@@ -536,6 +538,7 @@ const EN: ControlStrings = {
   toggleDone: 'finished tasks',
   toggleActive: 'only active',
   toggleDetail: 'detail pane',
+  sessionsDetailHide: 'd hides',
   asideSort: 'ORDER',
   asideStates: 'STATE',
   sessionsSorts: {
@@ -834,6 +837,7 @@ const PT: ControlStrings = {
   toggleDone: 'tarefas finalizadas',
   toggleActive: 'apenas ativas',
   toggleDetail: 'painel de detalhe',
+  sessionsDetailHide: 'd oculta',
   asideSort: 'ORDENAR',
   asideStates: 'ESTADO',
   sessionsSorts: {

--- a/packages/tui/src/control/sessions.test.ts
+++ b/packages/tui/src/control/sessions.test.ts
@@ -988,8 +988,11 @@ describe('sessionRunning', () => {
     expect(at('working')).toBe(true)
     expect(at('waiting')).toBe(true)
     expect(at('waiting-approval')).toBe(true)
-    // An external process's state cannot be read at all, so it is not evidence of anything.
-    expect(at('unknown')).toBe(false)
+    // An EXTERNAL session wears `unknown`, and it is running: the row exists because a live
+    // assistant process was found. What cannot be read there is the activity, not the existence —
+    // and treating the one as the other hid every session started outside agentop from the one
+    // filter meant to show what is happening.
+    expect(at('unknown')).toBe(true)
     expect(at('exited')).toBe(false)
     expect(at('lost')).toBe(false)
     expect(at('closed')).toBe(false)

--- a/packages/tui/src/control/sessions.ts
+++ b/packages/tui/src/control/sessions.ts
@@ -864,18 +864,28 @@ export type SessionToggle = 'closed' | 'exited' | 'unfiled' | 'done' | 'active' 
 export const SESSION_STATES: readonly SessionState[] =
   ['waiting-approval', 'waiting', 'working', 'exited', 'lost', 'closed', 'unknown'] as const
 
-/** The three that mean something is alive on the other end — what `only active` keeps. */
-export const ACTIVE_STATES: readonly SessionState[] = ['working', 'waiting', 'waiting-approval'] as const
+/**
+ * The states that mean something is ALIVE on the other end — what `only active` keeps.
+ *
+ * `unknown` is in the list, and that is not a hedge. It is the state of an EXTERNAL session, and an
+ * external row exists precisely because `/proc` reported a live assistant process: the thing that
+ * cannot be read is its ACTIVITY, never whether it is running. Leaving it out hid exactly the
+ * sessions someone opened outside agentop and is in the middle of — the ones most likely to be
+ * forgotten, since agentop is not the thing that started them.
+ */
+export const ACTIVE_STATES: readonly SessionState[] =
+  ['working', 'waiting', 'waiting-approval', 'unknown'] as const
 
 /**
  * Is this session RUNNING right now — PURE.
  *
- * The three states that mean something is alive on the other end. `exited`, `lost`, `closed` and
- * `unknown` (an external process, whose state cannot be read at all) are not running, and the
- * "only active" switch keeps none of them.
+ * `exited`, `lost` and `closed` are not. `unknown` IS: it is what an external session wears, and an
+ * external row exists because a live assistant process was found — what cannot be read there is the
+ * activity, not the existence. Treating "we cannot say what it is doing" as "it is not running" hid
+ * every session started outside agentop from the one filter meant to show what is happening.
  */
 export function sessionRunning(s: ControlSession): boolean {
-  return s.state === 'working' || s.state === 'waiting' || s.state === 'waiting-approval'
+  return ACTIVE_STATES.includes(s.state)
 }
 
 /**

--- a/packages/tui/src/control/tabs/Sessions.tsx
+++ b/packages/tui/src/control/tabs/Sessions.tsx
@@ -1134,6 +1134,10 @@ export function Sessions({
       {cockpit.detail > 0 && (ask || (!hideDetail && detail.length > 0)) ? (
         <Pane
           title={ask ? s.sessionsPaneAsk : s.sessionsPaneDetail}
+          // The key that puts this pane away, written ON the pane. It lives as a row in the `show`
+          // block too, but that block is collapsed by default and five rows deep — a control for a
+          // thing you are looking straight at belongs on the thing.
+          badge={ask ? '' : s.sessionsDetailHide}
           focused={Boolean(ask)}
           width={width}
           height={cockpit.detail}


### PR DESCRIPTION
An **external** row exists precisely because `/proc` reported a live assistant process. What cannot be read about it is its *activity* — nothing on that screen is capturable — never whether it is running.

`sessionRunning` treated "we cannot say what it is doing" as "it is not running", so the one filter meant to show what is happening hid every session started outside agentop: the ones most likely to be forgotten, since agentop is not what started them.

`unknown` joins `ACTIVE_STATES`, which is also what the state block ticks by default, so the two surfaces agree.

---

And the detail pane's switch is written **on the pane** (`d oculta`) as well as offered as a row in the *show* block. That block ships collapsed and the row is five deep in it, so the control existed and could not be found — a control for a thing you are looking straight at belongs on the thing.

Tests: 3162 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019vBSuKQLuyLhWZS4zbiu2s