### PR TITLE
feat(sessions): answer, prompt and recover a session without entering it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,12 +89,53 @@ packages/server/server/          — server-side modules (never bundled by Vite)
   │                          first prompt TYPED IN, because their `-p` exits after answering.
   │                          **What a session is DOING** is the pure `attention.ts` over two
   │                          signals — a probed screen marker and whether the frame moved — with
-  │                          `attention-rules.ts` holding six per-harness patterns **captured
-  │                          from six live dialogs**, each with its CLI version and date. There
+  │                          `attention-rules.ts` holding the per-harness patterns **captured
+  │                          from live dialogs**, each with its CLI version and date. There
   │                          is deliberately no `idle` state: an interactive assistant that is
   │                          alive and still is waiting for you, and the uncertainty that really
   │                          exists is about the REASON, which lives in an absent approval rule
-  │                          the UI states in words. `session-view.ts` merges the managed fleet
+  │                          the UI states in words. **One harness can have SEVERAL dialog
+  │                          components with different footers**: claude's startup select says
+  │                          `Enter to confirm · Esc to cancel` and its PERMISSION prompt says
+  │                          `Esc to cancel · Tab to amend`, and for one release only the first was
+  │                          probed — so a session sitting on "may I run this command" read as
+  │                          `waiting`, and a prompt sent to it went into the dialog's own filter
+  │                          where the submit took the highlighted option. Probe every dialog a
+  │                          harness draws, not the first one it shows you.
+  │                          **ACTING on a session without entering it** is `SessionBackend.sendText`
+  │                          / `sendKey` (they were already implemented, buried inside `spawn`) plus
+  │                          the pure `approval-spec.ts`: `Record<HarnessId, {key, probed} | null>`,
+  │                          where the key CONFIRMS THE HIGHLIGHTED OPTION and is not "approve". No
+  │                          CLI here reports which option is highlighted, so the keystroke is only
+  │                          half the design — the host RE-READS the screen immediately before
+  │                          sending (a poll is 5s old) and the confirmation SHOWS the dialog
+  │                          (`approvalTail`, which is deliberately not `frameTail`: that one cuts at
+  │                          the last rule and so cuts the dialog away). A prompt is refused on a
+  │                          session with a dialog OPEN, in words, for the same reason.
+  │                          **WHICH SESSIONS FELL TOGETHER** is the pure `crash-group.ts`. The hard
+  │                          part is not grouping, it is not admitting garbage: a `lost` row from
+  │                          three days ago never fell, and a group holding everything that ever ran
+  │                          cannot be reopened without reading it first. Membership needs evidence a
+  │                          session was ALIVE, which did not exist — so the registry carries
+  │                          `lastSeenMs`, stamped at birth and refreshed by a 60s HEARTBEAT that
+  │                          writes ONE timestamp for EVERY live session in one write. That is what
+  │                          makes the clustering exact rather than fuzzy. Every rule errs toward
+  │                          EXCLUDING (no `lastSeenMs` = not in the group, ever): a session wrongly
+  │                          left out costs one keypress on its own Reopen verb, one wrongly let in
+  │                          is invisible and makes the whole group untrustworthy.
+  │                          **What a session CALLS ITSELF** is `harness-session-file.ts` (pure) +
+  │                          `harness-sessions.ts`: Claude Code writes `~/.claude/sessions/<pid>.json`
+  │                          holding the name `/rename` set, the conversation id, the pid, and — for
+  │                          a session we started — the TMUX SESSION NAME, which is an EXACT link to
+  │                          one of our rows where everything else here has had to guess by
+  │                          harness-and-directory. `Record<HarnessId, source | null>`, claude only.
+  │                          `nameSource: 'derived'` marks a name the HARNESS invented (24 of 40 on
+  │                          a real machine) and it never competes; `pickTitle` settles the rest by
+  │                          recency where both sides say when, and otherwise gives it to the
+  │                          harness — `nameSince` exists only from claude 2.1.232, and the
+  │                          complaint this answers is a rename made inside the session that agentop
+  │                          went on ignoring. NEITHER name is discarded when they differ: the row
+  │                          says which place the one it is showing came from. `session-view.ts` merges the managed fleet
   │                          with the EXTERNAL assistants `/proc` reports (listed, marked, and
   │                          carrying no activity — nothing about them is capturable), and
   │                          `sessions-host.ts` is the 5s poller, whose failed poll keeps the
@@ -110,8 +151,13 @@ packages/server/server/          — server-side modules (never bundled by Vite)
   │                          row is not resurrected; an unresolvable one is skipped AND counted;
   │                          everything reopened RETIRES the row it replaced, or a laptop closed
   │                          twice leaves the task holding dead twins under one name). It is shared
-  │                          by `agentop session open` and the cockpit's verb, which were two
-  │                          implementations of one gesture and had already drifted.
+  │                          by `agentop session open`, the cockpit's verb and "reopen what fell",
+  │                          which were separate implementations of one gesture and had drifted.
+  │                          **Every poller must be given the same SOURCES** — `session ls` builds its
+  │                          own and went one commit missing `loadHarnessSessions`, so a row renamed
+  │                          inside its session read correctly in the cockpit and stale on the command
+  │                          line. It gets no heartbeat, though: a one-shot command must not stamp
+  │                          `lastSeenMs`.
   │                          `repo-facts.ts` answers which REPOSITORY a directory belongs to,
   │                          keyed on the git REMOTE — the only key a worktree provably shares with
   │                          its main checkout, since their directory names deliberately differ —

--- a/packages/server/server/cli-i18n.ts
+++ b/packages/server/server/cli-i18n.ts
@@ -104,6 +104,33 @@ export interface CliStrings {
   }
   /** Said on a session whose harness has no probed approval markers. */
   sessApprovalBlind: (harness: string) => string
+  /**
+   * Said on a session that IS visibly blocked, but whose dialog nobody has read.
+   *
+   * A different fact from `sessApprovalBlind`, which is about not being able to SEE the block. This
+   * one is about not knowing which key answers it — and a harness can have one and not the other.
+   */
+  sessApproveBlind: (harness: string) => string
+  /** The prompt was typed in and submitted. */
+  sessPrompted: (id: string) => string
+  /** Refused: the session is sitting on a dialog, so typed text would answer the menu. */
+  sessPromptBlocked: string
+  /** Refused: nothing is running there to type into. */
+  sessNotRunning: string
+  /** Refused: nothing was typed. */
+  sessPromptEmpty: string
+  /** The backend accepted neither the text nor the key. */
+  sessSendFailed: (id: string) => string
+  /** The keystroke went in — and the sentence says what it did, not that it "approved". */
+  sessApproved: (id: string) => string
+  /** Refused: it is not asking anything at this moment, whatever the list said a poll ago. */
+  sessNotAsking: string
+  /** Refused: this harness's dialog has never been read, so there is no key to send. */
+  sessApproveUnknown: (harness: string) => string
+  /** Nothing fell, or everything that did has already been picked back up. */
+  sessNoFell: string
+  sessFellOpened: (opened: number, skipped: number) => string
+  sessFellNoneOpened: (skipped: number) => string
   /** The fallback title for a session the user never named. */
   sessUntitled: (harness: string, project: string) => string
   sessKilled: (id: string) => string
@@ -323,6 +350,25 @@ const EN: CliStrings = {
   },
   sessApprovalBlind: (harness: string) =>
     `agentop has no verified screen markers for ${harness}, so a blocking question here shows as "waiting" like any other pause.`,
+  sessApproveBlind: (harness: string) =>
+    `nobody has read ${harness}'s dialog, so agentop does not know which key answers it — attach to this session to answer it there.`,
+  sessPrompted: (id: string) => `sent to ${id}.`,
+  sessPromptBlocked:
+    'that session has a question open, so typed text would be answering its menu. Approve it, or attach and answer it there.',
+  sessNotRunning: 'nothing is running in that session to type into.',
+  sessPromptEmpty: 'nothing to send.',
+  sessSendFailed: (id: string) => `${id} did not take the keystroke — it may have just ended.`,
+  sessApproved: (id: string) => `sent the confirm key to ${id}.`,
+  sessNotAsking: 'that session is not asking anything right now — nothing was sent.',
+  sessApproveUnknown: (harness: string) =>
+    `agentop has not read ${harness}'s dialog, so it will not guess which key answers it.`,
+  sessNoFell: 'nothing fell — no session was lost with the machine still on record.',
+  sessFellOpened: (opened: number, skipped: number) =>
+    skipped > 0
+      ? `reopened ${opened} of the session(s) that fell — ${skipped} could not be reopened.`
+      : `reopened ${opened} session(s) that fell.`,
+  sessFellNoneOpened: (skipped: number) =>
+    `none of the ${skipped} session(s) that fell could be reopened.`,
   sessUntitled: (harness: string, project: string) => (project ? `${harness} in ${project}` : harness),
   sessKilled: (id: string) => `stopped ${id}.`,
   sessNoTask: 'that session has no task.',
@@ -510,6 +556,25 @@ const PT: CliStrings = {
   },
   sessApprovalBlind: (harness: string) =>
     `o agentop não tem marcadores de tela verificados para ${harness}, então uma pergunta bloqueante aqui aparece como "aguardando", como qualquer outra pausa.`,
+  sessApproveBlind: (harness: string) =>
+    `ninguém leu o diálogo do ${harness}, então o agentop não sabe qual tecla responde — anexe na sessão para responder lá.`,
+  sessPrompted: (id: string) => `enviado para ${id}.`,
+  sessPromptBlocked:
+    'essa sessão está com uma pergunta aberta, então o texto digitado responderia o menu dela. Aprove, ou anexe e responda lá.',
+  sessNotRunning: 'não há nada rodando nessa sessão para digitar.',
+  sessPromptEmpty: 'nada para enviar.',
+  sessSendFailed: (id: string) => `${id} não aceitou a tecla — pode ter acabado de encerrar.`,
+  sessApproved: (id: string) => `tecla de confirmação enviada para ${id}.`,
+  sessNotAsking: 'essa sessão não está perguntando nada agora — nada foi enviado.',
+  sessApproveUnknown: (harness: string) =>
+    `o agentop não leu o diálogo do ${harness}, e não vai chutar qual tecla responde.`,
+  sessNoFell: 'nada caiu — nenhuma sessão foi perdida com registro de que estava viva.',
+  sessFellOpened: (opened: number, skipped: number) =>
+    skipped > 0
+      ? `${opened} sessão(ões) que caíram reabertas — ${skipped} não puderam ser reabertas.`
+      : `${opened} sessão(ões) que caíram reabertas.`,
+  sessFellNoneOpened: (skipped: number) =>
+    `nenhuma das ${skipped} sessão(ões) que caíram pôde ser reaberta.`,
   sessUntitled: (harness: string, project: string) => (project ? `${harness} em ${project}` : harness),
   sessKilled: (id: string) => `${id} encerrada.`,
   sessNoTask: 'essa sessão não tem tarefa.',

--- a/packages/server/server/cli-start.ts
+++ b/packages/server/server/cli-start.ts
@@ -92,13 +92,29 @@ import { repoFacts } from './sessions/repo-facts'
 // The `SessionView` -> `ControlSession` mapping, extracted so `agentop session ls` draws the same
 // rows from the same decision rather than mapping the fleet a second time.
 import { toControlSession } from './sessions/control-session'
-import { planTaskReopen, taskReopenSucceeded } from './sessions/task-reopen'
-import type { SpawnPlanError } from './sessions/types'
-import { addSession, newSessionId, patchSession, readRegistry, removeSession } from './sessions/registry'
+import { planTaskReopen, taskReopenSucceeded, type TaskReopenPlan } from './sessions/task-reopen'
+import { approvalFor } from './sessions/approval-spec'
+import { rulesFor } from './sessions/attention-rules'
+import { planCrashGroup } from './sessions/crash-group'
+import { loadHarnessSessions } from './sessions/harness-sessions'
+import type { ManagedSession, SpawnPlanError } from './sessions/types'
+import {
+  addSession, newSessionId, patchSession, readRegistry, removeSession, touchSessions,
+} from './sessions/registry'
 import { createSessionsPoller, type SessionsPoller } from './sessions/sessions-host'
 import { conversationForProcess, forgetConversations, loadConversations } from './sessions/conversations'
 
 export type StartResult = number | 'foreground'
+
+/**
+ * How much of the pane to re-read before writing into a session.
+ *
+ * The same depth the poller captures with, and for the same reason: the approval rules are matched
+ * against a frame, and matching them against a shallower one would make a dialog that scrolled its
+ * footer just off the top read as no dialog at all — which on this path means typing a sentence into
+ * an open menu.
+ */
+const SEND_CAPTURE_LINES = 60
 
 // ANSI, for the output this module still writes to the REAL terminal: the suspended commands,
 // the foreground handover and the non-interactive `agentop restart --all`.
@@ -1171,7 +1187,13 @@ let sessionsPoller: SessionsPoller | null = null
 async function ensureSessionsPoller(): Promise<SessionsPoller> {
   if (sessionsPoller) return sessionsPoller
   const backend = await resolveBackend()
-  sessionsPoller = createSessionsPoller({ backend, readRegistry, scanProcesses, loadConversations })
+  sessionsPoller = createSessionsPoller({
+    backend, readRegistry, scanProcesses, loadConversations, touchSessions,
+    loadHarnessSessions,
+    // Written once per session, not once per poll — the poller only calls this when the harness's
+    // own record disagrees with the registry.
+    recordConversation: (id, conversationId) => patchSession(id, { conversationId }),
+  })
   return sessionsPoller
 }
 
@@ -1256,6 +1278,10 @@ async function spawnManaged(req: {
     harness: req.harness,
     cwd: req.cwd,
     createdAt: new Date().toISOString(),
+    // Stamped at birth, not left to the first heartbeat: a session started and lost inside the same
+    // minute would otherwise carry no evidence it was ever alive, and would sit out the very crash
+    // it was part of. See `crash-group.ts`.
+    lastSeenMs: Date.now(),
     ...(req.model ? { model: req.model } : {}),
     ...(req.effort ? { effort: req.effort } : {}),
     ...(req.label ? { label: req.label } : {}),
@@ -1270,6 +1296,71 @@ async function spawnManaged(req: {
     message: s.sessStarted(name),
     ticket: { argv: backend.attachCommand(id), detachHint: await backend.detachHint(), label: name },
   }
+}
+
+/**
+ * Reopen a SET of registry rows in the background — the one implementation behind both "open the
+ * whole task" and "reopen everything that fell".
+ *
+ * The two differ only in how the set is chosen: a task is a name the user filed sessions under, a
+ * fall is a timestamp `crash-group.ts` matched them on. Everything after that — which rows are left
+ * alone, which are not resurrected, which are skipped and counted, and the retiring of every row
+ * that is replaced — is `planTaskReopen`, and writing it twice is exactly the drift that module was
+ * extracted to end.
+ */
+async function reopenEntries(
+  entries: readonly ManagedSession[],
+  s: CliStrings,
+): Promise<{ plan: TaskReopenPlan; opened: number; skipped: number }> {
+  const conversations = await loadConversations()
+  const backend = await resolveBackend()
+  const live = new Set(
+    (await backend.list().catch(() => [])).filter(b => b.alive).map(b => b.id),
+  )
+
+  // CLAIMED, one per row: the harness+directory match cannot tell two sessions of one repository
+  // apart, so a set of five rows used to start five copies of one conversation. A row that RECORDED
+  // which conversation it drives is exact and takes that one.
+  const taken = new Set<string>()
+  const plan = planTaskReopen({
+    entries,
+    liveIds: live,
+    conversationFor: entry => {
+      const own = entry.conversationId
+        ? conversations.find(c => c.sessionId === entry.conversationId)
+        : undefined
+      const conv = own ?? conversations.find(c =>
+        !taken.has(c.sessionId) && c.harness === entry.harness && c.cwd === entry.cwd)
+      if (!conv?.resumable) return null
+      taken.add(conv.sessionId)
+      return { sessionId: conv.sessionId, title: conv.title }
+    },
+  })
+
+  let opened = 0
+  let skipped = plan.skipped.length
+  for (const row of plan.reopen) {
+    const m = row.entry
+    const r = await spawnManaged({
+      harness: m.harness,
+      cwd: m.cwd,
+      resumeId: row.resumeId,
+      label: row.label,
+      attach: false,
+      // The task travels with the session, whichever set this reopen was chosen from: a fall does
+      // not un-file the work someone filed.
+      ...(m.task ? { task: m.task } : {}),
+    }, s)
+    if (!r.ok) { skipped++; continue }
+    opened++
+    if (r.id) await patchSession(r.id, { conversationId: row.resumeId })
+    // Retired, so a laptop closed and opened twice does not leave two dead twins and one live
+    // session standing under the same name.
+    await patchSession(m.id, { endedAt: new Date().toISOString() })
+    if (m.note && r.id) await patchSession(r.id, { note: m.note })
+  }
+  forgetConversations()
+  return { plan, opened, skipped }
 }
 
 function createControlHost(initialLang: CliLang, altScreen: Suspendable): StartHost {
@@ -1791,6 +1882,11 @@ function createControlHost(initialLang: CliLang, altScreen: Suspendable): StartH
         sessions: snap.sessions.map((v, i) => toControlSession(v, s, facts[i])),
         attention: snap.attention,
         rang: snap.rang,
+        // Only the COUNT and the instant travel: the rows themselves are already in `sessions`,
+        // marked `fell`, and shipping the set twice is two things that can disagree about it.
+        ...(snap.fell && snap.fell.entries.length > 0
+          ? { fell: { count: snap.fell.entries.length, atMs: snap.fell.atMs } }
+          : {}),
         ...(finishedTasks.length > 0 ? { finishedTasks } : {}),
         ...(detachHint ? { detachHint } : {}),
         ...(snap.unavailable ? { unavailable: snap.unavailable } : {}),
@@ -1852,7 +1948,10 @@ function createControlHost(initialLang: CliLang, altScreen: Suspendable): StartH
 
     async renameSession(id: string, label: string): Promise<ActionResult> {
       const s = S()
-      const ok = await patchSession(id, { label })
+      // The INSTANT goes down with the name. A session can also be renamed from inside the harness,
+      // and recency is the only non-arbitrary way to settle a disagreement between the two — a
+      // stored name with no timestamp cannot take part in that. See `pickTitle`.
+      const ok = await patchSession(id, { label, labelSince: Date.now() })
       return ok ? { ok: true, message: s.sessRenamed } : { ok: false, message: s.sessNoRegistryEntry }
     },
 
@@ -1931,57 +2030,105 @@ function createControlHost(initialLang: CliLang, altScreen: Suspendable): StartH
       const wanted = (await readRegistry()).filter(m => m.task === task)
       if (wanted.length === 0) return { ok: false, message: s.sessTaskEmpty(task) }
 
-      const conversations = await loadConversations()
-      const backend = await resolveBackend()
-      const live = new Set(
-        (await backend.list().catch(() => [])).filter(b => b.alive).map(b => b.id),
-      )
-      // The DECISION is the pure `planTaskReopen`, shared with `agentop session open` — the two
-      // were separate implementations of one gesture and had already drifted.
-      const plan = planTaskReopen({
-        entries: wanted,
-        liveIds: live,
-        // CLAIMED, one per row: the directory match cannot tell two sessions of one repository
-        // apart, so reopening a task of five rows used to start five copies of one conversation.
-        conversationFor: (m => {
-          const taken = new Set<string>()
-          return (entry: typeof m) => {
-            const own = entry.conversationId
-              ? conversations.find(c => c.sessionId === entry.conversationId)
-              : undefined
-            const conv = own ?? conversations.find(c =>
-              !taken.has(c.sessionId) && c.harness === entry.harness && c.cwd === entry.cwd)
-            if (!conv?.resumable) return null
-            taken.add(conv.sessionId)
-            return { sessionId: conv.sessionId, title: conv.title }
-          }
-        })(wanted[0]!),
-      })
-
-      let opened = 0
-      let skipped = plan.skipped.length
-      for (const row of plan.reopen) {
-        const m = row.entry
-        const r = await spawnManaged({
-          harness: m.harness,
-          cwd: m.cwd,
-          resumeId: row.resumeId,
-          label: row.label,
-          task,
-          attach: false,
-        }, s)
-        if (!r.ok) { skipped++; continue }
-        opened++
-        if (r.id) await patchSession(r.id, { conversationId: row.resumeId })
-        // Retired, so a laptop closed and opened twice does not leave the task holding two dead
-        // twins and one live session, all under the same name.
-        await patchSession(m.id, { endedAt: new Date().toISOString() })
-        if (m.note && r.id) await patchSession(r.id, { note: m.note })
-      }
-      forgetConversations()
+      // The DECISION is the pure `planTaskReopen`, and the PERFORMANCE is `reopenEntries` — shared
+      // with `reopenFell` below, which is the same gesture over a set chosen a different way.
+      const { plan, opened, skipped } = await reopenEntries(wanted, s)
       return taskReopenSucceeded(plan, opened)
         ? { ok: true, message: s.sessTaskOpened(task, opened, skipped) }
         : { ok: false, message: s.sessTaskNoneOpened(task, skipped) }
+    },
+
+    /**
+     * Reopen everything the machine took at once.
+     *
+     * The set is recomputed HERE rather than taken from the snapshot the screen is showing: a
+     * snapshot is up to five seconds old, and this spawns real assistants. Recomputing costs one
+     * registry read and one `tmux list-sessions`, and it is the difference between reopening what
+     * fell and reopening what fell as of a moment ago.
+     */
+    async reopenFell(): Promise<ActionResult> {
+      const s = S()
+      const backend = await resolveBackend()
+      const blocked = await backend.unavailable()
+      if (blocked) return { ok: false, message: blocked }
+
+      const backendIds = new Set((await backend.list().catch(() => [])).map(b => b.id))
+      const group = planCrashGroup({ entries: await readRegistry(), backendIds })
+      if (!group || group.entries.length === 0) return { ok: false, message: s.sessNoFell }
+
+      const { plan, opened, skipped } = await reopenEntries(group.entries, s)
+      return taskReopenSucceeded(plan, opened)
+        ? { ok: true, message: s.sessFellOpened(opened, skipped) }
+        : { ok: false, message: s.sessFellNoneOpened(skipped) }
+    },
+
+    /**
+     * Type one line into a session and submit it, without attaching.
+     *
+     * The screen is RE-READ here rather than trusted from the snapshot, and that is the whole of the
+     * safety: a session that was working five seconds ago may be sitting on a permission prompt now,
+     * where its input line is a menu and a typed sentence is an answer to a question nobody read. A
+     * poll-old belief is not good enough to write into somebody's session on.
+     */
+    async promptSession(id: string, text: string): Promise<ActionResult> {
+      const s = S()
+      const body = text.trim()
+      if (!body) return { ok: false, message: s.sessPromptEmpty }
+
+      const backend = await resolveBackend()
+      const blocked = await backend.unavailable()
+      if (blocked) return { ok: false, message: blocked }
+
+      const managed = (await readRegistry()).find(m => m.id === id)
+      if (!managed) return { ok: false, message: s.sessNoRegistryEntry }
+
+      const live = (await backend.list().catch(() => [])).find(b => b.id === id)
+      if (!live?.alive) return { ok: false, message: s.sessNotRunning }
+
+      const frame = await backend.capture(id, SEND_CAPTURE_LINES).catch(() => [] as string[])
+      const rules = rulesFor(managed.harness)
+      if (rules && rules.approval.some(re => re.test(frame.join('\n')))) {
+        return { ok: false, message: s.sessPromptBlocked }
+      }
+
+      return (await backend.sendText(id, body))
+        ? { ok: true, message: s.sessPrompted(id) }
+        : { ok: false, message: s.sessSendFailed(id) }
+    },
+
+    /**
+     * Send the key that takes the option this session's dialog is highlighting.
+     *
+     * Three things have to be true at THIS instant, and each is checked rather than assumed: the
+     * harness's dialog has been read (so the key is a recorded fact — `approval-spec.ts`), the
+     * session is still asking (re-read from the screen, not from a snapshot), and the backend
+     * accepted the keystroke. Anything less and an unconditional Enter goes into a session that has
+     * moved on — a blank turn at best, and at worst a menu answered while nobody was looking.
+     */
+    async approveSession(id: string): Promise<ActionResult> {
+      const s = S()
+      const backend = await resolveBackend()
+      const blocked = await backend.unavailable()
+      if (blocked) return { ok: false, message: blocked }
+
+      const managed = (await readRegistry()).find(m => m.id === id)
+      if (!managed) return { ok: false, message: s.sessNoRegistryEntry }
+
+      const spec = approvalFor(managed.harness)
+      if (!spec) return { ok: false, message: s.sessApproveUnknown(managed.harness) }
+
+      const live = (await backend.list().catch(() => [])).find(b => b.id === id)
+      if (!live?.alive) return { ok: false, message: s.sessNotRunning }
+
+      const rules = rulesFor(managed.harness)
+      const frame = await backend.capture(id, SEND_CAPTURE_LINES).catch(() => [] as string[])
+      if (!rules || !rules.approval.some(re => re.test(frame.join('\n')))) {
+        return { ok: false, message: s.sessNotAsking }
+      }
+
+      return (await backend.sendKey(id, spec.key))
+        ? { ok: true, message: s.sessApproved(id) }
+        : { ok: false, message: s.sessSendFailed(id) }
     },
 
     /**

--- a/packages/server/server/live-sessions.ts
+++ b/packages/server/server/live-sessions.ts
@@ -228,6 +228,15 @@ export interface HarnessProcess {
   sessionId?: string
   /** Process start time (epoch ms). Bounds which sessions an anonymous process could be driving. */
   startedMs?: number
+  /**
+   * The OS pid, when this record came from `/proc` rather than from an older caller's plain cwd.
+   *
+   * Carried because it is an EXACT key into what a harness writes about its own live sessions:
+   * Claude Code names its record `~/.claude/sessions/<pid>.json` (see `harness-sessions.ts`), so a
+   * process found here can be matched to the session it is running with no inference at all. Every
+   * other correlation in this area has had to guess by harness-and-directory.
+   */
+  pid?: number
 }
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
@@ -301,7 +310,7 @@ export async function scanProcesses(): Promise<{
       const startedMs = await processStartMs(pid, btimeSec, hz)
       // An open session file beats argv: it is what the process is writing to right now.
       const sessionId = (await sessionIdFromFds(pid, harness)) ?? sessionIdFromArgv(argv)
-      procs.push({ harness, cwd, sessionId, startedMs })
+      procs.push({ harness, cwd, sessionId, startedMs, pid: Number(pid) })
     } catch { /* process exited or not ours — ignore */ }
   }))
   const unavailable = procs.length > 0
