### PR TITLE
feat(sessions): `agentop session ls` prints the cockpit's table

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,10 +30,20 @@ packages/server/bin/cli.ts  (binary entry point — agentop)
   ├── agentop watch        → server/otel-watcher.ts (daemon only)
   ├── agentop central …    → server/cli-central.ts (wraps central.sh: up/init/down/logs/status/restart/pull; `up` takes -y/-n and --cache/--no-cache, honored on the standalone path too)
   ├── agentop member …     → server/cli-member.ts (connect/leave/status; whoami-verified, no browser)
-  ├── agentop session …    → server/sessions/cli-session.ts (start/list/attach/kill/rename/note;
+  ├── agentop session …    → server/sessions/cli-session.ts (start/ls/list/attach/kill/rename/note;
   │                          `--bg` detaches via tmux, attach prints the REAL detach key; `list`
   │                          reports what each session is DOING and names the harnesses whose
-  │                          approval detection is unavailable)
+  │                          approval detection is unavailable). **`ls` is the COCKPIT'S TABLE
+  │                          printed**: it consumes `packages/tui/src/control/sessions.ts` —
+  │                          `sessionColumns` / `groupSessions` / `sessionRows` / `sessionRunning`
+  │                          — through the pure `session-table.ts`, and owns only the DRAWING (ANSI,
+  │                          `process.stdout.columns`, a final clip so no row can wrap). A second
+  │                          implementation of the table would be a second set of rules, which is
+  │                          the bug `task-reopen.ts` exists to have fixed once. It is a NEW command
+  │                          rather than a flag: `list` is the tab-separated dump scripts already
+  │                          read, so its output is untouched and both print the same `--json`.
+  │                          Without a tty there is no colour and NO invented width — the table is
+  │                          as wide as its content, so `session ls | grep` works
   ├── agentop ci-push      → server/ci-push.ts (one-shot GitHub Actions runner → central push; env AGENTISTICS_CENTRAL_URL/AGENTISTICS_CI_TOKEN)
   ├── agentop autostart …  → server/autostart.ts (systemd user service + linger + ~/.bashrc + ~/.zshrc update-check hook)
   ├── agentop upgrade      → server/upgrade.ts
@@ -104,7 +114,12 @@ packages/server/server/          — server-side modules (never bundled by Vite)
   │                          falling back to the COMMON git dir's parent (`--show-toplevel` would
   │                          answer with the worktree, which is the one name that must not become
   │                          the key). Memoized by directory: the poll runs every five seconds.
-  │                          See docs/session-manager.md
+  │                          The pure `control-session.ts` is the ONE `SessionView` -> `ControlSession`
+  │                          mapping (it lived inside `cli-start.ts` while the cockpit was the only
+  │                          thing drawing a row) and `session-table.ts` is the pure renderer behind
+  │                          `agentop session ls` — including `emptyReason`, which keeps "the poll
+  │                          failed", "there is nothing" and "the filter withheld it" three different
+  │                          sentences. See docs/session-manager.md
   ├── cli-start.ts         → the control center's HOST (`ControlHost`): service detection, start/stop/restart, connect/disconnect, boot service, archive consent, language — every action returns an already-localized `ActionResult` instead of printing
   ├── cli-stream.ts        → the control center's OUTPUT CHANNEL: subscribers + `streamCommand` (both pipes captured, never `inherit`) → lines via the pure `@agentistics/tui/control/stream`
   ├── cli-ui.ts            → dependency-free arrow-key select/confirm/input/pause + clearScreen (bundles clean into the binary; no node_modules to resolve)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -428,6 +428,7 @@ apresentacao  1  ─────────────────────
 | `--group`, `-g` | `project` (default), `repo`, `task`, `harness`, `model`, `none` |
 | `--json` | The same JSON `list --json` prints — one machine-readable shape, not two |
 | `--width <n>` | Fit this many columns instead of asking the terminal |
+| `COLUMNS` (env) | Read **only when stdout is not a tty** — how wide the reader is when there is no terminal to ask (`ls \| less -S`) |
 | `--no-color` | Never colour, whatever the terminal says (`NO_COLOR` does the same) |
 
 It is a **separate command from `list`**, not a flag on it: `list` is the tab-separated dump scripts
@@ -447,6 +448,10 @@ Some particulars, all of them shared with the cockpit rather than re-decided her
   last resort, so a narrow terminal loses cells rather than wrapping every row onto the next.
 - **Piped output is plain.** No colour, no escapes, and no invented terminal width — the table comes
   out as wide as its content, so `agentop session ls | grep` works.
