### PR TITLE
feat(sessions): attached sessions can be scrolled

### DIFF
--- a/docs/session-manager.md
+++ b/docs/session-manager.md
@@ -220,6 +220,24 @@ one prompt non-interactively and exits — so agentop types the prompt in once t
 Codex's reasoning effort is a `-c key=value` configuration override rather than a flag; it is not
 wired up because the key could not be verified from the CLI itself, and agentop does not guess flags.
 
+## Scrolling an attached session
+
+Sessions are hosted on agentop's own tmux socket (`-L agentop`), and agentop sets three options on
+it before the first one exists: `remain-on-exit` (a finished session stays listable with its last
+frame readable), `mouse on`, and a `history-limit` of 50000 lines.
+
+The mouse is what makes the wheel scroll at all — without it a pane shows the last screenful and
+nothing else, so attaching to a session to read what it did was attaching to a session you cannot
+read. The trade is that dragging to select now goes to tmux rather than to your terminal: **hold
+shift** to select and copy the terminal's own way.
+
+The scrollback is set up front because it does not apply retroactively — a pane created before it
+keeps tmux's default 2000 for as long as it lives. Sessions started by an older agentop therefore
+keep the small buffer until they are reopened; the mouse, being a server option, applies to them
+immediately.
+
+None of this touches your own tmux: different socket, different server, different config.
+
 ## Where state lives
 
 `~/.agentistics/managed-sessions.json` — the sessions agentop started, with their labels, notes and

--- a/packages/server/server/sessions/backend-tmux.ts
+++ b/packages/server/server/sessions/backend-tmux.ts
@@ -5,7 +5,7 @@
 
 import {
   attachArgs, capturePaneArgs, isSessionGoneError, killSessionArgs, listSessionsArgs,
-  newSessionArgs, parsePrefix, parseTmuxList, remainOnExitArgs, sendKeysEnterArgs,
+  newSessionArgs, parsePrefix, parseTmuxList, serverOptionsArgs, sendKeysEnterArgs,
   sendKeysLiteralArgs, showPrefixArgs, trimCapture,
 } from './tmux-cli'
 import type { BackendSession, BackendSpawn, SessionBackend } from './types'
