### PR TITLE
release: cards grouped one band per group

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1170,6 +1170,24 @@ packages/tui/scripts/preview.tsx   dev tool: render ONE control-center frame to 
   A cell nothing on screen carries is ZERO and costs no gap. Measuring against the pane rather than
   its body made every column four characters too wide, and the table survived only because Ink
   truncated it.
+- **The CARD layout is the same rows in another shape, and a card names every fact it carries.**
+  `cardPages` walks the very `SessionRow[]` the list draws, so what a group is called, which ones
+  are muted and where the history section begins are decided ONCE, in `sessionRows`. A band belongs
+  to one GROUP — the air to the right of a one-card group is what separates it from the next, not
+  waste, and filling it with the following group's cards is how the grid used to ignore the
+  grouping it was drawn under. A heading is never placed without a row of cards under it, and a
+  group crossing a page break REPEATS its name (within a page it is said once — it is a band or two
+  above and plainly governs what follows). Each group is named exactly ONCE per card: by the band's
+  heading when there is one, and otherwise by the card's own frame title, with the session HANDLE
+  moving to the badge — cut to `paneTitleRoom`, because `paneTop` drops a badge whole rather than
+  truncate a title and the handle is the prefix `agentop session attach 3f5f` resolves. A fact whose
+  value IS that name is dropped from the card, the same rule `sessionColumns` applies to its `task`
+  cell while grouping by task. The facts a reader cannot name from the value alone — the folder, the
+  model, the task, the note — carry a LABEL, in the words `sessionsCols` already prints over the
+  list's columns; the labels are aligned in one column and given up ALL AT ONCE
+  (`cardLabelWidth`), because labels that come and go leave the values starting at different
+  columns. And a card is never taller than it has content for: `cardGrid` takes the line count the
+  screen measured, or rows of blank inside a frame are a box with a name in it.
 - **`stats-cache.json` stays Claude-only here too.** `selectors.ts` reads Claude totals from the
   cache and every other harness from per-session sums; `applyHarnessFilter` blanks the cache when
   a non-Claude harness is selected, or Claude's numbers would survive the filter.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1187,7 +1187,13 @@ packages/tui/scripts/preview.tsx   dev tool: render ONE control-center frame to 
   list's columns; the labels are aligned in one column and given up ALL AT ONCE
   (`cardLabelWidth`), because labels that come and go leave the values starting at different
   columns. And a card is never taller than it has content for: `cardGrid` takes the line count the
-  screen measured, or rows of blank inside a frame are a box with a name in it.
+  screen measured and each BAND is then sized to its own tallest card, because one height for the
+  whole grid is the height of the richest card in the fleet — one session carrying a model, a task
+  and a note made every other card two rows taller than it had anything to put in them, and rows of
+  blank inside a frame are a box with a name in it. The band and not the card: cards of one band
+  stand side by side, and giving each its own height leaves the row's bottom edge ragged, which is
+  worse to look at than the one blank line a short card beside a rich one still keeps. The rows a
+  short band gives back become another band on the page, not air under the pager.
 - **`stats-cache.json` stays Claude-only here too.** `selectors.ts` reads Claude totals from the
   cache and every other harness from per-session sums; `applyHarnessFilter` blanks the cache when
   a non-Claude harness is selected, or Claude's numbers would survive the filter.

--- a/packages/tui/src/control/chrome.test.ts
+++ b/packages/tui/src/control/chrome.test.ts
@@ -26,6 +26,7 @@ import {
   LEFT_MIN,
   paneTop,
   paneBadgeRoom,
+  paneTitleRoom,
   PANE_FRAME_X,
   PANE_FRAME_Y,
   PANE_MIN_ROWS,
@@ -40,6 +41,7 @@ import {
   type TabSpec,
 } from './chrome.ts'
 import { TAB_ORDER, type ControlService, type ServiceRuntimeState } from './types'
+import { truncate } from '../components/Primitives'
 import { PANE_ORDER } from './nav'
 import { brandMark, brandWidth, WORDMARK_ART } from '../components/Wordmark'
 import { controlStrings } from './i18n'
@@ -341,6 +343,32 @@ describe('paneTop', () => {
     expect(top.title).toBe('')
     expect(top.head.startsWith('╭')).toBe(true)
     expect(top.tail).toBe('╮')
+  })
+})
+
+describe('paneTitleRoom', () => {
+  // The inverse of `paneBadgeRoom`, for the caller whose BADGE is the thing that may not disappear:
+  // a card puts the session handle there, and `paneTop` would drop it whole rather than cut the
+  // project name in the title. Cutting the title first is what keeps the handle on the frame.
+  test('a title cut to this width never costs a badge the frame could have drawn', () => {
+    const long = 'a-very-long-project-name-indeed'
+    for (const badge of ['a1b2c', 'following']) {
+      for (let w = 0; w <= 120; w++) {
+        // What the frame can do at ALL at this width: the shortest possible title, which is the
+        // most room a badge can ever be given.
+        const best = paneTop('x', badge, w).badge
+        const cut = paneTop(truncate(long, paneTitleRoom(badge, w)), badge, w).badge
+        expect(cut).toBe(best)
+      }
+      // And the cut is only ever as deep as the badge needs: with the badge gone, the title takes
+      // everything the frame has.
+      expect(paneTitleRoom('', 40)).toBeGreaterThan(paneTitleRoom(badge, 40))
+    }
+  })
+
+  test('a pane with no badge gives the whole budget to the title', () => {
+    expect(paneTitleRoom('', 40)).toBeGreaterThan(paneTitleRoom('a1b2c', 40))
+    expect(paneTitleRoom('a1b2c', 0)).toBe(0)
   })
 })
 

--- a/packages/tui/src/control/chrome.ts
+++ b/packages/tui/src/control/chrome.ts
@@ -390,6 +390,23 @@ export function paneBadgeRoom(title: string, width: number): number {
   return Math.max(0, budget - shownTitle.length - 3)
 }
 
+/**
+ * The widest TITLE that still leaves `paneTop` room to draw this badge — PURE, and the inverse of
+ * `paneBadgeRoom`.
+ *
+ * `paneTop` serves the title first and then keeps the badge whole or not at all, which is right when
+ * the badge repeats something the pane's rows already say and wrong when the badge is the only place
+ * a fact appears. A card puts the session HANDLE there — the prefix `agentop session attach 3f5f`
+ * resolves, and the one thing on the card naming the session to anything outside this screen — so a
+ * long project name in the title must be cut to make room for it, rather than silently taking it.
+ */
+export function paneTitleRoom(badge: string, width: number): number {
+  if (width < TOP_MIN) return 0
+  const budget = width - TOP_OVERHEAD
+  const whole = Math.max(1, budget - 1)
+  return badge === '' ? whole : Math.max(1, Math.min(whole, budget - badge.length - 3))
+}
+
 // ---------------------------------------------------------------------------
 // row cells shared by the two band panes
 //

--- a/packages/tui/src/control/sessions.test.ts
+++ b/packages/tui/src/control/sessions.test.ts
@@ -10,10 +10,11 @@ import {
   cardGrid, cardPages, pageOfCard, CARD_PAGE_MAX, CARD_MIN_WIDTH, CARD_GAP, CARD_LINES,
   cardBadges, cardLines, fitCardLines, cardStateCells, cardLabelWidth, CARD_VALUE_MIN,
   cardBand, cardHit, cardStep, cardRows, cardPageRows, pagerCells, pagerHit,
-  askRows, fitApprovalPreview, APPROVAL_PREVIEW_MAX, QUESTION_ROWS,
+  askRows, fitApprovalPreview, APPROVAL_PREVIEW_MAX, QUESTION_ROWS, CARD_MIN_LINES,
   type CardBand, type CardLine, type SessionRow,
 } from './sessions'
 import type { ControlSession, SessionState } from './types'
+import { PANE_FRAME_Y } from './chrome.ts'
 import { controlStrings } from './i18n'
 
 /** The layout block every aside fixture carries — it is a required option, like the groupings. */
@@ -1327,9 +1328,9 @@ describe('cardPages', () => {
     expect(pages).toHaveLength(1)
     expect(pages[0]!.bands).toEqual([
       { kind: 'heading', label: 'agentistics', count: 2, muted: false },
-      { kind: 'cards', items: [0, 1] },
+      { kind: 'cards', items: [0, 1], height: 7 },
       { kind: 'heading', label: 'aipe', count: 1, muted: false },
-      { kind: 'cards', items: [2] },
+      { kind: 'cards', items: [2], height: 7 },
     ] satisfies CardBand[])
   })
 
@@ -1382,7 +1383,7 @@ describe('cardPages', () => {
           const pages = pack(grouped(['a', 5], ['b', 1], ['c', 9], ['d', 2]),
             { cols, gridRows, cardHeight, capacity: Math.min(cols * 3, CARD_PAGE_MAX) })
           for (const page of pages) {
-            expect(cardPageRows(page.bands, cardHeight)).toBeLessThanOrEqual(gridRows)
+            expect(cardPageRows(page.bands)).toBeLessThanOrEqual(gridRows)
             expect(page.items.length).toBeLessThanOrEqual(Math.min(cols * 3, CARD_PAGE_MAX))
           }
         }
@@ -1398,8 +1399,8 @@ describe('cardPages', () => {
       headed: false,
     })
     expect(pages[0]!.bands).toEqual([
-      { kind: 'cards', items: [0, 1, 2] },
-      { kind: 'cards', items: [3, 4] },
+      { kind: 'cards', items: [0, 1, 2], height: 7 },
+      { kind: 'cards', items: [3, 4], height: 7 },
     ] as CardBand[])
   })
 
