### PR TITLE
fix(sessions): the new-session wizard stopped eating prompts

### DIFF
--- a/docs/session-manager.md
+++ b/docs/session-manager.md
@@ -222,9 +222,14 @@ wired up because the key could not be verified from the CLI itself, and agentop 
 
 ## Scrolling an attached session
 
-Sessions are hosted on agentop's own tmux socket (`-L agentop`), and agentop sets three options on
+Sessions are hosted on agentop's own tmux socket (`-L agentop`), and agentop sets four options on
 it before the first one exists: `remain-on-exit` (a finished session stays listable with its last
-frame readable), `mouse on`, and a `history-limit` of 50000 lines.
+frame readable), `mouse on`, a `history-limit` of 50000 lines, and `status off`.
+
+The status bar is off because every fact it carries is wrong here: it lists windows and an agentop
+session is one window with one pane, it shows the session name and that name is `agentop-<id>`
+rather than anything a person chose, and the cockpit you came from already shows all of it. It costs
+a row of the assistant's screen to say nothing, in a colour that is hard to ignore.
 
 The mouse is what makes the wheel scroll at all — without it a pane shows the last screenful and
 nothing else, so attaching to a session to read what it did was attaching to a session you cannot

--- a/packages/server/server/sessions/tmux-cli.test.ts
+++ b/packages/server/server/sessions/tmux-cli.test.ts
@@ -135,3 +135,13 @@ describe('serverOptionsArgs', () => {
     expect(all.some(a => a.includes('remain-on-exit') && a.at(-1) === 'on')).toBe(true)
   })
 })
+
+describe('the status bar', () => {
+  it('is off — it costs a row to say nothing here', () => {
+    // tmux's band lists windows, the session name and a clock. An agentop session is one window
+    // with one pane, its name is `agentop-<id>` rather than anything a person chose, and the
+    // cockpit already shows all of it.
+    const status = serverOptionsArgs().find(a => a.includes('status'))
+    expect(status).toEqual(['-L', 'agentop', 'set-option', '-g', 'status', 'off'])
+  })
+})

--- a/packages/server/server/sessions/tmux-cli.ts
+++ b/packages/server/server/sessions/tmux-cli.ts
@@ -91,6 +91,13 @@ export function serverOptionsArgs(): string[][] {
     sock(['set-option', '-g', 'remain-on-exit', 'on']),
     sock(['set-option', '-g', 'mouse', 'on']),
     sock(['set-option', '-g', 'history-limit', String(HISTORY_LIMIT)]),
+    // No STATUS BAR. tmux draws a green band across the bottom listing the windows, the session
+    // name and a clock — useful when you are managing windows, and every one of those facts is
+    // wrong here: an agentop session is one window with one pane, its name is `agentop-<id>` rather
+    // than anything a person chose, and the cockpit you came from already shows all of it. So the
+    // band costs a row of the assistant's screen to say nothing, in a colour that is hard to
+    // ignore.
+    sock(['set-option', '-g', 'status', 'off']),
   ]
 }
 

--- a/packages/tui/scripts/preview.tsx
+++ b/packages/tui/scripts/preview.tsx
@@ -96,6 +96,8 @@ interface Options {
    * so it takes a start to reach it (`--keys enter,right,enter` on a stopped service).
    */
   pending: boolean
+  /** Make the fake host REFUSE to spawn, which is the wizard's failure path. */
+  failSpawn: boolean
 }
 
 const USAGE = `
@@ -117,11 +119,14 @@ const USAGE = `
                             reach it with --keys enter,enter
     --pending               history consent still unanswered, so a start opens the
                             gate: --pending --keys enter,right,enter
