### PR TITLE
release: v1.9.0 — external sessions count as active, and the release pipeline can count

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,17 @@ name: Build & Release
 on:
   push:
     branches: [main, feat/desktop]
+  # The manual valve. The version is otherwise computed from the tags and the commit subjects, which
+  # is right almost always and has no answer for the case where it got the number WRONG: 1.8.2 went
+  # out carrying a whole cockpit because the bump glob did not match scoped commits, and nothing
+  # short of inventing a commit could correct it. Given a version here, that computation is skipped
+  # entirely and this is the number that ships.
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release exactly this version (e.g. 1.9.0). Leave empty to compute it.'
+        required: false
+        type: string
 
 permissions:
   contents: write
@@ -27,8 +38,13 @@ jobs:
       - name: Skip if version bump commit
         id: skip_check
         run: |
+          # A FORCED release is never skipped. This guard exists so the workflow's own bump commit
+          # does not trigger it again; the head of main is always that commit, so honouring it on a
+          # manual dispatch would refuse every corrective release outright.
           MSG=$(git log -1 --pretty=format:"%s")
-          if echo "$MSG" | grep -q "chore: bump version"; then
+          if [ -n "${{ github.event.inputs.version }}" ]; then
+            echo "skip=false" >> $GITHUB_OUTPUT
+          elif echo "$MSG" | grep -q "chore: bump version"; then
             echo "skip=true" >> $GITHUB_OUTPUT
           else
             echo "skip=false" >> $GITHUB_OUTPUT
@@ -60,6 +76,28 @@ jobs:
         if: steps.skip_check.outputs.skip != 'true'
         id: version
         run: |
+          # An explicitly requested version wins outright: no tag arithmetic, no subject parsing, and
+          # no "no new commits" skip — a corrective release exists precisely because the automatic
+          # answer was wrong, so consulting it again would refuse the correction.
+          FORCED="${{ github.event.inputs.version }}"
+          if [ -n "$FORCED" ]; then
+            FORCED="${FORCED#v}"
+            case "$FORCED" in
+              [0-9]*.[0-9]*.[0-9]*) ;;
+              *) echo "::error::version must look like 1.9.0, got '$FORCED'"; exit 1 ;;
+            esac
+            if git rev-parse -q --verify "refs/tags/v$FORCED" >/dev/null; then
+              echo "::error::v$FORCED already exists"; exit 1
+            fi
+            echo "next=$FORCED"  >> $GITHUB_OUTPUT
+            echo "tag=v$FORCED"  >> $GITHUB_OUTPUT
+            echo "range=HEAD~20..HEAD" >> $GITHUB_OUTPUT
+            echo "bump=forced"   >> $GITHUB_OUTPUT
+            echo "skip=false"    >> $GITHUB_OUTPUT
+            echo "▶ forced release v$FORCED"
+            exit 0
+          fi
+
           # Last semver tag only (ignore 'latest')
           LAST_TAG=$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' --sort=-version:refname | head -1)
 
@@ -87,9 +125,14 @@ jobs:
           # Determine bump type from conventional commits
           BUMP="patch"
           while IFS= read -r subject; do
+            # SCOPES count. `feat:*` does not match `feat(sessions):`, so every scoped feature in
+            # this repository has been shipping as a patch — a whole cockpit went out as 1.8.2.
+            # The bang can sit on either side of the scope (`feat!:` and `feat(x)!:` are both
+            # conventional), so each is matched with and without one.
             case "$subject" in
               feat\!:*|fix\!:*|refactor\!:*|chore\!:*) BUMP="major"; break ;;
-              feat:*) [ "$BUMP" != "major" ] && BUMP="minor" ;;
+              feat\(*\)\!:*|fix\(*\)\!:*|refactor\(*\)\!:*|chore\(*\)\!:*) BUMP="major"; break ;;
+              feat:*|feat\(*\):*) [ "$BUMP" != "major" ] && BUMP="minor" ;;
             esac
             if echo "$subject" | grep -qi "BREAKING CHANGE"; then
               BUMP="major"; break
