### PR TITLE
fix(sessions): a band costs its cards AND the name over them

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1193,7 +1193,11 @@ packages/tui/scripts/preview.tsx   dev tool: render ONE control-center frame to 
   blank inside a frame are a box with a name in it. The band and not the card: cards of one band
   stand side by side, and giving each its own height leaves the row's bottom edge ragged, which is
   worse to look at than the one blank line a short card beside a rich one still keeps. The rows a
-  short band gives back become another band on the page, not air under the pager.
+  short band gives back become another band on the page, not air under the pager. And a band's cost
+  is its cards PLUS the name over them, so `cardGrid` is told whether headings will be drawn and
+  charges that row to EVERY band — sizing as though a band were only its cards measured the ceiling
+  for a region that then had to pay a row per band out of the very same rows, and the grouped grid
+  paged four times over. The trade it makes is one line of card for another group on the page.
 - **`stats-cache.json` stays Claude-only here too.** `selectors.ts` reads Claude totals from the
   cache and every other harness from per-session sums; `applyHarnessFilter` blanks the cache when
   a non-Claude harness is selected, or Claude's numbers would survive the filter.

--- a/packages/tui/src/control/sessions.test.ts
+++ b/packages/tui/src/control/sessions.test.ts
@@ -1301,6 +1301,35 @@ describe('cardGrid', () => {
     expect(g.cols).toBeLessThanOrEqual(4)
     expect(g.cardWidth).toBeGreaterThan(CARD_MIN_WIDTH)
   })