+    --fail-spawn            the new-session wizard's spawn is refused, so its failure
+                            path is drawn: --fail-spawn --keys a,enter,enter,enter,enter,enter,enter
 `
 
 function parseArgs(argv: string[]): Options {
   const opts: Options = {
-    cols: 100, rows: 34, lang: 'en', screen: 'services', mode: 'solo', keys: [], task: 'off', pending: false,
+    cols: 100, rows: 34, lang: 'en', screen: 'services', mode: 'solo', keys: [], task: 'off',
+    pending: false, failSpawn: false,
   }
   for (let i = 0; i < argv.length; i++) {
     const flag = argv[i]
@@ -132,6 +137,7 @@ function parseArgs(argv: string[]): Options {
       case '--lang': opts.lang = value === 'pt' ? 'pt' : 'en'; i++; break
       case '--keys': opts.keys = value.split(',').filter(Boolean); i++; break
       case '--pending': opts.pending = true; break
+      case '--fail-spawn': opts.failSpawn = true; break
       case '--task':
         opts.task = value === 'done' ? 'done' : 'running'
         i++
@@ -352,7 +358,11 @@ function fakeHost(opts: Options): ControlHost {
     ],
     searchProjects: async (query: string) => FAKE_PROJECTS
       .filter(p => p.label.toLowerCase().includes(query.trim().toLowerCase())),
-    spawnSession: async () => ({ ok: true, message: 'preview — nothing was performed' }),
+    // `--fail-spawn` drives the wizard's REFUSAL path, which is the one that used to eat the
+    // prompt: it closed the wizard and put the reason on a status line one row tall.
+    spawnSession: async () => (opts.failSpawn
+      ? { ok: false, message: 'tmux recusou: sessão duplicada' }
+      : { ok: true, message: 'preview — nothing was performed' }),
   }
 }
 

--- a/packages/tui/src/control/i18n.ts
+++ b/packages/tui/src/control/i18n.ts
@@ -329,6 +329,13 @@ export interface ControlStrings {
   wizPrompt: string
   wizPromptHint: string
   wizHow: string
+  /** Said while the session is being started, so `enter` is visibly doing something. */
+  wizStarting: string
+  /** Said under a failure: nothing you typed was thrown away. */
+  wizKeptDraft: string
+  wizNoSpawn: string
+  wizNeedHarness: string
+  wizNeedCwd: string
   wizAttached: string
   wizBackground: string
   wizSkip: string
@@ -637,6 +644,11 @@ const EN: ControlStrings = {
   wizPrompt: 'First prompt (optional)',
   wizPromptHint: 'leave empty to start with nothing typed',
   wizHow: 'Start it how?',
+  wizStarting: 'starting…',
+  wizKeptDraft: 'nothing you typed was lost — esc goes back a step, or try again',
+  wizNoSpawn: 'this build cannot start sessions.',
+  wizNeedHarness: 'pick an assistant first.',
+  wizNeedCwd: 'pick a folder first.',
   wizAttached: 'attached — take this terminal now',
   wizBackground: 'background — keep it running and stay here',
   wizSkip: 'use the default',
@@ -936,6 +948,11 @@ const PT: ControlStrings = {
   wizPrompt: 'Primeiro prompt (opcional)',
   wizPromptHint: 'deixe vazio para começar sem nada digitado',
   wizHow: 'Iniciar como?',
+  wizStarting: 'iniciando…',
+  wizKeptDraft: 'nada do que você digitou foi perdido — esc volta um passo, ou tente de novo',
+  wizNoSpawn: 'esta build não consegue iniciar sessões.',
+  wizNeedHarness: 'escolha um assistente primeiro.',
+  wizNeedCwd: 'escolha uma pasta primeiro.',
   wizAttached: 'anexada — assume este terminal agora',
   wizBackground: 'background — deixa rodando e fica aqui',
   wizSkip: 'usar o padrão',

--- a/packages/tui/src/control/sessions.test.ts
+++ b/packages/tui/src/control/sessions.test.ts
@@ -5,7 +5,7 @@ import {
   sessionColumns, sessionsCockpit, asideRows, asideSelectable, projectCounts, projectColumns,
   projectPickRows, groupProjects, asideSections, asideFold, scrollBar, THUMB, TRACK, sessionNamed,
   sessionHandle, worktreeName, sessionRunning, asideRowKey, resolveAsideCursor,
-  DEFAULT_ORDER, usageOf,
+  DEFAULT_ORDER, usageOf, planSubmit,
 } from './sessions'
 import type { ControlSession, SessionState } from './types'
 
@@ -1130,5 +1130,51 @@ describe('sortSessions', () => {
     const before = rows.map(s => s.id)
     sortSessions(rows, { by: 'name', dir: 'asc' })
     expect(rows.map(s => s.id)).toEqual(before)
+  })
+})
+
+describe('planSubmit', () => {
+  const harness = { id: 'claude', supportsModel: true }
+
+  it('NAMES every refusal instead of returning silently', () => {
+    // The component's version was `if (!spawn || !draft.harness || !draft.cwd) return`. The final
+    // enter of a six-step wizard did nothing at all, with no way to tell a dead key from a slow
+    // one — and the prompt just typed was still on screen, about to be thrown away.
+    expect(planSubmit({ draft: { harness, cwd: '/r' }, hasSpawn: false, attach: false }))
+      .toEqual({ ok: false, reason: 'no-host' })
+    expect(planSubmit({ draft: { cwd: '/r' }, hasSpawn: true, attach: false }))
+      .toEqual({ ok: false, reason: 'no-harness', step: 'harness' })
+    expect(planSubmit({ draft: { harness }, hasSpawn: true, attach: false }))
+      .toEqual({ ok: false, reason: 'no-cwd', step: 'where' })
+  })
+
+  it('sends a refusal BACK to the step that takes the missing answer', () => {
+    // A refusal with nowhere to go is a dead end; with a step it is a way back.
+    const noCwd = planSubmit({ draft: { harness }, hasSpawn: true, attach: false })
+    expect(noCwd.ok).toBe(false)
+    if (!noCwd.ok) expect(noCwd.step).toBe('where')
+  })
+
+  it('carries only what was actually answered', () => {
+    // An empty model is not a model called "".
+    const plan = planSubmit({
+      draft: { harness, cwd: '/r', prompt: 'do the thing', model: '', task: 'auth' },
+      hasSpawn: true,
+      attach: true,
+    })
+    expect(plan.ok).toBe(true)
+    if (plan.ok) {
+      expect(plan.req).toEqual({
+        harness: 'claude', cwd: '/r', attach: true, prompt: 'do the thing', task: 'auth',
+      })
+      expect('model' in plan.req).toBe(false)
+    }
+  })
+
+  it('keeps the prompt in the request, which is the expensive thing on that screen', () => {
+    const plan = planSubmit({
+      draft: { harness, cwd: '/r', prompt: 'p' }, hasSpawn: true, attach: false,
+    })
+    if (plan.ok) expect(plan.req.prompt).toBe('p')
   })
 })

--- a/packages/tui/src/control/sessions.ts
+++ b/packages/tui/src/control/sessions.ts
@@ -1380,3 +1380,56 @@ export function scrollBar(o: { offset: number; total: number; rows: number }): s
   // legible without competing with the frame it sits inside.
   return Array.from({ length: rows }, (_, i) => (i >= top && i < top + thumb ? THUMB : TRACK))
 }
+
+// ---------------------------------------------------------------------------
+// the new-session wizard's last step
+// ---------------------------------------------------------------------------
+
+/** What the wizard has collected so far. Only two of them are required to start anything. */
+export interface SessionDraft {
+  harness?: { id: string; supportsModel?: boolean }
+  cwd?: string
+  task?: string
+  prompt?: string
+  model?: string
+  effort?: string
+}
+
+export type SubmitPlan =
+  | { ok: true; req: { harness: string; cwd: string; attach: boolean } & Record<string, unknown> }
+  /** `step` is where the missing answer is given, so a refusal is a way BACK rather than a dead end. */
+  | { ok: false; reason: 'no-host' | 'no-harness' | 'no-cwd'; step?: 'harness' | 'where' }
+
+/**
+ * What pressing the last `enter` of the wizard should do — PURE.
+ *
+ * It exists because the component's version returned SILENTLY when it had nothing to spawn with:
+ * `if (!spawn || !draft.harness || !draft.cwd) return`. The final keystroke of a six-step wizard
+ * did nothing at all, with no way to tell a dead key from a slow one — and the prompt someone had
+ * just typed was still on screen, about to be thrown away by whatever they pressed next.
+ *
+ * Every refusal now NAMES itself and, where there is one, names the step that takes the missing
+ * answer. The caller reports it and stays put; nothing typed is discarded.
+ */
+export function planSubmit(o: {
+  draft: SessionDraft
+  hasSpawn: boolean
+  attach: boolean
+}): SubmitPlan {
+  if (!o.hasSpawn) return { ok: false, reason: 'no-host' }
+  if (!o.draft.harness) return { ok: false, reason: 'no-harness', step: 'harness' }
+  if (!o.draft.cwd) return { ok: false, reason: 'no-cwd', step: 'where' }
+  return {
+    ok: true,
+    req: {
+      harness: o.draft.harness.id,
+      cwd: o.draft.cwd,
+      attach: o.attach,
+      // Only what was actually answered travels: an empty model is not a model called "".
+      ...(o.draft.model ? { model: o.draft.model } : {}),
+      ...(o.draft.effort ? { effort: o.draft.effort } : {}),
+      ...(o.draft.prompt ? { prompt: o.draft.prompt } : {}),
+      ...(o.draft.task ? { task: o.draft.task } : {}),
+    },
+  }
+}

--- a/packages/tui/src/control/tabs/SessionWizard.tsx
+++ b/packages/tui/src/control/tabs/SessionWizard.tsx
@@ -19,7 +19,7 @@ import type {
 import type { ControlStrings } from '../i18n'
 import { resolveListKey, windowOffset, type NavKey } from '../nav'
 import {
-  PROJECT_LEAD, padCell, projectColumns, projectPickRows, type ProjectRow,
+  PROJECT_LEAD, padCell, planSubmit, projectColumns, projectPickRows, type ProjectRow,
 } from '../sessions'
 
 /**
@@ -79,6 +79,9 @@ export function SessionWizard({ host, strings: s, width, height, isActive, onCan
   const [step, setStep] = useState<Step>('harness')
   const [draft, setDraft] = useState<Draft>({})
   const [harnesses, setHarnesses] = useState<SessionHarnessOption[] | null>(null)
+  /** Why the last attempt did not start. Shown in the wizard, which stays put so nothing is lost. */
+  const [error, setError] = useState('')
+  const [busy, setBusy] = useState(false)
 
   useEffect(() => {
     const read = host.startableHarnesses
@@ -101,20 +104,44 @@ export function SessionWizard({ host, strings: s, width, height, isActive, onCan
     return 'how'
   }, [])
 
+  /**
+   * Start it — and on ANY failure, keep the wizard and everything typed into it.
+   *
+   * Two ways this used to lose someone's work. It returned SILENTLY when it had nothing to spawn
+   * with, so the last `enter` of a six-step wizard did nothing at all and there was no way to tell
+   * a dead key from a slow one. And a spawn that came back `ok: false` closed the wizard anyway and
+   * put the reason on the status line — one transient row — taking the prompt with it. A prompt is
+   * the most expensive thing on this screen; it is the one thing a failure must not consume.
+   *
+   * So: a missing answer sends you BACK to the step that takes it, a refusal is shown HERE and the
+   * draft stands, and only success unmounts.
+   */
   const submit = useCallback((attach: boolean) => {
     const spawn = host.spawnSession
-    if (!spawn || !draft.harness || !draft.cwd) return
-    const req: SpawnSessionRequest = {
-      harness: draft.harness.id,
-      cwd: draft.cwd,
-      attach,
-      ...(draft.model ? { model: draft.model } : {}),
-      ...(draft.effort ? { effort: draft.effort } : {}),
-      ...(draft.prompt ? { prompt: draft.prompt } : {}),
-      ...(draft.task ? { task: draft.task } : {}),
+    const plan = planSubmit({ draft, hasSpawn: Boolean(spawn), attach })
+    if (!plan.ok) {
+      setError(plan.reason === 'no-host' ? s.wizNoSpawn
+        : plan.reason === 'no-harness' ? s.wizNeedHarness
+        : s.wizNeedCwd)
+      if (plan.step) setStep(plan.step)
+      return
     }
-    void spawn.call(host, req).then(onDone)
-  }, [host, draft, onDone])
+    const req = plan.req as unknown as SpawnSessionRequest
+    setError('')
+    setBusy(true)
+    void spawn!.call(host, req)
+      .then(r => {
+        setBusy(false)
+        if (r.ok) return onDone(r)
+        setError(r.message)
+      })
+      // A REJECTED promise used to leave the screen exactly as it was, forever: no session, no
+      // message, and an `enter` that had visibly done something and then nothing.
+      .catch((e: unknown) => {
+        setBusy(false)
+        setError(e instanceof Error ? e.message : String(e))
+      })
+  }, [host, draft, onDone, s])
 
   // `esc` steps BACK rather than out, until there is nowhere back to go. A wizard that abandons six
   // answers because the sixth was a typo is a wizard people stop using.
@@ -126,6 +153,7 @@ export function SessionWizard({ host, strings: s, width, height, isActive, onCan
       const prev = order[j]!
       if (prev === 'model' && !draft.harness?.supportsModel) continue
       if (prev === 'effort' && (draft.harness?.efforts.length ?? 0) === 0) continue
+      setError('')
       return setStep(prev)
     }
     onCancel()
@@ -243,18 +271,31 @@ export function SessionWizard({ host, strings: s, width, height, isActive, onCan
   }
 
   return (
-    <Picker
-      label={s.wizHow}
-      options={[
-        { key: 'bg', label: s.wizBackground },
-        { key: 'fg', label: s.wizAttached },
-      ]}
-      empty=""
-      width={width}
-      height={height}
-      isActive={isActive}
-      onPick={key => submit(key === 'fg')}
-    />
+    <Box flexDirection="column" width={width}>
+      <Picker
+        label={s.wizHow}
+        options={[
+          { key: 'bg', label: s.wizBackground },
+          { key: 'fg', label: s.wizAttached },
+        ]}
+        empty=""
+        width={width}
+        // Two rows are spent below on the outcome, and a screen that draws more rows than it was
+        // given is composited over the ones under it by Ink rather than clipped.
+        height={Math.max(1, height - 2)}
+        isActive={isActive && !busy}
+        onPick={key => submit(key === 'fg')}
+      />
+      {/* The outcome, HERE. It used to go to the status line — one transient row — while this
+          screen unmounted and took the prompt with it. */}
+      {busy ? <Text dimColor>{truncate(s.wizStarting, width)}</Text> : null}
+      {error && !busy ? (
+        <>
+          <Text color={COLORS.danger} wrap="truncate">{truncate(error, width)}</Text>
+          <Text dimColor wrap="truncate">{truncate(s.wizKeptDraft, width)}</Text>
+        </>
+      ) : null}
+    </Box>
   )
 }
 


### PR DESCRIPTION
Reported from a real machine: six steps of the wizard, `enter` on the last one, no session, and the prompt gone.

Two ways it could do that, and both are fixed.

**It returned silently when it had nothing to spawn with** — `if (!spawn || !draft.harness || !draft.cwd) return`. The final keystroke of a six-step wizard did nothing at all, with no way to tell a dead key from a slow one, while the prompt just typed sat on screen waiting to be thrown away by whatever was pressed next. That decision is the pure `planSubmit` now: every refusal **names itself** and, where there is one, names the step that takes the missing answer — so a refusal is a way back rather than a dead end.

**And a failed spawn closed the wizard anyway**, putting the reason on the status line — one transient row — taking the draft with it. A prompt is the most expensive thing on that screen, and it is the one thing a failure must not consume. Only *success* unmounts now; a refusal is drawn in the wizard, in the danger colour, over a line saying nothing was lost.

A **rejected** promise did worse than either: it left the screen exactly as it was, forever — no session and no message, after an `enter` that had visibly done something and then nothing. It is caught.

`preview.tsx` grows `--fail-spawn` so the refusal path can be drawn at all.

Tests: 3424 pass, 4 new on `planSubmit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019vBSuKQLuyLhWZS4zbiu2s