### PR TITLE
feat(sessions): offer the fleet back after a crash, fold the menu, close a row from the row

### DIFF
--- a/packages/server/server/cli-i18n.ts
+++ b/packages/server/server/cli-i18n.ts
@@ -107,6 +107,10 @@ export interface CliStrings {
   /** The fallback title for a session the user never named. */
   sessUntitled: (harness: string, project: string) => string
   sessKilled: (id: string) => string
+  sessRestoreNone: string
+  sessRestoreDeclined: (n: number) => string
+  sessRestored: (opened: number, skipped: number) => string
+  sessRestoreFailed: (skipped: number) => string
   sessNoTask: string
   sessTaskFinished: (task: string) => string
   sessTaskReopened: (task: string) => string
@@ -325,6 +329,13 @@ const EN: CliStrings = {
     `agentop has no verified screen markers for ${harness}, so a blocking question here shows as "waiting" like any other pause.`,
   sessUntitled: (harness: string, project: string) => (project ? `${harness} in ${project}` : harness),
   sessKilled: (id: string) => `stopped ${id}.`,
+  sessRestoreNone: 'those sessions are no longer in the registry.',
+  sessRestoreDeclined: (n: number) =>
+    `left ${n} session${n === 1 ? '' : 's'} closed — still listed, still reopenable.`,
+  sessRestored: (opened: number, skipped: number) =>
+    `restored ${opened}${skipped ? `, ${skipped} could not be` : ''}.`,
+  sessRestoreFailed: (skipped: number) =>
+    `nothing could be restored${skipped ? ` — ${skipped} had no conversation to reopen` : ''}.`,
   sessNoTask: 'that session has no task.',
   sessTaskFinished: (task: string) => `"${task}" marked finished.`,
   sessTaskReopened: (task: string) => `"${task}" reopened.`,
@@ -512,6 +523,13 @@ const PT: CliStrings = {
     `o agentop não tem marcadores de tela verificados para ${harness}, então uma pergunta bloqueante aqui aparece como "aguardando", como qualquer outra pausa.`,
   sessUntitled: (harness: string, project: string) => (project ? `${harness} em ${project}` : harness),
   sessKilled: (id: string) => `${id} encerrada.`,
+  sessRestoreNone: 'essas sessões não estão mais no registro.',
+  sessRestoreDeclined: (n: number) =>
+    `${n} ${n === 1 ? 'sessão deixada fechada' : 'sessões deixadas fechadas'} — continuam listadas e reabríveis.`,
+  sessRestored: (opened: number, skipped: number) =>
+    `${opened} restaurada${opened === 1 ? '' : 's'}${skipped ? `, ${skipped} não deu` : ''}.`,
+  sessRestoreFailed: (skipped: number) =>
+    `nada pôde ser restaurado${skipped ? ` — ${skipped} sem conversa para reabrir` : ''}.`,
   sessNoTask: 'essa sessão não tem tarefa.',
   sessTaskFinished: (task: string) => `"${task}" marcada como finalizada.`,
   sessTaskReopened: (task: string) => `"${task}" reaberta.`,

--- a/packages/server/server/cli-start.ts
+++ b/packages/server/server/cli-start.ts
@@ -61,6 +61,7 @@ import type {
   StartOption,
   TabId,
   StartRequest,
+  RestoreCandidate,
 } from '@agentistics/tui/control'
 import { DEFAULT_SESSION_VIEW } from '@agentistics/tui/control'
 import { PORT, WEB_PORT } from './config'
@@ -93,6 +94,7 @@ import { repoFacts } from './sessions/repo-facts'
 // rows from the same decision rather than mapping the fleet a second time.
 import { toControlSession } from './sessions/control-session'
 import { planTaskReopen, taskReopenSucceeded } from './sessions/task-reopen'
+import { planRestore } from './sessions/session-restore'
 import type { SpawnPlanError } from './sessions/types'
 import { addSession, newSessionId, patchSession, readRegistry, removeSession } from './sessions/registry'
 import { createSessionsPoller, type SessionsPoller } from './sessions/sessions-host'
@@ -1272,6 +1274,42 @@ async function spawnManaged(req: {
   }
 }
 
+/**
+ * The sessions this machine LOST, as the cockpit's modal needs them.
+ *
+ * The decision is the pure `planRestore`; this is the I/O around it — the registry, what tmux still
+ * holds, and the conversation store. Claimed one per row, so a repository holding four lost rows is
+ * not offered four copies of one conversation.
+ */
+async function restorableSessions(): Promise<RestoreCandidate[]> {
+  const backend = await resolveBackend()
+  const live = new Set((await backend.list().catch(() => [])).filter(b => b.alive).map(b => b.id))
+  const conversations = await loadConversations()
+  const taken = new Set<string>()
+  const plan = planRestore({
+    entries: await readRegistry(),
+    liveIds: live,
+    conversationFor: m => {
+      const own = m.conversationId
+        ? conversations.find(c => c.sessionId === m.conversationId)
+        : undefined
+      const conv = own ?? conversations.find(c =>
+        !taken.has(c.sessionId) && c.harness === m.harness && c.cwd === m.cwd)
+      if (!conv?.resumable) return null
+      taken.add(conv.sessionId)
+      return { sessionId: conv.sessionId, title: conv.title }
+    },
+  })
+  return plan.map(c => ({
+    id: c.id,
+    label: c.label,
+    harness: c.harness,
+    // The last segment, the same key the "by project" grouping falls back to.
+    project: c.cwd.replace(/[/\\]+$/, '').split(/[/\\]/).pop() ?? '',
+    ...(c.startedMs !== undefined ? { startedAt: c.startedMs } : {}),
+  }))
+}
+
 function createControlHost(initialLang: CliLang, altScreen: Suspendable): StartHost {
   let lang = initialLang
   const S = () => cliStrings(lang)
@@ -1787,7 +1825,11 @@ function createControlHost(initialLang: CliLang, altScreen: Suspendable): StartH
       // this poll runs every five seconds over the whole fleet — asking git three times per session
       // per tick would be a hundred processes a minute to learn the same thing.
       const facts = await Promise.all(snap.sessions.map(v => repoFacts(v.cwd)))
+      // What the machine LOST and could start again. Computed on the snapshot rather than fetched
+      // separately, so the screen cannot ask twice and get two answers while a poll is in flight.
+      const restorable = await restorableSessions()
       return {
+        ...(restorable.length > 0 ? { restorable } : {}),
         sessions: snap.sessions.map((v, i) => toControlSession(v, s, facts[i])),
         attention: snap.attention,
         rang: snap.rang,
@@ -1839,6 +1881,58 @@ function createControlHost(initialLang: CliLang, altScreen: Suspendable): StartH
      * what the button just did. Nothing about the sessions changes: a finished task is a statement
      * about the WORK, and its sessions stay listed, attachable and killable behind one switch.
      */
+    /**
+     * Start the offered sessions again, detached — or decline them.
+     *
+     * Declining RETIRES the rows it was offered. "No" here means the work is over, and without that
+     * the same modal greets you on the next run and the one after, which is how a prompt becomes
+     * something people clear without reading. Nothing is destroyed either way: a retired row stays
+     * listed and individually reopenable.
+     */
+    async restoreSessions(ids: string[], accept: boolean): Promise<ActionResult> {
+      const s = S()
+      const registry = await readRegistry()
+      const wanted = registry.filter(m => ids.includes(m.id))
+      if (wanted.length === 0) return { ok: false, message: s.sessRestoreNone }
+
+      if (!accept) {
+        const stamp = new Date().toISOString()
+        for (const m of wanted) await patchSession(m.id, { endedAt: stamp })
+        return { ok: true, message: s.sessRestoreDeclined(wanted.length) }
+      }
+
+      const conversations = await loadConversations()
+      const taken = new Set<string>()
+      let opened = 0
+      let skipped = 0
+      for (const m of wanted) {
+        const own = m.conversationId
+          ? conversations.find(c => c.sessionId === m.conversationId)
+          : undefined
+        const conv = own ?? conversations.find(c =>
+          !taken.has(c.sessionId) && c.harness === m.harness && c.cwd === m.cwd)
+        if (!conv?.resumable) { skipped++; continue }
+        taken.add(conv.sessionId)
+        const r = await spawnManaged({
+          harness: m.harness,
+          cwd: m.cwd,
+          resumeId: conv.sessionId,
+          label: m.label ?? conv.title,
+          attach: false,
+          ...(m.task ? { task: m.task } : {}),
+        }, s)
+        if (!r.ok) { skipped++; continue }
+        opened++
+        if (r.id) await patchSession(r.id, { conversationId: conv.sessionId })
+        if (m.note && r.id) await patchSession(r.id, { note: m.note })
+        await patchSession(m.id, { endedAt: new Date().toISOString() })
+      }
+      forgetConversations()
+      return opened > 0
+        ? { ok: true, message: s.sessRestored(opened, skipped) }
+        : { ok: false, message: s.sessRestoreFailed(skipped) }
+    },
+
     async finishTask(task: string, done: boolean): Promise<ActionResult> {
       const s = S()
       if (!task) return { ok: false, message: s.sessNoTask }

--- a/packages/server/server/sessions/session-restore.test.ts
+++ b/packages/server/server/sessions/session-restore.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'bun:test'
+import { planRestore } from './session-restore'
+import type { ManagedSession } from './types'
+
+const entry = (id: string, over: Partial<ManagedSession> = {}): ManagedSession => ({
+  id, harness: 'claude', cwd: '/repo/a', createdAt: '2026-08-13T10:00:00.000Z', ...over,
+})
+const conv = (sessionId: string, title = 'a conversation') => () => ({ sessionId, title })
+
+describe('planRestore', () => {
+  it('offers a row the machine lost, with the name the user gave it', () => {
+    const got = planRestore({
+      entries: [entry('a', { label: 'the auth work' })],
+      liveIds: new Set(),
+      conversationFor: conv('c1', 'Refactor the token store'),
+    })
+    expect(got).toHaveLength(1)
+    expect(got[0]).toMatchObject({ id: 'a', label: 'the auth work', resumeId: 'c1' })
+  })
+
+  it('falls back to the conversation title when nobody named it', () => {
+    const got = planRestore({
+      entries: [entry('a')], liveIds: new Set(), conversationFor: conv('c1', 'Refactor'),
+    })
+    expect(got[0]!.label).toBe('Refactor')
+  })
+
+  it('offers NOTHING while something is still running', () => {
+    // A machine with live sessions did not lose everything — it is an ordinary restart of the app,
+    // and greeting that with a modal is a modal people learn to dismiss without reading.
+    const got = planRestore({
+      entries: [entry('a'), entry('b')],
+      liveIds: new Set(['b']),
+      conversationFor: conv('c1'),
+    })
+    expect(got).toEqual([])
+  })
+
+  it('never offers a session the user ENDED', () => {
+    // `endedAt` is a decision. Offering it back is offering to undo their last action.
+    const got = planRestore({
+      entries: [entry('a', { endedAt: '2026-08-13T11:00:00.000Z' })],
+      liveIds: new Set(),
+      conversationFor: conv('c1'),
+    })
+    expect(got).toEqual([])
+  })
+
+  it('never offers a row with nothing to reopen', () => {
+    const got = planRestore({
+      entries: [entry('a'), entry('b')],
+      liveIds: new Set(),
+      conversationFor: e => (e.id === 'a' ? { sessionId: 'c1', title: 't' } : null),
+    })
+    expect(got.map(r => r.id)).toEqual(['a'])
+  })
+
+  it('puts the newest first, because that is what someone was in the middle of', () => {
+    const got = planRestore({
+      entries: [
+        entry('old', { createdAt: '2026-08-01T10:00:00.000Z' }),
+        entry('new', { createdAt: '2026-08-13T10:00:00.000Z' }),
+      ],
+      liveIds: new Set(),
+      conversationFor: conv('c1'),
+    })
+    expect(got.map(r => r.id)).toEqual(['new', 'old'])
+  })
+
+  it('bounds the list, because a modal of forty rows is a wall and not an offer', () => {
+    const many = Array.from({ length: 30 }, (_, i) => entry(`s${i}`))
+    expect(planRestore({ entries: many, liveIds: new Set(), conversationFor: conv('c1') }))
+      .toHaveLength(8)
+    expect(planRestore({
+      entries: many, liveIds: new Set(), conversationFor: conv('c1'), limit: 3,
+    })).toHaveLength(3)
+  })
+
+  it('survives a registry timestamp nobody can read', () => {
+    const got = planRestore({
+      entries: [entry('a', { createdAt: '' })], liveIds: new Set(), conversationFor: conv('c1'),
+    })
+    expect(got).toHaveLength(1)
+    expect(got[0]!.startedMs).toBeUndefined()
+  })
+})

--- a/packages/server/server/sessions/session-restore.ts
+++ b/packages/server/server/sessions/session-restore.ts
@@ -1,0 +1,78 @@
+/**
+ * session-restore.ts — PURE: what to offer back after the machine took everything.
+ *
+ * A crash, a closed terminal, a WSL that fell over: tmux dies and every managed session reconciles
+ * to `lost` while the registry keeps its name, its note and its task. The rows are all still there
+ * and every one of them is reopenable — but finding that out means opening the app, noticing the
+ * list is not what it was, and reopening them one at a time. The offer is the whole feature.
+ *
+ * What this module decides is WHICH rows are worth offering, and the answer is narrower than "every
+ * lost row":
+ *
+ *  - A session the user ENDED is not lost work. `endedAt` is a decision, and an offer to restore
+ *    what someone deliberately stopped is an offer to undo their last action.
+ *  - A row with nothing to reopen is not an offer, it is a button that fails. Only rows whose
+ *    conversation resolves are listed.
+ *  - A conversation is CLAIMED once, so a repository holding four lost rows does not offer four
+ *    copies of one conversation — the bug this project has already shipped once.
+ *  - Nothing is offered while something is RUNNING. A machine that still has live sessions did not
+ *    lose everything; it is a normal restart of the app, and greeting that with a modal is a modal
+ *    people learn to dismiss without reading — which is the same as not having one.
+ */
+
+import type { ManagedSession } from './types'
+
+export interface RestoreCandidate {
+  id: string
+  /** The user's own name when there is one, else the conversation's. */
+  label: string
+  harness: string
+  cwd: string
+  /** The harness's conversation id this row would reopen. */
+  resumeId: string
+  /** When it started, epoch ms — absent when the registry's timestamp is unreadable. */
+  startedMs?: number
+}
+
+/**
+ * The rows worth offering back, newest first — PURE.
+ *
+ * Newest first because a restore is a list someone reads under one question, and the sessions they
+ * were in the middle of when the machine died are the recent ones. `limit` bounds it for the same
+ * reason the closed block is bounded: a modal listing forty rows is not an offer, it is a wall.
+ */
+export function planRestore(o: {
+  /** Every registry entry, with whether the backend still has it. */
+  entries: readonly ManagedSession[]
+  /** Ids the backend reports alive right now. */
+  liveIds: ReadonlySet<string>
+  /** The conversation this entry would reopen, or `null` when none resolves. */
+  conversationFor: (entry: ManagedSession) => { sessionId: string; title: string } | null
+  limit?: number
+}): RestoreCandidate[] {
+  // Something is still running: this is not a machine that lost everything.
+  if (o.entries.some(e => o.liveIds.has(e.id) && !e.endedAt)) return []
+
+  const out: RestoreCandidate[] = []
+  for (const entry of o.entries) {
+    // A session the user ENDED is not lost work — offering it back undoes their last action.
+    if (entry.endedAt) continue
+    if (o.liveIds.has(entry.id)) continue
+    const conv = o.conversationFor(entry)
+    // A row with nothing to reopen is a button that fails, not an offer.
+    if (!conv) continue
+    const started = Date.parse(entry.createdAt)
+    out.push({
+      id: entry.id,
+      label: entry.label ?? conv.title,
+      harness: entry.harness,
+      cwd: entry.cwd,
+      resumeId: conv.sessionId,
+      ...(Number.isFinite(started) ? { startedMs: started } : {}),
+    })
+  }
+
+  return out
+    .sort((a, b) => (b.startedMs ?? 0) - (a.startedMs ?? 0))
+    .slice(0, o.limit ?? 8)
+}

--- a/packages/server/server/sessions/session-view.ts
+++ b/packages/server/server/sessions/session-view.ts
@@ -279,15 +279,28 @@ export function buildSessionViews(o: {
   // covers its conversation, whether that row is one we host or one we merely observed.
   const shown = new Set<string>()
   for (const v of external) if (v.resume) shown.add(v.resume.sessionId)
-  for (const m of managed) {
-    // A managed row does not carry a conversation id, so it covers by the same harness+directory
-    // inference used for a foreign process. `exited` and `lost` rows cover nothing: their work IS
-    // over, and the conversation belongs in history where it can be reopened.
-    if (m.status !== 'running' && m.status !== 'unregistered') continue
-    const conv = m.harness
-      ? conversationForProcess(conversations, { harness: m.harness, cwd: m.cwd })
-      : undefined
-    if (conv) shown.add(conv.sessionId)
+  //
+  // A row that RECORDED its conversation covers exactly that one. The rest fall back to the
+  // harness+directory inference, and it is CLAIMED — because that inference answers with the FIRST
+  // conversation in the directory, so four live sessions in one repository all covered the same
+  // one. The other three stayed in history as `closed` rows for conversations that were open, and
+  // whichever conversation happened to be first vanished from history while it was the one nobody
+  // was running. "Some sessions do not appear" and "some appear twice" were the same bug, seen
+  // from its two ends.
+  const coveredConv = new Set<string>()
+  for (const r of o.reconciled) {
+    const m = managed.find(v => v.id === r.id)
+    // `exited` and `lost` rows cover nothing: their work IS over, and the conversation belongs in
+    // history where it can be reopened.
+    if (!m || (m.status !== 'running' && m.status !== 'unregistered')) continue
+    const own = r.managed?.conversationId
+    if (own) { shown.add(own); coveredConv.add(own); continue }
+    if (!m.harness) continue
+    const conv = conversations.find(c =>
+      !coveredConv.has(c.sessionId)
+      && c.harness === m.harness
+      && sessionAtCwd({ current_cwd: c.cwd, project_path: c.cwd }, m.cwd))
+    if (conv) { shown.add(conv.sessionId); coveredConv.add(conv.sessionId) }
   }
 
   const closed: SessionView[] = conversations

--- a/packages/tui/src/control/i18n.ts
+++ b/packages/tui/src/control/i18n.ts
@@ -224,12 +224,16 @@ export interface ControlStrings {
   sessionsPaneDetail: string
   sessionsPaneAsk: string
   sessionsPaneKeys: string
+  sessionsPaneRestore: string
+  restoreTitle: (n: number) => string
+  restoreAnswer: string
   /** What each key on the sessions screen does — the one list `ctrl+h` prints. */
   sessionsKeyWhat: {
     move: string; open: string; attach: string; menu: string; section: string
     newSession: string; search: string; clear: string; kill: string; rename: string
     note: string; task: string; mark: string; onlyActive: string; closed: string
-    exited: string; unfiled: string; group: string; detail: string; reset: string
+    exited: string; unfiled: string; group: string; detail: string; menuFold: string
+    reset: string
     tabs: string; help: string; quit: string
   }
   sessionsFinishConfirm: (task: string, count: number) => string
@@ -548,6 +552,10 @@ const EN: ControlStrings = {
   sessionsPaneDetail: 'detail',
   sessionsPaneAsk: 'question',
   sessionsPaneKeys: 'keys',
+  sessionsPaneRestore: 'last time',
+  restoreTitle: (n: number) =>
+    n === 1 ? 'Your last session was this one:' : `Your last ${n} sessions were these:`,
+  restoreAnswer: 'enter starts them in the background · esc leaves them closed',
   sessionsKeyWhat: {
     move: 'move the cursor',
     open: 'switch between the menu and the list',
@@ -568,6 +576,7 @@ const EN: ControlStrings = {
     unfiled: 'show sessions under no task',
     group: 'change the grouping',
     detail: 'hide the detail pane',
+    menuFold: 'fold the menu away — any digit brings it back',
     reset: 'back to how the app opens',
     tabs: 'change screen',
     help: 'this list',
@@ -879,6 +888,10 @@ const PT: ControlStrings = {
   sessionsPaneDetail: 'detalhe',
   sessionsPaneAsk: 'pergunta',
   sessionsPaneKeys: 'teclas',
+  sessionsPaneRestore: 'da última vez',
+  restoreTitle: (n: number) =>
+    n === 1 ? 'Sua última sessão foi esta:' : `Suas últimas ${n} sessões foram estas:`,
+  restoreAnswer: 'enter inicia em background · esc deixa fechadas',
   sessionsKeyWhat: {
     move: 'move o cursor',
     open: 'alterna entre o menu e a lista',
@@ -899,6 +912,7 @@ const PT: ControlStrings = {
     unfiled: 'mostra sessões sem tarefa',
     group: 'muda o agrupamento',
     detail: 'oculta o painel de detalhe',
+    menuFold: 'recolhe o menu — qualquer dígito traz de volta',
     reset: 'volta para como o app abre',
     tabs: 'muda de tela',
     help: 'esta lista',

--- a/packages/tui/src/control/index.ts
+++ b/packages/tui/src/control/index.ts
@@ -169,6 +169,7 @@ export type {
   SpawnSessionRequest,
   SpawnSessionResult,
   ProjectOption,
+  RestoreCandidate,
   ResumeSessionRequest,
   StartHow,
   StartOption,

--- a/packages/tui/src/control/sessions.test.ts
+++ b/packages/tui/src/control/sessions.test.ts
@@ -5,7 +5,7 @@ import {
   sessionColumns, sessionsCockpit, asideRows, asideSelectable, projectCounts, projectColumns,
   projectPickRows, groupProjects, asideSections, asideFold, scrollBar, THUMB, TRACK, sessionNamed,
   sessionHandle, worktreeName, sessionRunning, asideRowKey, resolveAsideCursor,
-  sessionAge, sessionKeyHelp, keyHelpColumn,
+  sessionAge, sessionKeyHelp, keyHelpColumn, closeCellWidth, canClose,
   DEFAULT_ORDER, usageOf, planSubmit,
 } from './sessions'
 import type { ControlSession, SessionState } from './types'
@@ -1212,7 +1212,7 @@ describe('sessionKeyHelp', () => {
   const words = Object.fromEntries(
     ['move', 'open', 'attach', 'menu', 'section', 'newSession', 'search', 'clear', 'kill',
       'rename', 'note', 'task', 'mark', 'onlyActive', 'closed', 'exited', 'unfiled', 'group',
-      'detail', 'reset', 'tabs', 'help', 'quit'].map(k => [k, `does ${k}`]),
+      'detail', 'menuFold', 'reset', 'tabs', 'help', 'quit'].map(k => [k, `does ${k}`]),
   ) as Parameters<typeof sessionKeyHelp>[0]
 
   it('describes every key it lists, with no blanks', () => {
@@ -1234,5 +1234,31 @@ describe('sessionKeyHelp', () => {
     const rows = sessionKeyHelp(words)
     expect(keyHelpColumn(rows)).toBe(Math.max(...rows.map(r => r.keys.length)))
     expect(keyHelpColumn([])).toBe(0)
+  })
+})
+
+describe('the per-row close control', () => {
+  const live = session('a', { state: 'waiting' as SessionState })
+  const closed = session('b', { state: 'closed' as SessionState, actionable: false })
+  const gone = session('c', { state: 'exited' as SessionState })
+
+  it('is offered only on a row agentop can actually stop', () => {
+    // An external process is someone else's to stop, and a closed conversation has nothing running
+    // to end. A control that is visible and refuses is worse than one that is absent.
+    expect(canClose(live)).toBe(true)
+    expect(canClose(closed)).toBe(false)
+    expect(canClose(gone)).toBe(false)
+    expect(canClose(session('d', { state: 'unknown' as SessionState, actionable: false }))).toBe(false)
+  })
+
+  it('costs nothing when nothing on screen can be closed', () => {
+    expect(closeCellWidth([closed, gone], 120)).toBe(0)
+    expect(closeCellWidth([live], 120)).toBe(2)
+  })
+
+  it('gives up on a narrow list rather than squeezing the table for a button', () => {
+    // The keyboard's `x` still works there, and a table squeezed to make room is the worse trade.
+    expect(closeCellWidth([live], 30)).toBe(0)
+    expect(closeCellWidth([live], 40)).toBe(2)
   })
 })

--- a/packages/tui/src/control/sessions.ts
+++ b/packages/tui/src/control/sessions.ts
@@ -814,11 +814,13 @@ export function sessionsCockpit(o: {
   asideLabel: number
   /** Rows the detail pane is asking for, `0` when there is nothing selected to describe. */
   detailWanted: number
+  /** Folded away by the user — the list takes the whole width, whatever it would have fitted. */
+  hideAside?: boolean
 }): CockpitLayout {
   const width = Math.max(1, o.width)
   const height = Math.max(1, o.height)
 
-  const aside = width >= ASIDE_NEEDS
+  const aside = o.hideAside ? 0 : width >= ASIDE_NEEDS
     // `+ 4` rather than `+ 2`: the rows carry a cursor, a state dot and — for a task or a project —
     // a trailing count, and sizing to the label alone truncated every long verb in the menu.
     ? Math.min(ASIDE_MAX, Math.max(ASIDE_MIN, o.asideLabel + 4))
@@ -1483,8 +1485,8 @@ export function sessionKeyHelp(w: {
   move: string; open: string; attach: string; menu: string; section: string
   newSession: string; search: string; clear: string; kill: string; rename: string
   note: string; task: string; mark: string; onlyActive: string; closed: string
-  exited: string; unfiled: string; group: string; detail: string; reset: string
-  tabs: string; help: string; quit: string
+  exited: string; unfiled: string; group: string; detail: string; menuFold: string
+  reset: string; tabs: string; help: string; quit: string
 }): KeyHelp[] {
   return [
     { keys: '↑ ↓ / j k', what: w.move },
@@ -1505,6 +1507,7 @@ export function sessionKeyHelp(w: {
     { keys: 'u', what: w.unfiled },
     { keys: 'v', what: w.group },
     { keys: 'd', what: w.detail },
+    { keys: 'ctrl+b', what: w.menuFold },
     { keys: 'ctrl+r', what: w.reset },
     { keys: '[ ]', what: w.tabs },
     { keys: '?', what: w.help },
@@ -1515,4 +1518,34 @@ export function sessionKeyHelp(w: {
 /** The width the keystroke column needs, so the descriptions line up — PURE. */
 export function keyHelpColumn(rows: readonly KeyHelp[]): number {
   return rows.reduce((n, r) => Math.max(n, r.keys.length), 0)
+}
+
+/** The glyph that closes a session from its own row. */
+export const CLOSE_CELL = '✕'
+
+/**
+ * Columns reserved at the right edge of the list for the per-row close control — PURE.
+ *
+ * Two: a gap and the glyph. Reserved from the width BEFORE the columns are measured, because a
+ * control drawn after a table that already spent the full width is a control drawn on top of the
+ * last cell.
+ *
+ * Zero when nothing on screen can be closed, and zero on a list too narrow to spare it — the
+ * keyboard's `x` still works there, and a table squeezed to make room for a button is a worse
+ * trade than a button that is only on the wider terminal.
+ */
+export function closeCellWidth(rows: readonly ControlSession[], width: number): number {
+  const NEEDS = 40
+  return width >= NEEDS && rows.some(canClose) ? 2 : 0
+}
+
+/**
+ * Can this row be closed at all?
+ *
+ * Only a session agentop HOSTS: an external process is someone else's to stop, and a closed
+ * conversation has nothing running to end. A row that cannot take it draws no glyph — a control
+ * that is visible and refuses is worse than one that is absent.
+ */
+export function canClose(s: ControlSession): boolean {
+  return s.actionable && s.state !== 'closed' && s.state !== 'exited'
 }

--- a/packages/tui/src/control/tabs/Sessions.tsx
+++ b/packages/tui/src/control/tabs/Sessions.tsx
@@ -15,8 +15,8 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Box, Text, useInput } from 'ink'
 import type {
-  ActionResult, ControlExit, ControlHost, ControlSession, ControlSessions, SessionState,
-  SessionViewPrefs,
+  ActionResult, ControlExit, ControlHost, ControlSession, ControlSessions, RestoreCandidate,
+  SessionState, SessionViewPrefs,
 } from '../types'
 import type { ControlStrings } from '../i18n'
 import type { TabChrome } from '../ControlCenter'
@@ -56,7 +56,7 @@ import {
   enabledActionIndexes, filterSessions,
   sessionActions, sessionsCockpit, summaryCells, sessionColumns, padCell,
   taskCounts, projectCounts, sessionMetric, sessionHandle, worktreeName, sessionRunning,
-  sessionAge, sessionKeyHelp, keyHelpColumn,
+  sessionAge, sessionKeyHelp, keyHelpColumn, closeCellWidth, canClose, CLOSE_CELL,
   DEFAULT_ORDER, ACTIVE_STATES, type SessionOrder,
   asideSections, asideFold, scrollBar, THUMB,
   sessionNamed,
@@ -161,6 +161,17 @@ export function Sessions({
    * seconds: a mark that meant "the third row" would be on someone else's session by the next poll.
    */
   const [marked, setMarked] = useState<ReadonlySet<string>>(new Set(view?.marked ?? []))
+  /**
+   * Whether the menu is folded away entirely, for when the list is what you came to read.
+   *
+   * NOT persisted, unlike every other part of the arrangement: it is a gesture you make to look at
+   * something, not a setting. A menu that was still hidden three days later would be a feature
+   * nobody could find their way back out of — and the keys that open it (`1`-`9`) are the same ones
+   * that jump to a section, so opening it is never a thing you have to remember how to do.
+   */
+  const [menuHidden, setMenuHidden] = useState(false)
+  /** Ids the user has already been asked about this run, so the offer is made once. */
+  const [restoreAsked, setRestoreAsked] = useState(false)
   /**
    * Whether the visible action row has the keyboard.
    *
@@ -408,11 +419,14 @@ export function Sessions({
   // narrow to carry the menu — where it is the only menu there is — and whether that is the case
   // depends on the width alone, so one extra call settles it without either budget guessing at the
   // other. A row taken without being paid for is composited over the one under it.
-  const probe = sessionsCockpit({ width, height, asideLabel, detailWanted })
+  // `hideAside` is passed to BOTH, or the probe answers with an aside the real layout will not draw
+  // and the action row is budgeted against a menu that is not there.
+  const fold = { asideLabel, hideAside: menuHidden }
+  const probe = sessionsCockpit({ width, height, detailWanted, ...fold })
   const actionRows = probe.aside > 0 ? 0 : height >= 12 ? 2 : height >= 8 ? 1 : 0
   const cockpit = actionRows === 0
     ? probe
-    : sessionsCockpit({ width, height: Math.max(1, height - actionRows), asideLabel, detailWanted })
+    : sessionsCockpit({ width, height: Math.max(1, height - actionRows), detailWanted, ...fold })
 
 
   /** Run one verb, whether it arrived from a letter, an arrow key or a click. */
@@ -566,9 +580,11 @@ export function Sessions({
     // The DIGITS jump straight to a menu section, from the list as well as from the menu — every
     // section wears its number, so this is a key the screen documents itself rather than one you
     // have to be told about. They work where the arrows are not available at all.
-    if (cockpit.aside > 0 && input >= '1' && input <= '9') {
+    // A digit brings the menu BACK as well as jumping to a section: the keys that reach the menu
+    // are the way out of having hidden it, so there is nothing extra to remember.
+    if (input >= '1' && input <= '9') {
       const n = Number(input) - 1
-      if (n < sections.length) { gotoSection(n); return }
+      if (n < sections.length) { setMenuHidden(false); gotoSection(n); return }
     }
 
     if (focus === 'aside' && cockpit.aside > 0) {
@@ -632,6 +648,7 @@ export function Sessions({
     // duplication here: `l` is what the footer has room to name, and a chord is what someone
     // reaches for without having read the footer at all.
     if (key.ctrl && input === 'a') { setOnlyActive(v => !v); setCursor(0); return }
+    if (key.ctrl && input === 'b') { setMenuHidden(v => !v); return }
     // `?` is the key, and `ctrl+h` is accepted where the terminal can tell it apart from backspace.
     // It usually cannot: `ctrl+h` IS ASCII 8, which is the backspace byte, so Ink reports it as
     // `key.backspace` and a binding on it would either never fire or fire on backspace. Measured
@@ -827,10 +844,18 @@ export function Sessions({
       // The summary row states what is being shown; the controls live in the view panel, which a
       // click on that row opens. One place to change these, rather than two that can disagree.
       if (cockpit.summary && y === 0) { setAsk({ kind: 'view' }); return }
-      const row = offset + (y - (cockpit.summary ? 1 : 0))
+      const row = offset + (y - (cockpit.summary ? 1 : 0) - (cockpit.header ? 1 : 0))
       if (row < 0 || row >= rows.length) return
       const found = selectable.indexOf(row)
-      if (found >= 0) setCursor(found)
+      if (found < 0) return
+      setCursor(found)
+      // The X at the right edge. It SELECTS the row first and then asks — so the confirmation names
+      // the session under the pointer, never the one that happened to be selected before.
+      const entry = rows[row]
+      const onClose = closeCell > 0 && p.x >= listX + PANE_EDGE_X + listBody - 1
+      if (onClose && entry?.kind === 'session' && canClose(entry.session)) {
+        setAsk({ kind: 'kill', session: entry.session })
+      }
       return
     }
 
@@ -887,6 +912,12 @@ export function Sessions({
   // full pane and then drawn beside a bar is a table truncated by one character on every row.
   const listBar = scrollBar({ offset, total: rows.length, rows: cockpit.listRows })
   const listBody = paneBody(cockpit.list) - (listBar.length > 0 ? 1 : 0)
+  // Reserved BEFORE the columns are measured: a control drawn after a table that already spent the
+  // full width is a control drawn on top of the last cell.
+  const closeCell = closeCellWidth(
+    visible.flatMap(r => (r.kind === 'session' ? [r.session] : [])),
+    listBody,
+  )
 
   // Slicing from zero would leave the view switches below the fold on a short terminal — invisible,
   // and still the thing `enter` would act on.
@@ -906,15 +937,15 @@ export function Sessions({
       visible.flatMap(r => (r.kind === 'session' ? [r.session] : [])),
       // The CONTENT width, not the pane's: measuring against the frame made every column four
       // characters wider than the row it was drawn into, and the table survived only because Ink
-      // truncated it.
-      listBody,
+      // truncated it. Minus whatever the close control took.
+      listBody - closeCell,
       {
         groupedByTask: grouping === 'task',
         ages,
         ...(cockpit.header ? { headings: s.sessionsCols } : {}),
       },
     ),
-    [visible, listBody, grouping, cockpit.header, ages, s],
+    [visible, listBody, closeCell, grouping, cockpit.header, ages, s],
   )
 
   // The wizard takes the WHOLE screen rather than the detail strip: it is six questions with a
@@ -935,6 +966,35 @@ export function Sessions({
           onShowClosed={v => { setShowClosed(v); setCursor(0) }}
           onHideEmptyTask={v => { setHideEmptyTask(v); setCursor(0) }}
           onClose={() => setAsk(null)}
+        />
+      </Box>
+    )
+  }
+
+  /**
+   * The offer, made ONCE and only when there is something to offer.
+   *
+   * It comes before the list because it is about the list: after a crash the fleet you are looking
+   * at is not the one you left, and finding that out by noticing what is missing is worse than
+   * being told. Declining retires those rows, so the same modal never greets you twice.
+   */
+  const restorable = fleet?.restorable ?? []
+  if (!restoreAsked && restorable.length > 0 && host.restoreSessions) {
+    return (
+      <Box flexDirection="column" width={width} flexShrink={0}>
+        <RestoreOffer
+          rows={restorable}
+          strings={s}
+          width={width}
+          height={height}
+          isActive={isActive}
+          onAnswer={accept => {
+            setRestoreAsked(true)
+            const restore = host.restoreSessions
+            if (!restore) return
+            void run(() => restore.call(host, restorable.map(r => r.id), accept))
+              .then(onRefreshFleet)
+          }}
         />
       </Box>
     )
@@ -1144,6 +1204,7 @@ export function Sessions({
                 ages={ages}
                 columns={columns}
                 width={listBody}
+                closeCell={closeCell}
               />
             )
           })}
@@ -1302,7 +1363,7 @@ function SummaryRow({
   )
 }
 
-function SessionRowView({ session, selected, marked, ages, columns, width }: {
+function SessionRowView({ session, selected, marked, ages, columns, width, closeCell }: {
   session: ControlSession
   selected: boolean
   /** Already-localized ages by session id — this component owns no clock and no strings. */
@@ -1311,6 +1372,8 @@ function SessionRowView({ session, selected, marked, ages, columns, width }: {
   marked: boolean
   columns: SessionColumns
   width: number
+  /** Columns reserved at the right edge for the close control — `0` when there is none. */
+  closeCell: number
 }) {
   // `harness` is a plain string here because it can be EMPTY — a session the registry has
   // forgotten runs a harness nobody recorded. An empty one simply gets no colour.
@@ -1376,7 +1439,62 @@ function SessionRowView({ session, selected, marked, ages, columns, width }: {
       {columns.where > 0 ? (
         <Text dimColor>{gap + padCell(session.projectGroup || session.project, columns.where)}</Text>
       ) : null}
+      {/* The close control, at the right edge and only on a row that can take it. It asks before
+          it acts — the same confirmation `x` opens, because a one-click stop on a list that
+          re-sorts under the pointer every five seconds is a session ended by accident. */}
+      {closeCell > 0 ? (
+        <Text color={canClose(session) ? COLORS.danger : undefined}>
+          {' ' + (canClose(session) ? CLOSE_CELL : ' ')}
+        </Text>
+      ) : null}
     </Text>
+  )
+}
+
+/**
+ * "Your last sessions were these — start them again?"
+ *
+ * Every row is NAMED, because the answer is a decision about specific work and a count is not
+ * enough to make it with: three sessions in a repository you have finished with and one you were
+ * in the middle of are the same "4" on screen.
+ */
+function RestoreOffer({ rows, strings: s, width, height, isActive, onAnswer }: {
+  rows: readonly RestoreCandidate[]
+  strings: ControlStrings
+  width: number
+  height: number
+  isActive: boolean
+  onAnswer: (accept: boolean) => void
+}) {
+  useInput((_i, key) => {
+    if (key.return) return onAnswer(true)
+    if (key.escape) return onAnswer(false)
+  }, { isActive })
+
+  const now = Date.now()
+  // Two rows of chrome above and two below; what is left is the list, and a list longer than that
+  // says how many it could not show rather than drawing over the answer.
+  const page = Math.max(1, height - 5)
+
+  return (
+    <Pane title={s.sessionsPaneRestore} focused width={width} height={height}>
+      <Text bold wrap="truncate">{truncate(s.restoreTitle(rows.length), paneBody(width))}</Text>
+      <Text> </Text>
+      {rows.slice(0, page).map(r => (
+        <Text key={r.id} wrap="truncate">
+          <Text color={COLORS.accent}>{'  ' + r.label}</Text>
+          <Text dimColor>{`  ${r.harness}  ${r.project}`}</Text>
+          {r.startedAt !== undefined ? (
+            <Text dimColor>
+              {`  ${s.sessionsAgo(Math.max(0, Math.round((now - r.startedAt) / 1000)))}`}
+            </Text>
+          ) : null}
+        </Text>
+      ))}
+      {rows.length > page ? <Text dimColor>{`  … +${rows.length - page}`}</Text> : null}
+      <Text> </Text>
+      <Text wrap="truncate">{truncate(s.restoreAnswer, paneBody(width))}</Text>
+    </Pane>
   )
 }
 

--- a/packages/tui/src/control/types.ts
+++ b/packages/tui/src/control/types.ts
@@ -457,6 +457,30 @@ export const DEFAULT_SESSION_VIEW: SessionViewPrefs = {
   onlyActive: true,
 }
 
+/**
+ * A session the machine lost that could be started again — see `planRestore`.
+ *
+ * Offered ONCE, on the run after everything went down, and never while anything is still running:
+ * a machine with live sessions did not lose everything, and a modal that greets an ordinary restart
+ * is a modal people learn to dismiss without reading.
+ */
+export interface RestoreCandidate {
+  id: string
+  /** Already-composed name: the user's own when there is one, else the conversation's. */
+  label: string
+  harness: string
+  /** The last path segment, for a list that has to stay narrow. */
+  project: string
+  /**
+   * When it started, epoch ms — absent when the registry's timestamp is unreadable.
+   *
+   * An instant rather than a duration, like every other time this contract carries: the screen
+   * repaints far more often than the poll runs, so a duration computed here would freeze at
+   * whatever it was when the host last looked.
+   */
+  startedAt?: number
+}
+
 export interface ControlSessions {
   sessions: ControlSession[]
   /** How many are waiting on a person. Drives the header counter, from every tab. */
@@ -482,6 +506,13 @@ export interface ControlSessions {
    * hidden by default and shown by a toggle.
    */
   finishedTasks?: string[]
+  /**
+   * Sessions the machine lost, worth offering back — empty whenever there is nothing to offer.
+   *
+   * On the SNAPSHOT rather than fetched separately so the screen cannot ask a second time and get a
+   * different answer while a poll is in flight.
+   */
+  restorable?: RestoreCandidate[]
 }
 
 export type TeamMode = 'solo' | 'central' | 'member'
@@ -691,6 +722,16 @@ export interface ControlHost {
    * way the moment two things happen between polls.
    */
   finishTask?(task: string, done: boolean): Promise<ActionResult>
+
+  /**
+   * Start the offered sessions again, detached, or decline them.
+   *
+   * DECLINING is not a no-op: it retires the rows it was offered (`endedAt`), because "no" here
+   * means the work is over. Without that the same modal greets you on the next run and the run
+   * after, which is how a prompt becomes something people clear without reading — and the rows
+   * stay listed and individually reopenable either way, so nothing is destroyed by saying no.
+   */
+  restoreSessions?(ids: string[], accept: boolean): Promise<ActionResult>
 
   /**
    * The harnesses this machine can actually START, with what each of them accepts.


### PR DESCRIPTION
Four things, and one of them is a bug that was **hiding sessions**.

## Some sessions did not appear — same root as the duplication

A live managed row covers its conversation so history does not list it twice, and it did that by asking `conversationForProcess`, which matches on harness and **directory** and answers with the **first** conversation there.

Four live sessions in one repository all covered the same one: the other three stayed in history as `closed` rows for conversations that were *open*, while whichever conversation happened to be first vanished from history although nobody was running it. "Some do not appear" and "some appear twice" were the same bug seen from its two ends.

A row that recorded its `conversationId` now covers exactly that one, and the fallback is **claimed** so no two rows take the same.

## "Your last sessions were these — start them again?"

After a crash the fleet you are looking at is not the one you left, and finding that out by noticing what is missing is worse than being told. `planRestore` is pure and narrower than "every lost row":

- Nothing is offered while anything is still **running** — that is an ordinary restart, and a modal greeting it is one people learn to dismiss without reading.
- A session the user **ended** is not lost work; offering it back undoes their last action.
- A row with nothing to reopen is a button that fails, not an offer.
- Conversations are claimed once, so four lost rows in one repo are not four copies of one.

Declining **retires** the rows it was offered: "no" means the work is over, and without that the same modal greets you on every run until it is furniture. Nothing is destroyed either way — a retired row stays listed and individually reopenable.

## `ctrl+b` folds the menu away

For when the list is what you came to read. Deliberately **not** persisted, unlike the rest of the arrangement: it is a gesture you make to look at something, not a setting, and a menu still hidden three days later is a feature nobody can find their way out of. Any digit brings it back — the keys that reach the menu are the way out of having hidden it.

## A row can be closed from the row

`✕` at the right edge, on rows agentop can actually stop — an external process is someone else's and a closed conversation has nothing running to end, and a control that is visible and refuses is worse than one that is absent.

It **asks before it acts**, the same confirmation `x` opens: a one-click stop on a list that re-sorts under the pointer every five seconds is a session ended by accident. The two columns are reserved *before* the table is measured, or the control is drawn on top of the last cell, and they are given up on a narrow list rather than squeezing the table for a button.

Tests: 3472 pass. Swept 45–190 columns and 12–34 rows, folded and not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019vBSuKQLuyLhWZS4zbiu2s