@@ -1414,6 +1415,63 @@ describe('cardPages', () => {
   it('has no pages at all for an empty fleet', () => {
     expect(pack([])).toEqual([])
     expect(pack([{ kind: 'heading', label: 'a', count: 0 }])).toEqual([])
+  })
+
+  // One height for the whole grid is the height of the RICHEST card in the fleet, so a single
+  // session carrying a model, a task and a note made every other card two rows taller than it had
+  // anything to put in them. Rows of blank inside a frame are a box with a name in it.
+  it('sizes each band to its own tallest card', () => {
+    // Six cards: the first band's are rich, the second band's have two facts each.
+    const [page] = cardPages({
+      rows: grouped(['rich', 2], ['plain', 2]),
+      cols: 2, gridRows: 40, cardHeight: 8, capacity: 8, headed: true,
+      lines: [6, 5, 2, 2],
+    })
+    const heights = page!.bands.flatMap(b => (b.kind === 'cards' ? [b.height] : []))
+    // The rich band takes its tallest card; the plain band gives the rows back.
+    expect(heights).toEqual([PANE_FRAME_Y + 6, PANE_FRAME_Y + CARD_MIN_LINES])
+  })
+
+  // A band is never squeezed below what makes a card a card, and never grows past what the region
+  // can afford — the ceiling `cardGrid` measured.
+  it('keeps every band between the card floor and the region’s ceiling', () => {
+    for (let cardHeight = 5; cardHeight <= 8; cardHeight++) {
+      const pages = cardPages({
+        rows: grouped(['a', 3], ['b', 2]),
+        cols: 2, gridRows: 44, cardHeight, capacity: 6, headed: true,
+        lines: [9, 1, 0, 4, 2],
+      })
+      for (const page of pages) {
+        for (const b of page.bands) {
+          if (b.kind !== 'cards') continue
+          expect(b.height).toBeGreaterThanOrEqual(
+            Math.min(cardHeight, PANE_FRAME_Y + CARD_MIN_LINES))
+          expect(b.height).toBeLessThanOrEqual(cardHeight)
+        }
+      }
+    }
+  })
+
+  // The rows a short band gives back become another band on the page, not air under the pager.
+  it('spends the rows a short band gives back on more bands', () => {
+    const rows = grouped(['a', 1], ['b', 1], ['c', 1], ['d', 1])
+    const uniform = cardPages({
+      rows, cols: 2, gridRows: 20, cardHeight: 8, capacity: 8, headed: true,
+    })
+    const measured = cardPages({
+      rows, cols: 2, gridRows: 20, cardHeight: 8, capacity: 8, headed: true,
+      lines: [3, 3, 3, 3],
+    })
+    // Four groups of one, so every band costs a heading plus a card: at the ceiling that is 9 rows
+    // and two fit; measured it is 6 and three do.
+    expect(uniform[0]!.items).toHaveLength(2)
+    expect(measured[0]!.items).toHaveLength(3)
+  })
+
+  // Without the counts every band takes the ceiling — the uniform grid, unchanged.
+  it('is the uniform grid when the caller counted nothing', () => {
+    const [page] = pack(grouped(['a', 2]))
+    expect(page!.bands.flatMap(b => (b.kind === 'cards' ? [b.height] : []))).toEqual([7])
   })
 })
 