@@ -482,6 +491,9 @@ export function resolveLiveSnapshot(
       cwd: p.cwd,
       ...(p.startedMs !== undefined ? { startedMs: p.startedMs } : {}),
       ...(p.sessionId ? { sessionId: p.sessionId } : {}),
+      // Carried through, because these are exactly the rows the cockpit lists as `external` — and
+      // the pid is the one key that names what each of them is actually running.
+      ...(p.pid !== undefined ? { pid: p.pid } : {}),
     })
   }
   return { liveSessionIds: [...open], liveProcesses: unmatched }

--- a/packages/server/server/sessions/approval-spec.test.ts
+++ b/packages/server/server/sessions/approval-spec.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'bun:test'
+import { HARNESS_ORDER } from '@agentistics/core'
+import { APPROVAL_SPECS, approvalFor } from './approval-spec'
+import { ATTENTION_RULES } from './attention-rules'
+
+describe('APPROVAL_SPECS', () => {
+  it('has decided about every harness — absence is a decision, never an omission', () => {
+    // The same rule `SPAWN_SPECS` and `ATTENTION_RULES` follow. A harness added to `HarnessId` must
+    // fail the build until somebody reads its dialog; `null` is how "nobody has" is said.
+    for (const id of HARNESS_ORDER) expect(id in APPROVAL_SPECS).toBe(true)
+    expect(Object.keys(APPROVAL_SPECS).sort()).toEqual([...HARNESS_ORDER].sort())
+  })
+
+  it('records where every key came from, with a version and a date', () => {
+    // Provenance is not decoration here: the key is sent into somebody's session, and a value with
+    // no probe behind it is a guess wearing the same shape as a measurement.
+    for (const [id, spec] of Object.entries(APPROVAL_SPECS)) {
+      if (!spec) continue
+      expect(spec.key.length, id).toBeGreaterThan(0)
+      // "<tool> <version>, <yyyy-mm-dd>"
+      expect(spec.probed, id).toMatch(/\d.*\d, \d{4}-\d{2}-\d{2}$/)
+    }
+  })
+
+  it('never offers a key for a harness whose screen cannot be read', () => {
+    // A spec is only ever REACHED through `waiting-approval`, which only exists where
+    // `ATTENTION_RULES` has approval patterns. A spec without them would be an unreachable promise —
+    // and, worse, would be the thing a future caller reaches for when it decides to trust the spec
+    // alone.
+    for (const id of HARNESS_ORDER) {
+      if (!APPROVAL_SPECS[id]) continue
+      expect(ATTENTION_RULES[id]?.approval.length ?? 0, id).toBeGreaterThan(0)
+    }
+  })
+
+  it('answers with undefined rather than null, and for an absent harness at all', () => {
+    expect(approvalFor('claude')?.key).toBe('Enter')
+    expect(approvalFor(undefined)).toBeUndefined()
+  })
+})

--- a/packages/server/server/sessions/approval-spec.ts
+++ b/packages/server/server/sessions/approval-spec.ts
@@ -1,0 +1,73 @@
+/**
+ * approval-spec.ts — PURE. The keystroke that ANSWERS each harness's blocking dialog.
+ *
+ * A sibling of `attention-rules.ts`, and deliberately a second file rather than a field on it,
+ * because the two answer different questions and can be known independently: `attention-rules.ts`
+ * says how to RECOGNISE that a session is blocked, this says what to SEND once it is. A harness
+ * could be probed for the first and not the second — a dialog whose footer names no key at all — and
+ * a single record would then force one guess to stand in for the other.
+ *
+ * ## What a spec claims, exactly
+ *
+ * `key` is the keystroke that CONFIRMS THE OPTION THE DIALOG HAS HIGHLIGHTED. It is not "approve",
+ * and the difference matters enough to be the reason this feature is built the way it is: none of
+ * these CLIs can be asked which option is highlighted, and a dialog whose default is "No, tell
+ * Claude what to do differently" would be answered by the same byte that approves everywhere else.
+ *
+ * So the keystroke is only half of the design. The other half is that the caller REREADS the screen
+ * immediately before sending (a poll is up to five seconds old — the dialog may already be gone) and
+ * SHOWS THE FRAME to the person answering. What is being confirmed is on the screen; the only thing
+ * this table supplies is the byte that presses it.
+ *
+ * ## Where the values come from
+ *
+ * Every one of them is the footer `attention-rules.ts` captured, read for what it says about keys —
+ * same probe, same CLI versions, same date, nothing added from memory of what a CLI prints:
+ *
+ *   claude       `Enter to confirm · Esc to cancel`
+ *   codex        `Press enter to continue`
+ *   kimi         `↑↓ navigate · Enter select · Esc exit`
+ *   gemini       `Enter to select · ↑/↓ to navigate`
+ *   copilot      `↑/↓ to navigate · enter to select`
+ *   antigravity  `↑/↓ Navigate · enter Confirm`
+ *
+ * All six name ENTER, and all six name it as the key that takes the highlighted option. That the
+ * table currently holds one value six times is a finding, not a shortcut — the footers disagree
+ * about wording, capitalisation and whether `esc` is even mentioned, which is exactly why each is
+ * recorded on its own row rather than collapsed into one shared assumption.
+ *
+ * `Record<HarnessId, … | null>` and not a `Partial`: a harness added to `HarnessId` must fail the
+ * build until someone decides, the same rule `SPAWN_SPECS`, `ATTENTION_RULES` and
+ * `HARNESS_CAPABILITIES` follow. `null` is that decision — "nobody has read this dialog" — and the
+ * verb is then ABSENT rather than offered and wrong, with the UI saying so in words.
+ *
+ * The values are tmux key names (`send-keys` argument syntax), because that is the only backend
+ * there is. When a second backend exists this becomes its own vocabulary; until then, inventing an
+ * abstraction over one implementation would be inventing a mapping nobody can check.
+ */
+
+import type { HarnessId } from '@agentistics/core'
+
+export interface ApprovalSpec {
+  /**
+   * The key that takes the option the dialog is currently highlighting, as tmux `send-keys` names
+   * it. NOT "the key that approves" — see the header.
+   */
+  key: string
+  /** Provenance — the exact CLI version the dialog came from, and the date. */
+  probed: string
+}
+
+export const APPROVAL_SPECS: Record<HarnessId, ApprovalSpec | null> = {
+  claude: { key: 'Enter', probed: 'claude 2.1.231, 2026-08-13' },
+  codex: { key: 'Enter', probed: 'codex 0.113.0, 2026-08-13' },
+  kimi: { key: 'Enter', probed: 'kimi 0.35.0, 2026-08-13' },
+  gemini: { key: 'Enter', probed: 'gemini 0.55.1, 2026-08-13' },
+  copilot: { key: 'Enter', probed: 'GitHub Copilot CLI 1.0.79, 2026-08-13' },
+  antigravity: { key: 'Enter', probed: 'agy 1.1.12, 2026-08-13' },
+}
+
+/** The spec for a harness, or `undefined` when its dialog was never read. */
+export function approvalFor(harness: HarnessId | undefined): ApprovalSpec | undefined {
+  return harness ? (APPROVAL_SPECS[harness] ?? undefined) : undefined
+}

--- a/packages/server/server/sessions/attention-rules.test.ts
+++ b/packages/server/server/sessions/attention-rules.test.ts
@@ -32,6 +32,50 @@ const CLAUDE_APPROVAL = [
   ' Enter to confirm · Esc to cancel',
 ]
 
