### PR TITLE
fix(sessions): one conversation is never reopened twice, and a down row says its age

### DIFF
--- a/packages/server/server/cli-start.ts
+++ b/packages/server/server/cli-start.ts
@@ -1904,6 +1904,10 @@ function createControlHost(initialLang: CliLang, altScreen: Suspendable): StartH
         ...(previous?.task ? { task: previous.task } : {}),
       }, s)
       if (spawned.ok) {
+        // We handed this id to the CLI, so the new row KNOWS which conversation it drives — there
+        // is no guessing left for the next reopen. Without it the fallback matches on directory
+        // alone, and every session in one repository resolves to the same conversation.
+        if (spawned.id) await patchSession(spawned.id, { conversationId: req.sessionId })
         if (previous?.note && spawned.id) await patchSession(spawned.id, { note: previous.note })
         // The old row is RETIRED rather than deleted: it is still a thing that happened, and it
         // stops standing beside its own continuation with the same name on it.
@@ -1937,10 +1941,21 @@ function createControlHost(initialLang: CliLang, altScreen: Suspendable): StartH
       const plan = planTaskReopen({
         entries: wanted,
         liveIds: live,
-        conversationFor: m => {
-          const conv = conversationForProcess(conversations, { harness: m.harness, cwd: m.cwd })
-          return conv?.resumable ? { sessionId: conv.sessionId, title: conv.title } : null
-        },
+        // CLAIMED, one per row: the directory match cannot tell two sessions of one repository
+        // apart, so reopening a task of five rows used to start five copies of one conversation.
+        conversationFor: (m => {
+          const taken = new Set<string>()
+          return (entry: typeof m) => {
+            const own = entry.conversationId
+              ? conversations.find(c => c.sessionId === entry.conversationId)
+              : undefined
+            const conv = own ?? conversations.find(c =>
+              !taken.has(c.sessionId) && c.harness === entry.harness && c.cwd === entry.cwd)
+            if (!conv?.resumable) return null
+            taken.add(conv.sessionId)
+            return { sessionId: conv.sessionId, title: conv.title }
+          }
+        })(wanted[0]!),
       })
 
       let opened = 0
@@ -1957,6 +1972,7 @@ function createControlHost(initialLang: CliLang, altScreen: Suspendable): StartH
         }, s)
         if (!r.ok) { skipped++; continue }
         opened++
+        if (r.id) await patchSession(r.id, { conversationId: row.resumeId })
         // Retired, so a laptop closed and opened twice does not leave the task holding two dead
         // twins and one live session, all under the same name.
         await patchSession(m.id, { endedAt: new Date().toISOString() })

--- a/packages/server/server/sessions/registry.ts
+++ b/packages/server/server/sessions/registry.ts
@@ -38,12 +38,27 @@ export function newSessionId(): string {
   return randomUUID().replace(/-/g, '').slice(0, 10)
 }
 