+
+  // A band's real cost is its cards PLUS the name over them. Sizing as though a band were only its
+  // cards is what made the grouped grid page four times over: the ceiling was measured for a region
+  // that then had to pay a row per band out of the very same rows.
+  it('charges a heading row to every band when the grid will draw them', () => {
+    for (let w = CARD_MIN_WIDTH; w <= 200; w += 7) {
+      for (let h = 2; h <= 44; h++) {
+        const g = cardGrid({ width: w, height: h, total: 40, headings: true })
+        if (!g) continue
+        expect(g.rows * (g.cardHeight + 1)).toBeLessThanOrEqual(h)
+        expect(g.cardHeight).toBeGreaterThanOrEqual(PANE_FRAME_Y + CARD_MIN_LINES)
+      }
+    }
+  })
+
+  // Same region, one more group on the page and one line less on each card.
+  it('trades a line of card for another band', () => {
+    const plain = cardGrid({ width: 100, height: 18, total: 9, lines: CARD_LINES })!
+    const headed = cardGrid({ width: 100, height: 18, total: 9, lines: CARD_LINES, headings: true })!
+    expect(headed.cardHeight).toBe(plain.cardHeight - 1)
+  })
+
+  // The degradation ladder is unchanged: a region that cannot carry a headed band is asked again
+  // without headings, and only then does the screen fall back to the list.
+  it('refuses a region too short for a band with a name over it', () => {
+    const floor = PANE_FRAME_Y + CARD_MIN_LINES
+    expect(cardGrid({ width: 120, height: floor, total: 9, headings: true })).toBeNull()
+    expect(cardGrid({ width: 120, height: floor, total: 9 })).not.toBeNull()
+  })
 })
 
 describe('cardPages', () => {

--- a/packages/tui/src/control/sessions.ts
+++ b/packages/tui/src/control/sessions.ts
@@ -1755,10 +1755,23 @@ export function cardGrid(o: {
    * in it. Counted, those rows go back to the region and another band fits on the page.
    */
   lines?: number
+  /**
+   * Whether the grid will draw a group HEADING over its bands.
+   *
+   * A band's real cost is its cards plus the name over them, and sizing as though a band were only
+   * its cards is what made the grouped grid page four times over: the ceiling was measured for a
+   * region that then had to pay a row per band out of the same rows. Counted here, one row per
+   * band, the cards give up a line and the page carries a group more.
+   *
+   * It is the ARITHMETIC of a band, not a rule of thumb — the same `+ PANE_FRAME_Y` this function
+   * already pays for a frame, for the row a heading occupies.
+   */
+  headings?: boolean
 }): CardGrid | null {
   const width = Math.max(0, o.width)
   const height = Math.max(0, o.height)
-  const floorHeight = PANE_FRAME_Y + CARD_MIN_LINES
+  const head = o.headings ? 1 : 0
+  const floorHeight = PANE_FRAME_Y + CARD_MIN_LINES + head
   const fullHeight = PANE_FRAME_Y
     + Math.max(CARD_MIN_LINES, Math.min(CARD_LINES, o.lines ?? CARD_LINES))
   if (width < CARD_MIN_WIDTH || height < floorHeight) return null
@@ -1777,8 +1790,10 @@ export function cardGrid(o: {
     Math.min(CARD_MAX_WIDTH, Math.floor((width - CARD_GAP * (cols - 1)) / cols)),
   )
   // As tall as the band affords, never taller than the card has content for: rows of blank inside
-  // a frame are not a card, they are a box with a name in it.
-  const cardHeight = Math.min(fullHeight, Math.floor(height / rows))
+  // a frame are not a card, they are a box with a name in it. `- head` is the row the name over the
+  // band takes — the cards of a headed grid are shorter by exactly what their headings cost, and
+  // `rows <= maxRows` is what keeps the result at or above the floor.
+  const cardHeight = Math.min(fullHeight, Math.floor(height / rows) - head)
 
   return {
     cols, rows, cardWidth, cardHeight, gap: CARD_GAP,

--- a/packages/tui/src/control/tabs/Sessions.tsx
+++ b/packages/tui/src/control/tabs/Sessions.tsx
@@ -516,10 +516,10 @@ export function Sessions({
   /**
    * Whether the grid draws the group HEADINGS the list draws.
    *
-   * It costs a row of the band, so it is asked as a question the geometry can answer: measure the
-   * grid one row shorter, and take the headings only if a whole card still fits. A band too short
-   * for both keeps the cards and gives them their group BADGE back — one of the two always says
-   * which group a card belongs to, and the fallback to the list is unchanged.
+   * It costs a row of every band, so it is asked as a question the geometry can answer: measure the
+   * grid with that row charged to each band, and take the headings only if a whole card still fits.
+   * A region too short for both keeps the cards and gives them their group BADGE back — one of the
+   * two always says which group a card belongs to, and the fallback to the list is unchanged.
    */
   const wantHeadings = layout === 'cards' && rows.some(r => r.kind === 'heading')
   /**
@@ -536,7 +536,10 @@ export function Sessions({
     : []), [layout, cards, badges, cardWords])
   const cardMaxLines = cardLineCounts.reduce((n, v) => Math.max(n, v), 0)
   const headedGrid: CardGrid | null = wantHeadings && rows.length > 0
-    ? cardGrid({ width: cardsBody, height: band.gridRows - 1, total: cards.length, lines: cardMaxLines })
+    ? cardGrid({
+        width: cardsBody, height: band.gridRows, total: cards.length,
+        lines: cardMaxLines, headings: true,
+      })
     : null
   const headed = headedGrid !== null
   const grid: CardGrid | null = layout === 'cards' && rows.length > 0


### PR DESCRIPTION
Follow-up to #110, which merged while this was being measured.

## The complaint

Grouping cost too many rows on a small terminal. At 130×30 the grouped grid drew **two cards a page
over four pages**, where the ungrouped one showed all nine at once. It looked like the price of the
grouping, and it was not — it was arithmetic.

## The cause

`cardGrid` sized the card ceiling as though a band were only its cards. The page then had to pay a
**heading row per band out of the very same rows** the cards had already been given. #110
compensated by measuring the grid one row shorter, which reserves ONE heading for a whole page
rather than one for each band — right for a page with a single group, and off by `bands - 1` for
every other page.

## The fix

The cost of a band is stated where a band is measured: `cardGrid` is told whether headings will be
drawn and charges that row to **every** band, exactly as it already charges `PANE_FRAME_Y` for a
frame. This is the band's arithmetic, not a rule of thumb — there is no new constant and no
threshold.

The trade is explicit and even: **one line of card for another group on the page.**

The degradation ladder now reads straight off the same function rather than off a caller's
subtraction — a region too short for a band with a name over it refuses, the screen asks again
without headings and the cards get their group badge back, and only a region too short for a bare
card falls to the list.

## Before / after, 130x30

**Before** — two cards, four pages; the region below the pager is dead:

```
 │ GROUP project   2 sessions fell 6m ago — R reopens them            9 sessions   2 waiting on you  │
 │ agentistics  1  ────────────────────────────────────────────────────────────────────────────────  │
 │ ╭─ a1b2c ─────────────────────╮                                                                   │
 │ │ migrate the auth store      │                                                                   │
 │ │ needs approval · claude     │                                                                   │
 │ │ 51.7k $1.24 · 22m ago       │                                                                   │
 │ │ model  opus                 │                                                                   │
 │ ╰─────────────────────────────╯                                                                   │
 │ agentistics · fell together  1  ────────────────────────────────────────────────────────────────  │
 │ ╭─ f00d0 ─────────────────────╮                                                                   │
 │ │ ledger reconciliation       │                                                                   │
 │ │ lost · claude               │                                                                   │
 │ │ 3h 0m ago                   │                                                                   │
 │ │ project  agentistics        │                                                                   │
 │ ╰─────────────────────────────╯                                                                   │
 │ ‹ 1 / 4 ›   2 of 9                                                                                │
 │                                                                                                   │
 │                                                                                                   │
 │                                                                                                   │
```

**After** — five cards, three pages; each card gives up its last fact and a third group fits:

```
 │ GROUP project   2 sessions fell 6m ago — R reopens them            9 sessions   2 waiting on you  │
 │ agentistics  1  ────────────────────────────────────────────────────────────────────────────────  │
 │ ╭─ a1b2c ─────────────────────╮                                                                   │
 │ │ migrate the auth store      │                                                                   │
 │ │ needs approval · claude     │                                                                   │
 │ │ 51.7k $1.24 · 22m ago       │                                                                   │
 │ ╰─────────────────────────────╯                                                                   │
 │ agentistics · fell together  1  ────────────────────────────────────────────────────────────────  │
 │ ╭─ f00d0 ─────────────────────╮                                                                   │
 │ │ ledger reconciliation       │                                                                   │
 │ │ lost · claude               │                                                                   │
 │ │ 3h 0m ago                   │                                                                   │
 │ ╰─────────────────────────────╯                                                                   │
 │ agentistics · closed  3  ───────────────────────────────────────────────────────────────────────  │
 │ ╭─ aabbc ─────────────────────╮ ╭─ claude ────────────────────╮ ╭─ codex ─────────────────────╮   │
 │ │ release notes               │ │ wire up the billing basis   │ │ billing: reconcile the led… │   │
 │ │ exited · claude             │ │ closed · claude             │ │ closed · codex              │   │
 │ │ 4h 0m ago                   │ │ 26h 0m ago                  │ │ 30h 0m ago                  │   │
 │ ╰─────────────────────────────╯ ╰─────────────────────────────╯ ╰─────────────────────────────╯   │
 │ ‹ 1 / 3 ›   5 of 9                                                                                │
```

**A tall terminal is unchanged** — at 190x44 the ceiling is the card's own content rather than the
region, so the cards keep every fact (`model`, `task`, and what the assistant is saying) and the
page still carries 6 of 9.

## Verification

- `bun tsc --noEmit` clean.
- `bun test` — **3754 pass, 0 fail** (3 new tests over the heading charge: that `rows × (cardHeight
  + 1)` never exceeds the region at any size, that the same region trades exactly one line of card
  for the heading, and that a region too short for a headed band refuses while the bare one does not).
- `packages/tui/scripts/preview.tsx` swept again at **60 / 74 / 90 / 110 / 130 / 160 / 190 columns ×
  12 / 16 / 20 / 24 / 30 / 36 / 44 rows**, both languages, three arrangements: **294 frames, every
  one asserting that no row overflows its terminal.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S5Pw28CqSYuCMiGi9gFcws