@@ -1611,12 +1669,13 @@ describe('cardHit', () => {
   const grid = cardGrid({ width: 100, height: 21, total: 10 })!
   const bands: CardBand[] = [
     { kind: 'heading', label: 'agentistics', count: 3, muted: false },
-    { kind: 'cards', items: [0, 1, 2] },
+    { kind: 'cards', items: [0, 1, 2], height: grid.cardHeight },
     { kind: 'heading', label: 'aipe', count: 1, muted: false },
-    { kind: 'cards', items: [3] },
+    // Shorter than the band above it — the bands of one page do NOT share a height.
+    { kind: 'cards', items: [3], height: grid.cardHeight - 1 },
   ]
   const hit = (x: number, y: number) =>
-    cardHit({ bands, cardWidth: grid.cardWidth, cardHeight: grid.cardHeight, gap: grid.gap, x, y })
+    cardHit({ bands, cardWidth: grid.cardWidth, gap: grid.gap, x, y })
 
   // Resolved against the bands that were DRAWN, never against a uniform grid: a heading costs a row
   // and re-deriving the geometry from `cols` answers with the card one row up.
@@ -1640,7 +1699,7 @@ describe('cardHit', () => {
   })
 
   it('never answers with a card the page does not hold', () => {
-    const height = cardPageRows(bands, grid.cardHeight)
+    const height = cardPageRows(bands)
     for (let y = 0; y < height + 2; y++) {
       for (let x = 0; x < grid.cols * (grid.cardWidth + grid.gap) + 2; x++) {
         const found = hit(x, y)
@@ -1657,13 +1716,13 @@ describe('cardStep', () => {
     {
       bands: [
         { kind: 'heading', label: 'a', count: 1, muted: false },
-        { kind: 'cards', items: [0] },
+        { kind: 'cards', items: [0], height: 7 },
         { kind: 'heading', label: 'b', count: 3, muted: false },
-        { kind: 'cards', items: [1, 2, 3] },
+        { kind: 'cards', items: [1, 2, 3], height: 7 },
       ] as CardBand[],
       items: [0, 1, 2, 3],
     },
-    { bands: [{ kind: 'cards', items: [4, 5] }] as CardBand[], items: [4, 5] },
+    { bands: [{ kind: 'cards', items: [4, 5], height: 7 }] as CardBand[], items: [4, 5] },
   ]
 
   it('steps band to band, keeping the column', () => {

--- a/packages/tui/src/control/sessions.test.ts
+++ b/packages/tui/src/control/sessions.test.ts
@@ -7,11 +7,11 @@ import {
   sessionHandle, worktreeName, sessionRunning, asideRowKey, resolveAsideCursor,
   sessionAge, sessionKeyHelp, keyHelpColumn,
   DEFAULT_ORDER, usageOf, planSubmit,
-  cardGrid, cardPage, CARD_PAGE_MAX, CARD_MIN_WIDTH, CARD_GAP,
-  cardBadges, cardLines, fitCardLines, cardStateCells,
-  cardBand, cardAt, pagerCells, pagerHit,
+  cardGrid, cardPages, pageOfCard, CARD_PAGE_MAX, CARD_MIN_WIDTH, CARD_GAP, CARD_LINES,
+  cardBadges, cardLines, fitCardLines, cardStateCells, cardLabelWidth, CARD_VALUE_MIN,
+  cardBand, cardHit, cardStep, cardRows, cardPageRows, pagerCells, pagerHit,
   askRows, fitApprovalPreview, APPROVAL_PREVIEW_MAX, QUESTION_ROWS,
-  type CardLine, type SessionRow,
+  type CardBand, type CardLine, type SessionRow,
 } from './sessions'
 import type { ControlSession, SessionState } from './types'
 import { controlStrings } from './i18n'
@@ -1302,19 +1302,133 @@ describe('cardGrid', () => {
   })
 })
 
-describe('cardPage', () => {
-  it('reports the pages a total actually needs', () => {
-    expect(cardPage(47, 6, 0)).toEqual({ page: 0, pages: 8, from: 0, to: 6 })
-    expect(cardPage(12, 6, 1)).toEqual({ page: 1, pages: 2, from: 6, to: 12 })
+describe('cardPages', () => {
+  /** `n` sessions under one heading, in the shape `sessionRows` hands over. */
+  const grouped = (...groups: Array<[string, number]>): SessionRow[] => {
+    const out: SessionRow[] = []
+    let n = 0
+    for (const [label, count] of groups) {
+      if (out.length > 0) out.push({ kind: 'spacer' })
+      out.push({ kind: 'heading', label, count })
+      for (let i = 0; i < count; i++) out.push({ kind: 'session', session: session(`s${n++}`) })
+    }
+    return out
+  }
+  const flat = (n: number): SessionRow[] =>
+    Array.from({ length: n }, (_, i) => ({ kind: 'session', session: session(`s${i}`) }))
+
+  const pack = (rows: SessionRow[], o: Partial<Parameters<typeof cardPages>[0]> = {}) =>
+    cardPages({ rows, cols: 3, gridRows: 24, cardHeight: 7, capacity: 9, headed: true, ...o })
+
+  // The whole point of the change: a band belongs to ONE group, so a short group leaves the rest of
+  // its band empty rather than being padded out with the next group's cards.
+  it('gives every group its own bands', () => {
+    const pages = pack(grouped(['agentistics', 2], ['aipe', 1]))
+    expect(pages).toHaveLength(1)
+    expect(pages[0]!.bands).toEqual([
+      { kind: 'heading', label: 'agentistics', count: 2, muted: false },
+      { kind: 'cards', items: [0, 1] },
+      { kind: 'heading', label: 'aipe', count: 1, muted: false },
+      { kind: 'cards', items: [2] },
+    ] satisfies CardBand[])
   })
 
-  // The list re-sorts every five seconds and a filter can empty it between two polls, so a page
-  // index is always one frame away from pointing past the end — and that is the frame someone
-  // presses a key on.
-  it('clamps a page left pointing past the end', () => {
-    expect(cardPage(7, 6, 9)).toEqual({ page: 1, pages: 2, from: 6, to: 7 })
-    expect(cardPage(0, 6, 3)).toEqual({ page: 0, pages: 1, from: 0, to: 0 })
-    expect(cardPage(7, 0, 0).pages).toBe(7)
+  // A group wider than the grid wraps into more bands of its OWN — never into the next group's.
+  it('wraps a long group into further bands under one name', () => {
+    const [page] = pack(grouped(['agentistics', 7]), { gridRows: 40, capacity: 9 })
+    expect(page!.bands.filter(b => b.kind === 'heading')).toHaveLength(1)
+    expect(page!.bands.filter(b => b.kind === 'cards').map(b => b.items))
+      .toEqual([[0, 1, 2], [3, 4, 5], [6]])
+  })
+
+  // A name with nothing named under it is a row spent saying nothing, and it is the row the page
+  // needed for the card that would have answered it.
+  it('never ends a page with a heading and no cards', () => {
+    for (let gridRows = 8; gridRows <= 40; gridRows++) {
+      for (const pages of [pack(grouped(['a', 3], ['b', 2], ['c', 4]), { gridRows })]) {
+        for (const page of pages) {
+          expect(page.bands.at(-1)?.kind).toBe('cards')
+          expect(page.items.length).toBeGreaterThan(0)
+        }
+      }
+    }
+  })
+
+  // A card under no name does not say what it belongs to — the same orphan the grouping exists to
+  // prevent, wearing a page break instead of a band break.
+  it('repeats a split group name at the top of the next page', () => {
+    const pages = pack(grouped(['agentistics', 6]), { gridRows: 14, cardHeight: 7 })
+    expect(pages.length).toBeGreaterThan(1)
+    for (const page of pages) expect(page.bands[0]).toMatchObject({ kind: 'heading', label: 'agentistics' })
+  })
+
+  // Every card is on exactly one page, in order — a packer that drops one loses a session from a
+  // screen whose whole job is showing them all.
+  it('places every card exactly once, in order', () => {
+    for (let cols = 1; cols <= 5; cols++) {
+      for (let gridRows = 9; gridRows <= 40; gridRows += 3) {
+        const pages = pack(grouped(['a', 4], ['b', 1], ['c', 7]), { cols, gridRows })
+        expect(pages.flatMap(p => p.items)).toEqual(Array.from({ length: 12 }, (_, i) => i))
+      }
+    }
+  })
+
+  // Every page must fit the band it was measured against: Ink composites the overflow onto the rows
+  // below rather than clipping it, which reads as a corrupted frame rather than a cramped one.
+  it('never packs a page taller than the region or wider than the cap', () => {
+    for (let cols = 1; cols <= 5; cols++) {
+      for (let cardHeight = 5; cardHeight <= 8; cardHeight++) {
+        for (let gridRows = cardHeight + 1; gridRows <= 44; gridRows++) {
+          const pages = pack(grouped(['a', 5], ['b', 1], ['c', 9], ['d', 2]),
+            { cols, gridRows, cardHeight, capacity: Math.min(cols * 3, CARD_PAGE_MAX) })
+          for (const page of pages) {
+            expect(cardPageRows(page.bands, cardHeight)).toBeLessThanOrEqual(gridRows)
+            expect(page.items.length).toBeLessThanOrEqual(Math.min(cols * 3, CARD_PAGE_MAX))
+          }
+        }
+      }
+    }
+  })
+
+  // With no grouping the screen must draw exactly what it drew before groups reached it: one dense
+  // run of cards, `cols` at a time, and no row spent on a name.
+  it('packs one dense nameless run when it is not drawing headings', () => {
+    const pages = cardPages({
+      rows: grouped(['a', 2], ['b', 3]), cols: 3, gridRows: 24, cardHeight: 7, capacity: 9,
+      headed: false,
+    })
+    expect(pages[0]!.bands).toEqual([
+      { kind: 'cards', items: [0, 1, 2] },
+      { kind: 'cards', items: [3, 4] },
+    ] as CardBand[])
+  })
+
+  it('is the plain grid when the rows carry no heading at all', () => {
+    const pages = cardPages({
+      rows: flat(5), cols: 2, gridRows: 21, cardHeight: 7, capacity: 6, headed: true,
+    })
+    expect(pages[0]!.bands.every(b => b.kind === 'cards')).toBe(true)
+    expect(pages[0]!.items).toEqual([0, 1, 2, 3, 4])
+  })
+
+  it('has no pages at all for an empty fleet', () => {
+    expect(pack([])).toEqual([])
+    expect(pack([{ kind: 'heading', label: 'a', count: 0 }])).toEqual([])
+  })
+})
+
+describe('pageOfCard', () => {
+  const pages = [
+    { bands: [], items: [0, 1] },
+    { bands: [], items: [2, 3] },
+  ]
+
+  it('finds the page holding a card, and opens the first for one no page holds', () => {
+    expect(pageOfCard(pages, 3)).toBe(1)
+    expect(pageOfCard(pages, 0)).toBe(0)
+    // A cursor past the end for one frame — which is the frame someone presses a key on.
+    expect(pageOfCard(pages, 99)).toBe(0)
+    expect(pageOfCard([], 0)).toBe(0)
   })
 })
 
@@ -1341,8 +1455,63 @@ describe('cardBadges', () => {
 })
 
 describe('cardLines', () => {
-  const labels = { attached: 'attached', blind: 'approval unknown', ago: () => '22min ago' }
+  const labels = {
+    attached: 'attached', blind: 'approval unknown', ago: () => '22min ago',
+    worktree: 'worktree', project: 'project', task: 'task', note: 'note', model: 'model',
+  }
   const base = session('a1b2c3', { title: 'migrate the auth store', harness: 'claude' })
+
+  // The complaint this whole change answers: `session-monitor` is a folder and
+  // `cockpit: event channel` is a task, drawn identically, with nothing on the card saying which is
+  // which. The list solves it with a column header the grid has no room for.
+  it('names every fact a reader cannot name from its value', () => {
+    const lines = cardLines({
+      ...base, project: 'session-monitor', projectGroup: 'agentistics', worktree: true,
+      model: 'opus', task: 'billing', note: 'blocked on the CSV encoding',
+    }, labels)
+    const label = (key: string) => lines.find(l => l.key === key)?.label
+    expect(label('where')).toBe('worktree')
+    expect(label('model')).toBe('model')
+    expect(label('task')).toBe('task')
+    expect(label('note')).toBe('note')
+    // And leaves alone the ones that say what they are.
+    expect(label('title')).toBeUndefined()
+    expect(label('state')).toBeUndefined()
+    expect(label('usage')).toBeUndefined()
+  })
+
+  // A worktree and a project are the same shape of word, so the label is what tells them apart.
+  it('says which KIND of place the folder is', () => {
+    expect(cardLines({ ...base, project: 'notes' }, labels).find(l => l.key === 'where'))
+      .toMatchObject({ text: 'notes', label: 'project' })
+    expect(cardLines(
+      { ...base, project: 'notes', projectGroup: 'agentistics', worktree: true }, labels,
+    ).find(l => l.key === 'where')).toMatchObject({ text: 'notes', label: 'worktree' })
+  })
+
+  // Appended to the folder it was a bare word after a path, which reads as another path.
+  it('gives the model a line of its own, and none when there is no model', () => {
+    expect(cardLines({ ...base, model: 'opus' }, labels).find(l => l.key === 'model')?.text)
+      .toBe('opus')
+    expect(cardLines(base, labels).some(l => l.key === 'model')).toBe(false)
+    expect(cardLines({ ...base, model: 'opus' }, labels).find(l => l.key === 'where')?.text)
+      .not.toContain('opus')
+  })
+
+  // The ORDER is the give-up order — `fitCardLines` cuts from the bottom — so it is the thing worth
+  // pinning: the name and the state can never be lost, and a card as tall as `CARD_LINES` reaches
+  // the task. The note and what the assistant is saying are below that and are the two a full card
+  // gives up, exactly as they were before the model took a line of its own.
+  it('composes its facts in the order a short card gives them up', () => {
+    const full = cardLines({
+      ...base, tokens: '51.7k', cost: '$1.24', model: 'opus', task: 'billing', note: 'a note',
+      lastLines: ['running the migration'],
+    }, labels)
+    expect(full.map(l => l.key))
+      .toEqual(['title', 'state', 'usage', 'where', 'model', 'task', 'note', 'say'])
+    expect(fitCardLines(full, CARD_LINES).map(l => l.key))
+      .toEqual(['title', 'state', 'usage', 'where', 'model', 'task'])
+  })
 
   it('always carries the name and the state, in that order', () => {
     const lines = cardLines(base, labels)
@@ -1412,33 +1581,109 @@ describe('cardBand', () => {
   })
 })
 
-describe('cardAt', () => {
+describe('cardLabelWidth', () => {
+  const lines: CardLine[] = [
+    { key: 'title', kind: 'title', text: 'migrate the auth store' },
+    { key: 'where', kind: 'fact', text: 'session-monitor', label: 'worktree' },
+    { key: 'task', kind: 'fact', text: 'billing', label: 'task' },
+  ]
+
+  // One column for every label on the card, so the values all start in the same place — the jumble
+  // `sessionColumns` prevents on the list, prevented on the card.
+  it('sizes the column to the widest label the card actually carries', () => {
+    expect(cardLabelWidth(lines, 40)).toBe('worktree'.length)
+  })
+
+  // `worktree  sess…` names the field and stops answering which one, which is the trade the labels
+  // exist to avoid. All-or-nothing per card: labels that come and go leave a ragged column.
+  it('gives up the labels rather than squeeze the values below what they need', () => {
+    expect(cardLabelWidth(lines, 'worktree'.length + 2 + CARD_VALUE_MIN)).toBe(8)
+    expect(cardLabelWidth(lines, 'worktree'.length + 2 + CARD_VALUE_MIN - 1)).toBe(0)
+  })
+
+  it('spends nothing on a card with no labelled line', () => {
+    expect(cardLabelWidth([lines[0]!], 40)).toBe(0)
+    expect(cardLabelWidth([], 40)).toBe(0)
+  })
+})
+
+describe('cardHit', () => {
   const grid = cardGrid({ width: 100, height: 21, total: 10 })!
+  const bands: CardBand[] = [
+    { kind: 'heading', label: 'agentistics', count: 3, muted: false },
+    { kind: 'cards', items: [0, 1, 2] },
+    { kind: 'heading', label: 'aipe', count: 1, muted: false },
+    { kind: 'cards', items: [3] },
+  ]
+  const hit = (x: number, y: number) =>
+    cardHit({ bands, cardWidth: grid.cardWidth, cardHeight: grid.cardHeight, gap: grid.gap, x, y })
 
-  it('answers with the card whose own cells were clicked', () => {
-    expect(cardAt(grid, 0, 0)).toBe(0)
-    expect(cardAt(grid, grid.cardWidth - 1, grid.cardHeight - 1)).toBe(0)
-    expect(cardAt(grid, grid.cardWidth + grid.gap, 0)).toBe(1)
-    expect(cardAt(grid, 0, grid.cardHeight)).toBe(grid.cols)
+  // Resolved against the bands that were DRAWN, never against a uniform grid: a heading costs a row
+  // and re-deriving the geometry from `cols` answers with the card one row up.
+  it('answers with the card whose own cells were clicked, headings paid for', () => {
+    expect(hit(0, 1)).toBe(0)
+    expect(hit(grid.cardWidth - 1, grid.cardHeight)).toBe(0)
+    expect(hit(grid.cardWidth + grid.gap, 1)).toBe(1)
+    // The second group's band starts after the first band AND its own heading row.
+    expect(hit(0, 1 + grid.cardHeight + 1)).toBe(3)
   })
 
-  // The gutter between two cards belongs to neither, and a hit test that rounds it into one of them
-  // answers a click the user did not make.
-  it('answers nothing for the gutter and for the air past the grid', () => {
-    expect(cardAt(grid, grid.cardWidth, 0)).toBeNull()
-    expect(cardAt(grid, grid.cols * (grid.cardWidth + grid.gap), 0)).toBeNull()
-    expect(cardAt(grid, 0, grid.rows * grid.cardHeight)).toBeNull()
-    expect(cardAt(grid, -1, 0)).toBeNull()
+  // The gutter belongs to neither card, a heading belongs to no card, and the empty right-hand end
+  // of a short group's band is not a card either — each is a click the user did not make.
+  it('answers nothing for the gutter, the headings and a short band’s empty end', () => {
+    expect(hit(grid.cardWidth, 1)).toBeNull()
+    expect(hit(0, 0)).toBeNull()
+    expect(hit(0, 1 + grid.cardHeight)).toBeNull()
+    expect(hit(grid.cardWidth + grid.gap, 1 + grid.cardHeight + 1)).toBeNull()
+    expect(hit(0, 99)).toBeNull()
+    expect(hit(-1, 1)).toBeNull()
   })
 
-  it('never answers past the page it drew', () => {
-    const small = cardGrid({ width: 200, height: 40, total: 3 })!
-    for (let y = 0; y < small.rows * small.cardHeight; y++) {
-      for (let x = 0; x < small.cols * (small.cardWidth + small.gap); x++) {
-        const hit = cardAt(small, x, y)
-        if (hit !== null) expect(hit).toBeLessThan(small.capacity)
+  it('never answers with a card the page does not hold', () => {
+    const height = cardPageRows(bands, grid.cardHeight)
+    for (let y = 0; y < height + 2; y++) {
+      for (let x = 0; x < grid.cols * (grid.cardWidth + grid.gap) + 2; x++) {
+        const found = hit(x, y)
+        if (found !== null) expect([0, 1, 2, 3]).toContain(found)
       }
     }
+  })
+})
+
+describe('cardStep', () => {
+  // Stepping by `cols` was right while every band was full, and jumped clean over the band below a
+  // one-card group the moment grouping arrived.
+  const pages = [
+    {
+      bands: [
+        { kind: 'heading', label: 'a', count: 1, muted: false },
+        { kind: 'cards', items: [0] },
+        { kind: 'heading', label: 'b', count: 3, muted: false },
+        { kind: 'cards', items: [1, 2, 3] },
+      ] as CardBand[],
+      items: [0, 1, 2, 3],
+    },
+    { bands: [{ kind: 'cards', items: [4, 5] }] as CardBand[], items: [4, 5] },
+  ]
+
+  it('steps band to band, keeping the column', () => {
+    expect(cardStep(pages, 0, 1)).toBe(1)
+    expect(cardStep(pages, 2, -1)).toBe(0)
+    expect(cardStep(pages, 2, 1)).toBe(5)
+  })
+
+  // The page FOLLOWS the cursor, so stepping off the bottom band is how the next page is reached.
+  it('walks across the page boundary and clamps at the ends', () => {
+    expect(cardStep(pages, 1, 1)).toBe(4)
+    expect(cardStep(pages, 0, -1)).toBe(0)
+    expect(cardStep(pages, 5, 1)).toBe(5)
+    // A shorter band takes the cursor at its last card rather than dropping it.
+    expect(cardStep(pages, 3, 1)).toBe(5)
+    expect(cardStep(pages, 99, 1)).toBe(99)
+  })
+
+  it('lists the bands of cards across every page, in drawing order', () => {
+    expect(cardRows(pages)).toEqual([[0], [1, 2, 3], [4, 5]])
   })
 })
 

--- a/packages/tui/src/control/sessions.ts
+++ b/packages/tui/src/control/sessions.ts
@@ -1701,8 +1701,15 @@ export const CARD_MIN_WIDTH = 28
  */
 export const CARD_MAX_WIDTH = 46
 
-/** Content lines a full card carries: name, state, usage, where, and what it is saying. */
-export const CARD_LINES = 5
+/**
+ * Content lines a full card carries: name, state, usage, where, model, and what it is filed under.
+ *
+ * Six rather than five since the MODEL took a line of its own. It used to ride the `where` line as
+ * ` · opus`, which is the one place a card could not say what it was: a bare word after a folder
+ * name reads as another folder. Naming it costs a line, and a card that draws one fewer fact than it
+ * has room for is cheaper than a card whose facts cannot be told apart.
+ */
+export const CARD_LINES = 6
 
 /** The fewest a card is worth: the name, the state, and one fact. Below that it is a list row. */
 export const CARD_MIN_LINES = 3
@@ -1734,11 +1741,26 @@ export interface CardGrid {
  * columns are the fewest that can place them in those rows, and every column left over is spent
  * making the cards WIDER rather than making more of them.
  */
-export function cardGrid(o: { width: number; height: number; total: number }): CardGrid | null {
+export function cardGrid(o: {
+  width: number
+  height: number
+  total: number
+  /**
+   * The most lines any card on screen will actually draw, when the caller has counted them.
+   *
+   * A card is as tall as the band affords and never taller than it has content for — the rule this
+   * function already followed against the CONSTANT, and which the constant alone cannot keep: a
+   * fleet whose richest session records no model, no task and no note draws four lines into a
+   * six-line frame, and two rows of blank inside a frame are not a card, they are a box with a name
+   * in it. Counted, those rows go back to the region and another band fits on the page.
+   */
+  lines?: number
+}): CardGrid | null {
   const width = Math.max(0, o.width)
   const height = Math.max(0, o.height)
   const floorHeight = PANE_FRAME_Y + CARD_MIN_LINES
-  const fullHeight = PANE_FRAME_Y + CARD_LINES
+  const fullHeight = PANE_FRAME_Y
+    + Math.max(CARD_MIN_LINES, Math.min(CARD_LINES, o.lines ?? CARD_LINES))
   if (width < CARD_MIN_WIDTH || height < floorHeight) return null
 
   // How many the region could carry at the floor — the ceiling on everything below.
@@ -1764,29 +1786,129 @@ export function cardGrid(o: { width: number; height: number; total: number }): C
   }
 }
 
+/**
+ * One horizontal BAND of a card page: a group's name, or a row of that group's cards.
+ *
+ * A band belongs to exactly ONE group. That is the whole model: a group opens a band with its name
+ * and its cards fill the bands under it, and a group with one card leaves the rest of its band
+ * EMPTY. The air to the right of a short group is not waste — it is what separates one group from
+ * the next, and filling it with the following group's cards is precisely how the grid used to
+ * ignore the grouping it was drawn under. (The control center's "air under a pane is a fault" rule
+ * is about air OUTSIDE a region; this air is inside the band and is doing work.)
+ */
+export type CardBand =
+  /** `muted` is the list's own reading: an absent key, a finished task, the history section. */
+  | { kind: 'heading'; label: string; count: number; muted: boolean }
+  /** Indexes into the flat card sequence — at most `cols` of them, all from one group. */
+  | { kind: 'cards'; items: number[] }
+
 export interface CardPage {
-  /** The page actually in force, clamped into range. */
-  page: number
-  pages: number
-  /** Index of the first card of this page, and one past its last. */
-  from: number
-  to: number
+  bands: CardBand[]
+  /** Every card index on this page, in order — what the pager counts. */
+  items: number[]
+}
+
+/** Rows a page's bands occupy: one per heading, `cardHeight` per row of cards — PURE. */
+export function cardPageRows(bands: readonly CardBand[], cardHeight: number): number {
+  return bands.reduce((n, b) => n + (b.kind === 'heading' ? 1 : Math.max(1, cardHeight)), 0)
 }
 
 /**
- * Which slice of the fleet a page names — PURE, and CLAMPED on every call.
+ * The fleet split into pages of bands — PURE, and the ONE arithmetic the grid is drawn from.
  *
- * Clamped rather than corrected in an effect, for the same reason the list's cursor is: a session
- * that ends between two polls shortens the list under the page, and a stored index would point past
- * the end for exactly one frame — which is the frame the user presses a key on.
+ * It walks the very `SessionRow[]` the LIST draws, so what a group is called, which ones are muted
+ * and where the history section begins are decided once, in `sessionRows`, for both layouts. Working
+ * the grouping out a second way here is a second implementation of it, and the two would disagree
+ * the first time either changed.
+ *
+ * Two rules paying for themselves:
+ *
+ *  - **A heading is never placed without a row of cards under it.** They go onto a page together or
+ *    neither does, so no page ever ends with a name and nothing named.
+ *  - **A group that crosses a page boundary REPEATS its name at the top of the next page.** Within
+ *    one page the name sits a band or two above and plainly governs the bands under it, so it is
+ *    said once; across a break it is gone, and a card under no name does not say what it belongs
+ *    to. The repeated heading carries the group's own count, not the count on this page — it is the
+ *    same statement the list makes, and the pager already says how much of the fleet is on screen.
+ *
+ * `headed: false` — a grouping of `none`, or a band too short to spend a row on a name — packs the
+ * whole fleet as one nameless group, which is exactly the dense grid this screen drew before.
  */
-export function cardPage(total: number, capacity: number, page: number): CardPage {
-  const size = Math.max(1, capacity)
-  const count = Math.max(0, total)
-  const pages = Math.max(1, Math.ceil(count / size))
-  const at = Math.max(0, Math.min(Math.floor(page), pages - 1))
-  const from = at * size
-  return { page: at, pages, from, to: Math.min(count, from + size) }
+export function cardPages(o: {
+  /** The rows the list would draw, headings and spacers included. */
+  rows: readonly SessionRow[]
+  cols: number
+  /** Rows the grid region has, pager already paid for. */
+  gridRows: number
+  cardHeight: number
+  /** The most cards one page may hold — see `CARD_PAGE_MAX`. */
+  capacity: number
+  headed: boolean
+}): CardPage[] {
+  const cols = Math.max(1, o.cols)
+  const cardHeight = Math.max(1, o.cardHeight)
+  const cap = Math.max(1, o.capacity)
+  const budget = Math.max(0, o.gridRows)
+
+  type Head = { label: string; count: number; muted: boolean }
+  const sections: Array<{ head: Head | null; items: number[] }> = []
+  let index = 0
+  for (const row of o.rows) {
+    if (row.kind === 'spacer') continue
+    if (row.kind === 'heading') {
+      // Unheaded, every row joins ONE nameless section, so nothing wraps early and the layout is
+      // byte-for-byte the one this screen drew before groups reached it.
+      if (o.headed) sections.push({ head: { label: row.label, count: row.count, muted: row.muted === true }, items: [] })
+      continue
+    }
+    const last = sections[sections.length - 1]
+    if (last && (o.headed || last.head === null)) last.items.push(index)
+    else sections.push({ head: null, items: [index] })
+    index++
+  }
+
+  const pages: CardPage[] = []
+  let bands: CardBand[] = []
+  let items: number[] = []
+  let used = 0
+  const flush = () => {
+    if (items.length > 0) pages.push({ bands, items })
+    bands = []
+    items = []
+    used = 0
+  }
+
+  for (const section of sections) {
+    // Whether THIS page already carries this section's name. Reset by every page break, which is
+    // what makes a split group say its name again.
+    let named = false
+    for (let i = 0; i < section.items.length; i += cols) {
+      const chunk = section.items.slice(i, i + cols)
+      const cost = () => (section.head && !named ? 1 : 0) + cardHeight
+      // A page break is the only way to make room, so it is only ever taken while there is
+      // something to break away from — the loop always terminates.
+      if (items.length > 0 && (used + cost() > budget || items.length + chunk.length > cap)) {
+        flush()
+        named = false
+      }
+      if (section.head && !named) {
+        bands.push({ kind: 'heading', ...section.head })
+        used += 1
+        named = true
+      }
+      bands.push({ kind: 'cards', items: chunk })
+      items.push(...chunk)
+      used += cardHeight
+    }
+  }
+  flush()
+  return pages
+}
+
+/** Which page holds a card — PURE. `0` for an index no page carries, which is the first frame. */
+export function pageOfCard(pages: readonly CardPage[], index: number): number {
+  const at = pages.findIndex(p => p.items.includes(index))
+  return at < 0 ? 0 : at
 }
 
 // ---------------------------------------------------------------------------
@@ -1803,6 +1925,10 @@ export function cardPage(total: number, capacity: number, page: number): CardPag
  *
  * With grouping off there is no heading, and the card falls back to the project — the fact every
  * session already carries. A blank badge is a frame with a gap in it.
+ *
+ * Read ONLY where the grid draws no group headings: with a heading over the band, the same name on
+ * every card under it is a column of one word, which is why the list drops its `task` cell while
+ * grouping by task. One of the two says it, never both and never neither.
  */
 export function cardBadges(rows: readonly SessionRow[]): string[] {
   const out: string[] = []
@@ -1822,6 +1948,19 @@ export interface CardLine {
   key: string
   kind: CardLineKind
   text: string
+  /**
+   * What this line IS, already localized — drawn dim in front of the value.
+   *
+   * Only on the lines a reader cannot name from the value alone. A card is narrow and the list
+   * solves this with a column HEADER the grid has no room for, so the naming moves onto the row:
+   * `session-monitor` and `cockpit: canal de eventos` are a folder and a task, drawn identically,
+   * and nothing on the card said which was which.
+   *
+   * Absent on the lines that say what they are: the name is the card's first line and its only bold
+   * one, the state word is coloured and unique, and `51.7k $1.24 · há 10h` names its own units.
+   * Rotulating those would spend the width that makes the ambiguous ones readable.
+   */
+  label?: string
   /** Drawn dim on the same row, after `text`. Given up first when the card is narrow. */
   tail?: string
 }
@@ -1832,7 +1971,44 @@ export interface CardLabels {
   attached: string
   /** Short caveat for a harness with no probed approval markers. */
   blind: string
+  /**
+   * The names of the facts, from the very table the list's column header prints (`sessionsCols`).
+   *
+   * The same words on purpose: the two layouts are one screen in two shapes, and a card that called
+   * the folder something the header does not would be a second vocabulary to learn.
+   */
+  worktree: string
+  project: string
+  task: string
+  note: string
+  model: string
   ago: (startedAt: number) => string
+}
+
+/** Columns between a card's label and its value. */
+export const CARD_LABEL_GAP = 2
+
+/**
+ * Below this a labelled card says LESS than an unlabelled one: `worktree  sess…` names the field and
+ * stops answering which one, which is the trade the labels exist to avoid.
+ */
+export const CARD_VALUE_MIN = 10
+
+/**
+ * The column the labels are drawn in, or `0` to draw none — PURE.
+ *
+ * All-or-nothing per CARD rather than per line, and that is the whole point: labels that come and go
+ * down a card leave the values starting at different columns, which is the jumble `sessionColumns`
+ * exists to prevent on the list. So either every fact is named and aligned, or none is.
+ *
+ * Dropping them is the right degradation because a label never removes a line — it only narrows the
+ * value. A card too narrow to carry both keeps the values whole and gives up the naming, which is
+ * exactly what the list does when it drops its header row.
+ */
+export function cardLabelWidth(lines: readonly CardLine[], width: number): number {
+  const widest = lines.reduce((n, l) => Math.max(n, (l.label ?? '').length), 0)
+  if (widest === 0) return 0
+  return width - widest - CARD_LABEL_GAP >= CARD_VALUE_MIN ? widest : 0
 }
 
 /**
@@ -1847,7 +2023,23 @@ export interface CardLabels {
  * usage would otherwise show every one of its sessions costing nothing, in the very place a person
  * looks to decide what to close. Same rule the detail pane and `sessionMetric` already follow.
  */
-export function cardLines(s: ControlSession, labels: CardLabels): CardLine[] {
+export function cardLines(
+  s: ControlSession,
+  labels: CardLabels,
+  /**
+   * The name of the band this card sits under, when there is one.
+   *
+   * A fact whose value IS that name is dropped: under a heading reading `agentistics`, a line
+   * reading `project  agentistics` spends one of four rows saying what the row above already said,
+   * and the row it costs is the one that would have carried the model or the task. The same rule
+   * `sessionColumns` applies to its `task` cell while grouping by task, one line lower down.
+   *
+   * Matched on the drawn LABEL, so a composite heading (`agentistics · closed`) keeps the line: it
+   * is not the same word, and dropping a fact because a heading merely contains it would be a card
+   * withholding something nothing on screen says.
+   */
+  group = '',
+): CardLine[] {
   const marks = [
     s.attached ? labels.attached : '',
     s.approvalBlind ? labels.blind : '',
@@ -1864,12 +2056,23 @@ export function cardLines(s: ControlSession, labels: CardLabels): CardLine[] {
   if (usage) out.push({ key: 'usage', kind: 'fact', text: usage })
 
   // WHERE, and which checkout of it: with several worktrees of one repository open at once, the
-  // folder name is the only thing telling them apart.
-  const where = [worktreeName(s) || s.projectGroup || s.project, s.model].filter(Boolean).join(' · ')
-  if (where) out.push({ key: 'where', kind: 'fact', text: where })
+  // folder name is the only thing telling them apart — and the label says WHICH of the two kinds of
+  // place this is, since a worktree's name and a project's name are the same shape of word.
+  const said = (text: string) => text !== '' && text !== group
+  const worktree = worktreeName(s)
+  const where = worktree || s.projectGroup || s.project
+  if (said(where)) {
+    out.push({
+      key: 'where', kind: 'fact', text: where,
+      label: worktree ? labels.worktree : labels.project,
+    })
+  }
+  // The MODEL on its own line rather than trailing the folder: appended there it was a bare word
+  // after a path, which reads as another path.
+  if (said(s.model ?? '')) out.push({ key: 'model', kind: 'fact', text: s.model!, label: labels.model })
 
-  if (s.task) out.push({ key: 'task', kind: 'fact', text: s.task })
-  if (s.note) out.push({ key: 'note', kind: 'fact', text: s.note })
+  if (said(s.task ?? '')) out.push({ key: 'task', kind: 'fact', text: s.task!, label: labels.task })
+  if (s.note) out.push({ key: 'note', kind: 'fact', text: s.note, label: labels.note })
 
   // What it is SAYING, last, because it is the line a short card gives up first — and the only one
   // that would be invented if it were not there. Present only for a session agentop hosts.
@@ -1926,21 +2129,74 @@ export function cardBand(o: { listRows: number; header: boolean }): {
 }
 
 /**
- * Which card a click landed on, in grid coordinates — PURE, and the SAME arithmetic that drew it.
+ * Which card a click landed on — PURE, and resolved against the very BANDS that were drawn.
  *
- * The gutter between two cards belongs to neither: rounding it into one of them answers a click
- * the user did not make, which is worse than not answering at all.
+ * Against the bands rather than against a uniform `cols × cardHeight` grid, because with grouping on
+ * the page is no longer uniform: a heading costs one row and a short group leaves the right of its
+ * band empty. Re-deriving the geometry from `cols` alone answers with the card one row up, or with a
+ * card that is not there.
+ *
+ * The gutter between two cards belongs to neither, a heading row belongs to no card, and the empty
+ * right-hand end of a short group's band is not a card either: each returns `null`, because
+ * answering a click the user did not make is worse than not answering at all.
  */
-export function cardAt(grid: CardGrid, x: number, y: number): number | null {
-  if (x < 0 || y < 0) return null
-  const stride = grid.cardWidth + grid.gap
-  const col = Math.floor(x / stride)
-  if (col >= grid.cols) return null
-  if (x - col * stride >= grid.cardWidth) return null
-  const row = Math.floor(y / grid.cardHeight)
-  if (row >= grid.rows) return null
-  const index = row * grid.cols + col
-  return index >= grid.capacity ? null : index
+export function cardHit(o: {
+  bands: readonly CardBand[]
+  cardWidth: number
+  cardHeight: number
+  gap: number
+  x: number
+  y: number
+}): number | null {
+  if (o.x < 0 || o.y < 0) return null
+  const cardHeight = Math.max(1, o.cardHeight)
+  let top = 0
+  for (const band of o.bands) {
+    if (band.kind === 'heading') {
+      if (o.y === top) return null
+      top += 1
+      continue
+    }
+    if (o.y < top + cardHeight) {
+      const stride = o.cardWidth + o.gap
+      const col = Math.floor(o.x / stride)
+      // The gap AFTER a card belongs to the gutter, not to the card in front of it.
+      if (o.x - col * stride >= o.cardWidth) return null
+      return band.items[col] ?? null
+    }
+    top += cardHeight
+  }
+  return null
+}
+
+/** Every band of cards, across every page, in drawing order — the sequence `↑`/`↓` walk. */
+export function cardRows(pages: readonly CardPage[]): number[][] {
+  return pages.flatMap(p => p.bands.flatMap(b => (b.kind === 'cards' ? [b.items] : [])))
+}
+
+/**
+ * Where `↑`/`↓` land from a card — PURE.
+ *
+ * Stepping by `cols` was right while every band was full and is wrong the moment a group is shorter
+ * than the grid is wide: `↓` from the only card of a one-card group jumped over the whole band
+ * underneath it. So the move is band to band, keeping the COLUMN — and clamped to the last card of a
+ * shorter band rather than falling off it.
+ *
+ * It walks every page, not just the open one, because the page FOLLOWS the cursor: stepping off the
+ * bottom band is how you reach the next page, and there is no second position to keep in step.
+ */
+export function cardStep(pages: readonly CardPage[], index: number, dy: number): number {
+  const rows = cardRows(pages)
+  let at = -1
+  let col = 0
+  rows.forEach((row, i) => {
+    const found = row.indexOf(index)
+    if (found >= 0) { at = i; col = found }
+  })
+  if (at < 0) return index
+  const target = rows[Math.max(0, Math.min(at + dy, rows.length - 1))]
+  if (!target || target.length === 0) return index
+  return target[Math.min(col, target.length - 1)] ?? index
 }
 
 export interface PagerCells {

--- a/packages/tui/src/control/sessions.ts
+++ b/packages/tui/src/control/sessions.ts
@@ -1799,8 +1799,20 @@ export function cardGrid(o: {
 export type CardBand =
   /** `muted` is the list's own reading: an absent key, a finished task, the history section. */
   | { kind: 'heading'; label: string; count: number; muted: boolean }
-  /** Indexes into the flat card sequence — at most `cols` of them, all from one group. */
-  | { kind: 'cards'; items: number[] }
+  /**
+   * Indexes into the flat card sequence — at most `cols` of them, all from one group — and the rows
+   * this band occupies, FRAME INCLUDED.
+   *
+   * The height is the BAND's, not the grid's, and that is the point: a single grid height is the
+   * height of the richest card in the whole fleet, so one session carrying a note and a model made
+   * every card on screen two rows taller than it had anything to put in them. Rows of blank inside a
+   * frame are not a card, they are a box with a name in it.
+   *
+   * It is the band and not the card because the cards of one band stand side by side: giving each
+   * its own height leaves the bottom edge of the row ragged, which is a worse thing to look at than
+   * the one blank line a short card beside a rich one still keeps.
+   */
+  | { kind: 'cards'; items: number[]; height: number }
 
 export interface CardPage {
   bands: CardBand[]
@@ -1808,9 +1820,9 @@ export interface CardPage {
   items: number[]
 }
 
-/** Rows a page's bands occupy: one per heading, `cardHeight` per row of cards — PURE. */
-export function cardPageRows(bands: readonly CardBand[], cardHeight: number): number {
-  return bands.reduce((n, b) => n + (b.kind === 'heading' ? 1 : Math.max(1, cardHeight)), 0)
+/** Rows a page's bands occupy: one per heading, its own height per row of cards — PURE. */
+export function cardPageRows(bands: readonly CardBand[]): number {
+  return bands.reduce((n, b) => n + (b.kind === 'heading' ? 1 : Math.max(1, b.height)), 0)
 }
 
 /**
@@ -1833,6 +1845,9 @@ export function cardPageRows(bands: readonly CardBand[], cardHeight: number): nu
  *
  * `headed: false` — a grouping of `none`, or a band too short to spend a row on a name — packs the
  * whole fleet as one nameless group, which is exactly the dense grid this screen drew before.
+ *
+ * Each band is also SIZED here, to the tallest card in it and no taller, which is why the rows it
+ * gives back turn into more bands on the page rather than into air.
  */
 export function cardPages(o: {
   /** The rows the list would draw, headings and spacers included. */
@@ -1840,7 +1855,14 @@ export function cardPages(o: {
   cols: number
   /** Rows the grid region has, pager already paid for. */
   gridRows: number
+  /** The TALLEST a band may be — the ceiling the region affords, from `cardGrid`. */
   cardHeight: number
+  /**
+   * How many lines each card has to draw, by card index — see `cardLines`.
+   *
+   * Absent, every band takes the ceiling, which is the uniform grid this screen drew before.
+   */
+  lines?: readonly number[]
   /** The most cards one page may hold — see `CARD_PAGE_MAX`. */
   capacity: number
   headed: boolean
@@ -1849,6 +1871,15 @@ export function cardPages(o: {
   const cardHeight = Math.max(1, o.cardHeight)
   const cap = Math.max(1, o.capacity)
   const budget = Math.max(0, o.gridRows)
+  /**
+   * The rows a band of these cards needs: its tallest card's lines plus the frame, never below the
+   * floor that makes a card a card, never above what the region affords.
+   */
+  const heightOf = (chunk: readonly number[]): number => {
+    if (!o.lines) return cardHeight
+    const most = chunk.reduce((n, i) => Math.max(n, o.lines![i] ?? 0), 0)
+    return Math.min(cardHeight, Math.max(PANE_FRAME_Y + CARD_MIN_LINES, PANE_FRAME_Y + most))
+  }
 
   type Head = { label: string; count: number; muted: boolean }
   const sections: Array<{ head: Head | null; items: number[] }> = []
@@ -1884,7 +1915,8 @@ export function cardPages(o: {
     let named = false
     for (let i = 0; i < section.items.length; i += cols) {
       const chunk = section.items.slice(i, i + cols)
-      const cost = () => (section.head && !named ? 1 : 0) + cardHeight
+      const height = heightOf(chunk)
+      const cost = () => (section.head && !named ? 1 : 0) + height
       // A page break is the only way to make room, so it is only ever taken while there is
       // something to break away from — the loop always terminates.
       if (items.length > 0 && (used + cost() > budget || items.length + chunk.length > cap)) {
@@ -1896,9 +1928,9 @@ export function cardPages(o: {
         used += 1
         named = true
       }
-      bands.push({ kind: 'cards', items: chunk })
+      bands.push({ kind: 'cards', items: chunk, height })
       items.push(...chunk)
-      used += cardHeight
+      used += height
     }
   }
   flush()
@@ -2143,13 +2175,11 @@ export function cardBand(o: { listRows: number; header: boolean }): {
 export function cardHit(o: {
   bands: readonly CardBand[]
   cardWidth: number
-  cardHeight: number
   gap: number
   x: number
   y: number
 }): number | null {
   if (o.x < 0 || o.y < 0) return null
-  const cardHeight = Math.max(1, o.cardHeight)
   let top = 0
   for (const band of o.bands) {
     if (band.kind === 'heading') {
@@ -2157,14 +2187,15 @@ export function cardHit(o: {
       top += 1
       continue
     }
-    if (o.y < top + cardHeight) {
+    const height = Math.max(1, band.height)
+    if (o.y < top + height) {
       const stride = o.cardWidth + o.gap
       const col = Math.floor(o.x / stride)
       // The gap AFTER a card belongs to the gutter, not to the card in front of it.
       if (o.x - col * stride >= o.cardWidth) return null
       return band.items[col] ?? null
     }
-    top += cardHeight
+    top += height
   }
   return null
 }

--- a/packages/tui/src/control/tabs/Sessions.tsx
+++ b/packages/tui/src/control/tabs/Sessions.tsx
@@ -24,7 +24,7 @@ import { DEFAULT_SESSION_VIEW } from '../types'
 import { resolveListKey, windowOffset, type NavKey } from '../nav'
 import { ACTION_SEP, actionAtColumn, fitActionRow } from '../chrome.ts'
 import { Divider } from '../Surface'
-import { PANE_MIN_ROWS, paneBadgeRoom } from '../chrome.ts'
+import { PANE_MIN_ROWS, paneBadgeRoom, paneTitleRoom } from '../chrome.ts'
 import { Pane, paneBody, paneRows } from '../Pane'
 
 /** Columns a pane spends on its left edge: one of border, one of padding. */
@@ -59,9 +59,9 @@ import {
   taskCounts, projectCounts, sessionMetric, sessionHandle, worktreeName, sessionRunning,
   sessionAge, sessionKeyHelp, keyHelpColumn,
   DEFAULT_ORDER, ACTIVE_STATES, type SessionOrder, type SessionLayout,
-  cardGrid, cardPage, cardBadges, cardLines, fitCardLines, cardStateCells, cardBand,
-  cardAt, pagerCells, pagerHit,
-  type CardGrid, type CardLine, type PagerCells,
+  cardGrid, cardPages, pageOfCard, cardBadges, cardLines, fitCardLines, cardStateCells, cardBand,
+  cardHit, cardStep, cardPageRows, cardLabelWidth, CARD_LABEL_GAP, pagerCells, pagerHit,
+  type CardBand, type CardGrid, type CardLabels, type CardLine, type CardPage, type PagerCells,
   asideSections, asideFold, scrollBar, THUMB,
   sessionNamed,
   type AsideRow, type OfferedAction, type SessionColumns, type SessionToggle,
@@ -493,18 +493,71 @@ export function Sessions({
   // instead: the same degradation the aside menu makes when it is dropped rather than squeezed.
   const cardsBody = paneBody(cockpit.list)
   const band = cardBand({ listRows: cockpit.listRows, header: cockpit.header })
-  const grid: CardGrid | null = layout === 'cards' && rows.length > 0
-    ? cardGrid({ width: cardsBody, height: band.gridRows, total: cards.length })
+  /**
+   * The words a card names its facts with — the very ones the list's column header prints, so the
+   * two layouts call one fact one thing.
+   *
+   * Composed once here rather than inside each card: the layout has to COUNT the lines before any
+   * card is drawn, and a second copy of this table is a second answer to what a card says.
+   */
+  const cardWords = useMemo(() => ({
+    attached: s.sessionsCardAttached,
+    blind: s.sessionsCardBlind,
+    worktree: s.sessionsCols.worktree,
+    project: s.sessionsCols.where,
+    task: s.sessionsCols.task,
+    note: s.sessionsNote,
+    model: s.sessionsModel,
+    // The clock arithmetic happens HERE, not in the pure module: a card repaints far more often
+    // than the poll runs, so a duration computed upstream would freeze at whatever it was.
+    ago: (startedAt: number) =>
+      s.sessionsAgo(Math.max(0, Math.round((Date.now() - startedAt) / 1000))),
+  }), [s])
+  /**
+   * Whether the grid draws the group HEADINGS the list draws.
+   *
+   * It costs a row of the band, so it is asked as a question the geometry can answer: measure the
+   * grid one row shorter, and take the headings only if a whole card still fits. A band too short
+   * for both keeps the cards and gives them their group BADGE back — one of the two always says
+   * which group a card belongs to, and the fallback to the list is unchanged.
+   */
+  const wantHeadings = layout === 'cards' && rows.some(r => r.kind === 'heading')
+  /**
+   * The most lines any card on screen will draw, so the frames are as tall as they have content for
+   * and no taller. Counted off the same `cardLines` the cards are drawn from — and off `badges`,
+   * which name each card's group whether or not the band ends up drawing a heading, so this number
+   * does not depend on the decision it feeds.
+   */
+  const cardMaxLines = useMemo(() => (layout === 'cards'
+    ? cards.reduce((n, c, i) => Math.max(n, cardLines(c, cardWords, badges[i] ?? '').length), 0)
+    : 0), [layout, cards, badges, cardWords])
+  const headedGrid: CardGrid | null = wantHeadings && rows.length > 0
+    ? cardGrid({ width: cardsBody, height: band.gridRows - 1, total: cards.length, lines: cardMaxLines })
     : null
+  const headed = headedGrid !== null
+  const grid: CardGrid | null = layout === 'cards' && rows.length > 0
+    ? headedGrid
+      ?? cardGrid({ width: cardsBody, height: band.gridRows, total: cards.length, lines: cardMaxLines })
+    : null
+  const pages = useMemo(() => (grid
+    ? cardPages({
+        rows,
+        cols: grid.cols,
+        gridRows: band.gridRows,
+        cardHeight: grid.cardHeight,
+        capacity: grid.capacity,
+        headed,
+      })
+    : []),
+  [grid?.cols, grid?.cardHeight, grid?.capacity, band.gridRows, headed, rows])
   // The page is the one holding the CURSOR — derived, never stored beside it. Turning a page is
   // therefore moving the cursor, and there is no second position that can fall out of step.
-  const page = grid
-    ? cardPage(cards.length, grid.capacity, Math.floor(Math.max(0, at) / grid.capacity))
-    : null
+  const pageAt = pages.length > 0 ? pageOfCard(pages, Math.max(0, at)) : 0
+  const page: CardPage | null = pages[pageAt] ?? null
   const pager = grid && page && band.pager
     ? pagerCells({
-        label: s.sessionsPage(page.page + 1, page.pages),
-        note: s.sessionsShowing(page.to - page.from, cards.length),
+        label: s.sessionsPage(pageAt + 1, pages.length),
+        note: s.sessionsShowing(page.items.length, cards.length),
         width: cardsBody,
       })
     : null
@@ -512,7 +565,7 @@ export function Sessions({
 
   // Updated only when the PAGE changes, never on every cursor move: `setSessionView` writes
   // `preferences.json` to disk, and a disk write per arrow key is not a thing this screen may do.
-  const pageAnchor = page ? cards[page.from]?.id : undefined
+  const pageAnchor = page ? cards[page.items[0] ?? 0]?.id : undefined
   useEffect(() => {
     if (pageAnchor && pageAnchor !== cardAnchor) setCardAnchor(pageAnchor)
   }, [pageAnchor, cardAnchor])
@@ -804,19 +857,23 @@ export function Sessions({
     if (input === 'R') return runAction('reopenFell')
 
     // A grid has two axes, so the arrows mean what they mean in a grid: `←`/`→` step one card,
-    // `↑`/`↓` step a whole row of them. The list's own reducer wraps a single column, which in a
+    // `↑`/`↓` step a whole BAND of them. The list's own reducer wraps a single column, which in a
     // grid would send the cursor from the top-left card to the bottom-RIGHT one.
     if (grid && selectable.length > 0) {
       const here = Math.max(0, at)
       const to = (n: number) => setCursor(Math.max(0, Math.min(n, selectable.length - 1)))
+      // Band to band rather than by `cols`: with grouping on, a band holding a one-card group is
+      // shorter than the grid is wide, and stepping by `cols` jumped clean over the band below it.
+      const step = (dy: number) => to(cardStep(pages, here, dy))
       if (key.leftArrow) return to(here - 1)
       if (key.rightArrow) return to(here + 1)
-      if (key.upArrow || input === 'k') return to(here - grid.cols)
-      if (key.downArrow || input === 'j') return to(here + grid.cols)
+      if (key.upArrow || input === 'k') return step(-1)
+      if (key.downArrow || input === 'j') return step(1)
       // The page is always the one holding the cursor, so turning a page IS moving the cursor —
-      // there is no second position to keep in sync with the first.
-      if (key.pageUp) return to(here - grid.capacity)
-      if (key.pageDown) return to(here + grid.capacity)
+      // there is no second position to keep in sync with the first. Onto the page's FIRST card
+      // rather than a fixed number of cards along: with headings the pages hold different amounts.
+      if (key.pageUp) return to(pages[Math.max(0, pageAt - 1)]?.items[0] ?? 0)
+      if (key.pageDown) return to(pages[Math.min(pages.length - 1, pageAt + 1)]?.items[0] ?? here)
       if (key.home || input === 'g') return to(0)
       if (key.end || input === 'G') return to(selectable.length - 1)
       return
@@ -1015,20 +1072,28 @@ export function Sessions({
         // one that was pointed at.
         const gy = y - (cockpit.summary ? 1 : 0)
         const gx = p.x - listX - PANE_EDGE_X
-        if (pager && gy === grid.rows * grid.cardHeight) {
+        // Measured off the bands actually on this page, never off `rows * cardHeight`: a heading
+        // costs a row and a short group's band still costs a whole one, so the pager does not sit
+        // where a uniform grid would have put it.
+        if (pager && gy === cardPageRows(page.bands, grid.cardHeight)) {
           const hit = pagerHit(pager, gx)
           // Turning a page IS moving the cursor — the page is derived from it, so there is nothing
           // else to set and nothing that can fall out of step.
           if (hit) {
-            const step = hit === 'next' ? grid.capacity : -grid.capacity
-            setCursor(c => Math.max(0, Math.min(Math.max(0, c) + step, selectable.length - 1)))
+            const next = pages[hit === 'next' ? pageAt + 1 : pageAt - 1]
+            if (next) setCursor(Math.min(next.items[0] ?? 0, selectable.length - 1))
           }
           return
         }
-        const slot = cardAt(grid, gx, gy)
-        if (slot === null) return
-        const index = page.from + slot
-        if (index < selectable.length) setCursor(index)
+        const index = cardHit({
+          bands: page.bands,
+          cardWidth: grid.cardWidth,
+          cardHeight: grid.cardHeight,
+          gap: grid.gap,
+          x: gx,
+          y: gy,
+        })
+        if (index !== null && index < selectable.length) setCursor(index)
         return
       }
       const row = offset + (y - (cockpit.summary ? 1 : 0))
@@ -1340,35 +1405,38 @@ export function Sessions({
         </Text>
       ) : grid && page ? (
         <Box flexDirection="column" width={cardsBody} flexShrink={0}>
-          {Array.from({ length: grid.rows }, (_, r) => (
-            <Box key={`row${r}`} flexDirection="row" height={grid.cardHeight} flexShrink={0}>
-              {Array.from({ length: grid.cols }, (_, c) => {
-                const slot = r * grid.cols + c
-                const index = page.from + slot
-                const card = slot < grid.capacity ? cards[index] : undefined
+          {/* One band per group, and the air to the right of a short group is DELIBERATE: it is
+              what separates one group from the next, and filling it with the following group's
+              cards is exactly how this grid used to ignore the grouping it was drawn under. */}
+          {page.bands.map((b, i) => (b.kind === 'heading' ? (
+            <GroupHeading key={`h${i}`} band={b} width={cardsBody} />
+          ) : (
+            <Box key={`b${i}`} flexDirection="row" height={grid.cardHeight} flexShrink={0}>
+              {b.items.map((index, c) => {
+                const card = cards[index]
+                if (!card) return null
                 return (
-                  <Box key={`col${c}`} flexDirection="row" flexShrink={0}>
+                  <Box key={card.id} flexDirection="row" flexShrink={0}>
                     {c > 0 ? <Box width={grid.gap} flexShrink={0} /> : null}
-                    {card ? (
-                      <SessionCard
-                        session={card}
-                        badge={badges[index] ?? ''}
-                        selected={selected?.id === card.id}
-                        marked={marked.has(card.id)}
-                        width={grid.cardWidth}
-                        height={grid.cardHeight}
-                        strings={s}
-                      />
-                    ) : (
-                      // An empty cell keeps the grid's shape without drawing a frame around
-                      // nothing — a card with no session in it is a box claiming to be one.
-                      <Box width={grid.cardWidth} height={grid.cardHeight} flexShrink={0} />
-                    )}
+                    <SessionCard
+                      session={card}
+                      // The group is named ONCE: by the heading over the band when there is one,
+                      // and by the card's own title when there is not. The card is told both which
+                      // group it is in and whether the band already said so — the same rule that
+                      // drops the list's `task` cell while grouping by task.
+                      group={badges[index] ?? ''}
+                      headed={headed}
+                      selected={selected?.id === card.id}
+                      marked={marked.has(card.id)}
+                      width={grid.cardWidth}
+                      height={grid.cardHeight}
+                      words={cardWords}
+                    />
                   </Box>
                 )
               })}
             </Box>
-          ))}
+          )))}
           {pager ? <Pager cells={pager} /> : null}
         </Box>
       ) : (
@@ -1690,44 +1758,75 @@ function KeyHelpScreen({ strings: s, width, height, onClose }: {
 }
 
 /**
+ * The name of a group, over the band holding its cards.
+ *
+ * Drawn exactly as the LIST draws its headings — accented and bold, with a dim rule running to the
+ * edge — because it is the same heading: both layouts read it off the same `sessionRows`, and a
+ * grouping that looked like two different things in two layouts would be two features.
+ */
+function GroupHeading({ band, width }: {
+  band: Extract<CardBand, { kind: 'heading' }>
+  width: number
+}) {
+  const head = `${band.label}  ${band.count}`
+  const rule = Math.max(0, width - head.length - 3)
+  return (
+    <Text wrap="truncate">
+      <Text color={band.muted ? COLORS.muted : COLORS.secondary} bold={!band.muted}>
+        {truncate(head, width)}
+      </Text>
+      <Text dimColor>{rule > 0 ? `  ${'─'.repeat(rule)}` : ''}</Text>
+    </Text>
+  )
+}
+
+/**
  * One session as a card — the same `Pane` every other framed region of this app uses.
  *
- * The frame's title is the HANDLE, because `agentop session attach 3f5f` takes a prefix and that is
- * the one thing on the card naming this session to anything but this screen; the badge is the GROUP,
- * so a card read on its own is never ambiguous about which project or task it belongs to.
+ * The frame names the card with what identifies it HERE and badges it with what identifies it
+ * elsewhere. Which is which depends on whether the band above already says the group:
+ *
+ *  - **Grouped**: the heading names the project, so the title is the HANDLE and there is no badge.
+ *  - **Ungrouped**: the title is the PROJECT — the thing a person scans a wall of cards for — and
+ *    the handle moves to the badge. It never simply disappears: it is the prefix
+ *    `agentop session attach 3f5f` resolves, and the only thing on the card naming this session to
+ *    anything outside this screen. So the project is cut to `paneTitleRoom` to leave space for it,
+ *    rather than taking the space and letting `paneTop`'s whole-or-nothing badge rule drop it.
+ *
+ * A conversation agentop did not start has no handle at all, and gets no badge rather than a
+ * stand-in: the harness is already on its state line, and five characters of a synthetic id would
+ * offer a handle the CLI cannot resolve.
  *
  * The lines come from the pure `cardLines`, cut from the bottom by `fitCardLines`, so what the card
  * gives up on a short terminal is decided in one place and tested there.
  */
-function SessionCard({ session, badge, selected, marked, width, height, strings: s }: {
+function SessionCard({ session, group, headed, selected, marked, width, height, words }: {
   session: ControlSession
-  badge: string
+  /** The group this card belongs to — the heading's own words, or the project when there is none. */
+  group: string
+  /** True while the band above already names that group, so the card must not repeat it. */
+  headed: boolean
   selected: boolean
   marked: boolean
   width: number
   height: number
-  strings: ControlStrings
+  /** The already-localized words, composed once by the screen — see `cardWords`. */
+  words: CardLabels
 }) {
   const inner = paneBody(width)
-  const lines = fitCardLines(
-    cardLines(session, {
-      attached: s.sessionsCardAttached,
-      blind: s.sessionsCardBlind,
-      // The clock arithmetic happens HERE, not in the pure module: the card repaints far more often
-      // than the poll runs, so a duration computed upstream would freeze at whatever it was.
-      ago: startedAt => s.sessionsAgo(Math.max(0, Math.round((Date.now() - startedAt) / 1000))),
-    }),
-    paneRows(height),
-  )
-  const handle = sessionHandle(session) || session.harness
+  const lines = fitCardLines(cardLines(session, words, group), paneRows(height))
+  const handle = sessionHandle(session)
+  // Grouped: the handle IS the title. Ungrouped: the project leads and the handle badges it.
+  const title = headed ? handle || session.harness : group || handle || session.harness
+  const badge = headed ? '' : handle
 
   return (
     <Pane
-      title={handle}
-      // Fitted HERE rather than left to `paneTop`, whose badge rule is whole-or-nothing: the group
-      // is the only place a card says which project or task it belongs to, so it is truncated
-      // rather than dropped. `paneBadgeRoom` is that frame's own arithmetic.
-      badge={truncate(badge, paneBadgeRoom(handle, width))}
+      title={truncate(title, paneTitleRoom(badge, width))}
+      // Fitted HERE rather than left to `paneTop`, whose badge rule is whole-or-nothing: the handle
+      // is the only place a card carries the name the CLI resolves, so it is truncated rather than
+      // dropped. `paneBadgeRoom` is that frame's own arithmetic.
+      badge={truncate(badge, paneBadgeRoom(title, width))}
       focused={selected}
       width={width}
       height={height}
@@ -1737,6 +1836,7 @@ function SessionCard({ session, badge, selected, marked, width, height, strings:
           key={line.key}
           line={line}
           width={inner}
+          labelWidth={cardLabelWidth(lines, inner)}
           marked={marked}
           selected={selected}
           stateColor={STATE_COLOR[session.state]}
@@ -1747,10 +1847,20 @@ function SessionCard({ session, badge, selected, marked, width, height, strings:
   )
 }
 
-/** One line of a card. The state keeps its colour and its WORD, exactly as the row does. */
-function CardLineView({ line, width, marked, selected, stateColor, bold }: {
+/**
+ * One line of a card. The state keeps its colour and its WORD, exactly as the row does.
+ *
+ * A labelled line pads its label to `labelWidth` so every value on the card starts at one column —
+ * `labelWidth` is `0` when the card is too narrow to name its facts and keep them readable, and then
+ * every line draws bare. The lines that name themselves (the title, the state, the usage, what the
+ * assistant is saying) take no indent: they are the card's headline, and pushing them right to line
+ * up with a label they do not have would spend the width for nothing.
+ */
+function CardLineView({ line, width, labelWidth, marked, selected, stateColor, bold }: {
   line: CardLine
   width: number
+  /** Columns the label column takes, or `0` to draw no labels at all. */
+  labelWidth: number
   marked: boolean
   selected: boolean
   stateColor: string | undefined
@@ -1772,11 +1882,18 @@ function CardLineView({ line, width, marked, selected, stateColor, bold }: {
       </Text>
     )
   }
+  const label = labelWidth > 0 && line.label ? line.label : ''
+  const room = label === '' ? width : Math.max(1, width - labelWidth - CARD_LABEL_GAP)
   // What the assistant said is drawn in the text colour: it is the content, and every other line is
   // a label for it.
   return (
-    <Text wrap="truncate" color={line.kind === 'say' ? COLORS.text : COLORS.secondary}>
-      {truncate(line.text, width)}
+    <Text wrap="truncate">
+      {label === '' ? null : (
+        <Text dimColor>{padCell(label, labelWidth) + ' '.repeat(CARD_LABEL_GAP)}</Text>
+      )}
+      <Text color={line.kind === 'say' ? COLORS.text : COLORS.secondary}>
+        {truncate(line.text, room)}
+      </Text>
     </Text>
   )
 }

--- a/packages/tui/src/control/tabs/Sessions.tsx
+++ b/packages/tui/src/control/tabs/Sessions.tsx
@@ -523,14 +523,18 @@ export function Sessions({
    */
   const wantHeadings = layout === 'cards' && rows.some(r => r.kind === 'heading')
   /**
-   * The most lines any card on screen will draw, so the frames are as tall as they have content for
-   * and no taller. Counted off the same `cardLines` the cards are drawn from — and off `badges`,
-   * which name each card's group whether or not the band ends up drawing a heading, so this number
-   * does not depend on the decision it feeds.
+   * How many lines each card will draw, so the frames are as tall as they have content for and no
+   * taller — the MAX sets the grid's ceiling, and `cardPages` sizes each band to its own tallest
+   * card inside it.
+   *
+   * Counted off the same `cardLines` the cards are drawn from, and off `badges`, which name each
+   * card's group whether or not the band ends up drawing a heading — so these numbers do not depend
+   * on the decision they feed.
    */
-  const cardMaxLines = useMemo(() => (layout === 'cards'
-    ? cards.reduce((n, c, i) => Math.max(n, cardLines(c, cardWords, badges[i] ?? '').length), 0)
-    : 0), [layout, cards, badges, cardWords])
+  const cardLineCounts = useMemo(() => (layout === 'cards'
+    ? cards.map((c, i) => cardLines(c, cardWords, badges[i] ?? '').length)
+    : []), [layout, cards, badges, cardWords])
+  const cardMaxLines = cardLineCounts.reduce((n, v) => Math.max(n, v), 0)
   const headedGrid: CardGrid | null = wantHeadings && rows.length > 0
     ? cardGrid({ width: cardsBody, height: band.gridRows - 1, total: cards.length, lines: cardMaxLines })
     : null
@@ -545,11 +549,12 @@ export function Sessions({
         cols: grid.cols,
         gridRows: band.gridRows,
         cardHeight: grid.cardHeight,
+        lines: cardLineCounts,
         capacity: grid.capacity,
         headed,
       })
     : []),
-  [grid?.cols, grid?.cardHeight, grid?.capacity, band.gridRows, headed, rows])
+  [grid?.cols, grid?.cardHeight, grid?.capacity, band.gridRows, headed, rows, cardLineCounts])
   // The page is the one holding the CURSOR — derived, never stored beside it. Turning a page is
   // therefore moving the cursor, and there is no second position that can fall out of step.
   const pageAt = pages.length > 0 ? pageOfCard(pages, Math.max(0, at)) : 0
@@ -1075,7 +1080,7 @@ export function Sessions({
         // Measured off the bands actually on this page, never off `rows * cardHeight`: a heading
         // costs a row and a short group's band still costs a whole one, so the pager does not sit
         // where a uniform grid would have put it.
-        if (pager && gy === cardPageRows(page.bands, grid.cardHeight)) {
+        if (pager && gy === cardPageRows(page.bands)) {
           const hit = pagerHit(pager, gx)
           // Turning a page IS moving the cursor — the page is derived from it, so there is nothing
           // else to set and nothing that can fall out of step.
@@ -1088,7 +1093,6 @@ export function Sessions({
         const index = cardHit({
           bands: page.bands,
           cardWidth: grid.cardWidth,
-          cardHeight: grid.cardHeight,
           gap: grid.gap,
           x: gx,
           y: gy,
@@ -1411,7 +1415,7 @@ export function Sessions({
           {page.bands.map((b, i) => (b.kind === 'heading' ? (
             <GroupHeading key={`h${i}`} band={b} width={cardsBody} />
           ) : (
-            <Box key={`b${i}`} flexDirection="row" height={grid.cardHeight} flexShrink={0}>
+            <Box key={`b${i}`} flexDirection="row" height={b.height} flexShrink={0}>
               {b.items.map((index, c) => {
                 const card = cards[index]
                 if (!card) return null
@@ -1429,7 +1433,7 @@ export function Sessions({
                       selected={selected?.id === card.id}
                       marked={marked.has(card.id)}
                       width={grid.cardWidth}
-                      height={grid.cardHeight}
+                      height={b.height}
                       words={cardWords}
                     />
                   </Box>


### PR DESCRIPTION
The card layout honours the grouping: **one band per group**. A group opens a band with its name and its cards fill the bands beneath it; a short group leaves the rest of its band empty, and that air is deliberate — it is what separates one group from the next, and it is never filled with the next group's card.

A group larger than a band breaks into more bands **of the same group**. Within a page the name is said once (it is a band or two above and plainly governs what follows); across a page break it repeats, because there it has left the screen and the card is orphaned.

Each group is named exactly **once**: with a header the card's frame title is the handle and there is no badge; without one, the title is the project and the handle takes the badge. A fact whose value *is* the group's name leaves the card — `projeto agentistics` under a header reading `agentistics` spent one of four lines repeating, and that line now carries the model or the task instead. It is the same rule `sessionColumns` already applies to the task cell when grouping by task.

**A band is as tall as its own tallest card.** One height for the whole grid is the height of the richest card in the fleet, so a session with a model, a task and a note left every other card two lines taller than it had anything to put in. Per *band* rather than per card: cards in one band sit side by side, and per-card height leaves the row's bottom edge ragged, which reads worse than a blank line in a short card beside a rich one. At 190x44 the old grid used 15 of 36 rows; the new one uses all 36.

**A trade worth stating**, not a bug: grouping costs rows. A fleet of many small groups pays a header each and leaves the rest of each band empty, so it pages more than an ungrouped grid — with the current fixtures at 130x30 that is 4 pages of 2 where it was 1 page of 9. That is the arithmetic of what was asked for, and the list is one key away when density is what you want.

Tests: 3751 pass. The preview swept 294 frames — 7 widths × 7 heights × 2 languages × 3 arrangements — none exceeding its width.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019vBSuKQLuyLhWZS4zbiu2s