+/**
+ * The fields a session's registry entry can be amended with after it exists.
+ *
+ * Named rather than inlined because it was written out at every call site and they had already
+ * drifted: adding a field to the store meant finding each copy, and the one that was missed failed
+ * as a type error at best and a silently dropped write at worst.
+ */
+export interface SessionPatch {
+  label?: string
+  note?: string
+  task?: string
+  endedAt?: string
+  conversationId?: string
+}
+
 export interface SessionRegistry {
   read(): Promise<ManagedSession[]>
   add(session: ManagedSession): Promise<void>
   remove(id: string): Promise<void>
   /** False when no session carries that id — never a silent success. */
-  patch(id: string, patch: { label?: string; note?: string; task?: string; endedAt?: string }): Promise<boolean>
+  patch(id: string, patch: SessionPatch): Promise<boolean>
 }
 
 /**
@@ -180,5 +195,5 @@ export const addSession = (s: ManagedSession): Promise<void> => defaultRegistry.
 export const removeSession = (id: string): Promise<void> => defaultRegistry.remove(id)
 export const patchSession = (
   id: string,
-  patch: { label?: string; note?: string; task?: string; endedAt?: string },
+  patch: SessionPatch,
 ): Promise<boolean> => defaultRegistry.patch(id, patch)

--- a/packages/server/server/sessions/session-table.test.ts
+++ b/packages/server/server/sessions/session-table.test.ts
@@ -7,7 +7,7 @@ import {
 
 const STRINGS: SessionTableStrings = {
   cols: {
-    id: 'id', state: 'state', title: 'session', task: 'task',
+    id: 'id', state: 'state', title: 'session', age: 'started', task: 'task',
     worktree: 'worktree', metrics: 'usage', harness: 'harness', where: 'project',
   },
   unknown: {

--- a/packages/server/server/sessions/session-view.ts
+++ b/packages/server/server/sessions/session-view.ts
@@ -14,7 +14,19 @@ import { rulesFor } from './attention-rules'
 import type { ReconciledSession } from './session-ref'
 import type { Conversation } from './conversations'
 import { conversationForProcess } from './conversations'
-import type { SessionActivity } from './types'
+import type { ManagedSession, SessionActivity } from './types'
+
+/**
+ * The registry's own record of when a session began, as epoch ms — PURE.
+ *
+ * `''` and anything unparseable yield nothing rather than 1970: a start time nobody can read is an
+ * absence, and an absence rendered as "56 years ago" is worse than a blank.
+ */
+export function registryCreatedMs(iso: string | undefined): { createdMs?: number } {
+  if (!iso) return {}
+  const ms = Date.parse(iso)
+  return Number.isFinite(ms) ? { createdMs: ms } : {}
+}
 
 export interface SessionView {
   id: string
@@ -148,6 +160,36 @@ export function buildSessionViews(o: {
    */
   closedLimit?: number
 }): SessionView[] {
+  /**
+   * Conversations already spoken for, so ONE is never offered to two rows.
+   *
+   * `conversationForProcess` matches on harness and directory, which is all it can do for a process
+   * it did not start — and every managed session in one directory therefore resolved to the SAME
+   * conversation. After a crash left five rows `lost` in this repository, reopening them handed
+   * three of them the same conversation and the fleet came back with one session listed three
+   * times, all wearing the same name. Reported from a real machine.
+   *
+   * A row that RECORDED which conversation it drives is exact and claims that one. The rest fall
+   * back to the directory guess, but only to a conversation nobody has taken.
+   */
+  const claimed = new Set<string>()
+  const claimResume = (
+    managed: ManagedSession | undefined,
+    harness: HarnessId,
+  ): { resume?: { sessionId: string; title: string } } => {
+    const pool = o.conversations ?? []
+    const own = managed?.conversationId
+      ? pool.find(c => c.sessionId === managed.conversationId)
+      : undefined
+    const conv = own ?? pool.find(c =>
+      !claimed.has(c.sessionId)
+      && c.harness === harness
+      && sessionAtCwd({ current_cwd: c.cwd, project_path: c.cwd }, managed?.cwd ?? ''))
+    if (!conv?.resumable) return {}
+    claimed.add(conv.sessionId)
+    return { resume: { sessionId: conv.sessionId, title: conv.title } }
+  }
+
   const managed: SessionView[] = o.reconciled.map(r => {
     const harness = r.managed?.harness
     // A session the user FINISHED reports `exited` whatever the backend still holds: the row exists
@@ -167,7 +209,12 @@ export function buildSessionViews(o: {
       ...(r.managed?.model ? { model: r.managed.model } : {}),
       ...(r.managed?.effort ? { effort: r.managed.effort } : {}),
       ...(r.managed?.task ? { task: r.managed.task } : {}),
-      ...(r.backend ? { createdMs: r.backend.createdMs } : {}),
+      // The backend's clock when there is a backend, the REGISTRY's when there is not. A row the
+      // machine lost has no tmux session left to ask, so it reported no start time at all — and a
+      // session you are deciding whether to reopen is one whose age is most of the decision.
+      ...(r.backend
+        ? { createdMs: r.backend.createdMs }
+        : registryCreatedMs(r.managed?.createdAt)),
       // Reopening a finished session is the whole reason its row is kept. Resolved the same way an
       // external process's conversation is — by harness and directory — and absent when nothing
       // can be resolved, rather than offering a verb with no target.
@@ -178,10 +225,7 @@ export function buildSessionViews(o: {
       // process's conversation is, and absent when nothing resolves rather than offering a verb
       // with no target.
       ...((finished || r.status === 'lost' || r.status === 'exited') && harness
-        ? (() => {
-            const conv = conversationForProcess(o.conversations ?? [], { harness, cwd: r.managed?.cwd ?? '' })
-            return conv?.resumable ? { resume: { sessionId: conv.sessionId, title: conv.title } } : {}
-          })()
+        ? claimResume(r.managed, harness)
         : {}),
       attached: r.backend?.attached ?? false,
       approvalDetection: harness !== undefined && rulesFor(harness) !== undefined,

--- a/packages/server/server/sessions/types.ts
+++ b/packages/server/server/sessions/types.ts
@@ -129,6 +129,19 @@ export interface ManagedSession {
    * thing that happened, and reopening it is the ordinary next thing to want.
    */
   endedAt?: string
+  /**
+   * The harness's own conversation id this session drives, when it is known exactly.
+   *
+   * Known for a session that was REOPENED from a conversation — we handed the id to the CLI, so
+   * there is no guessing left. Absent for one started fresh, because the conversation is created by
+   * the harness and is not reported back.
+   *
+   * It exists because the fallback is a guess that cannot tell two sessions apart:
+   * `conversationForProcess` matches on harness and directory, so every session in one repository
+   * resolves to the same conversation. A crash that left five rows `lost` here handed three of them
+   * the same one, and the fleet came back with a single session listed three times under one name.
+   */
+  conversationId?: string
 }
 
 /**

--- a/packages/tui/scripts/preview.tsx
+++ b/packages/tui/scripts/preview.tsx
@@ -113,7 +113,8 @@ const USAGE = `
                             norepo = no checkout here, so no rebuild is offered
     --keys   k,k,…          press these first, e.g. enter,down,enter
                             names: enter esc tab shift-tab up down left right
-                            pgup pgdn space; anything else is typed literally
+                            pgup pgdn space, and ctrl-<letter>; anything else is
+                            typed literally
     --task   running|done   the next start/restart streams a build into the output pane
                             and either never finishes (running) or does (done);
                             reach it with --keys enter,enter
@@ -417,7 +418,7 @@ const FAKE_FLEET: ControlSessions = {
       id: 'aabbcc', title: 'release notes', harness: 'claude',
       cwd: '/home/dev/agentistics/.claude/worktrees/notes', project: 'notes',
       repo: 'blpsoares/agentistics', projectGroup: 'agentistics', worktree: true,
-      state: 'exited', stateLabel: 'exited', actionable: true,
+      state: 'exited', stateLabel: 'exited', actionable: true, named: true,
       startedAt: Date.now() - 4 * 60 * 60_000, attached: false,
     },
     {
@@ -491,6 +492,18 @@ function ruler(cols: number): string[] {
  * unpreviewable: they exist only after a keypress, which is exactly the state a screenshot cannot
  * reach and therefore the state that shipped wrong twice.
  */
+/**
+ * A control chord as the byte a terminal actually sends: `ctrl-a` is 0x01, `ctrl-h` is 0x08.
+ *
+ * Named rather than typed literally because there is no way to type a control byte into a shell
+ * argument, and this screen now answers three of them — a key the preview cannot press is a key no
+ * layout check ever sees.
+ */
+function ctrlByte(name: string): string | undefined {
+  const m = /^ctrl-([a-z])$/.exec(name)
+  return m ? String.fromCharCode(m[1]!.charCodeAt(0) - 96) : undefined
+}
+
 const KEYS: Record<string, string> = {
   enter: '\r',
   esc: ESC,
@@ -539,7 +552,7 @@ async function main(): Promise<void> {
   // One key per tick, with the app given time to settle between them: a question opens on a state
   // change, and a burst written in one chunk would be parsed as a single garbled sequence.
   for (const key of opts.keys) {
-    app.stdin.write(KEYS[key] ?? key)
+    app.stdin.write(KEYS[key] ?? ctrlByte(key) ?? key)
     await sleep(60)
   }
 

--- a/packages/tui/src/control/i18n.ts
+++ b/packages/tui/src/control/i18n.ts
@@ -206,7 +206,7 @@ export interface ControlStrings {
   sessionsUnknownRepo: string
   sessionsWorktreeTag: string
   /** The sessions list's column headings — an unlabelled column is one you have to learn. */
-  sessionsCols: Record<'id' | 'state' | 'title' | 'task' | 'worktree' | 'metrics' | 'harness' | 'where', string>
+  sessionsCols: Record<'id' | 'state' | 'age' | 'title' | 'task' | 'worktree' | 'metrics' | 'harness' | 'where', string>
   /** Detail-pane field labels. */
   sessionsWhere: string
   sessionsModel: string
@@ -223,6 +223,15 @@ export interface ControlStrings {
   sessionsPaneMenu: string
   sessionsPaneDetail: string
   sessionsPaneAsk: string
+  sessionsPaneKeys: string
+  /** What each key on the sessions screen does — the one list `ctrl+h` prints. */
+  sessionsKeyWhat: {
+    move: string; open: string; attach: string; menu: string; section: string
+    newSession: string; search: string; clear: string; kill: string; rename: string
+    note: string; task: string; mark: string; onlyActive: string; closed: string
+    exited: string; unfiled: string; group: string; detail: string; reset: string
+    tabs: string; help: string; quit: string
+  }
   sessionsFinishConfirm: (task: string, count: number) => string
   sessionsReopenConfirm: (task: string) => string
   asideProjects: string
@@ -518,6 +527,7 @@ const EN: ControlStrings = {
   sessionsCols: {
     id: 'id',
     state: 'state',
+    age: 'started',
     title: 'session',
     task: 'task',
     worktree: 'worktree',
@@ -537,6 +547,32 @@ const EN: ControlStrings = {
   sessionsPaneMenu: 'menu',
   sessionsPaneDetail: 'detail',
   sessionsPaneAsk: 'question',
+  sessionsPaneKeys: 'keys',
+  sessionsKeyWhat: {
+    move: 'move the cursor',
+    open: 'switch between the menu and the list',
+    attach: 'attach — or reopen, when nothing is running',
+    menu: 'open the menu on this row',
+    section: 'jump to a menu section',
+    newSession: 'start a session',
+    search: 'search everything, closed conversations included',
+    clear: 'drop the search, then the project, then the task',
+    kill: 'stop this session',
+    rename: 'rename it',
+    note: 'write a note on it',
+    task: 'file it under a task',
+    mark: 'mark this row, and keep it marked',
+    onlyActive: 'show only what is running',
+    closed: 'show closed conversations',
+    exited: 'show sessions that ended',
+    unfiled: 'show sessions under no task',
+    group: 'change the grouping',
+    detail: 'hide the detail pane',
+    reset: 'back to how the app opens',
+    tabs: 'change screen',
+    help: 'this list',
+    quit: 'leave agentop',
+  },
   sessionsFinishConfirm: (task, count) =>
     `Mark "${task}" finished? Its ${count} session${count === 1 ? '' : 's'} stay listed behind the "finished tasks" switch.`,
   sessionsReopenConfirm: task => `Reopen "${task}"?`,
@@ -822,6 +858,7 @@ const PT: ControlStrings = {
   sessionsCols: {
     id: 'id',
     state: 'estado',
+    age: 'iniciada',
     title: 'sessão',
     task: 'tarefa',
     worktree: 'worktree',
@@ -841,6 +878,32 @@ const PT: ControlStrings = {
   sessionsPaneMenu: 'menu',
   sessionsPaneDetail: 'detalhe',
   sessionsPaneAsk: 'pergunta',
+  sessionsPaneKeys: 'teclas',
+  sessionsKeyWhat: {
+    move: 'move o cursor',
+    open: 'alterna entre o menu e a lista',
+    attach: 'anexa — ou reabre, quando não há nada rodando',
+    menu: 'abre o menu nessa linha',
+    section: 'pula para uma seção do menu',
+    newSession: 'inicia uma sessão',
+    search: 'busca tudo, inclusive conversas fechadas',
+    clear: 'limpa a busca, depois o projeto, depois a tarefa',
+    kill: 'encerra esta sessão',
+    rename: 'renomeia',
+    note: 'escreve uma nota nela',
+    task: 'arquiva sob uma tarefa',
+    mark: 'marca esta linha, e mantém marcada',
+    onlyActive: 'mostra só o que está rodando',
+    closed: 'mostra conversas fechadas',
+    exited: 'mostra sessões encerradas',
+    unfiled: 'mostra sessões sem tarefa',
+    group: 'muda o agrupamento',
+    detail: 'oculta o painel de detalhe',
+    reset: 'volta para como o app abre',
+    tabs: 'muda de tela',
+    help: 'esta lista',
+    quit: 'sai do agentop',
+  },
   sessionsFinishConfirm: (task, count) =>
     `Finalizar "${task}"? Suas ${count} sessõe${count === 1 ? '' : 's'} continuam listadas atrás do interruptor "tarefas finalizadas".`,
   sessionsReopenConfirm: task => `Reabrir "${task}"?`,

--- a/packages/tui/src/control/sessions.test.ts
+++ b/packages/tui/src/control/sessions.test.ts
@@ -5,6 +5,7 @@ import {
   sessionColumns, sessionsCockpit, asideRows, asideSelectable, projectCounts, projectColumns,
   projectPickRows, groupProjects, asideSections, asideFold, scrollBar, THUMB, TRACK, sessionNamed,
   sessionHandle, worktreeName, sessionRunning, asideRowKey, resolveAsideCursor,
+  sessionAge, sessionKeyHelp, keyHelpColumn,
   DEFAULT_ORDER, usageOf, planSubmit,
 } from './sessions'
 import type { ControlSession, SessionState } from './types'
@@ -1176,5 +1177,62 @@ describe('planSubmit', () => {
       draft: { harness, cwd: '/r', prompt: 'p' }, hasSpawn: true, attach: false,
     })
     if (plan.ok) expect(plan.req.prompt).toBe('p')
+  })
+})
+
+describe('sessionAge', () => {
+  const ago = (s: number) => `${s}s`
+
+  it('says nothing for a row that is running', () => {
+    // A live session's age is idle curiosity; the column exists for the "reopen this or not"
+    // decision, and a running row spends it on nothing.
+    const live = session('a', { state: 'waiting' as SessionState, startedAt: 0 })
+    expect(sessionAge(live, 60_000, ago)).toBe('')
+  })
+
+  it('says how long ago a row that is DOWN began', () => {
+    const down = session('a', { state: 'lost' as SessionState, startedAt: 0 })
+    expect(sessionAge(down, 60_000, ago)).toBe('60s')
+  })
+
+  it('says nothing when nobody recorded a start', () => {
+    // Absent is absent. A start time nobody has is not "1970", and rendering it as fifty-six years
+    // is worse than a blank.
+    const down = session('a', { state: 'lost' as SessionState })
+    expect(sessionAge(down, 60_000, ago)).toBe('')
+  })
+
+  it('never reports a negative age', () => {
+    const down = session('a', { state: 'exited' as SessionState, startedAt: 90_000 })
+    expect(sessionAge(down, 60_000, ago)).toBe('0s')
+  })
+})
+
+describe('sessionKeyHelp', () => {
+  const words = Object.fromEntries(
+    ['move', 'open', 'attach', 'menu', 'section', 'newSession', 'search', 'clear', 'kill',
+      'rename', 'note', 'task', 'mark', 'onlyActive', 'closed', 'exited', 'unfiled', 'group',
+      'detail', 'reset', 'tabs', 'help', 'quit'].map(k => [k, `does ${k}`]),
+  ) as Parameters<typeof sessionKeyHelp>[0]
+
+  it('describes every key it lists, with no blanks', () => {
+    const rows = sessionKeyHelp(words)
+    expect(rows.length).toBeGreaterThan(15)
+    for (const r of rows) {
+      expect(r.keys.length).toBeGreaterThan(0)
+      expect(r.what.length).toBeGreaterThan(0)
+    }
+  })
+
+  it('names each keystroke once', () => {
+    // Two rows claiming the same key is the reference disagreeing with itself.
+    const keys = sessionKeyHelp(words).map(r => r.keys)
+    expect(new Set(keys).size).toBe(keys.length)
+  })
+
+  it('sizes the keystroke column to its widest row', () => {
+    const rows = sessionKeyHelp(words)
+    expect(keyHelpColumn(rows)).toBe(Math.max(...rows.map(r => r.keys.length)))
+    expect(keyHelpColumn([])).toBe(0)
   })
 })

--- a/packages/tui/src/control/sessions.ts
+++ b/packages/tui/src/control/sessions.ts
@@ -589,6 +589,14 @@ export interface SessionColumns {
    */
   task: number
   /**
+   * How long ago it started, for a row that is NOT running.
+   *
+   * On the row rather than only in the detail pane, and only for what is down, because that is the
+   * one place it decides something: a live session's age is idle curiosity, while "reopen this or
+   * not" is mostly a question about how old it is. A running row spends the column on nothing.
+   */
+  age: number
+  /**
    * The worktree's own folder name. `0` when no row on screen is one — never a column of blanks.
    *
    * The NAME rather than the word "worktree": with the list grouped by project, the heading already
@@ -601,6 +609,17 @@ export interface SessionColumns {
   metrics: number
   harness: number
   where: number
+}
+
+/**
+ * How long ago a row that is not running began — PURE, and EMPTY for one that is.
+ *
+ * `now` is passed in rather than read: this is called on every repaint and a clock inside it would
+ * make the column's width depend on the second it was measured in.
+ */
+export function sessionAge(s: ControlSession, now: number, ago: (seconds: number) => string): string {
+  if (sessionRunning(s) || s.startedAt === undefined) return ''
+  return ago(Math.max(0, Math.round((now - s.startedAt) / 1000)))
 }
 
 /** How much of a session id a row shows. Enough to be unambiguous in practice, and to type. */
@@ -660,6 +679,8 @@ export function sessionColumns(
   o: {
     /** True while the HEADING above each row already names the task, so the cell would repeat it. */
     groupedByTask?: boolean
+    /** Already-localized age per row, keyed by session id — see `sessionAge`. */
+    ages?: ReadonlyMap<string, string>
     /**
      * The column HEADINGS, when a header row is being drawn.
      *
@@ -682,6 +703,7 @@ export function sessionColumns(
   const state = widest('state', s => s.stateLabel)
   const task = o.groupedByTask ? 0 : widest('task', s => s.task ?? '')
   const worktree = widest('worktree', worktreeName)
+  const age = widest('age', s => o.ages?.get(s.id) ?? '')
   const metrics = widest('metrics', sessionMetric)
   const harness = widest('harness', s => s.harness)
   // The PROJECT, not the directory: once the grouping keys on the main checkout, a folder cell
@@ -697,9 +719,9 @@ export function sessionColumns(
    * no session reports usage draws no metrics column, and paying its gap anyway would narrow every
    * title on the screen to reserve a space nothing occupies.
    */
-  const overhead = (wt: number, k: number, m: number, h: number, w: number) => {
-    const drawn = [id, state, 1, wt, k, m, h, w].filter(n => n > 0).length
-    return 2 + id + state + wt + k + m + h + w + GAP * (drawn - 1)
+  const overhead = (a: number, wt: number, k: number, m: number, h: number, w: number) => {
+    const drawn = [id, state, 1, a, wt, k, m, h, w].filter(n => n > 0).length
+    return 2 + id + state + a + wt + k + m + h + w + GAP * (drawn - 1)
   }
 
   // The fewest columns a title is worth. Below it the row has a state word and an ellipsis, which
@@ -710,28 +732,29 @@ export function sessionColumns(
   // STATE and the NAME are what a row cannot lose — the state because nothing else on the frame
   // says whether this session is waiting for you, the name because a row you cannot identify is not
   // a row you can act on.
-  const ladder: Array<[number, number, number, number, number]> = [
-    [worktree, task, metrics, harness, where],
-    [worktree, task, metrics, harness, 0],
-    [worktree, task, metrics, 0, 0],
-    [worktree, task, 0, 0, 0],
-    [worktree, 0, 0, 0, 0],
-    [0, 0, 0, 0, 0],
+  const ladder: Array<[number, number, number, number, number, number]> = [
+    [age, worktree, task, metrics, harness, where],
+    [age, worktree, task, metrics, harness, 0],
+    [age, worktree, task, metrics, 0, 0],
+    [age, worktree, task, 0, 0, 0],
+    [age, worktree, 0, 0, 0, 0],
+    [age, 0, 0, 0, 0, 0],
+    [0, 0, 0, 0, 0, 0],
   ]
-  for (const [wt, k, m, h, w] of ladder) {
-    const room = width - overhead(wt, k, m, h, w)
+  for (const [a, wt, k, m, h, w] of ladder) {
+    const room = width - overhead(a, wt, k, m, h, w)
     // The title takes what it NEEDS, not what is left: stretching it to the full remainder pushed
     // the trailing cells to the far edge with a field of blank between, which is the old
     // misalignment wearing a different shape.
-    if (room >= MIN_TITLE || (wt === 0 && k === 0 && m === 0 && h === 0 && w === 0)) {
+    if (room >= MIN_TITLE || (a === 0 && wt === 0 && k === 0 && m === 0 && h === 0 && w === 0)) {
       return {
         id, state, title: Math.max(1, Math.min(title, room)),
-        worktree: wt, task: k, metrics: m, harness: h, where: w,
+        age: a, worktree: wt, task: k, metrics: m, harness: h, where: w,
       }
     }
   }
   /* c8 ignore next */
-  return { id: 0, state: 1, title: 1, worktree: 0, task: 0, metrics: 0, harness: 0, where: 0 }
+  return { id: 0, state: 1, title: 1, age: 0, worktree: 0, task: 0, metrics: 0, harness: 0, where: 0 }
 }
 
 /** Pad or truncate a cell to exactly `w` columns. `0` means the column is not drawn. */
@@ -1432,4 +1455,64 @@ export function planSubmit(o: {
       ...(o.draft.task ? { task: o.draft.task } : {}),
     },
   }
+}
+
+// ---------------------------------------------------------------------------
+// what every key on this screen does
+// ---------------------------------------------------------------------------
+
+export interface KeyHelp {
+  /** The keystroke as a person types it. */
+  keys: string
+  /** Already-localized: what it does. */
+  what: string
+}
+
+/**
+ * Every key the sessions screen answers, in one place — PURE.
+ *
+ * One place because there were already two and they were drifting: the footer names a handful of
+ * keys chosen for width, and the keys themselves live in a long if-chain. Neither is a list anyone
+ * can read. This is the list, and `ctrl+h` prints it.
+ *
+ * It is grouped in the order someone learns them — move, act, filter, arrange — rather than
+ * alphabetically, because a reference sorted by character is a reference you can only use if you
+ * already know what you are looking for.
+ */
+export function sessionKeyHelp(w: {
+  move: string; open: string; attach: string; menu: string; section: string
+  newSession: string; search: string; clear: string; kill: string; rename: string
+  note: string; task: string; mark: string; onlyActive: string; closed: string
+  exited: string; unfiled: string; group: string; detail: string; reset: string
+  tabs: string; help: string; quit: string
+}): KeyHelp[] {
+  return [
+    { keys: '↑ ↓ / j k', what: w.move },
+    { keys: 'enter', what: w.menu },
+    { keys: 'o', what: w.attach },
+    { keys: 'tab', what: w.open },
+    { keys: '1-9 / ← →', what: w.section },
+    { keys: 'a', what: w.newSession },
+    { keys: '/', what: w.search },
+    { keys: 'esc', what: w.clear },
+    { keys: 'x', what: w.kill },
+    { keys: 'n', what: w.rename },
+    { keys: 't', what: w.note },
+    { keys: 'space', what: w.mark },
+    { keys: 'ctrl+a / l', what: w.onlyActive },
+    { keys: 'c', what: w.closed },
+    { keys: 'e', what: w.exited },
+    { keys: 'u', what: w.unfiled },
+    { keys: 'v', what: w.group },
+    { keys: 'd', what: w.detail },
+    { keys: 'ctrl+r', what: w.reset },
+    { keys: '[ ]', what: w.tabs },
+    { keys: '?', what: w.help },
+    { keys: 'q', what: w.quit },
+  ]
+}
+
+/** The width the keystroke column needs, so the descriptions line up — PURE. */
+export function keyHelpColumn(rows: readonly KeyHelp[]): number {
+  return rows.reduce((n, r) => Math.max(n, r.keys.length), 0)
 }

--- a/packages/tui/src/control/tabs/Sessions.tsx
+++ b/packages/tui/src/control/tabs/Sessions.tsx
@@ -56,6 +56,7 @@ import {
   enabledActionIndexes, filterSessions,
   sessionActions, sessionsCockpit, summaryCells, sessionColumns, padCell,
   taskCounts, projectCounts, sessionMetric, sessionHandle, worktreeName, sessionRunning,
+  sessionAge, sessionKeyHelp, keyHelpColumn,
   DEFAULT_ORDER, ACTIVE_STATES, type SessionOrder,
   asideSections, asideFold, scrollBar, THUMB,
   sessionNamed,
@@ -90,6 +91,8 @@ type Ask =
   /** Everything about WHAT the list shows, in one vertical panel. */
   | { kind: 'view' }
   | { kind: 'search' }
+  /** The whole key list. Its own kind because it answers nothing and acts on nothing. */
+  | { kind: 'keys' }
   /** Finishing or reopening a TASK — the session is only how the task was named. */
   | { kind: 'finishTask'; session: ControlSession }
   | { kind: 'task'; session: ControlSession }
@@ -625,6 +628,15 @@ export function Sessions({
     // you fiddled with three weeks ago follow you around — and finding your way out of it one
     // toggle at a time means knowing what the defaults were.
     if (key.ctrl && input === 'r') { resetView(); return }
+    // `ctrl+a` beside `l`, and `ctrl+h` for the list of everything. Two keys for one switch is not
+    // duplication here: `l` is what the footer has room to name, and a chord is what someone
+    // reaches for without having read the footer at all.
+    if (key.ctrl && input === 'a') { setOnlyActive(v => !v); setCursor(0); return }
+    // `?` is the key, and `ctrl+h` is accepted where the terminal can tell it apart from backspace.
+    // It usually cannot: `ctrl+h` IS ASCII 8, which is the backspace byte, so Ink reports it as
+    // `key.backspace` and a binding on it would either never fire or fire on backspace. Measured
+    // here, not assumed. `?` has no such collision and is what every list-shaped TUI already uses.
+    if (input === '?' || (key.ctrl && input === 'h')) { setAsk({ kind: 'keys' }); return }
     if (input === 'v') return runAction('group')
     if (input === 'c') { setShowClosed(v => !v); setCursor(0); return }
     if (input === 'e') { setShowExited(v => !v); setCursor(0); return }
@@ -837,6 +849,23 @@ export function Sessions({
     }
   }, { isActive })
 
+  /**
+   * How long ago each row that is NOT running began, already localized.
+   *
+   * Computed here because the clock lives here: the host reports the INSTANT a session started and
+   * this pane repaints far more often than the poll runs, so a duration computed upstream would
+   * freeze at whatever it was when the host last looked.
+   */
+  const ages = useMemo(() => {
+    const now = Date.now()
+    const out = new Map<string, string>()
+    for (const v of fleet?.sessions ?? []) {
+      const age = sessionAge(v, now, secs => s.sessionsAgo(secs))
+      if (age) out.set(v.id, age)
+    }
+    return out
+  }, [fleet?.sessions, s])
+
   const offset = windowOffset(at < 0 ? 0 : selectable[at]!, rows.length, cockpit.listRows)
   const visible = rows.slice(offset, offset + cockpit.listRows)
   /**
@@ -881,10 +910,11 @@ export function Sessions({
       listBody,
       {
         groupedByTask: grouping === 'task',
+        ages,
         ...(cockpit.header ? { headings: s.sessionsCols } : {}),
       },
     ),
-    [visible, listBody, grouping, cockpit.header, s],
+    [visible, listBody, grouping, cockpit.header, ages, s],
   )
 
   // The wizard takes the WHOLE screen rather than the detail strip: it is six questions with a
@@ -906,6 +936,14 @@ export function Sessions({
           onHideEmptyTask={v => { setHideEmptyTask(v); setCursor(0) }}
           onClose={() => setAsk(null)}
         />
+      </Box>
+    )
+  }
+
+  if (ask?.kind === 'keys') {
+    return (
+      <Box flexDirection="column" width={width} flexShrink={0}>
+        <KeyHelpScreen strings={s} width={width} height={height} onClose={() => setAsk(null)} />
       </Box>
     )
   }
@@ -1050,6 +1088,7 @@ export function Sessions({
           {'  ' + (columns.id > 0 ? padCell(s.sessionsCols.id, columns.id) + '  ' : '')
             + padCell(s.sessionsCols.state, columns.state)}
           {columns.title > 0 ? '  ' + padCell(s.sessionsCols.title, columns.title) : ''}
+          {columns.age > 0 ? '  ' + padCell(s.sessionsCols.age, columns.age) : ''}
           {columns.worktree > 0 ? '  ' + padCell(s.sessionsCols.worktree, columns.worktree) : ''}
           {columns.task > 0 ? '  ' + padCell(s.sessionsCols.task, columns.task) : ''}
           {columns.metrics > 0 ? '  ' + padCell(s.sessionsCols.metrics, columns.metrics) : ''}
@@ -1102,6 +1141,7 @@ export function Sessions({
                 session={row.session}
                 selected={selected?.id === row.session.id}
                 marked={marked.has(row.session.id)}
+                ages={ages}
                 columns={columns}
                 width={listBody}
               />
@@ -1144,7 +1184,7 @@ export function Sessions({
         >
           {ask ? (
             <Question
-              ask={ask as Exclude<Ask, { kind: 'new' } | { kind: 'view' }>}
+              ask={ask as Exclude<Ask, { kind: 'new' } | { kind: 'view' } | { kind: 'keys' }>}
               strings={s}
               width={paneBody(width)}
               onClose={() => setAsk(null)}
@@ -1262,9 +1302,11 @@ function SummaryRow({
   )
 }
 
-function SessionRowView({ session, selected, marked, columns, width }: {
+function SessionRowView({ session, selected, marked, ages, columns, width }: {
   session: ControlSession
   selected: boolean
+  /** Already-localized ages by session id — this component owns no clock and no strings. */
+  ages: ReadonlyMap<string, string>
   /** The user's own highlight. Survives re-sorting, and outlives the cursor moving away. */
   marked: boolean
   columns: SessionColumns
@@ -1303,6 +1345,11 @@ function SessionRowView({ session, selected, marked, columns, width }: {
           {gap + padCell(session.title, columns.title)}
         </Text>
       ) : null}
+      {/* How long ago it started, on rows that are NOT running — the age is most of the "reopen
+          this or not" decision, and it lived only in the detail pane. */}
+      {columns.age > 0 ? (
+        <Text dimColor>{gap + padCell(ages.get(session.id) ?? '', columns.age)}</Text>
+      ) : null}
       {/* A linked WORKTREE says so, because it changes what the row IS: three rows of one repo in
           three directories are three checkouts, and without the word they read as three projects.
           The word, never a glyph alone — a distinction announced in a symbol is one that has to be
@@ -1330,6 +1377,39 @@ function SessionRowView({ session, selected, marked, columns, width }: {
         <Text dimColor>{gap + padCell(session.projectGroup || session.project, columns.where)}</Text>
       ) : null}
     </Text>
+  )
+}
+
+/**
+ * Every key this screen answers, on one screen.
+ *
+ * The footer names the handful that fit; this is the rest. It reads the SAME list the pure module
+ * owns, so a key that exists and is not here would have to be left out of that list deliberately.
+ */
+function KeyHelpScreen({ strings: s, width, height, onClose }: {
+  strings: ControlStrings
+  width: number
+  height: number
+  onClose: () => void
+}) {
+  useInput((_i, key) => { if (key.escape || key.return) onClose() })
+
+  const rows = useMemo(() => sessionKeyHelp(s.sessionsKeyWhat), [s])
+  const keyCol = keyHelpColumn(rows)
+  // Two rows of chrome: the title and the blank under it. Budgeted, because Ink composites what
+  // does not fit rather than clipping it.
+  const page = Math.max(1, height - 3)
+
+  return (
+    <Pane title={s.sessionsPaneKeys} focused width={width} height={height}>
+      {rows.slice(0, page).map(r => (
+        <Text key={r.keys} wrap="truncate">
+          <Text color={COLORS.accent}>{padCell(r.keys, keyCol)}</Text>
+          <Text dimColor>{'  ' + truncate(r.what, Math.max(1, paneBody(width) - keyCol - 2))}</Text>
+        </Text>
+      ))}
+      {rows.length > page ? <Text dimColor>{`… +${rows.length - page}`}</Text> : null}
+    </Pane>
   )
 }
 
@@ -1381,7 +1461,7 @@ function Detail({ lines, width, rows }: {
  */
 function Question({ ask, strings: s, width, onClose, onRun, host, query, onQuery, fleet }: {
   /** Never `new` — the wizard takes the whole screen and is rendered before this is reached. */
-  ask: Exclude<Ask, { kind: 'new' } | { kind: 'view' }>
+  ask: Exclude<Ask, { kind: 'new' } | { kind: 'view' } | { kind: 'keys' }>
   strings: ControlStrings
   width: number
   onClose: () => void


### PR DESCRIPTION
A WSL crash left every session `lost`. Reopening one of them produced **three** rows called "Principal", all live, all driving the same conversation.

## The duplication

`conversationForProcess` matches on harness and **directory**, which is all it can do for a process it did not start — so every managed session in one repository resolved to the same conversation, and reopening two of them started two copies of one.

Two things fix it:

- A conversation is **claimed** as it is offered, so no two rows are handed the same one.
- A session that was reopened **records** the conversation id it was given (`ManagedSession.conversationId`) — we handed that id to the CLI ourselves, so there is nothing left to guess.

`openTask` claims too, or a task of five rows in one repo reopens as five copies of one.

## A lost row had no age

`createdMs` came from the backend, and a row the machine lost has no backend left to ask. It falls back to the registry's own `createdAt`, and the age is a **column** on rows that are down — a live session's age is idle curiosity, while "reopen this or not" is mostly a question about how old it is.

## Keys

`ctrl+a` toggles the active filter beside `l`. `?` prints every key this screen answers.

`ctrl+h` is accepted where a terminal can tell it apart from backspace, which usually it cannot: **ctrl+h is ASCII 8, the backspace byte**, so Ink reports it as `key.backspace` and a binding on it either never fires or fires on backspace. Measured in the preview rather than assumed — which the preview can now do at all, having learned to send control chords.

The key list is one pure table (`sessionKeyHelp`), not a second copy of the if-chain, and a test pins that no two rows claim the same keystroke.

## The wizard stopped eating prompts

It returned **silently** when it had nothing to spawn with, so the last `enter` of a six-step wizard did nothing and there was no way to tell a dead key from a slow one. And a spawn that came back `ok: false` closed the wizard anyway, putting the reason on the status line — one transient row — and taking the prompt with it.

A missing answer now sends you back to the step that takes it, a refusal is shown in the wizard and the draft stands, a rejected promise is caught, and only success unmounts.

Tests: 3427 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019vBSuKQLuyLhWZS4zbiu2s