### PR TITLE
release: the event channel, a name at birth, and a count that matches the screen

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,9 +45,15 @@ packages/server/bin/cli.ts  (binary entry point — agentop)
   │                          Without a tty there is no colour and the width comes from `COLUMNS`
   │                          when there is one — a pager IS a reader — so `session ls | grep` works
   ├── agentop hooks …      → server/cli-hooks.ts (install/uninstall/status/context — the Claude Code
-  │                          integration: a SKILL that teaches the `session batch` contract and a
-  │                          SessionStart HOOK that injects the live fleet. Explicit, idempotent,
-  │                          exactly reversible; see docs/claude-integration.md)
+  │                          integration: a SKILL that teaches the `session batch` contract, a
+  │                          SessionStart HOOK that injects the live fleet, and a Stop HOOK that
+  │                          feeds the event channel. Explicit, idempotent, exactly reversible;
+  │                          see docs/claude-integration.md)
+  ├── agentop events …     → server/cli-events.ts (watch/unwatch/status/tail/run/emit/test — the
+  │                          EVENT CHANNEL: a state TRANSITION reaches a person and the assistant
+  │                          orchestrating the fleet. See `events/` below and docs/session-events.md.
+  │                          It is `events`, not `watch`, because `agentop watch` is already the
+  │                          OTel daemon and `agentop restart watch` would become ambiguous)
   ├── agentop ci-push      → server/ci-push.ts (one-shot GitHub Actions runner → central push; env AGENTISTICS_CENTRAL_URL/AGENTISTICS_CI_TOKEN)
   ├── agentop autostart …  → server/autostart.ts (systemd user service + linger + ~/.bashrc + ~/.zshrc update-check hook)
   ├── agentop upgrade      → server/upgrade.ts
@@ -89,8 +95,16 @@ packages/server/server/          — server-side modules (never bundled by Vite)
   │                          first prompt TYPED IN, because their `-p` exits after answering.
   │                          **What a session is DOING** is the pure `attention.ts` over two
   │                          signals — a probed screen marker and whether the frame moved — with
-  │                          `attention-rules.ts` holding six per-harness patterns **captured
-  │                          from six live dialogs**, each with its CLI version and date. There
+  │                          `attention-rules.ts` holding the per-harness patterns **captured
+  │                          from live dialogs**, each with its CLI version and date. **One dialog
+  │                          per harness is not enough**: claude's rule was captured from the
+  │                          folder-trust prompt, and the TOOL PERMISSION prompt draws a completely
+  │                          different footer (`Esc to cancel · Tab to amend · ctrl+e to explain`,
+  │                          asking `Do you want to proceed?`) — so a session really blocked on `rm`
+  │                          was reported as an ordinary `waiting` for as long as the rule existed.
+  │                          That is the silent failure the file's own header warns about, and it
+  │                          happened anyway: a pattern that never matches does not throw and does
+  │                          not look wrong. There
   │                          is deliberately no `idle` state: an interactive assistant that is
   │                          alive and still is waiting for you, and the uncertainty that really
   │                          exists is about the REASON, which lives in an absent approval rule
@@ -159,7 +173,71 @@ packages/server/server/          — server-side modules (never bundled by Vite)
   │                          else's `~/.claude`; same distinction `mcp-list.ts` makes). The session
   │                          verbs are deliberately NOT MCP tools: `agentop session batch` already
   │                          exists as a CLI and Bash's permission prompt is the consent gate for