@@ -124,6 +167,9 @@ jobs:
               'packages/server/package.json',
               'packages/web/package.json',
               'packages/mcp/package.json',
+              // Left out until now, which is why it sat at 1.7.3 while everything else was 1.7.7:
+              // a package that never gets bumped reports a version no release ever produced.
+              'packages/tui/package.json',
             ];
             for (const f of targets) {
               const pkg = JSON.parse(fs.readFileSync(f, 'utf8'));

--- a/docs/session-manager.md
+++ b/docs/session-manager.md
@@ -102,11 +102,14 @@ in that colour. It is kept by session id, because the list re-sorts under it eve
 a mark meaning "the third row" would be on someone else's session by the next poll — and it survives
 detaching, which is exactly when you needed it.
 
-The detail pane has its own switch (`d`). It is a pane, not a fact, and a screen is allowed to be a
+The detail pane has its own switch (`d`), written on the pane itself as well as offered in the
+*show* block — a control for a thing you are looking straight at belongs on the thing. It is a pane, not a fact, and a screen is allowed to be a
 list — but a QUESTION still takes the region whatever the switch says, because a prompt with nowhere
 to draw cannot be answered.
 
-**`only active` (`l`) is the one switch that overrides that**, and it is why it leads the *show*
+**`only active` (`l`) counts EXTERNAL sessions as active**, because an external row exists precisely
+because a live assistant process was found: what cannot be read there is its activity, never whether
+it is running. It is the one switch that overrides the rule above, and it is why it leads the *show*
 block. The rule above is right by default, but on a machine with months of named work it shows all
 of it; this is how you ask for the four things you are actually doing and nothing else. Everything
 else in that block can only ever widen.

--- a/packages/tui/src/control/i18n.ts
+++ b/packages/tui/src/control/i18n.ts
@@ -232,6 +232,8 @@ export interface ControlStrings {
   toggleActive: string
   /** The detail pane's own switch: it is a pane, not a fact, and a screen is allowed to be a list. */
   toggleDetail: string
+  /** Written on the detail pane itself: the key that puts it away. */
+  sessionsDetailHide: string
   asideSort: string
   asideStates: string
   sessionsSorts: Record<'state' | 'name' | 'started' | 'usage' | 'project', string>
@@ -536,6 +538,7 @@ const EN: ControlStrings = {
   toggleDone: 'finished tasks',
   toggleActive: 'only active',
   toggleDetail: 'detail pane',
+  sessionsDetailHide: 'd hides',
   asideSort: 'ORDER',
   asideStates: 'STATE',
   sessionsSorts: {
@@ -834,6 +837,7 @@ const PT: ControlStrings = {
   toggleDone: 'tarefas finalizadas',
   toggleActive: 'apenas ativas',
   toggleDetail: 'painel de detalhe',
+  sessionsDetailHide: 'd oculta',
   asideSort: 'ORDENAR',
   asideStates: 'ESTADO',
   sessionsSorts: {

--- a/packages/tui/src/control/sessions.test.ts
+++ b/packages/tui/src/control/sessions.test.ts
@@ -988,8 +988,11 @@ describe('sessionRunning', () => {
     expect(at('working')).toBe(true)
     expect(at('waiting')).toBe(true)
     expect(at('waiting-approval')).toBe(true)
-    // An external process's state cannot be read at all, so it is not evidence of anything.
-    expect(at('unknown')).toBe(false)
+    // An EXTERNAL session wears `unknown`, and it is running: the row exists because a live
+    // assistant process was found. What cannot be read there is the activity, not the existence —
+    // and treating the one as the other hid every session started outside agentop from the one
+    // filter meant to show what is happening.
+    expect(at('unknown')).toBe(true)
     expect(at('exited')).toBe(false)
     expect(at('lost')).toBe(false)
     expect(at('closed')).toBe(false)

--- a/packages/tui/src/control/sessions.ts
+++ b/packages/tui/src/control/sessions.ts
@@ -864,18 +864,28 @@ export type SessionToggle = 'closed' | 'exited' | 'unfiled' | 'done' | 'active' 
 export const SESSION_STATES: readonly SessionState[] =
   ['waiting-approval', 'waiting', 'working', 'exited', 'lost', 'closed', 'unknown'] as const
 
-/** The three that mean something is alive on the other end — what `only active` keeps. */
-export const ACTIVE_STATES: readonly SessionState[] = ['working', 'waiting', 'waiting-approval'] as const
+/**
+ * The states that mean something is ALIVE on the other end — what `only active` keeps.
+ *
+ * `unknown` is in the list, and that is not a hedge. It is the state of an EXTERNAL session, and an
+ * external row exists precisely because `/proc` reported a live assistant process: the thing that
+ * cannot be read is its ACTIVITY, never whether it is running. Leaving it out hid exactly the
+ * sessions someone opened outside agentop and is in the middle of — the ones most likely to be
+ * forgotten, since agentop is not the thing that started them.
+ */
+export const ACTIVE_STATES: readonly SessionState[] =
+  ['working', 'waiting', 'waiting-approval', 'unknown'] as const
 
 /**
  * Is this session RUNNING right now — PURE.
  *
- * The three states that mean something is alive on the other end. `exited`, `lost`, `closed` and
- * `unknown` (an external process, whose state cannot be read at all) are not running, and the
- * "only active" switch keeps none of them.
+ * `exited`, `lost` and `closed` are not. `unknown` IS: it is what an external session wears, and an
+ * external row exists because a live assistant process was found — what cannot be read there is the
+ * activity, not the existence. Treating "we cannot say what it is doing" as "it is not running" hid
+ * every session started outside agentop from the one filter meant to show what is happening.
  */
 export function sessionRunning(s: ControlSession): boolean {
-  return s.state === 'working' || s.state === 'waiting' || s.state === 'waiting-approval'
+  return ACTIVE_STATES.includes(s.state)
 }
 
 /**

--- a/packages/tui/src/control/tabs/Sessions.tsx
+++ b/packages/tui/src/control/tabs/Sessions.tsx
@@ -1134,6 +1134,10 @@ export function Sessions({
       {cockpit.detail > 0 && (ask || (!hideDetail && detail.length > 0)) ? (
         <Pane
           title={ask ? s.sessionsPaneAsk : s.sessionsPaneDetail}
+          // The key that puts this pane away, written ON the pane. It lives as a row in the `show`
+          // block too, but that block is collapsed by default and five rows deep — a control for a
+          // thing you are looking straight at belongs on the thing.
+          badge={ask ? '' : s.sessionsDetailHide}
           focused={Boolean(ask)}
           width={width}
           height={cockpit.detail}


### PR DESCRIPTION
Two fixes on the sessions cockpit, and the reason the last one shipped under the wrong number.

## `only active` hid the sessions running outside agentop

An **external** row exists precisely because `/proc` reported a live assistant process. What cannot be read about it is its *activity* — nothing on that screen is capturable — never whether it is running. `sessionRunning` treated "we cannot say what it is doing" as "it is not running", so the one filter meant to show what is happening hid every session started outside agentop: the ones most likely to be forgotten, since agentop is not what started them.

## The detail pane's switch could not be found

It existed, as the fifth row of a block that ships collapsed. It is written **on the pane** now (`d oculta`) as well as in the menu — a control for a thing you are looking straight at belongs on the thing.

## The release pipeline could not count

The bump globs matched `feat:` and not `feat(sessions):`, so **every scoped feature this repository has ever shipped went out as a patch**. The session cockpit — forty-nine commits — released as 1.8.2. Scopes are matched now, and so is the bang on either side of one; the classification was exercised against ten commit shapes before landing, because a glob that looks right is exactly what shipped the last four releases wrong.

`workflow_dispatch` also takes a `version` now, which skips the computation entirely — a corrective release exists because the computed answer was wrong, so consulting it again would refuse the correction.

And `packages/tui/package.json` joins the bumped files: being left out is why it sat at 1.7.3 while everything else was at 1.7.7.

**This merge releases v1.9.0** — the fix's own subject is a scoped `feat`, which the corrected glob reads as a minor bump from 1.8.2, which is the number the cockpit should have carried.

Tests: 3162 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019vBSuKQLuyLhWZS4zbiu2s