### PR TITLE
fix(sessions): the header counted the fleet while the screen showed a filter

### DIFF
--- a/packages/tui/src/control/i18n.ts
+++ b/packages/tui/src/control/i18n.ts
@@ -195,7 +195,15 @@ export interface ControlStrings {
   /** Said when the host does not implement the fleet at all — not the same as an empty fleet. */
   sessionsUnsupported: string
   /** The summary row: "3 sessions · 1 waiting on you". */
-  sessionsCount: (n: number) => string
+  /**
+   * How many rows are ON SCREEN, and out of how many the machine has.
+   *
+   * Two numbers, always, because one of them alone lies: with `only active` on, a fleet of 44 shows
+   * ten rows, and a header reading "44 sessions" over ten of them describes a screen nobody is
+   * looking at. `shown === total` is the case where the second number says nothing new, and that is
+   * the only case where it is dropped.
+   */
+  sessionsCount: (shown: number, total: number) => string
   sessionsWaitingCount: (n: number) => string
   sessionsGroupBy: string
   sessionsGroupings: Record<'none' | 'harness' | 'model' | 'project' | 'task' | 'repo', string>
@@ -553,7 +561,9 @@ const EN: ControlStrings = {
   sessionsEmptyFiltered: 'nothing matches · esc clears the filter',
   sessionsLoading: 'reading…',
   sessionsUnsupported: 'session management is not available on this machine.',
-  sessionsCount: (n: number) => (n === 1 ? '1 session' : `${n} sessions`),
+  sessionsCount: (shown: number, total: number) => (shown === total
+    ? (total === 1 ? '1 session' : `${total} sessions`)
+    : `${shown} of ${total} sessions`),
   sessionsWaitingCount: (n: number) => (n === 1 ? '1 waiting on you' : `${n} waiting on you`),
   sessionsGroupBy: 'GROUP',
   sessionsGroupings: {
@@ -928,7 +938,9 @@ const PT: ControlStrings = {
   sessionsEmptyFiltered: 'nada corresponde · esc limpa o filtro',
   sessionsLoading: 'lendo…',
   sessionsUnsupported: 'gerenciamento de sessões não está disponível nesta máquina.',
-  sessionsCount: (n: number) => (n === 1 ? '1 sessão' : `${n} sessões`),
+  sessionsCount: (shown: number, total: number) => (shown === total
+    ? (total === 1 ? '1 sessão' : `${total} sessões`)
+    : `${shown} de ${total} sessões`),
   sessionsWaitingCount: (n: number) => (n === 1 ? '1 esperando por você' : `${n} esperando por você`),
   sessionsGroupBy: 'AGRUPAR',
   sessionsGroupings: {

--- a/packages/tui/src/control/sessions.test.ts
+++ b/packages/tui/src/control/sessions.test.ts
@@ -14,6 +14,7 @@ import {
   type CardLine, type SessionRow,
 } from './sessions'
 import type { ControlSession, SessionState } from './types'
+import { controlStrings } from './i18n'
 
 /** The layout block every aside fixture carries — it is a required option, like the groupings. */
 const LAYOUT = {
@@ -1734,5 +1735,32 @@ describe('detailLines — named in two places', () => {
       labels, ago,
     )
     expect(lines.map(l => l.key).slice(0, 3)).toEqual(['say0', 'also', 'where'])
+  })
+})
+
+describe('the header count', () => {
+  const en = controlStrings('en')
+  const pt = controlStrings('pt')
+
+  it('says how many are ON SCREEN and out of how many', () => {
+    // The header read the fleet's length, so with `only active` on it announced 44 over a screen
+    // showing ten — a number describing a screen nobody is looking at.
+    expect(en.sessionsCount(10, 44)).toBe('10 of 44 sessions')
+    expect(pt.sessionsCount(10, 44)).toBe('10 de 44 sessões')
+  })
+
+  it('drops the second number when it says nothing new', () => {
+    // Nothing is being withheld, so "9 of 9" is noise where "9" is the fact.
+    expect(en.sessionsCount(9, 9)).toBe('9 sessions')
+    expect(pt.sessionsCount(9, 9)).toBe('9 sessões')
+    expect(en.sessionsCount(1, 1)).toBe('1 session')
+    expect(pt.sessionsCount(1, 1)).toBe('1 sessão')
+  })
+
+  it('is honest about an empty screen over a fleet that is not', () => {
+    // The case that matters most: the filter emptied the list, and the row must not read as an
+    // empty machine.
+    expect(en.sessionsCount(0, 44)).toBe('0 of 44 sessions')
+    expect(pt.sessionsCount(0, 44)).toBe('0 de 44 sessões')
   })
 })

--- a/packages/tui/src/control/tabs/Sessions.tsx
+++ b/packages/tui/src/control/tabs/Sessions.tsx
@@ -1296,6 +1296,10 @@ export function Sessions({
           showClosed={showClosed}
           hideEmptyTask={grouping === 'task' ? hideEmptyTask : null}
           onlyActive={onlyActive}
+          // How many rows are ON SCREEN, counted from the very list being drawn. The header used to
+          // read the fleet's length, so with `only active` on it announced 44 over a screen showing
+          // ten — a number describing a screen nobody is looking at.
+          shown={rows.reduce((n, r) => n + (r.kind === 'session' ? 1 : 0), 0)}
           query={query}
           scope={projectFilter ?? taskFilter ?? ''}
           fell={fleet?.fell && fellAgo ? s.sessionsFellNote(fleet.fell.count, fellAgo) : ''}
@@ -1488,7 +1492,7 @@ export function Sessions({
  * to state the answer, so a glance tells you why the list looks the way it does.
  */
 function SummaryRow({
-  fleet, grouping, strings: s, width, showClosed, hideEmptyTask, onlyActive, query, scope, fell,
+  fleet, grouping, strings: s, width, showClosed, hideEmptyTask, onlyActive, shown, query, scope, fell,
 }: {
   fleet: ControlSessions | null | undefined
   grouping: SessionGrouping
@@ -1499,6 +1503,8 @@ function SummaryRow({
   hideEmptyTask: boolean | null
   /** The strict switch, which withholds more than the other two together. */
   onlyActive: boolean
+  /** Rows actually drawn, counted from the drawn list rather than from the fleet. */
+  shown: number
   /** The active search, or `''`. Stated HERE because a list narrowed silently reads as an empty one. */
   query: string
   /** The active task or project scope, already localized, or `''`. */
@@ -1539,7 +1545,7 @@ function SummaryRow({
   const cells = summaryCells({
     group: narrowed || `${s.sessionsGroupBy} ${s.sessionsGroupings[grouping]}`,
     hiding: hiding.length > 0 ? `− ${hiding.join(', ')}` : '',
-    count: s.sessionsCount(fleet?.sessions.length ?? 0),
+    count: s.sessionsCount(shown, fleet?.sessions.length ?? 0),
     waiting: waiting > 0 ? s.sessionsWaitingCount(waiting) : '',
     fell,
     width,


### PR DESCRIPTION
`44 sessões` over a screen showing ten.

The count read `fleet.sessions.length` — everything the machine has — while the list under it had been through `only active`, the history switches, a task scope and a search. A number that describes a screen nobody is looking at.

It counts the rows being **drawn**, from the same list the screen renders, and says both: `10 de 44 sessões`. Two numbers, because either alone lies — the first does not say how much is being withheld, the second does not say what is on screen. When they are equal the second says nothing new and is dropped, so an unfiltered list still reads `9 sessões`.

The case that mattered most to get right is the empty one: `0 de 44` is a filter hiding everything, and it must not read as an empty machine.

Tests: 3636 pass. Touches `i18n.ts` and the `SummaryRow` in `tabs/Sessions.tsx` — four other sessions are in that file right now, so whoever merges second rebases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019vBSuKQLuyLhWZS4zbiu2s