-  │                          starting N billable assistants. See docs/claude-integration.md
+  │                          starting N billable assistants. There are TWO hook events, held in one
+  │                          `HOOK_SPECS` table so there is exactly ONE settings merge: `SessionStart
+  │                          → hooks context` (the facts, 10s) and `Stop → events emit` (the exact
+  │                          end-of-turn signal for the event channel, 5s — it runs on EVERY turn, so
+  │                          a budget that is felt is a budget that is wrong). The command matcher is
+  │                          NARROWED by event, or removing one hook would delete a `Stop` entry
+  │                          somebody had moved under `SessionStart`. See docs/claude-integration.md
+  ├── events/              → **the EVENT CHANNEL** behind `agentop events`: a state TRANSITION
+  │                          reaching a person and the assistant orchestrating the fleet.
+  │                          **The producer MUST be long-lived, and that decides its home.**
+  │                          `createSessionsPoller` holds each session's last frame digest in
+  │                          memory, and MOVEMENT is the only universal `working` signal there is
+  │                          (codex draws an identical screen streaming and idle); tmux's own
+  │                          `session_activity` is no substitute — measured: a session working for
+  │                          53 minutes reported its last activity 3185s earlier, because nothing
+  │                          was attached. So a single-invocation poll reports WORKING sessions as
+  │                          FINISHED, and a cron-shaped design would announce five sessions
+  │                          finishing at the moment they all started. The producer therefore rides
+  │                          along with the daemon `agentop server` already runs (`daemon.ts` inside
+  │                          otel-watcher), never as a service the user must remember to start;
+  │                          `events run` is the foreground fallback and `events status` reports the
+  │                          producer as running / stale / ABSENT, because "nothing arrived" must be
+  │                          distinguishable from "nothing was watching". `event-plan.ts` is
+  │                          **pure** and holds the rule the whole feature is judged on: **a state
+  │                          counts only once it has been observed on TWO CONSECUTIVE POLLS.** A
+  │                          repaint (a tmux advisory line, a plugin notice) moves the frame for one
+  │                          poll, is correctly read as `working`, and reported the same session as
+  │                          `waiting` twice ten seconds apart. A TIME WINDOW does not fix it — that
+  │                          was the first attempt, the next flicker landed outside it, and any
+  │                          window wide enough also swallows a genuine follow-up turn. The cost is
+  │                          stated: a turn inside one poll interval is invisible to this source,
+  │                          which is exactly what the `Stop` hook covers. TWO SOURCES, not
+  │                          equivalent: the poll is the FLOOR (all six harnesses, reads the screen,
+  │                          the only thing that can see a permission prompt at all — Claude Code
+  │                          fires no `Stop` for one) and the hook is EXACT (Claude only).
+  │                          `event-dedupe.ts` drops the poll's copy of a turn a hook already
+  │                          reported, one-directionally, and NEVER dedupes `waiting-approval`.
+  │                          **The INBOX (`~/.agentistics/events.jsonl`, 0600) is the heart, not a
+  │                          cache**: a Claude session only exists while invoked, so an event
+  │                          delivered to a parked one happened to nobody — the socket and the toast
+  │                          make the read happen SOONER, never instead. A cursor is `offset:seq`
+  │                          because a byte offset is exactly what rotation invalidates, and a
+  │                          pre-rotation cursor reads from the start and SAYS `rotated` rather than
+  │                          returning nothing. `peer-target.ts` is **pure**: the registry says who
+  │                          EXISTS, the SOCKET says who is UP (measured: 79 records, 5 live
+  │                          sockets), a name matches WHOLE never by prefix, and the message carries
+  │                          the target's own `session_id` so a recycled pid cannot misdeliver a
+  │                          fleet event into an unrelated conversation. `notify-plan.ts` is
+  │                          **pure**: the desktop cascade ccn → notify-send → powershell → bell →
+  │                          none, each step named in a SENTENCE by `status`, because a notification
+  │                          that fails silently is worse than none. **ccn
+  │                          (`claude-code-notifications`) is DETECTED, never embedded** — it ships
+  │                          through the Claude Code plugin system with its own release cycle while
+  │                          agentop is one binary, so a copy would be a second version to drift;
+  │                          agentop shapes its event into the `Notification` hook envelope ccn
+  │                          already accepts and contributes the five harnesses ccn cannot see plus
+  │                          the task grouping neither has alone. Subscriptions are a FILE
+  │                          (`event-subscriptions.json`), not a process: a foreground watcher is
+  │                          one the user forgets to start and is dead when it matters.
+  │                          **THE FRONTIER**: an event carries facts and no instruction, a
+  │                          subscription can ask for DELIVERY and never for an ACTION, and
+  │                          `waiting-approval` is reported as waiting on A PERSON — nothing here
+  │                          may approve anything for anyone. `events-frontier.test.ts` asserts it
+  │                          over the module SOURCE, so a field named `action` or an imperative
+  │                          sentence fails the build. See docs/session-events.md
   ├── team-tokens.ts       → mint / rotate / revoke / validate tokens (stored as sha256 hashes only)
   ├── rotate-identity.ts   → **pure**: what a TOKEN ROTATION carries. `memberId = sha256(token)`, so rotating renames the machine in every collection keyed by that id — this module holds the ENUMERATION (`tokens`, `sessions`, `memberStats`, `workflows`, `machineKeys` and a tag's `machine` sources all migrate; `audit.targetId` is left as written, because an audit records what was true then; CI sessions are keyed by `ciMemberId(remote)` = `repo:<remote>` and move nothing; the member side's per-connection state is named by the LOCAL connection id and is reconciled by the sync fingerprint). **Any new collection keyed by a machine id must be added here or a rotation silently strands it — that is the same bug three times already.** `planEnvelopeRotation` is the mailbox decision and has NO re-address option: the routing is the GCM AAD, so mail addressed to the old id yields `recipient_mismatch` for anyone (dropped, and counted in the audit as a LOSS) while mail SENT by it still opens exactly as sealed (kept — re-stamping the sender would destroy it). `retargetMachineSources` matches on the source TYPE as well as the value, so an `account` id that happens to read the same is never dragged along. **Sibling pins are deliberately not carried**: to a sibling the rotated machine is new, is pinned on first sight and is ANNOUNCED — continuity would need a claim the central can forge (a "formerly" field, or "same public key", which a central can copy onto an invented machine), and the announcement is the one control against a fabricated peer
   ├── mongo-dates.ts       → **the date boundary**: BSON `Date` in Mongo, ISO string on the wire. Pure toBsonDate/fromBsonDate(+OrNull)/toBsonDates/fromBsonDates + `DATE_FIELDS` (every stored timestamp, by collection) + `migrateStringDatesToBson()` (idempotent, runs at boot; also `scripts/migrate-mongo-dates.ts`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,16 +95,8 @@ packages/server/server/          — server-side modules (never bundled by Vite)
   │                          first prompt TYPED IN, because their `-p` exits after answering.
   │                          **What a session is DOING** is the pure `attention.ts` over two
   │                          signals — a probed screen marker and whether the frame moved — with
-  │                          `attention-rules.ts` holding the per-harness patterns **captured
-  │                          from live dialogs**, each with its CLI version and date. **One dialog
-  │                          per harness is not enough**: claude's rule was captured from the
-  │                          folder-trust prompt, and the TOOL PERMISSION prompt draws a completely
-  │                          different footer (`Esc to cancel · Tab to amend · ctrl+e to explain`,
-  │                          asking `Do you want to proceed?`) — so a session really blocked on `rm`
-  │                          was reported as an ordinary `waiting` for as long as the rule existed.
-  │                          That is the silent failure the file's own header warns about, and it
-  │                          happened anyway: a pattern that never matches does not throw and does
-  │                          not look wrong. There
+  │                          `attention-rules.ts` holding six per-harness patterns **captured
+  │                          from six live dialogs**, each with its CLI version and date. There
   │                          is deliberately no `idle` state: an interactive assistant that is
   │                          alive and still is waiting for you, and the uncertainty that really
   │                          exists is about the REASON, which lives in an absent approval rule

--- a/docs/claude-integration.md
+++ b/docs/claude-integration.md
@@ -94,7 +94,7 @@ The file carries an **ownership marker** directly under its frontmatter. `instal
 `uninstall` deletes the file only while that marker is present — delete the line and the file is
 yours, permanently.
 
-### The hook
+### The hooks
 
 ```json
 {
@@ -102,7 +102,14 @@ yours, permanently.
     "SessionStart": [
       {
         "hooks": [
-          { "type": "command", "command": "agentop hooks context --hook-version 1", "timeout": 10 }
+          { "type": "command", "command": "agentop hooks context --hook-version 2", "timeout": 10 }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          { "type": "command", "command": "agentop events emit --hook-version 2", "timeout": 5 }
         ]
       }
     ]
@@ -110,8 +117,21 @@ yours, permanently.
 }
 ```
 
-No `matcher`, so it runs on every SessionStart source (`startup`, `resume`, `clear`, `compact`) —
-all of them are moments where this state was just lost or never had.
+Two events, because they answer two different questions and cost different things.
+
+`SessionStart` has no `matcher`, so it runs on every source (`startup`, `resume`, `clear`,
+`compact`) — all of them are moments where this state was just lost or never had.
+
+`Stop` fires when this session finishes answering, and its body writes ONE line into agentop's
+[event inbox](session-events.md). It prints nothing into anybody's context and its timeout is five
+seconds rather than ten, because it runs at the end of every turn and a budget that is felt is a
+budget that is wrong. It is the EXACT half of the event channel: Claude saying it stopped, instead
+of the fleet monitor inferring it from the screen up to five seconds later. The channel's poll
+source covers the other five harnesses, which have no hook to offer, and is the only thing that can
+see a permission prompt at all — Claude Code does not fire `Stop` for one.
+
+Both are planned against the same document and written **once**, so a refusal on the second leaves
+neither installed rather than half of the integration in place.
 
 `agentop hooks context` prints either nothing, or one block:
 
@@ -144,9 +164,9 @@ Rules it follows (`packages/server/server/session-context.ts`, pure and tested):
 |---|---|
 | **The user installs it, not the installer.** | `agentop setup` prints one line suggesting the command (and only while it is not already installed). Nothing writes to `~/.claude` on its own. Same rule `autostart.ts` follows for `~/.bashrc`. |
 | **Your `settings.json` is never overwritten.** | Every key, every foreign hook and every key agentop has never heard of is preserved. The merge (`planHookInstall`) adds one entry and touches nothing else. |
-| **A file it cannot merge into is refused, not fixed.** | A `settings.json` that is not JSON, whose `hooks` is not an object, or whose `SessionStart` is not an array: agentop reports it and writes **nothing**. |
+| **A file it cannot merge into is refused, not fixed.** | A `settings.json` that is not JSON, whose `hooks` is not an object, or whose `SessionStart` or `Stop` is not an array: agentop reports it and writes **nothing**. |
 | **Installing twice changes nothing.** | The second run reports `unchanged` and does not rewrite the file. |
-| **Uninstall is the exact inverse.** | Our hook entry goes, and the containers that existed only to hold it (`SessionStart`, `hooks`, the skill directory, an empty `skills/`). A group that also carries someone else's hook keeps that hook and its group. Verified byte-for-byte in the tests. |
+| **Uninstall is the exact inverse.** | Our hook entries go, and the containers that existed only to hold them (`SessionStart`, `Stop`, `hooks`, the skill directory, an empty `skills/`). A group that also carries someone else's hook keeps that hook and its group. Verified byte-for-byte in the tests. |
 | **No Claude Code, no files.** | No `~/.claude` and no `claude` on `PATH` → the command says so, exits 1, and creates neither directory nor file. |
 | **It never starts a session by itself.** | The skill's first rule is the consent rule; the hook's block says outright not to act on it. |
 
@@ -154,9 +174,11 @@ Rules it follows (`packages/server/server/session-context.ts`, pure and tested):
 
 Claude Code's hook entry is `{ type, command, timeout }` — there is no field for "who installed
 this", and inventing an unknown key in someone else's schema is how a settings file stops validating
-on the next release. So agentop identifies its entry by **the command it runs** (the verb pair
-`hooks context`, plus either `agentop` in the command or the `--hook-version` flag it always
-writes), and the version travels in that same command. `agentop hooks status` can therefore read a
+on the next release. So agentop identifies its entry by **the command it runs** — one of its own verb
+pairs (`hooks context`, `events emit`), plus either `agentop` in the command or the `--hook-version`
+flag it always writes — and the version travels in that same command. The match is NARROWED by
+event: a `Stop` entry someone moved under `SessionStart` is not ours to delete, or the two hooks
+would become one thing that cannot be administered separately. `agentop hooks status` can therefore read a
 file it has no memory of writing — one hand-edited, or copied from another machine — with no second
 store on the side to disagree with it.
 

--- a/docs/session-events.md
+++ b/docs/session-events.md
@@ -1,0 +1,248 @@
+# The event channel — `agentop events`
+
+Whoever fans five sessions out with [`agentop session batch`](session-manager.md#orchestrating-several-at-once)
+is blind between the moment they start and the moment they look. A session that finished, exited, or
+stopped on a permission prompt says so on its own screen, in a pane nobody is attached to.
+
+`agentop events` turns a state CHANGE into something that reaches you: an append-only inbox on disk,
+a message into another Claude Code session, and a notification on your desktop.
+
+```bash
+agentop events watch --task "auth-refactor" --notify cockpit --desktop
+agentop events status
+agentop events tail --since 8140:37 --json
+agentop events unwatch s1
+```
+
+---
+
+## The boundary, first
+
+Everything below is built so that this holds:
+
+- **An event informs.** It records when, which session, which task, from what state to what state,
+  and the last few lines that were on screen. It carries no instruction, no suggestion, no request.
+  `SessionEvent` has no field that could hold one, and a subscription has no field naming something
+  to run.
+- **Approval is never automatic.** A session blocked on a permission prompt is reported as
+  *"is waiting on a permission prompt — that prompt is for a person to answer"*, and that is the
+  whole of it. Nothing in this channel can answer such a prompt, and every message it sends carries
+  a standing note saying so.
+- **What travels is yours.** A screen tail can contain anything you typed. It is written to
+  `~/.agentistics/events.jsonl` with mode `0600` and does not leave the machine — not to a central,
+  not anywhere.
+
+`events-frontier.test.ts` asserts all three, including by reading the modules' own source: a field
+called `action` or a notification sentence in the imperative fails the build.
+
+---
+
+## Two sources, and they are not equivalent
+
+| | how it knows | covers | latency |
+|---|---|---|---|
+| **poll** | reads the SCREEN through `attention.ts` | every harness agentop manages | up to ~5 s |
+| **hook** | Claude Code's `Stop` event fires | Claude only | immediate |
+
+The **poll is the floor**. It works for codex, gemini, copilot, kimi and antigravity, none of which
+have a hook to offer, and it is the only thing that can see a permission prompt at all — Claude Code
+does not fire `Stop` for one.
+
+The **hook is exact**. `agentop hooks install` registers `Stop → agentop events emit`, which writes
+one line and exits. No polling, no inference, no five-second wait.
+
+Both report the same end of a Claude turn, so `event-dedupe.ts` drops the poll's copy when a hook
+event for the same conversation landed within twenty seconds. The rule is one-directional — the
+hook's exact record always survives — and `waiting-approval` is never deduped, because it has no
+hook counterpart and is the event nobody may lose.
+
+---
+
+## Why the producer is a daemon and not a command
+
+The fleet monitor holds two things between polls: each session's last frame digest, and each
+session's last state. Both are what make the answer correct, and neither survives a process that
+starts and exits:
+
+- **Movement is the only universal proof of work.** Several harnesses draw an identical screen while
+  streaming output and while sitting idle — codex's footer and ghost placeholder are byte-identical
+  either way. The only evidence a session is working is that the frame CHANGED since last time, and
+  a single-invocation poll has no last time.
+- **tmux's own activity timestamp cannot fill the gap.** Measured on a live machine: a session that
+  had been working continuously for 53 minutes reported its last tmux activity 3185 seconds earlier,
+  because nothing was attached to it.
+
+So a cron job or a per-invocation check would announce that five sessions had finished at the moment
+they all started. False notifications are worse than none — people stop looking.
+
+The producer therefore lives inside the daemon that `agentop server` already starts
+(`otel-watcher`), which is also what `agentop autostart` already covers. `agentop events run` starts
+the same producer in the foreground for someone who does not run the server, and `agentop events
+status` reports the producer as **running**, **stale** (its process is gone) or **absent** — because
+"nothing arrived" must be distinguishable from "nothing was watching".
+
+Set `AGENTISTICS_EVENTS=0` to keep the daemon from watching sessions at all.
+
+---
+
+## A state that lasted one frame is not a state
+
+The first version of this channel reported the same session as `waiting` twice, ten seconds apart.
+Nothing had happened: its pane repainted — a tmux advisory line appeared at the bottom — and a frame
+that MOVED is correctly read as `working`, so the next frame was correctly read as `waiting` again.
+It happened again forty-five seconds later when a plugin printed a notice into the same pane.
+
+A time window does not fix it. The first attempt was one, and the second flicker landed outside it;
+any window wide enough to catch a repaint also swallows a genuine follow-up turn, which is the
+primary thing this channel exists to report.
+
+So the rule uses the signal itself: **a state counts only once it has been observed on two
+consecutive polls**, and events are compared against the last CONFIRMED state. A repaint is one
+frame and is never confirmed. What it costs, stated plainly: a turn that begins and ends inside a
+single five-second interval is invisible to the poll source — which is precisely the case the
+`Stop` hook covers exactly, and a large part of why the hook exists.
+
+This is deliberately not a change to `attention.ts`. "The screen moved, so it is working" is the
+right rule for the cockpit and the only signal several harnesses give.
+
+---
+
+## The inbox
+
+`~/.agentistics/events.jsonl`, append-only JSONL, one event per line.
+
+It is not a cache. **A Claude session only exists while it is being invoked**, so an event delivered
+to a session that is parked happened to nobody. The inbox is what makes the channel work for the
+consumer that is not running: it reads what happened since it last looked, on its own schedule. The
+socket and the toast make that read happen *sooner*; they never replace it.
+
+- **Cursors are a pair, `offset:seq`.** A byte offset alone is exactly what rotation invalidates.
+  `agentop events tail --json` prints the cursor; `--since` takes it back. A cursor from before a
+  rotation reads from the start of the current file and says `rotated: true` rather than returning
+  nothing.
+- **It rotates at 2 MiB**, keeping exactly one previous generation as `events.jsonl.1`.
+- **An unreadable line costs that line.** A file written by a newer agentop, or truncated by a
+  crash, still reads — and `tail` / `status` report how many lines this version could not read
+  rather than silently showing an empty inbox.
+
+---
+
+## Delivering to another Claude session
+
+`--notify <name|pid>` names a Claude Code session. Claude Code registers each one as
+`~/.claude/sessions/<pid>.json` with a `messagingSocketPath`, and agentop delivers over that socket.
+
+Two things make it safe rather than merely working:
+
+- **The registry says who exists; the socket says who is UP.** Measured on one machine: 79 records,
+  five live sockets. A record is deliverable only when the socket it names is present.
+- **The message carries the target's own `session_id`**, which the receiver checks against its own.
+  Pid files outlive their processes and pids get reused; without it a stale record could deliver a
+  fleet event into an unrelated conversation.
+
+A session that is not up is **not** delivered to, and the command says so. The event stays in the
+inbox and that session reads it with `agentop events tail` when it next runs. There is no path here
+that reports a success it did not observe.
+
+The socket protocol is Claude Code's own and is not a published API. Every failure is reported as a
+failure — a broken socket costs latency, not the event.
+
+---
+
+## Delivering to you
+
+`--desktop` uses the first channel this machine actually has, in this order:
+
+1. **`claude-code-notifications`** (the `ccn` Claude Code plugin), when it is installed *and* its own
+   requirements (`jq`, `powershell.exe`) are present. On WSL it already solves the hard half — a real
+   Windows toast, a sound, and a click that focuses the session's window.
+2. **`notify-send`** — the Linux desktop standard, absent on WSL, which is why it is not first.
+3. **`powershell.exe`** — a plain Windows toast from WSL, no sound and no click target.
+4. **the terminal bell**, when there is a terminal.
+5. **nothing** — and `status` says so in a sentence naming everything it looked for.
+
+ccn is **detected, never embedded**. It ships through the Claude Code plugin system with its own
+release cycle while agentop is one compiled binary, so a bundled copy would be a second version to
+drift. What agentop sends it is the payload shape it already accepts — a Claude Code `Notification`
+hook envelope with a `message` and a `cwd` — so agentop contributes the five harnesses ccn cannot
+see and the task grouping neither tool has alone, without either knowing the other's internals.
+
+`agentop events test` delivers a probe through the real channels, so a broken one is found before
+you have spent a week trusting it. The probe is deliberately **not** written to the inbox: a test
+event among real ones is a fact that never happened.
+
+Set `AGENTISTICS_EVENTS_DESKTOP=0` to switch the desktop step off; `status` reports that as its own
+reason, distinct from "unavailable".
+
+---
+
+## Subscriptions are a file, not a process
+
+`agentop events watch` writes a row to `~/.agentistics/event-subscriptions.json`. Whichever producer
+is up delivers it. This is the point: a foreground command you must remember to start is a command
+that will not be running at the moment it matters, and a subscription in a file survives a reboot.
+
+```
+--task <name>      only sessions filed under that task (EXACT — "api" must not select "api-migration")
+--session <ref>    only that session, by agentop id prefix or by label
+--on <states>      working, waiting, waiting-approval, exited, turn-end
+                   (default: waiting, waiting-approval, exited)
+--notify <ref>     a Claude Code session to inform
+--desktop          a notification for you
+```
+
+A subscription with no delivery is legal and useful: it still shapes what the producer RECORDS, and
+`agentop events tail` reads that. `status` describes it as "inbox only" rather than as nothing.
+
+`watch` refuses a `--notify` naming a session nobody has registered, and prints the sessions that
+are running — a subscription that can never deliver is one you believe is working. A session that is
+merely not up right now is accepted and said out loud.
+
+---
+
+## Command reference
+
+```
+agentop events watch   [--task <name>] [--session <id|label>] [--on <states>]
+                       [--notify <claude-session>] [--desktop] [--note <text>] [--json]
+agentop events unwatch <id> | --all
+agentop events status  [--json]
+agentop events tail    [-n <count>] [--since <offset:seq>] [--task <name>] [--on <states>]
+                       [--follow] [--json]
+agentop events run     [--once]
+agentop events test    [--notify <claude-session>] [--desktop]
+```
+
+`--once` seeds and says so: one tick can only record where everything IS, because a transition needs
+a second look.
+
+It is `agentop events`, not `agentop watch`, because `agentop watch` is already the OpenTelemetry
+metrics daemon — taking that verb would make `agentop restart watch` ambiguous and silently retarget
+a name people have in scripts.
+
+---
+
+## Where each piece lives
+
+| module | what it decides |
+|---|---|
+| `events/event-types.ts` | the shape of an event, and what it may not carry |
+| `events/event-plan.ts` | **pure** — which transitions are events; the two-poll confirmation rule |
+| `events/event-line.ts` | **pure** — one event ↔ one line; tolerating a line this version cannot read |
+| `events/event-rotate.ts` | **pure** — the cap, and the cursor that survives a rotation |
+| `events/event-dedupe.ts` | **pure** — the same turn seen by both sources, read once |
+| `events/subscriptions.ts` | **pure** — who hears what |
+| `events/events-parse.ts` | **pure** — `agentop events …` |
+| `events/notify-text.ts` | **pure** — what a notification is allowed to say |
+| `events/notify-plan.ts` | **pure** — which desktop channel this machine has, and why |
+| `events/peer-target.ts` | **pure** — which Claude session a `--notify` names, and whether it is up |
+| `events/event-store.ts` | the inbox on disk |
+| `events/peer-client.ts` | the socket |
+| `events/desktop.ts` | the probe and the spawn |
+| `events/notifier.ts` | one batch, delivered |
+| `events/producer.ts` | the long-lived poller |
+| `events/daemon.ts` | it riding along with `otel-watcher` |
+| `cli-events.ts` | the command |
+
+See also [docs/claude-integration.md](claude-integration.md) for the `Stop` hook half and
+[docs/session-manager.md](session-manager.md) for the fleet it watches.

--- a/packages/server/bin/cli.ts
+++ b/packages/server/bin/cli.ts
@@ -62,7 +62,10 @@ Commands:
   session       Start / list / attach assistant sessions (tmux-backed; --bg detaches);
                 'session ls' prints the cockpit's table of what is running
   hooks         Teach Claude Code to run work in parallel through agentop
-                (installs a skill + a SessionStart hook; explicit, reversible)
+                (installs a skill + SessionStart/Stop hooks; explicit, reversible)
+  events        Be told when a session starts waiting, blocks on a permission prompt or
+                exits — in an inbox, in another Claude session, and on your desktop
+                ('events watch' to subscribe, 'events status' to see who is watching)
   ci-push       One-shot push of a CI runner's metrics to a central
   upgrade       Upgrade agentop to the latest version
   autostart     Start a mode with the system (systemd user service on Linux)
@@ -405,6 +408,12 @@ if (command === 'session') {
 if (command === 'hooks') {
   const { runHooks } = await import('../server/cli-hooks.ts')
   const code = await runHooks(args)
+  process.exit(code)
+}
+
+if (command === 'events') {
+  const { runEvents } = await import('../server/cli-events.ts')
+  const code = await runEvents(args)
   process.exit(code)
 }
 

--- a/packages/server/server/claude-hooks.test.ts
+++ b/packages/server/server/claude-hooks.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 import {
+  HOOK_SPECS,
   HOOK_EVENT,
   HOOK_VERSION,
   explainHookPlanError,
@@ -255,5 +256,69 @@ describe('parseHooksArgs', () => {
 
   test('context accepts the version the installed hook passes back to it', () => {
     expect(parseHooksArgs(['context', '--hook-version', '1'])).toEqual({ kind: 'context' })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Two events, one merge implementation
+// ---------------------------------------------------------------------------
+
+describe('the Stop hook alongside SessionStart', () => {
+  const START = 'agentop hooks context --hook-version 2'
+  const STOP = 'agentop events emit --hook-version 2'
+
+  test('installing both leaves both, under their own event keys', () => {
+    const a = planHookInstall({}, START, 'SessionStart')
+    expect(a.ok).toBe(true)
+    const b = planHookInstall((a as { settings: any }).settings, STOP, 'Stop')
+    expect(b.ok).toBe(true)
+    const hooks = (b as { settings: any }).settings.hooks
+    expect(hooks.SessionStart[0].hooks[0].command).toBe(START)
+    expect(hooks.Stop[0].hooks[0].command).toBe(STOP)
+  })
+
+  test('each hook carries its OWN timeout — a per-turn hook may not cost ten seconds', () => {
+    const a = planHookInstall({}, START, 'SessionStart') as { settings: any }
+    const b = planHookInstall(a.settings, STOP, 'Stop') as { settings: any }
+    expect(b.settings.hooks.SessionStart[0].hooks[0].timeout).toBe(10)
+    expect(b.settings.hooks.Stop[0].hooks[0].timeout).toBe(5)
+  })
+
+  test('removing one leaves the other completely alone', () => {
+    const a = planHookInstall({}, START, 'SessionStart') as { settings: any }
+    const b = planHookInstall(a.settings, STOP, 'Stop') as { settings: any }
+    const removed = planHookRemoval(b.settings, 'SessionStart') as { settings: any; changed: boolean }
+    expect(removed.changed).toBe(true)
+    expect(removed.settings.hooks.SessionStart).toBeUndefined()
+    expect(removed.settings.hooks.Stop[0].hooks[0].command).toBe(STOP)
+  })
+
+  test('the matcher is NARROWED by event — a Stop entry moved under SessionStart is not ours to delete', () => {
+    expect(isAgentopHookCommand(STOP, 'SessionStart')).toBe(false)
+    expect(isAgentopHookCommand(STOP, 'Stop')).toBe(true)
+    expect(isAgentopHookCommand(START, 'Stop')).toBe(false)
+    expect(isAgentopHookCommand(START, 'SessionStart')).toBe(true)
+    // With no event named, either of ours matches.
+    expect(isAgentopHookCommand(STOP)).toBe(true)
+    expect(isAgentopHookCommand(START)).toBe(true)
+  })
+
+  test('a v1 install (SessionStart only) reads as stale, so `install` brings it up to both', () => {
+    const v1 = { hooks: { SessionStart: [{ hooks: [{ type: 'command', command: 'agentop hooks context --hook-version 1' }] }] } }
+    expect(readHookStatus(v1, HOOK_VERSION, 'SessionStart').stale).toBe(true)
+    expect(readHookStatus(v1, HOOK_VERSION, 'Stop').installed).toBe(false)
+  })
+
+  test('every spec has a distinct event and a distinct verb pair', () => {
+    expect(new Set(HOOK_SPECS.map(s => s.event)).size).toBe(HOOK_SPECS.length)
+    expect(new Set(HOOK_SPECS.map(s => s.verb.join(' '))).size).toBe(HOOK_SPECS.length)
+    for (const spec of HOOK_SPECS) {
+      expect(hookCommand('agentop', HOOK_VERSION, spec.event))
+        .toBe(`agentop ${spec.verb[0]} ${spec.verb[1]} --hook-version ${HOOK_VERSION}`)
+    }
+  })
+
+  test('an event agentop has no hook for is refused rather than fabricated', () => {
+    expect(() => hookCommand('agentop', HOOK_VERSION, 'PreToolUse')).toThrow()
   })
 })

--- a/packages/server/server/claude-hooks.ts
+++ b/packages/server/server/claude-hooks.ts
@@ -30,15 +30,58 @@
  * machine, without a second store on the side that could disagree with it.
  */
 
-/** Bumped when the hook's CONTRACT changes (the verb it calls, what that verb prints). An installed
- *  hook at a lower version is reported as stale by `status` and rewritten in place by `install`. */
-export const HOOK_VERSION = 1
+/**
+ * Bumped when the hook CONTRACT changes — the verbs called, what they print, or which events are
+ * registered. An installed hook at a lower version is reported as stale by `status` and rewritten
+ * in place by `install`.
+ *
+ * v2 added the `Stop` hook: an install that predates it carries only `SessionStart`, so it is
+ * stale by exactly the definition above and `install` brings it up to both.
+ */
+export const HOOK_VERSION = 2
 
-/** The Claude Code event we register on. See `docs/claude-integration.md` for why this one. */
+/**
+ * The two Claude Code events agentop registers on, and why there are two.
+ *
+ * They answer different questions and cost different things:
+ *
+ *  - **`SessionStart` → `hooks context`** injects the FACTS a starting session cannot know: which
+ *    sessions are running now, which is blocked, which task reopens here. It prints nothing when
+ *    the fleet is empty, so a quiet machine pays no tokens.
+ *  - **`Stop` → `events emit`** records that this session finished a turn. It is the EXACT half of
+ *    the event channel — no polling, no inference, Claude saying so itself — and it is the only
+ *    reason the channel can report the end of a Claude turn instantly rather than up to five
+ *    seconds later. It prints nothing at all: it writes one line to the inbox and exits.
+ *
+ * Registered as a table rather than two constants so `planHookInstall` / `planHookRemoval` /
+ * `readHookStatus` take an event and there is exactly ONE merge implementation. A second copy of
+ * the settings merge for the second hook would be a second set of rules about somebody else's file.
+ */
+export interface HookSpec {
+  /** The Claude Code event name — the key under `hooks` in settings.json. */
+  event: string
+  /** The agentop verb pair this hook runs. Also its identity: see below. */
+  verb: readonly [string, string]
+  /** Seconds. A hook that hangs holds up the session it was supposed to serve. */
+  timeoutSec: number
+}
+
+export const HOOK_SPECS: readonly HookSpec[] = [
+  // Talks to tmux and reads `/proc`; ten is generous and bounded.
+  { event: 'SessionStart', verb: ['hooks', 'context'], timeoutSec: 10 },
+  // Appends one line to a local file. Five is already an eternity for that, and this one runs at
+  // the end of EVERY turn — the budget has to be small enough that it is never felt.
+  { event: 'Stop', verb: ['events', 'emit'], timeoutSec: 5 },
+]
+
+export function hookSpecFor(event: string): HookSpec | undefined {
+  return HOOK_SPECS.find(s => s.event === event)
+}
+
+/** The original single hook. Kept as the DEFAULT of every function below, so nothing that already
+ *  called them changed meaning when the second hook was added. */
 export const HOOK_EVENT = 'SessionStart'
 
-/** Seconds. The hook talks to tmux and reads `/proc`; ten is generous and bounded — a hook that
- *  hangs holds up the session it was supposed to inform. */
 export const HOOK_TIMEOUT_SEC = 10
 
 // ---------------------------------------------------------------------------
@@ -67,23 +110,38 @@ export function hookInvocation(o: { onPath?: boolean; execPath: string; script?:
     : shellQuote(o.execPath)
 }
 
-/** The full command string an installed hook runs. */
-export function hookCommand(invocation: string, version = HOOK_VERSION): string {
-  return `${invocation} hooks context --hook-version ${version}`
+/** The full command string an installed hook runs, for one event. */
+export function hookCommand(
+  invocation: string,
+  version = HOOK_VERSION,
+  event = HOOK_EVENT,
+): string {
+  const spec = hookSpecFor(event)
+  if (!spec) throw new Error(`No agentop hook is defined for the ${event} event.`)
+  return `${invocation} ${spec.verb[0]} ${spec.verb[1]} --hook-version ${version}`
 }
 
 /**
  * Is this command one of ours?
  *
- * The verb pair `hooks context` is required, and then one of two corroborating marks: the word
- * `agentop` somewhere in the command, or the `--hook-version` flag every install writes. Either
- * alone would be wrong — a source checkout runs `bun …/packages/server/bin/cli.ts`, which contains
- * no `agentop` at all, and `hooks context` on its own is a verb pair another tool could plausibly
- * use. Deliberately loose about everything else: an absolute path, a quoted path, an interpreter
- * prefix and a hand-added `--lang pt` all still match, and all of them are still our hook.
+ * One of our verb PAIRS is required, and then one of two corroborating marks: the word `agentop`
+ * somewhere in the command, or the `--hook-version` flag every install writes. Either alone would
+ * be wrong — a source checkout runs `bun …/packages/server/bin/cli.ts`, which contains no
+ * `agentop` at all, and `hooks context` on its own is a verb pair another tool could plausibly use.
+ * Deliberately loose about everything else: an absolute path, a quoted path, an interpreter prefix
+ * and a hand-added `--lang pt` all still match, and all of them are still our hook.
+ *
+ * `event` NARROWS it to that event's own verb pair, and every caller passes one. Without the
+ * narrowing, removing the `SessionStart` hook would also match — and delete — a `Stop` entry a user
+ * had moved there by hand: our two hooks would become one thing that cannot be administered
+ * separately. Called with no event it matches ANY of our verbs, which is what a general "is this
+ * line ours" question means.
  */
-export function isAgentopHookCommand(command: string): boolean {
-  if (!/(^|[\s"'])hooks\s+context(\s|$|["'])/.test(command)) return false
+export function isAgentopHookCommand(command: string, event?: string): boolean {
+  const specs = event === undefined ? HOOK_SPECS : HOOK_SPECS.filter(s => s.event === event)
+  const matchesVerb = specs.some(s =>
+    new RegExp(`(^|[\\s"'])${s.verb[0]}\\s+${s.verb[1]}(\\s|$|["'])`).test(command))
+  if (!matchesVerb) return false
   return /agentop/i.test(command) || /--hook-version/.test(command)
 }
 
@@ -126,14 +184,18 @@ export interface HookStatus {
 
 /** Read-only: what is in this settings document, as far as we are concerned. Never throws — an
  *  unreadable shape simply carries no hook of ours, which is the truth. */
-export function readHookStatus(settings: unknown, version = HOOK_VERSION): HookStatus {
+export function readHookStatus(
+  settings: unknown,
+  version = HOOK_VERSION,
+  event = HOOK_EVENT,
+): HookStatus {
   const commands: string[] = []
-  if (isObj(settings) && isObj(settings.hooks) && Array.isArray(settings.hooks[HOOK_EVENT])) {
-    for (const group of settings.hooks[HOOK_EVENT] as unknown[]) {
+  if (isObj(settings) && isObj(settings.hooks) && Array.isArray(settings.hooks[event])) {
+    for (const group of settings.hooks[event] as unknown[]) {
       if (!isObj(group) || !Array.isArray(group.hooks)) continue
       for (const hook of group.hooks as unknown[]) {
         if (!isObj(hook) || typeof hook.command !== 'string') continue
-        if (isAgentopHookCommand(hook.command)) commands.push(hook.command)
+        if (isAgentopHookCommand(hook.command, event)) commands.push(hook.command)
       }
     }
   }
@@ -154,15 +216,15 @@ export function readHookStatus(settings: unknown, version = HOOK_VERSION): HookS
  * user added to it, is kept. Replacing the whole entry would quietly undo a deliberate edit, and
  * "install refreshed my hook" is not a licence to discard the rest of the line it lives on.
  */
-export function planHookInstall(settings: unknown, command: string): HookPlan {
+export function planHookInstall(settings: unknown, command: string, event = HOOK_EVENT): HookPlan {
   if (settings === undefined || settings === null) settings = {}
   if (!isObj(settings)) return { ok: false, error: { code: 'settings-not-object' } }
 
   const hooksRaw = settings.hooks ?? {}
   if (!isObj(hooksRaw)) return { ok: false, error: { code: 'hooks-not-object' } }
 
-  const eventRaw = hooksRaw[HOOK_EVENT] ?? []
-  if (!Array.isArray(eventRaw)) return { ok: false, error: { code: 'event-not-array', event: HOOK_EVENT } }
+  const eventRaw = hooksRaw[event] ?? []
+  if (!Array.isArray(eventRaw)) return { ok: false, error: { code: 'event-not-array', event } }
 
   let changed = false
   let found = false
@@ -172,7 +234,7 @@ export function planHookInstall(settings: unknown, command: string): HookPlan {
     let touched = false
     const hooks = (group.hooks as unknown[]).map(hook => {
       if (!isObj(hook) || typeof hook.command !== 'string') return hook
-      if (!isAgentopHookCommand(hook.command)) return hook
+      if (!isAgentopHookCommand(hook.command, event)) return hook
       found = true
       if (hook.command === command) return hook
       touched = true
@@ -185,9 +247,10 @@ export function planHookInstall(settings: unknown, command: string): HookPlan {
 
   if (!found) {
     groups.push({
-      // No `matcher`: every SessionStart source is one where the facts this hook reports are worth
-      // having — a fresh start, a resume and a compact have all just lost or never had them.
-      hooks: [{ type: 'command', command, timeout: HOOK_TIMEOUT_SEC }],
+      // No `matcher`: every SessionStart source is one where the facts that hook reports are worth
+      // having — a fresh start, a resume and a compact have all just lost or never had them — and
+      // Stop has no matcher dimension at all.
+      hooks: [{ type: 'command', command, timeout: hookSpecFor(event)?.timeoutSec ?? HOOK_TIMEOUT_SEC }],
     })
     changed = true
   }
@@ -198,7 +261,7 @@ export function planHookInstall(settings: unknown, command: string): HookPlan {
 
   return {
     ok: true,
-    settings: { ...settings, hooks: { ...hooksRaw, [HOOK_EVENT]: groups } },
+    settings: { ...settings, hooks: { ...hooksRaw, [event]: groups } },
     changed: true,
   }
 }
@@ -211,7 +274,7 @@ export function planHookInstall(settings: unknown, command: string): HookPlan {
  * ambiguity is a `"hooks": {}` a user wrote by hand before installing: it is indistinguishable from
  * the one an install created, and it is pruned. An empty object either way changes no behaviour.
  */
-export function planHookRemoval(settings: unknown): HookPlan {
+export function planHookRemoval(settings: unknown, event = HOOK_EVENT): HookPlan {
   if (settings === undefined || settings === null) settings = {}
   if (!isObj(settings)) return { ok: false, error: { code: 'settings-not-object' } }
 
@@ -219,16 +282,16 @@ export function planHookRemoval(settings: unknown): HookPlan {
   if (hooksRaw === undefined) return { ok: true, settings, changed: false }
   if (!isObj(hooksRaw)) return { ok: false, error: { code: 'hooks-not-object' } }
 
-  const eventRaw = hooksRaw[HOOK_EVENT]
+  const eventRaw = hooksRaw[event]
   if (eventRaw === undefined) return { ok: true, settings, changed: false }
-  if (!Array.isArray(eventRaw)) return { ok: false, error: { code: 'event-not-array', event: HOOK_EVENT } }
+  if (!Array.isArray(eventRaw)) return { ok: false, error: { code: 'event-not-array', event } }
 
   let changed = false
   const groups: unknown[] = []
   for (const group of eventRaw) {
     if (!isObj(group) || !Array.isArray(group.hooks)) { groups.push(group); continue }
     const kept = (group.hooks as unknown[]).filter(hook =>
-      !(isObj(hook) && typeof hook.command === 'string' && isAgentopHookCommand(hook.command)))
+      !(isObj(hook) && typeof hook.command === 'string' && isAgentopHookCommand(hook.command, event)))
     if (kept.length === (group.hooks as unknown[]).length) { groups.push(group); continue }
     changed = true
     // A group emptied by that removal was ours; one that still carries someone else's hook stays,
@@ -239,8 +302,8 @@ export function planHookRemoval(settings: unknown): HookPlan {
   if (!changed) return { ok: true, settings, changed: false }
 
   const hooks: Obj = { ...hooksRaw }
-  if (groups.length > 0) hooks[HOOK_EVENT] = groups
-  else delete hooks[HOOK_EVENT]
+  if (groups.length > 0) hooks[event] = groups
+  else delete hooks[event]
 
   const next: Obj = { ...settings }
   if (Object.keys(hooks).length > 0) next.hooks = hooks

--- a/packages/server/server/cli-events.ts
+++ b/packages/server/server/cli-events.ts
@@ -1,0 +1,469 @@
+/**
+ * cli-events.ts — `agentop events watch | unwatch | status | tail | run | emit | test`.
+ *
+ * The I/O half of the event channel. Every DECISION it makes is already made by a pure module:
+ * `events-parse.ts` says what the words mean, `subscriptions.ts` says who hears what,
+ * `notify-plan.ts` says which desktop channel this machine has, `peer-target.ts` says whether a
+ * named Claude session can be reached, `notify-text.ts` says what a notification is allowed to say.
+ * This file reads files, spawns things, and reports.
+ *
+ * Two rules it exists to honour, both of them about not lying:
+ *
+ *  1. **A delivery that did not happen is reported as not having happened.** A `--notify` naming a
+ *     session that is not running leaves the event in the inbox and SAYS the session was not
+ *     reached. There is no path here that prints a success it did not observe.
+ *  2. **"Nobody is watching" is a state with a name.** `status` reports the producer as running,
+ *     stale or absent, and names the desktop channel in use — because an event channel that
+ *     silently has no producer is indistinguishable from a quiet machine.
+ */
+
+import { createEventStore } from './events/event-store'
+import { EMPTY_CURSOR, type EventCursor } from './events/event-rotate'
+import { EVENT_VERSION, type EventKind, type SessionEvent } from './events/event-types'
+import { parseEventsArgs, type EventsCommand, type TailOptions, type WatchOptions } from './events/events-parse'
+import { desktopSetup } from './events/desktop'
+import { deliver } from './events/notifier'
+import { desktopText, eventHeadline, peerMessage } from './events/notify-text'
+import { listLivePeers, resolvePeer, sendToPeer } from './events/peer-client'
+import { createHeartbeatWriter, producerState } from './events/producer-status'
+import { createHostProducer } from './events/producer'
+import {
+  addSubscription, clearSubscriptions, newSubscriptionId, removeSubscription, type Subscription,
+} from './events/subscriptions'
+import {
+  SUBSCRIPTIONS_FILE, readSubscriptionStore, writeSubscriptionStore,
+} from './events/subscription-store'
+
+const USAGE = `Usage:
+  agentop events watch   [--task <name>] [--session <id|label>] [--on <states>]
+                         [--notify <claude-session>] [--desktop] [--note <text>] [--json]
+  agentop events unwatch <id> | --all
+  agentop events status  [--json]
+  agentop events tail    [-n <count>] [--since <offset:seq>] [--task <name>] [--on <states>]
+                         [--follow] [--json]
+  agentop events run     [--once]
+  agentop events test    [--notify <claude-session>] [--desktop]
+
+Know what your sessions are doing without watching them.
+
+  A transition — a session starting to wait, blocking on a permission prompt, or exiting — is
+  written to an append-only inbox (~/.agentistics/events.jsonl) and, if something subscribed,
+  delivered to a Claude Code session over its own messaging socket and/or to your desktop.
+
+  watch    register a subscription. It is a FILE, not a process: whichever producer is up
+           delivers it, so it survives a reboot and does not need you to keep a terminal open.
+  tail     read the inbox. --since takes the cursor --json prints, so a session that was not
+           running reads exactly what it missed.
+  status   who is producing, what is subscribed, which desktop channel this machine has.
+  run      run the producer in the foreground (when you do not run \`agentop server\`).
+  test     deliver a probe through the real channels, so a broken one is found before it matters.
+
+States for --on: working, waiting, waiting-approval, exited, turn-end
+                 (default: waiting, waiting-approval, exited)
+
+Two sources feed the inbox. agentop's own five-second monitor reads the SCREEN, so it works for
+every harness it manages; a Claude Code \`Stop\` hook (\`agentop hooks install\`) reports the end of
+a Claude turn exactly and instantly. The same turn seen by both is written once.
+
+Events report facts. Nothing in this channel answers a permission prompt, and a session blocked on
+one is reported as waiting on a person.`
+
+export async function runEvents(argv: string[]): Promise<number> {
+  const cmd = parseEventsArgs(argv)
+  switch (cmd.kind) {
+    case 'help': console.log(USAGE); return 0
+    case 'error': console.error(cmd.message); console.error(`\n${USAGE}`); return 1
+    case 'watch': return watch(cmd.options)
+    case 'unwatch': return unwatch(cmd)
+    case 'status': return status(cmd.json)
+    case 'tail': return tail(cmd.options)
+    case 'run': return run(cmd.once)
+    case 'emit': return emit()
+    case 'test': return test(cmd)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// watch / unwatch
+// ---------------------------------------------------------------------------
+
+async function watch(o: WatchOptions): Promise<number> {
+  // A `--notify` naming a session nobody can reach is refused HERE rather than at delivery time: a
+  // subscription that can never deliver is a subscription the user believes is working.
+  if (o.notify !== undefined) {
+    const found = await resolvePeer(o.notify)
+    if (!found.ok && found.code === 'no-match') {
+      console.error(found.message)
+      await printLivePeers()
+      return 1
+    }
+    if (!found.ok && found.code === 'ambiguous') {
+      console.error(found.message)
+      for (const c of found.candidates) console.error(`  ${c}`)
+      return 1
+    }
+    // `not-live` is NOT refused: registering a subscription for a session that is currently
+    // restarting is a reasonable thing to do, and the events wait in the inbox regardless. It is
+    // said out loud instead.
+    if (!found.ok) console.log(`note: ${found.message}`)
+  }
+
+  const store = await readSubscriptionStore()
+  const sub: Subscription = {
+    id: newSubscriptionId(store.subscriptions),
+    createdAt: new Date().toISOString(),
+    ...(o.task !== undefined ? { task: o.task } : {}),
+    ...(o.session !== undefined ? { session: o.session } : {}),
+    kinds: o.kinds,
+    ...(o.notify !== undefined ? { notify: o.notify } : {}),
+    desktop: o.desktop,
+    ...(o.note !== undefined ? { note: o.note } : {}),
+  }
+  await writeSubscriptionStore(addSubscription(store, sub))
+
+  if (o.json) {
+    console.log(JSON.stringify(sub, null, 2))
+    return 0
+  }
+
+  console.log(`subscribed  ${sub.id}`)
+  console.log(`  on        ${sub.kinds.join(', ')}`)
+  console.log(`  scope     ${describeScope(sub)}`)
+  console.log(`  delivery  ${describeDelivery(sub)}`)
+  console.log(`  stored in ${SUBSCRIPTIONS_FILE}`)
+
+  // The one thing that makes this subscription useless is nothing producing events, so it is
+  // checked at the moment of subscribing rather than left for the user to discover in silence.
+  const p = await producerState()
+  if (p.state !== 'running') {
+    console.log('')
+    console.log(p.state === 'stale'
+      ? `warning: the last producer (pid ${p.heartbeat.pid}) is gone, so nothing is watching right now.`
+      : 'warning: nothing is producing events right now.')
+    console.log('  start one with `agentop server` (the daemon carries it) or `agentop events run`.')
+  }
+  return 0
+}
+
+async function unwatch(cmd: Extract<EventsCommand, { kind: 'unwatch' }>): Promise<number> {
+  const store = await readSubscriptionStore()
+  const r = cmd.all ? clearSubscriptions(store) : removeSubscription(store, cmd.id!)
+  if (r.removed.length === 0) {
+    console.error(cmd.all
+      ? 'There are no subscriptions to remove.'
+      : `No subscription "${cmd.id}". \`agentop events status\` lists them.`)
+    return 1
+  }
+  await writeSubscriptionStore(r.store)
+  for (const s of r.removed) console.log(`removed  ${s.id}  (${describeScope(s)} → ${describeDelivery(s)})`)
+  return 0
+}
+
+const describeScope = (s: Subscription): string => {
+  const parts = [
+    s.task !== undefined ? `task "${s.task}"` : '',
+    s.session !== undefined ? `session "${s.session}"` : '',
+  ].filter(p => p !== '')
+  return parts.length > 0 ? parts.join(', ') : 'every session'
+}
+
+const describeDelivery = (s: Subscription): string => {
+  const parts = [s.notify !== undefined ? `notify "${s.notify}"` : '', s.desktop ? 'desktop' : '']
+    .filter(p => p !== '')
+  // A subscription with no delivery still shapes what the producer RECORDS, so it is described as
+  // what it is rather than as nothing.
+  return parts.length > 0 ? parts.join(' + ') : 'inbox only'
+}
+
+// ---------------------------------------------------------------------------
+// status
+// ---------------------------------------------------------------------------
+
+async function status(json: boolean): Promise<number> {
+  const [state, store, info, setup, peers] = await Promise.all([
+    producerState(),
+    readSubscriptionStore(),
+    createEventStore().info(),
+    desktopSetup(),
+    listLivePeers(),
+  ])
+
+  if (json) {
+    console.log(JSON.stringify({
+      producer: state,
+      subscriptions: store.subscriptions,
+      inbox: info,
+      desktop: setup.decision,
+      livePeers: peers.map(p => ({ pid: p.pid, name: p.name, cwd: p.cwd })),
+      eventVersion: EVENT_VERSION,
+    }, null, 2))
+    return 0
+  }
+
+  console.log(`producer  ${state.state === 'running'
+    ? `running   pid ${state.heartbeat.pid} (${state.heartbeat.host}), since ${state.heartbeat.startedAt}`
+    : state.state === 'stale'
+      ? `NOT RUNNING — the last one (pid ${state.heartbeat.pid}, ${state.heartbeat.host}) is gone. Nothing is watching.`
+      : 'NOT RUNNING — nothing is watching. Start `agentop server`, or `agentop events run`.'}`)
+  if (state.state === 'running' && state.heartbeat.unavailable) {
+    console.log(`          but it cannot watch anything here: ${state.heartbeat.unavailable}`)
+  }
+
+  console.log(`inbox     ${info.file}  ${fmtBytes(info.bytes)}${info.previousBytes > 0 ? ` (+ ${fmtBytes(info.previousBytes)} rotated)` : ''}, last seq ${info.seq}`)
+  console.log(`desktop   ${setup.decision.channel}  — ${setup.decision.reason}`)
+
+  console.log(`\nsubscriptions (${store.subscriptions.length})`)
+  if (store.subscriptions.length === 0) {
+    console.log('  none — `agentop events watch --desktop` is the smallest useful one.')
+  }
+  for (const s of store.subscriptions) {
+    console.log(`  ${s.id}  ${describeScope(s)}`)
+    console.log(`      on ${s.kinds.join(', ')} → ${describeDelivery(s)}${s.note ? `  · ${s.note}` : ''}`)
+  }
+
+  console.log(`\nclaude code sessions reachable now (${peers.length})`)
+  if (peers.length === 0) console.log('  none running')
+  for (const p of peers) console.log(`  ${p.name ?? '(unnamed)'}  pid ${p.pid}  ${p.cwd ?? ''}`)
+  return 0
+}
+
+const fmtBytes = (n: number): string =>
+  n < 1024 ? `${n} B` : n < 1024 * 1024 ? `${(n / 1024).toFixed(1)} KB` : `${(n / 1024 / 1024).toFixed(1)} MB`
+
+async function printLivePeers(): Promise<void> {
+  const peers = await listLivePeers()
+  if (peers.length === 0) {
+    console.error('No Claude Code session is running on this machine right now.')
+    return
+  }
+  console.error('Running Claude Code sessions:')
+  for (const p of peers) console.error(`  ${p.name ?? '(unnamed)'}  pid ${p.pid}  ${p.cwd ?? ''}`)
+}
+
+// ---------------------------------------------------------------------------
+// tail
+// ---------------------------------------------------------------------------
+
+function wanted(e: SessionEvent, o: TailOptions): boolean {
+  if (o.task !== undefined && e.task !== o.task) return false
+  if (o.kinds && !o.kinds.includes(e.kind as EventKind)) return false
+  return true
+}
+
+async function tail(o: TailOptions): Promise<number> {
+  const store = createEventStore()
+  let cursor: EventCursor = o.since !== undefined
+    ? { offset: o.since, seq: o.sinceSeq ?? 0 }
+    : EMPTY_CURSOR
+
+  const read = o.since !== undefined
+    ? await store.since(cursor)
+    : { ...(await store.recent(o.count)), rotated: false }
+  cursor = read.cursor
+
+  const shown = read.events.filter(e => wanted(e, o))
+  printEvents(shown, o.json, read.rotated, read.unreadable, cursor)
+
+  if (!o.follow) return 0
+
+  // Following is a poll of the file, not a filesystem watch: the inbox is appended to by more than
+  // one process and a missed notification here costs a delay, not an event.
+  const stop = new Promise<void>(resolve => {
+    process.on('SIGINT', () => resolve())
+    process.on('SIGTERM', () => resolve())
+  })
+  let running = true
+  void stop.then(() => { running = false })
+  while (running) {
+    await new Promise(r => setTimeout(r, 1_000))
+    if (!running) break
+    const next = await store.since(cursor)
+    cursor = next.cursor
+    const fresh = next.events.filter(e => wanted(e, o))
+    if (fresh.length > 0 || next.rotated) printEvents(fresh, o.json, next.rotated, 0, cursor)
+  }
+  return 0
+}
+
+function printEvents(
+  events: readonly SessionEvent[],
+  json: boolean,
+  rotated: boolean,
+  unreadable: number,
+  cursor: EventCursor,
+): void {
+  if (json) {
+    console.log(JSON.stringify({
+      events,
+      cursor: `${cursor.offset}:${cursor.seq}`,
+      ...(rotated ? { rotated: true } : {}),
+      ...(unreadable > 0 ? { unreadable } : {}),
+    }, null, 2))
+    return
+  }
+  if (rotated) {
+    console.log('note: the inbox was rotated since that cursor — some older events are gone. Reading from the start of the current file.')
+  }
+  if (unreadable > 0) {
+    console.log(`note: ${unreadable} line${unreadable > 1 ? 's' : ''} in the inbox cannot be read by this version of agentop.`)
+  }
+  if (events.length === 0) {
+    console.log('no events')
+    console.log(`cursor ${cursor.offset}:${cursor.seq}`)
+    return
+  }
+  for (const e of events) {
+    console.log(`${e.at}  ${e.source === 'hook' ? 'hook' : 'poll'}  ${eventHeadline(e)}`)
+    console.log(`  ${e.cwd}`)
+    for (const l of (e.lines ?? []).slice(-3)) console.log(`  | ${l}`)
+  }
+  console.log(`cursor ${cursor.offset}:${cursor.seq}`)
+}
+
+// ---------------------------------------------------------------------------
+// run — the producer in the foreground
+// ---------------------------------------------------------------------------
+
+async function run(once: boolean): Promise<number> {
+  const made = await createHostProducer({ onError: m => console.error(`[events] ${m}`) })
+  if ('unavailable' in made) {
+    console.error(`Cannot watch sessions here: ${made.unavailable}`)
+    return 1
+  }
+  const beat = createHeartbeatWriter({ host: 'foreground' })
+
+  if (once) {
+    // One tick can only SEED — see `producer.ts`. Said plainly rather than letting someone conclude
+    // that a single run reports nothing because nothing happened.
+    await made.producer.tick()
+    console.log('seeded: recorded where every session is now. A transition needs a second look, so')
+    console.log('`--once` never reports one. Run without it to watch.')
+    return 0
+  }
+
+  const { SESSION_POLL_MS } = await import('./sessions/sessions-host')
+  await beat.beat()
+  console.log(`[events] watching — pid ${process.pid}, every ${SESSION_POLL_MS}ms. ctrl-c to stop.`)
+
+  let running = true
+  const stop = (): void => { running = false; made.producer.stop() }
+  process.on('SIGINT', stop)
+  process.on('SIGTERM', stop)
+
+  while (running) {
+    const t = await made.producer.tick().catch(e => {
+      // A bad tick is reported and the loop continues: a producer that dies on one failed poll is
+      // a producer that is not running at the moment it matters.
+      console.error(`[events] ${e instanceof Error ? e.message : String(e)}`)
+      return null
+    })
+    await beat.beat(t?.unavailable)
+    for (const e of t?.written ?? []) console.log(`${e.at}  ${eventHeadline(e)}`)
+    for (const l of t?.delivery.lines ?? []) console.log(`  ${l}`)
+    if (!running) break
+    await new Promise(r => setTimeout(r, SESSION_POLL_MS))
+  }
+
+  await beat.clear()
+  console.log('[events] stopped.')
+  return 0
+}
+
+// ---------------------------------------------------------------------------
+// emit — what the Claude Code Stop hook runs
+// ---------------------------------------------------------------------------
+
+/**
+ * The hook body. Reads the Claude Code hook payload on stdin and writes ONE event.
+ *
+ * Every failure path is silence with exit 0. This runs on the critical path of a Claude session
+ * finishing a turn; a hook that errors or prints a stack trace is worse in every case than one that
+ * says nothing — the same rule `agentop hooks context` follows, for the same reason.
+ */
+async function emit(): Promise<number> {
+  try {
+    const raw = await new Response(Bun.stdin.stream()).text()
+    if (raw.trim() === '') return 0
+    const payload = JSON.parse(raw) as Record<string, unknown>
+
+    const cwd = typeof payload.cwd === 'string' ? payload.cwd : process.cwd()
+    const conversationId = typeof payload.session_id === 'string' ? payload.session_id : undefined
+
+    // What agentop knows about this directory: the task and label the user gave the session. Read
+    // straight from the registry rather than through the poller — a hook must not spawn tmux.
+    const { readRegistry } = await import('./sessions/registry')
+    const managed = (await readRegistry().catch(() => []))
+      .filter(m => !m.endedAt && m.harness === 'claude' && m.cwd === cwd)
+      .sort((a, b) => Date.parse(b.createdAt) - Date.parse(a.createdAt))[0]
+
+    const event: SessionEvent = {
+      v: EVENT_VERSION,
+      seq: 0,
+      at: new Date().toISOString(),
+      source: 'hook',
+      kind: 'turn-end',
+      id: managed?.id ?? `claude:${conversationId ?? cwd}`,
+      harness: 'claude',
+      cwd,
+      ...(managed?.task ? { task: managed.task } : {}),
+      ...(managed?.label ? { label: managed.label } : {}),
+      ...(conversationId ? { conversationId } : {}),
+    }
+
+    const written = await createEventStore().append([event])
+    const subs = (await readSubscriptionStore()).subscriptions
+    if (subs.length > 0) await deliver({ events: written, subscriptions: subs })
+  } catch {
+    // Deliberately silent — see above.
+  }
+  return 0
+}
+
+// ---------------------------------------------------------------------------
+// test
+// ---------------------------------------------------------------------------
+
+async function test(cmd: Extract<EventsCommand, { kind: 'test' }>): Promise<number> {
+  const probe: SessionEvent = {
+    v: EVENT_VERSION,
+    seq: 0,
+    at: new Date().toISOString(),
+    source: 'poll',
+    kind: 'waiting',
+    id: 'probe',
+    harness: 'claude',
+    cwd: process.cwd(),
+    label: 'agentop events test',
+    lines: ['This is a test notification from `agentop events test`.'],
+  }
+
+  let failed = false
+
+  if (cmd.notify !== undefined) {
+    const r = await sendToPeer(cmd.notify, peerMessage([probe]))
+    if (r.ok) console.log(`notify    delivered to ${r.name ?? cmd.notify} (pid ${r.pid})`)
+    else { console.error(`notify    NOT delivered: ${r.message}`); failed = true }
+  }
+
+  if (cmd.desktop) {
+    const setup = await desktopSetup()
+    console.log(`desktop   channel: ${setup.decision.channel} — ${setup.decision.reason}`)
+    const r = await deliver({
+      events: [probe],
+      subscriptions: [{ id: 'probe', createdAt: probe.at, kinds: ['waiting'], desktop: true }],
+      desktop: setup,
+    })
+    if (r.toastsShown > 0) console.log('desktop   shown')
+    else {
+      console.error(`desktop   NOT shown${r.lines.length > 0 ? `: ${r.lines.join('; ')}` : ` (${setup.decision.reason})`}`)
+      failed = true
+    }
+  }
+
+  // The probe is deliberately NOT written to the inbox: a test event in the real inbox is a fact
+  // that never happened, and the next reader would report it as one.
+  console.log('')
+  console.log(desktopText(probe).title)
+  console.log(desktopText(probe).body)
+  return failed ? 1 : 0
+}

--- a/packages/server/server/cli-hooks.ts
+++ b/packages/server/server/cli-hooks.ts
@@ -26,7 +26,7 @@ import { dirname, join } from 'node:path'
 import { HARNESS_ORDER, type HarnessId } from '@agentistics/core'
 import { HOME_DIR } from './config'
 import {
-  HOOK_EVENT,
+  HOOK_SPECS,
   HOOK_VERSION,
   explainHookPlanError,
   hookCommand,
@@ -50,7 +50,7 @@ const USAGE = `Usage:
   agentop hooks uninstall  [--hook-only | --skill-only]
   agentop hooks status
 
-Teach Claude Code to run work in parallel through agentop.
+Teach Claude Code to run work in parallel through agentop, and to report when it stops.
 
   skill  ~/.claude/skills/${SKILL_NAME}/SKILL.md
          WHAT Claude needs to know: when a task splits into independent pieces, how to propose
@@ -58,10 +58,14 @@ Teach Claude Code to run work in parallel through agentop.
          \`agentop session batch\`. Claude loads it when the task matches its description and
          ignores it otherwise, so it costs nothing on a session that never parallelises.
 
-  hook   a SessionStart entry in ~/.claude/settings.json
-         FACTS a static file cannot hold: which agentop sessions are running right now, which
-         one is blocked on a permission prompt, which task can be reopened in this directory.
-         It prints NOTHING when there is nothing running, so a quiet machine pays no tokens.
+  hooks  two entries in ~/.claude/settings.json
+         SessionStart → FACTS a static file cannot hold: which agentop sessions are running
+         right now, which one is blocked on a permission prompt, which task can be reopened in
+         this directory. It prints NOTHING when there is nothing running, so a quiet machine
+         pays no tokens.
+         Stop → records that this session finished a turn, into agentop's event inbox. It is
+         the exact half of \`agentop events\`: Claude saying it stopped, rather than the fleet
+         monitor inferring it from the screen five seconds later. It prints nothing at all.
 
 A hook does not infer anything — it is a shell command on an event. The inference is Claude's,
 reading what the skill teaches and what the hook injected. See docs/claude-integration.md.
@@ -192,7 +196,6 @@ async function install(what: { hook: boolean; skill: boolean }): Promise<number>
 
   if (what.hook) {
     const file = settingsFile()
-    const command = hookCommand(invocation())
     let current: unknown
     try {
       current = await readSettings(file)
@@ -203,15 +206,27 @@ async function install(what: { hook: boolean; skill: boolean }): Promise<number>
       current = undefined
     }
     if (!failed) {
-      const plan = planHookInstall(current, command)
-      if (!plan.ok) {
-        console.error(explainHookPlanError(plan.error, tilde(file)))
-        failed = true
-      } else if (!plan.changed) {
-        console.log(`hook   already installed in ${tilde(file)} (v${HOOK_VERSION}) — unchanged.`)
-      } else {
-        await writeAtomic(file, `${JSON.stringify(plan.settings, null, 2)}\n`)
-        console.log(`hook   ${HOOK_EVENT} → ${command}`)
+      // Both hooks are planned against the SAME document, one after the other, and the file is
+      // written ONCE at the end. Writing per hook would leave a settings.json holding one of the
+      // two if the second plan refused — a half-installed integration that `status` would then
+      // report as partly stale forever.
+      let settings = current
+      const written: string[] = []
+      for (const spec of HOOK_SPECS) {
+        const command = hookCommand(invocation(), HOOK_VERSION, spec.event)
+        const plan = planHookInstall(settings, command, spec.event)
+        if (!plan.ok) {
+          console.error(explainHookPlanError(plan.error, tilde(file)))
+          failed = true
+          break
+        }
+        settings = plan.settings
+        if (plan.changed) written.push(`hook   ${spec.event} → ${command}`)
+        else console.log(`hook   ${spec.event} already installed in ${tilde(file)} (v${HOOK_VERSION}) — unchanged.`)
+      }
+      if (!failed && written.length > 0) {
+        await writeAtomic(file, `${JSON.stringify(settings, null, 2)}\n`)
+        for (const line of written) console.log(line)
         console.log(`       written to ${tilde(file)}`)
       }
     }
@@ -260,15 +275,23 @@ async function uninstall(what: { hook: boolean; skill: boolean }): Promise<numbe
       failed = true
     }
     if (!failed) {
-      const plan = planHookRemoval(current)
-      if (!plan.ok) {
-        console.error(explainHookPlanError(plan.error, tilde(file)))
-        failed = true
-      } else if (!plan.changed) {
+      let settings = current
+      const removed: string[] = []
+      for (const spec of HOOK_SPECS) {
+        const plan = planHookRemoval(settings, spec.event)
+        if (!plan.ok) {
+          console.error(explainHookPlanError(plan.error, tilde(file)))
+          failed = true
+          break
+        }
+        settings = plan.settings
+        if (plan.changed) removed.push(spec.event)
+      }
+      if (!failed && removed.length === 0) {
         console.log(`hook   not installed in ${tilde(file)} — nothing to remove.`)
-      } else {
-        await writeAtomic(file, `${JSON.stringify(plan.settings, null, 2)}\n`)
-        console.log(`hook   removed from ${tilde(file)}`)
+      } else if (!failed) {
+        await writeAtomic(file, `${JSON.stringify(settings, null, 2)}\n`)
+        console.log(`hook   removed ${removed.join(' + ')} from ${tilde(file)}`)
       }
     }
   }
@@ -303,20 +326,23 @@ async function status(): Promise<number> {
   const file = settingsFile()
   console.log(`claude   ${claudeCodePresent() ? tilde(claudeHome()) : 'not found (no ~/.claude, no `claude` on PATH)'}`)
 
-  let hookLine: string
   try {
-    const st = readHookStatus(await readSettings(file))
-    if (!st.installed) hookLine = `not installed  (${tilde(file)})`
-    else {
+    const settings = await readSettings(file)
+    for (const spec of HOOK_SPECS) {
+      const st = readHookStatus(settings, HOOK_VERSION, spec.event)
+      if (!st.installed) {
+        console.log(`hook     ${spec.event}: not installed  (${tilde(file)})`)
+        continue
+      }
       const version = st.version === null ? 'no version' : `v${st.version}`
       const stale = st.stale ? `  STALE — this agentop writes v${HOOK_VERSION}; run \`agentop hooks install\`` : ''
       const dupes = st.commands.length > 1 ? `  (${st.commands.length} copies)` : ''
-      hookLine = `installed ${version}${dupes}${stale}\n         ${tilde(file)}\n         ${st.commands[0]}`
+      console.log(`hook     ${spec.event}: installed ${version}${dupes}${stale}\n         ${st.commands[0]}`)
     }
+    console.log(`         ${tilde(file)}`)
   } catch (e) {
-    hookLine = `cannot read ${tilde(file)}: ${e instanceof Error ? e.message : String(e)}`
+    console.log(`hook     cannot read ${tilde(file)}: ${e instanceof Error ? e.message : String(e)}`)
   }
-  console.log(`hook     ${hookLine}`)
 
   const sf = skillFile()
   if (!existsSync(sf)) {
@@ -360,7 +386,7 @@ async function context(): Promise<number> {
     if (!text) return 0
 
     console.log(JSON.stringify({
-      hookSpecificOutput: { hookEventName: HOOK_EVENT, additionalContext: text },
+      hookSpecificOutput: { hookEventName: 'SessionStart', additionalContext: text },
     }))
   } catch {
     // Deliberately silent — see above.

--- a/packages/server/server/events/daemon.ts
+++ b/packages/server/server/events/daemon.ts
@@ -1,0 +1,96 @@
+/**
+ * daemon.ts — the event producer riding along with the daemon that is already running.
+ *
+ * ## Why it rides along instead of being its own service
+ *
+ * The producer must be long-lived (see `producer.ts`: a single-invocation poll cannot tell a
+ * working session from a finished one, because "working" is proven by the screen having MOVED since
+ * last time). Something long-lived has to host it, and the choice was between a new service and one
+ * that already exists.
+ *
+ * A new one loses. It would be a third thing to install, a third systemd unit, and — decisively —
+ * a process the user has to remember to start, which means it is dead at the moment the fleet does
+ * something worth knowing about. `otel-watcher` is already started by `agentop server`, already
+ * covered by `agentop autostart`, and already the thing that lives as long as the machine's
+ * agentistics does. So the producer starts here, and `agentop events run` exists for the person who
+ * does not run the server at all.
+ *
+ * ## It never takes the daemon down with it
+ *
+ * Everything is wrapped: a machine with no tmux reports the reason once and the daemon carries on
+ * doing what it was already doing. The event channel is an addition to that process, never a
+ * condition of it.
+ */
+
+import { createHeartbeatWriter } from './producer-status'
+import { createHostProducer } from './producer'
+import { SESSION_POLL_MS } from '../sessions/sessions-host'
+
+/** Set `AGENTISTICS_EVENTS=0` to keep the daemon from watching sessions at all. */
+const enabled = (): boolean => process.env.AGENTISTICS_EVENTS !== '0'
+
+export interface DaemonProducer {
+  stop(): Promise<void>
+}
+
+/**
+ * Start watching. Never throws; returns null when nothing was started, having said why.
+ *
+ * `log` is injected so the daemon's own prefix is used and this module owns no formatting.
+ */
+export async function startEventProducer(
+  log: (line: string) => void = console.log,
+): Promise<DaemonProducer | null> {
+  if (!enabled()) {
+    log('[events] disabled (AGENTISTICS_EVENTS=0)')
+    return null
+  }
+
+  let made: Awaited<ReturnType<typeof createHostProducer>>
+  try {
+    made = await createHostProducer({ onError: m => log(`[events] ${m}`) })
+  } catch (e) {
+    log(`[events] not watching: ${e instanceof Error ? e.message : String(e)}`)
+    return null
+  }
+
+  const beat = createHeartbeatWriter({ host: 'daemon' })
+
+  if ('unavailable' in made) {
+    // The producer cannot watch anything here, and that is a fact `agentop events status` must be
+    // able to state — otherwise "no events" reads as "nothing happened" on a machine where nothing
+    // ever could.
+    log(`[events] not watching: ${made.unavailable}`)
+    await beat.beat(made.unavailable)
+    return { stop: async () => { await beat.clear() } }
+  }
+
+  let running = true
+  const producer = made.producer
+
+  void (async () => {
+    await beat.beat()
+    while (running) {
+      try {
+        const t = await producer.tick()
+        await beat.beat(t.unavailable)
+        for (const e of t.written) log(`[events] ${e.kind} · ${e.label ?? e.cwd}`)
+        for (const l of t.delivery.lines) log(`[events] ${l}`)
+      } catch (e) {
+        log(`[events] ${e instanceof Error ? e.message : String(e)}`)
+      }
+      if (!running) break
+      await new Promise(r => setTimeout(r, SESSION_POLL_MS))
+    }
+  })()
+
+  log(`[events] watching sessions every ${SESSION_POLL_MS}ms — \`agentop events status\``)
+
+  return {
+    stop: async () => {
+      running = false
+      producer.stop()
+      await beat.clear()
+    },
+  }
+}

--- a/packages/server/server/events/desktop.ts
+++ b/packages/server/server/events/desktop.ts
@@ -1,0 +1,165 @@
+/**
+ * desktop.ts — the desktop half of the cascade: probing what this machine has, and using it.
+ *
+ * `notify-plan.ts` decides; this file looks and spawns. The split matters because "which channel"
+ * is the part with rules worth testing and "does `notify-send` exist" is the part that can only be
+ * answered by this machine.
+ *
+ * ## A delivery that failed says so
+ *
+ * Every send returns a result. A channel that was chosen and then failed (the toast command exited
+ * non-zero, ccn exited 0 having done nothing) is reported as a failed delivery, not swallowed. The
+ * event is in the inbox either way — the point of reporting is that `agentop events status` and the
+ * command output can tell the user their desktop notifications are not actually arriving, before
+ * they have spent a week trusting them.
+ */
+
+import { existsSync } from 'node:fs'
+import { readdir } from 'node:fs/promises'
+import { join } from 'node:path'
+import { HOME_DIR } from '../config'
+import {
+  ccnPayload, planDesktopChannel, type DesktopChannel, type DesktopDecision, type DesktopProbe,
+} from './notify-plan'
+import type { DesktopText } from './notify-text'
+
+/** A notification that hangs holds up the poll that produced it. */
+const NOTIFY_TIMEOUT_MS = 5_000
+
+/**
+ * Where `claude-code-notifications` installs its notifier.
+ *
+ * Two locations because it can arrive two ways: through the Claude Code plugin cache (versioned
+ * directory, which is why the version segment is globbed rather than pinned) or through its own
+ * `install.sh` into `~/.claude/hooks`. Detected, never embedded — see `notify-plan.ts`.
+ */
+async function findCcnScript(): Promise<string | undefined> {
+  const direct = join(HOME_DIR, '.claude', 'hooks', 'ccn', 'notify.sh')
+  if (existsSync(direct)) return direct
+
+  const cacheRoot = join(HOME_DIR, '.claude', 'plugins', 'cache', 'blpsoares', 'claude-code-notifications')
+  try {
+    const versions = (await readdir(cacheRoot)).sort().reverse()
+    for (const v of versions) {
+      const p = join(cacheRoot, v, 'scripts', 'notify.sh')
+      if (existsSync(p)) return p
+    }
+  } catch { /* not installed that way */ }
+  return undefined
+}
+
+/** What this machine actually has. */
+export async function probeDesktop(): Promise<DesktopProbe> {
+  const ccnScript = await findCcnScript()
+  return {
+    ...(ccnScript !== undefined ? { ccnScript } : {}),
+    hasJq: !!Bun.which('jq'),
+    hasPowershell: !!Bun.which('powershell.exe'),
+    hasNotifySend: !!Bun.which('notify-send'),
+    hasTty: process.stdout.isTTY === true,
+    // Absent reads as ENABLED here — unlike `chatAllowed`, because this switch turns off a
+    // notification rather than opening a door. Only an explicit `0` disables it.
+    disabled: process.env.AGENTISTICS_EVENTS_DESKTOP === '0',
+  }
+}
+
+export interface DesktopSetup {
+  probe: DesktopProbe
+  decision: DesktopDecision
+}
+
+/** Probe once, decide once. A caller that notifies repeatedly holds this rather than re-reading the
+ *  filesystem on every event. */
+export async function desktopSetup(): Promise<DesktopSetup> {
+  const probe = await probeDesktop()
+  return { probe, decision: planDesktopChannel(probe) }
+}
+
+export async function desktopDecision(): Promise<DesktopDecision> {
+  return (await desktopSetup()).decision
+}
+
+export type DesktopResult =
+  | { ok: true; channel: DesktopChannel }
+  | { ok: false; channel: DesktopChannel; message: string }
+
+async function run(cmd: string[], stdin?: string): Promise<{ code: number; err: string }> {
+  const proc = Bun.spawn(cmd, {
+    stdin: stdin === undefined ? 'ignore' : new TextEncoder().encode(stdin),
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+  const timer = setTimeout(() => { try { proc.kill() } catch { /* already gone */ } }, NOTIFY_TIMEOUT_MS)
+  try {
+    const code = await proc.exited
+    const err = await new Response(proc.stderr).text()
+    return { code, err: err.trim() }
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+/**
+ * Show one notification through whichever channel this machine has.
+ *
+ * `cwd` is passed because ccn derives its title and its footer from the directory — it is what
+ * makes a toast say which project, for the five harnesses that have no Claude transcript to read.
+ */
+export async function notifyDesktop(
+  text: DesktopText,
+  cwd: string,
+  setup?: DesktopSetup,
+): Promise<DesktopResult> {
+  const chosen = setup ?? await desktopSetup()
+  const d = chosen.decision
+  try {
+    switch (d.channel) {
+      case 'ccn': {
+        const r = await run(['bash', chosen.probe.ccnScript!], ccnPayload({ ...text, cwd }))
+        return r.code === 0
+          ? { ok: true, channel: 'ccn' }
+          : { ok: false, channel: 'ccn', message: `claude-code-notifications exited ${r.code}${r.err ? `: ${r.err}` : ''}` }
+      }
+      case 'notify-send': {
+        const r = await run(['notify-send', '--app-name=agentop', text.title, text.body])
+        return r.code === 0
+          ? { ok: true, channel: 'notify-send' }
+          : { ok: false, channel: 'notify-send', message: `notify-send exited ${r.code}${r.err ? `: ${r.err}` : ''}` }
+      }
+      case 'powershell': {
+        const r = await run(['powershell.exe', '-NoProfile', '-NonInteractive', '-Command', powershellToast(text)])
+        return r.code === 0
+          ? { ok: true, channel: 'powershell' }
+          : { ok: false, channel: 'powershell', message: `powershell.exe exited ${r.code}${r.err ? `: ${r.err}` : ''}` }
+      }
+      case 'bell':
+        // The one channel that needs no program: the terminal's own BEL.
+        process.stdout.write('\x07')
+        return { ok: true, channel: 'bell' }
+      case 'none':
+        return { ok: false, channel: 'none', message: d.reason }
+    }
+  } catch (e) {
+    return { ok: false, channel: d.channel, message: e instanceof Error ? e.message : String(e) }
+  }
+}
+
+/**
+ * A plain Windows toast from WSL, with no plugin involved.
+ *
+ * A screen tail is arbitrary user text and it is being placed inside a PowerShell string literal,
+ * so the one quoting rule that matters is applied here: a single quote is doubled, newlines are
+ * collapsed, and the length is bounded. Without that a stray apostrophe in someone's prompt ends
+ * the literal and the rest of their text is parsed as code.
+ */
+function powershellToast(text: DesktopText): string {
+  const esc = (s: string): string => s.replace(/[\r\n]+/g, ' ').replace(/'/g, "''").slice(0, 200)
+  return [
+    '[Windows.UI.Notifications.ToastNotificationManager, Windows.UI.Notifications, ContentType=WindowsRuntime] > $null;',
+    // 5 is ToastText02: a bold heading line and a body line, and no image to resolve.
+    '$t = [Windows.UI.Notifications.ToastNotificationManager]::GetTemplateContent(5);',
+    `$t.GetElementsByTagName('text').Item(0).AppendChild($t.CreateTextNode('${esc(text.title)}')) > $null;`,
+    `$t.GetElementsByTagName('text').Item(1).AppendChild($t.CreateTextNode('${esc(text.body)}')) > $null;`,
+    "[Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier('agentop').Show([Windows.UI.Notifications.ToastNotification]::new($t));",
+  ].join(' ')
+}

--- a/packages/server/server/events/event-core.test.ts
+++ b/packages/server/server/events/event-core.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, test } from 'bun:test'
+import { dedupeEvents, isDuplicate } from './event-dedupe'
+import { MAX_TAIL_LINES, parseEvent, parseEvents, serializeEvent } from './event-line'
+import { EMPTY_MEMORY, planEvents, seedMemory, type EventMemory } from './event-plan'
+import { EMPTY_CURSOR, advanceCursor, planRead, planRotation } from './event-rotate'
+import { EVENT_VERSION, type EventCandidate, type EventKind, type SessionEvent } from './event-types'
+import type { SessionActivity } from '../sessions/types'
+
+const NOW = '2026-08-14T12:00:00.000Z'
+const NOW_MS = Date.parse(NOW)
+
+const ev = (o: Partial<SessionEvent>): SessionEvent => ({
+  v: EVENT_VERSION, seq: 1, at: NOW, source: 'poll', kind: 'waiting',
+  id: 's1', cwd: '/w', ...o,
+})
+
+const sess = (o: Partial<EventCandidate>): EventCandidate => ({ id: 's1', cwd: '/w', ...o })
+
+/**
+ * Two polls make a state. `run` walks a sequence of readings through the planner exactly as the
+ * producer does, so what these tests exercise is the real loop rather than one call to it.
+ */
+const run = (
+  readings: SessionActivity[][],
+  o: { seed?: boolean; kinds?: readonly EventKind[] } = {},
+): { events: SessionEvent[][]; memory: EventMemory } => {
+  const toSessions = (row: SessionActivity[]): EventCandidate[] =>
+    row.map((activity, i) => sess({ id: `s${i + 1}`, activity }))
+  let memory: EventMemory = EMPTY_MEMORY
+  const events: SessionEvent[][] = []
+  for (const [i, row] of readings.entries()) {
+    if (i === 0 && o.seed !== false) { memory = seedMemory(toSessions(row)); events.push([]); continue }
+    const r = planEvents({ memory, sessions: toSessions(row), nowIso: NOW, ...(o.kinds ? { kinds: o.kinds } : {}) })
+    memory = r.memory
+    events.push(r.events)
+  }
+  return { events, memory }
+}
+
+const kinds = (rows: SessionEvent[][]): string[] => rows.flat().map(e => e.kind)
+
+describe('planEvents', () => {
+  test('a change held for two polls is an event, and it carries the state it came from', () => {
+    const out = planEvents({
+      memory: { lastSeen: new Map([['s1', 'waiting-approval']]), confirmed: new Map([['s1', 'working']]) },
+      sessions: [sess({ activity: 'waiting-approval', harness: 'claude', task: 'canal' })],
+      nowIso: NOW,
+    })
+    expect(out.events).toHaveLength(1)
+    expect(out.events[0]).toMatchObject({ kind: 'waiting-approval', from: 'working', task: 'canal', source: 'poll' })
+  })
+
+  test('the same state twice is not an event — a level never rings', () => {
+    expect(kinds(run([['waiting'], ['waiting'], ['waiting'], ['waiting']]).events)).toEqual([])
+  })
+
+  test('a session never seen before produces nothing — a restart must not replay the fleet', () => {
+    expect(kinds(run([['waiting'], ['waiting']]).events)).toEqual([])
+  })
+
+  test('a real turn is reported: several polls of work, then the wait', () => {
+    expect(kinds(run([
+      ['waiting'], ['working'], ['working'], ['working'], ['waiting'], ['waiting'],
+    ]).events)).toEqual(['working', 'waiting'])
+  })
+
+  test('the DEFAULT subscription hears only the wait, not the work that led to it', () => {
+    expect(kinds(run(
+      [['waiting'], ['working'], ['working'], ['waiting'], ['waiting']],
+      { kinds: ['waiting', 'waiting-approval', 'exited'] },
+    ).events)).toEqual(['waiting'])
+  })
+
+  test('a ONE-FRAME blip is not a state — the repaint that made this rule exist', () => {
+    // Measured on a real fleet: the pane redrew for a single poll, `attention.ts` correctly read
+    // the movement as `working`, and the next frame was `waiting` again. Nothing happened.
+    expect(kinds(run([
+      ['waiting'], ['working'], ['waiting'], ['waiting'], ['waiting'],
+    ]).events)).toEqual([])
+  })
+
+  test('a blip much later is suppressed too — the rule is not a time window', () => {
+    const quiet: SessionActivity[][] = Array.from({ length: 20 }, () => ['waiting'])
+    expect(kinds(run([...quiet, ['working'], ['waiting'], ['waiting']]).events)).toEqual([])
+  })
+
+  test('a `working` nobody subscribed to still advances what the channel believes', () => {
+    // Or the real `waiting` that follows would compare against a stale `waiting` and be swallowed.
+    expect(kinds(run(
+      [['waiting'], ['working'], ['working'], ['waiting'], ['waiting']],
+      { kinds: ['waiting'] },
+    ).events)).toEqual(['waiting'])
+  })
+
+  test('kinds narrow what is written, per session', () => {
+    const r = run([
+      ['working', 'working'], ['waiting', 'exited'], ['waiting', 'exited'],
+    ], { kinds: ['exited'] })
+    expect(r.events.flat().map(e => e.id)).toEqual(['s2'])
+  })
+
+  test('the memory carries only sessions still on screen', () => {
+    const r = run([['waiting', 'waiting'], ['waiting', 'waiting'], ['waiting']])
+    expect([...r.memory.confirmed.keys()]).toEqual(['s1'])
+  })
+
+  test('seeding treats what is on screen as already true, so nothing is reported about it', () => {
+    const seeded = seedMemory([sess({ activity: 'waiting-approval' })])
+    expect(seeded.confirmed.get('s1')).toBe('waiting-approval')
+    const out = planEvents({ memory: seeded, sessions: [sess({ activity: 'waiting-approval' })], nowIso: NOW })
+    expect(out.events).toEqual([])
+  })
+
+  test('a row with no activity is never remembered, so acquiring one is not a transition', () => {
+    const seeded = seedMemory([sess({ id: 'ext', activity: undefined })])
+    expect(seeded.confirmed.has('ext')).toBe(false)
+    const a = planEvents({ memory: seeded, sessions: [sess({ id: 'ext', activity: 'waiting' })], nowIso: NOW })
+    const b = planEvents({ memory: a.memory, sessions: [sess({ id: 'ext', activity: 'waiting' })], nowIso: NOW })
+    expect(b.events).toEqual([])
+  })
+})
+
+describe('serializeEvent / parseEvent', () => {
+  test('a screen tail with newlines in it stays ONE line', () => {
+    const line = serializeEvent(ev({ lines: ['a\nb', 'c\r\nd'] }))
+    expect(line.split('\n').filter(s => s !== '')).toHaveLength(1)
+    const back = parseEvent(line)
+    expect(back?.lines).toEqual(['a b', 'c d'])
+  })
+
+  test('the tail is clamped by the writer, wherever the writer is', () => {
+    const many = Array.from({ length: 40 }, (_, i) => `line ${i}`)
+    const back = parseEvent(serializeEvent(ev({ lines: many })))
+    expect(back?.lines).toHaveLength(MAX_TAIL_LINES)
+    expect(back?.lines?.[MAX_TAIL_LINES - 1]).toBe('line 39')
+  })
+
+  test('a round trip preserves a field this version does not know about', () => {
+    const line = serializeEvent({ ...ev({}), somethingNew: 42 } as unknown as SessionEvent)
+    expect((parseEvent(line) as unknown as { somethingNew: number }).somethingNew).toBe(42)
+  })
+
+  test('a line from a FUTURE version is unreadable rather than half-understood', () => {
+    expect(parseEvent(JSON.stringify({ ...ev({}), v: EVENT_VERSION + 1 }))).toBeNull()
+  })
+
+  test('junk in the middle of the file costs that line and nothing else', () => {
+    const text = [serializeEvent(ev({ id: 'a' })), 'not json\n', '{"v":1}\n', serializeEvent(ev({ id: 'b' }))].join('')
+    const r = parseEvents(text)
+    expect(r.events.map(e => e.id)).toEqual(['a', 'b'])
+    expect(r.unreadable).toBe(2)
+  })
+})
+
+describe('dedupe', () => {
+  const hook = ev({ source: 'hook', kind: 'turn-end', harness: 'claude', cwd: '/repo', conversationId: 'c1' })
+
+  test('the poller is suppressed by a hook for the same conversation inside the window', () => {
+    const poll = ev({ source: 'poll', kind: 'waiting', harness: 'claude', cwd: '/repo', conversationId: 'c1' })
+    expect(isDuplicate(poll, [hook], NOW_MS + 3_000)).toBe(true)
+  })
+
+  test('outside the window it is a second turn, not a duplicate', () => {
+    const poll = ev({ source: 'poll', kind: 'waiting', harness: 'claude', cwd: '/repo', conversationId: 'c1' })
+    expect(isDuplicate(poll, [hook], NOW_MS + 60_000)).toBe(false)
+  })
+
+  test('a hook event is never suppressed by a poll event — the exact record always lands', () => {
+    const poll = ev({ source: 'poll', kind: 'waiting', harness: 'claude', cwd: '/repo', conversationId: 'c1' })
+    expect(isDuplicate(hook, [poll], NOW_MS + 1_000)).toBe(false)
+  })
+
+  test('waiting-approval is never deduped — it is the event nobody may lose', () => {
+    const poll = ev({ source: 'poll', kind: 'waiting-approval', harness: 'claude', cwd: '/repo', conversationId: 'c1' })
+    expect(isDuplicate(poll, [hook], NOW_MS + 1_000)).toBe(false)
+  })
+
+  test('the cwd fallback applies only to claude', () => {
+    const claude = ev({ source: 'poll', kind: 'waiting', harness: 'claude', cwd: '/repo' })
+    const codex = ev({ source: 'poll', kind: 'waiting', harness: 'codex', cwd: '/repo' })
+    const hookNoConv = ev({ source: 'hook', kind: 'turn-end', harness: 'claude', cwd: '/repo' })
+    expect(isDuplicate(claude, [hookNoConv], NOW_MS)).toBe(true)
+    expect(isDuplicate(codex, [hookNoConv], NOW_MS)).toBe(false)
+  })
+
+  test('an empty history suppresses nothing', () => {
+    const poll = ev({ source: 'poll', kind: 'waiting', harness: 'claude', cwd: '/repo' })
+    expect(dedupeEvents([poll], [], NOW_MS)).toHaveLength(1)
+  })
+})
+
+describe('rotation and the cursor', () => {
+  test('rotation happens before the write that would exceed the cap', () => {
+    expect(planRotation(900, 200, 1000)).toBe(true)
+    expect(planRotation(700, 200, 1000)).toBe(false)
+    expect(planRotation(0, 5000, 1000)).toBe(false) // an empty file is never rotated
+  })
+
+  test('a cursor past the end of the file means rotated — read from the start and SAY so', () => {
+    expect(planRead({ offset: 900, seq: 40 }, 100)).toEqual({ from: 0, rotated: true })
+  })
+
+  test('a sequence ahead of the file is rotated even when the offset still fits', () => {
+    expect(planRead({ offset: 50, seq: 40 }, 5000, 3)).toEqual({ from: 0, rotated: true })
+  })
+
+  test('an ordinary resume reads from where it stopped', () => {
+    expect(planRead({ offset: 50, seq: 3 }, 5000, 9)).toEqual({ from: 50, rotated: false })
+  })
+
+  test('the empty cursor reads the whole file and is not a rotation', () => {
+    expect(planRead(EMPTY_CURSOR, 5000, 9)).toEqual({ from: 0, rotated: false })
+    expect(advanceCursor(120, 7)).toEqual({ offset: 120, seq: 7 })
+  })
+})

--- a/packages/server/server/events/event-core.test.ts
+++ b/packages/server/server/events/event-core.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test'
-import { dedupeEvents, isDuplicate } from './event-dedupe'
+import { DEDUPE_WINDOW_MS, dedupeEvents, isDuplicate } from './event-dedupe'
 import { MAX_TAIL_LINES, parseEvent, parseEvents, serializeEvent } from './event-line'
 import { EMPTY_MEMORY, planEvents, seedMemory, type EventMemory } from './event-plan'
 import { EMPTY_CURSOR, advanceCursor, planRead, planRotation } from './event-rotate'
@@ -160,9 +160,17 @@ describe('dedupe', () => {
     expect(isDuplicate(poll, [hook], NOW_MS + 3_000)).toBe(true)
   })
 
-  test('outside the window it is a second turn, not a duplicate', () => {
+  test('the MEASURED gap is inside the window — 32s between the hook and the poll copy', () => {
+    // Real numbers from a live fleet: hook 13:58:12.738, poll 13:58:44.818. The first window was
+    // 20s, sized before `event-plan.ts` began requiring two consecutive polls, and the user was
+    // told twice.
     const poll = ev({ source: 'poll', kind: 'waiting', harness: 'claude', cwd: '/repo', conversationId: 'c1' })
-    expect(isDuplicate(poll, [hook], NOW_MS + 60_000)).toBe(false)
+    expect(isDuplicate(poll, [hook], NOW_MS + 32_080)).toBe(true)
+  })
+
+  test('well outside the window it is a second turn, not a duplicate', () => {
+    const poll = ev({ source: 'poll', kind: 'waiting', harness: 'claude', cwd: '/repo', conversationId: 'c1' })
+    expect(isDuplicate(poll, [hook], NOW_MS + DEDUPE_WINDOW_MS + 1)).toBe(false)
   })
 
   test('a hook event is never suppressed by a poll event — the exact record always lands', () => {

--- a/packages/server/server/events/event-dedupe.ts
+++ b/packages/server/server/events/event-dedupe.ts
@@ -2,8 +2,9 @@
  * event-dedupe.ts — PURE. The same end of turn, seen twice, read once.
  *
  * A Claude session that stops answering is reported by BOTH sources: the `Stop` hook fires
- * immediately, and the poller notices up to five seconds later that the screen went quiet. They are
- * the same fact. The reader wants it once.
+ * immediately, and the poller notices tens of seconds later that the screen went quiet — it has to
+ * see the new state twice before it counts it (`event-plan.ts`) and it has a fleet of panes to
+ * capture. They are the same fact. The reader wants it once.
  *
  * ## The hook wins, and the rule is one-directional
  *
@@ -35,11 +36,27 @@ import type { SessionEvent } from './event-types'
 /**
  * How long a hook event shadows the poll event that duplicates it.
  *
- * Wider than the five-second poll (the poll that notices is the one AFTER the turn ended, so the
- * gap can be a full interval plus the capture) and narrow enough that a second turn in the same
- * conversation is its own event. Twenty seconds is two polls plus room.
+ * ## Why this is ninety seconds and not two poll intervals
+ *
+ * The first value here was twenty seconds, reasoned from "the poll that notices is the one after
+ * the turn ended, so the gap is one interval plus the capture". That reasoning was obsolete the
+ * moment `event-plan.ts` started requiring a state to be confirmed on TWO consecutive polls: the
+ * poll source now reports a turn end at least one further interval later, and on a fleet of eight
+ * sessions the capture of each pane adds more. **Measured**: a hook event at 13:58:12.738 and the
+ * poll's duplicate of the same turn at 13:58:44.818 — 32 seconds — so the user was told twice.
+ *
+ * Ninety seconds covers that with room for a slower machine or a larger fleet, and over-covering
+ * is the SAFE direction here, which is what makes the number defensible rather than arbitrary:
+ * suppression requires a hook event to already exist for that conversation. A Claude session with
+ * no `Stop` hook installed produces no hook events, so nothing of its is ever suppressed, however
+ * wide this is. And where the hook IS installed it fires on EVERY turn — so a second turn landing
+ * inside the window still reaches the reader, through its own hook event, which is the exact
+ * record rather than the inferred one.
+ *
+ * The residual case is narrow and stated: a session whose hook was uninstalled between two turns
+ * loses the poll copy of the second turn if it lands within ninety seconds of the first.
  */
-export const DEDUPE_WINDOW_MS = 20_000
+export const DEDUPE_WINDOW_MS = 90_000
 
 /** The kinds that describe "the turn ended", one word per source. */
 const TURN_END_KINDS = new Set(['turn-end', 'waiting'])

--- a/packages/server/server/events/event-dedupe.ts
+++ b/packages/server/server/events/event-dedupe.ts
@@ -1,0 +1,97 @@
+/**
+ * event-dedupe.ts — PURE. The same end of turn, seen twice, read once.
+ *
+ * A Claude session that stops answering is reported by BOTH sources: the `Stop` hook fires
+ * immediately, and the poller notices up to five seconds later that the screen went quiet. They are
+ * the same fact. The reader wants it once.
+ *
+ * ## The hook wins, and the rule is one-directional
+ *
+ * The hook is exact (Claude itself said the turn ended) and it is FIRST (no polling interval to
+ * wait out). So a hook event is always written, and a poll event is suppressed when a hook event
+ * for the same conversation already landed inside the window. Never the other way round: a poller
+ * event arriving first would mean the hook is not installed, or is slower than its own event, and
+ * dropping the hook's exact record in favour of an inference is the wrong trade in both cases.
+ *
+ * ## Matching, and why `cwd` is a fallback rather than the key
+ *
+ * `conversationId` is the only key both sources provably share, so it is preferred. It is often
+ * absent — agentop does not learn the conversation id of a session it started fresh — and the
+ * fallback is `harness === 'claude'` plus the same `cwd`. That is a heuristic, and it is bounded on
+ * purpose: it only ever applies to Claude (no other harness has a hook to collide with), and only
+ * inside `DEDUPE_WINDOW_MS`. Two Claude sessions in one directory finishing within that window
+ * would collapse into one line — a real, rare loss, chosen over the certain and constant duplicate.
+ *
+ * ## Only turn-shaped kinds are deduped
+ *
+ * `Stop` says the turn ended; the poller renders that as `waiting` (the screen stopped moving) and
+ * the hook as `turn-end`. Those two are the pair. A `waiting-approval` has no hook counterpart at
+ * all — Claude Code does not fire `Stop` for a permission prompt — so it is never suppressed, which
+ * matters because it is the event a person most needs to see.
+ */
+
+import type { SessionEvent } from './event-types'
+
+/**
+ * How long a hook event shadows the poll event that duplicates it.
+ *
+ * Wider than the five-second poll (the poll that notices is the one AFTER the turn ended, so the
+ * gap can be a full interval plus the capture) and narrow enough that a second turn in the same
+ * conversation is its own event. Twenty seconds is two polls plus room.
+ */
+export const DEDUPE_WINDOW_MS = 20_000
+
+/** The kinds that describe "the turn ended", one word per source. */
+const TURN_END_KINDS = new Set(['turn-end', 'waiting'])
+
+function sameConversation(a: SessionEvent, b: SessionEvent): boolean {
+  if (a.conversationId && b.conversationId) return a.conversationId === b.conversationId
+  // The fallback, deliberately narrow — see the header.
+  if (a.harness !== 'claude' || b.harness !== 'claude') return false
+  return a.cwd !== '' && a.cwd === b.cwd
+}
+
+/**
+ * Is this candidate a duplicate of something already in the inbox?
+ *
+ * `recent` is whatever the caller has to hand — the tail of the inbox is enough, and cheaper than
+ * the whole file. A caller that passes nothing suppresses nothing, which is the safe direction: an
+ * extra line is visible and self-correcting, a dropped one is not.
+ */
+export function isDuplicate(
+  candidate: SessionEvent,
+  recent: readonly SessionEvent[],
+  nowMs: number,
+  windowMs = DEDUPE_WINDOW_MS,
+): boolean {
+  // Only a POLL event is ever suppressed, and only a turn-shaped one.
+  if (candidate.source !== 'poll') return false
+  if (!TURN_END_KINDS.has(candidate.kind)) return false
+
+  for (const seen of recent) {
+    if (seen.source !== 'hook') continue
+    if (!TURN_END_KINDS.has(seen.kind)) continue
+    const seenMs = Date.parse(seen.at)
+    // An unparseable timestamp cannot be shown to be inside the window, so it does not suppress.
+    if (!Number.isFinite(seenMs)) continue
+    if (nowMs - seenMs > windowMs || seenMs > nowMs + windowMs) continue
+    if (sameConversation(candidate, seen)) return true
+  }
+  return false
+}
+
+/** The candidates that survive, in order. Each one is judged against the inbox tail AND against the
+ *  ones already kept from this same batch, so one poll cannot emit two duplicates of each other. */
+export function dedupeEvents(
+  candidates: readonly SessionEvent[],
+  recent: readonly SessionEvent[],
+  nowMs: number,
+  windowMs = DEDUPE_WINDOW_MS,
+): SessionEvent[] {
+  const kept: SessionEvent[] = []
+  for (const c of candidates) {
+    if (isDuplicate(c, [...recent, ...kept], nowMs, windowMs)) continue
+    kept.push(c)
+  }
+  return kept
+}

--- a/packages/server/server/events/event-line.ts
+++ b/packages/server/server/events/event-line.ts
@@ -1,0 +1,99 @@
+/**
+ * event-line.ts — PURE. One event, one line, and how to read a line somebody else wrote.
+ *
+ * The inbox is append-only JSONL because that is the format a later reader can start reading in the
+ * middle of. Two properties matter and both are tested:
+ *
+ *  - **A line is exactly one line.** Everything written goes through `serializeEvent`, which strips
+ *    newlines out of the free text it carries. A screen tail with a newline in it would otherwise
+ *    split one event into two half-lines, and the reader would drop both.
+ *  - **An unreadable line is skipped, never fatal.** The file survives upgrades, crashes mid-write
+ *    and a version of agentop that wrote fields this one has never heard of. `parseEvents` returns
+ *    what it could read and COUNTS what it could not, so `agentop events status` can say "4 lines
+ *    in this file are not readable by this version" instead of the file silently reading as empty.
+ *
+ * Unknown fields are preserved on read (the object is passed through), so a newer producer's extra
+ * fields survive a round trip through an older reader that only re-serializes what it parsed.
+ */
+
+import { EVENT_KINDS, EVENT_VERSION, type SessionEvent } from './event-types'
+
+/** How much of a screen tail one event may carry. A tail is context, not a transcript. */
+export const MAX_LINE_CHARS = 400
+export const MAX_TAIL_LINES = 8
+
+// U+2028 / U+2029 are line terminators to a JS parser but not to `split('\n')`, so they would
+// survive here and split one event in two on the way back out through some other reader.
+const oneLine = (s: string): string =>
+  s.replace(/[\r\n\u2028\u2029]+/g, ' ').slice(0, MAX_LINE_CHARS)
+
+/**
+ * The bytes of one event, newline included.
+ *
+ * The tail is clamped here rather than at the producer so that EVERY writer — the poller, the hook,
+ * a future one — is bounded by the same rule. An inbox is a file that grows; the cheapest place to
+ * stop it growing per-line is the one place every line goes through.
+ */
+export function serializeEvent(e: SessionEvent): string {
+  const clean: SessionEvent = {
+    ...e,
+    cwd: oneLine(e.cwd),
+    ...(e.task ? { task: oneLine(e.task) } : {}),
+    ...(e.label ? { label: oneLine(e.label) } : {}),
+    ...(e.lines ? { lines: e.lines.slice(-MAX_TAIL_LINES).map(oneLine) } : {}),
+  }
+  return `${JSON.stringify(clean)}\n`
+}
+
+/** One line back into an event, or null when this version cannot make sense of it. */
+export function parseEvent(line: string): SessionEvent | null {
+  const text = line.trim()
+  if (text === '') return null
+  let raw: unknown
+  try {
+    raw = JSON.parse(text) as unknown
+  } catch {
+    return null
+  }
+  if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) return null
+  const o = raw as Record<string, unknown>
+
+  // A line from the FUTURE is not readable by this version, and guessing at it is how a reader
+  // reports a half-understood event as a whole one. It is counted as unreadable, not silently kept.
+  if (typeof o.v !== 'number' || o.v > EVENT_VERSION) return null
+  if (typeof o.at !== 'string' || o.at === '') return null
+  if (typeof o.id !== 'string' || o.id === '') return null
+  if (typeof o.cwd !== 'string') return null
+  if (o.source !== 'poll' && o.source !== 'hook') return null
+  if (typeof o.kind !== 'string' || !EVENT_KINDS.includes(o.kind as never)) return null
+
+  return {
+    ...o,
+    v: o.v,
+    seq: typeof o.seq === 'number' ? o.seq : 0,
+    at: o.at,
+    source: o.source,
+    kind: o.kind as SessionEvent['kind'],
+    id: o.id,
+    cwd: o.cwd,
+    ...(Array.isArray(o.lines) ? { lines: (o.lines as unknown[]).filter((l): l is string => typeof l === 'string') } : {}),
+  } as SessionEvent
+}
+
+export interface ParsedEvents {
+  events: SessionEvent[]
+  /** Lines this version could not read. Reported, never hidden — see the header. */
+  unreadable: number
+}
+
+export function parseEvents(text: string): ParsedEvents {
+  const events: SessionEvent[] = []
+  let unreadable = 0
+  for (const line of text.split('\n')) {
+    if (line.trim() === '') continue
+    const e = parseEvent(line)
+    if (e) events.push(e)
+    else unreadable++
+  }
+  return { events, unreadable }
+}

--- a/packages/server/server/events/event-plan.ts
+++ b/packages/server/server/events/event-plan.ts
@@ -1,0 +1,161 @@
+/**
+ * event-plan.ts — PURE. Which transitions become events, and what those events say.
+ *
+ * ## A transition, never a level
+ *
+ * The rule is `bellTransitions`' rule, applied to a wider set of states: an event is written when a
+ * session's state is DIFFERENT from what it was, and never because it is still what it was. The
+ * poll runs every five seconds; a session sitting on a permission prompt for ten minutes is one
+ * event, not a hundred and twenty.
+ *
+ * ## A state that lasted one frame is a flicker, not a state
+ *
+ * This is the rule the rest of the module is shaped around, and it was written after watching the
+ * channel get it wrong on a real fleet. A session that had finished answering reported `waiting` at
+ * 13:12:20 and again at 13:12:30. In between, its pane repainted — a tmux advisory line appeared at
+ * the bottom — and a frame that MOVED is the only universal proof of work there is, so
+ * `attention.ts` correctly read the repaint as `working` and the next frame as `waiting` again.
+ * Nothing about the session had changed. It happened again forty-five seconds later when a plugin
+ * printed a notice into the same pane.
+ *
+ * For the cockpit that is a badge flickering for five seconds and nobody minds. For a channel that
+ * interrupts a person and another assistant, it is the failure this whole feature is judged on: a
+ * duplicate notification is how people learn to ignore notifications.
+ *
+ * The fix is NOT a time window. The first attempt was one, and the second flicker landed outside
+ * it — a wall clock cannot separate "the screen twitched" from "a short turn happened", and any
+ * window wide enough to catch the twitch also swallows a genuine follow-up turn, which is the
+ * primary thing this channel exists to report. So the rule uses the signal itself: **a state counts
+ * only once it has been observed on two consecutive polls.** A cosmetic repaint is one frame and is
+ * never confirmed; real work holds the screen for longer than one five-second interval. Events are
+ * compared against the last CONFIRMED state, so `waiting → (blip) → waiting` is not a transition at
+ * all, while `waiting → working → waiting` across several polls is two.
+ *
+ * What it costs, stated plainly: a turn that begins and ends inside a single poll interval is
+ * invisible to this source. That is precisely the case the Claude `Stop` hook covers exactly, which
+ * is a large part of why the hook exists — and for the other five harnesses, a sub-five-second turn
+ * is not something a five-second poll was ever going to see.
+ *
+ * It is deliberately not a change to `attention.ts`. "The screen moved, so it is working" is the
+ * right rule for the fleet monitor and the only signal several harnesses give; narrowing it there
+ * would blind the cockpit to real work in order to quieten a notification.
+ *
+ * ## Why the first sighting is not an event
+ *
+ * A producer that has just come up has no previous state for anyone, so nothing can be said to have
+ * changed. Emitting on first sighting would mean every restart replays the whole fleet into the
+ * inbox — the reader would see five sessions "start waiting" at the moment a daemon was bounced,
+ * which is a lie about the world told by a fact about the process. `seedMemory` exists for exactly
+ * this: a producer records where everyone IS, and reports only what happens next.
+ */
+
+import type { SessionActivity } from '../sessions/types'
+import {
+  EVENT_VERSION,
+  type EventCandidate,
+  type EventKind,
+  type SessionEvent,
+} from './event-types'
+
+/**
+ * What the producer carries between polls.
+ *
+ * Two maps, because they answer two different questions. `lastSeen` is the raw reading of the
+ * previous poll and exists only to decide whether the current reading is CONFIRMED. `confirmed` is
+ * the state the channel currently believes the session is in, and is what a new reading is compared
+ * against.
+ */
+export interface EventMemory {
+  lastSeen: ReadonlyMap<string, SessionActivity>
+  confirmed: ReadonlyMap<string, SessionActivity>
+}
+
+export const EMPTY_MEMORY: EventMemory = { lastSeen: new Map(), confirmed: new Map() }
+
+/** An activity is an event kind of the same name. Separate types, one mapping, stated once. */
+function kindOf(a: SessionActivity): EventKind {
+  return a
+}
+
+export interface PlanResult {
+  /** The events this poll produces. `seq` is left at 0 — the inbox stamps it on append. */
+  events: SessionEvent[]
+  /** What to carry into the next poll. */
+  memory: EventMemory
+}
+
+/**
+ * The events this poll produces, and the memory for the next one — PURE.
+ *
+ * `kinds` narrows what is WRITTEN, never what is tracked: the memory advances on every confirmed
+ * change whether or not anybody subscribed to it, or a `working` nobody asked for would leave the
+ * channel believing the session is still `waiting` and swallow the real `waiting` that follows.
+ */
+export function planEvents(o: {
+  memory: EventMemory
+  sessions: readonly EventCandidate[]
+  nowIso: string
+  /** Only these kinds are written. Defaults to everything. */
+  kinds?: readonly EventKind[]
+}): PlanResult {
+  const wanted = o.kinds
+  const events: SessionEvent[] = []
+  const lastSeen = new Map<string, SessionActivity>()
+  const confirmed = new Map<string, SessionActivity>()
+
+  for (const s of o.sessions) {
+    if (!s.activity) continue
+    lastSeen.set(s.id, s.activity)
+
+    const was = o.memory.confirmed.get(s.id)
+    // Sessions the producer has never confirmed anything about carry nothing forward until they
+    // are confirmed — an unconfirmed reading is not yet a state, so it is not yet a belief either.
+    if (was !== undefined) confirmed.set(s.id, was)
+
+    // Not yet held for two polls: a flicker, and nothing is said or believed about it.
+    if (o.memory.lastSeen.get(s.id) !== s.activity) continue
+
+    // Confirmed. Advance what the channel believes, whatever the kind filter goes on to do.
+    confirmed.set(s.id, s.activity)
+    if (was === undefined) continue // first confirmation — see the header
+    if (was === s.activity) continue
+
+    const kind = kindOf(s.activity)
+    if (wanted && !wanted.includes(kind)) continue
+
+    events.push({
+      v: EVENT_VERSION,
+      seq: 0,
+      at: o.nowIso,
+      source: 'poll',
+      kind,
+      from: was,
+      id: s.id,
+      ...(s.harness ? { harness: s.harness } : {}),
+      cwd: s.cwd,
+      ...(s.task ? { task: s.task } : {}),
+      ...(s.label ? { label: s.label } : {}),
+      ...(s.conversationId ? { conversationId: s.conversationId } : {}),
+      ...(s.lines && s.lines.length > 0 ? { lines: s.lines } : {}),
+    })
+  }
+
+  // Only sessions still on screen are carried, so the memory cannot grow with every session the
+  // machine has ever hosted.
+  return { events, memory: { lastSeen, confirmed } }
+}
+
+/**
+ * Where the fleet is right now, as a producer's opening belief.
+ *
+ * Both maps are filled from one reading: the point of seeding is that these states are already
+ * true and must not be reported, so they are treated as confirmed even though they have been seen
+ * once. Sessions with no activity are omitted rather than stored as undefined — an external row
+ * carries no activity at all (nothing about it is capturable), and remembering "it was nothing"
+ * would make its first real reading look like a transition the moment it acquired one.
+ */
+export function seedMemory(sessions: readonly EventCandidate[]): EventMemory {
+  const m = new Map<string, SessionActivity>()
+  for (const s of sessions) if (s.activity) m.set(s.id, s.activity)
+  return { lastSeen: m, confirmed: new Map(m) }
+}

--- a/packages/server/server/events/event-rotate.ts
+++ b/packages/server/server/events/event-rotate.ts
@@ -1,0 +1,74 @@
+/**
+ * event-rotate.ts — PURE. How the inbox stops growing, and how a reader picks up where it left off.
+ *
+ * ## The cursor is a pair, and it has to be
+ *
+ * "Read everything since I last looked" is the whole reason the inbox exists — a Claude session
+ * only runs when it is invoked, so events that happened while it was parked have to be waiting for
+ * it somewhere. The cheap way to express "since" is a byte offset, and a byte offset is exactly
+ * what rotation invalidates: after the file is rolled over, offset 8000 points at an unrelated
+ * event, or past the end.
+ *
+ * So a cursor is `{ offset, seq }`. `seq` is monotonic within one file and restarts at 1 after a
+ * rotation, and `planRead` cross-checks them: a cursor whose offset is past the end of the file, or
+ * whose sequence is ahead of what the file now holds, is a cursor from BEFORE a rotation. That case
+ * reads from the beginning and SAYS SO (`rotated: true`) rather than returning nothing — a reader
+ * told "no new events" when the file was rolled under it would go quiet forever.
+ *
+ * ## One previous generation is kept
+ *
+ * Rotation renames the file to `.1`, replacing whatever `.1` held. Keeping exactly one generation
+ * is the honest middle: enough that a rotation mid-read does not destroy the events being read,
+ * bounded so the channel cannot fill a disk. What falls off the end is gone, and `status` reports
+ * the rotation count so that is visible rather than assumed.
+ */
+
+/** Roll over past this many bytes. Two MiB is roughly 10k events — weeks of a busy fleet. */
+export const MAX_INBOX_BYTES = 2 * 1024 * 1024
+
+export interface EventCursor {
+  /** Byte offset into the CURRENT inbox file. */
+  offset: number
+  /** The `seq` of the last event read. 0 means "nothing read yet". */
+  seq: number
+}
+
+export const EMPTY_CURSOR: EventCursor = { offset: 0, seq: 0 }
+
+/** Should the file be rolled over before this write? */
+export function planRotation(currentBytes: number, incomingBytes: number, max = MAX_INBOX_BYTES): boolean {
+  // Rotate BEFORE the write that would exceed the cap, not after — so the cap is a cap, and a
+  // single very large write cannot leave the file permanently over it.
+  return currentBytes > 0 && currentBytes + incomingBytes > max
+}
+
+export interface ReadPlan {
+  /** Where to start reading the current file. */
+  from: number
+  /**
+   * The cursor could not be honoured — the file was rotated (or truncated) under the reader, so
+   * this read starts at the beginning and some events are gone. Reported, never silent.
+   */
+  rotated: boolean
+}
+
+/**
+ * Where to start reading, given a cursor and what the file looks like now.
+ *
+ * `latestSeq` is the highest sequence the file currently holds; a caller that does not know it
+ * passes `undefined` and only the offset check applies.
+ */
+export function planRead(cursor: EventCursor, fileBytes: number, latestSeq?: number): ReadPlan {
+  if (cursor.offset < 0 || cursor.seq < 0) return { from: 0, rotated: true }
+  // The file is SHORTER than where we stopped: it was rotated or truncated.
+  if (cursor.offset > fileBytes) return { from: 0, rotated: true }
+  // The file no longer reaches the sequence we had already read: same thing, caught in the case
+  // where the new file happens to be longer than the old offset.
+  if (latestSeq !== undefined && cursor.seq > 0 && latestSeq < cursor.seq) return { from: 0, rotated: true }
+  return { from: cursor.offset, rotated: false }
+}
+
+/** The cursor a reader should keep after consuming up to `offset`. */
+export function advanceCursor(offset: number, lastSeq: number): EventCursor {
+  return { offset, seq: lastSeq }
+}

--- a/packages/server/server/events/event-store.test.ts
+++ b/packages/server/server/events/event-store.test.ts
@@ -1,0 +1,195 @@
+/**
+ * event-store.test.ts — the inbox against a real filesystem, in a temp directory.
+ *
+ * The pure rules are tested in `event-core.test.ts`; what is checked here is that this file wires
+ * them to disk correctly — that a cursor really does survive a rotation, that a reader picks up
+ * exactly what it has not seen, and that the producer's "first poll writes nothing" holds against a
+ * real store rather than only in the planner.
+ */
+
+import { afterEach, describe, expect, test } from 'bun:test'
+import { mkdtempSync, rmSync, statSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { createEventStore } from './event-store'
+import { EMPTY_CURSOR } from './event-rotate'
+import { EVENT_VERSION, type SessionEvent } from './event-types'
+import { createProducer } from './producer'
+import type { SessionSnapshot } from '../sessions/sessions-host'
+
+const dirs: string[] = []
+const tmpFile = (): string => {
+  const d = mkdtempSync(join(tmpdir(), 'agentop-events-'))
+  dirs.push(d)
+  return join(d, 'events.jsonl')
+}
+afterEach(() => { for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true }) })
+
+const ev = (o: Partial<SessionEvent>): SessionEvent => ({
+  v: EVENT_VERSION, seq: 0, at: new Date().toISOString(), source: 'poll', kind: 'waiting',
+  id: 's1', cwd: '/w', ...o,
+})
+
+describe('the inbox on disk', () => {
+  test('appends are numbered from 1 and read back in order', async () => {
+    const store = createEventStore(tmpFile())
+    await store.append([ev({ id: 'a' }), ev({ id: 'b' })])
+    await store.append([ev({ id: 'c' })])
+    const r = await store.recent(10)
+    expect(r.events.map(e => e.id)).toEqual(['a', 'b', 'c'])
+    expect(r.events.map(e => e.seq)).toEqual([1, 2, 3])
+  })
+
+  test('a new store continues the numbering of a file it did not write', async () => {
+    const file = tmpFile()
+    await createEventStore(file).append([ev({ id: 'a' }), ev({ id: 'b' })])
+    await createEventStore(file).append([ev({ id: 'c' })])
+    expect((await createEventStore(file).recent(10)).events.map(e => e.seq)).toEqual([1, 2, 3])
+  })
+
+  test('the file is created 0600 — it holds the user\'s own screen text', async () => {
+    const file = tmpFile()
+    await createEventStore(file).append([ev({})])
+    expect(statSync(file).mode & 0o777).toBe(0o600)
+  })
+
+  test('`since` returns exactly what has not been read', async () => {
+    const store = createEventStore(tmpFile())
+    await store.append([ev({ id: 'a' })])
+    const first = await store.recent(10)
+    await store.append([ev({ id: 'b' }), ev({ id: 'c' })])
+    const next = await store.since(first.cursor)
+    expect(next.events.map(e => e.id)).toEqual(['b', 'c'])
+    expect(next.rotated).toBe(false)
+    // …and reading again from the new cursor yields nothing.
+    expect((await store.since(next.cursor)).events).toEqual([])
+  })
+
+  test('the REAL rotation restarts the numbering, keeps one generation, and invalidates the cursor', async () => {
+    const file = tmpFile()
+    // A cap small enough that the third event rolls the file over.
+    const store = createEventStore(file, 300)
+    await store.append([ev({ id: 'a' })])
+    await store.append([ev({ id: 'b' })])
+    const stale = (await store.recent(10)).cursor
+    expect(stale.seq).toBe(2)
+
+    await store.append([ev({ id: 'fresh' })])
+    const after = await store.recent(10)
+    expect(after.events.map(e => e.id)).toEqual(['fresh'])
+    expect(after.events[0]?.seq).toBe(1)
+    // The previous generation is kept, not deleted.
+    expect(statSync(`${file}.1`).size).toBeGreaterThan(0)
+
+    const r = await store.since(stale)
+    expect(r.rotated).toBe(true)
+    expect(r.events.map(e => e.id)).toEqual(['fresh'])
+  })
+
+  test('a garbage line costs that line and is COUNTED, not hidden', async () => {
+    const file = tmpFile()
+    const store = createEventStore(file)
+    await store.append([ev({ id: 'a' })])
+    writeFileSync(file, `${'{"broken":'}\n`, { flag: 'a' })
+    await store.append([ev({ id: 'b' })])
+    const r = await store.recent(10)
+    expect(r.events.map(e => e.id)).toEqual(['a', 'b'])
+    expect(r.unreadable).toBe(1)
+  })
+
+  test('the empty cursor reads everything, and an empty inbox reads as empty', async () => {
+    const store = createEventStore(tmpFile())
+    expect((await store.since(EMPTY_CURSOR)).events).toEqual([])
+    expect((await store.info()).bytes).toBe(0)
+  })
+})
+
+describe('the producer against a real store', () => {
+  const snapshot = (sessions: SessionSnapshot['sessions']): SessionSnapshot =>
+    ({ sessions, attention: 0, rang: [], polledAtMs: 0 })
+
+  const view = (o: Record<string, unknown>) => ({
+    id: 's1', cwd: '/w', status: 'running' as const, attached: false,
+    approvalDetection: true, searchText: '', ...o,
+  }) as SessionSnapshot['sessions'][number]
+
+  const producerOver = (snaps: SessionSnapshot[], file: string) => {
+    let i = 0
+    return createProducer({
+      poller: { poll: async () => snaps[Math.min(i++, snaps.length - 1)]! },
+      readSubscriptions: async () => [],
+      store: createEventStore(file),
+      intervalMs: 1,
+    })
+  }
+
+  test('the FIRST tick writes nothing — a daemon restart must not replay the fleet', async () => {
+    const file = tmpFile()
+    const p = producerOver([snapshot([view({ activity: 'waiting' })])], file)
+    expect((await p.tick()).written).toEqual([])
+    expect((await createEventStore(file).recent(10)).events).toEqual([])
+  })
+
+  test('a change CONFIRMED over two polls is written, and only for the session that changed', async () => {
+    const file = tmpFile()
+    const p = producerOver([
+      snapshot([view({ activity: 'working' }), view({ id: 's2', activity: 'working' })]),
+      snapshot([view({ activity: 'waiting-approval' }), view({ id: 's2', activity: 'working' })]),
+      snapshot([view({ activity: 'waiting-approval' }), view({ id: 's2', activity: 'working' })]),
+    ], file)
+    await p.tick() // seeds
+    expect((await p.tick()).written).toEqual([]) // one frame is not yet a state
+    const third = await p.tick()
+    expect(third.written.map(e => e.id)).toEqual(['s1'])
+    expect(third.written[0]).toMatchObject({ kind: 'waiting-approval', from: 'working' })
+  })
+
+  test('a one-frame blip between two polls of the same state writes nothing at all', async () => {
+    const file = tmpFile()
+    const p = producerOver([
+      snapshot([view({ activity: 'waiting' })]),
+      snapshot([view({ activity: 'working' })]), // the repaint
+      snapshot([view({ activity: 'waiting' })]),
+      snapshot([view({ activity: 'waiting' })]),
+      snapshot([view({ activity: 'waiting' })]),
+    ], file)
+    for (let i = 0; i < 5; i++) await p.tick()
+    expect((await createEventStore(file).recent(10)).events).toEqual([])
+  })
+
+  test('a poll that could not read the fleet writes nothing and reports the reason', async () => {
+    const file = tmpFile()
+    const p = producerOver([
+      snapshot([view({ activity: 'working' })]),
+      { ...snapshot([view({ activity: 'working' })]), unavailable: 'tmux went away' },
+    ], file)
+    await p.tick()
+    const t = await p.tick()
+    expect(t.written).toEqual([])
+    expect(t.unavailable).toBe('tmux went away')
+  })
+
+  test('a hook event already in the inbox suppresses the poller\'s duplicate of it', async () => {
+    const file = tmpFile()
+    const store = createEventStore(file)
+    await store.append([ev({
+      source: 'hook', kind: 'turn-end', harness: 'claude', cwd: '/repo', conversationId: 'c1',
+      at: new Date().toISOString(),
+    })])
+    let i = 0
+    const snaps = [
+      snapshot([view({ activity: 'working', harness: 'claude', cwd: '/repo', conversationId: 'c1' })]),
+      snapshot([view({ activity: 'waiting', harness: 'claude', cwd: '/repo', conversationId: 'c1' })]),
+      snapshot([view({ activity: 'waiting', harness: 'claude', cwd: '/repo', conversationId: 'c1' })]),
+    ]
+    const p = createProducer({
+      poller: { poll: async () => snaps[Math.min(i++, 2)]! },
+      readSubscriptions: async () => [],
+      store,
+      intervalMs: 1,
+    })
+    await p.tick()
+    await p.tick()
+    expect((await p.tick()).written).toEqual([])
+  })
+})

--- a/packages/server/server/events/event-store.ts
+++ b/packages/server/server/events/event-store.ts
@@ -1,0 +1,184 @@
+/**
+ * event-store.ts — the inbox on disk. Every DECISION here is already made by a pure module
+ * (`event-line.ts` for the bytes, `event-rotate.ts` for the cursor and the cap); this file opens
+ * files.
+ *
+ * ## Why there is an inbox at all
+ *
+ * A Claude session only exists while it is being invoked. An event delivered to a session that is
+ * parked is an event that happened to nobody. The inbox is what makes the channel work for the
+ * consumer that is not running: it reads what happened since it last looked, on its own schedule.
+ * Everything else in this feature — the socket, the toast — is a way of making that read HAPPEN
+ * SOONER, never a replacement for it.
+ *
+ * ## Appends are serialized in-process and atomic on disk
+ *
+ * Several producers can exist (the daemon, a foreground `agentop events run`, the Stop hook firing
+ * from Claude Code). `appendFile` with `O_APPEND` is atomic for writes under PIPE_BUF on Linux and
+ * each line is far smaller than that, so two writers interleave whole lines rather than shredding
+ * one. The in-process chain on top of it keeps `seq` monotonic within one producer; two producers
+ * can in principle both hand out the same seq, which is why `seq` is documented as a CURSOR
+ * ordinal and never as an identity.
+ *
+ * ## Permissions
+ *
+ * The file holds screen tails, which are the user's own text. It is created 0600 under
+ * `~/.agentistics`, the same directory (and the same expectation) as the rest of this app's local
+ * state, and nothing in this feature sends it off the machine.
+ */
+
+import { existsSync } from 'node:fs'
+import { appendFile, mkdir, open, readFile, rename, stat, writeFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import { AGENTISTICS_DATA_DIR } from '../config'
+import { parseEvents, serializeEvent } from './event-line'
+import {
+  EMPTY_CURSOR, MAX_INBOX_BYTES, advanceCursor, planRead, planRotation, type EventCursor,
+} from './event-rotate'
+import type { SessionEvent } from './event-types'
+
+export const EVENTS_FILE = process.env.AGENTISTICS_EVENTS_FILE ?? join(AGENTISTICS_DATA_DIR, 'events.jsonl')
+/** Exactly one previous generation. See `event-rotate.ts` for why one. */
+export const EVENTS_FILE_PREVIOUS = `${EVENTS_FILE}.1`
+
+const MODE = 0o600
+
+async function fileBytes(file: string): Promise<number> {
+  try {
+    return (await stat(file)).size
+  } catch {
+    return 0
+  }
+}
+
+/** The highest `seq` the current file holds, so a fresh producer continues the numbering rather
+ *  than restarting it in the middle of a file and breaking every cursor pointing into it. */
+async function lastSeq(file: string): Promise<number> {
+  const size = await fileBytes(file)
+  if (size === 0) return 0
+  // Only the tail is read: the answer is on the last readable line, and a two-megabyte read to
+  // learn one number is a cost paid on every producer start.
+  const from = Math.max(0, size - 64 * 1024)
+  const text = await readSlice(file, from)
+  const { events } = parseEvents(text)
+  return events.length > 0 ? (events[events.length - 1]!.seq ?? 0) : 0
+}
+
+async function readSlice(file: string, from: number): Promise<string> {
+  const fh = await open(file, 'r')
+  try {
+    const size = (await fh.stat()).size
+    if (from >= size) return ''
+    const length = size - from
+    const buf = Buffer.alloc(length)
+    await fh.read(buf, 0, length, from)
+    return buf.toString('utf8')
+  } finally {
+    await fh.close()
+  }
+}
+
+export interface EventStore {
+  /** Append these events, stamping `seq`. Returns them as written. */
+  append(events: readonly SessionEvent[]): Promise<SessionEvent[]>
+  /** The most recent `count` events, oldest first. */
+  recent(count: number): Promise<{ events: SessionEvent[]; unreadable: number; cursor: EventCursor }>
+  /** Everything after a cursor. `rotated` says the cursor could not be honoured. */
+  since(cursor: EventCursor): Promise<{
+    events: SessionEvent[]; unreadable: number; cursor: EventCursor; rotated: boolean
+  }>
+  /** For `status`: how big it is and where it is. */
+  info(): Promise<{ file: string; bytes: number; previousBytes: number; seq: number }>
+}
+
+export function createEventStore(file = EVENTS_FILE, maxBytes = MAX_INBOX_BYTES): EventStore {
+  const previous = `${file}.1`
+  // The next sequence number, resolved lazily from the file and then held. A promise rather than a
+  // number so two concurrent appends cannot both read "the file ends at 7" and both write 8.
+  let chain: Promise<number> | null = null
+
+  async function nextSeqStart(): Promise<number> {
+    return (await lastSeq(file)) + 1
+  }
+
+  async function append(events: readonly SessionEvent[]): Promise<SessionEvent[]> {
+    if (events.length === 0) return []
+    const run = async (seed: number): Promise<{ seq: number; written: SessionEvent[] }> => {
+      let seq = seed
+      const written = events.map(e => ({ ...e, seq: seq++ }))
+      const text = written.map(serializeEvent).join('')
+
+      await mkdir(dirname(file), { recursive: true })
+      const size = await fileBytes(file)
+      if (planRotation(size, Buffer.byteLength(text), maxBytes)) {
+        // Rename rather than copy-and-truncate: a reader mid-file keeps reading the inode it opened
+        // instead of watching its bytes vanish under it.
+        try { await rename(file, previous) } catch { /* gone already — the write below recreates it */ }
+        // The numbering restarts with the file, which is exactly what `planRead` cross-checks a
+        // cursor against.
+        seq = 1
+        const renumbered = events.map(e => ({ ...e, seq: seq++ }))
+        await writeFile(file, renumbered.map(serializeEvent).join(''), { encoding: 'utf8', mode: MODE })
+        return { seq, written: renumbered }
+      }
+
+      if (!existsSync(file)) await writeFile(file, '', { encoding: 'utf8', mode: MODE })
+      await appendFile(file, text, { encoding: 'utf8', mode: MODE })
+      return { seq, written }
+    }
+
+    // One in-flight append at a time, so `seq` is monotonic within this process.
+    const started = chain ?? nextSeqStart()
+    let resolveNext: (n: number) => void = () => {}
+    chain = new Promise<number>(r => { resolveNext = r })
+    try {
+      const { seq, written } = await run(await started)
+      resolveNext(seq)
+      return written
+    } catch (e) {
+      // A failed append must not leave the chain holding a sequence nobody will resolve, or every
+      // later append hangs. Re-resolve from the file on the next call.
+      chain = null
+      resolveNext(0)
+      throw e
+    }
+  }
+
+  async function recent(count: number) {
+    const size = await fileBytes(file)
+    if (size === 0) return { events: [], unreadable: 0, cursor: EMPTY_CURSOR }
+    const text = await readSlice(file, 0)
+    const { events, unreadable } = parseEvents(text)
+    const tail = events.slice(-count)
+    return {
+      events: tail,
+      unreadable,
+      cursor: advanceCursor(size, events.length > 0 ? events[events.length - 1]!.seq : 0),
+    }
+  }
+
+  async function since(cursor: EventCursor) {
+    const size = await fileBytes(file)
+    if (size === 0) return { events: [], unreadable: 0, cursor: EMPTY_CURSOR, rotated: false }
+    const plan = planRead(cursor, size, await lastSeq(file))
+    const text = await readSlice(file, plan.from)
+    const { events, unreadable } = parseEvents(text)
+    return {
+      events,
+      unreadable,
+      cursor: advanceCursor(size, events.length > 0 ? events[events.length - 1]!.seq : cursor.seq),
+      rotated: plan.rotated,
+    }
+  }
+
+  async function info() {
+    return {
+      file,
+      bytes: await fileBytes(file),
+      previousBytes: await fileBytes(previous),
+      seq: await lastSeq(file),
+    }
+  }
+
+  return { append, recent, since, info }
+}

--- a/packages/server/server/events/event-types.ts
+++ b/packages/server/server/events/event-types.ts
@@ -1,0 +1,107 @@
+/**
+ * event-types.ts — the whole contract of the event channel, in one place.
+ *
+ * ## What an event is, and what it is deliberately not
+ *
+ * A `SessionEvent` records that a session CHANGED STATE. It carries facts: when, which session,
+ * which task, from what to what, and — when there is one — the last few lines that were on its
+ * screen. It carries **no instruction, no suggestion and no request**.
+ *
+ * That is a hard boundary, not a style preference. This channel exists so a Claude session
+ * orchestrating other assistants knows what is happening without a person relaying it. The distance
+ * between "knows what is happening" and "acts on someone's behalf" is one field: an event with an
+ * `action`, a `suggest` or a `respondWith` would make the channel the thing that crosses it. So
+ * there is no such field, `events-frontier.test.ts` asserts there is none, and the ONE state that
+ * would most tempt one — `waiting-approval` — is reported as a fact and nothing more. Nothing in
+ * this channel may approve anything for anyone.
+ *
+ * ## Two sources that are not equivalent
+ *
+ * `poll` is agentop's own five-second monitor. It reads the SCREEN, so it works for all six
+ * harnesses, and it infers — it is the FLOOR, and the floor has to hold for codex, kimi and gemini
+ * which have no hook to offer.
+ *
+ * `hook` is a Claude Code `Stop` hook. It fires when a Claude session finishes answering: exact, no
+ * polling, no inference — and Claude only.
+ *
+ * Both report the same end of turn, so `event-dedupe.ts` decides which one the reader sees.
+ */
+
+import type { HarnessId } from '@agentistics/core'
+import type { SessionActivity } from '../sessions/types'
+
+/** The line format's version. Bumped when the SHAPE changes in a way a reader must notice. */
+export const EVENT_VERSION = 1
+
+/**
+ * What kind of transition this is.
+ *
+ * A superset of `SessionActivity` rather than the same type: `exited` as an activity means "the
+ * hosted command is no longer running", which is also what a session finishing normally looks like,
+ * and `turn-end` is a thing only the hook can see (Claude stopped answering while the session lives
+ * on). Keeping them distinct is what lets a subscriber ask for one without the other.
+ */
+export type EventKind =
+  | 'working'
+  | 'waiting'
+  | 'waiting-approval'
+  | 'exited'
+  | 'turn-end'
+
+export const EVENT_KINDS: readonly EventKind[] = [
+  'working', 'waiting', 'waiting-approval', 'exited', 'turn-end',
+]
+
+/** The states a subscriber is offered by default: the ones that mean "something needs you". */
+export const DEFAULT_EVENT_KINDS: readonly EventKind[] = ['waiting', 'waiting-approval', 'exited']
+
+export type EventSource = 'poll' | 'hook'
+
+export interface SessionEvent {
+  /** The line format this was written at. A reader tolerating an older one reads this first. */
+  v: number
+  /** Monotonic within one inbox file, restarting at 1 after a rotation. See `event-rotate.ts`. */
+  seq: number
+  /** ISO. The local JSON store's correct representation, per the house rule. */
+  at: string
+  source: EventSource
+  kind: EventKind
+  /** The state this session was in before, when it was known. Absent on the first sighting. */
+  from?: SessionActivity
+  /** agentop's session id for a managed row, `external:…` / `closed:…` otherwise. */
+  id: string
+  harness?: HarnessId
+  cwd: string
+  /** The piece of work this session belongs to — what `--task` filters on. */
+  task?: string
+  /** The session's name, when it has one. */
+  label?: string
+  /**
+   * The harness's own conversation id, when it is known exactly.
+   *
+   * This is the ONLY key a poll event and a hook event provably share, so it is what
+   * `event-dedupe.ts` prefers. Absent for a session started fresh, because the harness creates the
+   * conversation and does not report it back.
+   */
+  conversationId?: string
+  /**
+   * The last few lines of what the session had on screen.
+   *
+   * This is the user's own text — anything they typed can be in it. It stays in `~/.agentistics`
+   * with the permissions the rest of that directory uses, and nothing in this feature sends it
+   * anywhere off the machine.
+   */
+  lines?: string[]
+}
+
+/** What a producer knows about a session before it decides whether anything changed. */
+export interface EventCandidate {
+  id: string
+  harness?: HarnessId
+  cwd: string
+  task?: string
+  label?: string
+  conversationId?: string
+  activity?: SessionActivity
+  lines?: string[]
+}

--- a/packages/server/server/events/events-frontier.test.ts
+++ b/packages/server/server/events/events-frontier.test.ts
@@ -1,0 +1,125 @@
+/**
+ * events-frontier.test.ts — the boundary this channel may not cross, asserted.
+ *
+ * The event channel exists so a Claude session orchestrating other assistants knows what is
+ * happening. The distance between "knows" and "acts on the user's behalf" is short, and the two
+ * places it could be crossed are the SHAPE of an event (a field that carries an instruction) and
+ * the WORDS of a notification (a fact written as an order). Both are checked here, and this file is
+ * the review gate for anything added to the channel: a new field or a new sentence that fails these
+ * assertions is a product decision, not a drive-by.
+ *
+ * The greps over module source are deliberate — the same technique `billing-detect.test.ts` uses to
+ * pin what a module may name. A test that only exercised behaviour would pass the day somebody adds
+ * an `action` field nothing reads yet.
+ */
+
+import { describe, expect, test } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { serializeEvent } from './event-line'
+import { EVENT_KINDS, EVENT_VERSION, type SessionEvent } from './event-types'
+import { PEER_PREAMBLE, desktopText, eventHeadline, peerMessage, stateSentence } from './notify-text'
+import type { Subscription } from './subscriptions'
+
+const here = (f: string): string => readFileSync(join(import.meta.dir, f), 'utf8')
+
+const ev = (o: Partial<SessionEvent>): SessionEvent => ({
+  v: EVENT_VERSION, seq: 1, at: '2026-08-14T12:00:00.000Z', source: 'poll', kind: 'waiting',
+  id: 's1', cwd: '/home/me/repo', ...o,
+})
+
+describe('an event carries facts and nothing else', () => {
+  test('the SessionEvent type has no field that could carry an instruction', () => {
+    const src = here('event-types.ts')
+    // The interface body, so the prose above it is not what is being read.
+    const body = src.slice(src.indexOf('export interface SessionEvent'))
+    for (const forbidden of ['action', 'command', 'suggest', 'respondWith', 'reply', 'approve', 'answer', 'instruction']) {
+      expect(body).not.toMatch(new RegExp(`^\\s*${forbidden}\\??:`, 'm'))
+    }
+  })
+
+  test('a subscription can ask for DELIVERY, never for an action to be taken', () => {
+    const src = here('subscriptions.ts')
+    const body = src.slice(src.indexOf('export interface Subscription'), src.indexOf('export function newSubscriptionId'))
+    for (const forbidden of ['run', 'exec', 'command', 'script', 'onEvent', 'approve', 'autoApprove', 'answer']) {
+      expect(body).not.toMatch(new RegExp(`^\\s*${forbidden}\\??:`, 'm'))
+    }
+    // Stated positively too, so a reader of this test knows what the shape IS.
+    const shape: Record<keyof Subscription, true> = {
+      id: true, createdAt: true, task: true, session: true, kinds: true, notify: true,
+      desktop: true, note: true,
+    }
+    expect(Object.keys(shape).sort()).toEqual(
+      ['createdAt', 'desktop', 'id', 'kinds', 'note', 'notify', 'session', 'task'],
+    )
+  })
+
+  test('a serialized event round-trips without acquiring an executable field', () => {
+    const line = serializeEvent(ev({ kind: 'waiting-approval', lines: ['Do you want to proceed?'] }))
+    const parsed = JSON.parse(line) as Record<string, unknown>
+    expect(Object.keys(parsed).sort()).toEqual(['at', 'cwd', 'id', 'kind', 'lines', 'seq', 'source', 'v'])
+  })
+})
+
+describe('a notification states, and never orders', () => {
+  const IMPERATIVES = [
+    /\bapprove\b/i, /\bplease\b/i, /\byou should\b/i, /\byou must\b/i, /\bgo ahead\b/i,
+    /\brun\s+`/i, /\bpress\b/i, /\bconfirm\b/i, /\ballow it\b/i, /\bsay yes\b/i, /\baccept\b/i,
+  ]
+
+  const everySentence = (): string[] => {
+    const events = EVENT_KINDS.map(kind => ev({ kind, task: 'canal', label: 'backend', harness: 'claude', lines: ['esc to interrupt'] }))
+    return [
+      PEER_PREAMBLE,
+      peerMessage(events),
+      ...events.map(stateSentence),
+      ...events.map(eventHeadline),
+      ...events.flatMap(e => [desktopText(e).title, desktopText(e).body]),
+    ]
+  }
+
+  test('no sentence this channel can produce contains an instruction', () => {
+    for (const s of everySentence()) {
+      for (const bad of IMPERATIVES) {
+        // The preamble is allowed to say what may NOT be done; it is the one sentence about the
+        // boundary itself. Everything else is held to the plain rule.
+        if (s === PEER_PREAMBLE) continue
+        expect(s).not.toMatch(bad)
+      }
+    }
+  })
+
+  test('waiting-approval names WHO the prompt is for, and stops there', () => {
+    const s = stateSentence(ev({ kind: 'waiting-approval' }))
+    expect(s).toContain('permission prompt')
+    expect(s).toContain('for a person to answer')
+    expect(s).not.toMatch(/\byou\b/i)
+  })
+
+  test('the peer preamble states the channel is informational and disclaims approval', () => {
+    expect(PEER_PREAMBLE).toContain('informational')
+    expect(PEER_PREAMBLE).toContain('carries no instruction')
+    expect(PEER_PREAMBLE).toContain('cannot answer a permission prompt')
+  })
+
+  test('the preamble travels on EVERY peer message — a compacted context loses a one-off rule', () => {
+    expect(peerMessage([ev({})])).toContain(PEER_PREAMBLE)
+    expect(peerMessage([ev({ kind: 'exited' }), ev({ kind: 'working' })])).toContain(PEER_PREAMBLE)
+  })
+
+  test('several events are ONE message — five sessions finishing interrupt once', () => {
+    const msg = peerMessage([ev({ id: 'a' }), ev({ id: 'b' }), ev({ id: 'c' })])
+    expect(msg.split(PEER_PREAMBLE)).toHaveLength(2)
+  })
+})
+
+describe('the screen tail stays on this machine', () => {
+  test('nothing in the events modules posts anywhere', () => {
+    for (const f of ['event-store.ts', 'producer.ts', 'notifier.ts', 'peer-client.ts', 'desktop.ts']) {
+      let src = ''
+      try { src = here(f) } catch { continue }
+      expect(src).not.toMatch(/\bfetch\s*\(/)
+      expect(src).not.toMatch(/https?:\/\/(?!localhost)/)
+    }
+  })
+})

--- a/packages/server/server/events/events-parse.test.ts
+++ b/packages/server/server/events/events-parse.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, test } from 'bun:test'
+import { parseCursorRef, parseEventsArgs, parseKinds } from './events-parse'
+import { DEFAULT_EVENT_KINDS } from './event-types'
+import {
+  addSubscription, clearSubscriptions, kindsToRecord, newSubscriptionId, parseStore,
+  removeSubscription, subscribersOf, type Subscription,
+} from './subscriptions'
+import { livePeers, selectPeerTarget, type PeerRecord } from './peer-target'
+import { planDesktopChannel } from './notify-plan'
+
+describe('parseEventsArgs', () => {
+  test('bare and --help ask for help', () => {
+    expect(parseEventsArgs([])).toEqual({ kind: 'help' })
+    expect(parseEventsArgs(['--help'])).toEqual({ kind: 'help' })
+  })
+
+  test('watch defaults to the states that mean "something needs you"', () => {
+    const c = parseEventsArgs(['watch'])
+    expect(c).toMatchObject({ kind: 'watch' })
+    expect((c as { options: { kinds: string[] } }).options.kinds).toEqual([...DEFAULT_EVENT_KINDS])
+  })
+
+  test('watch takes both --flag value and --flag=value', () => {
+    const a = parseEventsArgs(['watch', '--task', 'canal', '--notify', 'cockpit', '--desktop'])
+    const b = parseEventsArgs(['watch', '--task=canal', '--notify=cockpit', '--desktop'])
+    expect((a as { options: unknown }).options).toEqual((b as { options: unknown }).options)
+    expect(a).toMatchObject({ options: { task: 'canal', notify: 'cockpit', desktop: true } })
+  })
+
+  test('a misspelled state is refused, and the message names the closed set', () => {
+    const c = parseEventsArgs(['watch', '--on', 'waitin'])
+    expect(c.kind).toBe('error')
+    expect((c as { message: string }).message).toContain('waiting-approval')
+  })
+
+  test('--on takes several and dedupes them', () => {
+    expect(parseKinds('waiting,exited,waiting')).toEqual({ kinds: ['waiting', 'exited'] })
+  })
+
+  test('a flag with a missing value is an error, not a silently swallowed next flag', () => {
+    expect(parseEventsArgs(['watch', '--task', '--desktop']).kind).toBe('error')
+  })
+
+  test('unwatch needs an id or --all, and refuses both', () => {
+    expect(parseEventsArgs(['unwatch'])).toMatchObject({ kind: 'error' })
+    expect(parseEventsArgs(['unwatch', 's1'])).toEqual({ kind: 'unwatch', id: 's1', all: false })
+    expect(parseEventsArgs(['unwatch', '--all'])).toEqual({ kind: 'unwatch', all: true })
+    expect(parseEventsArgs(['unwatch', 's1', '--all']).kind).toBe('error')
+  })
+
+  test('tail takes a count, a cursor and filters', () => {
+    expect(parseEventsArgs(['tail', '-n', '5', '--since', '120:7', '--task', 'canal', '--json']))
+      .toEqual({ kind: 'tail', options: { count: 5, since: 120, sinceSeq: 7, task: 'canal', json: true, follow: false } })
+  })
+
+  test('a cursor must carry BOTH halves — a bare offset cannot survive a rotation', () => {
+    expect(parseCursorRef('120')).toMatchObject({ error: expect.any(String) })
+    expect(parseCursorRef('120:7')).toEqual({ offset: 120, seq: 7 })
+  })
+
+  test('a bare `test` exercises the desktop channel rather than doing nothing', () => {
+    expect(parseEventsArgs(['test'])).toEqual({ kind: 'test', desktop: true })
+    expect(parseEventsArgs(['test', '--notify', 'cockpit'])).toEqual({ kind: 'test', notify: 'cockpit', desktop: false })
+  })
+
+  test('an unknown verb and an unknown option are both refused', () => {
+    expect(parseEventsArgs(['frobnicate']).kind).toBe('error')
+    expect(parseEventsArgs(['run', '--twice']).kind).toBe('error')
+  })
+})
+
+describe('subscriptions', () => {
+  const sub = (o: Partial<Subscription>): Subscription => ({
+    id: 's1', createdAt: '2026-08-14T00:00:00.000Z', kinds: ['waiting'], desktop: false, ...o,
+  })
+  const event = (o: Record<string, unknown>) => ({
+    v: 1, seq: 1, at: '2026-08-14T00:00:00.000Z', source: 'poll' as const, kind: 'waiting' as const,
+    id: 'abc123', cwd: '/w', ...o,
+  })
+
+  test('no filters means every session of the wanted kinds', () => {
+    expect(subscribersOf([sub({})], event({}))).toHaveLength(1)
+    expect(subscribersOf([sub({})], event({ kind: 'exited' }))).toHaveLength(0)
+  })
+
+  test('the task filter is exact — "api" must not select "api-migration"', () => {
+    expect(subscribersOf([sub({ task: 'api' })], event({ task: 'api' }))).toHaveLength(1)
+    expect(subscribersOf([sub({ task: 'api' })], event({ task: 'api-migration' }))).toHaveLength(0)
+  })
+
+  test('the session filter matches an id PREFIX or a whole label', () => {
+    expect(subscribersOf([sub({ session: 'abc' })], event({}))).toHaveLength(1)
+    expect(subscribersOf([sub({ session: 'Backend' })], event({ label: 'backend' }))).toHaveLength(1)
+    expect(subscribersOf([sub({ session: 'zzz' })], event({}))).toHaveLength(0)
+  })
+
+  test('kindsToRecord is a UNION and always holds the defaults', () => {
+    const k = kindsToRecord([sub({ kinds: ['working'] })])
+    expect(k).toContain('working')
+    for (const d of DEFAULT_EVENT_KINDS) expect(k).toContain(d)
+  })
+
+  test('ids do not collide with what is already there', () => {
+    expect(newSubscriptionId([])).toBe('s1')
+    expect(newSubscriptionId([sub({ id: 's1' }), sub({ id: 's2' })])).toBe('s3')
+  })
+
+  test('a malformed store reads as empty rather than throwing', () => {
+    expect(parseStore(null)).toEqual({ subscriptions: [] })
+    expect(parseStore('nope')).toEqual({ subscriptions: [] })
+    expect(parseStore({ subscriptions: 'nope' })).toEqual({ subscriptions: [] })
+    expect(parseStore({ subscriptions: [{ nope: 1 }] })).toEqual({ subscriptions: [] })
+  })
+
+  test('a stored subscription whose kinds are all unreadable falls back to the defaults, not silence', () => {
+    const r = parseStore({ subscriptions: [{ id: 's1', kinds: ['nonsense'], desktop: true }] })
+    expect(r.subscriptions[0]?.kinds).toEqual([...DEFAULT_EVENT_KINDS])
+  })
+
+  test('removal reports what it removed, so "no such subscription" can be said', () => {
+    const store = addSubscription({ subscriptions: [] }, sub({}))
+    expect(removeSubscription(store, 'nope').removed).toEqual([])
+    expect(removeSubscription(store, 's1').removed).toHaveLength(1)
+    expect(clearSubscriptions(store).store.subscriptions).toEqual([])
+  })
+})
+
+describe('selectPeerTarget', () => {
+  const rec = (o: Partial<PeerRecord>): PeerRecord => ({
+    pid: 1, name: 'cockpit', messagingSocketPath: '/run/1.sock', sessionId: 'c1', ...o,
+  })
+  const live = new Set(['/run/1.sock'])
+
+  test('a name resolves to the session holding a live socket', () => {
+    const r = selectPeerTarget([rec({})], 'cockpit', live)
+    expect(r).toMatchObject({ ok: true, target: { pid: 1, socketPath: '/run/1.sock', sessionId: 'c1' } })
+  })
+
+  test('a pid resolves too', () => {
+    expect(selectPeerTarget([rec({})], '1', live).ok).toBe(true)
+  })
+
+  test('a stale record with no live socket is NOT delivered to, and says so', () => {
+    const r = selectPeerTarget([rec({ messagingSocketPath: '/run/9.sock' })], 'cockpit', live)
+    expect(r).toMatchObject({ ok: false, code: 'not-live' })
+    expect((r as { message: string }).message).toContain('inbox')
+  })
+
+  test('a name nobody registered is a no-match, not a silent drop', () => {
+    expect(selectPeerTarget([rec({})], 'nobody', live)).toMatchObject({ ok: false, code: 'no-match' })
+  })
+
+  test('the match is whole, never a prefix — "cockpit" must not reach "cockpit-2"', () => {
+    expect(selectPeerTarget([rec({ name: 'cockpit-2' })], 'cockpit', live))
+      .toMatchObject({ ok: false, code: 'no-match' })
+  })
+
+  test('two live sessions under one name are ambiguous rather than a coin flip', () => {
+    const r = selectPeerTarget(
+      [rec({ pid: 1, startedAt: 1 }), rec({ pid: 2, messagingSocketPath: '/run/2.sock', startedAt: 2 })],
+      'cockpit',
+      new Set(['/run/1.sock', '/run/2.sock']),
+    )
+    expect(r).toMatchObject({ ok: false, code: 'ambiguous' })
+    expect((r as { candidates: string[] }).candidates).toHaveLength(2)
+  })
+
+  test('livePeers keeps only the ones with a socket, newest first', () => {
+    const out = livePeers(
+      [rec({ pid: 1, startedAt: 1 }), rec({ pid: 9, messagingSocketPath: '/run/9.sock', startedAt: 9 }),
+        rec({ pid: 2, messagingSocketPath: '/run/2.sock', startedAt: 2 })],
+      new Set(['/run/1.sock', '/run/2.sock']),
+    )
+    expect(out.map(r => r.pid)).toEqual([2, 1])
+  })
+})
+
+describe('planDesktopChannel', () => {
+  test('ccn wins when it can actually run', () => {
+    const d = planDesktopChannel({ ccnScript: '/p/notify.sh', hasJq: true, hasPowershell: true, hasNotifySend: true })
+    expect(d.channel).toBe('ccn')
+    expect(d.reason).toContain('/p/notify.sh')
+  })
+
+  test('ccn installed but missing its own requirements steps aside AND says why', () => {
+    const d = planDesktopChannel({ ccnScript: '/p/notify.sh', hasJq: false, hasNotifySend: true })
+    expect(d.channel).toBe('notify-send')
+    expect(d.reason).toContain('jq')
+  })
+
+  test('WSL without ccn falls to a plain powershell toast', () => {
+    expect(planDesktopChannel({ hasPowershell: true }).channel).toBe('powershell')
+  })
+
+  test('nothing but a terminal rings the bell', () => {
+    expect(planDesktopChannel({ hasTty: true }).channel).toBe('bell')
+  })
+
+  test('no channel at all is a SENTENCE, never a silent false', () => {
+    const d = planDesktopChannel({})
+    expect(d.channel).toBe('none')
+    expect(d.reason).toContain('notify-send')
+    expect(d.reason).toContain('inbox')
+  })
+
+  test('switched off is its own reason, not confused with unavailable', () => {
+    const d = planDesktopChannel({ disabled: true, hasNotifySend: true })
+    expect(d.channel).toBe('none')
+    expect(d.reason).toContain('switched off')
+  })
+})

--- a/packages/server/server/events/events-parse.ts
+++ b/packages/server/server/events/events-parse.ts
@@ -1,0 +1,226 @@
+/**
+ * events-parse.ts — PURE. `agentop events …`, and what each word means.
+ *
+ * ## Why this is not `agentop watch`
+ *
+ * `agentop watch` already exists: it is the OpenTelemetry metrics daemon, documented in the help
+ * and wired into `agentop restart watch` and the systemd unit. Taking that verb for a second,
+ * unrelated thing would make `agentop restart watch` ambiguous and would silently retarget a name
+ * people already have in scripts. So the channel is `agentop events`, and the register/deregister
+ * verbs are `watch` / `unwatch` under it — which reads better anyway (`agentop events watch --task
+ * X`).
+ *
+ * ## Two namespaces that must not be confused, and are not
+ *
+ * `--session` names an AGENTOP session (the fleet's own id or label) and filters what is heard
+ * about. `--notify` names a CLAUDE CODE session (the name or pid it registered in
+ * `~/.claude/sessions`) and says who to tell. They are different kinds of thing, so they are
+ * different flags — one flag doing both would resolve against whichever namespace answered first.
+ */
+
+import { DEFAULT_EVENT_KINDS, EVENT_KINDS, type EventKind } from './event-types'
+
+export interface WatchOptions {
+  task?: string
+  session?: string
+  kinds: EventKind[]
+  notify?: string
+  desktop: boolean
+  note?: string
+  json: boolean
+}
+
+export interface TailOptions {
+  /** How many of the most recent events. */
+  count: number
+  /** Read from this byte offset instead of the tail. Paired with `sinceSeq`. */
+  since?: number
+  sinceSeq?: number
+  task?: string
+  kinds?: EventKind[]
+  json: boolean
+  follow: boolean
+}
+
+export type EventsCommand =
+  | { kind: 'watch'; options: WatchOptions }
+  | { kind: 'unwatch'; id?: string; all: boolean }
+  | { kind: 'status'; json: boolean }
+  | { kind: 'tail'; options: TailOptions }
+  | { kind: 'run'; once: boolean }
+  | { kind: 'emit' }
+  | { kind: 'test'; notify?: string; desktop: boolean }
+  | { kind: 'help' }
+  | { kind: 'error'; message: string }
+
+const DEFAULT_TAIL = 20
+
+/** `--flag value` and `--flag=value` both. Returns null when the flag is absent, undefined-ish
+ *  errors are the caller's to report. */
+function takeValue(argv: string[], i: number, flag: string): { value?: string; next: number } {
+  const arg = argv[i]!
+  const eq = arg.indexOf('=')
+  if (arg.startsWith(`${flag}=`) && eq > 0) return { value: arg.slice(eq + 1), next: i + 1 }
+  const value = argv[i + 1]
+  if (value === undefined || value.startsWith('-')) return { next: i + 1 }
+  return { value, next: i + 2 }
+}
+
+/**
+ * `--on waiting,exited` → the kinds.
+ *
+ * An unknown word is REFUSED rather than ignored: `--on waitin` silently subscribing to the
+ * defaults is a subscription that appears to work and reports the wrong things. The message names
+ * what is accepted, because a closed set the user cannot see is a closed set they will guess at.
+ */
+export function parseKinds(value: string): { kinds: EventKind[] } | { error: string } {
+  const words = value.split(',').map(w => w.trim()).filter(w => w !== '')
+  if (words.length === 0) return { error: `--on needs at least one state (one of: ${EVENT_KINDS.join(', ')}).` }
+  const bad = words.filter(w => !(EVENT_KINDS as readonly string[]).includes(w))
+  if (bad.length > 0) {
+    return { error: `Unknown state${bad.length > 1 ? 's' : ''} ${bad.join(', ')} — accepted: ${EVENT_KINDS.join(', ')}.` }
+  }
+  return { kinds: [...new Set(words as EventKind[])] }
+}
+
+export function parseEventsArgs(argv: string[]): EventsCommand {
+  const [verb, ...rest] = argv
+  if (!verb || verb === 'help' || verb === '--help' || verb === '-h') return { kind: 'help' }
+
+  switch (verb) {
+    case 'watch': return parseWatch(rest)
+    case 'unwatch': return parseUnwatch(rest)
+    case 'status': return { kind: 'status', json: rest.includes('--json') }
+    case 'tail': return parseTail(rest)
+    case 'run': {
+      const unknown = rest.find(a => a.startsWith('-') && a !== '--once')
+      if (unknown) return { kind: 'error', message: `Unknown option ${unknown}.` }
+      return { kind: 'run', once: rest.includes('--once') }
+    }
+    case 'emit': return { kind: 'emit' }
+    case 'test': return parseTest(rest)
+    default: return { kind: 'error', message: `Unknown events action "${verb}".` }
+  }
+}
+
+function parseWatch(rest: string[]): EventsCommand {
+  const o: WatchOptions = { kinds: [...DEFAULT_EVENT_KINDS], desktop: false, json: false }
+  for (let i = 0; i < rest.length;) {
+    const a = rest[i]!
+    if (a === '--desktop') { o.desktop = true; i++; continue }
+    if (a === '--json') { o.json = true; i++; continue }
+    if (a.startsWith('--task')) {
+      const t = takeValue(rest, i, '--task')
+      if (t.value === undefined) return { kind: 'error', message: '--task needs a task name.' }
+      o.task = t.value; i = t.next; continue
+    }
+    if (a.startsWith('--session')) {
+      const t = takeValue(rest, i, '--session')
+      if (t.value === undefined) return { kind: 'error', message: '--session needs a session id or label.' }
+      o.session = t.value; i = t.next; continue
+    }
+    if (a.startsWith('--notify')) {
+      const t = takeValue(rest, i, '--notify')
+      if (t.value === undefined) return { kind: 'error', message: '--notify needs a Claude Code session name or pid.' }
+      o.notify = t.value; i = t.next; continue
+    }
+    if (a.startsWith('--note')) {
+      const t = takeValue(rest, i, '--note')
+      if (t.value === undefined) return { kind: 'error', message: '--note needs some text.' }
+      o.note = t.value; i = t.next; continue
+    }
+    if (a.startsWith('--on')) {
+      const t = takeValue(rest, i, '--on')
+      if (t.value === undefined) return { kind: 'error', message: `--on needs states (one of: ${EVENT_KINDS.join(', ')}).` }
+      const parsed = parseKinds(t.value)
+      if ('error' in parsed) return { kind: 'error', message: parsed.error }
+      o.kinds = parsed.kinds; i = t.next; continue
+    }
+    return { kind: 'error', message: `Unknown option ${a}.` }
+  }
+  // A subscription that tells nobody anything is almost certainly a mistake, but it is a legal and
+  // useful one: it still shapes what the producer RECORDS, and `agentop events tail` reads that.
+  // So it is allowed and said out loud by `status`, never refused here.
+  return { kind: 'watch', options: o }
+}
+
+function parseUnwatch(rest: string[]): EventsCommand {
+  const all = rest.includes('--all')
+  const id = rest.find(a => !a.startsWith('-'))
+  const unknown = rest.find(a => a.startsWith('-') && a !== '--all')
+  if (unknown) return { kind: 'error', message: `Unknown option ${unknown}.` }
+  if (all && id !== undefined) {
+    return { kind: 'error', message: 'Pass an id or --all, not both — together they mean two different removals.' }
+  }
+  if (!all && id === undefined) return { kind: 'error', message: 'Which subscription? Pass its id, or --all.' }
+  return { kind: 'unwatch', ...(id !== undefined ? { id } : {}), all }
+}
+
+function parseTail(rest: string[]): EventsCommand {
+  const o: TailOptions = { count: DEFAULT_TAIL, json: false, follow: false }
+  for (let i = 0; i < rest.length;) {
+    const a = rest[i]!
+    if (a === '--json') { o.json = true; i++; continue }
+    if (a === '--follow' || a === '-f') { o.follow = true; i++; continue }
+    if (a === '-n' || a.startsWith('--count')) {
+      const t = takeValue(rest, i, a === '-n' ? '-n' : '--count')
+      const n = Number(t.value)
+      if (t.value === undefined || !Number.isFinite(n) || n <= 0) {
+        return { kind: 'error', message: 'How many events? Pass a positive number to -n.' }
+      }
+      o.count = Math.floor(n); i = t.next; continue
+    }
+    if (a.startsWith('--since')) {
+      const t = takeValue(rest, i, '--since')
+      if (t.value === undefined) return { kind: 'error', message: '--since needs a cursor, as printed by `agentop events tail --json`.' }
+      const cursor = parseCursorRef(t.value)
+      if ('error' in cursor) return { kind: 'error', message: cursor.error }
+      o.since = cursor.offset; o.sinceSeq = cursor.seq; i = t.next; continue
+    }
+    if (a.startsWith('--task')) {
+      const t = takeValue(rest, i, '--task')
+      if (t.value === undefined) return { kind: 'error', message: '--task needs a task name.' }
+      o.task = t.value; i = t.next; continue
+    }
+    if (a.startsWith('--on')) {
+      const t = takeValue(rest, i, '--on')
+      if (t.value === undefined) return { kind: 'error', message: `--on needs states (one of: ${EVENT_KINDS.join(', ')}).` }
+      const parsed = parseKinds(t.value)
+      if ('error' in parsed) return { kind: 'error', message: parsed.error }
+      o.kinds = parsed.kinds; i = t.next; continue
+    }
+    return { kind: 'error', message: `Unknown option ${a}.` }
+  }
+  return { kind: 'tail', options: o }
+}
+
+/**
+ * `offset:seq` — the cursor `--json` prints.
+ *
+ * Both halves are required. A bare offset would be a cursor that cannot survive a rotation, which
+ * is the one thing `event-rotate.ts` exists to catch; accepting one would put the ambiguity back.
+ */
+export function parseCursorRef(value: string): { offset: number; seq: number } | { error: string } {
+  const m = /^(\d+):(\d+)$/.exec(value.trim())
+  if (!m) return { error: `--since takes a cursor of the form offset:seq (as printed by \`agentop events tail --json\`), not "${value}".` }
+  return { offset: Number(m[1]), seq: Number(m[2]) }
+}
+
+function parseTest(rest: string[]): EventsCommand {
+  let notify: string | undefined
+  let desktop = false
+  for (let i = 0; i < rest.length;) {
+    const a = rest[i]!
+    if (a === '--desktop') { desktop = true; i++; continue }
+    if (a.startsWith('--notify')) {
+      const t = takeValue(rest, i, '--notify')
+      if (t.value === undefined) return { kind: 'error', message: '--notify needs a Claude Code session name or pid.' }
+      notify = t.value; i = t.next; continue
+    }
+    return { kind: 'error', message: `Unknown option ${a}.` }
+  }
+  // With neither flag there is nothing to test but the inbox, which `tail` already shows. Both
+  // channels are exercised instead, which is what someone typing `agentop events test` means.
+  if (notify === undefined && !desktop) desktop = true
+  return { kind: 'test', ...(notify !== undefined ? { notify } : {}), desktop }
+}

--- a/packages/server/server/events/notifier.ts
+++ b/packages/server/server/events/notifier.ts
@@ -1,0 +1,107 @@
+/**
+ * notifier.ts — an event that was written, delivered to whoever asked for it.
+ *
+ * Writing and delivering are separate steps on purpose. The write is what makes the channel work
+ * for a consumer that is not running; delivery is what makes it work SOONER for one that is. A
+ * failed delivery is therefore never fatal and never silent: the event is already durable, and the
+ * failure is reported so that "my notifications stopped arriving" is a thing the user can be told
+ * rather than something they eventually notice.
+ *
+ * ## Batching
+ *
+ * One poll can produce several events, and five sessions finishing at once must interrupt a working
+ * assistant ONCE. So the events of one batch that a given subscription wants become one peer
+ * message. Desktop notifications are the opposite: a toast per event is what a person expects, so
+ * they are sent per event but capped, because ten toasts at once is a screen nobody reads.
+ */
+
+import { notifyDesktop, type DesktopSetup } from './desktop'
+import { desktopText, peerMessage } from './notify-text'
+import { sendToPeer } from './peer-client'
+import { subscribersOf, type Subscription } from './subscriptions'
+import type { SessionEvent } from './event-types'
+
+/** How many toasts one batch may raise. Beyond this the last one says how many were folded in. */
+const MAX_TOASTS_PER_BATCH = 3
+
+export interface DeliveryReport {
+  /** One line per attempt, already a sentence, for the command and the log to print. */
+  lines: string[]
+  peersReached: number
+  peersFailed: number
+  toastsShown: number
+  toastsFailed: number
+}
+
+export const EMPTY_REPORT: DeliveryReport = {
+  lines: [], peersReached: 0, peersFailed: 0, toastsShown: 0, toastsFailed: 0,
+}
+
+/**
+ * Deliver a batch.
+ *
+ * `desktop` is passed in rather than probed here so a long-running producer probes the filesystem
+ * once at startup instead of on every poll.
+ */
+export async function deliver(o: {
+  events: readonly SessionEvent[]
+  subscriptions: readonly Subscription[]
+  desktop?: DesktopSetup
+}): Promise<DeliveryReport> {
+  const report: DeliveryReport = { ...EMPTY_REPORT, lines: [] }
+  if (o.events.length === 0 || o.subscriptions.length === 0) return report
+
+  // Which events each subscription wants, resolved once for the whole batch.
+  const wanted = new Map<string, SessionEvent[]>()
+  for (const sub of o.subscriptions) wanted.set(sub.id, [])
+  for (const e of o.events) {
+    for (const sub of subscribersOf(o.subscriptions, e)) wanted.get(sub.id)!.push(e)
+  }
+
+  // --- the assistants -------------------------------------------------------
+  for (const sub of o.subscriptions) {
+    const mine = wanted.get(sub.id) ?? []
+    if (sub.notify === undefined || mine.length === 0) continue
+    const r = await sendToPeer(sub.notify, peerMessage(mine))
+    if (r.ok) {
+      report.peersReached++
+      report.lines.push(`notified ${r.name ?? sub.notify} (pid ${r.pid}) — ${mine.length} event${mine.length > 1 ? 's' : ''} [${sub.id}]`)
+    } else {
+      report.peersFailed++
+      // Not an error the caller has to handle: the event is durable. It IS something the user must
+      // be told, which is what this line is.
+      report.lines.push(`not delivered to "${sub.notify}" [${sub.id}]: ${r.message}`)
+    }
+  }
+
+  // --- the person -----------------------------------------------------------
+  // An event wanted by two desktop subscriptions is one toast, not two: the person is one person.
+  const toast: SessionEvent[] = []
+  for (const sub of o.subscriptions) {
+    if (!sub.desktop) continue
+    for (const e of wanted.get(sub.id) ?? []) if (!toast.includes(e)) toast.push(e)
+  }
+
+  const shown = toast.slice(0, MAX_TOASTS_PER_BATCH)
+  const folded = toast.length - shown.length
+  for (const [i, e] of shown.entries()) {
+    const text = desktopText(e)
+    const last = i === shown.length - 1
+    const r = await notifyDesktop(
+      last && folded > 0 ? { ...text, body: `${text.body} · and ${folded} more` } : text,
+      e.cwd,
+      o.desktop,
+    )
+    if (r.ok) {
+      report.toastsShown++
+    } else {
+      report.toastsFailed++
+      report.lines.push(`desktop notification failed (${r.channel}): ${r.message}`)
+    }
+  }
+  if (report.toastsShown > 0) {
+    report.lines.push(`desktop: ${report.toastsShown} notification${report.toastsShown > 1 ? 's' : ''}${folded > 0 ? ` (${folded} folded in)` : ''}`)
+  }
+
+  return report
+}

--- a/packages/server/server/events/notify-plan.ts
+++ b/packages/server/server/events/notify-plan.ts
@@ -1,0 +1,105 @@
+/**
+ * notify-plan.ts — PURE. Which desktop channel this machine can actually use, and why.
+ *
+ * ## Absence is absence
+ *
+ * A notification that fails silently is worse than none: the person stops watching the screen
+ * because something is watching it for them, and nothing is. So the cascade is DECLARED — every
+ * step is probed, the chosen one is named by `agentop events status`, and "there is no desktop
+ * channel here" is a sentence this module returns rather than a `false` somebody renders as
+ * nothing.
+ *
+ * ## The order, and why ccn is first
+ *
+ * 1. **ccn** — `claude-code-notifications`, the user's own Claude Code plugin. On WSL it already
+ *    solves the hard half: a real Windows toast, a configurable sound, and a click that focuses the
+ *    session's window. It is DETECTED, never embedded: it ships through the Claude Code plugin
+ *    system with its own release cycle while agentop is one compiled binary, so a bundled copy
+ *    would be a second version to drift. What we send it is the payload shape it already accepts —
+ *    a Claude Code `Notification` hook envelope with a `message` and a `cwd` — so agentop adds the
+ *    five harnesses ccn cannot see and the task grouping neither tool has alone, without either
+ *    knowing about the other's internals.
+ * 2. **notify-send** — the Linux desktop standard. Present on a normal desktop session, absent on
+ *    WSL, which is exactly why it is not first.
+ * 3. **powershell.exe** — WSL without ccn: a plain Windows toast, no sound and no click target, but
+ *    it reaches the user's actual screen.
+ * 4. **bell** — the terminal's own `\a`. Only when there is a terminal to ring.
+ * 5. **none** — the inbox holds the event and `status` says the desktop is unreachable.
+ *
+ * Probing is the caller's job (it is filesystem and PATH work); deciding is this module's.
+ */
+
+export type DesktopChannel = 'ccn' | 'notify-send' | 'powershell' | 'bell' | 'none'
+
+/** What the impure side found. Every field is a fact about this machine, never a preference. */
+export interface DesktopProbe {
+  /** Absolute path to the ccn plugin's `notify.sh`, when one is installed. */
+  ccnScript?: string
+  /** ccn shells out to both; without them it exits 0 having done nothing, which would look like a
+   *  delivered notification. So its own requirements are part of the probe. */
+  hasJq?: boolean
+  hasPowershell?: boolean
+  hasNotifySend?: boolean
+  /** A tty to ring. */
+  hasTty?: boolean
+  /** The user turned the desktop step off for this machine. */
+  disabled?: boolean
+}
+
+export interface DesktopDecision {
+  channel: DesktopChannel
+  /** Already a sentence, for `status` to print. Names what was chosen AND what was not available. */
+  reason: string
+}
+
+/**
+ * The chosen channel and the sentence explaining it.
+ *
+ * The reason names the runners-up on purpose: "no desktop channel" is only actionable if it says
+ * what was looked for.
+ */
+export function planDesktopChannel(p: DesktopProbe): DesktopDecision {
+  if (p.disabled) {
+    return { channel: 'none', reason: 'desktop notifications are switched off for this machine (AGENTISTICS_EVENTS_DESKTOP=0).' }
+  }
+  if (p.ccnScript && p.hasJq && p.hasPowershell) {
+    return { channel: 'ccn', reason: `claude-code-notifications (${p.ccnScript}) — Windows toast with sound, from WSL.` }
+  }
+  if (p.hasNotifySend) {
+    const ccnNote = p.ccnScript
+      ? ' (claude-code-notifications is installed but cannot run here: it needs both jq and powershell.exe)'
+      : ''
+    return { channel: 'notify-send', reason: `notify-send${ccnNote}.` }
+  }
+  if (p.hasPowershell) {
+    const ccnNote = p.ccnScript && !p.hasJq
+      ? ' claude-code-notifications is installed but jq is missing, so it is skipped.'
+      : ''
+    return { channel: 'powershell', reason: `powershell.exe — a plain Windows toast from WSL, no sound and no click target.${ccnNote}` }
+  }
+  if (p.hasTty) {
+    return { channel: 'bell', reason: 'the terminal bell — no notify-send, no powershell.exe, no claude-code-notifications on this machine.' }
+  }
+  return {
+    channel: 'none',
+    reason: 'no desktop channel on this machine — none of claude-code-notifications, notify-send or powershell.exe is usable, and there is no terminal to ring. Events are still written to the inbox.',
+  }
+}
+
+/**
+ * The ccn payload for one notification.
+ *
+ * Shaped as a Claude Code `Notification` hook envelope because that is ccn's published input: it
+ * reads `hook_event_name`, `message` and `cwd` from stdin, and derives its title from the directory
+ * when there is no transcript to read — which is precisely the case for every harness that is not
+ * Claude. Deliberately no `transcript_path`: agentop has no Claude transcript for a codex session,
+ * and pointing ccn at one that is not this session's would put another conversation's text in the
+ * toast.
+ */
+export function ccnPayload(o: { title: string; body: string; cwd: string }): string {
+  return JSON.stringify({
+    hook_event_name: 'Notification',
+    message: `${o.title} — ${o.body}`,
+    cwd: o.cwd,
+  })
+}

--- a/packages/server/server/events/notify-text.ts
+++ b/packages/server/server/events/notify-text.ts
@@ -1,0 +1,119 @@
+/**
+ * notify-text.ts — PURE. What an event SAYS, to a person and to another assistant.
+ *
+ * ## This module is where the boundary is actually held
+ *
+ * `event-types.ts` makes it structurally impossible for an event to carry an instruction. That is
+ * necessary and not sufficient: a message whose every field is a fact can still be written as an
+ * order. "Session 3 is blocked — approve it" carries no `action` field and is exactly the thing
+ * this channel must never send.
+ *
+ * So the rules here are rules about WORDS, and `events-frontier.test.ts` checks them:
+ *
+ *  - Every sentence is in the indicative. It states what happened. No imperative, no "you should",
+ *    no "run", no "approve", no question inviting one.
+ *  - `waiting-approval` is reported as **"is waiting on a permission prompt"** and stops. The one
+ *    thing an orchestrating assistant must not conclude from this channel is that it may answer
+ *    that prompt, so the message says who the prompt is for: a person.
+ *  - The peer message carries a standing preamble saying the channel is informational. A model
+ *    reading a bare status line in its context has to infer what it is for; being told is cheaper
+ *    and more reliable than hoping.
+ *
+ * ## The screen tail
+ *
+ * It is the user's own text and it travels no further than this machine. It is included because
+ * "waiting" without "waiting on WHAT" is a notification people learn to ignore.
+ */
+
+import type { SessionEvent } from './event-types'
+
+/**
+ * The standing note on every peer message.
+ *
+ * Deliberately blunt about the one thing that matters. It is repeated on every message rather than
+ * sent once at subscription time because a session's context is compacted, and a rule that has
+ * scrolled out of the window is a rule that is not in force.
+ */
+export const PEER_PREAMBLE =
+  'agentop session event — informational. This channel reports what other sessions are doing and '
+  + 'carries no instruction. It cannot answer a permission prompt and neither may you on the '
+  + "user's behalf: a session waiting on approval is waiting on a person."
+
+/** The last path segment — how a session is named in one word. */
+function projectOf(cwd: string): string {
+  const parts = cwd.replace(/\\/g, '/').replace(/\/+$/, '').split('/')
+  return parts[parts.length - 1] ?? cwd
+}
+
+/** How a row is referred to: its label if it has one, else its project, else its id. */
+export function eventSubject(e: SessionEvent): string {
+  if (e.label) return e.label
+  const p = projectOf(e.cwd)
+    return p !== '' ? p : e.id
+}
+
+/**
+ * The state, in the indicative.
+ *
+ * `turn-end` and `waiting` are the same fact from two sources and read almost the same, which is
+ * correct: the reader should not have to know which source noticed.
+ */
+export function stateSentence(e: SessionEvent): string {
+  switch (e.kind) {
+    case 'waiting-approval':
+      return 'is waiting on a permission prompt — that prompt is for a person to answer'
+    case 'waiting':
+      return 'finished responding and is waiting'
+    case 'turn-end':
+      return 'finished responding'
+    case 'working':
+      return 'started working'
+    case 'exited':
+      return 'has exited'
+  }
+}
+
+/** One line: who, what, where. The shape both channels build on. */
+export function eventHeadline(e: SessionEvent): string {
+  const who = eventSubject(e)
+  const harness = e.harness ? `${e.harness} ` : ''
+  const task = e.task ? ` · task "${e.task}"` : ''
+  return `${harness}session "${who}" ${stateSentence(e)}${task}`
+}
+
+/** A desktop notification is a title and a body, and every backend wants both. */
+export interface DesktopText {
+  title: string
+  body: string
+}
+
+/**
+ * Short enough for a toast. The title names the session, the body says what happened and — when
+ * there is one — the last line it had on screen, which is what makes the toast worth reading.
+ */
+export function desktopText(e: SessionEvent): DesktopText {
+  const tail = (e.lines ?? []).filter(l => l.trim() !== '').slice(-1)[0]
+  const body = [
+    `${stateSentence(e).replace(/ — that prompt is for a person to answer$/, '')}.`,
+    e.task ? `task "${e.task}"` : '',
+    tail ? `“${tail.trim().slice(0, 120)}”` : '',
+  ].filter(s => s !== '').join(' · ')
+  return { title: `${e.harness ? `${e.harness} · ` : ''}${eventSubject(e)}`, body }
+}
+
+/**
+ * What lands in another Claude session's context.
+ *
+ * The preamble first, then the facts, then the tail. Several events are ONE message: five sessions
+ * finishing at once should interrupt a working assistant once, not five times.
+ */
+export function peerMessage(events: readonly SessionEvent[]): string {
+  const lines: string[] = [PEER_PREAMBLE, '']
+  for (const e of events) {
+    lines.push(`- ${e.at} · ${eventHeadline(e)}`)
+    lines.push(`  ${e.cwd}${e.source === 'hook' ? ' (reported by the Claude Code Stop hook)' : ''}`)
+    const tail = (e.lines ?? []).filter(l => l.trim() !== '').slice(-3)
+    for (const t of tail) lines.push(`  | ${t.trim().slice(0, 200)}`)
+  }
+  return lines.join('\n')
+}

--- a/packages/server/server/events/peer-client.ts
+++ b/packages/server/server/events/peer-client.ts
@@ -1,0 +1,164 @@
+/**
+ * peer-client.ts — delivering an event into another Claude Code session, over the socket that
+ * session already listens on.
+ *
+ * ## What this speaks, and how it was established
+ *
+ * Claude Code registers every session as `~/.claude/sessions/<pid>.json`, carrying its `sessionId`,
+ * its `cwd`, the `name` it registered under and a `messagingSocketPath`. Beside it sits
+ * `<pid>.<hash>.key` holding a `peerToken`. The socket is a newline-delimited JSON stream: the
+ * first line authenticates, and subsequent lines are messages. That is the mechanism Claude Code's
+ * own cross-session messaging uses, read out of the shipped binary (2.1.232) rather than guessed —
+ * the same standard the session manager holds itself to when it reads a harness's `--help`.
+ *
+ * Two consequences of it being someone else's protocol:
+ *
+ *  - **`session_id` is sent with every message.** The receiver drops a message whose `session_id`
+ *    does not match its own. Pid files outlive their processes and pids are reused, so this is what
+ *    turns "the socket answered" into "the session I meant received it". Without it a stale record
+ *    could deliver a fleet event into an unrelated conversation.
+ *  - **It can stop working.** It is not a published API. Every failure is reported as a failure —
+ *    the event is already in the inbox, so a broken socket costs latency, not the event.
+ */
+
+import { existsSync } from 'node:fs'
+import { readFile, readdir } from 'node:fs/promises'
+import { connect } from 'node:net'
+import { join } from 'node:path'
+import { HOME_DIR } from '../config'
+import { livePeers, selectPeerTarget, type PeerRecord, type PeerSelection } from './peer-target'
+
+/**
+ * Deliberately HOME_DIR, not CLAUDE_DIR — the same distinction `cli-hooks.ts` makes. CLAUDE_DIR can
+ * be a container's read-only mount of someone else's `~/.claude`; the sessions we can message are
+ * the ones running as this user on this machine.
+ */
+const sessionsDir = (): string => join(HOME_DIR, '.claude', 'sessions')
+
+/** How long to wait for a connect + write. A notification that blocks a poll is a broken poll. */
+const SEND_TIMEOUT_MS = 2_000
+
+/** Every `<pid>.json` this machine holds, readable ones only. Never throws. */
+export async function readPeerRecords(dir = sessionsDir()): Promise<PeerRecord[]> {
+  let names: string[]
+  try {
+    names = await readdir(dir)
+  } catch {
+    return []
+  }
+  const out: PeerRecord[] = []
+  await Promise.all(names.filter(n => /^\d+\.json$/.test(n)).map(async n => {
+    try {
+      const raw = JSON.parse(await readFile(join(dir, n), 'utf8')) as Record<string, unknown>
+      if (typeof raw.pid !== 'number') return
+      out.push({
+        pid: raw.pid,
+        ...(typeof raw.sessionId === 'string' ? { sessionId: raw.sessionId } : {}),
+        ...(typeof raw.name === 'string' ? { name: raw.name } : {}),
+        ...(typeof raw.cwd === 'string' ? { cwd: raw.cwd } : {}),
+        ...(typeof raw.messagingSocketPath === 'string' ? { messagingSocketPath: raw.messagingSocketPath } : {}),
+        ...(typeof raw.startedAt === 'number' ? { startedAt: raw.startedAt } : {}),
+      })
+    } catch { /* a record we cannot read is a record we do not have */ }
+  }))
+  return out
+}
+
+/**
+ * The socket paths that exist right now.
+ *
+ * Existence of the socket FILE, not a connect: probing by connecting would wake every session on
+ * the machine on every poll. A socket file left behind by a crash is the residual error, and it is
+ * caught one step later — the send fails and is reported as a failed send.
+ */
+export function liveSocketPaths(records: readonly PeerRecord[]): Set<string> {
+  const out = new Set<string>()
+  for (const r of records) {
+    if (r.messagingSocketPath && existsSync(r.messagingSocketPath)) out.add(r.messagingSocketPath)
+  }
+  return out
+}
+
+/** The token a session authenticates its peers with, from `<pid>.<hash>.key`. */
+async function peerToken(pid: number, dir = sessionsDir()): Promise<string | null> {
+  try {
+    const names = await readdir(dir)
+    const key = names.find(n => n.startsWith(`${pid}.`) && n.endsWith('.key'))
+    if (!key) return null
+    const raw = JSON.parse(await readFile(join(dir, key), 'utf8')) as { peerToken?: unknown }
+    return typeof raw.peerToken === 'string' ? raw.peerToken : null
+  } catch {
+    return null
+  }
+}
+
+export type PeerSendResult =
+  | { ok: true; pid: number; name?: string }
+  | { ok: false; message: string }
+
+/** Resolve a `--notify` reference against what is on disk right now. */
+export async function resolvePeer(ref: string): Promise<PeerSelection> {
+  const records = await readPeerRecords()
+  return selectPeerTarget(records, ref, liveSocketPaths(records))
+}
+
+/** The live sessions, for `agentop events status` to list. */
+export async function listLivePeers(): Promise<PeerRecord[]> {
+  const records = await readPeerRecords()
+  return livePeers(records, liveSocketPaths(records))
+}
+
+/**
+ * Send one message to one session.
+ *
+ * `priority: 'next'` rather than `'now'`: the receiving session picks it up at its next turn
+ * boundary instead of interrupting the middle of one. This channel reports what other sessions are
+ * doing — that is worth a session's attention, not worth cutting into its current work.
+ */
+export async function sendToPeer(ref: string, body: string): Promise<PeerSendResult> {
+  const found = await resolvePeer(ref)
+  if (!found.ok) return { ok: false, message: found.message }
+
+  const token = await peerToken(found.target.pid)
+  if (!token) {
+    return {
+      ok: false,
+      message: `Claude Code session "${ref}" is running but its messaging key is unreadable, so agentop cannot authenticate to it. The event is in the inbox.`,
+    }
+  }
+
+  const { socketPath, sessionId, pid, name } = found.target
+  return new Promise<PeerSendResult>(resolve => {
+    let settled = false
+    const done = (r: PeerSendResult): void => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      try { socket.destroy() } catch { /* already gone */ }
+      resolve(r)
+    }
+
+    const timer = setTimeout(() => done({
+      ok: false,
+      message: `Claude Code session "${ref}" did not accept the message within ${SEND_TIMEOUT_MS}ms. The event is in the inbox.`,
+    }), SEND_TIMEOUT_MS)
+
+    const socket = connect({ path: socketPath })
+    socket.on('error', e => done({
+      ok: false,
+      message: `Could not reach Claude Code session "${ref}" on ${socketPath}: ${e.message}. The event is in the inbox.`,
+    }))
+    socket.on('connect', () => {
+      socket.write(`${JSON.stringify({ type: 'auth', token })}\n`)
+      socket.write(`${JSON.stringify({
+        type: 'user',
+        // The receiver refuses a mismatch, which is what makes a stale pid file safe.
+        ...(sessionId ? { session_id: sessionId } : {}),
+        priority: 'next',
+        message: { content: body },
+      })}\n`)
+      // `end` flushes what was written and closes; the receiver processes the final buffer.
+      socket.end(() => done({ ok: true, pid, ...(name !== undefined ? { name } : {}) }))
+    })
+  })
+}

--- a/packages/server/server/events/peer-target.ts
+++ b/packages/server/server/events/peer-target.ts
@@ -1,0 +1,127 @@
+/**
+ * peer-target.ts — PURE. Which Claude Code session a `--notify` names, and whether it is alive.
+ *
+ * ## The registry says who EXISTS; the socket says who is UP
+ *
+ * Claude Code writes `~/.claude/sessions/<pid>.json` for every session and does not always remove
+ * it when that session ends. Measured on this machine: 79 records, five live sockets. Several
+ * records share one `sessionId` — a session that was resumed leaves the old record behind, holding
+ * the same conversation id and a pid that is now somebody else's or nobody's.
+ *
+ * So the record alone answers nothing. The pair does: a record is DELIVERABLE only when the socket
+ * it names is present. That is the whole of the liveness rule, and it is the reason this module
+ * takes the set of live socket paths as an argument rather than deriving anything from the record.
+ *
+ * ## A target that is not up is reported, never assumed
+ *
+ * `selectPeerTarget` returns a discriminated result. There is no "probably fine" branch: the event
+ * stays in the inbox, the command SAYS it was not delivered, and the session reads it the next time
+ * it looks. Pretending otherwise is how a channel becomes something people trust and shouldn't.
+ */
+
+/** One `~/.claude/sessions/<pid>.json`, as far as this module cares. */
+export interface PeerRecord {
+  pid: number
+  /** Claude's own conversation id. Sent with the message so a stale pid cannot misdeliver it. */
+  sessionId?: string
+  /** The name the session registered under, when it has one. */
+  name?: string
+  cwd?: string
+  messagingSocketPath?: string
+  /** Epoch ms. Newest wins when two live records answer to one name. */
+  startedAt?: number
+}
+
+export interface PeerTarget {
+  pid: number
+  socketPath: string
+  sessionId?: string
+  name?: string
+  cwd?: string
+}
+
+export type PeerSelection =
+  | { ok: true; target: PeerTarget }
+  | { ok: false; code: 'no-match'; message: string }
+  | { ok: false; code: 'not-live'; message: string }
+  | { ok: false; code: 'ambiguous'; message: string; candidates: string[] }
+
+const label = (r: PeerRecord): string => `${r.name ?? '(unnamed)'} (pid ${r.pid})`
+
+/**
+ * Resolve a `--notify` reference against the records.
+ *
+ * A reference matches a record's NAME (case-insensitively, whole) or its PID (exactly). Not a
+ * prefix: session names here are chosen by people and are frequently prefixes of each other
+ * ("cockpit", "cockpit-2"), and delivering a message to the wrong assistant is not a mistake that
+ * announces itself.
+ *
+ * `liveSockets` is the set of socket paths that exist right now.
+ */
+export function selectPeerTarget(
+  records: readonly PeerRecord[],
+  ref: string,
+  liveSockets: ReadonlySet<string>,
+): PeerSelection {
+  const want = ref.trim().toLowerCase()
+  if (want === '') return { ok: false, code: 'no-match', message: 'No session was named.' }
+
+  const matched = records.filter(r =>
+    String(r.pid) === want || (r.name !== undefined && r.name.toLowerCase() === want))
+
+  if (matched.length === 0) {
+    return {
+      ok: false,
+      code: 'no-match',
+      message: `No Claude Code session is registered as "${ref}". \`agentop events status\` lists the ones that are.`,
+    }
+  }
+
+  const live = matched.filter(r =>
+    r.messagingSocketPath !== undefined && liveSockets.has(r.messagingSocketPath))
+
+  if (live.length === 0) {
+    return {
+      ok: false,
+      code: 'not-live',
+      message: `Claude Code session "${ref}" is registered but not running (no messaging socket) — `
+        + `${matched.map(label).join(', ')}. The event is in the inbox; that session reads it with `
+        + '`agentop events tail` when it next runs.',
+    }
+  }
+
+  if (live.length > 1) {
+    // Two LIVE sessions answering to one name is genuinely ambiguous, and picking the newest would
+    // be a coin flip dressed as a rule. The caller is told which ones, so it can name a pid.
+    const sorted = [...live].sort((a, b) => (b.startedAt ?? 0) - (a.startedAt ?? 0))
+    return {
+      ok: false,
+      code: 'ambiguous',
+      message: `"${ref}" names ${live.length} running Claude Code sessions — pass a pid instead.`,
+      candidates: sorted.map(label),
+    }
+  }
+
+  const r = live[0]!
+  return {
+    ok: true,
+    target: {
+      pid: r.pid,
+      socketPath: r.messagingSocketPath!,
+      ...(r.sessionId !== undefined ? { sessionId: r.sessionId } : {}),
+      ...(r.name !== undefined ? { name: r.name } : {}),
+      ...(r.cwd !== undefined ? { cwd: r.cwd } : {}),
+    },
+  }
+}
+
+/** The live sessions, newest first — what `agentop events status` lists so a `--notify` can be
+ *  typed without guessing. */
+export function livePeers(
+  records: readonly PeerRecord[],
+  liveSockets: ReadonlySet<string>,
+): PeerRecord[] {
+  return records
+    .filter(r => r.messagingSocketPath !== undefined && liveSockets.has(r.messagingSocketPath))
+    .sort((a, b) => (b.startedAt ?? 0) - (a.startedAt ?? 0))
+}

--- a/packages/server/server/events/producer-status.ts
+++ b/packages/server/server/events/producer-status.ts
@@ -1,0 +1,123 @@
+/**
+ * producer-status.ts — is anything actually watching?
+ *
+ * "No events arrived" has two causes that look identical from the outside: nothing happened, or
+ * nobody was watching. The second is the one that makes a person stop trusting the channel, so it
+ * has to be a state `agentop events status` can NAME. A running producer stamps a small heartbeat
+ * file; `status` reads it and reports the producer as running, stale (a heartbeat whose process is
+ * gone, i.e. a daemon that was killed) or absent.
+ *
+ * The heartbeat is throttled rather than written every tick: the poll runs every five seconds and
+ * the point of this file is liveness, not a log.
+ *
+ * Liveness is confirmed against the PID, not against the timestamp alone — a machine that was
+ * suspended for an hour has a stale-looking heartbeat and a perfectly alive daemon.
+ */
+
+import { existsSync } from 'node:fs'
+import { mkdir, readFile, rename, rm, writeFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import { AGENTISTICS_DATA_DIR } from '../config'
+
+export const PRODUCER_STATUS_FILE =
+  process.env.AGENTISTICS_EVENT_PRODUCER_FILE ?? join(AGENTISTICS_DATA_DIR, 'events-producer.json')
+
+/** How often the heartbeat is refreshed. */
+export const HEARTBEAT_MS = 30_000
+
+export interface ProducerHeartbeat {
+  pid: number
+  /** `daemon` — riding along with `agentop server` / `agentop watch`. `foreground` — `events run`. */
+  host: 'daemon' | 'foreground'
+  startedAt: string
+  updatedAt: string
+  /** Set when the producer is up but cannot watch anything (no tmux here). */
+  unavailable?: string
+}
+
+export async function readHeartbeat(file = PRODUCER_STATUS_FILE): Promise<ProducerHeartbeat | null> {
+  try {
+    if (!existsSync(file)) return null
+    const raw = JSON.parse(await readFile(file, 'utf8')) as Partial<ProducerHeartbeat>
+    if (typeof raw.pid !== 'number') return null
+    return {
+      pid: raw.pid,
+      host: raw.host === 'foreground' ? 'foreground' : 'daemon',
+      startedAt: typeof raw.startedAt === 'string' ? raw.startedAt : '',
+      updatedAt: typeof raw.updatedAt === 'string' ? raw.updatedAt : '',
+      ...(typeof raw.unavailable === 'string' ? { unavailable: raw.unavailable } : {}),
+    }
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Is that pid still there? `kill(pid, 0)` asks the kernel and changes nothing.
+ *
+ * Both failures mean "not our producer": ESRCH is gone, and EPERM is a pid that now belongs to
+ * another user — a recycled number, not the daemon that wrote this file. Reporting a producer as
+ * running because some unrelated process holds its old pid is the one wrong answer here.
+ */
+export function pidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch {
+    return false
+  }
+}
+
+export type ProducerState =
+  | { state: 'running'; heartbeat: ProducerHeartbeat }
+  | { state: 'stale'; heartbeat: ProducerHeartbeat }
+  | { state: 'absent' }
+
+export async function producerState(file = PRODUCER_STATUS_FILE): Promise<ProducerState> {
+  const hb = await readHeartbeat(file)
+  if (!hb) return { state: 'absent' }
+  return pidAlive(hb.pid) ? { state: 'running', heartbeat: hb } : { state: 'stale', heartbeat: hb }
+}
+
+/** A writer that throttles itself. Returns a `beat()` to call from the loop and a `clear()` for a
+ *  clean shutdown, so a producer that exits normally does not leave a heartbeat behind. */
+export function createHeartbeatWriter(o: {
+  host: ProducerHeartbeat['host']
+  file?: string
+  now?: () => number
+  everyMs?: number
+}): { beat(unavailable?: string): Promise<void>; clear(): Promise<void> } {
+  const file = o.file ?? PRODUCER_STATUS_FILE
+  const now = o.now ?? (() => Date.now())
+  const every = o.everyMs ?? HEARTBEAT_MS
+  const startedAt = new Date(now()).toISOString()
+  let lastWrite = 0
+
+  return {
+    async beat(unavailable?: string) {
+      const t = now()
+      if (lastWrite !== 0 && t - lastWrite < every) return
+      lastWrite = t
+      const doc: ProducerHeartbeat = {
+        pid: process.pid,
+        host: o.host,
+        startedAt,
+        updatedAt: new Date(t).toISOString(),
+        ...(unavailable !== undefined ? { unavailable } : {}),
+      }
+      try {
+        await mkdir(dirname(file), { recursive: true })
+        const tmp = `${file}.agentop-tmp`
+        await writeFile(tmp, `${JSON.stringify(doc, null, 2)}\n`, { encoding: 'utf8', mode: 0o600 })
+        await rename(tmp, file)
+      } catch { /* a heartbeat that cannot be written costs `status` a line, never the producer */ }
+    },
+    async clear() {
+      // Only ours. A heartbeat belonging to another producer is not this one's to delete.
+      try {
+        const hb = await readHeartbeat(file)
+        if (hb?.pid === process.pid) await rm(file)
+      } catch { /* nothing to clear */ }
+    },
+  }
+}

--- a/packages/server/server/events/producer.ts
+++ b/packages/server/server/events/producer.ts
@@ -1,0 +1,222 @@
+/**
+ * producer.ts — the thing that watches. One long-lived poller, and everything that follows from
+ * that being long-lived.
+ *
+ * ## Why this MUST be long-lived, and why it therefore rides along with the daemon
+ *
+ * `createSessionsPoller` holds two things between polls: the digest of each session's last frame,
+ * and each session's last activity. Both are in memory, and both are what make the answer correct:
+ *
+ *  - **Movement is the only universal "working" signal.** For several harnesses the screen looks
+ *    identical whether they are streaming output or sitting idle — codex draws the same footer
+ *    either way — so the only proof of work is that the frame CHANGED since last time. A process
+ *    that polls once has no "last time".
+ *  - **tmux's own `session_activity` is not a substitute.** Measured on this machine while writing
+ *    this: a session that had been working continuously for 53 minutes reported its last tmux
+ *    activity 3185 seconds earlier, because nothing was attached to it. That is well past the
+ *    marker staleness window, so a single-invocation read discards the `esc to interrupt` marker
+ *    too and lands on `waiting`.
+ *
+ * Put together: **a single-invocation poll reports working sessions as finished.** A `agentop
+ * events` implemented as a cron job or a per-invocation check would announce that five sessions
+ * finished at the moment they all started. False notifications are worse than none — people stop
+ * looking — so the producer is a loop that keeps its memory, and there is no single-shot event
+ * source in this design except the Claude `Stop` hook, which is exact by construction and infers
+ * nothing.
+ *
+ * That settles the daemon question. A separate process the user must remember to start is a process
+ * that will be dead when it matters, so the producer runs INSIDE the daemon `agentop server`
+ * already starts (`otel-watcher`), where it costs one extra tmux capture per session per five
+ * seconds and starts with the machine. `agentop events run` starts the same producer in the
+ * foreground for someone who does not run the server — and `agentop events status` says which of
+ * the two is up, because "nothing is producing events" must be a visible state.
+ *
+ * ## First poll writes nothing
+ *
+ * See `event-plan.ts`: a session the producer has never seen has no previous state, so nothing can
+ * be said to have changed about it. Restarting the daemon therefore does not replay the fleet into
+ * the inbox as a flood of "started waiting".
+ */
+
+import type { HarnessProcess } from '../live-sessions'
+import type { SessionSnapshot, SessionsPoller } from '../sessions/sessions-host'
+import { SESSION_POLL_MS } from '../sessions/sessions-host'
+import { dedupeEvents } from './event-dedupe'
+import { EMPTY_MEMORY, planEvents, seedMemory, type EventMemory } from './event-plan'
+import { createEventStore, type EventStore } from './event-store'
+import type { EventCandidate, SessionEvent } from './event-types'
+import { deliver, type DeliveryReport } from './notifier'
+import { desktopSetup, type DesktopSetup } from './desktop'
+import { kindsToRecord, type Subscription } from './subscriptions'
+
+/** How many recent events the dedupe is judged against. Two polls' worth of a large fleet. */
+const DEDUPE_LOOKBACK = 50
+
+/** A `SessionView` reduced to what an event needs. Exported so the tests can build one. */
+export function toCandidate(v: {
+  id: string
+  harness?: EventCandidate['harness']
+  cwd: string
+  task?: string
+  label?: string
+  conversationId?: string
+  activity?: EventCandidate['activity']
+  lastLines?: string[]
+}): EventCandidate {
+  return {
+    id: v.id,
+    ...(v.harness ? { harness: v.harness } : {}),
+    cwd: v.cwd,
+    ...(v.task ? { task: v.task } : {}),
+    ...(v.label ? { label: v.label } : {}),
+    ...(v.conversationId ? { conversationId: v.conversationId } : {}),
+    ...(v.activity ? { activity: v.activity } : {}),
+    ...(v.lastLines && v.lastLines.length > 0 ? { lines: v.lastLines } : {}),
+  }
+}
+
+export interface ProducerTick {
+  /** What was written this tick. Empty on most ticks, which is the point. */
+  written: SessionEvent[]
+  delivery: DeliveryReport
+  /** Why the fleet reading may be incomplete, already a sentence. */
+  unavailable?: string
+}
+
+export interface Producer {
+  /** One poll. Returns what it wrote and what it delivered. */
+  tick(): Promise<ProducerTick>
+  /** Loop until `stop()`. Resolves when the loop has ended. */
+  run(): Promise<void>
+  stop(): void
+  /** What the producer believes about the fleet — what makes the next tick a comparison. */
+  memory(): EventMemory
+}
+
+export function createProducer(o: {
+  poller: SessionsPoller
+  /** Read on every tick, so a subscription registered while the producer runs takes effect without
+   *  restarting it. A user who has to bounce a daemon to add a filter will not add the filter. */
+  readSubscriptions: () => Promise<Subscription[]>
+  store?: EventStore
+  desktop?: DesktopSetup
+  nowIso?: () => string
+  nowMs?: () => number
+  intervalMs?: number
+  /** Reported to the caller instead of thrown: a producer that dies on one bad poll is a producer
+   *  that is not running when it matters. */
+  onError?: (message: string) => void
+}): Producer {
+  const store = o.store ?? createEventStore()
+  const nowIso = o.nowIso ?? (() => new Date().toISOString())
+  const nowMs = o.nowMs ?? (() => Date.now())
+  const interval = o.intervalMs ?? SESSION_POLL_MS
+
+  let memory: EventMemory = EMPTY_MEMORY
+  let seeded = false
+  let stopped = false
+  let desktop = o.desktop
+
+  async function tick(): Promise<ProducerTick> {
+    const snap: SessionSnapshot = await o.poller.poll()
+    const sessions = snap.sessions.map(toCandidate)
+
+    // A failed poll returns the PREVIOUS list plus a reason. Comparing against it would report
+    // nothing changed, which is true of the list and not of the world — so a tick that could not
+    // read the fleet writes no events and says why, rather than producing a confident silence.
+    if (snap.unavailable !== undefined) {
+      return { written: [], delivery: { lines: [], peersReached: 0, peersFailed: 0, toastsShown: 0, toastsFailed: 0 }, unavailable: snap.unavailable }
+    }
+
+    const subs = await o.readSubscriptions().catch(() => [] as Subscription[])
+
+    if (!seeded) {
+      // The first sighting is not a transition. See the header.
+      memory = seedMemory(sessions)
+      seeded = true
+      return { written: [], delivery: { lines: [], peersReached: 0, peersFailed: 0, toastsShown: 0, toastsFailed: 0 } }
+    }
+
+    const planned = planEvents({ memory, sessions, nowIso: nowIso(), kinds: kindsToRecord(subs) })
+    // The memory advances whether or not anything was written — see `planEvents`.
+    memory = planned.memory
+    const candidates = planned.events
+
+    if (candidates.length === 0) {
+      return { written: [], delivery: { lines: [], peersReached: 0, peersFailed: 0, toastsShown: 0, toastsFailed: 0 } }
+    }
+
+    // The hook may already have reported the same end of turn. Judged against the inbox tail rather
+    // than against in-memory state, because the hook writes from a DIFFERENT process.
+    const recent = (await store.recent(DEDUPE_LOOKBACK).catch(() => ({ events: [] as SessionEvent[] }))).events
+    const fresh = dedupeEvents(candidates, recent, nowMs())
+    if (fresh.length === 0) {
+      return { written: [], delivery: { lines: [], peersReached: 0, peersFailed: 0, toastsShown: 0, toastsFailed: 0 } }
+    }
+
+    const written = await store.append(fresh)
+    if (desktop === undefined && subs.some(s => s.desktop)) desktop = await desktopSetup()
+    const delivery = await deliver({
+      events: written,
+      subscriptions: subs,
+      ...(desktop ? { desktop } : {}),
+    })
+    return { written, delivery }
+  }
+
+  async function run(): Promise<void> {
+    stopped = false
+    while (!stopped) {
+      try {
+        await tick()
+      } catch (e) {
+        o.onError?.(e instanceof Error ? e.message : String(e))
+      }
+      if (stopped) break
+      await new Promise(r => setTimeout(r, interval))
+    }
+  }
+
+  return { tick, run, stop: () => { stopped = true }, memory: () => memory }
+}
+
+/**
+ * The producer this machine's daemon runs, wired to the real backend.
+ *
+ * Null when the session backend cannot run here at all — on Windows there is no tmux and no fleet
+ * to watch, and a producer that polls a backend that will never answer is a loop burning a process
+ * to learn the same nothing. The caller reports the reason.
+ */
+export async function createHostProducer(o?: {
+  readSubscriptions?: () => Promise<Subscription[]>
+  onError?: (message: string) => void
+}): Promise<{ producer: Producer } | { unavailable: string }> {
+  const [{ resolveBackend }, { readRegistry }, { scanProcesses }, { createSessionsPoller }, { loadConversations }] =
+    await Promise.all([
+      import('../sessions/index'),
+      import('../sessions/registry'),
+      import('../live-sessions'),
+      import('../sessions/sessions-host'),
+      import('../sessions/conversations'),
+    ])
+
+  const backend = await resolveBackend()
+  const blocked = await backend.unavailable()
+  if (blocked) return { unavailable: blocked }
+
+  const poller = createSessionsPoller({
+    backend,
+    readRegistry,
+    scanProcesses: scanProcesses as () => Promise<{ procs: HarnessProcess[] }>,
+    loadConversations,
+  })
+
+  const { readSubscriptions } = await import('./subscription-store')
+  return {
+    producer: createProducer({
+      poller,
+      readSubscriptions: o?.readSubscriptions ?? readSubscriptions,
+      ...(o?.onError ? { onError: o.onError } : {}),
+    }),
+  }
+}

--- a/packages/server/server/events/subscription-store.ts
+++ b/packages/server/server/events/subscription-store.ts
@@ -1,0 +1,44 @@
+/**
+ * subscription-store.ts — the subscriptions on disk. `subscriptions.ts` decides; this file reads
+ * and writes one small JSON file.
+ *
+ * Written atomically (temp file + rename) for the same reason `cli-hooks.ts` writes settings that
+ * way: a crash mid-write must leave the old file or the new one, never a truncated one that the
+ * producer then reads as "no subscriptions" and goes quiet.
+ *
+ * A file that cannot be read is an EMPTY store, never an exception. The producer runs inside the
+ * daemon; a subscription file somebody hand-edited into invalid JSON must cost the filters, not the
+ * daemon.
+ */
+
+import { existsSync } from 'node:fs'
+import { mkdir, readFile, rename, writeFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import { AGENTISTICS_DATA_DIR } from '../config'
+import { EMPTY_STORE, parseStore, type Subscription, type SubscriptionStore } from './subscriptions'
+
+export const SUBSCRIPTIONS_FILE =
+  process.env.AGENTISTICS_EVENT_SUBSCRIPTIONS_FILE ?? join(AGENTISTICS_DATA_DIR, 'event-subscriptions.json')
+
+export async function readSubscriptionStore(file = SUBSCRIPTIONS_FILE): Promise<SubscriptionStore> {
+  try {
+    if (!existsSync(file)) return EMPTY_STORE
+    return parseStore(JSON.parse(await readFile(file, 'utf8')) as unknown)
+  } catch {
+    return EMPTY_STORE
+  }
+}
+
+export async function readSubscriptions(file = SUBSCRIPTIONS_FILE): Promise<Subscription[]> {
+  return (await readSubscriptionStore(file)).subscriptions
+}
+
+export async function writeSubscriptionStore(
+  store: SubscriptionStore,
+  file = SUBSCRIPTIONS_FILE,
+): Promise<void> {
+  await mkdir(dirname(file), { recursive: true })
+  const tmp = `${file}.agentop-tmp`
+  await writeFile(tmp, `${JSON.stringify(store, null, 2)}\n`, { encoding: 'utf8', mode: 0o600 })
+  await rename(tmp, file)
+}

--- a/packages/server/server/events/subscriptions.ts
+++ b/packages/server/server/events/subscriptions.ts
@@ -1,0 +1,151 @@
+/**
+ * subscriptions.ts — PURE. Who wants to hear about what, and how a stored one is matched.
+ *
+ * ## Why a subscription is persisted rather than a running process
+ *
+ * The obvious shape for "tell me when a session needs me" is a foreground command that watches and
+ * prints. That shape has one fatal property: it is a process the user has to remember to start, and
+ * it will be dead at the moment it matters. So a subscription is a ROW in a file. Whatever producer
+ * is up — the daemon `agentop server` already runs, or a foreground `agentop events run` — reads
+ * the file and delivers. Registering and producing are separated for exactly that reason.
+ *
+ * ## A subscription narrows; it never widens
+ *
+ * `task` and `session` are filters, `kinds` is a filter. A subscription with none of them hears
+ * about every transition of the default kinds, which is the useful default for someone who just
+ * fanned five sessions out. There is no field that makes a subscription hear about something the
+ * producer did not observe.
+ *
+ * ## What it can ask for is DELIVERY, never ACTION
+ *
+ * `notify` names a Claude session to inform and `desktop` asks for a toast. Both carry an event
+ * that states a fact. There is deliberately no field naming a command to run, a key to press or an
+ * answer to give: a subscription that could run something would make this channel the thing that
+ * answers a permission prompt on the user's behalf, which is the one thing it must never be able to
+ * do. `events-frontier.test.ts` asserts the shape has no such field.
+ */
+
+import { DEFAULT_EVENT_KINDS, type EventKind, type SessionEvent } from './event-types'
+
+export interface Subscription {
+  /** Short, stable, and what `agentop events unwatch <id>` takes. */
+  id: string
+  /** ISO — this is a local JSON store, where ISO is the correct representation. */
+  createdAt: string
+  /** Only sessions whose task is exactly this. Absent means every task. */
+  task?: string
+  /** Only this session: agentop's session id, or its label. Absent means every session. */
+  session?: string
+  /** Which transitions. Never empty — a subscription that wants nothing is not a subscription. */
+  kinds: EventKind[]
+  /** A Claude session to inform, by the name or pid it registered under. Absent means nobody. */
+  notify?: string
+  /** Ask for a desktop notification. */
+  desktop: boolean
+  /** What created it, for `status` to show. Free text, never acted on. */
+  note?: string
+}
+
+/** A short id from a counter plus what already exists — no clock, no randomness, so it is pure. */
+export function newSubscriptionId(existing: readonly Subscription[]): string {
+  let n = 1
+  const taken = new Set(existing.map(s => s.id))
+  while (taken.has(`s${n}`)) n++
+  return `s${n}`
+}
+
+/**
+ * Does this subscription want to hear about this event?
+ *
+ * The session filter matches either the id or the label, and matches the id by PREFIX so a person
+ * can type the first few characters of one — the same courtesy `resolveSessionRef` extends. The
+ * task filter is EXACT: a task is a name the user chose, and prefix-matching names is how "api"
+ * quietly starts selecting "api-migration" too.
+ */
+export function subscriptionWants(sub: Subscription, e: SessionEvent): boolean {
+  if (!sub.kinds.includes(e.kind)) return false
+  if (sub.task !== undefined && e.task !== sub.task) return false
+  if (sub.session !== undefined) {
+    const ref = sub.session.toLowerCase()
+    const byId = e.id.toLowerCase().startsWith(ref)
+    const byLabel = (e.label ?? '').toLowerCase() === ref
+    if (!byId && !byLabel) return false
+  }
+  return true
+}
+
+/** The subscriptions that want this event, in the order they were registered. */
+export function subscribersOf(subs: readonly Subscription[], e: SessionEvent): Subscription[] {
+  return subs.filter(s => subscriptionWants(s, e))
+}
+
+/**
+ * Every kind any subscription asks for.
+ *
+ * The producer uses this to decide what to WRITE. It is a union, never a narrowing: two
+ * subscriptions asking for different things must both be served, and a producer with no
+ * subscriptions at all still records the default kinds, because the inbox is read by people and by
+ * `agentop events tail` as well as by subscribers.
+ */
+export function kindsToRecord(subs: readonly Subscription[]): EventKind[] {
+  const out = new Set<EventKind>(DEFAULT_EVENT_KINDS)
+  for (const s of subs) for (const k of s.kinds) out.add(k)
+  return [...out]
+}
+
+export interface SubscriptionStore {
+  subscriptions: Subscription[]
+}
+
+export const EMPTY_STORE: SubscriptionStore = { subscriptions: [] }
+
+/**
+ * Read a store written by anyone, including a version that wrote fields this one has no name for.
+ *
+ * Total: a file that is not a store reads as an EMPTY store rather than throwing. A malformed
+ * subscriptions file must not be able to stop the producer — silence about a filter is recoverable,
+ * a daemon that will not start is not.
+ */
+export function parseStore(raw: unknown): SubscriptionStore {
+  if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) return { subscriptions: [] }
+  const list = (raw as { subscriptions?: unknown }).subscriptions
+  if (!Array.isArray(list)) return { subscriptions: [] }
+  const out: Subscription[] = []
+  for (const item of list) {
+    if (typeof item !== 'object' || item === null || Array.isArray(item)) continue
+    const o = item as Record<string, unknown>
+    if (typeof o.id !== 'string' || o.id === '') continue
+    const kinds = Array.isArray(o.kinds)
+      ? (o.kinds as unknown[]).filter((k): k is EventKind => typeof k === 'string' && (DEFAULT_EVENT_KINDS as readonly string[]).concat('working', 'turn-end').includes(k))
+      : []
+    // A subscription that survives the read with no kinds left would silently hear nothing. It is
+    // given the defaults rather than dropped: the user asked for something, and the honest recovery
+    // is the documented default, not silence.
+    out.push({
+      ...o,
+      id: o.id,
+      createdAt: typeof o.createdAt === 'string' ? o.createdAt : '',
+      kinds: kinds.length > 0 ? kinds : [...DEFAULT_EVENT_KINDS],
+      desktop: o.desktop === true,
+    } as Subscription)
+  }
+  return { subscriptions: out }
+}
+
+export function addSubscription(store: SubscriptionStore, sub: Subscription): SubscriptionStore {
+  return { ...store, subscriptions: [...store.subscriptions, sub] }
+}
+
+/** Removal reports whether anything was there, so the caller can say "no such subscription"
+ *  instead of a cheerful "removed" that removed nothing. */
+export function removeSubscription(
+  store: SubscriptionStore,
+  id: string,
+): { store: SubscriptionStore; removed: Subscription[] } {
+  const removed = store.subscriptions.filter(s => s.id === id)
+  return { store: { ...store, subscriptions: store.subscriptions.filter(s => s.id !== id) }, removed }
+}
+
+export function clearSubscriptions(store: SubscriptionStore): { store: SubscriptionStore; removed: Subscription[] } {
+  return { store: { ...store, subscriptions: [] }, removed: [...store.subscriptions] }
+}

--- a/packages/server/server/otel-watcher.ts
+++ b/packages/server/server/otel-watcher.ts
@@ -606,11 +606,19 @@ async function main() {
   // Also do periodic polling as a fallback (chokidar can miss events in some edge cases)
   setInterval(() => rebuildSnapshot(), WATCH_INTERVAL_SEC * 1000)
 
+  // The session-event producer rides along here rather than being its own service: it has to be
+  // long-lived to tell a working session from a finished one (see events/producer.ts), and a
+  // separate process the user must remember to start is a process that will be dead at the moment
+  // it matters. Never fatal to this daemon — see events/daemon.ts.
+  const { startEventProducer } = await import('./events/daemon')
+  const events = await startEventProducer()
+
   console.log('[watcher] Running — use `bun run dev` in a separate terminal for the dashboard UI')
 
   // Graceful shutdown
   const shutdown = async () => {
     console.log('\n[watcher] Shutting down...')
+    await events?.stop()
     if (otel) await otel.shutdown()
     process.exit(0)
   }

--- a/packages/server/server/sessions/attention-rules.test.ts
+++ b/packages/server/server/sessions/attention-rules.test.ts
@@ -32,6 +32,29 @@ const CLAUDE_APPROVAL = [
   ' Enter to confirm · Esc to cancel',
 ]
 
+/**
+ * claude 2.1.232 — the TOOL PERMISSION prompt, captured 2026-08-14 from a session sitting on
+ * `rm -v /tmp/agentop-e2e/hello.txt`.
+ *
+ * It is here because the rule set had only CLAUDE_APPROVAL, and the two dialogs do NOT share a
+ * footer: this one says `Esc to cancel · Tab to amend · ctrl+e to explain`. A real session blocked
+ * on this prompt was reported as an ordinary `waiting` — the one state the event channel exists
+ * for, read as the one state that means nothing needs you.
+ */
+const CLAUDE_PERMISSION = [
+  ' Bash command',
+  '',
+  '   rm -v /tmp/agentop-e2e/hello.txt',
+  '   Remove o arquivo hello.txt',
+  '',
+  ' Do you want to proceed?',
+  ' ❯ 1. Yes',
+  '   2. Yes, and always allow access to agentop-e2e/ from this project',
+  '   3. No',
+  '',
+  ' Esc to cancel · Tab to amend · ctrl+e to explain',
+]
+
 /** claude 2.1.231 — mid-turn. Note the input box is drawn EXACTLY as it is when idle. */
 const CLAUDE_WORKING = [
   '✢ Orbiting… (5s · ↓ 76 tokens)',
@@ -104,6 +127,17 @@ describe('ATTENTION_RULES', () => {
 describe('claude', () => {
   it('sees the blocking dialog', () => {
     expect(quiet(CLAUDE_APPROVAL, 'claude')).toBe('waiting-approval')
+  })
+
+  it('sees the TOOL PERMISSION prompt, which draws a different footer entirely', () => {
+    expect(quiet(CLAUDE_PERMISSION, 'claude')).toBe('waiting-approval')
+  })
+
+  it('recognises the permission prompt by its question as well as by its footer', () => {
+    // The footer varies with what the prompt offers — a plan-mode prompt has no `Tab to amend` —
+    // so the question has to stand on its own.
+    const noFooter = CLAUDE_PERMISSION.filter(l => !l.includes('Tab to amend'))
+    expect(quiet(noFooter, 'claude')).toBe('waiting-approval')
   })
 
   it('sees a running turn from the footer, not from the input box', () => {

--- a/packages/server/server/sessions/attention-rules.test.ts
+++ b/packages/server/server/sessions/attention-rules.test.ts
@@ -33,26 +33,47 @@ const CLAUDE_APPROVAL = [
 ]
 
 /**
- * claude 2.1.232 — the TOOL PERMISSION prompt, captured 2026-08-14 from a session sitting on
- * `rm -v /tmp/agentop-e2e/hello.txt`.
+ * claude 2.1.232, 2026-08-14 — the PERMISSION prompt, verbatim from a live session.
  *
- * It is here because the rule set had only CLAUDE_APPROVAL, and the two dialogs do NOT share a
- * footer: this one says `Esc to cancel · Tab to amend · ctrl+e to explain`. A real session blocked
- * on this prompt was reported as an ordinary `waiting` — the one state the event channel exists
- * for, read as the one state that means nothing needs you.
+ * A DIFFERENT component from the folder-trust dialog above, with a different footer, and the rule
+ * probed from that one does not match it. Measured the hard way: this exact frame reported
+ * `waiting`, and the prompt then typed into the session went into the dialog's own filter, where
+ * the submit took the highlighted option and approved a shell command nobody had read.
  */
-const CLAUDE_PERMISSION = [
+const CLAUDE_BASH_PERMISSION = [
   ' Bash command',
   '',
-  '   rm -v /tmp/agentop-e2e/hello.txt',
-  '   Remove o arquivo hello.txt',
+  '   env | head -3',
+  '   Show first 3 environment variables',
+  '',
+  ' This command requires approval',
   '',
   ' Do you want to proceed?',
   ' ❯ 1. Yes',
-  '   2. Yes, and always allow access to agentop-e2e/ from this project',
+  '   2. Yes, and don’t ask again for: env',
   '   3. No',
   '',
   ' Esc to cancel · Tab to amend · ctrl+e to explain',
+]
+
+/**
+ * claude 2.1.232, 2026-08-14 — the same component asking about a FILE, verbatim.
+ *
+ * The second capture is what makes the matched text the component's footer rather than one dialog's
+ * wording: this one offers no `ctrl+e to explain`, because there is no command to explain.
+ */
+const CLAUDE_WRITE_PERMISSION = [
+  ' Create file',
+  ' agentop-write-probe.txt',
+  '╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌',
+  '  1 hello',
+  '╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌',
+  ' Do you want to create agentop-write-probe.txt?',
+  ' ❯ 1. Yes',
+  '   2. Yes, allow all edits during this session (shift+tab)',
+  '   3. No',
+  '',
+  ' Esc to cancel · Tab to amend',
 ]
 
 /** claude 2.1.231 — mid-turn. Note the input box is drawn EXACTLY as it is when idle. */
@@ -129,15 +150,29 @@ describe('claude', () => {
     expect(quiet(CLAUDE_APPROVAL, 'claude')).toBe('waiting-approval')
   })
 
-  it('sees the TOOL PERMISSION prompt, which draws a different footer entirely', () => {
-    expect(quiet(CLAUDE_PERMISSION, 'claude')).toBe('waiting-approval')
+  it('sees the PERMISSION prompt, which is a different component with a different footer', () => {
+    // The bug this replaced: the rule was probed from the folder-trust dialog alone, so the one
+    // dialog people actually meet — "may I run this command" — read as `waiting`. It was not merely
+    // a wrong label: with the block invisible, typing a prompt into that session put the text into
+    // the dialog's filter and submitted it, taking the highlighted option.
+    expect(quiet(CLAUDE_BASH_PERMISSION, 'claude')).toBe('waiting-approval')
+    expect(quiet(CLAUDE_WRITE_PERMISSION, 'claude')).toBe('waiting-approval')
   })
 
-  it('recognises the permission prompt by its question as well as by its footer', () => {
-    // The footer varies with what the prompt offers — a plan-mode prompt has no `Tab to amend` —
-    // so the question has to stand on its own.
-    const noFooter = CLAUDE_PERMISSION.filter(l => !l.includes('Tab to amend'))
-    expect(quiet(noFooter, 'claude')).toBe('waiting-approval')
+  it('keys on the part BOTH permission dialogs share', () => {
+    // `ctrl+e to explain` is offered only where there is a command to explain, so a rule keyed on it
+    // would have gone on missing every file edit — the same class of miss all over again.
+    const rules = rulesFor('claude')!
+    const hits = (frame: string[]) =>
+      rules.approval.filter(re => re.test(frame.join('\n'))).length
+    expect(hits(CLAUDE_BASH_PERMISSION)).toBe(1)
+    expect(hits(CLAUDE_WRITE_PERMISSION)).toBe(1)
+  })
+
+  it('does not call a working turn blocked, now that there are two approval patterns', () => {
+    // A second pattern is a second chance to match something that is not a dialog.
+    expect(quiet(CLAUDE_WORKING, 'claude')).toBe('working')
+    expect(quiet(CLAUDE_IDLE, 'claude')).toBe('waiting')
   })
 
   it('sees a running turn from the footer, not from the input box', () => {

--- a/packages/server/server/sessions/attention-rules.ts
+++ b/packages/server/server/sessions/attention-rules.ts
@@ -33,10 +33,23 @@ import type { AttentionRules } from './types'
 
 export const ATTENTION_RULES: Record<HarnessId, AttentionRules | null> = {
   claude: {
-    probed: 'claude 2.1.231, 2026-08-13',
-    // The select component every blocking question uses — captured from the folder-trust dialog it
-    // opens with. The permission prompts and `/model` draw the same footer.
-    approval: [/Enter to confirm · Esc to cancel/],
+    probed: 'claude 2.1.231 2026-08-13; permission prompt re-probed on 2.1.232, 2026-08-14',
+    approval: [
+      // Captured from the folder-trust dialog claude opens with, and from `/model`.
+      /Enter to confirm · Esc to cancel/,
+      // THE PERMISSION PROMPT DOES NOT DRAW THAT FOOTER, and the comment here used to claim it did.
+      // Caught by watching a real session sit on `rm -v …` while the monitor reported plain
+      // `waiting`: a tool-permission prompt draws `Esc to cancel · Tab to amend · ctrl+e to
+      // explain` and asks `Do you want to proceed?`. Both are matched, because they fail
+      // independently — the footer varies with what the prompt offers (a plan-mode prompt has no
+      // `Tab to amend`), while the question is the component's own and does not.
+      //
+      // This is exactly the failure mode this file's header warns about, and it is worth recording
+      // that it happened anyway: a pattern that never matches does not throw and does not look
+      // wrong. It reported the ONE state this whole channel exists for as an ordinary wait.
+      /Do you want to proceed\?/,
+      /Esc to cancel · Tab to amend/,
+    ],
     // The footer while a turn runs. `? for shortcuts` takes its place when the turn ends.
     working: [/esc to interrupt/],
   },

--- a/packages/server/server/sessions/attention-rules.ts
+++ b/packages/server/server/sessions/attention-rules.ts
@@ -33,21 +33,24 @@ import type { AttentionRules } from './types'
 
 export const ATTENTION_RULES: Record<HarnessId, AttentionRules | null> = {
   claude: {
-    probed: 'claude 2.1.231 2026-08-13; permission prompt re-probed on 2.1.232, 2026-08-14',
+    probed: 'claude 2.1.231 + 2.1.232, 2026-08-13 and 2026-08-14',
     approval: [
-      // Captured from the folder-trust dialog claude opens with, and from `/model`.
+      // The startup/select component: the folder-trust dialog it opens with, and `/model`.
       /Enter to confirm · Esc to cancel/,
-      // THE PERMISSION PROMPT DOES NOT DRAW THAT FOOTER, and the comment here used to claim it did.
-      // Caught by watching a real session sit on `rm -v …` while the monitor reported plain
-      // `waiting`: a tool-permission prompt draws `Esc to cancel · Tab to amend · ctrl+e to
-      // explain` and asks `Do you want to proceed?`. Both are matched, because they fail
-      // independently — the footer varies with what the prompt offers (a plan-mode prompt has no
-      // `Tab to amend`), while the question is the component's own and does not.
+      // **The PERMISSION prompt, and it is a DIFFERENT component with a different footer.** The
+      // line above does not match it, which was measured the hard way on 2026-08-14: a live claude
+      // 2.1.232 sitting on "Do you want to proceed?" reported `waiting`, and the prompt that was
+      // then typed into it went into the dialog's own filter — where the submit selected the
+      // highlighted option and approved a shell command nobody had read. That is the exact accident
+      // this whole feature exists to prevent, and it was one rule away.
       //
-      // This is exactly the failure mode this file's header warns about, and it is worth recording
-      // that it happened anyway: a pattern that never matches does not throw and does not look
-      // wrong. It reported the ONE state this whole channel exists for as an ordinary wait.
-      /Do you want to proceed\?/,
+      // Captured from TWO distinct permission dialogs, which is what makes this the component's
+      // footer rather than one dialog's wording — the same standard the gemini entry below holds
+      // itself to:
+      //   Bash   `Esc to cancel · Tab to amend · ctrl+e to explain`
+      //   Write  `Esc to cancel · Tab to amend`
+      // The shared part is what is matched. `ctrl+e to explain` is offered only where there is a
+      // command to explain, so keying on it would have missed every file edit.
       /Esc to cancel · Tab to amend/,
     ],
     // The footer while a turn runs. `? for shortcuts` takes its place when the turn ends.

--- a/packages/server/server/sessions/session-view.ts
+++ b/packages/server/server/sessions/session-view.ts
@@ -63,6 +63,16 @@ export interface SessionView {
   effort?: string
   /** The piece of work this session belongs to, when the user said. Groups the list. */
   task?: string
+  /**
+   * The harness's own conversation id this row drives, when it is known EXACTLY.
+   *
+   * Carried from `ManagedSession.conversationId`, so it is present only for a session that was
+   * reopened from a conversation — we handed the id to the CLI, so there is nothing to guess. It is
+   * deliberately NOT filled from the harness+directory inference behind `resume`: that guess is
+   * good enough to offer a verb the user confirms by title, and not good enough to be the key the
+   * event channel deduplicates on. Absent is absent.
+   */
+  conversationId?: string
   createdMs?: number
   attached: boolean
   /**
@@ -209,6 +219,7 @@ export function buildSessionViews(o: {
       ...(r.managed?.model ? { model: r.managed.model } : {}),
       ...(r.managed?.effort ? { effort: r.managed.effort } : {}),
       ...(r.managed?.task ? { task: r.managed.task } : {}),
+      ...(r.managed?.conversationId ? { conversationId: r.managed.conversationId } : {}),
       // The backend's clock when there is a backend, the REGISTRY's when there is not. A row the
       // machine lost has no tmux session left to ask, so it reported no start time at all — and a
       // session you are deciding whether to reopen is one whose age is most of the decision.

--- a/packages/tui/src/control/i18n.ts
+++ b/packages/tui/src/control/i18n.ts
@@ -380,6 +380,8 @@ export interface ControlStrings {
   wizEffort: string
   wizPrompt: string
   wizPromptHint: string
+  wizName: string
+  wizNameHint: string
   wizHow: string
   /** Said while the session is being started, so `enter` is visibly doing something. */
   wizStarting: string
@@ -767,6 +769,8 @@ const EN: ControlStrings = {
   wizEffort: 'Which reasoning effort?',
   wizPrompt: 'First prompt (optional)',
   wizPromptHint: 'leave empty to start with nothing typed',
+  wizName: 'Call it what?',
+  wizNameHint: 'a name of your own — enter alone derives one from the harness and the folder',
   wizHow: 'Start it how?',
   wizStarting: 'starting…',
   wizKeptDraft: 'nothing you typed was lost — esc goes back a step, or try again',
@@ -1140,6 +1144,8 @@ const PT: ControlStrings = {
   wizEffort: 'Qual nível de raciocínio?',
   wizPrompt: 'Primeiro prompt (opcional)',
   wizPromptHint: 'deixe vazio para começar sem nada digitado',
+  wizName: 'Chamar de quê?',
+  wizNameHint: 'um nome seu — enter vazio deriva um do harness e da pasta',
   wizHow: 'Iniciar como?',
   wizStarting: 'iniciando…',
   wizKeptDraft: 'nada do que você digitou foi perdido — esc volta um passo, ou tente de novo',

--- a/packages/tui/src/control/i18n.ts
+++ b/packages/tui/src/control/i18n.ts
@@ -195,7 +195,15 @@ export interface ControlStrings {
   /** Said when the host does not implement the fleet at all — not the same as an empty fleet. */
   sessionsUnsupported: string
   /** The summary row: "3 sessions · 1 waiting on you". */
-  sessionsCount: (n: number) => string
+  /**
+   * How many rows are ON SCREEN, and out of how many the machine has.
+   *
+   * Two numbers, always, because one of them alone lies: with `only active` on, a fleet of 44 shows
+   * ten rows, and a header reading "44 sessions" over ten of them describes a screen nobody is
+   * looking at. `shown === total` is the case where the second number says nothing new, and that is
+   * the only case where it is dropped.
+   */
+  sessionsCount: (shown: number, total: number) => string
   sessionsWaitingCount: (n: number) => string
   sessionsGroupBy: string
   sessionsGroupings: Record<'none' | 'harness' | 'model' | 'project' | 'task' | 'repo', string>
@@ -553,7 +561,9 @@ const EN: ControlStrings = {
   sessionsEmptyFiltered: 'nothing matches · esc clears the filter',
   sessionsLoading: 'reading…',
   sessionsUnsupported: 'session management is not available on this machine.',
-  sessionsCount: (n: number) => (n === 1 ? '1 session' : `${n} sessions`),
+  sessionsCount: (shown: number, total: number) => (shown === total
+    ? (total === 1 ? '1 session' : `${total} sessions`)
+    : `${shown} of ${total} sessions`),
   sessionsWaitingCount: (n: number) => (n === 1 ? '1 waiting on you' : `${n} waiting on you`),
   sessionsGroupBy: 'GROUP',
   sessionsGroupings: {
@@ -928,7 +938,9 @@ const PT: ControlStrings = {
   sessionsEmptyFiltered: 'nada corresponde · esc limpa o filtro',
   sessionsLoading: 'lendo…',
   sessionsUnsupported: 'gerenciamento de sessões não está disponível nesta máquina.',
-  sessionsCount: (n: number) => (n === 1 ? '1 sessão' : `${n} sessões`),
+  sessionsCount: (shown: number, total: number) => (shown === total
+    ? (total === 1 ? '1 sessão' : `${total} sessões`)
+    : `${shown} de ${total} sessões`),
   sessionsWaitingCount: (n: number) => (n === 1 ? '1 esperando por você' : `${n} esperando por você`),
   sessionsGroupBy: 'AGRUPAR',
   sessionsGroupings: {

--- a/packages/tui/src/control/sessions.test.ts
+++ b/packages/tui/src/control/sessions.test.ts
@@ -1736,3 +1736,22 @@ describe('detailLines — named in two places', () => {
     expect(lines.map(l => l.key).slice(0, 3)).toEqual(['say0', 'also', 'where'])
   })
 })
+
+describe('the wizard name step', () => {
+  const harness = { id: 'claude', supportsModel: true }
+
+  it('carries a name the user typed', () => {
+    const plan = planSubmit({
+      draft: { harness, cwd: '/r', label: 'a refatoração do token' }, hasSpawn: true, attach: false,
+    })
+    expect(plan.ok).toBe(true)
+    if (plan.ok) expect(plan.req.label).toBe('a refatoração do token')
+  })
+
+  it('carries NO name when the step was skipped', () => {
+    // Enter on an untouched field means "no name of my own", and the row derives one from the
+    // harness and the folder. An empty string is not a name called "".
+    const plan = planSubmit({ draft: { harness, cwd: '/r', label: '' }, hasSpawn: true, attach: false })
+    if (plan.ok) expect('label' in plan.req).toBe(false)
+  })
+})

--- a/packages/tui/src/control/sessions.test.ts
+++ b/packages/tui/src/control/sessions.test.ts
@@ -14,6 +14,7 @@ import {
   type CardLine, type SessionRow,
 } from './sessions'
 import type { ControlSession, SessionState } from './types'
+import { controlStrings } from './i18n'
 
 /** The layout block every aside fixture carries — it is a required option, like the groupings. */
 const LAYOUT = {
@@ -1734,5 +1735,32 @@ describe('detailLines — named in two places', () => {
       labels, ago,
     )
     expect(lines.map(l => l.key).slice(0, 3)).toEqual(['say0', 'also', 'where'])
+  })
+})
+
+describe('the header count', () => {
+  const en = controlStrings('en')
+  const pt = controlStrings('pt')
+
+  it('says how many are ON SCREEN and out of how many', () => {
+    // The header read the fleet's length, so with `only active` on it announced 44 over a screen
+    // showing ten — a number describing a screen nobody is looking at.
+    expect(en.sessionsCount(10, 44)).toBe('10 of 44 sessions')
+    expect(pt.sessionsCount(10, 44)).toBe('10 de 44 sessões')
+  })
+
+  it('drops the second number when it says nothing new', () => {
+    // Nothing is being withheld, so "9 of 9" is noise where "9" is the fact.
+    expect(en.sessionsCount(9, 9)).toBe('9 sessions')
+    expect(pt.sessionsCount(9, 9)).toBe('9 sessões')
+    expect(en.sessionsCount(1, 1)).toBe('1 session')
+    expect(pt.sessionsCount(1, 1)).toBe('1 sessão')
+  })
+
+  it('is honest about an empty screen over a fleet that is not', () => {
+    // The case that matters most: the filter emptied the list, and the row must not read as an
+    // empty machine.
+    expect(en.sessionsCount(0, 44)).toBe('0 of 44 sessions')
+    expect(pt.sessionsCount(0, 44)).toBe('0 de 44 sessões')
   })
 })

--- a/packages/tui/src/control/sessions.ts
+++ b/packages/tui/src/control/sessions.ts
@@ -1541,6 +1541,8 @@ export interface SessionDraft {
   harness?: { id: string; supportsModel?: boolean }
   cwd?: string
   task?: string
+  /** The name the user typed for this session. Absent means "no name of my own" — the row derives one. */
+  label?: string
   prompt?: string
   model?: string
   effort?: string
@@ -1581,6 +1583,7 @@ export function planSubmit(o: {
       ...(o.draft.effort ? { effort: o.draft.effort } : {}),
       ...(o.draft.prompt ? { prompt: o.draft.prompt } : {}),
       ...(o.draft.task ? { task: o.draft.task } : {}),
+      ...(o.draft.label ? { label: o.draft.label } : {}),
     },
   }
 }

--- a/packages/tui/src/control/tabs/SessionWizard.tsx
+++ b/packages/tui/src/control/tabs/SessionWizard.tsx
@@ -56,12 +56,13 @@ import { COLORS } from '../../theme'
  * such flag: a question whose only answer is "not applicable" is a question that should not have
  * been asked, and `advance` is the single place that decides which ones a harness earns.
  */
-type Step = 'harness' | 'where' | 'task' | 'model' | 'effort' | 'prompt' | 'how'
+type Step = 'harness' | 'where' | 'task' | 'model' | 'effort' | 'prompt' | 'name' | 'how'
 
 interface Draft {
   harness?: SessionHarnessOption
   cwd?: string
   task?: string
+  label?: string
   model?: string
   effort?: string
   prompt?: string
@@ -93,7 +94,7 @@ export function SessionWizard({ host, strings: s, width, height, isActive, onCan
 
   /** The next step this harness actually earns, skipping the questions it has no flag for. */
   const nextAfter = useCallback((from: Step, h: SessionHarnessOption | undefined): Step => {
-    const order: Step[] = ['harness', 'where', 'task', 'model', 'effort', 'prompt', 'how']
+    const order: Step[] = ['harness', 'where', 'task', 'model', 'effort', 'prompt', 'name', 'how']
     let i = order.indexOf(from) + 1
     while (i < order.length) {
       const candidate = order[i]!
@@ -147,7 +148,7 @@ export function SessionWizard({ host, strings: s, width, height, isActive, onCan
   // answers because the sixth was a typo is a wizard people stop using.
   useInput((_input, key) => {
     if (!key.escape) return
-    const order: Step[] = ['harness', 'where', 'task', 'model', 'effort', 'prompt', 'how']
+    const order: Step[] = ['harness', 'where', 'task', 'model', 'effort', 'prompt', 'name', 'how']
     const i = order.indexOf(step)
     for (let j = i - 1; j >= 0; j--) {
       const prev = order[j]!
@@ -265,6 +266,29 @@ export function SessionWizard({ host, strings: s, width, height, isActive, onCan
             setStep(nextAfter('prompt', draft.harness))
           }}
           onCancel={() => setStep('where')}
+        />
+      </Box>
+    )
+  }
+
+  if (step === 'name') {
+    return (
+      <Box flexDirection="column" width={width}>
+        <Text dimColor>{truncate(s.wizNameHint, width)}</Text>
+        <TextPrompt
+          label={s.wizName}
+          // A PLACEHOLDER, never a `defaultValue`: `TextPrompt` treats a default as the answer to an
+          // empty submit, which is right for renaming and wrong here — enter on an untouched field
+          // means "no name of my own", and the row falls back to the derived one.
+          placeholder={draft.task ?? ''}
+          width={width}
+          isActive={isActive}
+          onSubmit={value => {
+            const label = value.trim()
+            setDraft(d => ({ ...d, ...(label ? { label } : {}) }))
+            setStep(nextAfter('name', draft.harness))
+          }}
+          onCancel={() => setStep('prompt')}
         />
       </Box>
     )

--- a/packages/tui/src/control/tabs/Sessions.tsx
+++ b/packages/tui/src/control/tabs/Sessions.tsx
@@ -1296,6 +1296,10 @@ export function Sessions({
           showClosed={showClosed}
           hideEmptyTask={grouping === 'task' ? hideEmptyTask : null}
           onlyActive={onlyActive}
+          // How many rows are ON SCREEN, counted from the very list being drawn. The header used to
+          // read the fleet's length, so with `only active` on it announced 44 over a screen showing
+          // ten — a number describing a screen nobody is looking at.
+          shown={rows.reduce((n, r) => n + (r.kind === 'session' ? 1 : 0), 0)}
           query={query}
           scope={projectFilter ?? taskFilter ?? ''}
           fell={fleet?.fell && fellAgo ? s.sessionsFellNote(fleet.fell.count, fellAgo) : ''}
@@ -1488,7 +1492,7 @@ export function Sessions({
  * to state the answer, so a glance tells you why the list looks the way it does.
  */
 function SummaryRow({
-  fleet, grouping, strings: s, width, showClosed, hideEmptyTask, onlyActive, query, scope, fell,
+  fleet, grouping, strings: s, width, showClosed, hideEmptyTask, onlyActive, shown, query, scope, fell,
 }: {
   fleet: ControlSessions | null | undefined
   grouping: SessionGrouping
@@ -1499,6 +1503,8 @@ function SummaryRow({
   hideEmptyTask: boolean | null
   /** The strict switch, which withholds more than the other two together. */
   onlyActive: boolean
+  /** Rows actually drawn, counted from the drawn list rather than from the fleet. */
+  shown: number
   /** The active search, or `''`. Stated HERE because a list narrowed silently reads as an empty one. */
   query: string
   /** The active task or project scope, already localized, or `''`. */
@@ -1539,7 +1545,7 @@ function SummaryRow({
   const cells = summaryCells({
     group: narrowed || `${s.sessionsGroupBy} ${s.sessionsGroupings[grouping]}`,
     hiding: hiding.length > 0 ? `− ${hiding.join(', ')}` : '',
-    count: s.sessionsCount(fleet?.sessions.length ?? 0),
+    count: s.sessionsCount(shown, fleet?.sessions.length ?? 0),
     waiting: waiting > 0 ? s.sessionsWaitingCount(waiting) : '',
     fell,
     width,


### PR DESCRIPTION
## A state change reaches you

`agentop events` — a transition in any session (waiting, waiting on approval, exited) lands in an append-only inbox at `~/.agentistics/events.jsonl`, and from there notifies both the user and the Claude session orchestrating the fleet.

The inbox is the point, not a cache: whoever consumes may not be running at the time, and an event delivered to nobody is an event lost. It is fed by two sources — the poller (every harness, reads the screen) and Claude Code's `Stop` hook (exact, no inference) — de-duplicated, because the same end-of-turn arrives by both.

**A state only counts once observed in two consecutive polls.** The first attempt was a time window and it did not work: a repaint flickered the state 10s apart, then 45s apart when a plugin printed a notice, and any window wide enough to swallow the second also swallows a legitimate second turn — which is the thing the channel exists to report. A repaint is one frame and never confirms.

The producer rides the daemon `agentop server` already runs rather than being a service of its own: a process the user must remember to start is a process that is dead when it matters. `events status` reports it as running / stale / **absent**, because "nothing arrived" and "nobody was watching" are different facts.

Desktop notification is a declared cascade — **ccn** → `notify-send` → `powershell.exe` → terminal bell → inbox only — each rung named in a sentence by `status`. ccn is *detected*, not vendored: it ships through Claude Code's plugin system on its own release cycle, and a bundled copy is two versions that drift. What the pairing buys is what neither does alone: ccn only knows Claude sessions, and agentop detects transitions in all six harnesses and knows the task.

**The frontier is code, not intention.** `SessionEvent` carries no field that could hold an instruction, a subscription may request delivery and never action, and `events-frontier.test.ts` reads the modules' own source — a field named `action` or a sentence in the imperative fails the build.

## The wizard asks what to call it

Seven steps and none of them was the name, so a session started from the cockpit wore the derived label until someone renamed it afterwards. The field is a placeholder, never a `defaultValue`: enter on an untouched field means "no name of my own", and an empty string is not a name called "".

## A count that matches the screen

The header read the fleet's length while the list under it had been through `only active`, the history switches, a scope and a search — `44 sessões` over ten rows. It counts what is drawn and says both: `10 de 44`. When they are equal the second says nothing new and is dropped.

Tests: 3638 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019vBSuKQLuyLhWZS4zbiu2s