+/**
+ * claude 2.1.232, 2026-08-14 — the PERMISSION prompt, verbatim from a live session.
+ *
+ * A DIFFERENT component from the folder-trust dialog above, with a different footer, and the rule
+ * probed from that one does not match it. Measured the hard way: this exact frame reported
+ * `waiting`, and the prompt then typed into the session went into the dialog's own filter, where
+ * the submit took the highlighted option and approved a shell command nobody had read.
+ */
+const CLAUDE_BASH_PERMISSION = [
+  ' Bash command',
+  '',
+  '   env | head -3',
+  '   Show first 3 environment variables',
+  '',
+  ' This command requires approval',
+  '',
+  ' Do you want to proceed?',
+  ' ❯ 1. Yes',
+  '   2. Yes, and don’t ask again for: env',
+  '   3. No',
+  '',
+  ' Esc to cancel · Tab to amend · ctrl+e to explain',
+]
+
+/**
+ * claude 2.1.232, 2026-08-14 — the same component asking about a FILE, verbatim.
+ *
+ * The second capture is what makes the matched text the component's footer rather than one dialog's
+ * wording: this one offers no `ctrl+e to explain`, because there is no command to explain.
+ */
+const CLAUDE_WRITE_PERMISSION = [
+  ' Create file',
+  ' agentop-write-probe.txt',
+  '╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌',
+  '  1 hello',
+  '╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌',
+  ' Do you want to create agentop-write-probe.txt?',
+  ' ❯ 1. Yes',
+  '   2. Yes, allow all edits during this session (shift+tab)',
+  '   3. No',
+  '',
+  ' Esc to cancel · Tab to amend',
+]
+
 /** claude 2.1.231 — mid-turn. Note the input box is drawn EXACTLY as it is when idle. */
 const CLAUDE_WORKING = [
   '✢ Orbiting… (5s · ↓ 76 tokens)',
@@ -104,6 +148,31 @@ describe('ATTENTION_RULES', () => {
 describe('claude', () => {
   it('sees the blocking dialog', () => {
     expect(quiet(CLAUDE_APPROVAL, 'claude')).toBe('waiting-approval')
+  })
+
+  it('sees the PERMISSION prompt, which is a different component with a different footer', () => {
+    // The bug this replaced: the rule was probed from the folder-trust dialog alone, so the one
+    // dialog people actually meet — "may I run this command" — read as `waiting`. It was not merely
+    // a wrong label: with the block invisible, typing a prompt into that session put the text into
+    // the dialog's filter and submitted it, taking the highlighted option.
+    expect(quiet(CLAUDE_BASH_PERMISSION, 'claude')).toBe('waiting-approval')
+    expect(quiet(CLAUDE_WRITE_PERMISSION, 'claude')).toBe('waiting-approval')
+  })
+
+  it('keys on the part BOTH permission dialogs share', () => {
+    // `ctrl+e to explain` is offered only where there is a command to explain, so a rule keyed on it
+    // would have gone on missing every file edit — the same class of miss all over again.
+    const rules = rulesFor('claude')!
+    const hits = (frame: string[]) =>
+      rules.approval.filter(re => re.test(frame.join('\n'))).length
+    expect(hits(CLAUDE_BASH_PERMISSION)).toBe(1)
+    expect(hits(CLAUDE_WRITE_PERMISSION)).toBe(1)
+  })
+
+  it('does not call a working turn blocked, now that there are two approval patterns', () => {
+    // A second pattern is a second chance to match something that is not a dialog.
+    expect(quiet(CLAUDE_WORKING, 'claude')).toBe('working')
+    expect(quiet(CLAUDE_IDLE, 'claude')).toBe('waiting')
   })
 
   it('sees a running turn from the footer, not from the input box', () => {

--- a/packages/server/server/sessions/attention-rules.ts
+++ b/packages/server/server/sessions/attention-rules.ts
@@ -33,10 +33,26 @@ import type { AttentionRules } from './types'
 
 export const ATTENTION_RULES: Record<HarnessId, AttentionRules | null> = {
   claude: {
-    probed: 'claude 2.1.231, 2026-08-13',
-    // The select component every blocking question uses — captured from the folder-trust dialog it
-    // opens with. The permission prompts and `/model` draw the same footer.
-    approval: [/Enter to confirm · Esc to cancel/],
+    probed: 'claude 2.1.231 + 2.1.232, 2026-08-13 and 2026-08-14',
+    approval: [
+      // The startup/select component: the folder-trust dialog it opens with, and `/model`.
+      /Enter to confirm · Esc to cancel/,
+      // **The PERMISSION prompt, and it is a DIFFERENT component with a different footer.** The
+      // line above does not match it, which was measured the hard way on 2026-08-14: a live claude
+      // 2.1.232 sitting on "Do you want to proceed?" reported `waiting`, and the prompt that was
+      // then typed into it went into the dialog's own filter — where the submit selected the
+      // highlighted option and approved a shell command nobody had read. That is the exact accident
+      // this whole feature exists to prevent, and it was one rule away.
+      //
+      // Captured from TWO distinct permission dialogs, which is what makes this the component's
+      // footer rather than one dialog's wording — the same standard the gemini entry below holds
+      // itself to:
+      //   Bash   `Esc to cancel · Tab to amend · ctrl+e to explain`
+      //   Write  `Esc to cancel · Tab to amend`
+      // The shared part is what is matched. `ctrl+e to explain` is offered only where there is a
+      // command to explain, so keying on it would have missed every file edit.
+      /Esc to cancel · Tab to amend/,
+    ],
     // The footer while a turn runs. `? for shortcuts` takes its place when the turn ends.
     working: [/esc to interrupt/],
   },

--- a/packages/server/server/sessions/attention.test.ts
+++ b/packages/server/server/sessions/attention.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'bun:test'
-import { QUIET_MS, attentionOf, digestFrame, frameTail } from './attention'
+import { QUIET_MS, approvalTail, attentionOf, digestFrame, frameTail } from './attention'
 import type { AttentionRules } from './types'
 
 const NOW = 1_786_600_000_000
@@ -178,5 +178,60 @@ describe('a working marker that outlives the screen', () => {
       prevDigest: 'old',
       rules,
     })).toBe('working')
+  })
+})
+
+/**
+ * A real claude permission dialog, in the shape `capture-pane` hands it over: a conversation above,
+ * then the box, then the footer naming the key. Trimmed to what a 60-line capture would end on.
+ */
+const DIALOG = [
+  '● I will run the migration now.',
+  '',
+  '╭──────────────────────────────────────────╮',
+  '│ Bash command                             │',
+  '│                                          │',
+  '│   bun run db:migrate                     │',
+  '│                                          │',
+  '│ Do you want to proceed?                  │',
+  '│ ❯ 1. Yes                                 │',
+  '│   2. No, and tell Claude what to do      │',
+  '│                                          │',
+  '│ Enter to confirm · Esc to cancel         │',
+  '╰──────────────────────────────────────────╯',
+]
+
+describe('approvalTail', () => {
+  it('keeps the dialog exactly as drawn — borders, options and footer included', () => {
+    const out = approvalTail(DIALOG, 6)
+    expect(out).toHaveLength(6)
+    // The three that decide anything: which options there are, which one is highlighted, and the
+    // key that takes it. None of them survives being tidied.
+    expect(out.join('\n')).toContain('❯ 1. Yes')
+    expect(out.join('\n')).toContain('2. No')
+    expect(out.join('\n')).toContain('Enter to confirm')
+  })
+
+  it('is NOT frameTail — that one throws the dialog away and keeps what came before it', () => {
+    // The reason this function exists. `frameTail` answers "what is it SAYING", so it cuts at the
+    // last rule; on a blocked session that cut lands above the box, and the result reads perfectly
+    // plausibly under a heading saying "this is what you are confirming".
+    const said = frameTail(DIALOG, 4).join('\n')
+    expect(said).not.toContain('Do you want to proceed?')
+    expect(approvalTail(DIALOG, 6).join('\n')).toContain('Do you want to proceed?')
+  })
+
+  it('takes the BOTTOM, because that is where the answer is', () => {
+    expect(approvalTail(DIALOG, 1)).toEqual(['╰──────────────────────────────────────────╯'])
+  })
+
+  it('drops padding at either end without touching the blanks inside a dialog', () => {
+    expect(approvalTail(['', '  ', 'a', '', 'b', '  ', ''], 10)).toEqual(['a', '', 'b'])
+  })
+
+  it('survives an empty or all-blank frame rather than inventing a line', () => {
+    expect(approvalTail([], 6)).toEqual([])
+    expect(approvalTail(['', '  '], 6)).toEqual([])
+    expect(approvalTail(DIALOG, 0)).toEqual([])
   })
 })

--- a/packages/server/server/sessions/attention.ts
+++ b/packages/server/server/sessions/attention.ts
@@ -89,6 +89,32 @@ export function attentionOf(o: {
   return 'waiting'
 }
 
+/**
+ * The BOTTOM of the frame, verbatim — what a blocked session is asking, PURE.
+ *
+ * Deliberately not `frameTail`, and the difference is the whole point. `frameTail` answers "what is
+ * this session SAYING", so it cuts at the last rule and throws away the input box and the status
+ * strip — which for a session sitting on a dialog throws away the dialog, and leaves whatever the
+ * assistant said before it opened. That text read perfectly plausibly under a heading saying "you
+ * are about to confirm this", which is the worst possible way to be wrong.
+ *
+ * So this takes the last lines AS DRAWN, chrome included. The options, the highlighted one and the
+ * footer naming the key are the answer to "what am I agreeing to", and none of them survive being
+ * tidied. Blank lines at either end are dropped because they are padding rather than content;
+ * everything between is kept exactly as the pane rendered it.
+ *
+ * It is the only thing standing between `approvalFor()`'s keystroke and a confirmation the user
+ * cannot check — see `approval-spec.ts`.
+ */
+export function approvalTail(frame: readonly string[], max = 10): string[] {
+  const lines = frame.slice(Math.max(0, frame.length - Math.max(0, max)))
+  let start = 0
+  let end = lines.length
+  while (start < end && (lines[start] ?? '').trim() === '') start++
+  while (end > start && (lines[end - 1] ?? '').trim() === '') end--
+  return lines.slice(start, end)
+}
+
 /** A line that is only box-drawing or rule characters — a frame's furniture, never its content. */
 const RULE = /^[─━═╌┄┈╭╰╮╯┌└┐┘│|+\-=_~]+$/
 /** An empty input box: the prompt glyph with nothing after it. */

--- a/packages/server/server/sessions/backend-tmux.ts
+++ b/packages/server/server/sessions/backend-tmux.ts
@@ -5,7 +5,7 @@
 
 import {
   attachArgs, capturePaneArgs, isSessionGoneError, killSessionArgs, listSessionsArgs,
-  newSessionArgs, parsePrefix, parseTmuxList, serverOptionsArgs, sendKeysEnterArgs,
+  newSessionArgs, parsePrefix, parseTmuxList, serverOptionsArgs, sendKeysNamedArgs,
   sendKeysLiteralArgs, showPrefixArgs, trimCapture,
 } from './tmux-cli'
 import type { BackendSession, BackendSpawn, SessionBackend } from './types'
@@ -26,6 +26,26 @@ async function tmux(args: string[]): Promise<{ code: number; out: string; err: s
 }
 
 const sleep = (ms: number) => new Promise(r => setTimeout(r, ms))
+
+/**
+ * Type text and submit it, as two separate `send-keys` calls.
+ *
+ * `-l` (literal) for the text so a prompt containing `;` or `C-c` is typed rather than interpreted,
+ * then the named `Enter` — which is why they cannot be one call.
+ *
+ * The submit is only sent once the text was accepted. Half a prompt followed by an unconditional
+ * Enter is a blank turn sent to an assistant, which is the exact accident this feature exists to
+ * avoid.
+ *
+ * A free function rather than a method on the object below, because `spawn` calls it: reaching it
+ * through `this` would break the moment a caller spread or destructured the backend, and `index.ts`
+ * spreads it.
+ */
+async function sendTextTo(id: string, text: string): Promise<boolean> {
+  const typed = await tmux(sendKeysLiteralArgs(id, text))
+  if (typed.code !== 0) return false
+  return (await tmux(sendKeysNamedArgs(id, 'Enter'))).code === 0
+}
 
 let tmuxPresent: boolean | null = null
 
@@ -48,10 +68,18 @@ export const tmuxBackend: SessionBackend = {
     const { code, out } = await tmux(newSessionArgs({ id: req.id, cwd: req.cwd, argv: req.argv }))
     if (code !== 0) throw new Error(out.trim() || `tmux new-session failed (code ${code})`)
     if (req.sendKeys) {
+      // The harness has to have drawn its prompt before anything typed into it lands anywhere. Only
+      // the OPENING line needs this wait; `sendText` below is called on a session that is already up
+      // and must not pay for it.
       await sleep(SEND_KEYS_DELAY_MS)
-      await tmux(sendKeysLiteralArgs(req.id, req.sendKeys))
-      await tmux(sendKeysEnterArgs(req.id))
+      await sendTextTo(req.id, req.sendKeys)
     }
+  },
+
+  sendText: sendTextTo,
+
+  async sendKey(id: string, key: string) {
+    return (await tmux(sendKeysNamedArgs(id, key))).code === 0
   },
 
   async list(): Promise<BackendSession[]> {

--- a/packages/server/server/sessions/cli-session.ts
+++ b/packages/server/server/sessions/cli-session.ts
@@ -24,6 +24,7 @@ import { addSession, newSessionId, patchSession, readRegistry, removeSession } f
 import { conversationForProcess, loadConversations } from './conversations'
 import { resolveBackend } from './index'
 import { scanProcesses } from '../live-sessions'
+import { loadHarnessSessions } from './harness-sessions'
 import { createSessionsPoller, type SessionSnapshot } from './sessions-host'
 import { needsAttention, type SessionView } from './session-view'
 import { planTaskReopen, taskReopenSucceeded } from './task-reopen'
@@ -317,9 +318,25 @@ function fleetJson(snap: SessionSnapshot): unknown {
   }
 }
 
-/** The whole fleet, from the registry, the backend, `/proc` and the conversation store. */
+/**
+ * The whole fleet, from the registry, the backend, `/proc`, the conversation store and what each
+ * harness records about its own sessions.
+ *
+ * It reads the SAME sources the cockpit's poller does, and that is the point rather than a detail:
+ * `session ls` is the cockpit's table printed, so a source wired into one and not the other is how
+ * one session ends up wearing two different names depending on where you look at it. It was missing
+ * `loadHarnessSessions` for exactly one commit, and the row a user had renamed inside the session
+ * read correctly in the cockpit and stale on the command line.
+ *
+ * There is deliberately NO heartbeat here: a one-shot command must not stamp `lastSeenMs`. It runs
+ * once and exits, so a run that happened to be the last thing before a reboot would be indistinguish-
+ * able from a fleet that was alive — and `crash-group.ts` would be reading a write nobody made a
+ * claim with.
+ */
 async function pollFleet(backend: SessionBackend): Promise<SessionSnapshot> {
-  const poller = createSessionsPoller({ backend, readRegistry, scanProcesses, loadConversations })
+  const poller = createSessionsPoller({
+    backend, readRegistry, scanProcesses, loadConversations, loadHarnessSessions,
+  })
   return await poller.poll()
 }
 

--- a/packages/server/server/sessions/control-session.ts
+++ b/packages/server/server/sessions/control-session.ts
@@ -16,6 +16,8 @@
 import { fmt, fmtCost } from '@agentistics/core'
 import type { ControlSession, SessionState } from '@agentistics/tui/control'
 import type { CliStrings } from '../cli-i18n'
+import { approvalFor } from './approval-spec'
+import { pickTitle } from './harness-session-file'
 import type { RepoFacts } from './repo-facts'
 import type { SessionView } from './session-view'
 
@@ -64,11 +66,30 @@ export function toControlSession(
   const state = sessionState(v)
   const project = projectName(v.cwd)
   const harness = v.harness ?? ''
+  // A session can be named in TWO places — here, and inside the harness with its own `/rename` — and
+  // the precedence between them is the pure `pickTitle`. It is not a one-liner and it is not
+  // obvious: a name the harness INVENTED for itself must never win, and neither name may be thrown
+  // away when the two disagree.
+  const picked = pickTitle({
+    ...(v.label ? { label: v.label } : {}),
+    ...(v.labelSince !== undefined ? { labelSince: v.labelSince } : {}),
+    ...(v.harnessName
+      ? {
+          file: {
+            name: v.harnessName,
+            ...(v.harnessNameSince !== undefined ? { nameSince: v.harnessNameSince } : {}),
+          },
+        }
+      : {}),
+    fallback: s.sessUntitled(harness || '?', project),
+  })
   return {
     id: v.id,
-    // The user's own label wins over anything derived: naming a session is the whole point of
-    // being able to name one.
-    title: v.label ?? s.sessUntitled(harness || '?', project),
+    title: picked.title,
+    // Said only where the two sources DISAGREE — `other` is absent otherwise, so an ordinary row
+    // carries nothing extra. Without it, someone who renamed in both places sees one name and
+    // concludes the other rename silently failed, which is the complaint this answers in reverse.
+    ...(picked.other ? { titleSource: picked.source, titleOther: picked.other } : {}),
     harness,
     cwd: v.cwd,
     project,
@@ -87,8 +108,10 @@ export function toControlSession(
     ...(v.createdMs !== undefined ? { startedAt: v.createdMs } : {}),
     ...(v.task ? { task: v.task } : {}),
     // Marked BY THE USER — a label, a note or a task. `title` cannot answer this: it always has a
-    // value, because the host derives one whenever there is no label.
-    ...(v.label || v.note || v.task ? { named: true } : {}),
+    // value, because the host derives one whenever there is no label. A name typed INSIDE the
+    // session counts too: it is the same act of naming, performed one window over, and a row named
+    // there being hidden by the history switches is the same bug as one named here being hidden.
+    ...(v.label || v.harnessName || v.note || v.task ? { named: true } : {}),
     ...(facts.repo ? { repo: facts.repo } : {}),
     // Only when it differs: a session in the main checkout groups under its own folder already, and
     // a field repeating what is beside it is one more thing that can disagree.
@@ -96,6 +119,21 @@ export function toControlSession(
     ...(facts.worktree ? { worktree: true } : {}),
     ...(v.resume ? { resume: v.resume } : {}),
     ...(v.lastLines?.length ? { lastLines: v.lastLines } : {}),
+    ...(v.approvalLines?.length ? { approvalLines: v.approvalLines } : {}),
+    // The verb exists only where BOTH halves are true: the session is asking, and somebody has read
+    // this harness's dialog and recorded the key that answers it. Either missing and the action is
+    // absent rather than present and wrong — the same rule the wizard applies to a harness with no
+    // spawn spec.
+    ...(state === 'waiting-approval' && approvalFor(v.harness)
+      ? { canApprove: true as const }
+      : {}),
+    // Said only where it is TRUE, which is a narrower place than `approvalBlind`: that one explains
+    // why a blocked session may be reading as plain `waiting`, this one explains why a session that
+    // is VISIBLY blocked cannot be answered from here. A harness can have one and not the other.
+    ...(state === 'waiting-approval' && !approvalFor(v.harness) && harness
+      ? { approveBlind: s.sessApproveBlind(harness) }
+      : {}),
+    ...(v.fell ? { fell: true as const } : {}),
     // Already formatted, because formatting is a presentation concern the host owns for everything
     // else it hands over — and `fmt`/`fmtCost` are the shared helpers the dashboard uses.
     ...(v.tokens !== undefined ? { tokens: fmt(v.tokens) } : {}),

--- a/packages/server/server/sessions/crash-group.test.ts
+++ b/packages/server/server/sessions/crash-group.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'bun:test'
+import { CRASH_WINDOW_MS, HEARTBEAT_MS, planCrashGroup } from './crash-group'
+import type { ManagedSession } from './types'
+
+const NOW = 1_786_700_000_000
+
+const row = (id: string, over: Partial<ManagedSession> = {}): ManagedSession => ({
+  id,
+  harness: 'claude',
+  cwd: '/repo/a',
+  createdAt: '2026-08-13T10:00:00.000Z',
+  lastSeenMs: NOW,
+  ...over,
+})
+
+const ids = (o: ReturnType<typeof planCrashGroup>) => (o?.entries ?? []).map(e => e.id)
+
+describe('planCrashGroup', () => {
+  it('groups the sessions the backend no longer knows about, sharing one heartbeat', () => {
+    const group = planCrashGroup({
+      entries: [row('a'), row('b'), row('c')],
+      backendIds: new Set(),
+    })
+    expect(ids(group)).toEqual(['a', 'b', 'c'])
+    expect(group?.atMs).toBe(NOW)
+  })
+
+  it('keeps registry order, so a task comes back the way it was built', () => {
+    const group = planCrashGroup({
+      entries: [row('c'), row('a'), row('b')],
+      backendIds: new Set(),
+    })
+    expect(ids(group)).toEqual(['c', 'a', 'b'])
+  })
+
+  // --- the garbage rules, which are the whole point ------------------------------------------
+
+  it('never includes a session the user FINISHED — that is a decision, not a fall', () => {
+    const group = planCrashGroup({
+      entries: [row('a'), row('done', { endedAt: '2026-08-13T11:00:00.000Z' })],
+      backendIds: new Set(),
+    })
+    expect(ids(group)).toEqual(['a'])
+  })
+
+  it('never includes a session the backend still holds, running or exited', () => {
+    // tmux keeps a finished session listable (`remain-on-exit`), so a command that ended on its own
+    // is still something the backend can name. Nothing took it.
+    const group = planCrashGroup({
+      entries: [row('a'), row('alive'), row('deadPane')],
+      backendIds: new Set(['alive', 'deadPane']),
+    })
+    expect(ids(group)).toEqual(['a'])
+  })
+
+  it('never includes a row with no evidence it was ever alive', () => {
+    // A registry written by an older build, or a row this process never once saw. It is EXCLUDED
+    // rather than guessed at from `createdAt` — which is equally true of a session abandoned three
+    // weeks ago, and is exactly how a crash group turns into a list of everything that ever ran.
+    const group = planCrashGroup({
+      entries: [row('a'), row('legacy', { lastSeenMs: undefined })],
+      backendIds: new Set(),
+    })
+    expect(ids(group)).toEqual(['a'])
+  })
+
+  it('refuses a lastSeenMs that is not a real number, however the file got that way', () => {
+    // `managed-sessions.json` is hand-editable. A NaN reaching the comparison below would put an
+    // always-false test in charge of which sessions get reopened.
+    const group = planCrashGroup({
+      entries: [row('a'), row('junk', { lastSeenMs: Number.NaN })],
+      backendIds: new Set(),
+    })
+    expect(ids(group)).toEqual(['a'])
+  })
+
+  it('leaves out an OLDER fall — a machine that crashed twice has two events, not one', () => {
+    const group = planCrashGroup({
+      entries: [
+        row('old', { lastSeenMs: NOW - 3 * 24 * 60 * 60_000 }),
+        row('new1'),
+        row('new2'),
+      ],
+      backendIds: new Set(),
+    })
+    expect(ids(group)).toEqual(['new1', 'new2'])
+    expect(group?.atMs).toBe(NOW)
+  })
+
+  it('is null when nothing qualifies, rather than an empty group', () => {
+    expect(planCrashGroup({ entries: [], backendIds: new Set() })).toBeNull()
+    expect(planCrashGroup({
+      entries: [row('a', { endedAt: 'x' })],
+      backendIds: new Set(),
+    })).toBeNull()
+  })
+
+  // --- the window ----------------------------------------------------------------------------
+
+  it('absorbs one heartbeat of spread, which is the widest a genuine fall can be', () => {
+    // The oldest possible member carries the previous heartbeat's stamp while a session created
+    // just after it carries its own creation stamp. That gap is one interval, and no more.
+    const group = planCrashGroup({
+      entries: [row('older', { lastSeenMs: NOW - HEARTBEAT_MS }), row('newer')],
+      backendIds: new Set(),
+    })
+    expect(ids(group)).toEqual(['older', 'newer'])
+  })
+
+  it('is wider than the heartbeat, or a real fall would be split into two groups', () => {
+    expect(CRASH_WINDOW_MS).toBeGreaterThan(HEARTBEAT_MS)
+  })
+
+  it('excludes anything outside the window, erring toward leaving a real casualty out', () => {
+    // The deliberate direction of the error: a session wrongly left out is still on screen with its
+    // own Reopen verb — one keypress. A session wrongly let in is invisible, and makes the whole
+    // group untrustworthy.
+    const group = planCrashGroup({
+      entries: [row('edge', { lastSeenMs: NOW - CRASH_WINDOW_MS - 1 }), row('now')],
+      backendIds: new Set(),
+    })
+    expect(ids(group)).toEqual(['now'])
+  })
+
+  it('includes a lone session — one thing open when the laptop died is one thing that fell', () => {
+    const group = planCrashGroup({ entries: [row('a')], backendIds: new Set() })
+    expect(ids(group)).toEqual(['a'])
+  })
+
+  it('says nothing about whether a row can be RESUMED — that is planTaskReopen business', () => {
+    // Filtering unresolvable rows here would make the group quietly smaller than the fall it
+    // describes; `planTaskReopen` already reports them as skipped AND counted.
+    const group = planCrashGroup({
+      entries: [row('a', { harness: 'gemini' })],
+      backendIds: new Set(),
+    })
+    expect(ids(group)).toEqual(['a'])
+  })
+})

--- a/packages/server/server/sessions/crash-group.ts
+++ b/packages/server/server/sessions/crash-group.ts
@@ -1,0 +1,111 @@
+/**
+ * crash-group.ts — PURE. Which sessions FELL TOGETHER, so all of them can be picked back up at once.
+ *
+ * A reboot, an OOM kill or a `tmux kill-server` takes the whole backend at once: every managed
+ * session reconciles to `lost` in the same instant, keeping its name, its note and its task. Getting
+ * them all back is one gesture, and this decides what "them all" means.
+ *
+ * ## The hard part is not the grouping, it is the garbage
+ *
+ * A registry that keeps a row for everything it ever started will happily hand you fifty `lost`
+ * sessions, of which three actually fell — the other forty-seven were over days ago. A group like
+ * that is a list of everything that has ever existed, and it cannot be reopened without reading
+ * every row first, which is the whole of the work this is meant to remove.
+ *
+ * So membership needs evidence that a session was ALIVE when the machine went down, and no such
+ * evidence existed: `createdAt` says when it started (a session opened three weeks ago and abandoned
+ * has one just the same), and `BackendSession.lastActivityMs` only exists for a session the backend
+ * still knows about — which is precisely not the case for one that fell. The registry therefore
+ * records `lastSeenMs`, stamped when a session is created and refreshed by the poller's heartbeat.
+ *
+ * The heartbeat writes ONE timestamp for EVERY session alive at that moment, in a single write. That
+ * is what makes the clustering exact rather than fuzzy: sessions that died together do not merely
+ * have nearby `lastSeenMs`, they have the same one. The window below exists only to absorb the gap
+ * between a session created since the last heartbeat (stamped at creation) and its older siblings
+ * (stamped at the heartbeat), which is at most one interval — hence the invariant that the window is
+ * wider than the heartbeat, asserted in the tests.
+ *
+ * ## Which way this errs, and why
+ *
+ * Two errors are possible, and they do not cost the same:
+ *
+ *  - **Admitting garbage** makes the group useless. It is the failure that was asked for by name,
+ *    and it is silent: a group of forty rows looks exactly like a correct group of forty rows.
+ *  - **Leaving out a session that really fell** costs one keypress. The row is still on the screen,
+ *    still named, and still carries its own `Reopen` verb — which is what recovers it today.
+ *
+ * So every rule here errs toward EXCLUDING. In particular there is no fallback when `lastSeenMs` is
+ * absent: a registry written by an older build, or a row this process never once saw alive, is not
+ * in the group. It will join the next one, because the heartbeat stamps it as soon as it is seen.
+ *
+ * ## What is deliberately NOT a rule
+ *
+ *  - **No minimum size.** One session open when the laptop died is one session that fell, and the
+ *    heading states the count and the time, so a group of one claims nothing a group of six does not.
+ *  - **No maximum age.** A fall from three days ago that was never picked up is still the sessions
+ *    that fell. The UI says WHEN, so "three days ago" is never mistaken for "just now".
+ *  - **No requirement that the conversation be resolvable.** That is `planTaskReopen`'s business, and
+ *    it already reports an unresolvable row as skipped AND counted. Filtering here instead would make
+ *    the group quietly smaller than the fall it describes.
+ */
+
+import type { ManagedSession } from './types'
+
+/**
+ * How often the poller stamps every live session's `lastSeenMs`.
+ *
+ * Sixty seconds, and the number is a disk-write budget rather than a precision one: the poll runs
+ * every five seconds over the whole fleet, and rewriting `managed-sessions.json` on every tick would
+ * be twelve writes a minute for a fact that is only ever read at this granularity.
+ */
+export const HEARTBEAT_MS = 60_000
+
+/**
+ * How far apart two `lastSeenMs` values may be and still describe ONE fall.
+ *
+ * Twice the heartbeat: the widest genuine spread is one interval (a session created just after the
+ * last heartbeat carries its creation stamp while its siblings carry the heartbeat's), and doubling
+ * it leaves room for a poll that ran late without opening the door to a session that stopped being
+ * alive minutes earlier.
+ */
+export const CRASH_WINDOW_MS = 2 * HEARTBEAT_MS
+
+export interface CrashGroup {
+  /** When the fall happened, as the newest evidence of life among its members. */
+  atMs: number
+  /** The registry rows that fell, in registry order. */
+  entries: ManagedSession[]
+}
+
+export function planCrashGroup(o: {
+  entries: readonly ManagedSession[]
+  /**
+   * Every id the backend still knows about — RUNNING OR EXITED.
+   *
+   * Exited counts as known: tmux keeps a finished session listable (`remain-on-exit`), so a command
+   * that ended on its own is still something the backend can name. Only a session the backend has no
+   * record of at all is one the machine took, which is the event this describes.
+   */
+  backendIds: ReadonlySet<string>
+  windowMs?: number
+}): CrashGroup | null {
+  const window = o.windowMs ?? CRASH_WINDOW_MS
+
+  const candidates = o.entries.filter(e => {
+    // Ending a session is a decision. It is never a fall, whatever else is true of the row.
+    if (e.endedAt) return false
+    // The backend still has it: it is running, or it exited on its own. Either way nothing took it.
+    if (o.backendIds.has(e.id)) return false
+    // No evidence it was ever alive under a build that records evidence. Excluded rather than
+    // guessed at from `createdAt`, which says nothing about whether it was still open.
+    return typeof e.lastSeenMs === 'number' && Number.isFinite(e.lastSeenMs)
+  })
+  if (candidates.length === 0) return null
+
+  // The LAST fall, not every fall. A machine that crashed twice has two clusters, and the older one
+  // is a different event — offering both under one heading would be the garbage problem again, one
+  // level up.
+  const atMs = candidates.reduce((n, e) => Math.max(n, e.lastSeenMs!), 0)
+  const entries = candidates.filter(e => e.lastSeenMs! >= atMs - window)
+  return { atMs, entries }
+}

--- a/packages/server/server/sessions/harness-session-file.test.ts
+++ b/packages/server/server/sessions/harness-session-file.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from 'bun:test'
+import { HARNESS_ORDER } from '@agentistics/core'
+import {
+  HARNESS_SESSION_SOURCES, chosenName, parseHarnessSessionFile, pickTitle, tmuxSessionName,
+} from './harness-session-file'
+
+/**
+ * VERBATIM from `~/.claude/sessions/` on 2026-08-14, claude 2.1.232 — the two shapes that matter.
+ * The `.key` sibling files in that directory are not records and are excluded by `matches`.
+ */
+const NAMED_BY_USER = {
+  pid: 10259,
+  sessionId: 'b9665719-4a7a-4253-ac9e-d90f9ae86599',
+  cwd: '/home/mithrandir/aipe',
+  startedAt: 1786675466447,
+  version: '2.1.232',
+  kind: 'interactive',
+  tmux: 'agentop-ebd7dedf2e:@2.%2',
+  name: 'principal do cockpit',
+  nameSince: 1786675466447,
+  status: 'waiting',
+  waitingFor: 'input needed',
+}
+
+const NAMED_BY_CLAUDE = {
+  pid: 1032969,
+  sessionId: '4ebcabfe-8016-4ef5-bed0-f58fff00dc40',
+  cwd: '/home/mithrandir/agentistics',
+  name: 'agentistics-77',
+  nameSource: 'derived',
+}
+
+describe('parseHarnessSessionFile', () => {
+  it('reads the fields anything downstream relies on', () => {
+    const f = parseHarnessSessionFile(NAMED_BY_USER)!
+    expect(f.pid).toBe(10259)
+    expect(f.sessionId).toBe('b9665719-4a7a-4253-ac9e-d90f9ae86599')
+    expect(f.name).toBe('principal do cockpit')
+    expect(f.nameSince).toBe(1786675466447)
+    expect(f.tmux).toBe('agentop-ebd7dedf2e:@2.%2')
+  })
+
+  it('drops a field of the wrong type rather than the record', () => {
+    // Undocumented, internal format: a release that changes one field's shape must cost that field
+    // and nothing else. Same discipline as `antigravity-protobuf.ts`, which never throws.
+    const f = parseHarnessSessionFile({ ...NAMED_BY_USER, pid: 'ten', nameSince: 'today' })!
+    expect(f.pid).toBeUndefined()
+    expect(f.nameSince).toBeUndefined()
+    expect(f.sessionId).toBe('b9665719-4a7a-4253-ac9e-d90f9ae86599')
+  })
+
+  it('is null for anything that is not an object, and never throws', () => {
+    expect(parseHarnessSessionFile(null)).toBeNull()
+    expect(parseHarnessSessionFile('{}')).toBeNull()
+    expect(parseHarnessSessionFile([1, 2])).toBeNull()
+    expect(parseHarnessSessionFile(undefined)).toBeNull()
+  })
+
+  it('treats an empty string as absent, never as a name of ""', () => {
+    expect(parseHarnessSessionFile({ name: '', cwd: '' })).toEqual({})
+  })
+})
+
+describe('chosenName', () => {
+  it('is the name a PERSON typed', () => {
+    expect(chosenName(parseHarnessSessionFile(NAMED_BY_USER)!)).toBe('principal do cockpit')
+  })
+
+  it('is nothing when the harness made the name up', () => {
+    // Measured on this machine: 24 of 40 named session files are `derived`. Letting `agentistics-77`
+    // replace a label somebody typed in agentop is the "reopen renamed the row back to the
+    // transcript's title" bug wearing a new hat.
+    expect(chosenName(parseHarnessSessionFile(NAMED_BY_CLAUDE)!)).toBeUndefined()
+  })
+
+  it('is nothing when there is no file or no name', () => {
+    expect(chosenName(undefined)).toBeUndefined()
+    expect(chosenName({})).toBeUndefined()
+  })
+})
+
+describe('tmuxSessionName', () => {
+  it('takes the session, dropping the window and the pane', () => {
+    // A session of ours is one window with one pane; the id is the only part naming anything we hold.
+    expect(tmuxSessionName({ tmux: 'agentop-ebd7dedf2e:@2.%2' })).toBe('agentop-ebd7dedf2e')
+  })
+
+  it('is nothing when the harness is not under tmux at all', () => {
+    expect(tmuxSessionName({})).toBeUndefined()
+    expect(tmuxSessionName(undefined)).toBeUndefined()
+    expect(tmuxSessionName({ tmux: ':@2.%2' })).toBeUndefined()
+  })
+})
+
+describe('pickTitle', () => {
+  const fallback = 'claude in tmp'
+
+  it('falls back when nobody has named anything, and SAYS it is derived', () => {
+    expect(pickTitle({ fallback })).toEqual({ title: fallback, source: 'derived' })
+  })
+
+  it('takes the only name there is, from either side', () => {
+    expect(pickTitle({ label: 'Principal', fallback }))
+      .toEqual({ title: 'Principal', source: 'label' })
+    expect(pickTitle({ file: { name: 'principal do cockpit' }, fallback }))
+      .toEqual({ title: 'principal do cockpit', source: 'harness' })
+  })
+
+  it('ignores a name the harness invented, whatever else is true', () => {
+    expect(pickTitle({ file: { name: 'aipe-c9', nameSource: 'derived' }, fallback }))
+      .toEqual({ title: fallback, source: 'derived' })
+    expect(pickTitle({
+      label: 'Principal', file: { name: 'aipe-c9', nameSource: 'derived' }, fallback,
+    })).toEqual({ title: 'Principal', source: 'label' })
+  })
+
+  it('takes the NEWER name when both sides said when', () => {
+    const file = { name: 'principal do cockpit', nameSince: 200 }
+    expect(pickTitle({ label: 'Principal', labelSince: 100, file, fallback }))
+      .toEqual({ title: 'principal do cockpit', source: 'harness', other: 'Principal' })
+    expect(pickTitle({ label: 'Principal', labelSince: 300, file, fallback }))
+      .toEqual({ title: 'Principal', source: 'label', other: 'principal do cockpit' })
+  })
+
+  it('takes the HARNESS name when the timestamps cannot be compared', () => {
+    // The judgement call, and the reason it goes this way: `nameSince` exists only from claude
+    // 2.1.232, so on today's machines the recency branch above almost never fires — and the
+    // complaint that produced this feature is exactly someone renaming inside the session and
+    // agentop going on showing its own older label.
+    expect(pickTitle({ label: 'Principal', file: { name: 'principal do cockpit' }, fallback }))
+      .toEqual({ title: 'principal do cockpit', source: 'harness', other: 'Principal' })
+  })
+
+  it('NEVER throws either name away when they disagree', () => {
+    // A rename that vanishes without a word is indistinguishable from a rename that failed.
+    for (const labelSince of [undefined, 1, 999]) {
+      const picked = pickTitle({
+        label: 'A', ...(labelSince ? { labelSince } : {}),
+        file: { name: 'B', nameSince: 500 }, fallback,
+      })
+      expect([picked.title, picked.other].sort()).toEqual(['A', 'B'])
+    }
+  })
+
+  it('says nothing about a second name when the two agree', () => {
+    const picked = pickTitle({ label: 'same', file: { name: 'same' }, fallback })
+    expect(picked.other).toBeUndefined()
+  })
+
+  it('treats a blank label as no label', () => {
+    expect(pickTitle({ label: '   ', fallback })).toEqual({ title: fallback, source: 'derived' })
+  })
+})
+
+describe('HARNESS_SESSION_SOURCES', () => {
+  it('has decided about every harness — absence is a decision', () => {
+    expect(Object.keys(HARNESS_SESSION_SOURCES).sort()).toEqual([...HARNESS_ORDER].sort())
+  })
+
+  it('is claude only, because this is a Claude Code specific file', () => {
+    for (const id of HARNESS_ORDER) {
+      if (id === 'claude') expect(HARNESS_SESSION_SOURCES[id]).not.toBeNull()
+      else expect(HARNESS_SESSION_SOURCES[id], id).toBeNull()
+    }
+  })
+
+  it('matches the session records and NOT the key files beside them', () => {
+    const { matches } = HARNESS_SESSION_SOURCES.claude!
+    expect(matches.test('10259.json')).toBe(true)
+    expect(matches.test('10259.1d78a4b41b072a6ab45882018ce6922232c6d996cb91d247fa18d79bfad5ac6b.key'))
+      .toBe(false)
+    expect(matches.test('notes.json')).toBe(false)
+  })
+})
+
+describe('chosenName — the nameSource values seen in real files', () => {
+  it('keeps a COLLISION name: it is the user own, with a disambiguator', () => {
+    // Observed on 2026-08-14: `principal do cockpit-mutable-spring`, written when two sessions
+    // chose the same name. Rejecting it would delete something a person typed.
+    expect(chosenName({
+      name: 'principal do cockpit-mutable-spring', nameSource: 'collision',
+    })).toBe('principal do cockpit-mutable-spring')
+  })
+
+  it('keeps a name whose source this module has never seen', () => {
+    // A rejection list, not an allow list. An unknown fourth value in an undocumented, internal
+    // format must not silently blank a name.
+    expect(chosenName({ name: 'whatever', nameSource: 'something-new' })).toBe('whatever')
+  })
+})

--- a/packages/server/server/sessions/harness-session-file.ts
+++ b/packages/server/server/sessions/harness-session-file.ts
@@ -1,0 +1,219 @@
+/**
+ * harness-session-file.ts — PURE. What a harness records ABOUT ITS OWN SESSION, and which name wins.
+ *
+ * Claude Code writes `~/.claude/sessions/<pid>.json` while a session is alive. It holds the name the
+ * user gave it with `/rename`, the conversation id, the pid, and — for a session started under our
+ * backend — the tmux session name. That last field is the interesting one: it is an EXACT link from
+ * a harness's own record to an agentop row, where everything else in this codebase has had to guess
+ * by harness-and-directory.
+ *
+ * ## This is one harness's private file, so it is read like one
+ *
+ * The format is undocumented and internal to Claude Code; it can change shape in any release. So:
+ * every field is checked, a missing or wrong-typed one yields "I do not know" rather than a throw or
+ * an invented value, and a file that will not parse is simply absent. Same discipline as
+ * `antigravity-protobuf.ts`, which never throws.
+ *
+ * `Record<HarnessId, … | null>` for the same reason `SPAWN_SPECS` is one: the other five harnesses
+ * have no such file, or have one in a shape nobody has read, and they must go on behaving exactly as
+ * they do today rather than being handed a guess.
+ *
+ * ## Which name wins, and why it is not the obvious answer
+ *
+ * `nameSource: 'derived'` marks a name CLAUDE INVENTED (`agentistics-77`, `aipe-c9`) rather than one
+ * a person typed. Measured on this machine: 24 of 40 named session files are derived. A derived name
+ * is not a name, and letting one replace a label somebody chose in agentop would be the "reopen
+ * renamed the row back to the transcript's title" bug wearing a new hat. It is dropped before
+ * anything else is considered.
+ *
+ * `nameSince` would settle the rest by recency, and it is the field this cannot lean on: it appears
+ * only in claude 2.1.232 (3 of 16 user-named files here; every older version writes the name with no
+ * timestamp at all). So the rule has to work when the comparison is impossible, and `pickTitle`
+ * spells out what it does in each case rather than pretending the timestamps are there.
+ *
+ * When the two names disagree, NEITHER is thrown away: the winner becomes the title, the loser stays
+ * on the row's facts, and `source` says which is which. Someone who renamed in both places must be
+ * able to see that both renames happened — otherwise the one that lost reads as a rename that
+ * silently failed.
+ */
+
+import type { HarnessId } from '@agentistics/core'
+
+/** One harness session record, reduced to the fields anything here may rely on. */
+export interface HarnessSessionFile {
+  /** The OS pid the harness is running as. Matches what `/proc` reports for an external session. */
+  pid?: number
+  /** The harness's own conversation id — exact, not inferred from a directory. */
+  sessionId?: string
+  cwd?: string
+  /** The session's own name. Absent when it has none. */
+  name?: string
+  /**
+   * Where that name came from. `'derived'` means the HARNESS invented it, which is not a name a
+   * person chose and is treated as no name at all.
+   */
+  nameSource?: string
+  /** When the name was set, epoch ms. Absent on every claude before 2.1.232. */
+  nameSince?: number
+  /**
+   * The tmux session this harness is running inside, as `<session>:@window.%pane`.
+   *
+   * Present only when the harness was started under tmux, which for our purposes means: started by
+   * agentop. It is the EXACT link between a harness's own record and a managed row.
+   */
+  tmux?: string
+}
+
+/**
+ * Parse one session file's already-decoded JSON — total, and never a throw.
+ *
+ * `null` for anything that is not an object. Every field is dropped individually on a type
+ * mismatch, so a release that changes one field's shape costs that field and not the record.
+ */
+export function parseHarnessSessionFile(raw: unknown): HarnessSessionFile | null {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null
+  const s = raw as Record<string, unknown>
+  const str = (v: unknown): string | undefined =>
+    typeof v === 'string' && v !== '' ? v : undefined
+  const num = (v: unknown): number | undefined =>
+    typeof v === 'number' && Number.isFinite(v) ? v : undefined
+  return {
+    ...(num(s.pid) !== undefined ? { pid: num(s.pid)! } : {}),
+    ...(str(s.sessionId) ? { sessionId: str(s.sessionId)! } : {}),
+    ...(str(s.cwd) ? { cwd: str(s.cwd)! } : {}),
+    ...(str(s.name) ? { name: str(s.name)! } : {}),
+    ...(str(s.nameSource) ? { nameSource: str(s.nameSource)! } : {}),
+    ...(num(s.nameSince) !== undefined ? { nameSince: num(s.nameSince)! } : {}),
+    ...(str(s.tmux) ? { tmux: str(s.tmux)! } : {}),
+  }
+}
+
+/**
+ * The name a person chose INSIDE the session, or `undefined` — PURE.
+ *
+ * Only `derived` is rejected: it is what the harness makes up from the folder when nobody has said
+ * anything (`agentistics-77`, `aipe-c9`), and it changes nothing about what the session is.
+ *
+ * Three values have been seen in real files on 2026-08-14, and the third is why this is a rejection
+ * list rather than an allow list:
+ *   absent      the ordinary case for a name typed with `/rename`
+ *   `derived`   invented by the harness — not a name
+ *   `collision` the user's name plus a disambiguating suffix, when two sessions chose the same one
+ *               (`principal do cockpit-mutable-spring`). That IS the user's name, so it passes.
+ * An unknown fourth value therefore shows the name rather than blanking it: a field this module
+ * does not recognise must not silently delete something a person typed.
+ */
+export function chosenName(file: HarnessSessionFile | undefined): string | undefined {
+  if (!file?.name) return undefined
+  return file.nameSource === 'derived' ? undefined : file.name
+}
+
+/**
+ * Our managed session's id, read out of the harness's own `tmux` field — PURE.
+ *
+ * `agentop-ebd7dedf2e:@2.%2` -> `ebd7dedf2e`. The window and pane are dropped: a session of ours is
+ * one window with one pane, and the id is the only part that names anything we hold.
+ *
+ * `undefined` for a tmux session that is not ours, which is the ordinary case for a user's own tmux.
+ * The caller supplies the prefix test rather than this module importing the backend, so the pure
+ * layer stays free of the platform.
+ */
+export function tmuxSessionName(file: HarnessSessionFile | undefined): string | undefined {
+  const raw = file?.tmux
+  if (!raw) return undefined
+  const name = raw.split(':')[0] ?? ''
+  return name === '' ? undefined : name
+}
+
+/** Where a row's displayed name came from. Said on the row when the two sources disagree. */
+export type TitleSource = 'label' | 'harness' | 'derived'
+
+export interface PickedTitle {
+  title: string
+  source: TitleSource
+  /**
+   * The name that LOST, when there was one and it differs.
+   *
+   * Kept so the row can say that both renames happened. A rename that vanishes without a word is
+   * indistinguishable from a rename that failed, which is the complaint this feature answers — in
+   * the other direction.
+   */
+  other?: string
+}
+
+/**
+ * Which name a row wears — PURE, and the ONE place the precedence lives.
+ *
+ * The cases, in the order they are decided:
+ *
+ *  1. **Neither.** The caller's derived fallback (`claude in tmp`), marked `derived` so nothing
+ *     downstream mistakes it for something a person typed.
+ *  2. **One of them.** That one. No contest to resolve.
+ *  3. **Both, and both timestamps are known.** The NEWER one, which is the only reading that
+ *     respects a deliberate rename made afterwards in either place.
+ *  4. **Both, and the timestamps cannot be compared.** The HARNESS's, and this is the judgement
+ *     call, so here is the reasoning. The complaint that produced this feature is precisely someone
+ *     renaming inside the session and agentop going on showing its own older label; `nameSince`
+ *     exists only from claude 2.1.232, so on today's machines case 3 almost never fires and a rule
+ *     that preferred the label would leave the feature not working for most people. It is not the
+ *     bug the repo has already paid for either: THAT was a name NOBODY chose (a transcript title)
+ *     replacing one somebody did, and a non-derived harness name is a name somebody typed. And
+ *     nothing is lost — the label comes back as `other`, on the row.
+ */
+export function pickTitle(o: {
+  /** The name typed into agentop, when there is one. */
+  label?: string
+  /** When that was written, epoch ms. Absent on a row renamed before agentop recorded it. */
+  labelSince?: number
+  /** The harness's session record, when one could be read. */
+  file?: HarnessSessionFile
+  /** What to call a row nobody has named. Already localized. */
+  fallback: string
+}): PickedTitle {
+  const harness = chosenName(o.file)
+  const label = o.label && o.label.trim() !== '' ? o.label : undefined
+
+  if (!label && !harness) return { title: o.fallback, source: 'derived' }
+  if (!harness) return { title: label!, source: 'label' }
+  if (!label) return { title: harness, source: 'harness' }
+  if (label === harness) return { title: label, source: 'label' }
+
+  const since = o.file?.nameSince
+  if (o.labelSince !== undefined && since !== undefined) {
+    return o.labelSince >= since
+      ? { title: label, source: 'label', other: harness }
+      : { title: harness, source: 'harness', other: label }
+  }
+  return { title: harness, source: 'harness', other: label }
+}
+
+/**
+ * Which harnesses record a session file agentop knows how to read.
+ *
+ * A `Record`, so a harness added to `HarnessId` fails the build until somebody decides. `null` means
+ * "no such file, or one nobody has read" — and that harness goes on behaving exactly as it does
+ * today, which is the point: this is a Claude Code specific format, and inventing a reader for the
+ * other five would be inventing their data.
+ *
+ * `dir` is relative to the harness's own home, resolved by the caller — the pure layer names no path
+ * on this machine.
+ */
+export interface HarnessSessionSource {
+  /** Directory under the harness home holding one JSON file per live session. */
+  dir: string
+  /** File names to consider: `<pid>.json`, never the sibling `<pid>.<hash>.key` files. */
+  matches: RegExp
+}
+
+export const HARNESS_SESSION_SOURCES: Record<HarnessId, HarnessSessionSource | null> = {
+  // Probed on 2026-08-14 against claude 2.1.232: `~/.claude/sessions/<pid>.json`, one per live
+  // session, holding pid / sessionId / cwd / name / nameSource / nameSince / tmux. The directory
+  // also holds `<pid>.<hash>.key` files, which are NOT session records.
+  claude: { dir: 'sessions', matches: /^\d+\.json$/ },
+  // The other five write no such file, or write one nobody has read. Absent, never guessed.
+  codex: null,
+  gemini: null,
+  copilot: null,
+  antigravity: null,
+  kimi: null,
+}

--- a/packages/server/server/sessions/harness-sessions.ts
+++ b/packages/server/server/sessions/harness-sessions.ts
@@ -1,0 +1,168 @@
+/**
+ * harness-sessions.ts — the IO half of `harness-session-file.ts`: reading what each harness records
+ * about its own live sessions, cheaply enough to do it every five seconds.
+ *
+ * ## What this buys, in order of value
+ *
+ *  1. **An EXACT link between a harness's own record and one of our rows.** Claude writes the tmux
+ *     session it is running inside, which for a session agentop started is `agentop-<our id>`. Every
+ *     other correlation in this feature has had to guess by harness-and-directory — the guess that
+ *     resolved every session in one repository to the same conversation and reopened three rows onto
+ *     one conversation (`session-view.ts` records that bug). Here there is nothing to guess.
+ *  2. **The conversation id, exactly**, for a session we started FRESH. `ManagedSession.conversationId`
+ *     is otherwise only known for a row we reopened, because we handed the id over ourselves.
+ *  3. **The name the user gave the session from inside it**, which is what this was asked for.
+ *
+ * ## Cost
+ *
+ * The poll runs every five seconds over the whole fleet, so the directory is listed once per poll and
+ * each file is read only when its mtime has moved — the same shape of memo `repo-facts.ts` keeps per
+ * directory. A machine with fifty stale session files pays one `readdir` and no reads at all.
+ *
+ * Failure is always ABSENCE. An unreadable directory, an unparseable file, a field of the wrong
+ * type: the answer is "nothing is known about that session", which leaves every row exactly as it
+ * behaves today. Nothing here may throw into the poll.
+ */
+
+import { readFile, readdir, stat } from 'node:fs/promises'
+import { join } from 'node:path'
+import type { HarnessId } from '@agentistics/core'
+import { CLAUDE_DIR } from '../config'
+import {
+  HARNESS_SESSION_SOURCES, parseHarnessSessionFile, tmuxSessionName,
+  type HarnessSessionFile,
+} from './harness-session-file'
+import { idFromTmuxName } from './tmux-cli'
+
+/**
+ * Where each harness's own session records live on THIS machine.
+ *
+ * Resolved here rather than in the pure module, and from `CLAUDE_DIR` rather than `HOME_DIR`,
+ * because that is the directory this product already treats as "the Claude installation being
+ * measured" — a container mounting someone else's `~/.claude` reads that one, and reading the
+ * container's own empty home instead would report a fleet of nothing.
+ */
+function homeOf(harness: HarnessId): string | undefined {
+  return harness === 'claude' ? CLAUDE_DIR : undefined
+}
+
+interface Cached {
+  mtimeMs: number
+  file: HarnessSessionFile | null
+}
+
+const cache = new Map<string, Cached>()
+
+/** Reset the memo. Tests only. */
+export function forgetHarnessSessions(): void {
+  cache.clear()
+}
+
+/** Read one record, from the memo unless the file has changed since. Never throws. */
+async function readOne(path: string): Promise<Keyed | null> {
+  let mtimeMs: number
+  try {
+    mtimeMs = (await stat(path)).mtimeMs
+  } catch {
+    cache.delete(path)
+    return null
+  }
+  const hit = cache.get(path)
+  if (hit && hit.mtimeMs === mtimeMs) return hit.file ? { file: hit.file, mtimeMs } : null
+
+  let file: HarnessSessionFile | null = null
+  try {
+    file = parseHarnessSessionFile(JSON.parse(await readFile(path, 'utf-8')))
+  } catch {
+    // Unreadable, mid-write, or not JSON at all. Absence, never a throw — and it is CACHED against
+    // this mtime so a permanently broken file is not re-read every five seconds forever.
+    file = null
+  }
+  cache.set(path, { mtimeMs, file })
+  return file ? { file, mtimeMs } : null
+}
+
+export interface HarnessSessionIndex {
+  /** Keyed by OUR managed session id, read out of the harness's `tmux` field. Exact. */
+  byManagedId: Map<string, HarnessSessionFile>
+  /** Keyed by OS pid — how an EXTERNAL session found in `/proc` is matched. Exact. */
+  byPid: Map<number, HarnessSessionFile>
+}
+
+/**
+ * ## These records OUTLIVE their processes, and that is mostly a feature
+ *
+ * Measured on this machine on 2026-08-14: 53 files, of which about a dozen belong to processes that
+ * are still running. A record left behind by a session that has ended is exactly what keeps the name
+ * a person typed inside it readable on the `lost` row afterwards, which is the point.
+ *
+ * The one thing staleness can do is put TWO records under one key, when a pid was reused or a file
+ * was left behind for a tmux session name that came round again. `readdir` order would then decide
+ * which one wins, which is no decision at all — so the NEWEST file wins, and `mtimeMs` is already
+ * being read for the memo.
+ *
+ * `byPid` needs no such care in practice: it is only ever looked up with a pid `/proc` just reported,
+ * so a record for a dead process is never asked for.
+ */
+interface Keyed {
+  file: HarnessSessionFile
+  mtimeMs: number
+}
+
+const EMPTY: HarnessSessionIndex = { byManagedId: new Map(), byPid: new Map() }
+
+/** An empty index, for a caller that has nothing to look up. */
+export function emptyHarnessSessionIndex(): HarnessSessionIndex {
+  return { byManagedId: new Map(), byPid: new Map() }
+}
+
+/**
+ * Every live session record this machine's harnesses have written, indexed both ways it is looked up.
+ *
+ * Both indexes are EXACT — a tmux session name and an OS pid — which is the whole point of reading
+ * these files rather than inferring anything.
+ */
+export async function loadHarnessSessions(
+  harnesses: readonly HarnessId[] = ['claude'],
+): Promise<HarnessSessionIndex> {
+  const out = emptyHarnessSessionIndex()
+  // How fresh the record already sitting under each managed id is, so the newest wins rather than
+  // whichever `readdir` happened to hand over last. See the note above `Keyed`.
+  const seenAt = new Map<string, number>()
+
+  for (const harness of harnesses) {
+    const source = HARNESS_SESSION_SOURCES[harness]
+    const home = homeOf(harness)
+    // A harness with no reader behaves exactly as it does today. Absence is the decision.
+    if (!source || !home) continue
+
+    const dir = join(home, source.dir)
+    let names: string[]
+    try {
+      names = await readdir(dir)
+    } catch {
+      continue // no such directory: this harness has never run here, which is not an error
+    }
+
+    for (const name of names) {
+      // `<pid>.json` only. The directory also holds `<pid>.<hash>.key` files, which are not records.
+      if (!source.matches.test(name)) continue
+      const read = await readOne(join(dir, name))
+      if (!read) continue
+      const { file, mtimeMs } = read
+      if (file.pid !== undefined) out.byPid.set(file.pid, file)
+      const tmux = tmuxSessionName(file)
+      const managedId = tmux ? idFromTmuxName(tmux) : null
+      // `idFromTmuxName` returns null for a tmux session that is not ours, which is the ordinary
+      // case for a user's own tmux — claimed rows would then be somebody else's.
+      if (!managedId) continue
+      if (mtimeMs < (seenAt.get(managedId) ?? -Infinity)) continue
+      seenAt.set(managedId, mtimeMs)
+      out.byManagedId.set(managedId, file)
+    }
+  }
+
+  return out
+}
+
+export { EMPTY as EMPTY_HARNESS_SESSIONS }

--- a/packages/server/server/sessions/index.ts
+++ b/packages/server/server/sessions/index.ts
@@ -47,11 +47,17 @@ export async function resolveBackend(): Promise<SessionBackend> {
 export * from './types'
 export { SPAWN_SPECS, planSpawn } from './spawn-spec'
 export { reconcileSessions, resolveSessionRef } from './session-ref'
-export { addSession, newSessionId, patchSession, readRegistry, removeSession } from './registry'
+export {
+  addSession, newSessionId, patchSession, readRegistry, removeSession, touchSessions,
+} from './registry'
 export { SESSION_POLL_MS, createSessionsPoller, type SessionSnapshot } from './sessions-host'
+export { APPROVAL_SPECS, approvalFor, type ApprovalSpec } from './approval-spec'
+export {
+  CRASH_WINDOW_MS, HEARTBEAT_MS, planCrashGroup, type CrashGroup,
+} from './crash-group'
 export {
   attentionCount, bellTransitions, buildSessionViews, groupSessions, needsAttention,
   type SessionGroup, type SessionGrouping, type SessionView,
 } from './session-view'
 export { ATTENTION_RULES, rulesFor } from './attention-rules'
-export { QUIET_MS, attentionOf, digestFrame } from './attention'
+export { QUIET_MS, approvalTail, attentionOf, digestFrame } from './attention'

--- a/packages/server/server/sessions/registry.test.ts
+++ b/packages/server/server/sessions/registry.test.ts
@@ -117,3 +117,64 @@ describe('newSessionId', () => {
     for (const id of ids) expect(id).toMatch(/^[a-z0-9]{10}$/)
   })
 })
+
+describe('the heartbeat', () => {
+  it('stamps every id given with ONE timestamp, in one write', async () => {
+    // One shared timestamp is what makes `crash-group.ts` exact rather than fuzzy: sessions that
+    // later fall together do not merely have nearby `lastSeenMs`, they have the same one.
+    const reg = createSessionRegistry(file)
+    await reg.add(session('a'))
+    await reg.add(session('b'))
+    expect(await reg.touch(['a', 'b'], 1_786_700_000_000)).toBe(2)
+    const rows = await reg.read()
+    expect(rows.map(r => r.lastSeenMs)).toEqual([1_786_700_000_000, 1_786_700_000_000])
+  })
+
+  it('leaves alone the ids it was not given', async () => {
+    const reg = createSessionRegistry(file)
+    await reg.add(session('a'))
+    await reg.add(session('b'))
+    await reg.touch(['a'], 42)
+    const rows = await reg.read()
+    expect(rows.find(r => r.id === 'a')?.lastSeenMs).toBe(42)
+    expect(rows.find(r => r.id === 'b')?.lastSeenMs).toBeUndefined()
+  })
+
+  it('does not write at all when no id matches', async () => {
+    // A heartbeat runs every minute forever. Touching the file to change nothing would be a write a
+    // minute for the life of the process, on a fleet this registry does not hold.
+    const reg = createSessionRegistry(file)
+    await reg.add(session('a'))
+    const before = await readFile(file, 'utf-8')
+    expect(await reg.touch(['nope'], 42)).toBe(0)
+    expect(await readFile(file, 'utf-8')).toBe(before)
+  })
+
+  it('survives an empty registry', async () => {
+    expect(await createSessionRegistry(file).touch(['a'], 42)).toBe(0)
+  })
+})
+
+describe('what survives a round trip', () => {
+  it('keeps conversationId, which the sanitiser used to drop', async () => {
+    // It was written by `resumeSession` and then read back as absent, so the exact conversation a
+    // reopened session drives was recorded and never used — and the next reopen fell back to the
+    // harness+directory guess that cannot tell two sessions of one repository apart.
+    const reg = createSessionRegistry(file)
+    await reg.add(session('a'))
+    await reg.patch('a', { conversationId: 'conv-1' })
+    expect((await reg.read())[0]!.conversationId).toBe('conv-1')
+  })
+
+  it('refuses a lastSeenMs that is not a finite number', async () => {
+    // Hand-editable file. A NaN reaching `crash-group.ts` would put an always-false comparison in
+    // charge of which sessions get reopened.
+    await writeFile(file, JSON.stringify([
+      { ...session('a'), lastSeenMs: 'yesterday' },
+      { ...session('b'), lastSeenMs: 7 },
+    ]), 'utf-8')
+    const rows = await createSessionRegistry(file).read()
+    expect(rows[0]!.lastSeenMs).toBeUndefined()
+    expect(rows[1]!.lastSeenMs).toBe(7)
+  })
+})

--- a/packages/server/server/sessions/registry.ts
+++ b/packages/server/server/sessions/registry.ts
@@ -47,6 +47,8 @@ export function newSessionId(): string {
  */
 export interface SessionPatch {
   label?: string
+  /** Written alongside `label`, never on its own — see `ManagedSession.labelSince`. */
+  labelSince?: number
   note?: string
   task?: string
   endedAt?: string
@@ -59,6 +61,18 @@ export interface SessionRegistry {
   remove(id: string): Promise<void>
   /** False when no session carries that id — never a silent success. */
   patch(id: string, patch: SessionPatch): Promise<boolean>
+  /**
+   * Stamp `lastSeenMs` on every id given, in ONE write — the poller's heartbeat.
+   *
+   * One write is not an optimization, it is what makes `crash-group.ts` exact: every session alive at
+   * this moment gets the SAME timestamp, so sessions that later fall together are identifiable by
+   * equality rather than by a tolerance. `patch` in a loop would rewrite the file once per session
+   * and stamp each with a slightly different clock.
+   *
+   * Returns the number stamped. Nothing is written when no id matches — a heartbeat on an empty
+   * fleet must not touch the file every minute forever.
+   */
+  touch(ids: readonly string[], atMs: number): Promise<number>
 }
 
 /**
@@ -83,9 +97,22 @@ function sanitize(raw: unknown): ManagedSession | null {
     ...(typeof s.model === 'string' ? { model: s.model } : {}),
     ...(typeof s.effort === 'string' ? { effort: s.effort } : {}),
     ...(typeof s.label === 'string' ? { label: s.label } : {}),
+    ...(typeof s.labelSince === 'number' && Number.isFinite(s.labelSince)
+      ? { labelSince: s.labelSince }
+      : {}),
     ...(typeof s.note === 'string' ? { note: s.note } : {}),
     ...(typeof s.task === 'string' ? { task: s.task } : {}),
     ...(typeof s.endedAt === 'string' ? { endedAt: s.endedAt } : {}),
+    // Written by `resumeSession` and `openTask` and, until this line existed, dropped on the way back
+    // in — so the exact conversation a reopened session drives was recorded and then never read, and
+    // the next reopen fell back to the harness+directory guess that cannot tell two sessions of one
+    // repository apart. `SessionPatch` has carried the field all along.
+    ...(typeof s.conversationId === 'string' ? { conversationId: s.conversationId } : {}),
+    // A number, and finite: this is a hand-editable file, and `lastSeenMs: "yesterday"` reaching
+    // `crash-group.ts` would put a NaN comparison in charge of which sessions get reopened.
+    ...(typeof s.lastSeenMs === 'number' && Number.isFinite(s.lastSeenMs)
+      ? { lastSeenMs: s.lastSeenMs }
+      : {}),
   }
 }
 
@@ -184,6 +211,23 @@ export function createSessionRegistry(file: string): SessionRegistry {
         return true
       })
     },
+    touch(ids, atMs) {
+      return enqueue(async () => {
+        const wanted = new Set(ids)
+        const list = await read()
+        let stamped = 0
+        const next = list.map(s => {
+          if (!wanted.has(s.id)) return s
+          stamped++
+          return { ...s, lastSeenMs: atMs }
+        })
+        // No id matched — a heartbeat on a fleet whose rows this registry does not hold. Writing
+        // anyway would touch the file every minute forever to change nothing.
+        if (stamped === 0) return 0
+        await write(next)
+        return stamped
+      })
+    },
   }
 }
 
@@ -197,3 +241,7 @@ export const patchSession = (
   id: string,
   patch: SessionPatch,
 ): Promise<boolean> => defaultRegistry.patch(id, patch)
+export const touchSessions = (
+  ids: readonly string[],
+  atMs: number,
+): Promise<number> => defaultRegistry.touch(ids, atMs)

--- a/packages/server/server/sessions/session-view.test.ts
+++ b/packages/server/server/sessions/session-view.test.ts
@@ -210,3 +210,82 @@ describe('bellTransitions', () => {
     expect(bellTransitions(new Map(), external)).toEqual([])
   })
 })
+
+describe("what the harness says about its OWN session", () => {
+  const index = (over: {
+    byManagedId?: Record<string, Record<string, unknown>>
+    byPid?: Record<number, Record<string, unknown>>
+  }) => ({
+    byManagedId: new Map(Object.entries(over.byManagedId ?? {})),
+    byPid: new Map(Object.entries(over.byPid ?? {}).map(([k, v]) => [Number(k), v])),
+  }) as never
+
+  const managed = (id: string, o: Partial<ManagedSession> = {}): ManagedSession => ({
+    id, harness: 'claude', cwd: '/repo/a', createdAt: '2026-08-14T10:00:00.000Z', ...o,
+  })
+
+  it('carries a name a person typed inside the session', () => {
+    const [v] = buildSessionViews({
+      reconciled: [{ id: 'm1', managed: managed('m1'), status: 'lost' }],
+      activity: new Map(),
+      processes: [],
+      harnessSessions: index({ byManagedId: { m1: { name: 'principal do cockpit' } } }),
+    })
+    expect(v!.harnessName).toBe('principal do cockpit')
+    // And it is SEARCHABLE, because it may be the only name the person remembers.
+    expect(v!.searchText).toContain('principal do cockpit')
+  })
+
+  it('carries nothing for a name the harness invented for itself', () => {
+    const [v] = buildSessionViews({
+      reconciled: [{ id: 'm1', managed: managed('m1'), status: 'lost' }],
+      activity: new Map(),
+      processes: [],
+      harnessSessions: index({
+        byManagedId: { m1: { name: 'agentistics-77', nameSource: 'derived' } },
+      }),
+    })
+    expect(v!.harnessName).toBeUndefined()
+  })
+
+  it('resolves the conversation EXACTLY, over the directory guess', () => {
+    // The guess this replaces matches on harness+directory, so every session in one repository
+    // resolves to the same conversation — the bug that reopened three rows onto one conversation.
+    const conv = (sessionId: string, title: string, lastActivityMs: number) => ({
+      sessionId, title, lastActivityMs,
+      harness: 'claude' as const, cwd: '/repo/a', resumable: true, firstPrompt: '',
+    })
+    // The newest is deliberately the WRONG one, so the directory guess and the exact answer differ.
+    const conversations = [conv('wrong', 'the guess', 2), conv('right', 'the truth', 1)]
+    const [v] = buildSessionViews({
+      reconciled: [{ id: 'm1', managed: managed('m1'), status: 'exited' }],
+      activity: new Map(),
+      processes: [],
+      conversations,
+      harnessSessions: index({ byManagedId: { m1: { sessionId: 'right' } } }),
+    })
+    expect(v!.resume?.sessionId).toBe('right')
+  })
+
+  it('matches an EXTERNAL process by its pid', () => {
+    const views = buildSessionViews({
+      reconciled: [],
+      activity: new Map(),
+      processes: [{ harness: 'claude', cwd: '/repo/z', pid: 4242, startedMs: 10 }],
+      harnessSessions: index({ byPid: { 4242: { name: 'the one in the other window' } } }),
+    })
+    expect(views[0]!.harnessName).toBe('the one in the other window')
+  })
+
+  it('leaves every row exactly as it was when nothing can be read', () => {
+    // A harness with no such file, an unreadable directory, a container that cannot see it: the
+    // feature costs the extra name and nothing else.
+    const [v] = buildSessionViews({
+      reconciled: [{ id: 'm1', managed: managed('m1', { label: 'Principal' }), status: 'lost' }],
+      activity: new Map(),
+      processes: [],
+    })
+    expect(v!.harnessName).toBeUndefined()
+    expect(v!.label).toBe('Principal')
+  })
+})

--- a/packages/server/server/sessions/session-view.ts
+++ b/packages/server/server/sessions/session-view.ts
@@ -11,6 +11,8 @@
 import type { HarnessId } from '@agentistics/core'
 import { type HarnessProcess, sessionAtCwd } from '../live-sessions'
 import { rulesFor } from './attention-rules'
+import { chosenName, type HarnessSessionFile } from './harness-session-file'
+import type { HarnessSessionIndex } from './harness-sessions'
 import type { ReconciledSession } from './session-ref'
 import type { Conversation } from './conversations'
 import { conversationForProcess } from './conversations'
@@ -57,7 +59,37 @@ export interface SessionView {
    * decide the state, so it costs nothing extra, and there is no frame to read for anything else.
    */
   lastLines?: string[]
+  /**
+   * The BOTTOM of the screen verbatim, present only while this session is blocked on a dialog.
+   *
+   * A different reading of the same frame from `lastLines`, and it has to be: `frameTail` cuts the
+   * input box and the status strip off, which for a session sitting on a dialog cuts the dialog off.
+   * This is what the person answering actually needs to read — the options, which one is highlighted
+   * and the footer naming the key — because the keystroke that answers cannot know which option it
+   * is taking. See `approval-spec.ts` and `approvalTail`.
+   */
+  approvalLines?: string[]
+  /**
+   * This session was taken by the machine along with the others, and is offered back with them.
+   *
+   * Decided by `crash-group.ts` over the whole registry, so it cannot be derived from this row: the
+   * question "did these fall together" is about a set, and a per-row rule could only ever guess.
+   */
+  fell?: boolean
   label?: string
+  /** When `label` was written, epoch ms — the recency side of the title contest. */
+  labelSince?: number
+  /**
+   * The name the user gave this session FROM INSIDE IT, and when.
+   *
+   * Read from what the harness records about its own live sessions (`harness-sessions.ts`), matched
+   * EXACTLY — by the tmux session for a row we host, by pid for one we merely observed. A name the
+   * harness invented for itself is not carried here at all: `chosenName` drops it, because a
+   * generated `agentistics-77` replacing a label somebody typed is the "reopen renamed the row back"
+   * bug in a new costume.
+   */
+  harnessName?: string
+  harnessNameSince?: number
   note?: string
   model?: string
   effort?: string
@@ -147,6 +179,19 @@ export function buildSessionViews(o: {
   activity: ReadonlyMap<string, SessionActivity>
   /** The tail of each hosted session's screen, keyed by session id. */
   tails?: ReadonlyMap<string, string[]>
+  /** The DIALOG a blocked session is showing, keyed by session id — see `SessionView.approvalLines`. */
+  approvals?: ReadonlyMap<string, string[]>
+  /** The ids `crash-group.ts` decided fell together. A set, because the question is about a set. */
+  fell?: ReadonlySet<string>
+  /**
+   * What each harness records about its OWN live sessions, indexed by the two exact keys — the tmux
+   * session a managed row runs in, and the pid of a process found on the host.
+   *
+   * It is what makes this the one correlation in this file that is not a guess: a row matched here
+   * knows its conversation id exactly, so `claimResume` never has to fall back to "some conversation
+   * in this directory" — the fallback that once reopened three rows onto one conversation.
+   */
+  harnessSessions?: HarnessSessionIndex
   processes: readonly HarnessProcess[]
   /** Everything this machine has ever recorded, newest first. Used to name what an external process
    *  is driving, and to offer the conversations that are not running at all. */
@@ -176,11 +221,20 @@ export function buildSessionViews(o: {
   const claimResume = (
     managed: ManagedSession | undefined,
     harness: HarnessId,
+    /**
+     * The conversation the HARNESS ITSELF says this row is driving.
+     *
+     * Outranks the registry's own record and the directory guess alike, because it is the only one
+     * of the three that is a fact rather than a recollection or an inference: the harness wrote it
+     * about the session it is running, and the row was matched to it by tmux session or by pid.
+     */
+    exactId?: string,
   ): { resume?: { sessionId: string; title: string } } => {
     const pool = o.conversations ?? []
-    const own = managed?.conversationId
+    const exact = exactId ? pool.find(c => c.sessionId === exactId) : undefined
+    const own = exact ?? (managed?.conversationId
       ? pool.find(c => c.sessionId === managed.conversationId)
-      : undefined
+      : undefined)
     const conv = own ?? pool.find(c =>
       !claimed.has(c.sessionId)
       && c.harness === harness
@@ -192,6 +246,10 @@ export function buildSessionViews(o: {
 
   const managed: SessionView[] = o.reconciled.map(r => {
     const harness = r.managed?.harness
+    // What the harness says about ITSELF, matched by the tmux session it recorded — the one exact
+    // link between its record and this row.
+    const own: HarnessSessionFile | undefined = o.harnessSessions?.byManagedId.get(r.id)
+    const ownName = chosenName(own)
     // A session the user FINISHED reports `exited` whatever the backend still holds: the row exists
     // to be reopened, and calling it `running` because a dead tmux pane lingers would put it back
     // among the things you can talk to.
@@ -204,7 +262,16 @@ export function buildSessionViews(o: {
       status: finished ? ('exited' as const) : r.status,
       ...(activity ? { activity } : {}),
       ...((o.tails?.get(r.id)?.length ?? 0) > 0 ? { lastLines: o.tails!.get(r.id)! } : {}),
+      // Only while it is genuinely asking. A dialog frame carried on a row that has moved on would
+      // be shown under "what you are about to confirm" for a question that is no longer open.
+      ...(activity === 'waiting-approval' && (o.approvals?.get(r.id)?.length ?? 0) > 0
+        ? { approvalLines: o.approvals!.get(r.id)! }
+        : {}),
+      ...(o.fell?.has(r.id) ? { fell: true as const } : {}),
       ...(r.managed?.label ? { label: r.managed.label } : {}),
+      ...(r.managed?.labelSince !== undefined ? { labelSince: r.managed.labelSince } : {}),
+      ...(ownName ? { harnessName: ownName } : {}),
+      ...(ownName && own?.nameSince !== undefined ? { harnessNameSince: own.nameSince } : {}),
       ...(r.managed?.note ? { note: r.managed.note } : {}),
       ...(r.managed?.model ? { model: r.managed.model } : {}),
       ...(r.managed?.effort ? { effort: r.managed.effort } : {}),
@@ -225,11 +292,19 @@ export function buildSessionViews(o: {
       // process's conversation is, and absent when nothing resolves rather than offering a verb
       // with no target.
       ...((finished || r.status === 'lost' || r.status === 'exited') && harness
-        ? claimResume(r.managed, harness)
+        // `own?.sessionId` is only ever present for a row still ALIVE — the harness deletes its
+        // record when the process goes — so on a `lost` row this is `undefined` and the registry's
+        // own `conversationId` decides, exactly as before. That is not a gap: the id was recorded
+        // into the registry while the session was up, by the branch below.
+        ? claimResume(r.managed, harness, own?.sessionId)
         : {}),
       attached: r.backend?.attached ?? false,
       approvalDetection: harness !== undefined && rulesFor(harness) !== undefined,
-      searchText: searchTextOf(harness, r.managed?.cwd, r.managed?.label, r.managed?.note, r.managed?.task),
+      // The harness's own name is searchable too: it is the name the person reading this screen may
+      // well be the only one they remember, having typed it inside the session.
+      searchText: searchTextOf(
+        harness, r.managed?.cwd, r.managed?.label, ownName, r.managed?.note, r.managed?.task,
+      ),
     }
   })
 
@@ -248,25 +323,31 @@ export function buildSessionViews(o: {
   const conversations = o.conversations ?? []
 
   const external: SessionView[] = o.processes.filter(p => !covered(p)).map(p => {
-    // What this process appears to be driving. Offered, never acted on: the confirmation names the
-    // conversation's own title, which is what lets the person judge whether it is the right one.
+    // What the harness says about ITSELF, keyed on the pid `/proc` reported. Exact where every other
+    // reading of an external process is an inference from its directory.
+    const own = p.pid !== undefined ? o.harnessSessions?.byPid.get(p.pid) : undefined
+    const ownName = chosenName(own)
+    // What this process appears to be driving. The harness's own `sessionId` outranks the argv one
+    // and the directory guess alike: it is what the process is writing to, said by the process.
     const conv = conversationForProcess(conversations, {
       harness: p.harness,
       cwd: p.cwd,
-      ...(p.sessionId ? { namedId: p.sessionId } : {}),
+      ...(own?.sessionId ?? p.sessionId ? { namedId: own?.sessionId ?? p.sessionId! } : {}),
     })
     return {
       id: externalId(p),
       harness: p.harness,
       cwd: p.cwd,
       status: 'external' as const,
+      ...(ownName ? { harnessName: ownName } : {}),
+      ...(ownName && own?.nameSince !== undefined ? { harnessNameSince: own.nameSince } : {}),
       ...(p.startedMs !== undefined ? { createdMs: p.startedMs } : {}),
       attached: false,
       approvalDetection: false,
       ...(conv?.resumable ? { resume: { sessionId: conv.sessionId, title: conv.title } } : {}),
       ...(conv?.tokens !== undefined ? { tokens: conv.tokens } : {}),
       ...(conv?.costUSD !== undefined ? { costUSD: conv.costUSD } : {}),
-      searchText: searchTextOf(p.harness, p.cwd, conv?.title, conv?.firstPrompt),
+      searchText: searchTextOf(p.harness, p.cwd, ownName, conv?.title, conv?.firstPrompt),
     }
   })
 

--- a/packages/server/server/sessions/sessions-host.test.ts
+++ b/packages/server/server/sessions/sessions-host.test.ts
@@ -34,6 +34,8 @@ function fakeBackend(o: {
     async kill() { return true },
     attachCommand(id) { return ['tmux', 'attach', id] },
     async detachHint() { return 'Ctrl-b then d' },
+    async sendText() { return true },
+    async sendKey() { return true },
   }
 }
 
@@ -42,11 +44,15 @@ const poller = (o: {
   registry?: ManagedSession[]
   processes?: HarnessProcess[]
   now?: () => number
+  touchSessions?: (ids: readonly string[], atMs: number) => Promise<unknown>
+  heartbeatMs?: number
 }) => createSessionsPoller({
   backend: o.backend,
   readRegistry: async () => o.registry ?? [],
   scanProcesses: async () => ({ procs: o.processes ?? [] }),
   now: o.now ?? (() => NOW),
+  ...(o.touchSessions ? { touchSessions: o.touchSessions } : {}),
+  ...(o.heartbeatMs !== undefined ? { heartbeatMs: o.heartbeatMs } : {}),
 })
 
 describe('createSessionsPoller', () => {
@@ -157,5 +163,134 @@ describe('createSessionsPoller', () => {
     expect(snap.sessions).toHaveLength(1)
     expect(snap.sessions[0]!.status).toBe('external')
     expect(snap.attention).toBe(0)
+  })
+})
+
+describe('the heartbeat', () => {
+  it('stamps every ALIVE session on the first poll, so a fleet already up is on record', () => {
+    // `-Infinity` as the initial mark is what makes this true. A control center opened onto a fleet
+    // that was already running would otherwise carry no evidence of life until a minute in, and
+    // would sit out a fall that happened in that minute.
+    const calls: Array<{ ids: readonly string[]; atMs: number }> = []
+    const p = poller({
+      backend: fakeBackend({
+        sessions: [backendSession('a'), backendSession('dead', { alive: false })],
+      }),
+      registry: [managed('a'), managed('dead')],
+      touchSessions: async (ids, atMs) => { calls.push({ ids, atMs }) },
+    })
+    return p.poll().then(() => {
+      expect(calls).toHaveLength(1)
+      // A dead pane is not alive. Stamping it would put a session that ended on its own into the
+      // same cluster as the ones a reboot took.
+      expect(calls[0]!.ids).toEqual(['a'])
+      expect(calls[0]!.atMs).toBe(NOW)
+    })
+  })
+
+  it('does not write on every poll — the poll runs every five seconds', async () => {
+    let n = 0
+    let clock = NOW
+    const p = poller({
+      backend: fakeBackend({ sessions: [backendSession('a')] }),
+      registry: [managed('a')],
+      touchSessions: async () => { n++ },
+      now: () => clock,
+      heartbeatMs: 60_000,
+    })
+    await p.poll()
+    expect(n).toBe(1)
+    clock += 5_000
+    await p.poll()
+    clock += 5_000
+    await p.poll()
+    expect(n).toBe(1)
+    clock += 60_000
+    await p.poll()
+    expect(n).toBe(2)
+  })
+
+  it('keeps polling when the registry cannot be written', async () => {
+    // A registry that cannot be written costs the crash group, not the fleet on screen.
+    const p = poller({
+      backend: fakeBackend({ sessions: [backendSession('a')], frames: { a: ['x'] } }),
+      registry: [managed('a')],
+      touchSessions: async () => { throw new Error('read-only filesystem') },
+    })
+    const snap = await p.poll()
+    expect(snap.unavailable).toBeUndefined()
+    expect(snap.sessions).toHaveLength(1)
+  })
+})
+
+describe('the sessions that fell together', () => {
+  it('marks the rows and reports the group when the backend has lost them', async () => {
+    const p = poller({
+      backend: fakeBackend({ sessions: [] }),
+      registry: [
+        managed('a', { lastSeenMs: NOW - 10_000 }),
+        managed('b', { lastSeenMs: NOW - 10_000 }),
+      ],
+    })
+    const snap = await p.poll()
+    expect(snap.fell?.entries.map(e => e.id)).toEqual(['a', 'b'])
+    expect(snap.sessions.every(v => v.fell === true)).toBe(true)
+  })
+
+  it('says nothing when there is nothing to say', async () => {
+    const p = poller({
+      backend: fakeBackend({ sessions: [backendSession('a')], frames: { a: ['x'] } }),
+      registry: [managed('a', { lastSeenMs: NOW })],
+    })
+    const snap = await p.poll()
+    expect(snap.fell).toBeUndefined()
+    expect(snap.sessions[0]!.fell).toBeUndefined()
+  })
+
+  it('keeps the group when a poll fails, alongside the sessions it describes', async () => {
+    let fail = false
+    const backend = fakeBackend({ sessions: [] })
+    const broken: SessionBackend = {
+      ...backend,
+      async list() {
+        if (fail) throw new Error('boom')
+        return []
+      },
+    }
+    const p = poller({ backend: broken, registry: [managed('a', { lastSeenMs: NOW })] })
+    await p.poll()
+    fail = true
+    const snap = await p.poll()
+    expect(snap.fell?.entries.map(e => e.id)).toEqual(['a'])
+    expect(snap.unavailable).toContain('boom')
+  })
+})
+
+describe('the dialog a blocked session is showing', () => {
+  const DIALOG = [
+    '● running the migration',
+    '│ Do you want to proceed?  │',
+    '│ ❯ 1. Yes                 │',
+    '│ Enter to confirm · Esc to cancel │',
+  ]
+
+  it('carries the bottom of the screen, verbatim, only while it is asking', async () => {
+    const p = poller({
+      backend: fakeBackend({ sessions: [backendSession('a')], frames: { a: DIALOG } }),
+      registry: [managed('a')],
+    })
+    const snap = await p.poll()
+    expect(snap.sessions[0]!.activity).toBe('waiting-approval')
+    // The options and the highlight, which nothing else on the screen carries: `lastLines` cuts at
+    // the last rule and would hand back the conversation above the dialog.
+    expect(snap.sessions[0]!.approvalLines?.join('\n')).toContain('❯ 1. Yes')
+  })
+
+  it('carries nothing on a session that is not blocked', async () => {
+    const p = poller({
+      backend: fakeBackend({ sessions: [backendSession('a')], frames: { a: ['❯ '] } }),
+      registry: [managed('a')],
+    })
+    expect((await p.poll()).sessions[0]!.approvalLines).toBeUndefined()
   })
 })

--- a/packages/server/server/sessions/sessions-host.ts
+++ b/packages/server/server/sessions/sessions-host.ts
@@ -14,8 +14,10 @@
 import { createLimiter } from '../utils'
 import type { HarnessProcess } from '../live-sessions'
 import { rulesFor } from './attention-rules'
-import { attentionOf, digestFrame, frameTail } from './attention'
+import { approvalTail, attentionOf, digestFrame, frameTail } from './attention'
 import { loadConversations, type Conversation } from './conversations'
+import { HEARTBEAT_MS, planCrashGroup, type CrashGroup } from './crash-group'
+import { emptyHarnessSessionIndex, type HarnessSessionIndex } from './harness-sessions'
 import { reconcileSessions } from './session-ref'
 import {
   attentionCount, bellTransitions, buildSessionViews, type SessionView,
@@ -38,6 +40,15 @@ const CAPTURE_CONCURRENCY = 4
  *  with; the pane cuts from the bottom to whatever it can actually draw. */
 const TAIL_LINES = 8
 
+/**
+ * How much of a blocked session's screen to carry as the dialog.
+ *
+ * Ten lines holds a permission prompt with three options, its question and its footer — measured
+ * against the frames `attention-rules.ts` was probed from. More would start carrying the
+ * conversation above the dialog into a pane whose whole job is to show only what is being answered.
+ */
+const APPROVAL_LINES = 10
+
 export interface SessionSnapshot {
   sessions: SessionView[]
   /** How many are waiting on a person. Drives the header counter. */
@@ -45,6 +56,13 @@ export interface SessionSnapshot {
   /** Ids that JUST started waiting — the caller rings the bell for these. */
   rang: string[]
   polledAtMs: number
+  /**
+   * The sessions the machine took all at once, when there are any — see `crash-group.ts`.
+   *
+   * On the snapshot rather than derived from `sessions`, because it is a statement about a SET: a row
+   * is in it because of when every other row was last alive, which no per-row rule can answer.
+   */
+  fell?: CrashGroup
   /**
    * Why this list may not be the whole truth, already a sentence.
    *
@@ -68,11 +86,39 @@ export function createSessionsPoller(o: {
    * exercise the poller's real logic must not need one.
    */
   loadConversations?: () => Promise<Conversation[]>
+  /**
+   * What each harness records about its OWN live sessions — the name typed inside a session, and
+   * the conversation it is driving, both keyed EXACTLY. Injected and optional, like
+   * `loadConversations`: it is a filesystem read, and a harness with no such file simply has none.
+   */
+  loadHarnessSessions?: () => Promise<HarnessSessionIndex>
+  /**
+   * Stamp `lastSeenMs` on the sessions that are alive right now — the HEARTBEAT.
+   *
+   * Injected and optional for the same reason `loadConversations` is: it writes to disk, and the
+   * tests that exercise the poller's real logic must not need a filesystem. It is what makes "these
+   * fell together" answerable at all — see `crash-group.ts`.
+   */
+  touchSessions?: (ids: readonly string[], atMs: number) => Promise<unknown>
+  /**
+   * Record the conversation a managed row is EXACTLY known to be driving.
+   *
+   * Called only when the harness's own record says so and the registry does not already agree, so it
+   * writes once per session rather than once per poll. It is what carries the exact id past the
+   * session's own lifetime: the harness deletes its file when the process goes, and a `lost` row
+   * with nothing recorded falls back to the harness-and-directory guess that cannot tell two
+   * sessions of one repository apart — the guess that once reopened three rows onto one
+   * conversation.
+   */
+  recordConversation?: (id: string, conversationId: string) => Promise<unknown>
   now?: () => number
   captureLines?: number
+  /** Overridable so a test can drive several heartbeats without waiting a minute for each. */
+  heartbeatMs?: number
 }): SessionsPoller {
   const now = o.now ?? (() => Date.now())
   const lines = o.captureLines ?? CAPTURE_LINES
+  const heartbeatMs = o.heartbeatMs ?? HEARTBEAT_MS
   const limit = createLimiter(CAPTURE_CONCURRENCY)
 
   // Carried between polls: what each session's screen looked like, and what state it was in. The
@@ -80,6 +126,15 @@ export function createSessionsPoller(o: {
   let prevDigest = new Map<string, string>()
   let prevActivity = new Map<string, SessionActivity>()
   let last: SessionSnapshot | null = null
+  /**
+   * When the heartbeat last wrote. `-Infinity` so the FIRST poll always stamps.
+   *
+   * Stamping immediately matters: a machine that comes up, has three sessions reopened into it and
+   * then falls again inside the first minute would otherwise have three rows carrying only their
+   * creation stamps — which is fine — but a fleet that was already running when this process started
+   * would carry nothing at all, and would sit out the next crash entirely.
+   */
+  let lastHeartbeatMs = -Infinity
 
   async function poll(): Promise<SessionSnapshot> {
     const nowMs = now()
@@ -95,13 +150,18 @@ export function createSessionsPoller(o: {
     }
 
     try {
-      const [registry, backendSessions, processes, conversations] = await Promise.all([
+      const [registry, backendSessions, processes, conversations, harnessSessions] = await Promise.all([
         o.readRegistry(),
         o.backend.list(),
         o.scanProcesses().then(r => r.procs).catch(() => [] as HarnessProcess[]),
         // History is an enrichment, never a prerequisite: a store that cannot be read costs the
         // closed rows, not the running ones.
         o.loadConversations ? o.loadConversations().catch(() => [] as Conversation[]) : Promise.resolve([]),
+        // Same rule: unreadable costs the harness's own names and its exact conversation ids, and
+        // every row falls back to behaving exactly as it did before this existed.
+        o.loadHarnessSessions
+          ? o.loadHarnessSessions().catch(() => emptyHarnessSessionIndex())
+          : Promise.resolve(emptyHarnessSessionIndex()),
       ])
 
       const reconciled = reconcileSessions(registry, backendSessions)
@@ -110,6 +170,7 @@ export function createSessionsPoller(o: {
       const nextDigest = new Map<string, string>()
       const activity = new Map<string, SessionActivity>()
       const tails = new Map<string, string[]>()
+      const approvals = new Map<string, string[]>()
 
       await Promise.all(reconciled.map(r => limit(async () => {
         const b = r.backend
@@ -124,7 +185,7 @@ export function createSessionsPoller(o: {
         const harness = harnessOf.get(r.id)
         const rules = harness ? rulesFor(harness) : undefined
         const before = prevDigest.get(r.id)
-        activity.set(r.id, attentionOf({
+        const state = attentionOf({
           alive: true,
           lastActivityMs: b.lastActivityMs,
           nowMs,
@@ -132,10 +193,48 @@ export function createSessionsPoller(o: {
           frameDigest,
           ...(before !== undefined ? { prevDigest: before } : {}),
           ...(rules ? { rules } : {}),
-        }))
+        })
+        activity.set(r.id, state)
+        // The dialog is kept from the frame that DECIDED the state, so the two can never describe
+        // different moments — and it costs nothing extra, the frame is already here.
+        if (state === 'waiting-approval') approvals.set(r.id, approvalTail(frame, APPROVAL_LINES))
       })))
 
-      const sessions = buildSessionViews({ reconciled, activity, tails, processes, conversations })
+      // The heartbeat: one write, one timestamp, every session the backend reports as ALIVE. See
+      // `crash-group.ts` for why one shared timestamp is what makes the grouping exact.
+      const aliveIds = backendSessions.filter(b => b.alive).map(b => b.id)
+      if (o.touchSessions && nowMs - lastHeartbeatMs >= heartbeatMs) {
+        lastHeartbeatMs = nowMs
+        // Best effort, and never awaited into the poll's own failure path: a registry that cannot be
+        // written costs the crash group, not the fleet on screen.
+        await o.touchSessions(aliveIds, nowMs).catch(() => undefined)
+      }
+
+      // The exact conversation, written down while there is still a harness to ask. Only where it
+      // would CHANGE the registry, so this is one write per session and not one per poll.
+      if (o.recordConversation) {
+        for (const m of registry) {
+          const exact = harnessSessions.byManagedId.get(m.id)?.sessionId
+          if (!exact || m.conversationId === exact) continue
+          await o.recordConversation(m.id, exact).catch(() => undefined)
+        }
+      }
+
+      // Decided against the BACKEND's own list rather than the reconciled statuses, because that is
+      // the question: a row the backend has never heard of is one the machine took.
+      const backendIds = new Set(backendSessions.map(b => b.id))
+      const fell = planCrashGroup({ entries: registry, backendIds })
+
+      const sessions = buildSessionViews({
+        reconciled,
+        activity,
+        tails,
+        approvals,
+        processes,
+        conversations,
+        harnessSessions,
+        ...(fell ? { fell: new Set(fell.entries.map(e => e.id)) } : {}),
+      })
       const rang = bellTransitions(prevActivity, sessions)
 
       prevDigest = nextDigest
@@ -147,6 +246,7 @@ export function createSessionsPoller(o: {
 
       const snap: SessionSnapshot = {
         sessions, attention: attentionCount(sessions), rang, polledAtMs: nowMs,
+        ...(fell ? { fell } : {}),
       }
       last = snap
       return snap
@@ -159,6 +259,10 @@ export function createSessionsPoller(o: {
         attention: last?.attention ?? 0,
         rang: [],
         polledAtMs: nowMs,
+        // Carried with the rest of the previous answer: the crash group is a fact about the same
+        // sessions this snapshot is still showing, and dropping it would make the offer to reopen
+        // them blink out on exactly the tick that already told the user something went wrong.
+        ...(last?.fell ? { fell: last.fell } : {}),
         unavailable: `could not refresh sessions: ${message}`,
       }
     }

--- a/packages/server/server/sessions/tmux-cli.test.ts
+++ b/packages/server/server/sessions/tmux-cli.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from 'bun:test'
 import {
   LIST_FORMAT, attachArgs, capturePaneArgs, idFromTmuxName, isSessionGoneError, killSessionArgs,
-  newSessionArgs, parsePrefix, parseTmuxList, sendKeysEnterArgs, sendKeysLiteralArgs, trimCapture,
+  newSessionArgs, parsePrefix, parseTmuxList, sendKeysEnterArgs, sendKeysLiteralArgs,
+  sendKeysNamedArgs, trimCapture,
   tmuxName,
   serverOptionsArgs, HISTORY_LIMIT,
 } from './tmux-cli'
@@ -34,6 +35,19 @@ describe('the other argv builders', () => {
     expect(sendKeysLiteralArgs('a1', 'hello there')).toEqual(['-L', 'agentop', 'send-keys', '-t', 'agentop-a1', '-l', 'hello there'])
     expect(sendKeysEnterArgs('a1')).toEqual(['-L', 'agentop', 'send-keys', '-t', 'agentop-a1', 'Enter'])
     expect(attachArgs('a1')).toEqual(['tmux', '-L', 'agentop', 'attach-session', '-t', 'agentop-a1'])
+  })
+
+  it('sends a NAMED key without -l, which is the opposite of sending text', () => {
+    // Getting these two the wrong way round fails silently: `send-keys -l Enter` types the five
+    // characters `E n t e r` into the assistant's prompt and reports success.
+    expect(sendKeysNamedArgs('a1', 'Enter')).toEqual(['-L', 'agentop', 'send-keys', '-t', 'agentop-a1', 'Enter'])
+    expect(sendKeysNamedArgs('a1', 'Escape')).toEqual(['-L', 'agentop', 'send-keys', '-t', 'agentop-a1', 'Escape'])
+    expect(sendKeysNamedArgs('a1', 'Enter')).not.toContain('-l')
+    expect(sendKeysLiteralArgs('a1', 'Enter')).toContain('-l')
+  })
+
+  it('builds the Enter argv through the named one, so there is a single answer', () => {
+    expect(sendKeysEnterArgs('a1')).toEqual(sendKeysNamedArgs('a1', 'Enter'))
   })
 })
 

--- a/packages/server/server/sessions/tmux-cli.ts
+++ b/packages/server/server/sessions/tmux-cli.ts
@@ -50,8 +50,20 @@ export function sendKeysLiteralArgs(id: string, text: string): string[] {
   return sock(['send-keys', '-t', tmuxName(id), '-l', text])
 }
 
+/**
+ * One NAMED key — `Enter`, `Escape`, `Down` — which is the opposite of `-l` above.
+ *
+ * Without `-l` tmux interprets the argument as a key name, and that is the whole point here: the
+ * approval keystroke is a key, not text. It is a separate builder rather than a flag on the literal
+ * one because getting the two the wrong way round fails SILENTLY — `send-keys -l Enter` types the
+ * five characters `E n t e r` into the assistant's prompt and reports success.
+ */
+export function sendKeysNamedArgs(id: string, key: string): string[] {
+  return sock(['send-keys', '-t', tmuxName(id), key])
+}
+
 export function sendKeysEnterArgs(id: string): string[] {
-  return sock(['send-keys', '-t', tmuxName(id), 'Enter'])
+  return sendKeysNamedArgs(id, 'Enter')
 }
 
 export function listSessionsArgs(): string[] {

--- a/packages/server/server/sessions/types.ts
+++ b/packages/server/server/sessions/types.ts
@@ -111,6 +111,16 @@ export interface ManagedSession {
   model?: string
   effort?: string
   label?: string
+  /**
+   * When the label was written, epoch ms — so a name typed HERE can be compared with one typed
+   * inside the session.
+   *
+   * A harness records its own name too (`/rename` in Claude Code), and the two can disagree. The
+   * only non-arbitrary way to settle that is recency, which needs both sides to say WHEN — this is
+   * our side. Absent on a row renamed before agentop recorded it, which `pickTitle` handles rather
+   * than treating as "long ago". See `harness-session-file.ts`.
+   */
+  labelSince?: number
   note?: string
   /**
    * The piece of work this session belongs to.
@@ -120,6 +130,20 @@ export interface ManagedSession {
    * carrying the same task are that task's sessions, and can be reopened together.
    */
   task?: string
+  /**
+   * The last time this session was OBSERVED ALIVE, epoch ms — stamped at creation, then refreshed by
+   * the poller's heartbeat for every session the backend reports as running.
+   *
+   * It exists so that "these fell together" can be answered at all. A machine that reboots takes the
+   * backend with it, so nothing about a `lost` row says whether it was open at the time: `createdAt`
+   * is equally true of a session abandoned three weeks ago, and `BackendSession.lastActivityMs` only
+   * exists for a session the backend still has. See `crash-group.ts`.
+   *
+   * Absent on a row written by a build that predates it, and on one this process has never seen
+   * alive. Absent is never guessed at — it simply keeps the row out of a crash group until the next
+   * heartbeat stamps it.
+   */
+  lastSeenMs?: number
   /**
    * When this session was FINISHED, ISO — set instead of deleting the entry.
    *
@@ -184,6 +208,25 @@ export interface SessionBackend {
   list(): Promise<BackendSession[]>
   /** Newest-last lines of the last rendered frame, trailing blanks removed. */
   capture(id: string, lines: number): Promise<string[]>
+  /**
+   * Type `text` into the session and submit it — what a person does at the keyboard.
+   *
+   * A capability of its own rather than something only `spawn` may do. It was already implemented
+   * (kimi and copilot have no interactive prompt flag, so their opening line is TYPED IN), but it was
+   * buried inside the spawn path, so the one thing the backend could do that nothing else could ask
+   * for was talking to a session that already exists.
+   *
+   * `false` when the backend could not deliver it. Never a throw: a session that ended between the
+   * poll and the keystroke is an ordinary outcome, not an error to crash a caller with.
+   */
+  sendText(id: string, text: string): Promise<boolean>
+  /**
+   * Press ONE named key — the backend's own vocabulary (`Enter`, `Escape`).
+   *
+   * Separate from `sendText` because the two are opposites and confusing them fails silently: sent
+   * as text, `Enter` is five characters typed into the assistant's prompt.
+   */
+  sendKey(id: string, key: string): Promise<boolean>
   /**
    * Kill the session and report whether it is confirmed GONE afterwards. "Already gone" (the
    * session finished or was removed between `list` and this call) counts as success — the caller

--- a/packages/tui/scripts/preview.tsx
+++ b/packages/tui/scripts/preview.tsx
@@ -364,6 +364,12 @@ function fakeHost(opts: Options): ControlHost {
     spawnSession: async () => (opts.failSpawn
       ? { ok: false, message: 'tmux recusou: sessão duplicada' }
       : { ok: true, message: 'preview — nothing was performed' }),
+    // Present so the three verbs that write into a session are reachable here at all. They perform
+    // nothing: the questions are what a layout check needs to see, and the preview must never send
+    // a keystroke anywhere.
+    promptSession: done,
+    approveSession: done,
+    reopenFell: done,
   }
 }
 
@@ -389,21 +395,62 @@ const FAKE_FLEET: ControlSessions = {
   rang: [],
   detachHint: 'Ctrl-b then d',
   finishedTasks: ['billing'],
+  // A fall on record, so the summary row's note, the "fell together" section and the reopen
+  // confirmation are all reachable here. Reach the rows with `--keys l` (the default view is only
+  // what is running, and a session that fell is by definition not).
+  fell: { count: 2, atMs: Date.now() - 6 * MINUTES },
   sessions: withSearchText([
     {
       id: 'a1b2c3', title: 'migrate the auth store', harness: 'claude',
-      cwd: '/home/dev/agentistics', project: 'agentistics', model: 'opus', task: 'billing',
+      cwd: '/home/dev/agentistics', project: 'agentistics', model: 'opus', task: 'auth store',
       repo: 'blpsoares/agentistics',
+      // NOT under `billing`, deliberately: that task is finished in this fixture, so a row filed
+      // under it is hidden by default — and the one row this preview exists to reach is the blocked
+      // one. `f00d01` carries `billing` instead, which keeps the finished-task case covered.
       state: 'waiting-approval', stateLabel: 'needs approval', actionable: true,
       // Usage on SOME rows and not others, deliberately: the column is sized to the widest row that
       // has any, and a fixture where every row carries one would never exercise the padding.
       tokens: '51.7k', cost: '$1.24',
       lastLines: ['applying migration 003_auth_store.sql', 'waiting for your approval'],
+      // The dialog, at the width a real one is drawn at — which is the point: the confirmation has
+      // to fit it into a pane that is often much narrower, and a fixture of short lines would never
+      // show that.
+      canApprove: true,
+      approvalLines: [
+        '│ Bash command                                                    │',
+        '│   bun run db:migrate --env production                           │',
+        '│                                                                 │',
+        '│ Do you want to proceed?                                         │',
+        '│ ❯ 1. Yes                                                        │',
+        '│   2. No, and tell Claude what to do differently                 │',
+        '│ Enter to confirm · Esc to cancel                                │',
+      ],
       startedAt: Date.now() - 22 * 60_000, attached: false,
+    },
+    // The two the machine took together. `lost`, named, and carrying their task — which is what a
+    // reboot leaves behind and what "reopen what fell" puts back.
+    {
+      id: 'f00d01', title: 'ledger reconciliation', harness: 'claude',
+      cwd: '/home/dev/agentistics', project: 'agentistics', repo: 'blpsoares/agentistics',
+      task: 'billing', named: true, fell: true,
+      state: 'lost', stateLabel: 'lost', actionable: true,
+      resume: { sessionId: 'r1', title: 'ledger reconciliation' },
+      startedAt: Date.now() - 3 * 60 * 60_000, attached: false,
+    },
+    {
+      id: 'f00d02', title: 'invoice export', harness: 'codex',
+      cwd: '/home/dev/prontuario', project: 'prontuario', repo: 'org/prontuario',
+      named: true, fell: true,
+      state: 'lost', stateLabel: 'lost', actionable: true,
+      resume: { sessionId: 'r2', title: 'invoice export' },
+      startedAt: Date.now() - 3 * 60 * 60_000, attached: false,
     },
     {
       id: 'd4e5f6', title: 'flaky test hunt', harness: 'codex',
       cwd: '/home/dev/prontuario', project: 'prontuario', task: 'flaky triage', repo: 'org/prontuario',
+      // Named in BOTH places, so the detail pane's "the other name" row is on screen: the title is
+      // the one typed inside the session, and `named here` states the agentop label that lost.
+      titleSource: 'harness', titleOther: 'flaky-triage',
       note: 'reproduces only on CI', state: 'waiting', stateLabel: 'waiting',
       actionable: true, approvalBlind: 'agentop has no verified screen markers for codex, so a blocking question here shows as "waiting" like any other pause.',
       startedAt: Date.now() - 3 * 60_000, attached: false,

--- a/packages/tui/src/control/i18n.ts
+++ b/packages/tui/src/control/i18n.ts
@@ -215,6 +215,9 @@ export interface ControlStrings {
   sessionsDoing: string
   sessionsTask: string
   sessionsMetrics: string
+  /** The name that did NOT win, when a session is named in agentop AND inside the harness. */
+  sessionsAlsoLabel: string
+  sessionsAlsoHarness: string
   /** Label of the detail line stating how to LEAVE an attached session. */
   sessionsDetach: string
   /** Marks a finished task's heading, and the word the toggle uses. */
@@ -231,9 +234,32 @@ export interface ControlStrings {
     note: string; task: string; mark: string; onlyActive: string; closed: string
     exited: string; unfiled: string; group: string; detail: string; reset: string
     tabs: string; help: string; quit: string
+    approve: string; prompt: string; reopenFell: string
   }
-  sessionsFinishConfirm: (task: string, count: number) => string
+  /**
+   * The finish-task confirmation.
+   *
+   * It states what finishing a task ACTUALLY does, which is hide its sessions behind a switch —
+   * nothing is stopped and nothing is deleted, and `running` is called out separately because a
+   * warning that implied otherwise would be worse than no warning at all. See `finishTask` in
+   * `cli-start.ts`.
+   */
+  sessionsFinishConfirm: (task: string, count: number, running: number) => string
   sessionsReopenConfirm: (task: string) => string
+  /** The heading over the sessions the machine took at once. */
+  sessionsFellWord: string
+  /** Said on the summary row and in the empty state: N fell, this long ago, and the key. */
+  sessionsFellNote: (count: number, ago: string) => string
+  /** The confirmation, naming how many and when. */
+  sessionsFellConfirm: (count: number, ago: string) => string
+  /** The prompt field, and the sentence above it saying where the text is going. */
+  sessionsPromptLabel: (title: string) => string
+  sessionsPromptHint: string
+  /** The approval confirmation — and its caveat, which is the whole design. */
+  sessionsApproveConfirm: (title: string) => string
+  sessionsApproveCaveat: string
+  /** Heading over the dialog lines carried into the confirmation. */
+  sessionsApproveWhat: string
   asideProjects: string
   asideAllProjects: string
   toggleDone: string
@@ -279,6 +305,8 @@ export interface ControlStrings {
   keySessionsNew: string
   keySessionsSearch: string
   keySessionsActions: string
+  keySessionsApprove: string
+  keySessionsPrompt: string
   /** The visible action row — the same verbs the letters run, spelled out and clickable. */
   actSessions: {
     attach: string
@@ -286,8 +314,11 @@ export interface ControlStrings {
     rename: string
     note: string
     task: string
+    approve: string
+    prompt: string
     kill: string
     openTask: string
+    reopenFell: string
     finishTask: string
     newSession: string
     search: string
@@ -378,6 +409,10 @@ export interface ControlStrings {
   sessionsKillConfirm: (title: string) => string
   /** Said when a verb is pressed on a row that cannot take it. */
   sessionsNotActionable: string
+  /** Said when the approve key is pressed on a session that is not blocked on anything. */
+  sessionsNotAsking: string
+  /** Said when "reopen what fell" is pressed and nothing did. */
+  sessionsNoFell: string
 
   /** Static tabs. */
   helpIntro: string
@@ -554,6 +589,8 @@ const EN: ControlStrings = {
   sessionsDoing: 'saying',
   sessionsTask: 'task',
   sessionsMetrics: 'usage',
+  sessionsAlsoLabel: 'named here',
+  sessionsAlsoHarness: 'named inside',
   sessionsDetach: 'to detach',
   sessionsDoneWord: 'finished',
   sessionsPaneMenu: 'menu',
@@ -584,10 +621,33 @@ const EN: ControlStrings = {
     tabs: 'change screen',
     help: 'this list',
     quit: 'leave agentop',
+    approve: 'answer the question this session is blocked on',
+    prompt: 'send it a line without attaching',
+    reopenFell: 'reopen everything the machine took at once',
   },
-  sessionsFinishConfirm: (task, count) =>
-    `Mark "${task}" finished? Its ${count} session${count === 1 ? '' : 's'} stay listed behind the "finished tasks" switch.`,
+  // Says what finishing ACTUALLY does. It marks the task and hides its sessions behind a switch —
+  // it stops nothing — so the sentence names the count, calls out the ones still running, and names
+  // the switch that brings them back.
+  sessionsFinishConfirm: (task, count, running) =>
+    `Mark "${task}" finished? Its ${count} session${count === 1 ? '' : 's'}`
+    + `${running > 0 ? ` (${running} still running)` : ''}`
+    + (count === 1
+      ? ' is NOT stopped — it keeps running and stays'
+      : ' are NOT stopped — they keep running and stay')
+    + ' listed behind the "finished tasks" switch.',
   sessionsReopenConfirm: task => `Reopen "${task}"?`,
+  sessionsFellWord: 'fell together',
+  sessionsFellNote: (count, ago) =>
+    `${count} session${count === 1 ? '' : 's'} fell ${ago} — R reopens them`,
+  sessionsFellConfirm: (count, ago) =>
+    `Reopen the ${count} session${count === 1 ? '' : 's'} that fell ${ago}? `
+    + 'Each comes back as a new session resuming its own conversation; anything still running is left alone.',
+  sessionsPromptLabel: (title: string) => `Send to "${title}"`,
+  sessionsPromptHint: 'typed straight into the session — it reads it when it gets there',
+  sessionsApproveConfirm: (title: string) => `Send the confirm key to "${title}"?`,
+  sessionsApproveCaveat:
+    'it takes whichever option the dialog above has highlighted — read it first.',
+  sessionsApproveWhat: 'on its screen right now',
   asideProjects: 'PROJECTS',
   asideAllProjects: 'every project',
   toggleDone: 'finished tasks',
@@ -635,14 +695,21 @@ const EN: ControlStrings = {
   keySessionsNew: 'a new',
   keySessionsSearch: '/ search',
   keySessionsActions: 'tab actions',
+  keySessionsApprove: 'y approve',
+  keySessionsPrompt: 'p send',
   actSessions: {
     attach: 'Attach',
     resume: 'Reopen',
+    // "Answer" rather than "Approve": the key takes whichever option is highlighted, and the verb
+    // must not promise more than the keystroke can deliver.
+    approve: 'Answer its question',
+    prompt: 'Send a prompt',
     rename: 'Rename',
     note: 'Note',
     task: 'Task',
     kill: 'Stop session',
     openTask: 'Open whole task',
+    reopenFell: 'Reopen what fell',
     finishTask: 'Finish task',
     newSession: 'New session',
     search: 'Search',
@@ -723,6 +790,8 @@ const EN: ControlStrings = {
   sessionsNotePrompt: 'Describe this session',
   sessionsKillConfirm: (title: string) => `Stop "${title}"? The assistant running in it is ended.`,
   sessionsNotActionable: 'that session was not started by agentop, so it cannot be driven from here.',
+  sessionsNotAsking: 'that session is not blocked on a question — there is nothing to answer.',
+  sessionsNoFell: 'nothing fell — no session was lost with the machine still on record.',
 
   helpIntro: 'Every command, with the flags that matter. `agentop --help` prints this plain.',
   cheatIntro: 'The commands worth remembering.',
@@ -894,6 +963,8 @@ const PT: ControlStrings = {
   sessionsDoing: 'dizendo',
   sessionsTask: 'tarefa',
   sessionsMetrics: 'uso',
+  sessionsAlsoLabel: 'nome daqui',
+  sessionsAlsoHarness: 'nome de dentro',
   sessionsDetach: 'para sair',
   sessionsDoneWord: 'finalizada',
   sessionsPaneMenu: 'menu',
@@ -924,10 +995,32 @@ const PT: ControlStrings = {
     tabs: 'muda de tela',
     help: 'esta lista',
     quit: 'sai do agentop',
+    approve: 'responde a pergunta que travou a sessão',
+    prompt: 'envia uma linha para ela sem anexar',
+    reopenFell: 'reabre tudo que a máquina levou de uma vez',
   },
-  sessionsFinishConfirm: (task, count) =>
-    `Finalizar "${task}"? Suas ${count} sessõe${count === 1 ? '' : 's'} continuam listadas atrás do interruptor "tarefas finalizadas".`,
+  sessionsFinishConfirm: (task, count, running) =>
+    `Finalizar "${task}"? ${count === 1 ? 'A sessão dela' : `As ${count} sessões dela`}`
+    + `${running > 0 ? ` (${running} ainda rodando)` : ''}`
+    + (count === 1
+      ? ' NÃO é encerrada — continua rodando e fica listada'
+      : ' NÃO são encerradas — continuam rodando e ficam listadas')
+    + ' atrás do interruptor "tarefas finalizadas".',
   sessionsReopenConfirm: task => `Reabrir "${task}"?`,
+  sessionsFellWord: 'caíram juntas',
+  sessionsFellNote: (count, ago) =>
+    (count === 1 ? `1 sessão caiu ${ago} — R reabre` : `${count} sessões caíram ${ago} — R reabre todas`),
+  sessionsFellConfirm: (count, ago) =>
+    (count === 1
+      ? `Reabrir a sessão que caiu ${ago}? `
+      : `Reabrir as ${count} sessões que caíram ${ago}? `)
+    + 'Cada uma volta como uma sessão nova retomando a própria conversa; o que ainda estiver rodando fica como está.',
+  sessionsPromptLabel: (title: string) => `Enviar para "${title}"`,
+  sessionsPromptHint: 'digitado direto na sessão — ela lê quando chegar lá',
+  sessionsApproveConfirm: (title: string) => `Enviar a tecla de confirmação para "${title}"?`,
+  sessionsApproveCaveat:
+    'ela pega a opção que o diálogo acima está destacando — leia antes.',
+  sessionsApproveWhat: 'na tela dela agora',
   asideProjects: 'PROJETOS',
   asideAllProjects: 'todos os projetos',
   toggleDone: 'tarefas finalizadas',
@@ -975,14 +1068,21 @@ const PT: ControlStrings = {
   keySessionsNew: 'a nova',
   keySessionsSearch: '/ buscar',
   keySessionsActions: 'tab ações',
+  keySessionsApprove: 'y aprovar',
+  keySessionsPrompt: 'p enviar',
   actSessions: {
     attach: 'Anexar',
     resume: 'Reabrir',
+    // "Responder", não "Aprovar": a tecla pega a opção destacada, e o verbo não pode prometer mais
+    // do que a tecla entrega.
+    approve: 'Responder a pergunta',
+    prompt: 'Enviar prompt',
     rename: 'Renomear',
     note: 'Nota',
     task: 'Tarefa',
     kill: 'Encerrar sessão',
     openTask: 'Abrir tarefa toda',
+    reopenFell: 'Reabrir o que caiu',
     finishTask: 'Finalizar tarefa',
     newSession: 'Nova sessão',
     search: 'Buscar',
@@ -1063,6 +1163,8 @@ const PT: ControlStrings = {
   sessionsNotePrompt: 'Descreva esta sessão',
   sessionsKillConfirm: (title: string) => `Encerrar "${title}"? O assistente que roda nela é finalizado.`,
   sessionsNotActionable: 'essa sessão não foi iniciada pelo agentop, então não dá para controlá-la daqui.',
+  sessionsNotAsking: 'essa sessão não está travada em uma pergunta — não há o que responder.',
+  sessionsNoFell: 'nada caiu — nenhuma sessão foi perdida com registro de que estava viva.',
 
   helpIntro: 'Todos os comandos, com as flags que importam. `agentop --help` imprime isto puro.',
   cheatIntro: 'Os comandos que vale a pena lembrar.',

--- a/packages/tui/src/control/sessions.test.ts
+++ b/packages/tui/src/control/sessions.test.ts
@@ -10,6 +10,7 @@ import {
   cardGrid, cardPage, CARD_PAGE_MAX, CARD_MIN_WIDTH, CARD_GAP,
   cardBadges, cardLines, fitCardLines, cardStateCells,
   cardBand, cardAt, pagerCells, pagerHit,
+  askRows, fitApprovalPreview, APPROVAL_PREVIEW_MAX, QUESTION_ROWS,
   type CardLine, type SessionRow,
 } from './sessions'
 import type { ControlSession, SessionState } from './types'
@@ -207,6 +208,7 @@ describe('detailLines', () => {
   const labels = {
     where: 'where', model: 'model', note: 'note', started: 'started',
     external: 'started outside agentop', closed: 'not running', doing: 'saying', task: 'task', metrics: 'usage',
+    alsoLabel: 'named here', alsoHarness: 'named inside',
   }
   const ago = () => '5m ago'
 
@@ -238,7 +240,8 @@ describe('detailLines', () => {
 describe('sessionActions', () => {
   const words = {
     attach: 'Attach', resume: 'Reopen', rename: 'Rename', note: 'Note', task: 'Task',
-    kill: 'Stop', openTask: 'Open whole task', finishTask: 'Finish task',
+    kill: 'Stop', openTask: 'Open whole task', reopenFell: 'Reopen what fell',
+    finishTask: 'Finish task', approve: 'Answer', prompt: 'Send',
     new: 'New', search: 'Search', group: 'Group',
   }
   const of = (s?: ControlSession) => sessionActions(s).map(a => a.action)
@@ -306,6 +309,7 @@ describe('detailLines — the two non-actionable rows say different things', () 
     where: 'where', model: 'model', note: 'note', started: 'started',
     external: 'started outside agentop', closed: 'not running', doing: 'saying',
     task: 'task', metrics: 'usage',
+    alsoLabel: 'named here', alsoHarness: 'named inside',
   }
   const ago = () => '5m ago'
 
@@ -351,7 +355,7 @@ describe('summaryCells', () => {
 
   it('keeps everything when the row fits', () => {
     expect(summaryCells(full)).toEqual({
-      group: full.group, hiding: full.hiding, count: full.count, waiting: full.waiting,
+      group: full.group, hiding: full.hiding, count: full.count, waiting: full.waiting, fell: '',
     })
   })
 
@@ -523,7 +527,8 @@ describe('sessionsCockpit', () => {
 describe('asideRows', () => {
   const words = {
     attach: 'Attach', resume: 'Reopen', rename: 'Rename', note: 'Note', task: 'Task',
-    kill: 'Stop', openTask: 'Open whole task', finishTask: 'Finish task',
+    kill: 'Stop', openTask: 'Open whole task', reopenFell: 'Reopen what fell',
+    finishTask: 'Finish task', approve: 'Answer', prompt: 'Send',
     new: 'New', search: 'Search', group: 'Group',
   }
   const groupWords = { repo: 'repo', none: 'flat', task: 'tasks', harness: 'harness', model: 'model', project: 'project' }
@@ -1017,7 +1022,8 @@ describe('the only-active toggle', () => {
     actions: sessionActions(session('m')),
     actionWords: {
       attach: 'A', resume: 'R', rename: 'N', note: 'O', task: 'T', kill: 'K',
-      openTask: 'OT', finishTask: 'FT', new: 'NW', search: 'S', group: 'G',
+      openTask: 'OT', reopenFell: 'RF', finishTask: 'FT', approve: 'AP', prompt: 'PR',
+      new: 'NW', search: 'S', group: 'G',
     },
     grouping: 'project',
     groupWords: {
@@ -1225,7 +1231,8 @@ describe('sessionKeyHelp', () => {
   const words = Object.fromEntries(
     ['move', 'open', 'attach', 'menu', 'section', 'newSession', 'search', 'clear', 'kill',
       'rename', 'note', 'task', 'mark', 'onlyActive', 'closed', 'exited', 'unfiled', 'group',
-      'detail', 'reset', 'tabs', 'help', 'quit'].map(k => [k, `does ${k}`]),
+      'detail', 'reset', 'tabs', 'help', 'quit',
+      'approve', 'prompt', 'reopenFell'].map(k => [k, `does ${k}`]),
   ) as Parameters<typeof sessionKeyHelp>[0]
 
   it('describes every key it lists, with no blanks', () => {
@@ -1466,7 +1473,8 @@ describe('asideRows — the layout section', () => {
     actions: sessionActions(session('m')),
     actionWords: {
       attach: 'A', resume: 'R', rename: 'N', note: 'O', task: 'T', kill: 'K',
-      openTask: 'OT', finishTask: 'FT', new: 'NW', search: 'S', group: 'G',
+      openTask: 'OT', reopenFell: 'RF', finishTask: 'FT', approve: 'AP', prompt: 'PR',
+      new: 'NW', search: 'S', group: 'G',
     },
     grouping: 'project',
     groupWords: {
@@ -1501,5 +1509,230 @@ describe('asideRows — the layout section', () => {
     const rows = rowsFor('list')
     const index = rows.findIndex(r => r.kind === 'layout')
     expect(asideSelectable(rows)).toContain(index)
+  })
+})
+
+describe('the sessions that fell together', () => {
+  const fallen = (id: string) =>
+    session(id, { state: 'lost' as SessionState, stateLabel: 'lost', fell: true })
+  const history = (id: string) =>
+    session(id, { state: 'closed' as SessionState, stateLabel: 'closed' })
+  const live = (id: string) => session(id, { state: 'working' as SessionState, stateLabel: 'working' })
+
+  const headings = (rows: SessionRow[]) =>
+    rows.filter(r => r.kind === 'heading').map(r => (r as { label: string }).label)
+
+  it('is its own section, between what is running and what is history', () => {
+    const rows = sessionRows(
+      groupSessions([live('w'), fallen('f'), history('c')], 'none', UNKNOWN),
+      'closed', 'finished', 'fell together',
+    )
+    expect(headings(rows)).toEqual(['fell together', 'closed'])
+    // In reading order: the live rows, then what fell, then history.
+    const ids = rows.flatMap(r => (r.kind === 'session' ? [r.session.id] : []))
+    expect(ids).toEqual(['w', 'f', 'c'])
+  })
+
+  it('is NOT muted — it is the one block on this screen asking to be acted on', () => {
+    const rows = sessionRows(
+      groupSessions([fallen('f'), history('c')], 'none', UNKNOWN),
+      'closed', 'finished', 'fell together',
+    )
+    const fell = rows.find(r => r.kind === 'heading' && r.label === 'fell together')
+    const closed = rows.find(r => r.kind === 'heading' && r.label === 'closed')
+    expect((fell as { muted?: boolean }).muted).toBeUndefined()
+    expect((closed as { muted?: boolean }).muted).toBe(true)
+  })
+
+  it('leaves the rows exactly where they were when nothing fell', () => {
+    // The section is an addition to the reading order, never a change to which rows are listed. A
+    // machine with no fall on record must draw the same screen it drew before this existed.
+    const before = sessionRows(groupSessions([fallen('f')], 'none', UNKNOWN), 'closed', 'finished')
+    expect(headings(before)).toEqual(['closed'])
+  })
+
+  it('never claims a RUNNING row fell, whatever the flag says', () => {
+    // A row can be marked and then come back — a reopen leaves the flag on the retired row, not the
+    // new one, but a stale snapshot could still pair the two. Something running is not something
+    // lost, and the live section is decided before the mark is consulted.
+    const rows = sessionRows(
+      groupSessions([session('w', { state: 'working' as SessionState, stateLabel: 'working', fell: true })], 'none', UNKNOWN),
+      'closed', 'finished', 'fell together',
+    )
+    expect(headings(rows)).toEqual([])
+  })
+
+  it('says which group a fallen row belongs to, so a heading read alone is never ambiguous', () => {
+    const rows = sessionRows(
+      groupSessions([fallen('f')], 'project', UNKNOWN),
+      'closed', 'finished', 'fell together',
+    )
+    expect(headings(rows)).toEqual(['f · fell together'])
+  })
+})
+
+describe('sessionActions — the fleet verb', () => {
+  const of = (s: ControlSession | undefined, fleet?: { fell?: number }) =>
+    sessionActions(s, fleet).find(a => a.action === 'reopenFell')
+
+  it('is offered only when something actually fell', () => {
+    expect(of(session('a'), { fell: 3 })?.enabled).toBe(true)
+    expect(of(session('a'), { fell: 0 })?.enabled).toBe(false)
+    expect(of(session('a'))?.enabled).toBe(false)
+  })
+
+  it('never disappears — the row keeps its shape, and the dim verb says why nothing happens', () => {
+    expect(of(undefined)).toBeDefined()
+  })
+})
+
+describe('sessionActions — approve and prompt', () => {
+  const find = (s: ControlSession, a: 'approve' | 'prompt') =>
+    sessionActions(s).find(x => x.action === a)!
+
+  const blocked = session('b', {
+    state: 'waiting-approval' as SessionState, stateLabel: 'needs approval', canApprove: true,
+  })
+
+  it('offers approve only where the HOST said it can work', () => {
+    expect(find(blocked, 'approve').enabled).toBe(true)
+    // Blocked, but nobody has read this harness's dialog: there is no key to send, so the verb is
+    // dim rather than present and guessing.
+    expect(find(session('b2', {
+      state: 'waiting-approval' as SessionState, stateLabel: 'needs approval',
+    }), 'approve').enabled).toBe(false)
+    // Not blocked at all. Sending the confirm key here is a blank turn.
+    expect(find(session('w', { state: 'working' as SessionState }), 'approve').enabled).toBe(false)
+  })
+
+  it('offers prompt on anything RUNNING, blocked included', () => {
+    // A session sitting on a dialog is still refused — but by the HOST, which re-reads the screen.
+    // Deciding it here would decide it from a list up to a poll old.
+    expect(find(blocked, 'prompt').enabled).toBe(true)
+    expect(find(session('w', { state: 'working' as SessionState }), 'prompt').enabled).toBe(true)
+    expect(find(session('e', { state: 'exited' as SessionState }), 'prompt').enabled).toBe(false)
+    expect(find(session('x', {
+      state: 'unknown' as SessionState, actionable: false,
+    }), 'prompt').enabled).toBe(false)
+  })
+})
+
+describe('askRows', () => {
+  it('is the question floor when there is no evidence to show', () => {
+    expect(askRows({ preview: 0, detail: 0 })).toBe(QUESTION_ROWS)
+  })
+
+  it('BUDGETS the dialog, plus the rule between it and the question', () => {
+    // Ink composites what does not fit, so an unbudgeted preview does not crowd the two answers —
+    // it draws over whatever sits under them.
+    expect(askRows({ preview: 4, detail: 0 })).toBe(QUESTION_ROWS + 5)
+  })
+
+  it('never asks for more preview than a confirmation will ever draw', () => {
+    expect(askRows({ preview: 99, detail: 0 })).toBe(QUESTION_ROWS + APPROVAL_PREVIEW_MAX + 1)
+  })
+
+  it('still gives the facts their rows when they need more', () => {
+    expect(askRows({ preview: 0, detail: 20 })).toBe(20)
+  })
+
+  it('never goes negative on nonsense input', () => {
+    expect(askRows({ preview: -5, detail: -5 })).toBe(QUESTION_ROWS)
+  })
+})
+
+describe('fitApprovalPreview', () => {
+  const DIALOG = ['context', 'Do you want to proceed?', '❯ 1. Yes', '  2. No', 'Enter to confirm']
+
+  it('cuts from the TOP, so the options and the footer survive', () => {
+    // The bottom is the part being answered. Cutting the other way round leaves a question with its
+    // answers off screen, which is the one thing a confirmation may not do.
+    expect(fitApprovalPreview(DIALOG, 2)).toEqual(['  2. No', 'Enter to confirm'])
+  })
+
+  it('shows a short dialog whole', () => {
+    expect(fitApprovalPreview(['a', 'b'], 6)).toEqual(['a', 'b'])
+  })
+
+  it('is capped however many rows it is offered', () => {
+    const long = Array.from({ length: 30 }, (_, i) => `l${i}`)
+    expect(fitApprovalPreview(long, 99)).toHaveLength(APPROVAL_PREVIEW_MAX)
+  })
+
+  it('draws nothing when there is no room, rather than one useless line', () => {
+    expect(fitApprovalPreview(DIALOG, 0)).toEqual([])
+    expect(fitApprovalPreview(DIALOG, -3)).toEqual([])
+  })
+})
+
+describe('summaryCells — the fall', () => {
+  const full = {
+    group: 'GROUP task',
+    hiding: '− closed conversations',
+    count: '18 sessions',
+    waiting: '3 waiting on you',
+    fell: '4 sessions fell 2m ago — R reopens them',
+    width: 200,
+  }
+
+  const rendered = (c: ReturnType<typeof summaryCells>) => {
+    const kept = [c.group, c.hiding, c.count, c.waiting, c.fell].filter(Boolean)
+    return kept.reduce((n, p) => n + p.length, 0) + 3 * Math.max(0, kept.length - 1)
+  }
+
+  it('outlives the cells that merely DESCRIBE the list', () => {
+    // Everything beside it says what the list contains; this says what is one keypress from coming
+    // back. It is also usually absent, so it costs nothing on an ordinary machine.
+    const c = summaryCells({ ...full, width: 55 })
+    expect(c.fell).toBe(full.fell)
+    expect(c.hiding).toBe('')
+    expect(c.count).toBe('')
+  })
+
+  it('is given up before the grouping, which explains the arrangement', () => {
+    const c = summaryCells({ ...full, width: 12 })
+    expect(c.fell).toBe('')
+    expect(c.group).toContain('GROUP')
+  })
+
+  it('NEVER renders wider than it was given, at any width', () => {
+    for (let w = 0; w <= 240; w++) {
+      expect(rendered(summaryCells({ ...full, width: w }))).toBeLessThanOrEqual(Math.max(w, 0) || 0)
+    }
+  })
+})
+
+describe('detailLines — named in two places', () => {
+  const labels = {
+    where: 'where', model: 'model', note: 'note', started: 'started',
+    external: 'external', closed: 'closed', doing: 'saying', task: 'task', metrics: 'usage',
+    alsoLabel: 'named here', alsoHarness: 'named inside',
+  }
+  const ago = () => '5m ago'
+  const row = (over: Partial<ControlSession>) =>
+    detailLines(session('a', over), labels, ago).find(l => l.key === 'also')
+
+  it('names the OTHER name, and which place it came from', () => {
+    // The label says where the LOSER came from, which is the fact that matters: without it someone
+    // who renamed in both places cannot tell whether the name on the row is the one they typed here
+    // or the one they typed inside the session — and one of the two renames reads as failed.
+    expect(row({ titleSource: 'harness', titleOther: 'Principal' }))
+      .toMatchObject({ label: 'named here', value: 'Principal' })
+    expect(row({ titleSource: 'label', titleOther: 'principal do cockpit' }))
+      .toMatchObject({ label: 'named inside', value: 'principal do cockpit' })
+  })
+
+  it('says nothing at all on an ordinary row', () => {
+    expect(row({})).toBeUndefined()
+  })
+
+  it('sits right under what the session is SAYING, above every other fact', () => {
+    // It answers "did my rename work", which is the question someone has the moment they notice the
+    // row saying something other than what they typed.
+    const lines = detailLines(
+      session('a', { titleSource: 'harness', titleOther: 'Principal', lastLines: ['thinking'] }),
+      labels, ago,
+    )
+    expect(lines.map(l => l.key).slice(0, 3)).toEqual(['say0', 'also', 'where'])
   })
 })

--- a/packages/tui/src/control/sessions.ts
+++ b/packages/tui/src/control/sessions.ts
@@ -232,6 +232,14 @@ export function sessionRows(
   closedLabel?: string,
   /** Already-localized word marking a finished task's heading, e.g. "finished". */
   doneLabel?: string,
+  /**
+   * Already-localized word for the sessions the machine took at once, e.g. "fell together".
+   *
+   * Absent — on a machine where nothing fell, and in the tests that predate the section — leaves
+   * those rows exactly where they used to be, in the history block. The section is an addition to
+   * the reading order, never a change to which rows are listed.
+   */
+  fellLabel?: string,
 ): SessionRow[] {
   const out: SessionRow[] = []
 
@@ -248,15 +256,28 @@ export function sessionRows(
   // no idea what happened to it, so it is certainly not something you are working in.
   const isLive = (s: ControlSession) =>
     s.state !== 'closed' && s.state !== 'exited' && s.state !== 'lost'
+  // A row the machine TOOK, carved out of the history block it would otherwise sit in. It is not
+  // history: it is work that was open a moment ago and is one action away from being open again,
+  // and burying it among conversations that ended days ago is what made "reopen what I lost" a
+  // matter of reading forty rows first.
+  const hasFell = Boolean(fellLabel)
+  const isFell = (s: ControlSession) => hasFell && s.fell === true && !isLive(s)
 
   for (const g of groups) {
     const live = g.sessions.filter(isLive)
-    const closed = g.sessions.filter(s => !isLive(s))
+    const fell = g.sessions.filter(isFell)
+    const closed = g.sessions.filter(s => !isLive(s) && !isFell(s))
     // An empty KEY is an absence ("no task"), not a category, and is drawn as one. A FINISHED task
     // says so in its heading and is muted with it: the sessions are still listed and still
     // attachable, so the screen must say why they are set apart rather than merely dimming them.
     const head = g.done && doneLabel ? `${g.label} · ${doneLabel}` : g.label
     push(head, live, g.key === '' || Boolean(g.done))
+    if (fell.length > 0) {
+      // NOT muted: everything else set apart on this screen is set apart because it is over, and
+      // this block is the opposite — it is the one thing on the list asking to be acted on.
+      const label = fellLabel ?? ''
+      push(g.label !== '' && label ? `${g.label} · ${label}` : label, fell)
+    }
     if (closed.length > 0) {
       // Inside a named group the closed block still says which group it belongs to, so a heading
       // read on its own is never ambiguous.
@@ -371,6 +392,16 @@ export function detailLines(s: ControlSession, labels: {
   task: string
   metrics: string
   /**
+   * Labels for the OTHER name, when a session is named in both places.
+   *
+   * Two of them, because which one is the other depends on which one won — and a single label
+   * saying "also called" would leave a person unable to tell whether the name on the row is the one
+   * they typed here or the one they typed inside the session. That distinction is the entire point:
+   * it is what says both renames landed.
+   */
+  alsoLabel: string
+  alsoHarness: string
+  /**
    * How to LEAVE an attached session, already localized, and the real keystroke the backend
    * reported — never an assumed `Ctrl-b`.
    *
@@ -391,6 +422,17 @@ export function detailLines(s: ControlSession, labels: {
     })
   }
 
+  // The name that did NOT win, right under what it is saying and above everything else, because it
+  // answers "did my rename work" — which is the question someone has the moment they notice the row
+  // saying something other than what they typed. The label names WHICH place it came from.
+  if (s.titleOther) {
+    out.push({
+      key: 'also',
+      // `titleSource` is where the WINNER came from, so the loser is the other place.
+      label: s.titleSource === 'harness' ? labels.alsoLabel : labels.alsoHarness,
+      value: s.titleOther,
+    })
+  }
   out.push({ key: 'where', label: labels.where, value: s.cwd })
   if (s.task) out.push({ key: 'task', label: labels.task, value: s.task })
   if (s.model) out.push({ key: 'model', label: labels.model, value: s.model })
@@ -432,6 +474,46 @@ export function detailLines(s: ControlSession, labels: {
  */
 export const QUESTION_ROWS = 5
 
+/**
+ * The most of a blocked session's dialog a confirmation will show.
+ *
+ * Six lines carries a question, three options and the footer naming the key — measured against the
+ * frames `attention-rules.ts` was probed from. It is a CAP rather than a size: a shorter dialog
+ * shows whole, and the pane asks for only what it has.
+ */
+export const APPROVAL_PREVIEW_MAX = 6
+
+/**
+ * The dialog cut to the rows there are — from the TOP, so the BOTTOM survives — PURE.
+ *
+ * The bottom is where the options are, where the highlight is, and where the footer names the key.
+ * That is the part being answered; the lines above it are the context that led there, and context is
+ * what a short pane can afford to lose. Cutting the other way round would leave a question with its
+ * answers off screen, which is the one thing a confirmation may not do.
+ */
+export function fitApprovalPreview(lines: readonly string[], rows: number): string[] {
+  const keep = Math.max(0, Math.min(rows, APPROVAL_PREVIEW_MAX))
+  return lines.slice(Math.max(0, lines.length - keep))
+}
+
+/**
+ * How many rows the detail region must be given for the question that is open — PURE.
+ *
+ * A question ALWAYS outranks the facts: a prompt with nowhere to draw cannot be answered, which is
+ * why `QUESTION_ROWS` is the floor. What is new here is that one question carries evidence — the
+ * dialog a person has to read before agreeing — and those rows have to be BUDGETED rather than
+ * drawn on top of the answers. Ink composites what does not fit, so an unbudgeted preview does not
+ * crowd the two answers, it draws over whatever was under them.
+ *
+ * `+ 1` for the row that LABELS the evidence. It is not decoration: the dialog being quoted has its
+ * own numbered options, the confirmation under it has two of its own, and without a line saying
+ * which is which the pane is two menus stacked on top of each other.
+ */
+export function askRows(o: { preview: number; detail: number }): number {
+  const preview = Math.max(0, Math.min(o.preview, APPROVAL_PREVIEW_MAX))
+  return Math.max(QUESTION_ROWS + (preview > 0 ? preview + 1 : 0), Math.max(0, o.detail))
+}
+
 
 // ---------------------------------------------------------------------------
 // the visible action row
@@ -439,7 +521,8 @@ export const QUESTION_ROWS = 5
 
 /** What a verb DOES, independent of what it is called in either language. */
 export type SessionAction =
-  | 'attach' | 'resume' | 'rename' | 'note' | 'task' | 'kill' | 'openTask' | 'finishTask'
+  | 'attach' | 'resume' | 'approve' | 'prompt' | 'rename' | 'note' | 'task' | 'kill'
+  | 'openTask' | 'reopenFell' | 'finishTask'
   | 'new' | 'search' | 'group'
 
 /**
@@ -469,7 +552,11 @@ export interface OfferedAction {
  * — the cursor skips them and a click does nothing — but the screen no longer implies that renaming
  * a session stopped existing because the one you selected cannot be renamed.
  */
-export function sessionActions(selected: ControlSession | undefined): OfferedAction[] {
+export function sessionActions(
+  selected: ControlSession | undefined,
+  /** Facts about the FLEET rather than the row — what the fleet-level verbs need. */
+  fleet: { fell?: number } = {},
+): OfferedAction[] {
   // A row agentop still HOSTS: it has a registry entry, so it can be renamed, filed and stopped.
   // `exited` and `lost` are hosted — a reboot loses every backend session while the registry keeps
   // every name, and losing the verbs that edit those names is how a rename disappears.
@@ -491,10 +578,24 @@ export function sessionActions(selected: ControlSession | undefined): OfferedAct
     ...(live
       ? [{ action: 'attach' as const, enabled: true }]
       : [{ action: 'resume' as const, enabled: canReopen }]),
+    // APPROVE leads the rest because a session blocked on a question is the reason this screen
+    // exists. The host decides `canApprove`, and it is true only when the session is genuinely
+    // asking AND somebody has read this harness's dialog — a keystroke sent into a session that is
+    // not asking is a blank turn, or an option taken out of a menu nobody was looking at.
+    { action: 'approve', enabled: Boolean(selected?.canApprove) },
+    // Typing into a session needs it to be RUNNING and nothing more: a session that is working will
+    // read what it was handed when it gets there. The one case that must not go through is a
+    // session sitting on a dialog, where the prompt is a menu — and that is refused by the HOST,
+    // which re-reads the screen, rather than here from a list up to a poll old.
+    { action: 'prompt', enabled: live },
     { action: 'rename', enabled: hosted },
     { action: 'note', enabled: hosted },
     { action: 'task', enabled: hosted },
     { action: 'openTask', enabled: hosted && hasTask },
+    // A FLEET verb sitting among the row verbs, because that is where the hand already is when a
+    // reboot has just emptied the screen. Enabled only when something actually fell — offered and
+    // doing nothing is the shape this menu already refuses everywhere else.
+    { action: 'reopenFell', enabled: (fleet.fell ?? 0) > 0 },
     // Finishing needs only a TASK, not a live session: the ordinary moment to close a piece of work
     // is when its last session has already ended, and requiring a hosted row would make the verb
     // unreachable at exactly that moment.
@@ -531,17 +632,23 @@ export function enabledActionIndexes(actions: readonly OfferedAction[]): number[
  * looks like, and nothing about it says the cause was one row too wide.
  *
  * Cells are given up in the order the row can afford to lose them: the list of what is being HIDDEN
- * first (the panel one keypress away states it in full), then the waiting count, then the total.
- * The grouping is last because it is the only cell that explains why the rows are arranged as they
- * are, and it is truncated rather than dropped.
+ * first (the panel one keypress away states it in full), then the waiting count, then the total,
+ * then the fall. The grouping is last because it is the only cell that explains why the rows are
+ * arranged as they are, and it is truncated rather than dropped.
+ *
+ * The FALL outlives the other three because it is the only cell that is an OFFER: the rest describe
+ * the list, and this one names work that is one keypress from coming back. It is also the only cell
+ * that is usually absent, so it costs nothing on an ordinary machine.
  */
 export function summaryCells(o: {
   group: string
   hiding: string
   count: string
   waiting: string
+  /** "N sessions fell X ago — R reopens them", or `''` when nothing did. */
+  fell?: string
   width: number
-}): { group: string; hiding: string; count: string; waiting: string } {
+}): { group: string; hiding: string; count: string; waiting: string; fell: string } {
   const GAP = 3
   const width = Math.max(0, o.width)
   const fits = (parts: string[]) => {
@@ -549,16 +656,20 @@ export function summaryCells(o: {
     return kept.reduce((n, p) => n + p.length, 0) + GAP * Math.max(0, kept.length - 1) <= width
   }
 
-  const full = { group: o.group, hiding: o.hiding, count: o.count, waiting: o.waiting }
-  if (fits([full.group, full.hiding, full.count, full.waiting])) return full
+  const fell = o.fell ?? ''
+  const full = { group: o.group, hiding: o.hiding, count: o.count, waiting: o.waiting, fell }
+  if (fits([full.group, full.hiding, full.count, full.waiting, full.fell])) return full
 
   const noHiding = { ...full, hiding: '' }
-  if (fits([noHiding.group, noHiding.count, noHiding.waiting])) return noHiding
+  if (fits([noHiding.group, noHiding.count, noHiding.waiting, noHiding.fell])) return noHiding
 
   const noWaiting = { ...noHiding, waiting: '' }
-  if (fits([noWaiting.group, noWaiting.count])) return noWaiting
+  if (fits([noWaiting.group, noWaiting.count, noWaiting.fell])) return noWaiting
 
-  const groupOnly = { group: o.group, hiding: '', count: '', waiting: '' }
+  const noCount = { ...noWaiting, count: '' }
+  if (fits([noCount.group, noCount.fell])) return noCount
+
+  const groupOnly = { group: o.group, hiding: '', count: '', waiting: '', fell: '' }
   if (fits([groupOnly.group])) return groupOnly
 
   return { ...groupOnly, group: o.group.slice(0, Math.max(0, width)) }
@@ -1502,11 +1613,17 @@ export function sessionKeyHelp(w: {
   note: string; task: string; mark: string; onlyActive: string; closed: string
   exited: string; unfiled: string; group: string; detail: string; reset: string
   tabs: string; help: string; quit: string
+  approve: string; prompt: string; reopenFell: string
 }): KeyHelp[] {
   return [
     { keys: '↑ ↓ / j k', what: w.move },
     { keys: 'enter', what: w.menu },
     { keys: 'o', what: w.attach },
+    // The two that act on a session WITHOUT entering it, listed right under the one that enters it:
+    // they answer the same question ("this one needs me") in the two cheaper ways.
+    { keys: 'y', what: w.approve },
+    { keys: 'p', what: w.prompt },
+    { keys: 'R', what: w.reopenFell },
     { keys: 'tab', what: w.open },
     { keys: '1-9 / ← →', what: w.section },
     { keys: 'a', what: w.newSession },

--- a/packages/tui/src/control/tabs/Sessions.tsx
+++ b/packages/tui/src/control/tabs/Sessions.tsx
@@ -52,7 +52,8 @@ import { SessionWizard } from './SessionWizard'
 import { TaskChoice } from '../TaskChoice'
 import {
   GROUPINGS, detailLines, groupSessions, selectableIndexes, sessionCells, sessionRows,
-  QUESTION_ROWS, actionLabels, asideRows, asideSelectable, asideRowKey, resolveAsideCursor,
+  QUESTION_ROWS, askRows, fitApprovalPreview, actionLabels, asideRows, asideSelectable,
+  asideRowKey, resolveAsideCursor,
   enabledActionIndexes, filterSessions,
   sessionActions, sessionsCockpit, summaryCells, sessionColumns, padCell,
   taskCounts, projectCounts, sessionMetric, sessionHandle, worktreeName, sessionRunning,
@@ -87,6 +88,31 @@ const STATE_COLOR: Record<SessionState, string | undefined> = {
 }
 
 /**
+ * The already-localized word for every verb, in ONE place.
+ *
+ * It was written out twice — once for the action row and once for the aside menu — and the two are
+ * `Record<SessionAction, string>`s of the same map, so adding a verb meant finding both copies. The
+ * compiler catches a missing key, which is exactly why the duplicate was cheap enough to survive
+ * three verbs and then cost an afternoon on the fourth.
+ */
+const ACTION_WORDS = (s: ControlStrings): Record<SessionAction, string> => ({
+  attach: s.actSessions.attach,
+  resume: s.actSessions.resume,
+  approve: s.actSessions.approve,
+  prompt: s.actSessions.prompt,
+  rename: s.actSessions.rename,
+  note: s.actSessions.note,
+  task: s.actSessions.task,
+  kill: s.actSessions.kill,
+  openTask: s.actSessions.openTask,
+  reopenFell: s.actSessions.reopenFell,
+  finishTask: s.actSessions.finishTask,
+  new: s.actSessions.newSession,
+  search: s.actSessions.search,
+  group: s.actSessions.group,
+})
+
+/**
  * A question this screen is asking. While one is open it reports `capture`, so the global keys stand
  * down — typing a session name would otherwise quit the app on the `q` and refresh it on the `r`.
  */
@@ -104,6 +130,18 @@ type Ask =
   | { kind: 'rename'; session: ControlSession }
   | { kind: 'note'; session: ControlSession }
   | { kind: 'kill'; session: ControlSession }
+  /** Typing a line into a session without entering it. */
+  | { kind: 'prompt'; session: ControlSession }
+  /**
+   * Answering the dialog a session is blocked on.
+   *
+   * The only question on this screen that carries EVIDENCE: the dialog itself is drawn above the
+   * confirmation, because the keystroke takes whichever option is highlighted and nothing but the
+   * screen can say which that is.
+   */
+  | { kind: 'approve'; session: ControlSession }
+  /** Reopening everything the machine took at once — a FLEET question, so it names no session. */
+  | { kind: 'reopenFell' }
   /** Starting a new one — the only question that needs no selected row. */
   | { kind: 'new' }
 
@@ -268,9 +306,12 @@ export function Sessions({
     },
     fleet?.finishedTasks ?? [],
     order,
-  ), s.sessionsClosedWord, s.sessionsDoneWord), [
-    fleet?.sessions, fleet?.finishedTasks, done, grouping, query, showClosed, showExited,
-    hideEmptyTask, showDone, onlyActive, states, order, taskFilter, projectFilter, s,
+    // The heading is passed only when something ACTUALLY fell. `sessionRows` treats an absent word
+    // as "there is no such section", so on an ordinary machine the reading order is unchanged
+    // rather than carrying an empty block that exists to say nothing.
+  ), s.sessionsClosedWord, s.sessionsDoneWord, fleet?.fell ? s.sessionsFellWord : undefined), [
+    fleet?.sessions, fleet?.finishedTasks, fleet?.fell, done, grouping, query, showClosed,
+    showExited, hideEmptyTask, showDone, onlyActive, states, order, taskFilter, projectFilter, s,
   ])
 
   const selectable = useMemo(() => selectableIndexes(rows), [rows])
@@ -294,6 +335,13 @@ export function Sessions({
   // The detail pane asks for exactly what it has to say, and the list absorbs the difference. A
   // pane sized to a constant leaves dead rows under it — air under a pane is a fault, and a list
   // with room to grow is not air, it is a list.
+  /** Whether typing into the selected row is a thing that can work — the same rule
+   *  `sessionActions` applies, read once so the footer and the verb cannot disagree. */
+  const canPrompt = Boolean(selected)
+    && selected!.actionable
+    && (selected!.state === 'working' || selected!.state === 'waiting'
+      || selected!.state === 'waiting-approval')
+
   const detail = useMemo(() => (selected ? detailLines(selected, {
     where: s.sessionsWhere,
     model: s.sessionsModel,
@@ -304,6 +352,8 @@ export function Sessions({
     doing: s.sessionsDoing,
     task: s.sessionsTask,
     metrics: s.sessionsMetrics,
+    alsoLabel: s.sessionsAlsoLabel,
+    alsoHarness: s.sessionsAlsoHarness,
     // Absent when the backend did not report one — an invented keystroke is worse than none, since
     // the whole point of this line is that it is the key that actually works here.
     ...(fleet?.detachHint ? { detach: { label: s.sessionsDetach, keys: fleet.detachHint } } : {}),
@@ -324,8 +374,12 @@ export function Sessions({
   // the whole band goes to the grid — a fleet drawn twice on one screen is half a screen wasted. A
   // QUESTION still gets its rows, switch or no switch: a prompt with nowhere to draw cannot be
   // answered.
+  // The one question that carries EVIDENCE. Its rows are BUDGETED here rather than drawn on top of
+  // the answers: Ink composites what does not fit, so an unbudgeted preview would not crowd the two
+  // answers, it would draw over whatever sits under them.
+  const askPreview = ask?.kind === 'approve' ? (ask.session.approvalLines?.length ?? 0) : 0
   const detailWanted = ask
-    ? Math.max(QUESTION_ROWS, detail.length)
+    ? askRows({ preview: askPreview, detail: detail.length })
     : layout === 'cards' || hideDetail ? 0 : detail.length
 
   /**
@@ -336,25 +390,16 @@ export function Sessions({
    * refusal is a sentence rather than a silently ignored keypress: a control that does nothing and
    * says nothing is indistinguishable from a broken one.
    */
-  const actions = useMemo(() => sessionActions(selected), [selected])
+  const actions = useMemo(
+    () => sessionActions(selected, { fell: fleet?.fell?.count ?? 0 }),
+    [selected, fleet?.fell?.count],
+  )
   // The cursor moves over the ENABLED verbs only; the dim ones keep the row's shape and are never
   // landed on. Clamped every render, because which are enabled changes with the selection.
   const liveActions = useMemo(() => enabledActionIndexes(actions), [actions])
   const liveAt = liveActions.length === 0 ? 0 : Math.min(actionIndex, liveActions.length - 1)
   const at2 = liveActions[liveAt] ?? 0
-  const actionWords = useMemo(() => actionLabels(actions, {
-    attach: s.actSessions.attach,
-    resume: s.actSessions.resume,
-    rename: s.actSessions.rename,
-    note: s.actSessions.note,
-    task: s.actSessions.task,
-    kill: s.actSessions.kill,
-    openTask: s.actSessions.openTask,
-    finishTask: s.actSessions.finishTask,
-    new: s.actSessions.newSession,
-    search: s.actSessions.search,
-    group: s.actSessions.group,
-  }), [actions, s])
+  const actionWords = useMemo(() => actionLabels(actions, ACTION_WORDS(s)), [actions, s])
 
   /** How many sessions wear each state, over the WHOLE fleet — see the note in `asideRows`. */
   const stateCounts = useMemo(() => {
@@ -365,13 +410,7 @@ export function Sessions({
 
   const asideList = useMemo(() => asideRows({
     actions,
-    actionWords: {
-      attach: s.actSessions.attach, resume: s.actSessions.resume, rename: s.actSessions.rename,
-      note: s.actSessions.note, task: s.actSessions.task, kill: s.actSessions.kill,
-      openTask: s.actSessions.openTask, finishTask: s.actSessions.finishTask,
-      new: s.actSessions.newSession,
-      search: s.actSessions.search, group: s.actSessions.group,
-    },
+    actionWords: ACTION_WORDS(s),
     grouping,
     groupWords: s.sessionsGroupings,
     layout: { heading: s.asideLayout, words: s.sessionsLayouts, value: layout },
@@ -486,6 +525,17 @@ export function Sessions({
     // what the options were, or what the current one is, is a control people stop trusting — and
     // the hide-closed and hide-unfiled switches had nowhere to live at all.
     if (a === 'group') { setAsk({ kind: 'view' }); return }
+    // A FLEET verb: it names no row, so it must not be gated on one being selected. Refused in a
+    // SENTENCE when nothing fell, never silently — a control that does nothing and says nothing is
+    // indistinguishable from a broken one.
+    if (a === 'reopenFell') {
+      if (!fleet?.fell || !host.reopenFell) {
+        void run(async () => ({ ok: false, message: s.sessionsNoFell }))
+        return
+      }
+      setAsk({ kind: 'reopenFell' })
+      return
+    }
     if (!selected) return
     if (a === 'attach') return actOn('attach')
     if (a === 'resume') { setAsk({ kind: 'resume', session: selected }); return }
@@ -493,10 +543,21 @@ export function Sessions({
     // Asked rather than done: finishing is a statement about a whole piece of work, and the
     // confirmation is where the screen says what happens to its sessions.
     if (a === 'finishTask') { setAsk({ kind: 'finishTask', session: selected }); return }
+    // Refused in words rather than by a key that does nothing: pressing `y` on a session that is
+    // working is a reasonable thing to try, and the answer is "it is not asking anything", which is
+    // information. Two different refusals, because they are two different facts — the harness's
+    // dialog was never read, or this row is not blocked at all.
+    if (a === 'approve' && !selected.canApprove) {
+      const why = selected.approveBlind ?? s.sessionsNotAsking
+      void run(async () => ({ ok: false, message: why }))
+      return
+    }
     return actOn(a)
-  }, [host, grouping, selected])
+  }, [host, grouping, selected, fleet?.fell, run, s])
 
-  const actOn = useCallback((kind: Ask['kind'] | 'attach') => {
+  // Only the kinds that NAME a session. `reopenFell` is a fleet question and is handled in
+  // `runAction`; routing it through here would hand it a row it must not act on.
+  const actOn = useCallback((kind: Extract<Ask, { session: ControlSession }>['kind'] | 'attach') => {
     if (!selected) return
     // Asking to ATTACH to something with nothing running is asking to pick that conversation back
     // up — so it is answered with the reopen question rather than refused. Pressing the one key
@@ -732,6 +793,15 @@ export function Sessions({
     if (input === 'x') return runAction('kill')
     if (input === 'n') return runAction('rename')
     if (input === 't') return runAction('note')
+    // The two that act on a session WITHOUT entering it. `y` for yes and `p` for prompt, both
+    // unclaimed on this screen — and neither is a navigation key, which is the rule `x` exists for:
+    // a key that moves the cursor on one screen and writes into somebody's session on another is
+    // the shape of a real accident.
+    if (input === 'y') return runAction('approve')
+    if (input === 'p') return runAction('prompt')
+    // Capital `R`, so it cannot be hit while reaching for anything else. It is the one verb here
+    // that acts on the whole fleet.
+    if (input === 'R') return runAction('reopenFell')
 
     // A grid has two axes, so the arrows mean what they mean in a grid: `←`/`→` step one card,
     // `↑`/`↓` step a whole row of them. The list's own reducer wraps a single column, which in a
@@ -854,12 +924,18 @@ export function Sessions({
             hints: [
               s.keyQuit, s.keyTabsAlt, s.keySessionsActions, s.keyAsideSection,
               s.keySessionsAttach, s.keyMove,
+              // Named only where the key actually does something on the selected row. The footer is
+              // the only documentation this screen has, and a hint for an inert key is the one bug
+              // it exists to prevent.
+              ...(selected?.canApprove ? [s.keySessionsApprove] : []),
+              ...(canPrompt ? [s.keySessionsPrompt] : []),
               s.keySessionsSearch, s.keySessionsNew, s.keySessionsGroup, s.keySessionsClosed,
               ...(grouping === 'task' ? [s.keySessionsNoTask] : []),
               s.keySessionsReset,
             ],
           })
-  }, [isActive, onChrome, s, ask, actionsFocused, focus, cockpit.aside, grouping])
+  }, [isActive, onChrome, s, ask, actionsFocused, focus, cockpit.aside, grouping,
+      selected?.canApprove, canPrompt])
 
   usePointer(p => {
     const wheel = wheelDelta(p.button)
@@ -1006,8 +1082,25 @@ export function Sessions({
    */
   const runningCount = (fleet?.sessions ?? []).filter(sessionRunning).length
   const narrowed = Boolean(query || projectFilter !== null || taskFilter !== null)
+  /**
+   * How long ago the fall was, already localized — `undefined` when nothing fell.
+   *
+   * The clock lives here for the same reason every other age on this screen does: the host reports
+   * the INSTANT, and this pane repaints far more often than the poll runs.
+   */
+  const fellAgo = fleet?.fell
+    ? s.sessionsAgo(Math.max(0, Math.round((Date.now() - fleet.fell.atMs) / 1000)))
+    : undefined
   const emptyReason = onlyActive && runningCount === 0 && (fleet?.sessions.length ?? 0) > 0
-    ? s.sessionsEmptyActive(fleet!.sessions.length)
+    // The strict filter empties the list on exactly the machine that has just rebooted, and the
+    // sessions it is withholding are the ones somebody most wants back. So when a fall is on record
+    // the sentence names IT and the key that reopens it, rather than only the switch that would
+    // reveal the rows. The filter is not overridden — `only active` means what it says, no
+    // exceptions — but a blank pane must not be the only thing standing between a user and their
+    // work.
+    ? (fleet!.fell && fellAgo
+        ? `${s.sessionsEmptyActive(fleet!.sessions.length)} · ${s.sessionsFellNote(fleet!.fell.count, fellAgo)}`
+        : s.sessionsEmptyActive(fleet!.sessions.length))
     : narrowed ? s.sessionsEmptyFiltered
     : s.sessionsEmpty
 
@@ -1205,6 +1298,7 @@ export function Sessions({
           onlyActive={onlyActive}
           query={query}
           scope={projectFilter ?? taskFilter ?? ''}
+          fell={fleet?.fell && fellAgo ? s.sessionsFellNote(fleet.fell.count, fellAgo) : ''}
         />
       ) : null}
 
@@ -1348,6 +1442,8 @@ export function Sessions({
               ask={ask as Exclude<Ask, { kind: 'new' } | { kind: 'view' } | { kind: 'keys' }>}
               strings={s}
               width={paneBody(width)}
+              rows={paneRows(cockpit.detail)}
+              fellAgo={fellAgo}
               onClose={() => setAsk(null)}
               onRun={(fn, label) => {
                 setAsk(null)
@@ -1392,7 +1488,7 @@ export function Sessions({
  * to state the answer, so a glance tells you why the list looks the way it does.
  */
 function SummaryRow({
-  fleet, grouping, strings: s, width, showClosed, hideEmptyTask, onlyActive, query, scope,
+  fleet, grouping, strings: s, width, showClosed, hideEmptyTask, onlyActive, query, scope, fell,
 }: {
   fleet: ControlSessions | null | undefined
   grouping: SessionGrouping
@@ -1407,6 +1503,14 @@ function SummaryRow({
   query: string
   /** The active task or project scope, already localized, or `''`. */
   scope: string
+  /**
+   * Already-localized "N sessions fell X ago — R reopens them", or `''`.
+   *
+   * On this row rather than only in the empty state, because the list is NOT always empty after a
+   * fall: a machine where one session survived, or where the history switches are on, shows rows —
+   * and the offer to get the rest back would then have no place to be said at all.
+   */
+  fell: string
 }) {
   if (fleet?.unavailable) {
     return <Text color={COLORS.accent} wrap="truncate">{truncate(fleet.unavailable, width)}</Text>
@@ -1437,6 +1541,7 @@ function SummaryRow({
     hiding: hiding.length > 0 ? `− ${hiding.join(', ')}` : '',
     count: s.sessionsCount(fleet?.sessions.length ?? 0),
     waiting: waiting > 0 ? s.sessionsWaitingCount(waiting) : '',
+    fell,
     width,
   })
 
@@ -1452,6 +1557,10 @@ function SummaryRow({
           </>
         )}
         {cells.hiding ? <Text dimColor>{`   ${cells.hiding}`}</Text> : null}
+        {/* The fall is an OFFER, not a description, so it is the one cell on this row that wears a
+            colour: everything beside it says what the list contains, and this says what is one
+            keypress from coming back. */}
+        {cells.fell ? <Text color={COLORS.info} bold>{`   ${cells.fell}`}</Text> : null}
       </Text>
       <Text wrap="truncate">
         <Text dimColor>{cells.count}</Text>
@@ -1724,11 +1833,17 @@ function Detail({ lines, width, rows }: {
  * In place of the facts rather than over them: a modal floating above a list is a second thing to
  * read at the moment the user is deciding, and the row being acted on stays visible above.
  */
-function Question({ ask, strings: s, width, onClose, onRun, host, query, onQuery, fleet }: {
+function Question({
+  ask, strings: s, width, rows, fellAgo, onClose, onRun, host, query, onQuery, fleet,
+}: {
   /** Never `new` — the wizard takes the whole screen and is rendered before this is reached. */
   ask: Exclude<Ask, { kind: 'new' } | { kind: 'view' } | { kind: 'keys' }>
   strings: ControlStrings
   width: number
+  /** Rows this pane was actually given — what the dialog preview is cut against. */
+  rows: number
+  /** How long ago the fall was, already localized. Absent when nothing fell. */
+  fellAgo?: string
   onClose: () => void
   onRun: (fn: () => Promise<ActionResult>, label?: string) => void
   host: ControlHost
@@ -1758,7 +1873,89 @@ function Question({ ask, strings: s, width, onClose, onRun, host, query, onQuery
     )
   }
 
+  // The FLEET question: it names no session, so it is answered before `session` is reached at all.
+  if (ask.kind === 'reopenFell') {
+    const fell = fleet?.fell
+    return (
+      <ConfirmPrompt
+        // The count AND when. A fall from three days ago is a perfectly legitimate thing to offer,
+        // and an offer that does not say when reads as one that just happened.
+        label={s.sessionsFellConfirm(fell?.count ?? 0, fellAgo ?? '')}
+        yesLabel={s.yes}
+        noLabel={s.no}
+        width={width}
+        height={rows}
+        onCancel={onClose}
+        onAnswer={(yes: boolean) => {
+          const reopen = host.reopenFell
+          if (!yes || !reopen) return onClose()
+          onRun(() => reopen.call(host), s.actSessions.reopenFell)
+        }}
+      />
+    )
+  }
+
   const { session } = ask
+
+  /**
+   * Answering the dialog a session is blocked on — the only question here that shows EVIDENCE.
+   *
+   * The dialog is drawn ABOVE the confirmation, and the caveat under it says in words what the
+   * keystroke actually does: it takes whichever option is highlighted. Nothing in this product can
+   * read which option that is, so the screen showing the dialog is not a nicety, it IS the check.
+   */
+  if (ask.kind === 'approve') {
+    // What is left for the dialog once the confirmation has taken its rows. Cut from the TOP, so
+    // the options and the footer — the part being answered — are what survives a short pane.
+    const room = Math.max(0, rows - QUESTION_ROWS - 1)
+    const preview = fitApprovalPreview(session.approvalLines ?? [], room)
+    return (
+      <Box flexDirection="column" width={width}>
+        {preview.length > 0 ? (
+          <>
+            <Text dimColor>{truncate(s.sessionsApproveWhat, width)}</Text>
+            {preview.map((line, i) => (
+              <Text key={`ap${i}`} wrap="truncate" color={COLORS.text}>{truncate(line, width)}</Text>
+            ))}
+          </>
+        ) : null}
+        <ConfirmPrompt
+          label={`${s.sessionsApproveConfirm(session.title)} ${s.sessionsApproveCaveat}`}
+          yesLabel={s.yes}
+          noLabel={s.no}
+          width={width}
+          height={Math.max(QUESTION_ROWS, rows - preview.length - (preview.length > 0 ? 1 : 0))}
+          onCancel={onClose}
+          onAnswer={(yes: boolean) => {
+            const approve = host.approveSession
+            if (!yes || !approve) return onClose()
+            onRun(() => approve.call(host, session.id), s.actSessions.approve)
+          }}
+        />
+      </Box>
+    )
+  }
+
+  if (ask.kind === 'prompt') {
+    return (
+      <Box flexDirection="column" width={width}>
+        <Text dimColor>{truncate(s.sessionsPromptHint, width)}</Text>
+        <TextPrompt
+          label={s.sessionsPromptLabel(session.title)}
+          width={width}
+          onCancel={onClose}
+          onSubmit={value => {
+            const text = value.trim()
+            const send = host.promptSession
+            // An empty submit is a CANCEL, never a blank turn sent to an assistant — the same rule
+            // the rename prompt follows for the same reason.
+            if (!send || !text) return onClose()
+            onRun(() => send.call(host, session.id, text), s.actSessions.prompt)
+          }}
+        />
+      </Box>
+    )
+  }
 
   if (ask.kind === 'kill') {
     return (
@@ -1836,15 +2033,26 @@ function Question({ ask, strings: s, width, onClose, onRun, host, query, onQuery
   if (ask.kind === 'finishTask') {
     const task = session.task ?? ''
     const already = (fleet?.finishedTasks ?? []).includes(task)
-    const count = (fleet?.sessions ?? []).filter(v => v.task === task).length
+    const mine = (fleet?.sessions ?? []).filter(v => v.task === task)
+    const count = mine.length
+    // Counted separately and stated separately. "N sessions" alone does not tell you whether any of
+    // them is an assistant currently burning tokens, and that is the fact somebody is worried about
+    // when they hesitate over this button.
+    const running = mine.filter(sessionRunning).length
     return (
       <ConfirmPrompt
-        // The question states what happens to the SESSIONS, because that is the part nobody can
-        // guess: finishing a task hides them behind a switch, it does not stop or delete anything.
-        label={already ? s.sessionsReopenConfirm(task) : s.sessionsFinishConfirm(task, count)}
+        // The question states what finishing ACTUALLY does — mark the task, hide its sessions
+        // behind a switch — and says outright that nothing is stopped. It must not describe
+        // something the code does not do: a warning that claims to end everything, over an action
+        // that ends nothing, is worse than no warning, because it teaches people that the warnings
+        // on this screen can be ignored.
+        label={already
+          ? s.sessionsReopenConfirm(task)
+          : s.sessionsFinishConfirm(task, count, running)}
         yesLabel={s.yes}
         noLabel={s.no}
         width={width}
+        height={rows}
         onCancel={onClose}
         onAnswer={(yes: boolean) => {
           const finish = host.finishTask

--- a/packages/tui/src/control/types.ts
+++ b/packages/tui/src/control/types.ts
@@ -295,8 +295,28 @@ export type SessionState =
  */
 export interface ControlSession {
   id: string
-  /** Already-localized display name: the user's label when there is one, else a derived one. */
+  /**
+   * Already-localized display name.
+   *
+   * A session can be named in TWO places — in agentop, and inside the harness with its own
+   * `/rename` — and the host decides which one this is. See `titleSource`.
+   */
   title: string
+  /**
+   * Where `title` came from, present ONLY when the two names disagree.
+   *
+   * `label` is the name typed in agentop, `harness` the one typed inside the session. Its presence
+   * is the statement: an ordinary row, named in one place or neither, carries nothing here.
+   */
+  titleSource?: 'label' | 'harness' | 'derived'
+  /**
+   * The name that LOST, when there was one and it differs.
+   *
+   * Neither name is ever discarded. Someone who renamed in both places must be able to see that both
+   * renames happened — a rename that vanishes without a word is indistinguishable from one that
+   * failed, which is the complaint this whole field exists to answer.
+   */
+  titleOther?: string
   /** Harness id, or `''` when the registry has forgotten it. The colour and grouping key. */
   harness: string
   cwd: string
@@ -349,6 +369,39 @@ export interface ControlSession {
    * invented one would be the worst possible thing to put under "what is it doing".
    */
   lastLines?: string[]
+  /**
+   * The DIALOG this session is blocked on, verbatim — present only while it is asking.
+   *
+   * A different reading of the frame from `lastLines`, which cuts the input box and the status strip
+   * away and would therefore cut the dialog away. This is what a person has to READ before agreeing:
+   * the options, which one is highlighted, and the footer naming the key. The keystroke that answers
+   * cannot know which option it is taking, so the screen showing this IS the safety.
+   */
+  approvalLines?: string[]
+  /**
+   * Whether the approve verb can run on this row at all.
+   *
+   * True only when the session is blocked on a dialog AND this harness's dialog has been read, so
+   * the keystroke that answers it is a recorded fact rather than a guess. False everywhere else,
+   * including on a perfectly healthy working session — approving something that is not asking
+   * anything sends a blank turn, or takes an option out of a menu nobody was looking at.
+   */
+  canApprove?: boolean
+  /**
+   * Why approving is unavailable HERE, already localized — present only when the session is blocked
+   * and nobody has read this harness's dialog.
+   *
+   * Its presence is the statement, the same shape as `approvalBlind`: absence is not a reassurance,
+   * and a verb that vanished without a word reads as the feature being broken.
+   */
+  approveBlind?: string
+  /**
+   * This session was taken by the machine along with the others, and comes back with them.
+   *
+   * Decided over the WHOLE registry rather than from this row — "did these fall together" is a
+   * question about a set — so the host hands the answer down rather than the screen inferring one.
+   */
+  fell?: boolean
   /** Already-formatted token count, when this row's conversation has metrics. */
   tokens?: string
   /** Already-formatted cost, same. */
@@ -499,6 +552,18 @@ export interface ControlSessions {
    * hidden by default and shown by a toggle.
    */
   finishedTasks?: string[]
+  /**
+   * The sessions the machine took ALL AT ONCE, when there are any.
+   *
+   * A reboot, an OOM kill or a lost tmux server turns every managed session into a `lost` row in the
+   * same instant. This names that event so all of them can be picked back up with one action — which
+   * is the whole point: a list of forty rows that includes everything that ever ran cannot be
+   * reopened without reading each one first.
+   *
+   * `atMs` is when it happened, and the UI must SAY it: a fall from three days ago is a perfectly
+   * legitimate thing to offer, and an offer that does not say when reads as one that just happened.
+   */
+  fell?: { count: number; atMs: number }
 }
 
 export type TeamMode = 'solo' | 'central' | 'member'
@@ -668,6 +733,41 @@ export interface ControlHost {
   attachSession?(id: string): Promise<AttachTicket | null>
 
   killSession?(id: string): Promise<ActionResult>
+
+  /**
+   * Type one line into a session and submit it, WITHOUT attaching to it.
+   *
+   * The ordinary case is a session that is working or waiting: the text lands in its prompt and it
+   * reads it when it gets there. The case that must be refused is a session with a DIALOG open —
+   * there the prompt is not a prompt, it is a menu, and a sentence typed into it is an answer to a
+   * question nobody read. The host re-reads the screen before sending and refuses in words; the
+   * screen cannot decide it, because its list is up to a poll old.
+   */
+  promptSession?(id: string, text: string): Promise<ActionResult>
+
+  /**
+   * Press the key that takes the option this session's dialog is HIGHLIGHTING.
+   *
+   * Not "approve", and the contract says so on purpose: no CLI here reports which option is
+   * selected, so what this sends is a keystroke and what it confirms is whatever is on the screen.
+   * That is why `ControlSession.approvalLines` exists and why the confirmation must show it.
+   *
+   * The host re-reads the frame immediately before sending and refuses when the session is no longer
+   * asking — a snapshot is up to five seconds old, and an unconditional Enter into a session that
+   * has moved on is a blank turn at best.
+   */
+  approveSession?(id: string): Promise<ActionResult>
+
+  /**
+   * Reopen every session of the last fall, in the background.
+   *
+   * The same arithmetic `openTask` runs (`task-reopen.ts`), over the set `ControlSessions.fell`
+   * names instead of over a task: a row still running is left alone and reported as such, a row
+   * already finished is not resurrected, an unresolvable one is skipped AND counted, and everything
+   * reopened retires the row it replaced.
+   */
+  reopenFell?(): Promise<ActionResult>
+
   renameSession?(id: string, label: string): Promise<ActionResult>
   noteSession?(id: string, text: string): Promise<ActionResult>
   /** File this session under a piece of work. Empty string clears it. */


### PR DESCRIPTION
Four things a person had to attach to a session to do, and now does not — plus one detection bug found by doing them for real.

## The bug this turned up first

`attention-rules.ts` had claude's approval pattern probed from the **folder-trust** dialog it opens with. Its **permission** prompt is a different component with a different footer, so the one dialog people actually meet never matched.

Measured against a live claude 2.1.232, not reasoned about: a session sitting on `Do you want to proceed?` reported `waiting`, and the prompt then typed into it went into the dialog's own filter — where the submit took the highlighted option and **approved a shell command nobody had read**. That is the exact accident this whole feature exists to prevent, and it was one rule away.

Fixed from two captured dialogs (Bash and Write), keyed on the part they share. Both frames are in the tests verbatim. The lesson is written into CLAUDE.md: probe every dialog a harness draws, not the first one it shows you.

## 1 · Act on the selected session, without entering it

`SessionBackend` gains `sendText` / `sendKey`. Both were already implemented — buried inside `spawn`, for the harnesses whose `-p` exits after answering — so the one thing the backend could do that nothing else could ask for was talking to a session that already exists.

The approval keystroke is the pure `approval-spec.ts`: `Record<HarnessId, {key, probed} | null>`, a probed CLI version and date per entry, absent harness = absent verb. All six currently say Enter, and that is a **finding** rather than a shortcut — the footers disagree about wording, capitalisation and whether `esc` is even mentioned, which is why each is recorded on its own row.

**The key confirms the HIGHLIGHTED OPTION and is not "approve".** No CLI here reports which option that is, so the key alone would be a coin flip on a menu nobody read. The other half is the design:

- the host **re-reads the screen** immediately before sending — a poll is up to 5s old — and refuses if the session is no longer asking;
- the confirmation **shows the dialog**, via `approvalTail`. Deliberately not `frameTail`: that one cuts at the last rule, so on a blocked session it cuts the dialog away and hands back whatever was said before it — text that reads perfectly plausibly under "this is what you are confirming";
- a **prompt is refused, in a sentence**, on a session with a dialog open: there the input line is a menu.

External rows refuse in a sentence, never silently. Keys `y` / `p`, footer-hinted only where they do something.

## 2 · The sessions that fell together

The hard part is not the grouping, it is not admitting garbage. A `lost` row from three days ago never fell, and a group holding everything that ever ran cannot be reopened without reading it first.

Membership needs evidence a session was **alive**, which did not exist: `createdAt` is equally true of a session abandoned weeks ago, and the backend's activity clock is gone precisely when a session falls. So the registry carries `lastSeenMs`, stamped at birth and refreshed by a **60s heartbeat that writes ONE timestamp for EVERY live session in a single write**. That is what makes the clustering exact rather than fuzzy — sessions that died together have the *same* stamp, not merely nearby ones.

**Which way it errs, stated:** every rule excludes rather than includes. A session wrongly left out costs one keypress on the Reopen verb it already has; one wrongly let in is invisible and makes the whole group untrustworthy. No `lastSeenMs` → never in a group. `endedAt` → never a fall. Still in the backend (`remain-on-exit` keeps an exited pane listable) → nothing took it.

Reopening reuses `planTaskReopen`, extracted so "open the task" and "reopen what fell" cannot drift.

## 3 · The finish-task modal

`finishTask` **marks the task and hides its sessions behind a switch. It stops nothing.** So the modal says that, names the task, its session count and how many are still running.

Chosen over making it destructive because `finishTask(task, done)` is a **toggle**: a destructive finish could not be undone by the reopen half, and `showDone` would become a switch over corpses. A warning that claimed to end everything, over an action that ends nothing, is worse than no warning — it teaches people to clear the prompts.

## 4 · The name a session gave itself *(requested mid-flight by a peer session)*

Claude Code writes `~/.claude/sessions/<pid>.json` holding the name `/rename` set, the conversation id, the pid, and — for a session we started — the **tmux session name**. That last field is an *exact* link to one of our rows, where every other correlation here has had to guess by harness-and-directory: the guess that resolved every session in one repository to the same conversation and reopened three rows onto one. The exact conversation id is now written into the registry while the harness is alive, so it survives the fall too.

`nameSource: 'derived'` marks a name the harness invented — 24 of 40 named files on a real machine — and never competes; letting `agentistics-77` replace a label somebody typed is the "reopen renamed the row back to the transcript's title" bug in a new costume. `pickTitle` settles the rest by recency where both sides say when, and otherwise gives it to the harness: `nameSince` exists only from claude 2.1.232, and the complaint this answers *is* a rename made inside the session that agentop went on ignoring. **Neither name is discarded** — the detail pane names the one that lost and which place it came from.

Read defensively: one harness, `Record<HarnessId, source | null>`, every field type-checked, a bad file is an absence and never a throw, newest record wins when two claim one row, memoized by mtime.

## Verification

- `bun tsc --noEmit` clean; `bun test` **3633 pass / 0 fail** (was 3541).
- Preview swept over **60/90/130/190 columns × 12/20/30/44 rows × EN/PT**, with each new question on screen — no row overflows, no composited frame.
- **Proven on this machine, not only in tests:** a prompt sent from outside a real claude session was answered; `sendKey('Enter')` took the highlighted option of a real Write permission dialog and the file appeared on disk; `agentop session ls` now shows the peer's session under the name it was given *inside* it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016iGuSq9Sg5uEotxJ2Vwiq4