### PR TITLE
feat(sessions): the wizard asks what to call the session

### DIFF
--- a/packages/tui/src/control/i18n.ts
+++ b/packages/tui/src/control/i18n.ts
@@ -380,6 +380,8 @@ export interface ControlStrings {
   wizEffort: string
   wizPrompt: string
   wizPromptHint: string
+  wizName: string
+  wizNameHint: string
   wizHow: string
   /** Said while the session is being started, so `enter` is visibly doing something. */
   wizStarting: string
@@ -767,6 +769,8 @@ const EN: ControlStrings = {
   wizEffort: 'Which reasoning effort?',
   wizPrompt: 'First prompt (optional)',
   wizPromptHint: 'leave empty to start with nothing typed',
+  wizName: 'Call it what?',
+  wizNameHint: 'a name of your own — enter alone derives one from the harness and the folder',
   wizHow: 'Start it how?',
   wizStarting: 'starting…',
   wizKeptDraft: 'nothing you typed was lost — esc goes back a step, or try again',
@@ -1140,6 +1144,8 @@ const PT: ControlStrings = {
   wizEffort: 'Qual nível de raciocínio?',
   wizPrompt: 'Primeiro prompt (opcional)',
   wizPromptHint: 'deixe vazio para começar sem nada digitado',
+  wizName: 'Chamar de quê?',
+  wizNameHint: 'um nome seu — enter vazio deriva um do harness e da pasta',
   wizHow: 'Iniciar como?',
   wizStarting: 'iniciando…',
   wizKeptDraft: 'nada do que você digitou foi perdido — esc volta um passo, ou tente de novo',

--- a/packages/tui/src/control/sessions.test.ts
+++ b/packages/tui/src/control/sessions.test.ts
@@ -1736,3 +1736,22 @@ describe('detailLines — named in two places', () => {
     expect(lines.map(l => l.key).slice(0, 3)).toEqual(['say0', 'also', 'where'])
   })
 })
+
+describe('the wizard name step', () => {
+  const harness = { id: 'claude', supportsModel: true }
+
+  it('carries a name the user typed', () => {
+    const plan = planSubmit({
+      draft: { harness, cwd: '/r', label: 'a refatoração do token' }, hasSpawn: true, attach: false,
+    })
+    expect(plan.ok).toBe(true)
+    if (plan.ok) expect(plan.req.label).toBe('a refatoração do token')
+  })
+
+  it('carries NO name when the step was skipped', () => {
+    // Enter on an untouched field means "no name of my own", and the row derives one from the
+    // harness and the folder. An empty string is not a name called "".
+    const plan = planSubmit({ draft: { harness, cwd: '/r', label: '' }, hasSpawn: true, attach: false })
+    if (plan.ok) expect('label' in plan.req).toBe(false)
+  })
+})

--- a/packages/tui/src/control/sessions.ts
+++ b/packages/tui/src/control/sessions.ts
@@ -1541,6 +1541,8 @@ export interface SessionDraft {
   harness?: { id: string; supportsModel?: boolean }
   cwd?: string
   task?: string
+  /** The name the user typed for this session. Absent means "no name of my own" — the row derives one. */
+  label?: string
   prompt?: string
   model?: string
   effort?: string
@@ -1581,6 +1583,7 @@ export function planSubmit(o: {
       ...(o.draft.effort ? { effort: o.draft.effort } : {}),
       ...(o.draft.prompt ? { prompt: o.draft.prompt } : {}),
       ...(o.draft.task ? { task: o.draft.task } : {}),
+      ...(o.draft.label ? { label: o.draft.label } : {}),
     },
   }
 }

--- a/packages/tui/src/control/tabs/SessionWizard.tsx
+++ b/packages/tui/src/control/tabs/SessionWizard.tsx
@@ -56,12 +56,13 @@ import { COLORS } from '../../theme'
  * such flag: a question whose only answer is "not applicable" is a question that should not have
  * been asked, and `advance` is the single place that decides which ones a harness earns.
  */
-type Step = 'harness' | 'where' | 'task' | 'model' | 'effort' | 'prompt' | 'how'
+type Step = 'harness' | 'where' | 'task' | 'model' | 'effort' | 'prompt' | 'name' | 'how'
 
 interface Draft {
   harness?: SessionHarnessOption
   cwd?: string
   task?: string
+  label?: string
   model?: string
   effort?: string
   prompt?: string
@@ -93,7 +94,7 @@ export function SessionWizard({ host, strings: s, width, height, isActive, onCan
 
   /** The next step this harness actually earns, skipping the questions it has no flag for. */
   const nextAfter = useCallback((from: Step, h: SessionHarnessOption | undefined): Step => {
-    const order: Step[] = ['harness', 'where', 'task', 'model', 'effort', 'prompt', 'how']
+    const order: Step[] = ['harness', 'where', 'task', 'model', 'effort', 'prompt', 'name', 'how']
     let i = order.indexOf(from) + 1
     while (i < order.length) {
       const candidate = order[i]!
@@ -147,7 +148,7 @@ export function SessionWizard({ host, strings: s, width, height, isActive, onCan
   // answers because the sixth was a typo is a wizard people stop using.
   useInput((_input, key) => {
     if (!key.escape) return
-    const order: Step[] = ['harness', 'where', 'task', 'model', 'effort', 'prompt', 'how']
+    const order: Step[] = ['harness', 'where', 'task', 'model', 'effort', 'prompt', 'name', 'how']
     const i = order.indexOf(step)
     for (let j = i - 1; j >= 0; j--) {
       const prev = order[j]!
@@ -265,6 +266,29 @@ export function SessionWizard({ host, strings: s, width, height, isActive, onCan
             setStep(nextAfter('prompt', draft.harness))
           }}
           onCancel={() => setStep('where')}
+        />
+      </Box>
+    )
+  }
+
+  if (step === 'name') {
+    return (
+      <Box flexDirection="column" width={width}>
+        <Text dimColor>{truncate(s.wizNameHint, width)}</Text>
+        <TextPrompt
+          label={s.wizName}
+          // A PLACEHOLDER, never a `defaultValue`: `TextPrompt` treats a default as the answer to an
+          // empty submit, which is right for renaming and wrong here — enter on an untouched field
+          // means "no name of my own", and the row falls back to the derived one.
+          placeholder={draft.task ?? ''}
+          width={width}
+          isActive={isActive}
+          onSubmit={value => {
+            const label = value.trim()
+            setDraft(d => ({ ...d, ...(label ? { label } : {}) }))
+            setStep(nextAfter('name', draft.harness))
+          }}
+          onCancel={() => setStep('prompt')}
         />
       </Box>
     )


### PR DESCRIPTION
`agentop session claude --name "…"` has always taken a name. The wizard — seven steps, from the harness to background-or-attached — never asked for one, so a session started from the cockpit could only wear the derived label (`claude in agentistics`) until someone renamed it afterwards. The one place where naming costs nothing is the moment you are already answering questions about the session.

It sits between the prompt and how-to-start, so the last thing asked before the session goes is still the one that decides whether it takes the terminal.

The field carries a **placeholder**, never a `defaultValue`: `TextPrompt` treats a default as the answer to an empty submit — right for renaming, where enter means "leave it as it is", and exactly wrong here, where enter on an untouched field means "no name of my own" and the row should derive one. An empty string is not a name called "".

Tests: 3635 pass. Preview swept 60/100/140/190.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019vBSuKQLuyLhWZS4zbiu2s