+- **A pipe can still state a width**, and a pager is a reader: with no tty to ask,
+  `COLUMNS=80 agentop session ls | less -S` fits 80 columns, the same lever `git` and `ls` honour.
+  The order is `--width` → the terminal → `COLUMNS` → as wide as the content; a `COLUMNS` that is
+  not a width (`abc`, `0`) is ignored rather than obeyed, and no minimum is imposed on one that is.
 
 `--bg` detaches and returns immediately; without it the session takes over your terminal, and the
 detach keystroke is printed first (read from your own tmux prefix, never assumed to be `Ctrl-b`).

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -34,7 +34,7 @@ agentop --version    # print version (and a notice if an update exists)
 | [`watch`](#watch) | OpenTelemetry metrics daemon only (headless) |
 | [`central`](#central) | Manage the Team Mode central (wraps `central.sh`) |
 | [`member`](#member) | Join / leave / inspect a Team Mode central from this machine |
-| [`session`](#session) | Start / list / attach / kill background assistant sessions (tmux-backed) |
+| [`session`](#session) | Start / list / attach / kill background assistant sessions (tmux-backed); `ls` prints the cockpit's table |
 | [`ci-push`](#ci-push) | One-shot push of a GitHub Actions run's metrics to a central (per repo) |
 | [`autostart`](#autostart) | Start a mode with the system (systemd user service) |
 | [`upgrade`](#upgrade) | Upgrade `agentop` to the latest release |
@@ -394,6 +394,7 @@ with your own tmux sessions.
 
 ```bash
 agentop session <harness> [-p "prompt"] [--bg] [--model <id>] [--effort <level>] [--cwd <path>] [--name "label"] [--task "<name>"]
+agentop session ls     [--all] [--group repo|project|task|harness|model|none] [--json] [--width <n>] [--no-color]
 agentop session list   [--json]
 agentop session attach <id|name>
 agentop session kill   <id|name>
@@ -404,6 +405,48 @@ agentop session note   <id|name> "text"
 agentop session batch --task "<name>" [--cwd <path>] --session "<harness>: <prompt>" [--session ...] [--json]
 agentop session open  "<task>" [--json]
 ```
+
+### `ls` — the cockpit's table, printed
+
+`agentop session ls` prints the very table the control center's **sessions** tab draws: aligned
+columns, a section per project, and the state word first. By default it answers the question a
+person means by "what have I got open" — **only what is running**, grouped by project:
+
+```
+  id     state         session                     worktree         task                 harness  project
+agentistics  4  ────────────────────────────────────────────────────────────────────────────────────────
+  df831  working       claude hook                 claude-hook      cli: claude hook     claude   agentistics
+  bda77  needs approval  session ls on the cli     session-ls       cli: session ls      claude   agentistics
+
+apresentacao  1  ───────────────────────────────────────────────────────────────────────────────────────
+  b87a4  waiting       drop the invented metrics                                         claude   apresentacao
+```
+
+| Flag | Effect |
+|------|--------|
+| `--all`, `-a` | Also list what is **not** running: finished, lost and closed conversations |
+| `--group`, `-g` | `project` (default), `repo`, `task`, `harness`, `model`, `none` |
+| `--json` | The same JSON `list --json` prints — one machine-readable shape, not two |
+| `--width <n>` | Fit this many columns instead of asking the terminal |
+| `--no-color` | Never colour, whatever the terminal says (`NO_COLOR` does the same) |
+
+It is a **separate command from `list`**, not a flag on it: `list` is the tab-separated dump scripts
+already read line by line, and widening it into columns underneath them would break those scripts
+for a cosmetic reason. Both print the same `--json`.
+
+Some particulars, all of them shared with the cockpit rather than re-decided here:
+
+- **A session running outside agentop counts as running.** It is listed as `external` because
+  `/proc` found a live assistant; what cannot be read there is its *activity*, never whether it is
+  alive. It carries no id, because `agentop session attach` cannot resolve one for it.
+- **An absent number is absent.** A conversation that recorded no usage shows no usage — the column
+  does not exist unless something on screen fills it, and a `0` would be a confident wrong figure.
+- **An empty list says why.** "Nothing is running" names the flag that lists the rest; a poll that
+  failed says so and never claims the machine is idle.
+- **Nothing exceeds the width.** Columns are measured across the page and the row is clipped as a
+  last resort, so a narrow terminal loses cells rather than wrapping every row onto the next.
+- **Piped output is plain.** No colour, no escapes, and no invented terminal width — the table comes
+  out as wide as its content, so `agentop session ls | grep` works.
 
 `--bg` detaches and returns immediately; without it the session takes over your terminal, and the
 detach keystroke is printed first (read from your own tmux prefix, never assumed to be `Ctrl-b`).

--- a/docs/session-manager.md
+++ b/docs/session-manager.md
@@ -20,11 +20,39 @@ nothing else changes.
 
     agentop session <harness> [-p "prompt"] [--bg] [--model <id>] [--effort <level>]
                               [--cwd <path>] [--name "label"] [--task "<name>"]
+    agentop session ls     [--all] [--group repo|project|task|harness|model|none]
+                           [--json] [--width <n>] [--no-color]
     agentop session list   [--json]
     agentop session attach <id|name>
     agentop session kill   <id|name>
     agentop session rename <id|name> "label"
     agentop session note   <id|name> "text"
+
+### `ls` — the cockpit's table, printed once
+
+`ls` is the fleet for a PERSON to read: the same table the cockpit's fleet pane draws, printed to
+stdout and gone. Only what is running, grouped by project — `--all` adds the finished, lost and
+closed conversations, `--group` changes the sections.
+
+    agentop session ls                    # what is running, by project
+    agentop session ls --all --group repo # everything, by repository
+    agentop session ls --json             # exactly what `list --json` prints
+
+It draws by CONSUMING the cockpit's own arithmetic (`packages/tui/src/control/sessions.ts`) rather
+than by re-implementing it: `sessionColumns` measures the page so the columns line up, `groupSessions`
+and `sessionRows` decide the sections and the air between them, `sessionRunning` decides what
+"running" means — an `external` row included, since it exists because a live assistant process was
+found. A second copy of any of those would be a second set of rules that agree until the day they do
+not, which this repository has already paid for once. What `agentop session ls` owns is the
+DRAWING: ANSI written to a terminal instead of Ink components, the width taken from
+`process.stdout.columns`, and a final clip so no row can wrap.
+
+`ls` is a new command rather than a flag on `list`, because `list` is the tab-separated dump scripts
+already read line by line. Its output does not change.
+
+Piped output is plain: `process.stdout.isTTY` decides colour (`NO_COLOR` and `--no-color` override
+it), and a pipe gets no invented terminal width — the table comes out as wide as its content, so
+nothing is truncated to fit a terminal nobody is looking at.
 
 ## Orchestrating several at once
 
@@ -178,7 +206,7 @@ keystroke is printed before it does. `--cwd` defaults to the directory you are i
 
 ## What a session is doing
 
-`agentop session list` reports a state per session:
+`agentop session ls` / `list` report a state per session:
 
 | State | Meaning |
 |---|---|
@@ -196,7 +224,7 @@ moving is waiting for you; there is no third thing it could be doing. What canno
 Telling a blocking question apart from an ordinary pause needs screen markers captured from the real
 CLI, so it exists only for the harnesses that were probed (claude, codex, kimi). For any other
 harness a blocking question shows as `waiting` — still counted, still surfaced, but the reason
-cannot be named. `list` says so rather than leaving you to assume otherwise.
+cannot be named. `ls` and `list` both say so rather than leaving you to assume otherwise.
 
 The states are also honest about their own timing. When a turn ends, the poll that *observes* it
 ending sees a frame that changed since the last one, which is movement — so the session reads

--- a/docs/session-manager.md
+++ b/docs/session-manager.md
@@ -54,6 +54,13 @@ Piped output is plain: `process.stdout.isTTY` decides colour (`NO_COLOR` and `--
 it), and a pipe gets no invented terminal width — the table comes out as wide as its content, so
 nothing is truncated to fit a terminal nobody is looking at.
 
+A pipe can still SAY how wide it is, though, and a pager is a reader: `resolveWidth` takes `--width`
+first, then the terminal's own columns, then **`COLUMNS`** when there is no tty to ask, and only then
+the natural width. `COLUMNS=80 agentop session ls | less -S` therefore fits 80 columns instead of
+handing `less` a row it has to break. A `COLUMNS` that is not a width falls through rather than
+throwing, and no minimum is imposed on one that is — a caller asking for twenty columns gets twenty,
+and the clip is what keeps the rows inside them.
+
 ## Orchestrating several at once
 
 The form an ASSISTANT should drive. It exists because doing this through the single-session command

--- a/packages/server/bin/cli.ts
+++ b/packages/server/bin/cli.ts
@@ -59,7 +59,8 @@ Commands:
   watch         Start the background metrics daemon only
   central       Manage the team central (Docker; runs from anywhere)
   member        Configure this machine as a team member
-  session       Start / list / attach assistant sessions (tmux-backed; --bg detaches)
+  session       Start / list / attach assistant sessions (tmux-backed; --bg detaches);
+                'session ls' prints the cockpit's table of what is running
   ci-push       One-shot push of a CI runner's metrics to a central
   upgrade       Upgrade agentop to the latest version
   autostart     Start a mode with the system (systemd user service on Linux)

--- a/packages/server/server/cli-i18n.ts
+++ b/packages/server/server/cli-i18n.ts
@@ -129,6 +129,27 @@ export interface CliStrings {
   sessSpawnNoModel: (harness: string) => string
   sessSpawnNoEffort: (harness: string) => string
   sessSpawnBadEffort: (harness: string, value: string, accepted: string[]) => string
+
+  /**
+   * What `agentop session ls` says AROUND the table. The table's own chrome — its column headings
+   * and its group labels — comes from the control center's strings, because it is the same table.
+   */
+  sessLs: {
+    /** The fleet really is empty. Only ever printed when the poll actually succeeded. */
+    none: string
+    /**
+     * Nothing is RUNNING, and the rows the filter withheld are still there.
+     *
+     * It names the flag that lifts it, for the same reason the cockpit's empty list does: a mute
+     * blank is indistinguishable from a broken command, and the sessions a reboot turned into
+     * `lost` rows are still named, still filed and still reopenable.
+     */
+    noneRunning: (hidden: number) => string
+    waiting: (n: number, names: string) => string
+    /** Harnesses whose approval prompts cannot be told from an ordinary pause. */
+    blind: (harnesses: string) => string
+  }
+
   dockerMissing: string
   dockerUnreachable: string
   foregroundLater: string
@@ -331,6 +352,17 @@ const EN: CliStrings = {
   sessSpawnNoEffort: (harness: string) => `${harness} has no effort flag, so an effort cannot be set.`,
   sessSpawnBadEffort: (harness: string, value: string, accepted: string[]) =>
     `${harness} does not accept effort "${value}". Accepted: ${accepted.join(', ')}.`,
+
+  sessLs: {
+    none: 'No sessions.',
+    noneRunning: (hidden: number) =>
+      `Nothing is running — ${hidden} session${hidden === 1 ? '' : 's'} withheld. Run \`agentop session ls --all\` to list them.`,
+    waiting: (n: number, names: string) =>
+      `${n} session${n === 1 ? '' : 's'} waiting on you: ${names}`,
+    blind: (harnesses: string) =>
+      `Approval detection is not available for: ${harnesses} — those sessions show as "waiting" either way.`,
+  },
+
   dockerMissing: 'docker not installed',
   dockerUnreachable: 'docker is installed but not answering',
   foregroundLater: 'foreground starts once this screen closes.',
@@ -507,6 +539,17 @@ const PT: CliStrings = {
   sessSpawnNoEffort: (harness: string) => `${harness} não tem flag de effort, então não dá para definir um.`,
   sessSpawnBadEffort: (harness: string, value: string, accepted: string[]) =>
     `${harness} não aceita o effort "${value}". Aceitos: ${accepted.join(', ')}.`,
+
+  sessLs: {
+    none: 'Nenhuma sessão.',
+    noneRunning: (hidden: number) =>
+      `Nada rodando — ${hidden} ${hidden === 1 ? 'sessão retida' : 'sessões retidas'}. Rode \`agentop session ls --all\` para ver.`,
+    waiting: (n: number, names: string) =>
+      `${n} ${n === 1 ? 'sessão esperando' : 'sessões esperando'} por você: ${names}`,
+    blind: (harnesses: string) =>
+      `Detecção de aprovação não está disponível para: ${harnesses} — essas sessões aparecem como "aguardando" de qualquer jeito.`,
+  },
+
   dockerMissing: 'docker não instalado',
   dockerUnreachable: 'docker instalado, mas não responde',
   foregroundLater: 'o foreground sobe assim que esta tela fechar.',

--- a/packages/server/server/cli-start.ts
+++ b/packages/server/server/cli-start.ts
@@ -33,7 +33,7 @@ import { writeSync } from 'node:fs'
 import { join } from 'node:path'
 import { homedir, platform } from 'node:os'
 import {
-  DEFAULT_TEAM, HARNESS_ORDER, fmt, fmtCost, repoShortName,
+  DEFAULT_TEAM, HARNESS_ORDER, repoShortName,
   type HarnessId, type TeamConnection,
 } from '@agentistics/core'
 import type {
@@ -43,7 +43,6 @@ import type {
   BootState,
   ControlHost,
   ControlService,
-  ControlSession,
   ControlSessions,
   ControlStatus,
   LogSource,
@@ -54,7 +53,6 @@ import type {
   ServiceRuntimeState,
   ServiceState,
   SessionHarnessOption,
-  SessionState,
   SessionViewPrefs,
   SpawnSessionRequest,
   SpawnSessionResult,
@@ -90,13 +88,15 @@ import { resolveBackend } from './sessions'
 import { SPAWN_SPECS, planSpawn } from './sessions/spawn-spec'
 import { findProjects } from './sessions/project-source'
 import { candidatePath } from './sessions/project-search'
-import { repoFacts, type RepoFacts } from './sessions/repo-facts'
+import { repoFacts } from './sessions/repo-facts'
+// The `SessionView` -> `ControlSession` mapping, extracted so `agentop session ls` draws the same
+// rows from the same decision rather than mapping the fleet a second time.
+import { toControlSession } from './sessions/control-session'
 import { planTaskReopen, taskReopenSucceeded } from './sessions/task-reopen'
 import type { SpawnPlanError } from './sessions/types'
 import { addSession, newSessionId, patchSession, readRegistry, removeSession } from './sessions/registry'
 import { createSessionsPoller, type SessionsPoller } from './sessions/sessions-host'
 import { conversationForProcess, forgetConversations, loadConversations } from './sessions/conversations'
-import type { SessionView } from './sessions/session-view'
 
 export type StartResult = number | 'foreground'
 
@@ -1269,92 +1269,6 @@ async function spawnManaged(req: {
     id,
     message: s.sessStarted(name),
     ticket: { argv: backend.attachCommand(id), detachHint: await backend.detachHint(), label: name },
-  }
-}
-
-/** The state word each session wears, and the machine-readable state beside it. */
-function sessionState(v: SessionView): SessionState {
-  if (v.status === 'closed') return 'closed'
-  if (v.status === 'external') return 'unknown'
-  if (v.status === 'lost') return 'lost'
-  switch (v.activity) {
-    case 'waiting-approval': return 'waiting-approval'
-    case 'waiting': return 'waiting'
-    case 'working': return 'working'
-    case 'exited': return 'exited'
-    // A row with no activity that is not external is one the poller could not read this time round.
-    // `lost` is the honest word for it: something is known to exist and nothing can be said about it.
-    default: return 'lost'
-  }
-}
-
-function stateLabel(state: SessionState, s: CliStrings): string {
-  switch (state) {
-    case 'working': return s.sessState.working
-    case 'waiting-approval': return s.sessState.waitingApproval
-    case 'waiting': return s.sessState.waiting
-    case 'exited': return s.sessState.exited
-    case 'lost': return s.sessState.lost
-    case 'unknown': return s.sessState.external
-    case 'closed': return s.sessState.closed
-  }
-}
-
-/** The last path segment — the "by project" grouping key, decided here so the TUI never parses a
- *  path of its own. Backslashes normalised first, because a WSL machine sees both separators. */
-function projectName(cwd: string): string {
-  const parts = cwd.replace(/\\/g, '/').replace(/\/+$/, '').split('/')
-  return parts[parts.length - 1] ?? cwd
-}
-
-/** One server-side view, mapped to what the control center renders — every word already localized. */
-function toControlSession(
-  v: SessionView,
-  s: CliStrings,
-  /** What repository this session's directory belongs to, already resolved and memoized. */
-  facts: RepoFacts = { worktree: false },
-): ControlSession {
-  const state = sessionState(v)
-  const project = projectName(v.cwd)
-  const harness = v.harness ?? ''
-  return {
-    id: v.id,
-    // The user's own label wins over anything derived: naming a session is the whole point of
-    // being able to name one.
-    title: v.label ?? s.sessUntitled(harness || '?', project),
-    harness,
-    cwd: v.cwd,
-    project,
-    ...(v.model ? { model: v.model } : {}),
-    ...(v.note ? { note: v.note } : {}),
-    state,
-    stateLabel: stateLabel(state, s),
-    actionable: v.status !== 'external' && v.status !== 'closed',
-    // Stated only where it is TRUE and only for a session we actually HOST. A row that is closed or
-    // running outside agentop has no screen to read at all, so "approval detection is unavailable
-    // for this harness" is not merely noise there — it is false, and it said so about claude, which
-    // is probed.
-    ...(v.status !== 'external' && v.status !== 'closed' && !v.approvalDetection && harness
-      ? { approvalBlind: s.sessApprovalBlind(harness) }
-      : {}),
-    ...(v.createdMs !== undefined ? { startedAt: v.createdMs } : {}),
-    ...(v.task ? { task: v.task } : {}),
-    // Marked BY THE USER — a label, a note or a task. `title` cannot answer this: it always has a
-    // value, because the host derives one whenever there is no label.
-    ...(v.label || v.note || v.task ? { named: true } : {}),
-    ...(facts.repo ? { repo: facts.repo } : {}),
-    // Only when it differs: a session in the main checkout groups under its own folder already, and
-    // a field repeating what is beside it is one more thing that can disagree.
-    ...(facts.root && facts.root !== project ? { projectGroup: facts.root } : {}),
-    ...(facts.worktree ? { worktree: true } : {}),
-    ...(v.resume ? { resume: v.resume } : {}),
-    ...(v.lastLines?.length ? { lastLines: v.lastLines } : {}),
-    // Already formatted, because formatting is a presentation concern the host owns for everything
-    // else it hands over — and `fmt`/`fmtCost` are the shared helpers the dashboard uses.
-    ...(v.tokens !== undefined ? { tokens: fmt(v.tokens) } : {}),
-    ...(v.costUSD !== undefined ? { cost: fmtCost(v.costUSD) } : {}),
-    searchText: v.searchText,
-    attached: v.attached,
   }
 }
 

--- a/packages/server/server/sessions/cli-parse.test.ts
+++ b/packages/server/server/sessions/cli-parse.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'bun:test'
-import { parseSessionArgs } from './cli-parse'
+import { LS_DEFAULT, parseSessionArgs } from './cli-parse'
 
 describe('parseSessionArgs', () => {
   it('starts a background session on the given harness', () => {
@@ -33,6 +33,60 @@ describe('parseSessionArgs', () => {
     expect(parseSessionArgs(['kill', 'a1'])).toEqual({ kind: 'kill', ref: 'a1' })
     expect(parseSessionArgs(['rename', 'a1', 'refactor auth'])).toEqual({ kind: 'rename', ref: 'a1', label: 'refactor auth' })
     expect(parseSessionArgs(['note', 'a1', 'split the god object'])).toEqual({ kind: 'note', ref: 'a1', text: 'split the god object' })
+  })
+
+  it('ls defaults to the running sessions, grouped by project', () => {
+    expect(parseSessionArgs(['ls'])).toEqual({ kind: 'ls', all: false, group: 'project' })
+    expect(LS_DEFAULT).toEqual({ all: false, group: 'project' })
+  })
+
+  it('ls takes --all, --group, --json, --width and the colour override', () => {
+    expect(parseSessionArgs(['ls', '--all', '--group', 'repo', '--json'])).toEqual({
+      kind: 'ls', all: true, group: 'repo', json: true,
+    })
+    expect(parseSessionArgs(['ls', '-a', '-g', 'task'])).toEqual({ kind: 'ls', all: true, group: 'task' })
+    expect(parseSessionArgs(['ls', '--width', '80', '--no-color'])).toEqual({
+      kind: 'ls', all: false, group: 'project', width: 80, color: false,
+    })
+    expect(parseSessionArgs(['ls', '--color'])).toEqual({
+      kind: 'ls', all: false, group: 'project', color: true,
+    })
+  })
+
+  it('ls refuses a grouping the table cannot draw', () => {
+    expect(parseSessionArgs(['ls', '--group', 'nonsense'])).toEqual({
+      kind: 'error', message: expect.stringContaining('nonsense'),
+    })
+  })
+
+  it('ls never swallows the next flag as a value', () => {
+    // `--group --json` used to be the shape that grouped by "--json" and then printed no JSON.
+    expect(parseSessionArgs(['ls', '--group', '--json'])).toEqual({
+      kind: 'error', message: expect.stringContaining('Missing value'),
+    })
+    expect(parseSessionArgs(['ls', '--width', '--all'])).toEqual({
+      kind: 'error', message: expect.stringContaining('Missing value'),
+    })
+  })
+
+  it('ls refuses a width that is not a positive number of columns', () => {
+    expect(parseSessionArgs(['ls', '--width', 'wide'])).toEqual({
+      kind: 'error', message: expect.stringContaining('--width'),
+    })
+    expect(parseSessionArgs(['ls', '--width', '0'])).toEqual({
+      kind: 'error', message: expect.stringContaining('--width'),
+    })
+  })
+
+  it('ls rejects an option it does not know rather than ignoring it', () => {
+    expect(parseSessionArgs(['ls', '--sort'])).toEqual({
+      kind: 'error', message: expect.stringContaining('--sort'),
+    })
+  })
+
+  it('list is untouched by ls — a script reading it keeps its dump', () => {
+    expect(parseSessionArgs(['list'])).toEqual({ kind: 'list' })
+    expect(parseSessionArgs(['list', '--json'])).toEqual({ kind: 'list', json: true })
   })
 
   it('rejects a harness that is not a harness', () => {

--- a/packages/server/server/sessions/cli-parse.ts
+++ b/packages/server/server/sessions/cli-parse.ts
@@ -10,6 +10,10 @@
  */
 
 import { HARNESS_ORDER, type HarnessId } from '@agentistics/core'
+// `GROUPINGS` is the ONE list of the dimensions a fleet can be grouped along — the same rule
+// `HARNESS_SORT` follows: a second hand-written list here would accept a value the table cannot
+// draw, or refuse one it can, and TypeScript would accept both.
+import { GROUPINGS, type SessionGrouping } from '@agentistics/tui/control/sessions'
 
 export type SessionCommand =
   | {
@@ -24,6 +28,26 @@ export type SessionCommand =
       task?: string
     }
   | { kind: 'list'; json?: boolean }
+  /**
+   * The fleet as a TABLE, for a person to read — the cockpit's sessions screen printed once.
+   *
+   * A separate command from `list` rather than a flag on it. `list` is a tab-separated dump that
+   * scripts already read line by line, and widening it into columns under those scripts would break
+   * them for a cosmetic reason. `ls` starts life as the human one, so it can default to what a
+   * person means by the question — what is running, grouped by where I am working — while `list`
+   * keeps meaning everything.
+   */
+  | {
+      kind: 'ls'
+      /** Include what is not running: finished, lost and closed conversations. */
+      all: boolean
+      group: SessionGrouping
+      json?: boolean
+      /** Columns to fit, when the caller states one rather than letting the terminal answer. */
+      width?: number
+      /** Colour, when the caller overrides what the terminal and `NO_COLOR` would decide. */
+      color?: boolean
+    }
   /**
    * Start SEVERAL sessions at once, all filed under one task.
    *
@@ -72,6 +96,8 @@ export function parseSessionArgs(argv: string[]): SessionCommand {
 
   if (head === 'list') return { kind: 'list', ...(jsonFlag ? { json: true } : {}) }
 
+  if (head === 'ls') return parseLs(argv.slice(1), jsonFlag)
+
   if (head === 'batch') return parseBatch(argv.slice(1), jsonFlag)
 
   if (head === 'open') {
@@ -103,7 +129,7 @@ export function parseSessionArgs(argv: string[]): SessionCommand {
   if (!isHarness(head)) {
     return {
       kind: 'error',
-      message: `Unknown harness or action: ${head}. Expected one of ${HARNESS_ORDER.join(', ')} — or list, attach, kill, rename, note.`,
+      message: `Unknown harness or action: ${head}. Expected one of ${HARNESS_ORDER.join(', ')} — or ls, list, attach, kill, rename, note.`,
     }
   }
 
@@ -137,6 +163,66 @@ export function parseSessionArgs(argv: string[]): SessionCommand {
     else if (arg === '--effort') cmd.effort = value
     else if (arg === '--cwd') cmd.cwd = value
     else if (arg === '--name') cmd.label = value
+  }
+
+  return cmd
+}
+
+/**
+ * What `ls` shows when nobody says otherwise: what is RUNNING, grouped by the project it runs in.
+ *
+ * Stated once, here, so the parser, the help text and the docs cannot drift into describing three
+ * different defaults — the same reason the cockpit keeps a `DEFAULT_SESSION_VIEW`.
+ */
+export const LS_DEFAULT: { all: boolean; group: SessionGrouping } = { all: false, group: 'project' }
+
+function isGrouping(v: string): v is SessionGrouping {
+  return (GROUPINGS as readonly string[]).includes(v)
+}
+
+/** `agentop session ls [--all] [--group <dimension>] [--json] [--width <n>] [--no-color]`. */
+function parseLs(argv: string[], json: boolean): SessionCommand {
+  const cmd: Extract<SessionCommand, { kind: 'ls' }> = {
+    kind: 'ls', all: LS_DEFAULT.all, group: LS_DEFAULT.group, ...(json ? { json: true } : {}),
+  }
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]!
+    if (arg === '--json') continue
+    if (arg === '--all' || arg === '-a') { cmd.all = true; continue }
+    if (arg === '--no-color' || arg === '--no-colour') { cmd.color = false; continue }
+    if (arg === '--color' || arg === '--colour') { cmd.color = true; continue }
+
+    if (arg === '--group' || arg === '-g') {
+      const value = argv[i + 1]
+      // A flag whose value is missing is an ERROR, never a swallowed neighbour: `--group --json`
+      // must not quietly group by "--json" and then drop the JSON output.
+      if (value === undefined || value.startsWith('-')) {
+        return { kind: 'error', message: `Missing value for ${arg}. Accepted: ${GROUPINGS.join(', ')}.` }
+      }
+      i++
+      if (!isGrouping(value)) {
+        return { kind: 'error', message: `Unknown grouping "${value}". Accepted: ${GROUPINGS.join(', ')}.` }
+      }
+      cmd.group = value
+      continue
+    }
+
+    if (arg === '--width' || arg === '-w') {
+      const value = argv[i + 1]
+      if (value === undefined || value.startsWith('-')) {
+        return { kind: 'error', message: `Missing value for ${arg}` }
+      }
+      i++
+      const n = Number(value)
+      if (!Number.isInteger(n) || n <= 0) {
+        return { kind: 'error', message: `--width takes a positive number of columns, not "${value}".` }
+      }
+      cmd.width = n
+      continue
+    }
+
+    return { kind: 'error', message: `Unknown option: ${arg}` }
   }
 
   return cmd

--- a/packages/server/server/sessions/cli-session.ts
+++ b/packages/server/server/sessions/cli-session.ts
@@ -17,7 +17,7 @@ import { resolveLang } from '../cli-lang'
 import { readPreferences } from '../preferences'
 import { toControlSession } from './control-session'
 import { repoFacts } from './repo-facts'
-import { NATURAL_WIDTH, emptyReason, renderSessionTable } from './session-table'
+import { emptyReason, renderSessionTable, resolveWidth } from './session-table'
 import { SPAWN_SPECS, planSpawn } from './spawn-spec'
 import { reconcileSessions, resolveSessionRef, type ReconciledSession, type RefCandidate } from './session-ref'
 import { addSession, newSessionId, patchSession, readRegistry, removeSession } from './registry'
@@ -362,10 +362,15 @@ async function ls(
   const shown = cmd.all ? fleet : fleet.filter(sessionRunning)
 
   const tty = process.stdout.isTTY === true
-  // A pipe has no width. Inventing one would truncate a session's name to fit a terminal nobody is
-  // looking at, so the natural width is used instead and the lines come out as long as their
-  // content — which is what `agentop session ls | grep` needs.
-  const width = cmd.width ?? (tty ? (process.stdout.columns || 100) : NATURAL_WIDTH)
+  // `--width`, then the terminal, then `COLUMNS`, then the natural width — the precedence is
+  // `resolveWidth`'s, so it is stated and tested in one place. `columns` is passed ONLY on a tty:
+  // off one it is undefined anyway, and asking for it would make the fallback depend on a value
+  // that cannot exist.
+  const width = resolveWidth({
+    ...(cmd.width !== undefined ? { explicit: cmd.width } : {}),
+    ...(tty && process.stdout.columns ? { columns: process.stdout.columns } : {}),
+    ...(process.env.COLUMNS !== undefined ? { env: process.env.COLUMNS } : {}),
+  })
   const color = cmd.color ?? (tty && !process.env.NO_COLOR)
   // Every SENTENCE this command prints is wrapped, never truncated: they name sessions and flags,
   // and a cut one hides the very thing it exists to say. Through the app's own `wrapText`, and a

--- a/packages/server/server/sessions/cli-session.ts
+++ b/packages/server/server/sessions/cli-session.ts
@@ -8,14 +8,23 @@
 
 import { resolve } from 'node:path'
 import { HARNESS_ORDER, type HarnessId } from '@agentistics/core'
-import { parseSessionArgs, type SessionCommand } from './cli-parse'
+import { sessionRunning } from '@agentistics/tui/control/sessions'
+import { controlStrings } from '@agentistics/tui/control/i18n'
+import { wrapText } from '@agentistics/tui/control/surface'
+import { parseSessionArgs, LS_DEFAULT, type SessionCommand } from './cli-parse'
+import { cliStrings } from '../cli-i18n'
+import { resolveLang } from '../cli-lang'
+import { readPreferences } from '../preferences'
+import { toControlSession } from './control-session'
+import { repoFacts } from './repo-facts'
+import { NATURAL_WIDTH, emptyReason, renderSessionTable } from './session-table'
 import { SPAWN_SPECS, planSpawn } from './spawn-spec'
 import { reconcileSessions, resolveSessionRef, type ReconciledSession, type RefCandidate } from './session-ref'
 import { addSession, newSessionId, patchSession, readRegistry, removeSession } from './registry'
 import { conversationForProcess, loadConversations } from './conversations'
 import { resolveBackend } from './index'
 import { scanProcesses } from '../live-sessions'
-import { createSessionsPoller } from './sessions-host'
+import { createSessionsPoller, type SessionSnapshot } from './sessions-host'
 import { needsAttention, type SessionView } from './session-view'
 import { planTaskReopen, taskReopenSucceeded } from './task-reopen'
 import type { SessionBackend, SpawnPlanError } from './types'
@@ -25,11 +34,17 @@ const STARTABLE: HarnessId[] = HARNESS_ORDER.filter(h => SPAWN_SPECS[h] !== null
 
 const USAGE = `Usage:
   agentop session <harness> [-p "prompt"] [--bg] [--model <id>] [--effort <level>] [--cwd <path>] [--name "label"]
+  agentop session ls     [--all] [--group repo|project|task|harness|model|none] [--json]
   agentop session list
   agentop session attach <id|name>
   agentop session kill   <id|name>
   agentop session rename <id|name> "label"
   agentop session note   <id|name> "text"
+
+  \`ls\` is the table a PERSON reads: aligned columns, one section per project, and only what is
+  running — \`--all\` adds the finished, lost and closed conversations, \`--group\` changes the
+  sections. \`list\` stays the tab-separated dump a script can read line by line; both take
+  \`--json\` and print the same data.
 
 Orchestrating several at once — the form an assistant should use:
 
@@ -88,6 +103,7 @@ export async function runSession(argv: string[]): Promise<number> {
     case 'batch': return batch(cmd, backend)
     case 'open': return openTask(cmd.task, cmd.json ?? false, backend)
     case 'list': return list(backend, cmd.json ?? false)
+    case 'ls': return ls(cmd, backend)
     case 'attach': return attach(cmd.ref, backend)
     case 'kill': return kill(cmd.ref, backend)
     case 'rename': return patch(cmd.ref, { label: cmd.label }, 'renamed', backend)
@@ -281,27 +297,134 @@ async function openTask(task: string, json: boolean, backend: SessionBackend): P
   return taskReopenSucceeded(plan, started.length) ? 0 : 1
 }
 
-async function list(backend: SessionBackend, json = false): Promise<number> {
-  const poller = createSessionsPoller({ backend, readRegistry, scanProcesses, loadConversations })
-  const snap = await poller.poll()
+/** The fleet as DATA, so an assistant orchestrating sessions reads it rather than parsing a table
+ *  meant for a person. One shape for every command that offers `--json`: `ls` prints exactly what
+ *  `list` prints, because a second machine-readable format is a second thing to keep in step. */
+function fleetJson(snap: SessionSnapshot): unknown {
+  return {
+    sessions: snap.sessions.map(v => ({
+      id: v.id,
+      status: v.status,
+      activity: v.activity ?? null,
+      harness: v.harness ?? null,
+      cwd: v.cwd,
+      label: v.label ?? null,
+      task: v.task ?? null,
+      resumeId: v.resume?.sessionId ?? null,
+    })),
+    attention: snap.attention,
+    unavailable: snap.unavailable ?? null,
+  }
+}
 
-  // Machine-readable on request, so an assistant orchestrating sessions reads its own fleet as data
-  // rather than parsing a table meant for a person.
+/** The whole fleet, from the registry, the backend, `/proc` and the conversation store. */
+async function pollFleet(backend: SessionBackend): Promise<SessionSnapshot> {
+  const poller = createSessionsPoller({ backend, readRegistry, scanProcesses, loadConversations })
+  return await poller.poll()
+}
+
+/**
+ * `agentop session ls` — the cockpit's sessions table, printed once.
+ *
+ * Everything about what a row IS comes from the same modules the Sessions tab uses: `pollFleet`
+ * gathers the fleet, `toControlSession` maps it, `renderSessionTable` draws it. What is decided here
+ * is what a COMMAND LINE has to decide — which rows the question is about (what is running, unless
+ * `--all`), how wide the output may be, and whether anything is going to a terminal at all.
+ */
+async function ls(
+  cmd: Extract<SessionCommand, { kind: 'ls' }>,
+  backend: SessionBackend,
+): Promise<number> {
+  const snap = await pollFleet(backend)
+  if (cmd.json) { console.log(JSON.stringify(fleetJson(snap), null, 2)); return 0 }
+
+  const lang = await resolveLang()
+  const s = cliStrings(lang)
+  // The TABLE's own chrome — its column headings and the words an empty grouping key wears — is the
+  // control center's, because it is the control center's table. Two copies of "usage" and "no task"
+  // are two places for them to disagree about what a column is called.
+  const c = controlStrings(lang)
+
+  // Said BEFORE the table: an unavailable backend has not established that nothing is running, and
+  // the rows below may be a previous poll rather than a fresh one.
+  if (snap.unavailable) console.error(snap.unavailable)
+
+  // Resolved per session and memoized by directory — the same read the cockpit does, and what makes
+  // three worktrees of one repository group under the project rather than under three names.
+  const facts = await Promise.all(snap.sessions.map(v => repoFacts(v.cwd)))
+  // A preferences file that cannot be read costs the "finished" mark on a task heading, never the
+  // table: the fleet is what the command is for.
+  const finishedTasks = await readPreferences().then(p => p.finishedTasks ?? []).catch(() => [])
+  const fleet = snap.sessions.map((v, i) => toControlSession(v, s, facts[i]))
+  // `sessionRunning` rather than a state list of our own: an EXTERNAL row is running — it exists
+  // because `/proc` found a live assistant — and what cannot be read there is its activity, never
+  // whether it is alive.
+  const shown = cmd.all ? fleet : fleet.filter(sessionRunning)
+
+  const tty = process.stdout.isTTY === true
+  // A pipe has no width. Inventing one would truncate a session's name to fit a terminal nobody is
+  // looking at, so the natural width is used instead and the lines come out as long as their
+  // content — which is what `agentop session ls | grep` needs.
+  const width = cmd.width ?? (tty ? (process.stdout.columns || 100) : NATURAL_WIDTH)
+  const color = cmd.color ?? (tty && !process.env.NO_COLOR)
+  // Every SENTENCE this command prints is wrapped, never truncated: they name sessions and flags,
+  // and a cut one hides the very thing it exists to say. Through the app's own `wrapText`, and a
+  // no-op at a pipe's natural width — where one long line is what `grep` wants.
+  const say = (text: string) => { for (const l of wrapText(text, width)) console.log(l) }
+
+  // A mute blank is indistinguishable from a broken command, so an empty list says which of the
+  // three things happened. The decision is pure; only the sentence is chosen here.
+  const empty = emptyReason({
+    fleet: fleet.length,
+    shown: shown.length,
+    ...(snap.unavailable ? { unavailable: snap.unavailable } : {}),
+  })
+  if (empty !== null) {
+    // `unavailable` was already printed above, and it is the whole explanation.
+    if (empty === 'empty') say(s.sessLs.none)
+    else if (empty === 'filtered') say(s.sessLs.noneRunning(fleet.length))
+    return empty === 'unavailable' ? 1 : 0
+  }
+
+  for (const line of renderSessionTable({
+    sessions: shown,
+    width,
+    grouping: cmd.group,
+    color,
+    doneTasks: finishedTasks,
+    strings: {
+      cols: c.sessionsCols,
+      unknown: {
+        harness: c.sessionsUnknownHarness,
+        model: c.sessionsUnknownModel,
+        project: c.sessionsUnknownProject,
+        task: c.sessionsUnknownTask,
+        repo: c.sessionsUnknownRepo,
+      },
+      closed: c.sessionsClosedWord,
+      done: c.sessionsDoneWord,
+    },
+  })) console.log(line)
+
+  const waiting = shown.filter(v => v.state === 'waiting' || v.state === 'waiting-approval')
+  if (waiting.length > 0) {
+    console.log('')
+    say(s.sessLs.waiting(waiting.length, waiting.map(v => v.title).join(', ')))
+  }
+
+  // A harness with no probed rules cannot tell a permission prompt from an ordinary pause. Saying so
+  // is the difference between a gap and a wrong answer — and `approvalBlind` is set only on the rows
+  // that can lack it, so a closed conversation never names a harness that is in fact probed.
+  const blind = [...new Set(shown.filter(v => v.approvalBlind).map(v => v.harness))]
+  if (blind.length > 0) say(s.sessLs.blind(blind.join(', ')))
+  return 0
+}
+
+async function list(backend: SessionBackend, json = false): Promise<number> {
+  const snap = await pollFleet(backend)
+
   if (json) {
-    console.log(JSON.stringify({
-      sessions: snap.sessions.map(v => ({
-        id: v.id,
-        status: v.status,
-        activity: v.activity ?? null,
-        harness: v.harness ?? null,
-        cwd: v.cwd,
-        label: v.label ?? null,
-        task: v.task ?? null,
-        resumeId: v.resume?.sessionId ?? null,
-      })),
-      attention: snap.attention,
-      unavailable: snap.unavailable ?? null,
-    }, null, 2))
+    console.log(JSON.stringify(fleetJson(snap), null, 2))
     return 0
   }
 

--- a/packages/server/server/sessions/control-session.ts
+++ b/packages/server/server/sessions/control-session.ts
@@ -1,0 +1,106 @@
+/**
+ * control-session.ts — PURE. One server-side `SessionView`, mapped to the `ControlSession` every
+ * surface that DRAWS the fleet consumes.
+ *
+ * It lived inside `cli-start.ts` while the control center was the only thing drawing a session row.
+ * `agentop session ls` draws the same table into a plain terminal, and the alternative was a second
+ * mapping — which is how the same session ends up wearing one state word in the cockpit and another
+ * on the command line, and how a row named by the user keeps its name in one place and loses it in
+ * the other. The repo has already paid for that once (`task-reopen.ts`), so the decision is extracted
+ * and both sides execute it.
+ *
+ * Pure and stringless in the sense that matters: every word it emits arrives as an already-localized
+ * `CliStrings`, so this module owns no copy of any sentence.
+ */
+
+import { fmt, fmtCost } from '@agentistics/core'
+import type { ControlSession, SessionState } from '@agentistics/tui/control'
+import type { CliStrings } from '../cli-i18n'
+import type { RepoFacts } from './repo-facts'
+import type { SessionView } from './session-view'
+
+/** The state word each session wears, and the machine-readable state beside it. */
+export function sessionState(v: SessionView): SessionState {
+  if (v.status === 'closed') return 'closed'
+  if (v.status === 'external') return 'unknown'
+  if (v.status === 'lost') return 'lost'
+  switch (v.activity) {
+    case 'waiting-approval': return 'waiting-approval'
+    case 'waiting': return 'waiting'
+    case 'working': return 'working'
+    case 'exited': return 'exited'
+    // A row with no activity that is not external is one the poller could not read this time round.
+    // `lost` is the honest word for it: something is known to exist and nothing can be said about it.
+    default: return 'lost'
+  }
+}
+
+export function stateLabel(state: SessionState, s: CliStrings): string {
+  switch (state) {
+    case 'working': return s.sessState.working
+    case 'waiting-approval': return s.sessState.waitingApproval
+    case 'waiting': return s.sessState.waiting
+    case 'exited': return s.sessState.exited
+    case 'lost': return s.sessState.lost
+    case 'unknown': return s.sessState.external
+    case 'closed': return s.sessState.closed
+  }
+}
+
+/** The last path segment — the "by project" grouping key, decided here so the TUI never parses a
+ *  path of its own. Backslashes normalised first, because a WSL machine sees both separators. */
+export function projectName(cwd: string): string {
+  const parts = cwd.replace(/\\/g, '/').replace(/\/+$/, '').split('/')
+  return parts[parts.length - 1] ?? cwd
+}
+
+/** One server-side view, mapped to what the control center renders — every word already localized. */
+export function toControlSession(
+  v: SessionView,
+  s: CliStrings,
+  /** What repository this session's directory belongs to, already resolved and memoized. */
+  facts: RepoFacts = { worktree: false },
+): ControlSession {
+  const state = sessionState(v)
+  const project = projectName(v.cwd)
+  const harness = v.harness ?? ''
+  return {
+    id: v.id,
+    // The user's own label wins over anything derived: naming a session is the whole point of
+    // being able to name one.
+    title: v.label ?? s.sessUntitled(harness || '?', project),
+    harness,
+    cwd: v.cwd,
+    project,
+    ...(v.model ? { model: v.model } : {}),
+    ...(v.note ? { note: v.note } : {}),
+    state,
+    stateLabel: stateLabel(state, s),
+    actionable: v.status !== 'external' && v.status !== 'closed',
+    // Stated only where it is TRUE and only for a session we actually HOST. A row that is closed or
+    // running outside agentop has no screen to read at all, so "approval detection is unavailable
+    // for this harness" is not merely noise there — it is false, and it said so about claude, which
+    // is probed.
+    ...(v.status !== 'external' && v.status !== 'closed' && !v.approvalDetection && harness
+      ? { approvalBlind: s.sessApprovalBlind(harness) }
+      : {}),
+    ...(v.createdMs !== undefined ? { startedAt: v.createdMs } : {}),
+    ...(v.task ? { task: v.task } : {}),
+    // Marked BY THE USER — a label, a note or a task. `title` cannot answer this: it always has a
+    // value, because the host derives one whenever there is no label.
+    ...(v.label || v.note || v.task ? { named: true } : {}),
+    ...(facts.repo ? { repo: facts.repo } : {}),
+    // Only when it differs: a session in the main checkout groups under its own folder already, and
+    // a field repeating what is beside it is one more thing that can disagree.
+    ...(facts.root && facts.root !== project ? { projectGroup: facts.root } : {}),
+    ...(facts.worktree ? { worktree: true } : {}),
+    ...(v.resume ? { resume: v.resume } : {}),
+    ...(v.lastLines?.length ? { lastLines: v.lastLines } : {}),
+    // Already formatted, because formatting is a presentation concern the host owns for everything
+    // else it hands over — and `fmt`/`fmtCost` are the shared helpers the dashboard uses.
+    ...(v.tokens !== undefined ? { tokens: fmt(v.tokens) } : {}),
+    ...(v.costUSD !== undefined ? { cost: fmtCost(v.costUSD) } : {}),
+    searchText: v.searchText,
+    attached: v.attached,
+  }
+}

--- a/packages/server/server/sessions/session-table.test.ts
+++ b/packages/server/server/sessions/session-table.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, test } from 'bun:test'
 import type { ControlSession, SessionState } from '@agentistics/tui/control'
 import {
-  NATURAL_WIDTH, composeLine, emptyReason, renderSessionTable, type SessionTableStrings,
+  NATURAL_WIDTH, composeLine, emptyReason, renderSessionTable, resolveWidth,
+  type SessionTableStrings,
 } from './session-table'
 
 const STRINGS: SessionTableStrings = {
@@ -136,6 +137,46 @@ describe('renderSessionTable', () => {
       doneTasks: ['auth-refactor'],
     })
     expect(lines.join('\n')).toContain('auth-refactor · finished')
+  })
+})
+
+describe('resolveWidth', () => {
+  test('--width outranks everything, including a terminal that disagrees', () => {
+    expect(resolveWidth({ explicit: 72, columns: 200, env: '30' })).toBe(72)
+  })
+
+  test('a terminal answers for itself', () => {
+    expect(resolveWidth({ columns: 118, env: '30' })).toBe(118)
+  })
+
+  test('with no tty, COLUMNS is what says how wide the reader is', () => {
+    // `agentop session ls | less -S` in an 80-column terminal: a pipe is not evidence that nobody
+    // is reading, and COLUMNS is the only thing left that says how wide the reader is.
+    expect(resolveWidth({ env: '80' })).toBe(80)
+    expect(resolveWidth({ env: ' 96 ' })).toBe(96)
+  })
+
+  test('a pipe that says nothing gets the natural width, so nothing is truncated', () => {
+    expect(resolveWidth({})).toBe(NATURAL_WIDTH)
+    expect(resolveWidth({ env: undefined })).toBe(NATURAL_WIDTH)
+    expect(resolveWidth({ env: '' })).toBe(NATURAL_WIDTH)
+  })
+
+  test('a COLUMNS that is not a width falls through rather than exploding', () => {
+    for (const junk of ['abc', '0', '-1', '12.5', 'NaN', '1e3px', ' ']) {
+      expect(resolveWidth({ env: junk })).toBe(NATURAL_WIDTH)
+    }
+  })
+
+  test('no floor is invented — a caller asking for twenty columns gets twenty', () => {
+    expect(resolveWidth({ env: '20' })).toBe(20)
+    expect(resolveWidth({ explicit: 1 })).toBe(1)
+    // ...and the table still fits inside them, which is the clip's job, not a minimum's.
+    const lines = renderSessionTable({
+      sessions: FLEET, width: resolveWidth({ env: '20' }), grouping: 'project',
+      strings: STRINGS, color: true,
+    })
+    for (const line of lines) expect(stripAnsi(line).length).toBeLessThanOrEqual(20)
   })
 })
 

--- a/packages/server/server/sessions/session-table.test.ts
+++ b/packages/server/server/sessions/session-table.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, test } from 'bun:test'
+import type { ControlSession, SessionState } from '@agentistics/tui/control'
+import {
+  NATURAL_WIDTH, composeLine, emptyReason, renderSessionTable, type SessionTableStrings,
+} from './session-table'
+
+const STRINGS: SessionTableStrings = {
+  cols: {
+    id: 'id', state: 'state', title: 'session', task: 'task',
+    worktree: 'worktree', metrics: 'usage', harness: 'harness', where: 'project',
+  },
+  unknown: {
+    harness: 'harness unknown', model: 'no model recorded', project: 'no directory recorded',
+    task: 'no task', repo: 'no repository',
+  },
+  closed: 'closed',
+  done: 'finished',
+}
+
+function session(o: Partial<ControlSession> & { id: string }): ControlSession {
+  const state: SessionState = o.state ?? 'working'
+  return {
+    harness: 'claude',
+    cwd: `/home/dev/${o.project ?? 'app'}`,
+    project: 'app',
+    title: `session ${o.id}`,
+    stateLabel: state === 'waiting-approval' ? 'needs approval' : state,
+    state,
+    actionable: true,
+    attached: false,
+    searchText: '',
+    ...o,
+  }
+}
+
+const FLEET: ControlSession[] = [
+  session({ id: 'aaaa1', project: 'agentistics', title: 'refactor the parser', state: 'waiting-approval', tokens: '51.7k', cost: '$1.20' }),
+  session({ id: 'bbbb2', project: 'agentistics', title: 'port the tests', harness: 'codex', task: 'auth-refactor' }),
+  session({ id: 'external:claude:/home/dev/prontuario:12', project: 'prontuario', title: 'claude in prontuario', harness: 'claude', state: 'unknown', stateLabel: 'external' }),
+  session({ id: 'cccc3', project: 'embark', title: 'a very long session title that will not fit a narrow terminal', state: 'exited', stateLabel: 'exited', worktree: true, projectGroup: 'embark' }),
+]
+
+const stripAnsi = (s: string) => s.replace(/\x1b\[[0-9;]*m/g, '')
+
+describe('renderSessionTable', () => {
+  test('no line ever exceeds the width, at any width, coloured or not', () => {
+    for (let width = 8; width <= 200; width++) {
+      for (const color of [false, true]) {
+        const lines = renderSessionTable({
+          sessions: FLEET, width, grouping: 'project', strings: STRINGS, color,
+        })
+        for (const line of lines) {
+          expect(stripAnsi(line).length).toBeLessThanOrEqual(width)
+        }
+      }
+    }
+  })
+
+  test('a piped run at the natural width truncates nothing', () => {
+    const lines = renderSessionTable({
+      sessions: FLEET, width: NATURAL_WIDTH, grouping: 'project', strings: STRINGS, color: false,
+    })
+    expect(lines.join('\n')).toContain('a very long session title that will not fit a narrow terminal')
+    expect(lines.some(l => l.includes('…'))).toBe(false)
+  })
+
+  test('a heading rules to the edge of the TABLE, never of the budget', () => {
+    // At a pipe's width the budget is ten thousand columns and the table is a few dozen. Ruling to
+    // the budget drew ten thousand dashes over four sessions.
+    const lines = renderSessionTable({
+      sessions: FLEET, width: NATURAL_WIDTH, grouping: 'project', strings: STRINGS, color: false,
+    })
+    const widest = Math.max(...lines.map(l => l.length))
+    expect(widest).toBeLessThan(200)
+    expect(lines.some(l => l.includes('─'))).toBe(true)
+  })
+
+  test('the same table with colour off is the coloured one with the escapes removed', () => {
+    const opts = { sessions: FLEET, width: 100, grouping: 'project' as const, strings: STRINGS }
+    const plain = renderSessionTable({ ...opts, color: false })
+    const coloured = renderSessionTable({ ...opts, color: true })
+    expect(coloured.map(stripAnsi)).toEqual(plain)
+    expect(coloured.join('')).toContain('\x1b[')
+  })
+
+  test('groups by project, heading each section with its count', () => {
+    const lines = renderSessionTable({
+      sessions: FLEET, width: 120, grouping: 'project', strings: STRINGS, color: false,
+    })
+    const headings = lines.filter(l => /^\S/.test(l) && !l.startsWith('  '))
+    expect(headings.some(h => h.startsWith('agentistics  2'))).toBe(true)
+    expect(headings.some(h => h.startsWith('prontuario  1'))).toBe(true)
+  })
+
+  test('a session with no recorded usage prints no zero', () => {
+    const noUsage = [session({ id: 'aaaa1' }), session({ id: 'bbbb2' })]
+    const lines = renderSessionTable({
+      sessions: noUsage, width: 120, grouping: 'none', strings: STRINGS, color: false,
+    })
+    // The usage column does not exist at all — an absent metric is never a confident 0.
+    expect(lines[0]).not.toContain('usage')
+    expect(lines.join('\n')).not.toMatch(/\b0\b/)
+  })
+
+  test('usage is shown for the rows that have it, and only for those', () => {
+    const lines = renderSessionTable({
+      sessions: FLEET, width: 140, grouping: 'none', strings: STRINGS, color: false,
+    })
+    expect(lines[0]).toContain('usage')
+    expect(lines.join('\n')).toContain('51.7k $1.20')
+  })
+
+  test('an external row is listed and wears its own word', () => {
+    const lines = renderSessionTable({
+      sessions: FLEET, width: 140, grouping: 'none', strings: STRINGS, color: false,
+    })
+    expect(lines.join('\n')).toContain('external')
+    // ...and carries no handle: `agentop session attach` cannot resolve one for it.
+    const row = lines.find(l => l.includes('claude in prontuario'))!
+    expect(row).not.toContain('exter ')
+  })
+
+  test('an empty fleet renders nothing at all — the caller says why', () => {
+    expect(renderSessionTable({
+      sessions: [], width: 80, grouping: 'project', strings: STRINGS, color: false,
+    })).toEqual([])
+  })
+
+  test('a finished task says so on its heading', () => {
+    const lines = renderSessionTable({
+      sessions: [session({ id: 'aaaa1', task: 'auth-refactor' })],
+      width: 120,
+      grouping: 'task',
+      strings: STRINGS,
+      color: false,
+      doneTasks: ['auth-refactor'],
+    })
+    expect(lines.join('\n')).toContain('auth-refactor · finished')
+  })
+})
+
+describe('emptyReason', () => {
+  test('a table is drawn, so there is nothing to explain', () => {
+    expect(emptyReason({ fleet: 3, shown: 1 })).toBeNull()
+  })
+
+  test('a failed poll never claims that nothing is running', () => {
+    expect(emptyReason({ fleet: 0, shown: 0, unavailable: 'tmux is not answering' })).toBe('unavailable')
+    // Even with rows carried over from the previous poll, the reason is the failure.
+    expect(emptyReason({ fleet: 4, shown: 0, unavailable: 'tmux is not answering' })).toBe('unavailable')
+  })
+
+  test('an empty machine and a filtered one are different sentences', () => {
+    expect(emptyReason({ fleet: 0, shown: 0 })).toBe('empty')
+    expect(emptyReason({ fleet: 7, shown: 0 })).toBe('filtered')
+  })
+})
+
+describe('composeLine', () => {
+  test('clips on visible characters, never on the escapes', () => {
+    const line = composeLine([{ text: 'abcdefgh', code: '\x1b[2m' }], 4, true)
+    expect(stripAnsi(line)).toBe('abcd')
+  })
+
+  test('drops the padding at the end of the line, coloured or not', () => {
+    const segs = [{ text: 'ab' }, { text: '  cd    ', code: '\x1b[2m' }]
+    expect(composeLine(segs, 40, false)).toBe('ab  cd')
+    expect(stripAnsi(composeLine(segs, 40, true))).toBe('ab  cd')
+  })
+
+  test('a zero width yields an empty line rather than a partial one', () => {
+    expect(composeLine([{ text: 'abc' }], 0, false)).toBe('')
+  })
+})

--- a/packages/server/server/sessions/session-table.ts
+++ b/packages/server/server/sessions/session-table.ts
@@ -134,13 +134,52 @@ export interface SessionTableOptions {
 }
 
 /**
- * A width no row reaches, for output that is not going to a terminal.
+ * A width no row reaches, for output that is not going to a terminal and says nothing about one.
  *
- * A pipe has no width, and inventing one truncates a session's name to fit a terminal nobody is
- * looking at. Passed as the budget, `sessionColumns` gives every column its natural size and the
- * lines come out exactly as long as their content.
+ * A pipe has no width of its own, and inventing one truncates a session's name to fit a terminal
+ * nobody is looking at. Passed as the budget, `sessionColumns` gives every column its natural size
+ * and the lines come out exactly as long as their content.
+ *
+ * It is the LAST answer, not the first — see `resolveWidth`.
  */
 export const NATURAL_WIDTH = 10_000
+
+/**
+ * How many columns to fit — PURE, and the whole precedence in one place.
+ *
+ *  1. `explicit` — `--width`. Somebody stated it; nothing else gets a say.
+ *  2. `columns` — the terminal's own, via `process.stdout.columns`, which exists only on a tty.
+ *  3. `env` — `COLUMNS`. **The reason this function exists.** Without a tty the width was the
+ *     natural one, so `agentop session ls | less -S` in an 80-column terminal received a table as
+ *     wide as its content and `less` broke every row. A pipe is not evidence that nobody is
+ *     reading: a pager IS a reader, and when there is no tty to ask, `COLUMNS` is the only thing
+ *     left that says how wide the reader is. It is the convention `git` and `ls` follow.
+ *  4. The natural width — a pipe that said nothing about a width still gets nothing truncated.
+ *
+ * A `COLUMNS` that is present but not a width (`abc`, `0`, `-1`, `12.5`) falls through to the next
+ * answer rather than throwing or being coerced: the variable is set by all sorts of things, and a
+ * junk value is a statement about the environment, not an instruction. There is no MINIMUM applied
+ * either — a caller asking for twenty columns gets twenty, and the clip is what keeps the rows
+ * inside them. A floor here would silently overrule the one thing the caller actually said.
+ */
+export function resolveWidth(o: {
+  /** `--width`, when it was given. */
+  explicit?: number
+  /** `process.stdout.columns` — pass it only when stdout really is a tty. */
+  columns?: number
+  /** The raw `COLUMNS` variable, exactly as the environment holds it. */
+  env?: string
+}): number {
+  if (isWidth(o.explicit)) return o.explicit
+  if (isWidth(o.columns)) return o.columns
+  const fromEnv = o.env === undefined || o.env.trim() === '' ? Number.NaN : Number(o.env)
+  if (isWidth(fromEnv)) return fromEnv
+  return NATURAL_WIDTH
+}
+
+function isWidth(n: number | undefined): n is number {
+  return n !== undefined && Number.isInteger(n) && n > 0
+}
 
 /**
  * Why there is no table — PURE, and `null` when there is one.

--- a/packages/server/server/sessions/session-table.ts
+++ b/packages/server/server/sessions/session-table.ts
@@ -1,0 +1,275 @@
+/**
+ * session-table.ts — PURE. The sessions table, drawn as plain terminal lines.
+ *
+ * This is the cockpit's table printed instead of mounted: `agentop session ls` asks the same
+ * question the Sessions tab answers ("what is running, grouped by where I am working") and a person
+ * reading a log wants the same aligned columns and the same section headings. What changes is the
+ * DRAWING — ANSI written once to stdout rather than Ink components repainted — and nothing else.
+ *
+ * So every rule about what a row IS lives in `@agentistics/tui/control/sessions` and is consumed
+ * here: `sessionColumns` measures the page, `groupSessions` + `sessionRows` decide the sections and
+ * the air between them, `sessionHandle` / `worktreeName` / `sessionMetric` / `padCell` fill the
+ * cells. A second implementation of any of them is a second set of rules that agree until the day
+ * they do not — this repository has already paid for that once, with a task `open` written twice
+ * that left the registry in two different states depending on which one you pressed.
+ *
+ * Two things ARE this module's own, because they are drawing:
+ *
+ *  - **Nothing may exceed the width.** Ink truncates an over-wide row with `wrap="truncate"`; a
+ *    terminal wraps it, and a wrapped row shears every column under it. `sessionColumns` fits the
+ *    row for every width a person actually uses, but at ~20 columns its own floor (the state word
+ *    plus a one-character title) is already wider than the terminal — so the last step here CLIPS,
+ *    counting only visible characters.
+ *  - **Colour is optional and is never measured.** It is applied to a cell that is already padded,
+ *    so a pipe and a terminal are the same table with the same column positions.
+ */
+
+import {
+  DEFAULT_ORDER,
+  groupSessions,
+  padCell,
+  sessionColumns,
+  sessionHandle,
+  sessionMetric,
+  sessionRows,
+  worktreeName,
+  type SessionColumns,
+  type SessionGrouping,
+  type SessionOrder,
+} from '@agentistics/tui/control/sessions'
+import type { ControlSession, SessionState } from '@agentistics/tui/control'
+
+/**
+ * The words the table wears. Supplied by the caller, already localized — the same split every pure
+ * module in the control center keeps, and the reason `agentop session ls` can print the very
+ * headings the cockpit prints without either of them owning a copy of the other's strings.
+ */
+export interface SessionTableStrings {
+  cols: Record<keyof SessionColumns, string>
+  unknown: { harness: string; model: string; project: string; task: string; repo: string }
+  /** Heads the block of conversations that are not running. */
+  closed: string
+  /** Marks a task the user finished, on its heading. */
+  done: string
+}
+
+// ---------------------------------------------------------------------------
+// colour
+// ---------------------------------------------------------------------------
+
+const ESC = '\x1b'
+const RESET = `${ESC}[0m`
+const DIM = `${ESC}[2m`
+const CYAN = `${ESC}[36m`
+
+/**
+ * The state palette, mirroring the cockpit's `STATE_COLOR` intent in the sixteen colours a plain
+ * terminal is guaranteed to have.
+ *
+ * The theme's hex values are not reused directly: Ink resolves them through chalk, which downgrades
+ * per terminal, and writing a truecolor escape ourselves would render as nothing on a terminal that
+ * does not speak it — on the one cell of the row that nothing else repeats.
+ */
+const STATE_ANSI: Record<SessionState, string> = {
+  'waiting-approval': `${ESC}[1;31m`,
+  waiting: `${ESC}[33m`,
+  working: `${ESC}[32m`,
+  exited: DIM,
+  lost: DIM,
+  unknown: DIM,
+  closed: DIM,
+}
+
+/** One piece of a line: its text, and the escape that colours it when colour is on. */
+interface Seg {
+  text: string
+  code?: string
+}
+
+/**
+ * Segments to one line, clipped to `width` — the only place a line is finished.
+ *
+ * Clipping counts the TEXT, never the escapes, so a coloured table and a piped one break in exactly
+ * the same column. A segment that straddles the edge is cut; the ones after it are dropped whole.
+ */
+export function composeLine(segs: readonly Seg[], width: number, color: boolean): string {
+  let left = Math.max(0, width)
+  const kept: Seg[] = []
+  for (const seg of segs) {
+    if (left === 0) break
+    const text = seg.text.length > left ? seg.text.slice(0, left) : seg.text
+    if (text === '') continue
+    left -= text.length
+    kept.push({ text, ...(seg.code ? { code: seg.code } : {}) })
+  }
+
+  // The last cell's padding is blanks nobody can see, and it is what makes two identical rows differ
+  // in a diff. Trimmed on the TEXT, before any escape is applied — a trailing space wrapped in a
+  // colour would survive a trim of the finished string, so a coloured table and a piped one would
+  // not end in the same place.
+  while (kept.length > 0) {
+    const last = kept[kept.length - 1]!
+    last.text = last.text.replace(/\s+$/, '')
+    if (last.text !== '') break
+    kept.pop()
+  }
+
+  return kept.map(s => (color && s.code ? `${s.code}${s.text}${RESET}` : s.text)).join('')
+}
+
+// ---------------------------------------------------------------------------
+// the table
+// ---------------------------------------------------------------------------
+
+export interface SessionTableOptions {
+  sessions: readonly ControlSession[]
+  /** Columns available. See `naturalWidth` for what a pipe gets instead of a terminal's. */
+  width: number
+  grouping: SessionGrouping
+  strings: SessionTableStrings
+  color: boolean
+  /** Tasks the user marked finished — their headings say so. */
+  doneTasks?: readonly string[]
+  order?: SessionOrder
+}
+
+/**
+ * A width no row reaches, for output that is not going to a terminal.
+ *
+ * A pipe has no width, and inventing one truncates a session's name to fit a terminal nobody is
+ * looking at. Passed as the budget, `sessionColumns` gives every column its natural size and the
+ * lines come out exactly as long as their content.
+ */
+export const NATURAL_WIDTH = 10_000
+
+/**
+ * Why there is no table — PURE, and `null` when there is one.
+ *
+ * A blank where a list was expected is indistinguishable from a command that broke, so an empty run
+ * has to say which of three things happened, and they are genuinely different claims:
+ *
+ *  - `unavailable` — the poll did not establish anything. Claiming "nothing is running" here would
+ *    be a confident zero, which is the one answer this monitor may never give.
+ *  - `empty` — the machine really has no sessions.
+ *  - `filtered` — sessions exist and the default question ("what is running") withheld them. They
+ *    are still named, still filed and still reopenable, so the caller names the flag that lists
+ *    them.
+ */
+export function emptyReason(o: {
+  /** How many rows the fleet holds, before the filter. */
+  fleet: number
+  /** How many are left after it. */
+  shown: number
+  unavailable?: string
+}): 'unavailable' | 'empty' | 'filtered' | null {
+  if (o.shown > 0) return null
+  if (o.unavailable) return 'unavailable'
+  return o.fleet === 0 ? 'empty' : 'filtered'
+}
+
+/** The whole table as lines — headings, the column header, the rows, and the air between sections. */
+export function renderSessionTable(o: SessionTableOptions): string[] {
+  const groups = groupSessions(
+    o.sessions,
+    o.grouping,
+    o.strings.unknown,
+    o.doneTasks ?? [],
+    o.order ?? DEFAULT_ORDER,
+  )
+  const rows = sessionRows(groups, o.strings.closed, o.strings.done)
+  if (rows.length === 0) return []
+
+  // Measured across every row that will be PRINTED. Unlike the cockpit there is no window here —
+  // the whole fleet is the page — so a long title does widen the column for all of it, which is
+  // correct for a log: it is read as one block, not scrolled.
+  const columns = sessionColumns(
+    rows.flatMap(r => (r.kind === 'session' ? [r.session] : [])),
+    o.width,
+    { groupedByTask: o.grouping === 'task', headings: o.strings.cols },
+  )
+
+  // Every line except the headings, first — because a heading's rule runs to the edge of the TABLE
+  // and the table is only as wide as its widest row. Ruling to the budget instead is invisible at a
+  // terminal's width and absurd at a pipe's, where it drew ten thousand dashes over four sessions.
+  const drawn = [headerSegs(columns, o.strings.cols), ...rows.map(
+    r => (r.kind === 'session' ? rowSegs(r.session, columns) : null),
+  )]
+  const table = drawn.reduce(
+    (n, segs) => (segs ? Math.max(n, plainWidth(segs)) : n),
+    0,
+  )
+  const edge = Math.min(o.width, table)
+
+  const out: string[] = [composeLine(drawn[0]!, o.width, o.color)]
+  rows.forEach((row, i) => {
+    const segs = drawn[i + 1]
+    if (segs) { out.push(composeLine(segs, o.width, o.color)); return }
+    if (row.kind === 'spacer') { out.push(''); return }
+    if (row.kind === 'heading') {
+      out.push(composeLine(headingSegs(row.label, row.count, edge, row.muted), o.width, o.color))
+    }
+  })
+  return out
+}
+
+/** What these segments occupy on screen, escapes excluded — they are added after this is decided. */
+function plainWidth(segs: readonly Seg[]): number {
+  // Joined THEN trimmed, never per segment: the padding inside a row is real width, and only what
+  // trails the last cell is the padding `composeLine` drops.
+  return segs.map(s => s.text).join('').replace(/\s+$/, '').length
+}
+
+const GAP = '  '
+
+/** The header row — the same cells, from the same measured widths, so a heading can never sit over
+ *  a column it no longer names. */
+function headerSegs(c: SessionColumns, words: Record<keyof SessionColumns, string>): Seg[] {
+  const segs: Seg[] = [{ text: GAP }]
+  if (c.id > 0) segs.push({ text: padCell(words.id, c.id) + GAP, code: DIM })
+  segs.push({ text: padCell(words.state, c.state), code: DIM })
+  const rest: Array<[number, string]> = [
+    [c.title, words.title],
+    [c.worktree, words.worktree],
+    [c.task, words.task],
+    [c.metrics, words.metrics],
+    [c.harness, words.harness],
+    [c.where, words.where],
+  ]
+  for (const [w, word] of rest) {
+    if (w > 0) segs.push({ text: GAP + padCell(word, w), code: DIM })
+  }
+  return segs
+}
+
+/**
+ * A section heading: its name, how many rows are under it, and a rule out to the edge.
+ *
+ * The rule is what makes the sections visible in a wall of scrollback. A heading dimmed to the same
+ * weight as its rows is not a hierarchy — it is a list that happens to be sorted.
+ */
+function headingSegs(label: string, count: number, width: number, muted?: boolean): Seg[] {
+  const head = `${label}  ${count}`
+  const rule = Math.max(0, width - head.length - 3)
+  return [
+    { text: head, code: muted ? DIM : CYAN },
+    ...(rule > 0 ? [{ text: `${GAP}${'─'.repeat(rule)}`, code: DIM }] : []),
+  ]
+}
+
+/** One session row. The cell order and the give-up order are `sessionColumns`', not this module's. */
+function rowSegs(s: ControlSession, c: SessionColumns): Seg[] {
+  // Two columns where the cockpit draws its cursor and its mark. Kept rather than reclaimed: it is
+  // what `sessionColumns` budgets for, and it is what leaves the rows indented under their heading.
+  const segs: Seg[] = [{ text: GAP }]
+  if (c.id > 0) segs.push({ text: padCell(sessionHandle(s), c.id) + GAP, code: DIM })
+  segs.push({ text: padCell(s.stateLabel, c.state), code: STATE_ANSI[s.state] })
+  if (c.title > 0) segs.push({ text: GAP + padCell(s.title, c.title) })
+  if (c.worktree > 0) segs.push({ text: GAP + padCell(worktreeName(s), c.worktree), code: DIM })
+  if (c.task > 0) segs.push({ text: GAP + padCell(s.task ?? '', c.task), code: DIM })
+  if (c.metrics > 0) segs.push({ text: GAP + padCell(sessionMetric(s), c.metrics), code: DIM })
+  if (c.harness > 0) segs.push({ text: GAP + padCell(s.harness, c.harness), code: CYAN })
+  if (c.where > 0) {
+    segs.push({ text: GAP + padCell(s.projectGroup || s.project, c.where), code: DIM })
+  }
+  return segs
+}

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -8,7 +8,10 @@
     ".": "./src/index.tsx",
     "./control": "./src/control/index.ts",
     "./control/altScreen": "./src/control/altScreen.ts",
-    "./control/stream": "./src/control/stream.ts"
+    "./control/stream": "./src/control/stream.ts",
+    "./control/sessions": "./src/control/sessions.ts",
+    "./control/surface": "./src/control/surface.ts",
+    "./control/i18n": "./src/control/i18n.ts"
   },
   "scripts": {
     "dev": "bun run src/index.tsx",


### PR DESCRIPTION
## What

`agentop session ls` — the sessions cockpit's table, printed to stdout and gone. By default it
answers what a person means by "what have I got open": **only what is running, grouped by project**.

```
  id     state       session                     worktree         task                 harness  project
agentistics  4  ──────────────────────────────────────────────────────────────────────────────────────
  df831  waiting     claude hook                 claude-hook      cli: claude hook     claude   agentistics
  bda77  working     session ls on the cli       session-ls       cli: session ls      claude   agentistics

apresentacao  1  ─────────────────────────────────────────────────────────────────────────────────────
  b87a4  waiting     drop the invented metrics                                         claude   apresentacao

1 session waiting on you: drop the invented metrics
```

`--all` adds the finished, lost and closed conversations; `--group repo|project|task|harness|model|none`
changes the sections; `--json` prints **exactly** what `list --json` prints; `--width <n>` and
`--no-color` are overrides for the two things the terminal normally answers.

## Why a new command and not a flag

`agentop session list` is a tab-separated dump that scripts already read line by line. Widening it
into columns underneath them would break them for a cosmetic reason. `list` is untouched — same
output, byte for byte — and both take `--json`, which is one shape, not two.

## The table is not reimplemented

`session-table.ts` **consumes** `packages/tui/src/control/sessions.ts`:

- `sessionColumns` measures the page, so the columns line up and the give-up order under width
  pressure is the cockpit's
- `groupSessions` + `sessionRows` decide the sections, the counts and the air between them
- `sessionRunning` decides what "running" means — an `external` row included, because it exists
  because `/proc` found a live assistant, and what cannot be read there is its *activity*, never
  whether it is alive
- `sessionHandle` / `worktreeName` / `sessionMetric` / `padCell` fill the cells

**That file is not modified** (another session is adding a cards view to it). The two additions
outside this feature's own files are one line of `packages/tui/package.json` subpath exports, and
moving `toControlSession` out of `cli-start.ts` into the pure `sessions/control-session.ts` — it was
the cockpit's mapping only because the cockpit was the only thing drawing a row. A second copy of
either would be a second set of rules that agree until the day they do not, which is the bug
`task-reopen.ts` exists to have fixed once.

## What this feature does own — the drawing

Ink's rules and a terminal's differ, and every difference here was a real defect first:

- **Nothing may exceed the width.** Ink truncates an over-wide row with `wrap="truncate"`; a
  terminal wraps it, and a wrapped row shears every column under it. The last step clips, counting
  visible characters, never the escapes — so a coloured table and a piped one break in the same
  column. `sessionColumns`' own floor is wider than the terminal at ~20 columns, so this is not
  theoretical.
- **A heading rules to the edge of the TABLE, not of the budget.** Ruling to the budget drew ten
  thousand dashes over four sessions the first time it was piped.
- **The sentences under the table are wrapped, not cut** (through the app's own `wrapText`) — they
  name sessions, and a truncated one hides the thing it exists to say.
- **Piped output is plain.** `isTTY` decides colour (`NO_COLOR` and `--no-color` override), and a
  pipe gets no invented terminal width — the lines come out as long as their content, so
  `agentop session ls | grep` works.
- **An empty list says why**, and the pure `emptyReason` keeps three different claims apart: a poll
  that failed never says the machine is idle, an empty machine says so, and a list the default
  filter emptied names the flag that lists the rest.
- **Absence stays absence.** A conversation that recorded no usage draws no usage column at all.

## Tests

`session-table.test.ts` (16) + `cli-parse.test.ts` (+7):

- every line at every width from 8 to 200, coloured and plain, fits
- the piped natural width truncates nothing, and the heading rule stays with the table
- the coloured table is the plain one with the escapes removed
- no zero for an absent metric; usage only for the rows that have it
- `emptyReason`'s three answers
- `--group --json` does not swallow the flag as a value; a bad grouping and a bad width are refused
- `list` and `list --json` parse exactly as before

`bun tsc --noEmit` clean, `bun test` 3439 pass / 0 fail.

## Verified for real

Against the **compiled binary** (`bun run build:binary`), in real ptys at 30 / 40 / 55 / 72 / 100 /
160 columns with `--all`: max visible line == the terminal width, never over. Piped: zero escape
sequences, `grep` matches. `session ls --json` is byte-identical to `session list --json`.