@@ -41,9 +41,10 @@ export const tmuxBackend: SessionBackend = {
   },
 
   async spawn(req: BackendSpawn) {
-    // Set BEFORE the session exists, so a command that exits immediately is still held. Setting it
-    // afterwards is a race the fast-failing case always wins.
-    await tmux(remainOnExitArgs())
+    // Set BEFORE the session exists. `remain-on-exit` afterwards is a race the fast-failing case
+    // always wins, and `history-limit` afterwards does not apply to this pane at all — see
+    // `serverOptionsArgs`.
+    for (const args of serverOptionsArgs()) await tmux(args)
     const { code, out } = await tmux(newSessionArgs({ id: req.id, cwd: req.cwd, argv: req.argv }))
     if (code !== 0) throw new Error(out.trim() || `tmux new-session failed (code ${code})`)
     if (req.sendKeys) {

--- a/packages/server/server/sessions/tmux-cli.test.ts
+++ b/packages/server/server/sessions/tmux-cli.test.ts
@@ -3,6 +3,7 @@ import {
   LIST_FORMAT, attachArgs, capturePaneArgs, idFromTmuxName, isSessionGoneError, killSessionArgs,
   newSessionArgs, parsePrefix, parseTmuxList, sendKeysEnterArgs, sendKeysLiteralArgs, trimCapture,
   tmuxName,
+  serverOptionsArgs, HISTORY_LIMIT,
 } from './tmux-cli'
 
 describe('names', () => {
@@ -105,5 +106,32 @@ describe('isSessionGoneError', () => {
   it('treats any other stderr as a real failure, never a guessed "gone"', () => {
     expect(isSessionGoneError('permission denied')).toBe(false)
     expect(isSessionGoneError('')).toBe(false)
+  })
+})
+
+describe('serverOptionsArgs', () => {
+  const all = serverOptionsArgs()
+
+  it('touches only agentop own socket', () => {
+    // The whole reason setting global options is safe: none of this reaches the user's tmux, their
+    // config, or the sessions they started themselves.
+    for (const args of all) expect(args.slice(0, 2)).toEqual(['-L', 'agentop'])
+  })
+
+  it('turns the mouse on, because a pane you cannot scroll is a pane you cannot read', () => {
+    const mouse = all.find(a => a.includes('mouse'))
+    expect(mouse).toEqual(['-L', 'agentop', 'set-option', '-g', 'mouse', 'on'])
+  })
+
+  it('raises the scrollback well past tmux own 2000', () => {
+    // Two thousand lines of an assistant transcript is a few minutes of work: attaching to a
+    // session that has run for an hour and scrolling up finds the middle of a sentence.
+    const history = all.find(a => a.includes('history-limit'))
+    expect(history?.at(-1)).toBe(String(HISTORY_LIMIT))
+    expect(HISTORY_LIMIT).toBeGreaterThan(2000)
+  })
+
+  it('still holds a finished session listable', () => {
+    expect(all.some(a => a.includes('remain-on-exit') && a.at(-1) === 'on')).toBe(true)
   })
 })

--- a/packages/server/server/sessions/tmux-cli.ts
+++ b/packages/server/server/sessions/tmux-cli.ts
@@ -58,9 +58,40 @@ export function listSessionsArgs(): string[] {
   return sock(['list-sessions', '-F', LIST_FORMAT])
 }
 
-/** Keeps a finished session listable, with its last frame still capturable — the `exited` state. */
-export function remainOnExitArgs(): string[] {
-  return sock(['set-option', '-g', 'remain-on-exit', 'on'])
+/**
+ * How many lines of scrollback each pane keeps.
+ *
+ * tmux's own default is 2000, which for an assistant transcript is a few minutes of work: attaching
+ * to a session that has been running an hour and scrolling up finds the middle of a sentence. This
+ * is roughly a day of it, and costs memory only for what was actually printed.
+ */
+export const HISTORY_LIMIT = 50_000
+
+/**
+ * Every option agentop sets on ITS OWN tmux server, applied before the first session exists.
+ *
+ * On its own socket (`-L agentop`), which is the whole reason this is safe: none of it reaches the
+ * user's tmux, their config, or the sessions they started themselves.
+ *
+ * Applied UP FRONT, not afterwards, and that is not a style choice for any of the three:
+ * `remain-on-exit` set after the fact is a race a fast-failing command always wins, and
+ * `history-limit` only ever applies to panes created after it — a session started first keeps
+ * tmux's 2000 forever, which is the exact case someone hits when they attach to the long-running
+ * one and find nothing above the fold.
+ *
+ * `mouse on` is what makes the wheel scroll at all. Without it the pane is a window onto the last
+ * screenful and nothing else, so attaching to a session to read what it did is attaching to a
+ * session you cannot read. It has a cost worth stating rather than discovering: with the mouse
+ * captured, dragging to select goes to tmux instead of to the terminal, and SHIFT is the bypass —
+ * the same trade the control center already documents for its own mouse mode.
+ */
+export function serverOptionsArgs(): string[][] {
+  return [
+    // Keeps a finished session listable, with its last frame still capturable — the `exited` state.
+    sock(['set-option', '-g', 'remain-on-exit', 'on']),
+    sock(['set-option', '-g', 'mouse', 'on']),
+    sock(['set-option', '-g', 'history-limit', String(HISTORY_LIMIT)]),
+  ]
 }
 
 export function showPrefixArgs(): string[] {


### PR DESCRIPTION
Attaching to a session showed the last screenful and nothing else. tmux ships with the mouse **off**, so the wheel does nothing in a pane and the scrollback sits behind copy-mode — attaching to a session to read what it did was attaching to a session you cannot read. That is half the point of hosting them.

`mouse on` and a `history-limit` of 50000 join `remain-on-exit` as options agentop sets on **its own socket** (`-L agentop`). That is the whole reason this is safe: none of it reaches the user's tmux, their config, or the sessions they started themselves.

Both are applied **before the first session exists**, and for `history-limit` that is not the same reasoning as `remain-on-exit`. The latter set afterwards is a race the fast-failing case always wins; the former set afterwards does not apply to existing panes *at all* — a session started before it keeps tmux's 2000 for as long as it lives, which is exactly the long-running one someone attaches to and finds nothing above the fold. Two thousand lines of an assistant transcript is a few minutes of work.

The mouse has a cost worth stating rather than discovering: with it captured, dragging to select goes to tmux instead of to the terminal, and **shift** is the bypass — the same trade the control center already documents for its own mouse mode. Documented in `docs/session-manager.md`.

Verified on the real socket: before, `mouse off` / `history-limit 2000`; after spawning one session through the rebuilt binary, `mouse on` / `history-limit 50000`.

Tests: 3420 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019vBSuKQLuyLhWZS4zbiu2s