### PR TITLE
feat(release): scoped commits count toward the bump, and a manual version valve

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,17 @@ name: Build & Release
 on:
   push:
     branches: [main, feat/desktop]
+  # The manual valve. The version is otherwise computed from the tags and the commit subjects, which
+  # is right almost always and has no answer for the case where it got the number WRONG: 1.8.2 went
+  # out carrying a whole cockpit because the bump glob did not match scoped commits, and nothing
+  # short of inventing a commit could correct it. Given a version here, that computation is skipped
+  # entirely and this is the number that ships.
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release exactly this version (e.g. 1.9.0). Leave empty to compute it.'
+        required: false
+        type: string
 
 permissions:
   contents: write
@@ -27,8 +38,13 @@ jobs:
       - name: Skip if version bump commit
         id: skip_check
         run: |
+          # A FORCED release is never skipped. This guard exists so the workflow's own bump commit
+          # does not trigger it again; the head of main is always that commit, so honouring it on a
+          # manual dispatch would refuse every corrective release outright.
           MSG=$(git log -1 --pretty=format:"%s")
-          if echo "$MSG" | grep -q "chore: bump version"; then
+          if [ -n "${{ github.event.inputs.version }}" ]; then
+            echo "skip=false" >> $GITHUB_OUTPUT
+          elif echo "$MSG" | grep -q "chore: bump version"; then
             echo "skip=true" >> $GITHUB_OUTPUT
           else
             echo "skip=false" >> $GITHUB_OUTPUT
@@ -60,6 +76,28 @@ jobs:
         if: steps.skip_check.outputs.skip != 'true'
         id: version
         run: |
+          # An explicitly requested version wins outright: no tag arithmetic, no subject parsing, and
+          # no "no new commits" skip — a corrective release exists precisely because the automatic
+          # answer was wrong, so consulting it again would refuse the correction.
+          FORCED="${{ github.event.inputs.version }}"
+          if [ -n "$FORCED" ]; then
+            FORCED="${FORCED#v}"
+            case "$FORCED" in
+              [0-9]*.[0-9]*.[0-9]*) ;;
+              *) echo "::error::version must look like 1.9.0, got '$FORCED'"; exit 1 ;;
+            esac
+            if git rev-parse -q --verify "refs/tags/v$FORCED" >/dev/null; then
+              echo "::error::v$FORCED already exists"; exit 1
+            fi
+            echo "next=$FORCED"  >> $GITHUB_OUTPUT
+            echo "tag=v$FORCED"  >> $GITHUB_OUTPUT
+            echo "range=HEAD~20..HEAD" >> $GITHUB_OUTPUT
+            echo "bump=forced"   >> $GITHUB_OUTPUT
+            echo "skip=false"    >> $GITHUB_OUTPUT
+            echo "▶ forced release v$FORCED"
+            exit 0
+          fi
+
           # Last semver tag only (ignore 'latest')
           LAST_TAG=$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' --sort=-version:refname | head -1)
 
@@ -87,9 +125,14 @@ jobs:
           # Determine bump type from conventional commits
           BUMP="patch"
           while IFS= read -r subject; do
+            # SCOPES count. `feat:*` does not match `feat(sessions):`, so every scoped feature in
+            # this repository has been shipping as a patch — a whole cockpit went out as 1.8.2.
+            # The bang can sit on either side of the scope (`feat!:` and `feat(x)!:` are both
+            # conventional), so each is matched with and without one.
             case "$subject" in
               feat\!:*|fix\!:*|refactor\!:*|chore\!:*) BUMP="major"; break ;;
-              feat:*) [ "$BUMP" != "major" ] && BUMP="minor" ;;
+              feat\(*\)\!:*|fix\(*\)\!:*|refactor\(*\)\!:*|chore\(*\)\!:*) BUMP="major"; break ;;
+              feat:*|feat\(*\):*) [ "$BUMP" != "major" ] && BUMP="minor" ;;
             esac
             if echo "$subject" | grep -qi "BREAKING CHANGE"; then
               BUMP="major"; break
@@ -124,6 +167,9 @@ jobs:
               'packages/server/package.json',
               'packages/web/package.json',
               'packages/mcp/package.json',
+              // Left out until now, which is why it sat at 1.7.3 while everything else was 1.7.7:
+              // a package that never gets bumped reports a version no release ever produced.
+              'packages/tui/package.json',
             ];
             for (const f of targets) {
               const pkg = JSON.parse(fs.readFileSync(f, 'utf8'));


### PR DESCRIPTION
The bump globs matched `feat:` and not `feat(sessions):`, so **every scoped feature this repository has ever shipped went out as a patch**. The session cockpit — forty-nine commits of it — released as 1.8.2.

Scopes are matched now, and so is the bang on either side of one: `feat!:` and `feat(api)!:` are both conventional and only the first was recognised, so a scoped breaking change was silently a patch too.

The classification was **exercised against ten commit shapes** before this landed rather than reasoned about — a glob that looks right is exactly what shipped the last four releases wrong:

| subject | bump |
|---|---|
| `feat: x` | minor |
| `feat(sessions): x` | minor |
| `fix: x` / `fix(sessions): x` | patch |
| `feat!: x` / `feat(api)!: x` | major |
| `fix(api)!: x` / `refactor(core)!: x` | major |
| `chore(deps): x` / `docs: x` | patch |

## The valve

`workflow_dispatch` now takes a `version`, and given one it skips the tag arithmetic, the subject parsing and the no-new-commits check entirely. All three exist to compute the right answer, and a corrective release exists precisely because the computed answer was wrong — consulting them again would refuse the correction. It also skips the bump-commit guard, since the head of `main` is always that commit and honouring it would refuse every manual release outright. The version is validated, and refused if the tag already exists.

## One more

`packages/tui/package.json` joins the bumped files. Being left out is why it sat at 1.7.3 while everything else was at 1.7.7 — a package that never gets bumped reports a version no release ever produced.

Merging this to `main` releases **v1.9.0**: the subject is a scoped `feat`, which the fixed glob reads as a minor bump from 1.8.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019vBSuKQLuyLhWZS4zbiu2s