### PR TITLE
feat(sessions): reconcile #102, answer dialogs by choosing, fix the false-positive block

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,17 +107,47 @@ packages/server/server/          — server-side modules (never bundled by Vite)
   │                          probed — so a session sitting on "may I run this command" read as
   │                          `waiting`, and a prompt sent to it went into the dialog's own filter
   │                          where the submit took the highlighted option. Probe every dialog a
-  │                          harness draws, not the first one it shows you.
+  │                          harness draws, not the first one it shows you. It has since been THREE
+  │                          for claude — startup select, permission prompt, `AskUserQuestion` —
+  │                          each with its own footer, so assume there is another until somebody has
+  │                          looked. Two harnesses MAY share a footer (claude and gemini measurably
+  │                          do); that is a fact about the CLIs, not a loose pattern, and costs
+  │                          nothing because `rulesFor` only ever tests a harness against itself.
+  │                          **A footer is matched in the LAST FEW LINES ONLY** (`FOOTER_LINES`), and
+  │                          a frame whose FOOTER carries the WORKING marker is never `waiting-
+  │                          approval`. Matching anywhere in a 60-line capture meant any session that
+  │                          QUOTED a footer read as sitting in that dialog — guaranteed here rather
+  │                          than unlikely, since agentop is developed with agentop: a session
+  │                          editing `attention-rules.ts` has those exact strings on screen all day,
+  │                          and one was offered a destructive key over a question it never asked.
+  │                          The working-marker veto is deliberately checked in the FOOTER and not
+  │                          over the whole frame — claude prints `esc to interrupt` whenever
+  │                          anything is interruptible, background subagents included, so a
+  │                          whole-frame veto would suppress a REAL permission prompt on a busy
+  │                          session. Suppressing a real block is the one error worse than the one
+  │                          being fixed.
   │                          **ACTING on a session without entering it** is `SessionBackend.sendText`
   │                          / `sendKey` (they were already implemented, buried inside `spawn`) plus
-  │                          the pure `approval-spec.ts`: `Record<HarnessId, {key, probed} | null>`,
-  │                          where the key CONFIRMS THE HIGHLIGHTED OPTION and is not "approve". No
-  │                          CLI here reports which option is highlighted, so the keystroke is only
-  │                          half the design — the host RE-READS the screen immediately before
-  │                          sending (a poll is 5s old) and the confirmation SHOWS the dialog
-  │                          (`approvalTail`, which is deliberately not `frameTail`: that one cuts at
-  │                          the last rule and so cuts the dialog away). A prompt is refused on a
-  │                          session with a dialog OPEN, in words, for the same reason.
+  │                          the pure `approval-spec.ts` + `dialog-choice.ts`. **Most dialogs are not
+  │                          yes/no**: claude's permission prompt is itself `1. Yes / 2. Yes, always
+  │                          / 3. No`, and an `AskUserQuestion` can offer five answers that do
+  │                          different work. A key that "approves" takes whichever row is
+  │                          HIGHLIGHTED, which on such a dialog is choosing for the user — reported
+  │                          by one, looking at "how do I promote to prod?" with four answers. So
+  │                          `parseDialogOptions` reads the options OFF THE SCREEN (bottom-up,
+  │                          stopping at `1.`, and refusing unless they come out exactly `1..n` —
+  │                          half-read options are worse than none because they get OFFERED), the UI
+  │                          lists them, and the PICKED one is sent. `ApprovalSpec.choice` says how
+  │                          to select by number and exists ONLY for claude, verified by driving a
+  │                          live session; everywhere else a numbered dialog is REFUSED in words
+  │                          naming what does work (attach), because falling back to the confirm key
+  │                          is the defect. The bare confirm survives only where there is genuinely
+  │                          nothing to choose between (codex's `Press enter to continue`). The host
+  │                          RE-READS the screen immediately before sending (a poll is 5s old) and
+  │                          refuses when the options CHANGED, and the question SHOWS the dialog
+  │                          (`approvalTail`, deliberately not `frameTail`: that one cuts at the last
+  │                          rule and so cuts the dialog away). A prompt is refused on a session with
+  │                          a dialog OPEN, in words, for the same reason.
   │                          **WHICH SESSIONS FELL TOGETHER** is the pure `crash-group.ts`. The hard
   │                          part is not grouping, it is not admitting garbage: a `lost` row from
   │                          three days ago never fell, and a group holding everything that ever ran

--- a/packages/server/server/cli-i18n.ts
+++ b/packages/server/server/cli-i18n.ts
@@ -127,6 +127,16 @@ export interface CliStrings {
   sessNotAsking: string
   /** Refused: this harness's dialog has never been read, so there is no key to send. */
   sessApproveUnknown: (harness: string) => string
+  /** Said on a row whose dialog offers OPTIONS and whose harness has no verified way to pick one. */
+  sessChooseBlind: (harness: string) => string
+  /** Refused: the dialog offers N options, so there is nothing to merely "approve". */
+  sessNeedsChoice: (n: number) => string
+  /** Refused: the question changed between being shown and being answered. */
+  sessChoiceGone: string
+  /** Refused: no verified way to select an option by number on this harness. */
+  sessChooseUnknown: (harness: string) => string
+  /** The chosen option went in — and the sentence names WHICH, because that is the whole point. */
+  sessAnswered: (label: string) => string
   /** Nothing fell, or everything that did has already been picked back up. */
   sessNoFell: string
   sessFellOpened: (opened: number, skipped: number) => string
@@ -366,6 +376,15 @@ const EN: CliStrings = {
   sessNotAsking: 'that session is not asking anything right now — nothing was sent.',
   sessApproveUnknown: (harness: string) =>
     `agentop has not read ${harness}'s dialog, so it will not guess which key answers it.`,
+  sessChooseBlind: (harness: string) =>
+    `this dialog is a choice, and nobody has verified how to pick an option on ${harness} — attach to answer it there.`,
+  sessNeedsChoice: (n: number) =>
+    `that dialog offers ${n} options, so there is nothing to simply approve — pick one.`,
+  sessChoiceGone:
+    'the session is asking something else now — nothing was sent. Look again before answering.',
+  sessChooseUnknown: (harness: string) =>
+    `agentop has no verified way to pick an option on ${harness}, and will not confirm the highlighted one for you — attach to answer it there.`,
+  sessAnswered: (label: string) => `answered: ${label}`,
   sessNoFell: 'nothing fell — no session was lost with the machine still on record.',
   sessFellOpened: (opened: number, skipped: number) =>
     skipped > 0
@@ -579,6 +598,15 @@ const PT: CliStrings = {
   sessNotAsking: 'essa sessão não está perguntando nada agora — nada foi enviado.',
   sessApproveUnknown: (harness: string) =>
     `o agentop não leu o diálogo do ${harness}, e não vai chutar qual tecla responde.`,
+  sessChooseBlind: (harness: string) =>
+    `esse diálogo é uma escolha, e ninguém verificou como selecionar uma opção no ${harness} — anexe para responder lá.`,
+  sessNeedsChoice: (n: number) =>
+    `esse diálogo tem ${n} opções, então não há o que simplesmente aprovar — escolha uma.`,
+  sessChoiceGone:
+    'a sessão está perguntando outra coisa agora — nada foi enviado. Olhe de novo antes de responder.',
+  sessChooseUnknown: (harness: string) =>
+    `o agentop não tem forma verificada de escolher uma opção no ${harness}, e não vai confirmar a destacada por você — anexe para responder lá.`,
+  sessAnswered: (label: string) => `respondido: ${label}`,
   sessNoFell: 'nada caiu — nenhuma sessão foi perdida com registro de que estava viva.',
   sessFellOpened: (opened: number, skipped: number) =>
     skipped > 0

--- a/packages/server/server/cli-i18n.ts
+++ b/packages/server/server/cli-i18n.ts
@@ -134,6 +134,10 @@ export interface CliStrings {
   /** The fallback title for a session the user never named. */
   sessUntitled: (harness: string, project: string) => string
   sessKilled: (id: string) => string
+  sessRestoreNone: string
+  sessRestoreDeclined: (n: number) => string
+  sessRestored: (opened: number, skipped: number) => string
+  sessRestoreFailed: (skipped: number) => string
   sessNoTask: string
   sessTaskFinished: (task: string) => string
   sessTaskReopened: (task: string) => string
@@ -371,6 +375,13 @@ const EN: CliStrings = {
     `none of the ${skipped} session(s) that fell could be reopened.`,
   sessUntitled: (harness: string, project: string) => (project ? `${harness} in ${project}` : harness),
   sessKilled: (id: string) => `stopped ${id}.`,
+  sessRestoreNone: 'those sessions are no longer in the registry.',
+  sessRestoreDeclined: (n: number) =>
+    `left ${n} session${n === 1 ? '' : 's'} closed — still listed, still reopenable.`,
+  sessRestored: (opened: number, skipped: number) =>
+    `restored ${opened}${skipped ? `, ${skipped} could not be` : ''}.`,
+  sessRestoreFailed: (skipped: number) =>
+    `nothing could be restored${skipped ? ` — ${skipped} had no conversation to reopen` : ''}.`,
   sessNoTask: 'that session has no task.',
   sessTaskFinished: (task: string) => `"${task}" marked finished.`,
   sessTaskReopened: (task: string) => `"${task}" reopened.`,
@@ -577,6 +588,13 @@ const PT: CliStrings = {
     `nenhuma das ${skipped} sessão(ões) que caíram pôde ser reaberta.`,
   sessUntitled: (harness: string, project: string) => (project ? `${harness} em ${project}` : harness),
   sessKilled: (id: string) => `${id} encerrada.`,
+  sessRestoreNone: 'essas sessões não estão mais no registro.',
+  sessRestoreDeclined: (n: number) =>
+    `${n} ${n === 1 ? 'sessão deixada fechada' : 'sessões deixadas fechadas'} — continuam listadas e reabríveis.`,
+  sessRestored: (opened: number, skipped: number) =>
+    `${opened} restaurada${opened === 1 ? '' : 's'}${skipped ? `, ${skipped} não deu` : ''}.`,
+  sessRestoreFailed: (skipped: number) =>
+    `nada pôde ser restaurado${skipped ? ` — ${skipped} sem conversa para reabrir` : ''}.`,
   sessNoTask: 'essa sessão não tem tarefa.',
   sessTaskFinished: (task: string) => `"${task}" marcada como finalizada.`,
   sessTaskReopened: (task: string) => `"${task}" reaberta.`,

--- a/packages/server/server/cli-start.ts
+++ b/packages/server/server/cli-start.ts
@@ -94,7 +94,8 @@ import { repoFacts } from './sessions/repo-facts'
 // rows from the same decision rather than mapping the fleet a second time.
 import { toControlSession } from './sessions/control-session'
 import { planTaskReopen, taskReopenSucceeded, type TaskReopenPlan } from './sessions/task-reopen'
-import { approvalFor } from './sessions/approval-spec'
+import { approvalFor, choiceKey } from './sessions/approval-spec'
+import { needsChoice, parseDialogOptions } from './sessions/dialog-choice'
 import { rulesFor } from './sessions/attention-rules'
 import { planCrashGroup, planFellOffer } from './sessions/crash-group'
 import { loadHarnessSessions } from './sessions/harness-sessions'
@@ -2183,15 +2184,14 @@ function createControlHost(initialLang: CliLang, altScreen: Suspendable): StartH
     },
 
     /**
-     * Send the key that takes the option this session's dialog is highlighting.
+     * Answer the dialog this session is blocked on.
      *
-     * Three things have to be true at THIS instant, and each is checked rather than assumed: the
-     * harness's dialog has been read (so the key is a recorded fact — `approval-spec.ts`), the
-     * session is still asking (re-read from the screen, not from a snapshot), and the backend
-     * accepted the keystroke. Anything less and an unconditional Enter goes into a session that has
-     * moved on — a blank turn at best, and at worst a menu answered while nobody was looking.
+     * Everything is checked at THIS instant rather than assumed from a snapshot: the session is
+     * still asking, the options on screen are still the ones the user was shown, and the harness has
+     * a verified way to select the one they picked. A snapshot is up to five seconds old, and an
+     * answer sent to a question that has changed underneath it is both wrong and silent.
      */
-    async approveSession(id: string): Promise<ActionResult> {
+    async answerSession(id: string, choice?: number): Promise<ActionResult> {
       const s = S()
       const backend = await resolveBackend()
       const blocked = await backend.unavailable()
@@ -2212,6 +2212,30 @@ function createControlHost(initialLang: CliLang, altScreen: Suspendable): StartH
         return { ok: false, message: s.sessNotAsking }
       }
 
+      // What is on the screen RIGHT NOW, not what was drawn up to a poll ago.
+      const options = parseDialogOptions(frame)
+
+      if (needsChoice(options)) {
+        // A numbered dialog is NEVER answered with a bare confirm. `Enter` takes whichever row is
+        // highlighted, and on "only my fix / promote everything / stop here / type something" that
+        // is choosing between four different outcomes on somebody else's repository.
+        if (choice === undefined) return { ok: false, message: s.sessNeedsChoice(options.length) }
+        const picked = options.find(o => o.number === choice)
+        // The question CHANGED between being shown and being answered. Sending "3" to a question
+        // that now has different answers is worse than sending nothing, and nothing about it would
+        // be visible afterwards — so it is refused by name.
+        if (!picked) return { ok: false, message: s.sessChoiceGone }
+        const key = choiceKey(spec, choice)
+        if (!key) return { ok: false, message: s.sessChooseUnknown(managed.harness) }
+        return (await backend.sendKey(id, key))
+          ? { ok: true, message: s.sessAnswered(picked.label) }
+          : { ok: false, message: s.sessSendFailed(id) }
+      }
+
+      // No readable options: the codex-shaped `Press enter to continue`, where there genuinely is
+      // nothing to choose between. A choice offered here would be answering a question with no
+      // answers, so it is refused rather than quietly ignored.
+      if (choice !== undefined) return { ok: false, message: s.sessChoiceGone }
       return (await backend.sendKey(id, spec.key))
         ? { ok: true, message: s.sessApproved(id) }
         : { ok: false, message: s.sessSendFailed(id) }

--- a/packages/server/server/cli-start.ts
+++ b/packages/server/server/cli-start.ts
@@ -61,6 +61,7 @@ import type {
   StartOption,
   TabId,
   StartRequest,
+  RestoreCandidate,
 } from '@agentistics/tui/control'
 import { DEFAULT_SESSION_VIEW } from '@agentistics/tui/control'
 import { PORT, WEB_PORT } from './config'
@@ -95,7 +96,7 @@ import { toControlSession } from './sessions/control-session'
 import { planTaskReopen, taskReopenSucceeded, type TaskReopenPlan } from './sessions/task-reopen'
 import { approvalFor } from './sessions/approval-spec'
 import { rulesFor } from './sessions/attention-rules'
-import { planCrashGroup } from './sessions/crash-group'
+import { planCrashGroup, planFellOffer } from './sessions/crash-group'
 import { loadHarnessSessions } from './sessions/harness-sessions'
 import type { ManagedSession, SpawnPlanError } from './sessions/types'
 import {
@@ -115,6 +116,7 @@ export type StartResult = number | 'foreground'
  * an open menu.
  */
 const SEND_CAPTURE_LINES = 60
+
 
 // ANSI, for the output this module still writes to the REAL terminal: the suspended commands,
 // the foreground handover and the non-interactive `agentop restart --all`.
@@ -1363,6 +1365,52 @@ async function reopenEntries(
   return { plan, opened, skipped }
 }
 
+/**
+ * The fall, named ROW BY ROW — what the offer made on the way in shows.
+ *
+ * The SELECTION is `planCrashGroup` and nothing else. This started life as a second selection
+ * (`planRestore`, from the branch this is reconciled with), and the two agreed about `endedAt` and
+ * about claiming a conversation once while disagreeing about the thing that matters: `planRestore`
+ * had no evidence a row was ever ALIVE, so it offered every resolvable `lost` row — which on a
+ * machine with months of history is the "sessões lixo" complaint this feature was built to answer.
+ * Two selections is two sets of rules; the repo has paid for that once already (`task-reopen.ts`).
+ *
+ * Exactly ONE rule is added on top, and it belongs here rather than in the pure selection because it
+ * is about the OFFER and not about the fall: a row whose conversation cannot be resolved is dropped,
+ * because this list is clickable and a row that cannot be reopened is a button that fails. It stays
+ * inside `fell`, where `reopenEntries` counts it as skipped — the fall is what happened, and the
+ * offer is what can be done about it.
+ */
+async function restorableSessions(fell: readonly ManagedSession[]): Promise<RestoreCandidate[]> {
+  if (fell.length === 0) return []
+  const conversations = await loadConversations()
+  const taken = new Set<string>()
+
+  // The DECISION is the pure `planFellOffer`; this is the I/O around it — the conversation store,
+  // and the claiming that stops four fallen rows in one repository being offered four copies of one
+  // conversation.
+  return planFellOffer({
+    entries: fell,
+    conversationFor: m => {
+      const own = m.conversationId
+        ? conversations.find(c => c.sessionId === m.conversationId)
+        : undefined
+      const conv = own ?? conversations.find(c =>
+        !taken.has(c.sessionId) && c.harness === m.harness && c.cwd === m.cwd)
+      if (!conv?.resumable) return null
+      taken.add(conv.sessionId)
+      return { sessionId: conv.sessionId, title: conv.title }
+    },
+  }).map(o => ({
+    id: o.entry.id,
+    label: o.label,
+    harness: o.entry.harness,
+    // The last segment, the same key the "by project" grouping falls back to.
+    project: o.entry.cwd.replace(/[/\\]+$/, '').split(/[/\\]/).pop() ?? '',
+    ...(o.startedMs !== undefined ? { startedAt: o.startedMs } : {}),
+  }))
+}
+
 function createControlHost(initialLang: CliLang, altScreen: Suspendable): StartHost {
   let lang = initialLang
   const S = () => cliStrings(lang)
@@ -1878,7 +1926,13 @@ function createControlHost(initialLang: CliLang, altScreen: Suspendable): StartH
       // this poll runs every five seconds over the whole fleet — asking git three times per session
       // per tick would be a hundred processes a minute to learn the same thing.
       const facts = await Promise.all(snap.sessions.map(v => repoFacts(v.cwd)))
+      // What the machine LOST and could start again — named row by row for the offer, from the
+      // SAME selection the count below reports. Read off the snapshot the poll already produced
+      // rather than recomputed, so the screen cannot be shown two answers to one question while a
+      // poll is in flight.
+      const restorable = await restorableSessions(snap.fell?.entries ?? [])
       return {
+        ...(restorable.length > 0 ? { restorable } : {}),
         sessions: snap.sessions.map((v, i) => toControlSession(v, s, facts[i])),
         attention: snap.attention,
         rang: snap.rang,
@@ -1935,6 +1989,38 @@ function createControlHost(initialLang: CliLang, altScreen: Suspendable): StartH
      * what the button just did. Nothing about the sessions changes: a finished task is a statement
      * about the WORK, and its sessions stay listed, attachable and killable behind one switch.
      */
+    /**
+     * Start the offered sessions again, detached — or decline them.
+     *
+     * ACCEPTING is `reopenEntries`, the same thing "open the whole task" and "reopen what fell"
+     * perform. It arrived here as its own copy of that loop, which made THREE implementations of
+     * one gesture — the drift `task-reopen.ts` was extracted to end, reintroduced by two sessions
+     * that could not see each other's work. The set is different, the act is not.
+     *
+     * DECLINING retires the rows it was offered. "No" here means the work is over, and without it
+     * the same offer greets you on the next run and the one after, which is how a prompt becomes
+     * something people clear without reading. Nothing is destroyed either way: a retired row stays
+     * listed, and `endedAt` is exactly what keeps it out of the next crash group while leaving it
+     * individually reopenable.
+     */
+    async restoreSessions(ids: string[], accept: boolean): Promise<ActionResult> {
+      const s = S()
+      const registry = await readRegistry()
+      const wanted = registry.filter(m => ids.includes(m.id))
+      if (wanted.length === 0) return { ok: false, message: s.sessRestoreNone }
+
+      if (!accept) {
+        const stamp = new Date().toISOString()
+        for (const m of wanted) await patchSession(m.id, { endedAt: stamp })
+        return { ok: true, message: s.sessRestoreDeclined(wanted.length) }
+      }
+
+      const { opened, skipped } = await reopenEntries(wanted, s)
+      return opened > 0
+        ? { ok: true, message: s.sessRestored(opened, skipped) }
+        : { ok: false, message: s.sessRestoreFailed(skipped) }
+    },
+
     async finishTask(task: string, done: boolean): Promise<ActionResult> {
       const s = S()
       if (!task) return { ok: false, message: s.sessNoTask }

--- a/packages/server/server/sessions/approval-spec.test.ts
+++ b/packages/server/server/sessions/approval-spec.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'bun:test'
 import { HARNESS_ORDER } from '@agentistics/core'
-import { APPROVAL_SPECS, approvalFor } from './approval-spec'
+import { APPROVAL_SPECS, approvalFor, choiceKey } from './approval-spec'
 import { ATTENTION_RULES } from './attention-rules'
 
 describe('APPROVAL_SPECS', () => {
@@ -36,5 +36,45 @@ describe('APPROVAL_SPECS', () => {
   it('answers with undefined rather than null, and for an absent harness at all', () => {
     expect(approvalFor('claude')?.key).toBe('Enter')
     expect(approvalFor(undefined)).toBeUndefined()
+  })
+})
+
+describe('choiceKey', () => {
+  it('types the option NUMBER on a harness where that was verified', () => {
+    // Driven against a live claude 2.1.232 twice on 2026-08-14: `3` at a Write permission prompt
+    // produced `User rejected write` (option 3 = No), and `3` at an AskUserQuestion selected that
+    // question's third answer.
+    expect(choiceKey(approvalFor('claude'), 3)).toBe('3')
+  })
+
+  it('REFUSES on a harness where nobody has verified how to choose', () => {
+    // There is no safe fallback to the confirm key. Confirming the highlighted row on a dialog
+    // somebody is being shown four answers to is choosing for them, which is the whole defect.
+    for (const id of ['codex', 'kimi', 'gemini', 'copilot', 'antigravity'] as const) {
+      expect(choiceKey(approvalFor(id), 1), id).toBeNull()
+    }
+  })
+
+  it('refuses a number that is not a typeable option', () => {
+    const claude = approvalFor('claude')
+    expect(choiceKey(claude, 0)).toBeNull()
+    expect(choiceKey(claude, -1)).toBeNull()
+    expect(choiceKey(claude, 1.5)).toBeNull()
+    // Past nine there is no single key to type, and inventing a mechanism for a dialog nobody has
+    // seen is how a guess ships.
+    expect(choiceKey(claude, 10)).toBeNull()
+  })
+
+  it('refuses when there is no spec at all', () => {
+    expect(choiceKey(undefined, 1)).toBeNull()
+  })
+})
+
+describe('the choice capability', () => {
+  it('records where it was verified, like every other probed value here', () => {
+    for (const [id, spec] of Object.entries(APPROVAL_SPECS)) {
+      if (!spec?.choice) continue
+      expect(spec.choice.probed, id).toMatch(/\d.*\d, \d{4}-\d{2}-\d{2}/)
+    }
   })
 })

--- a/packages/server/server/sessions/approval-spec.ts
+++ b/packages/server/server/sessions/approval-spec.ts
@@ -54,17 +54,53 @@ export interface ApprovalSpec {
    * it. NOT "the key that approves" — see the header.
    */
   key: string
+  /**
+   * How to pick option N of a numbered dialog, when that is known for this harness.
+   *
+   * `digit` means typing the option's own number selects it outright. ABSENT means nobody has
+   * verified how to choose on this harness — and a caller must then REFUSE a multi-option dialog in
+   * words rather than falling back to `key`, which would confirm whichever row happened to be
+   * highlighted. That fallback is precisely the defect this field exists to close: a person pressing
+   * a key called "approve" and unknowingly picking one of four different courses of action.
+   *
+   * Only `claude` has one, and it was verified by driving a live session twice on 2026-08-14 —
+   * sending `3` at a Write permission prompt produced `User rejected write` (option 3 = No), and
+   * sending `3` at an `AskUserQuestion` selected that question's third answer. Nothing here is
+   * inferred from the other harnesses' footers, which say `Enter select` and nothing about digits.
+   */
+  choice?: { kind: 'digit'; probed: string }
   /** Provenance — the exact CLI version the dialog came from, and the date. */
   probed: string
 }
 
 export const APPROVAL_SPECS: Record<HarnessId, ApprovalSpec | null> = {
-  claude: { key: 'Enter', probed: 'claude 2.1.231, 2026-08-13' },
+  claude: {
+    key: 'Enter',
+    probed: 'claude 2.1.231, 2026-08-13',
+    choice: { kind: 'digit', probed: 'claude 2.1.232, 2026-08-14 (permission prompt + AskUserQuestion)' },
+  },
+  // No `choice` below this line, and that is a statement rather than a gap: each of these footers
+  // says `Enter` selects, and none of them says anything about typing a number. Nobody has driven
+  // one to find out, so a numbered dialog on these harnesses is refused with the reason.
   codex: { key: 'Enter', probed: 'codex 0.113.0, 2026-08-13' },
   kimi: { key: 'Enter', probed: 'kimi 0.35.0, 2026-08-13' },
   gemini: { key: 'Enter', probed: 'gemini 0.55.1, 2026-08-13' },
   copilot: { key: 'Enter', probed: 'GitHub Copilot CLI 1.0.79, 2026-08-13' },
   antigravity: { key: 'Enter', probed: 'agy 1.1.12, 2026-08-13' },
+}
+
+/**
+ * The keystroke that picks option `n`, or `null` when this harness has no verified way to choose.
+ *
+ * `null` is the refusal, and it must be honoured: there is no safe fallback to the confirm key,
+ * because confirming the highlighted row on a dialog the user is being shown four answers to is
+ * choosing for them.
+ */
+export function choiceKey(spec: ApprovalSpec | undefined, n: number): string | null {
+  if (!spec?.choice || !Number.isInteger(n) || n < 1) return null
+  // Only single digits are typeable as one key. A dialog with more than nine options would need a
+  // different mechanism, and inventing one for a case nobody has seen is how a guess ships.
+  return spec.choice.kind === 'digit' && n <= 9 ? String(n) : null
 }
 
 /** The spec for a harness, or `undefined` when its dialog was never read. */

--- a/packages/server/server/sessions/attention-rules.test.ts
+++ b/packages/server/server/sessions/attention-rules.test.ts
@@ -243,6 +243,19 @@ describe('the harnesses probed alongside their spawn specs', () => {
     // a pattern loose enough to match both would fire on any list with arrow-key help on it.
     expect(quiet(AGY_APPROVAL, 'copilot')).toBe('waiting')
     expect(quiet(COPILOT_APPROVAL, 'antigravity')).toBe('waiting')
-    expect(quiet(GEMINI_APPROVAL, 'claude')).toBe('waiting')
+  })
+
+  it('lets claude and gemini overlap, because they MEASURABLY share that footer', () => {
+    // `GEMINI_APPROVAL` used to be asserted alongside the two above, and that was right until
+    // claude's THIRD dialog was probed on 2026-08-14: its `AskUserQuestion` footer really does read
+    // `Enter to select · ↑/↓ to navigate · Esc to cancel`, which is gemini's line exactly.
+    //
+    // So the overlap is a FACT about the two CLIs rather than a pattern written too loosely, and it
+    // costs nothing: `rulesFor(harness)` only ever tests a harness's own rules against its own
+    // frames, so neither is ever asked about the other outside this test. What the rule above still
+    // protects is the thing that mattered — nobody writing ONE pattern to cover several harnesses
+    // in place of probing each of them.
+    expect(quiet(GEMINI_APPROVAL, 'claude')).toBe('waiting-approval')
+    expect(quiet(GEMINI_APPROVAL, 'gemini')).toBe('waiting-approval')
   })
 })

--- a/packages/server/server/sessions/attention-rules.ts
+++ b/packages/server/server/sessions/attention-rules.ts
@@ -52,6 +52,17 @@ export const ATTENTION_RULES: Record<HarnessId, AttentionRules | null> = {
       // The shared part is what is matched. `ctrl+e to explain` is offered only where there is a
       // command to explain, so keying on it would have missed every file edit.
       /Esc to cancel · Tab to amend/,
+      // **A THIRD component, with a third footer**, captured from a live `AskUserQuestion` on
+      // 2026-08-14 (claude 2.1.232):
+      //   `Enter to select · ↑/↓ to navigate · Esc to cancel`
+      // Neither line above matches it, so a session waiting on a question with four answers read as
+      // plain `waiting` — which is how a user came to be looking at "how do I promote this to prod?"
+      // with no way to answer it from here.
+      //
+      // Three claude dialogs, three footers. The lesson from the second one — probe every dialog a
+      // harness draws, not the first one it shows you — is now a measured pattern rather than an
+      // inference: assume there is another until somebody has looked.
+      /Enter to select · ↑\/↓ to navigate/,
     ],
     // The footer while a turn runs. `? for shortcuts` takes its place when the turn ends.
     working: [/esc to interrupt/],

--- a/packages/server/server/sessions/attention.test.ts
+++ b/packages/server/server/sessions/attention.test.ts
@@ -235,3 +235,74 @@ describe('approvalTail', () => {
     expect(approvalTail(DIALOG, 0)).toEqual([])
   })
 })
+
+describe('a footer is the BOTTOM of the screen, not any line on it', () => {
+  const rules: AttentionRules = {
+    probed: 'test',
+    approval: [/Esc to cancel · Tab to amend/],
+    working: [/esc to interrupt/],
+  }
+  const read = (frame: string[]) => attentionOf({
+    alive: true,
+    // Quiet and unmoving, so the frame is the only thing that can decide.
+    lastActivityMs: NOW - 30_000,
+    nowMs: NOW,
+    frame,
+    frameDigest: 'same',
+    prevDigest: 'same',
+    rules,
+  })
+
+  /**
+   * VERBATIM in shape from the session that was misreported on 2026-08-14: it had spent the morning
+   * WRITING the approval rules, so the footer string was on its screen as source code while it was
+   * plainly working — spinner running, `esc to interrupt` in the real footer.
+   */
+  const QUOTING_THE_FOOTER = [
+    '● Editing attention-rules.ts',
+    '   approval: [',
+    '     /Esc to cancel · Tab to amend/,',
+    '   ],',
+    '✻ Leavening… (18m 20s · ↓ 23.0k tokens)',
+    '❯ ',
+    '⏵⏵ auto mode on (shift+tab to cycle) · PR #108 · esc to interrupt · ← 6 agents',
+  ]
+
+  it('does not call a session blocked because it QUOTED a dialog footer', () => {
+    // The bug this fixes, and in this repository it is guaranteed rather than unlikely: agentop is
+    // developed with agentop. The user was offered a destructive key over a question nobody asked.
+    expect(read(QUOTING_THE_FOOTER)).toBe('working')
+  })
+
+  it('still sees the footer when it is where a footer actually is', () => {
+    expect(read([
+      '● I will write the file',
+      ' Do you want to create x.txt?',
+      ' ❯ 1. Yes',
+      '   2. No',
+      ' Esc to cancel · Tab to amend',
+    ])).toBe('waiting-approval')
+  })
+
+  it('does not read a footer that has scrolled up out of the footer region', () => {
+    // Six lines of conversation below it: whatever that string is, it is not this screen's footer.
+    expect(read([
+      ' Esc to cancel · Tab to amend',
+      '● one', '● two', '● three', '● four', '● five', '● six',
+    ])).not.toBe('waiting-approval')
+  })
+
+  it('vetoes on the FOOTER only, so background agents cannot hide a real prompt', () => {
+    // claude prints `esc to interrupt` whenever anything is interruptible, background subagents
+    // included. A whole-frame veto would therefore suppress a genuine permission prompt on a busy
+    // session — suppressing a real block is worse than the false positive being fixed.
+    expect(read([
+      '  ⏵⏵ auto mode on · esc to interrupt · ← 6 agents',
+      '● main',
+      ' Do you want to proceed?',
+      ' ❯ 1. Yes',
+      '   2. No',
+      ' Esc to cancel · Tab to amend',
+    ])).toBe('waiting-approval')
+  })
+})

--- a/packages/server/server/sessions/attention.ts
+++ b/packages/server/server/sessions/attention.ts
@@ -41,6 +41,22 @@ export const QUIET_MS = 6_000
 export const MARKER_STALE_MS = 60_000
 
 /**
+ * How much of the BOTTOM of a frame counts as its footer.
+ *
+ * Every approval pattern in `attention-rules.ts` is a footer, and every dialog probed for this
+ * feature draws its footer on the last line — the three claude components, codex, kimi, gemini,
+ * copilot and agy alike. Four leaves room for a trailing blank or a strip drawn beneath it without
+ * reaching far enough up to catch the conversation.
+ *
+ * The window is the point. Matching a footer anywhere in a sixty-line capture means any session
+ * that QUOTES one is read as sitting in it, and in this repository that is guaranteed rather than
+ * unlikely: agentop is developed with agentop, so a session editing `attention-rules.ts` has those
+ * exact strings on screen all day. One was offered a destructive key over a question it had never
+ * asked. A quotation lives in the middle of a screen; a footer lives at the end of it.
+ */
+export const FOOTER_LINES = 4
+
+/**
  * FNV-1a over the frame, joined with newlines.
  *
  * Dependency-free, and deliberately not a crypto hash: the only question ever asked of this value is
@@ -73,12 +89,28 @@ export function attentionOf(o: {
   if (!o.alive) return 'exited'
 
   const text = o.frame.join('\n')
-  if (o.rules && o.rules.approval.some(re => re.test(text))) return 'waiting-approval'
+  // A dialog's footer is a property of the BOTTOM of the screen, and matching it anywhere in the
+  // frame is what let a session that merely TALKED about one be reported as blocked in it. That is
+  // not a hypothetical here: this project is built with agentop, so sessions spend whole mornings
+  // with strings like `Esc to cancel · Tab to amend` on screen as source code — and one of them was
+  // offered a destructive key over a question it had never asked. Reported from a real machine.
+  const footer = o.frame.slice(Math.max(0, o.frame.length - FOOTER_LINES)).join('\n')
+  const working = (haystack: string) =>
+    Boolean(o.rules?.working && o.rules.working.some(re => re.test(haystack)))
+  // A frame whose FOOTER says something is interruptible is not a frame sitting on a dialog: the
+  // dialog's own footer takes that row while it is open. Checked in the footer rather than over the
+  // whole frame, and that narrowness is deliberate — claude prints `esc to interrupt` whenever
+  // anything is interruptible INCLUDING BACKGROUND AGENTS, so a whole-frame veto would suppress a
+  // genuine permission prompt on a session whose subagents happen to be running. Suppressing a real
+  // block is the one error worse than the one being fixed.
+  if (o.rules && !working(footer) && o.rules.approval.some(re => re.test(footer))) {
+    return 'waiting-approval'
+  }
 
   // The marker is PROOF of work only while the screen has been moving at all recently. A footer
   // that lingers is not evidence, and silence eventually outweighs it — see `MARKER_STALE_MS`.
   const silentFor = o.nowMs - o.lastActivityMs
-  if (silentFor <= MARKER_STALE_MS && o.rules?.working && o.rules.working.some(re => re.test(text))) {
+  if (silentFor <= MARKER_STALE_MS && working(text)) {
     return 'working'
   }
 

--- a/packages/server/server/sessions/control-session.ts
+++ b/packages/server/server/sessions/control-session.ts
@@ -17,6 +17,7 @@ import { fmt, fmtCost } from '@agentistics/core'
 import type { ControlSession, SessionState } from '@agentistics/tui/control'
 import type { CliStrings } from '../cli-i18n'
 import { approvalFor } from './approval-spec'
+import { needsChoice } from './dialog-choice'
 import { pickTitle } from './harness-session-file'
 import type { RepoFacts } from './repo-facts'
 import type { SessionView } from './session-view'
@@ -120,11 +121,24 @@ export function toControlSession(
     ...(v.resume ? { resume: v.resume } : {}),
     ...(v.lastLines?.length ? { lastLines: v.lastLines } : {}),
     ...(v.approvalLines?.length ? { approvalLines: v.approvalLines } : {}),
+    ...(v.dialogOptions?.length ? { dialogOptions: v.dialogOptions } : {}),
+    // Picking one of them needs a VERIFIED way to select by number on this harness. Only claude has
+    // one; everywhere else the options are shown and the answer is a refusal that names why, because
+    // falling back to the confirm key would choose for the user among things that differ.
+    ...(needsChoice(v.dialogOptions ?? []) && approvalFor(v.harness)?.choice
+      ? { canChoose: true as const }
+      : {}),
+    ...(needsChoice(v.dialogOptions ?? []) && !approvalFor(v.harness)?.choice && harness
+      ? { chooseBlind: s.sessChooseBlind(harness) }
+      : {}),
     // The verb exists only where BOTH halves are true: the session is asking, and somebody has read
     // this harness's dialog and recorded the key that answers it. Either missing and the action is
     // absent rather than present and wrong — the same rule the wizard applies to a harness with no
     // spawn spec.
-    ...(state === 'waiting-approval' && approvalFor(v.harness)
+    // A bare confirm is only ever offered where there is NOTHING to choose between — the
+    // codex-shaped `Press enter to continue`. On a numbered dialog it would take whichever row is
+    // highlighted, which on "only my fix / promote everything / stop here" is picking for somebody.
+    ...(state === 'waiting-approval' && approvalFor(v.harness) && !needsChoice(v.dialogOptions ?? [])
       ? { canApprove: true as const }
       : {}),
     // Said only where it is TRUE, which is a narrower place than `approvalBlind`: that one explains

--- a/packages/server/server/sessions/crash-group.test.ts
+++ b/packages/server/server/sessions/crash-group.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'bun:test'
-import { CRASH_WINDOW_MS, HEARTBEAT_MS, planCrashGroup } from './crash-group'
+import {
+  CRASH_WINDOW_MS, HEARTBEAT_MS, OFFER_LIMIT, planCrashGroup, planFellOffer,
+} from './crash-group'
 import type { ManagedSession } from './types'
 
 const NOW = 1_786_700_000_000
@@ -135,5 +137,69 @@ describe('planCrashGroup', () => {
       backendIds: new Set(),
     })
     expect(ids(group)).toEqual(['a'])
+  })
+})
+
+describe('planFellOffer', () => {
+  const conv = (sessionId: string, title = sessionId) => ({ sessionId, title })
+  const all = (e: ManagedSession) => conv(`c-${e.id}`)
+
+  it('names each row with the user own label, falling back to the conversation title', () => {
+    const out = planFellOffer({
+      entries: [row('a', { label: 'my work' }), row('b')],
+      conversationFor: e => conv(`c-${e.id}`, `titled ${e.id}`),
+    })
+    expect(out.map(o => o.label)).toEqual(['my work', 'titled b'])
+  })
+
+  it('drops a row whose conversation does not resolve — a button that fails is not an offer', () => {
+    const out = planFellOffer({
+      entries: [row('a'), row('b')],
+      conversationFor: e => (e.id === 'a' ? conv('c-a') : null),
+    })
+    expect(out.map(o => o.entry.id)).toEqual(['a'])
+  })
+
+  it('is NARROWER than the fall, and only here — the count must not shrink with it', () => {
+    // A row that cannot be reopened still fell. `planCrashGroup` keeps it so the summary row and the
+    // heading describe the event, and `reopenEntries` reports it as skipped rather than pretending
+    // it was never there.
+    const entries = [row('a'), row('cannot')]
+    const group = planCrashGroup({ entries, backendIds: new Set() })
+    expect(group?.entries).toHaveLength(2)
+    expect(planFellOffer({
+      entries: group!.entries,
+      conversationFor: e => (e.id === 'a' ? conv('c-a') : null),
+    })).toHaveLength(1)
+  })
+
+  it('is newest first — what someone was in the middle of is the recent work', () => {
+    const out = planFellOffer({
+      entries: [
+        row('old', { createdAt: '2026-08-01T10:00:00.000Z' }),
+        row('new', { createdAt: '2026-08-14T10:00:00.000Z' }),
+      ],
+      conversationFor: all,
+    })
+    expect(out.map(o => o.entry.id)).toEqual(['new', 'old'])
+  })
+
+  it('survives a start time nobody can read, rather than sorting it as 1970', () => {
+    const out = planFellOffer({
+      entries: [row('bad', { createdAt: 'not a date' }), row('good')],
+      conversationFor: all,
+    })
+    expect(out.map(o => o.entry.id)).toEqual(['good', 'bad'])
+    expect(out.find(o => o.entry.id === 'bad')?.startedMs).toBeUndefined()
+  })
+
+  it('is BOUNDED — a modal listing forty rows is a wall, not an offer', () => {
+    const many = Array.from({ length: 40 }, (_, i) => row(`s${i}`))
+    expect(planFellOffer({ entries: many, conversationFor: all })).toHaveLength(OFFER_LIMIT)
+    expect(planFellOffer({ entries: many, conversationFor: all, limit: 3 })).toHaveLength(3)
+  })
+
+  it('is empty for an empty fall, without inventing a row', () => {
+    expect(planFellOffer({ entries: [], conversationFor: all })).toEqual([])
   })
 })

--- a/packages/server/server/sessions/crash-group.ts
+++ b/packages/server/server/sessions/crash-group.ts
@@ -109,3 +109,61 @@ export function planCrashGroup(o: {
   const entries = candidates.filter(e => e.lastSeenMs! >= atMs - window)
   return { atMs, entries }
 }
+
+/**
+ * How many rows the "start these again?" offer will NAME.
+ *
+ * A list read under one question, so it is bounded for the same reason the closed block is: a modal
+ * listing forty rows is not an offer, it is a wall. What it cannot show, the caller counts.
+ */
+export const OFFER_LIMIT = 8
+
+/** One fallen row, reduced to what an offer has to show to be decidable. */
+export interface FellOffer {
+  entry: ManagedSession
+  /** The user's own name when there is one, else the conversation's. */
+  label: string
+  resumeId: string
+  /** When it started, epoch ms — absent when the registry's timestamp is unreadable. */
+  startedMs?: number
+}
+
+/**
+ * The fall as an OFFER — PURE, and deliberately narrower than the fall itself by exactly one rule.
+ *
+ * The SELECTION is `planCrashGroup` and stays there. This is the presentation question on top of
+ * it: which of those rows can be put in a list someone clicks. A row whose conversation does not
+ * resolve is dropped, because such a row is a button that fails — and it is dropped HERE rather
+ * than in the selection, because it is still a session that fell. `reopenEntries` counts it as
+ * skipped, which is the honest report; leaving it out of `planCrashGroup` would make the count on
+ * the summary row quietly smaller than the event it describes.
+ *
+ * Ordered newest first: this is read under one question, and the sessions somebody was in the
+ * middle of are the recent ones.
+ *
+ * A conversation is CLAIMED once. The harness+directory fallback answers with the first
+ * conversation in a directory, so four fallen rows in one repository would otherwise be offered
+ * four copies of one conversation — a bug this project has already shipped once.
+ */
+export function planFellOffer(o: {
+  entries: readonly ManagedSession[]
+  /** The conversation this entry would reopen, or `null` when none resolves. */
+  conversationFor: (entry: ManagedSession) => { sessionId: string; title: string } | null
+  limit?: number
+}): FellOffer[] {
+  const out: FellOffer[] = []
+  for (const entry of o.entries) {
+    const conv = o.conversationFor(entry)
+    if (!conv) continue
+    const started = Date.parse(entry.createdAt)
+    out.push({
+      entry,
+      label: entry.label ?? conv.title,
+      resumeId: conv.sessionId,
+      ...(Number.isFinite(started) ? { startedMs: started } : {}),
+    })
+  }
+  return out
+    .sort((a, b) => (b.startedMs ?? 0) - (a.startedMs ?? 0))
+    .slice(0, o.limit ?? OFFER_LIMIT)
+}

--- a/packages/server/server/sessions/dialog-choice.test.ts
+++ b/packages/server/server/sessions/dialog-choice.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from 'bun:test'
+import { needsChoice, parseDialogOptions } from './dialog-choice'
+
+/**
+ * VERBATIM from a live claude 2.1.232 Write permission prompt, 2026-08-14.
+ *
+ * The dialog this feature's first version treated as a yes/no. It is not one: option 2 grants
+ * standing permission for the rest of the session, which is a materially different answer from
+ * option 1, and a keystroke called "approve" picked whichever was highlighted.
+ */
+const WRITE_PERMISSION = [
+  ' Create file',
+  ' agentop-choice-probe.txt',
+  '╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌',
+  '  1 probe',
+  '╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌',
+  ' Do you want to create agentop-choice-probe.txt?',
+  ' ❯ 1. Yes',
+  '   2. Yes, allow all edits during this session (shift+tab)',
+  '   3. No',
+  '',
+  ' Esc to cancel · Tab to amend',
+]
+
+/**
+ * VERBATIM from a live claude 2.1.232 `AskUserQuestion`, 2026-08-14.
+ *
+ * The shape the user was looking at when they reported this: options with DESCRIPTION lines under
+ * them, a free-text escape hatch, and a fifth option below a horizontal rule.
+ */
+const ASK_QUESTION = [
+  '────────────────────────────────────────',
+  ' ☐ Deploy',
+  '',
+  'Como você quer fazer o deploy?',
+  '',
+  '❯ 1. Deploy manual via CLI',
+  '     Você (ou eu) roda o comando de deploy direto do terminal — controle total, sem',
+  '     configuração extra, mas cada release depende de alguém executar o comando.',
+  '  2. CI/CD automático no push',
+  '     Um pipeline faz build, testes e deploy a cada push na branch principal.',
+  '  3. Deploy por tag/release',
+  '     O pipeline dispara só quando você cria uma tag ou release.',
+  '  4. Type something.',
+  '────────────────────────────────────────',
+  '  5. Chat about this',
+  '',
+  'Enter to select · ↑/↓ to navigate · Esc to cancel',
+]
+
+describe('parseDialogOptions', () => {
+  it('reads a permission prompt as the THREE-way choice it actually is', () => {
+    const out = parseDialogOptions(WRITE_PERMISSION)
+    expect(out.map(o => o.number)).toEqual([1, 2, 3])
+    expect(out.map(o => o.label)).toEqual([
+      'Yes',
+      'Yes, allow all edits during this session (shift+tab)',
+      'No',
+    ])
+  })
+
+  it('marks the row the dialog is highlighting, and only that one', () => {
+    const out = parseDialogOptions(WRITE_PERMISSION)
+    expect(out.filter(o => o.selected).map(o => o.number)).toEqual([1])
+  })
+
+  it('reads a question whose options carry DESCRIPTIONS under them', () => {
+    // The continuation lines are indented prose, not options, and must not become entries.
+    const out = parseDialogOptions(ASK_QUESTION)
+    expect(out.map(o => o.number)).toEqual([1, 2, 3, 4, 5])
+    expect(out[0]!.label).toBe('Deploy manual via CLI')
+    expect(out[3]!.label).toBe('Type something.')
+  })
+
+  it('crosses the rule that separates the last option from the block', () => {
+    // `5. Chat about this` sits below a horizontal rule. Stopping at the rule would drop a real
+    // answer, and the numbers would then still look consecutive — a silent, plausible truncation.
+    expect(parseDialogOptions(ASK_QUESTION).map(o => o.label)).toContain('Chat about this')
+  })
+
+  // --- the confidence gates ------------------------------------------------------------------
+
+  it('reads the LAST block, not a numbered list further up the conversation', () => {
+    const frame = [
+      '● Here is my plan:',
+      '  1. read the file',
+      '  2. change it',
+      '  3. run the tests',
+      '',
+      ' Do you want to proceed?',
+      ' ❯ 1. Yes',
+      '   2. No',
+      ' Esc to cancel · Tab to amend',
+    ]
+    expect(parseDialogOptions(frame).map(o => o.label)).toEqual(['Yes', 'No'])
+  })
+
+  it('refuses a list whose numbers are not exactly 1..n', () => {
+    // Half-read options are worse than none: they would be OFFERED, as if they were the whole menu.
+    expect(parseDialogOptions([' 1. a', ' 3. c'])).toEqual([])
+    expect(parseDialogOptions([' 2. b', ' 3. c'])).toEqual([])
+    expect(parseDialogOptions([' 1. a', ' 2. b', ' 2. b again'])).toEqual([])
+  })
+
+  it('refuses a single option — that is a statement, not a choice', () => {
+    expect(parseDialogOptions([' 1. Yes'])).toEqual([])
+  })
+
+  it('refuses a frame showing two cursors, which it does not understand', () => {
+    expect(parseDialogOptions([' ❯ 1. a', ' ❯ 2. b'])).toEqual([])
+  })
+
+  it('refuses a bare number with no text after it', () => {
+    // Far more likely an ordinal in prose than a menu entry.
+    expect(parseDialogOptions([' 1. ', ' 2. '])).toEqual([])
+  })
+
+  it('is empty for a dialog that offers nothing to choose between', () => {
+    // codex: `Press enter to continue`. There is genuinely no choice, and the caller confirms.
+    expect(parseDialogOptions(['Update available', '', 'Press enter to continue'])).toEqual([])
+    expect(parseDialogOptions([])).toEqual([])
+  })
+
+  it('does not scan the whole scrollback looking for a 1', () => {
+    const long = Array.from({ length: 500 }, (_, i) => `line ${i}`)
+    expect(parseDialogOptions([...long, ' 7. stray'])).toEqual([])
+  })
+})
+
+describe('needsChoice', () => {
+  it('is the question the UI asks before it may send a bare confirm', () => {
+    expect(needsChoice(parseDialogOptions(WRITE_PERMISSION))).toBe(true)
+    expect(needsChoice(parseDialogOptions(ASK_QUESTION))).toBe(true)
+    expect(needsChoice([])).toBe(false)
+  })
+})

--- a/packages/server/server/sessions/dialog-choice.ts
+++ b/packages/server/server/sessions/dialog-choice.ts
@@ -1,0 +1,123 @@
+/**
+ * dialog-choice.ts — PURE. The OPTIONS a blocked session is offering, read off its screen.
+ *
+ * ## Why this exists
+ *
+ * `approval-spec.ts` shipped with one keystroke per harness and the honest warning that it
+ * "confirms the highlighted option and is not approve". That warning turns out to describe a real
+ * hole rather than a caveat, and a user found it: a session sitting on
+ *
+ *     ❯ 1. Só o meu fix, isolado
+ *       2. Promover dev→main inteiro
+ *       3. Parar em dev por enquanto
+ *       4. Type something.
+ *
+ * has no "approve". Pressing a key called approve there picks, blind, between four things that do
+ * different work on somebody's repository. It is the same class of mistake as the prompt that fell
+ * into a dialog's filter and approved a command nobody had read — quieter, and just as bad.
+ *
+ * The fix is not a better keystroke, it is READING THE OPTIONS and letting a person choose one.
+ * They are on the screen; the frame is already captured to decide the state.
+ *
+ * ## Why the discriminator is the options and not the footer
+ *
+ * The obvious design is to tell "yes/no" dialogs from "choose one of N" by their footers, the way
+ * `attention-rules.ts` tells one claude dialog from another. It does not survive contact with the
+ * data: claude's PERMISSION prompt is itself a numbered list —
+ *
+ *     ❯ 1. Yes
+ *       2. Yes, allow all edits during this session (shift+tab)
+ *       3. No
+ *
+ * — so there is no yes/no dialog to separate out. There is one select component whose options
+ * differ, and "Yes" being first is a convention, not a guarantee. The footer answers "is a dialog
+ * open"; only the options answer "what would I be choosing".
+ *
+ * ## Confidence, and what happens without it
+ *
+ * A list of numbers is easy to hallucinate: an assistant that printed `1. foo / 2. bar` in its
+ * answer would look exactly like a menu. Three things bound that:
+ *
+ *  - This is only ever run on a frame `attention-rules.ts` has ALREADY matched as a dialog.
+ *  - The scan runs BOTTOM-UP and stops at the first `1.` it meets, so it reads the last block on
+ *    the screen — the dialog is drawn at the bottom.
+ *  - The numbers must come out as exactly `1..n` with nothing missing and nothing repeated. A
+ *    prose list that happens to sit at the bottom will usually fail this; when it cannot be shown
+ *    to be a menu, the answer is NO options, and the caller says so instead of guessing.
+ *
+ * Verified against three real claude 2.1.232 dialogs on 2026-08-14 (a Bash permission prompt, a
+ * Write permission prompt and an `AskUserQuestion`), all captured from live sessions.
+ */
+
+/** One option a dialog is offering. */
+export interface DialogOption {
+  /** The number the dialog printed, which is also what is typed to pick it. */
+  number: number
+  /** The option's own line, without its number and without the cursor. */
+  label: string
+  /** True for the one the dialog is currently highlighting. */
+  selected: boolean
+}
+
+/**
+ * A numbered option line.
+ *
+ * The cursor glyph is optional and is what marks the highlighted row. The label must start with a
+ * non-space, so `1.` on its own is not an option — a bare number with no text is far more likely to
+ * be an ordinal in prose than a menu entry.
+ */
+const OPTION = /^\s*(❯|>)?\s*(\d{1,2})\.\s+(\S.*?)\s*$/
+
+/**
+ * How far up the frame to look for the block.
+ *
+ * The dialog is at the bottom and the tallest real one measured is well inside this. A bound
+ * matters because the scan is looking for a `1.` to stop at, and without one it would read the
+ * whole scrollback on a frame that has no menu in it at all.
+ */
+const SCAN_LINES = 40
+
+/**
+ * The options on screen, in order — PURE, and EMPTY when they cannot be read with confidence.
+ *
+ * Empty is a real answer and the caller must treat it as one: it means "this is a dialog, and
+ * agentop cannot tell you what it is offering". Inventing a list there is exactly the failure this
+ * module was written to remove.
+ */
+export function parseDialogOptions(frame: readonly string[]): DialogOption[] {
+  const from = Math.max(0, frame.length - SCAN_LINES)
+  const found: DialogOption[] = []
+
+  // Bottom-up, stopping at `1.` — the dialog is the last block on the screen, and its first option
+  // is where that block begins.
+  for (let i = frame.length - 1; i >= from; i--) {
+    const m = OPTION.exec(frame[i] ?? '')
+    if (!m) continue
+    const number = Number(m[2])
+    found.push({ number, label: m[3]!, selected: m[1] !== undefined })
+    if (number === 1) break
+  }
+
+  found.reverse()
+
+  // A menu is at least a choice. One option is a statement, and the caller confirms it instead.
+  if (found.length < 2) return []
+  // Exactly `1..n`, in order. A gap, a repeat or a wrong start means this was not read correctly —
+  // and half-read options are worse than none, because they would be offered as if they were whole.
+  if (found.some((o, i) => o.number !== i + 1)) return []
+  // At most one highlighted row. Two cursors is a frame this parser does not understand.
+  if (found.filter(o => o.selected).length > 1) return []
+
+  return found
+}
+
+/**
+ * Does this dialog need a CHOICE rather than a confirmation? — PURE.
+ *
+ * The question the UI asks before deciding whether it may send a bare confirm key. `false` for a
+ * dialog with no readable options, which is the codex-shaped `Press enter to continue` case: there
+ * really is nothing to choose between.
+ */
+export function needsChoice(options: readonly DialogOption[]): boolean {
+  return options.length > 1
+}

--- a/packages/server/server/sessions/session-view.ts
+++ b/packages/server/server/sessions/session-view.ts
@@ -371,15 +371,28 @@ export function buildSessionViews(o: {
   // covers its conversation, whether that row is one we host or one we merely observed.
   const shown = new Set<string>()
   for (const v of external) if (v.resume) shown.add(v.resume.sessionId)
-  for (const m of managed) {
-    // A managed row does not carry a conversation id, so it covers by the same harness+directory
-    // inference used for a foreign process. `exited` and `lost` rows cover nothing: their work IS
-    // over, and the conversation belongs in history where it can be reopened.
-    if (m.status !== 'running' && m.status !== 'unregistered') continue
-    const conv = m.harness
-      ? conversationForProcess(conversations, { harness: m.harness, cwd: m.cwd })
-      : undefined
-    if (conv) shown.add(conv.sessionId)
+  //
+  // A row that RECORDED its conversation covers exactly that one. The rest fall back to the
+  // harness+directory inference, and it is CLAIMED — because that inference answers with the FIRST
+  // conversation in the directory, so four live sessions in one repository all covered the same
+  // one. The other three stayed in history as `closed` rows for conversations that were open, and
+  // whichever conversation happened to be first vanished from history while it was the one nobody
+  // was running. "Some sessions do not appear" and "some appear twice" were the same bug, seen
+  // from its two ends.
+  const coveredConv = new Set<string>()
+  for (const r of o.reconciled) {
+    const m = managed.find(v => v.id === r.id)
+    // `exited` and `lost` rows cover nothing: their work IS over, and the conversation belongs in
+    // history where it can be reopened.
+    if (!m || (m.status !== 'running' && m.status !== 'unregistered')) continue
+    const own = r.managed?.conversationId
+    if (own) { shown.add(own); coveredConv.add(own); continue }
+    if (!m.harness) continue
+    const conv = conversations.find(c =>
+      !coveredConv.has(c.sessionId)
+      && c.harness === m.harness
+      && sessionAtCwd({ current_cwd: c.cwd, project_path: c.cwd }, m.cwd))
+    if (conv) { shown.add(conv.sessionId); coveredConv.add(conv.sessionId) }
   }
 
   const closed: SessionView[] = conversations

--- a/packages/server/server/sessions/session-view.ts
+++ b/packages/server/server/sessions/session-view.ts
@@ -11,6 +11,7 @@
 import type { HarnessId } from '@agentistics/core'
 import { type HarnessProcess, sessionAtCwd } from '../live-sessions'
 import { rulesFor } from './attention-rules'
+import type { DialogOption } from './dialog-choice'
 import { chosenName, type HarnessSessionFile } from './harness-session-file'
 import type { HarnessSessionIndex } from './harness-sessions'
 import type { ReconciledSession } from './session-ref'
@@ -69,6 +70,14 @@ export interface SessionView {
    * is taking. See `approval-spec.ts` and `approvalTail`.
    */
   approvalLines?: string[]
+  /**
+   * The OPTIONS that dialog is offering, when they could be read with confidence.
+   *
+   * Present only alongside `approvalLines`, and empty rather than invented when the screen cannot be
+   * parsed — see `dialog-choice.ts`. It is what makes answering a four-way question possible at all:
+   * a keystroke that confirms the highlighted row is choosing on the user's behalf.
+   */
+  dialogOptions?: DialogOption[]
   /**
    * This session was taken by the machine along with the others, and is offered back with them.
    *
@@ -191,6 +200,8 @@ export function buildSessionViews(o: {
   tails?: ReadonlyMap<string, string[]>
   /** The DIALOG a blocked session is showing, keyed by session id — see `SessionView.approvalLines`. */
   approvals?: ReadonlyMap<string, string[]>
+  /** The options that dialog offers, keyed by session id. Absent where they could not be read. */
+  dialogOptions?: ReadonlyMap<string, DialogOption[]>
   /** The ids `crash-group.ts` decided fell together. A set, because the question is about a set. */
   fell?: ReadonlySet<string>
   /**
@@ -276,6 +287,9 @@ export function buildSessionViews(o: {
       // be shown under "what you are about to confirm" for a question that is no longer open.
       ...(activity === 'waiting-approval' && (o.approvals?.get(r.id)?.length ?? 0) > 0
         ? { approvalLines: o.approvals!.get(r.id)! }
+        : {}),
+      ...(activity === 'waiting-approval' && (o.dialogOptions?.get(r.id)?.length ?? 0) > 0
+        ? { dialogOptions: o.dialogOptions!.get(r.id)! }
         : {}),
       ...(o.fell?.has(r.id) ? { fell: true as const } : {}),
       ...(r.managed?.label ? { label: r.managed.label } : {}),

--- a/packages/server/server/sessions/sessions-host.ts
+++ b/packages/server/server/sessions/sessions-host.ts
@@ -15,6 +15,7 @@ import { createLimiter } from '../utils'
 import type { HarnessProcess } from '../live-sessions'
 import { rulesFor } from './attention-rules'
 import { approvalTail, attentionOf, digestFrame, frameTail } from './attention'
+import { parseDialogOptions, type DialogOption } from './dialog-choice'
 import { loadConversations, type Conversation } from './conversations'
 import { HEARTBEAT_MS, planCrashGroup, type CrashGroup } from './crash-group'
 import { emptyHarnessSessionIndex, type HarnessSessionIndex } from './harness-sessions'
@@ -171,6 +172,7 @@ export function createSessionsPoller(o: {
       const activity = new Map<string, SessionActivity>()
       const tails = new Map<string, string[]>()
       const approvals = new Map<string, string[]>()
+      const dialogOptions = new Map<string, DialogOption[]>()
 
       await Promise.all(reconciled.map(r => limit(async () => {
         const b = r.backend
@@ -197,7 +199,14 @@ export function createSessionsPoller(o: {
         activity.set(r.id, state)
         // The dialog is kept from the frame that DECIDED the state, so the two can never describe
         // different moments — and it costs nothing extra, the frame is already here.
-        if (state === 'waiting-approval') approvals.set(r.id, approvalTail(frame, APPROVAL_LINES))
+        if (state === 'waiting-approval') {
+          approvals.set(r.id, approvalTail(frame, APPROVAL_LINES))
+          // Read from the SAME frame that decided the state, so what is offered and what the state
+          // says can never describe different moments. Empty when the screen cannot be parsed with
+          // confidence, which the UI reports rather than papering over.
+          const options = parseDialogOptions(frame)
+          if (options.length > 0) dialogOptions.set(r.id, options)
+        }
       })))
 
       // The heartbeat: one write, one timestamp, every session the backend reports as ALIVE. See
@@ -230,6 +239,7 @@ export function createSessionsPoller(o: {
         activity,
         tails,
         approvals,
+        dialogOptions,
         processes,
         conversations,
         harnessSessions,

--- a/packages/tui/scripts/preview.tsx
+++ b/packages/tui/scripts/preview.tsx
@@ -39,6 +39,7 @@ import {
   type ControlSession,
   type ControlSessions,
   type ProjectOption,
+  type RestoreCandidate,
   type ControlService,
   type ControlStatus,
   type ServiceRuntimeState,
@@ -98,6 +99,14 @@ interface Options {
   pending: boolean
   /** Make the fake host REFUSE to spawn, which is the wizard's failure path. */
   failSpawn: boolean
+  /**
+   * Show the "your last sessions were these" offer.
+   *
+   * Its own flag because the offer renders in FRONT of the list: stocking the fixture with it
+   * unconditionally would put a modal over every other sessions preview, so the screen this exists
+   * to check would be the only one anybody could ever see.
+   */
+  restore: boolean
 }
 
 const USAGE = `
@@ -122,12 +131,14 @@ const USAGE = `
                             gate: --pending --keys enter,right,enter
     --fail-spawn            the new-session wizard's spawn is refused, so its failure
                             path is drawn: --fail-spawn --keys a,enter,enter,enter,enter,enter,enter
+    --restore               the machine lost its fleet, so the "start these again?"
+                            offer is drawn in front of the list
 `
 
 function parseArgs(argv: string[]): Options {
   const opts: Options = {
     cols: 100, rows: 34, lang: 'en', screen: 'services', mode: 'solo', keys: [], task: 'off',
-    pending: false, failSpawn: false,
+    pending: false, failSpawn: false, restore: false,
   }
   for (let i = 0; i < argv.length; i++) {
     const flag = argv[i]
@@ -139,6 +150,7 @@ function parseArgs(argv: string[]): Options {
       case '--keys': opts.keys = value.split(',').filter(Boolean); i++; break
       case '--pending': opts.pending = true; break
       case '--fail-spawn': opts.failSpawn = true; break
+      case '--restore': opts.restore = true; break
       case '--task':
         opts.task = value === 'done' ? 'done' : 'running'
         i++
@@ -351,7 +363,10 @@ function fakeHost(opts: Options): ControlHost {
       return () => { watchers.delete(handler) }
     },
     readLog: async (source, maxLines) => (LOG[source] ?? []).slice(-maxLines),
-    sessions: async () => FAKE_FLEET,
+    sessions: async () => (opts.restore
+      ? { ...FAKE_FLEET, restorable: FAKE_RESTORABLE }
+      : FAKE_FLEET),
+    restoreSessions: done,
     startableHarnesses: async () => [
       { id: 'claude', label: 'claude', modelSuggestions: ['opus', 'sonnet', 'haiku'], supportsModel: true, efforts: ['low', 'medium', 'high', 'xhigh', 'max'] },
       { id: 'codex', label: 'codex', modelSuggestions: ['gpt-5.4', 'gpt-5.4-mini'], supportsModel: true, efforts: [] },
@@ -388,6 +403,18 @@ const FAKE_PROJECTS: ProjectOption[] = [
   { path: '/home/dev/embark', label: 'embark', detail: '~/orgs/opvibes/embark', source: 'repo' },
   { path: '/home/dev/embark2', label: 'embark', detail: '~/archive/2024/embark', source: 'folder' },
   { path: '/home/dev/scratch', label: 'scratch', detail: '~/scratch', source: 'folder' },
+]
+
+/**
+ * What the offer names after a fall — the awkward cases rather than the tidy one: a long label that
+ * has to be truncated beside its harness and project, a row with no start time at all, and enough
+ * of them to reach the pane's own limit on a short terminal.
+ */
+const FAKE_RESTORABLE: RestoreCandidate[] = [
+  { id: 'f00d01', label: 'ledger reconciliation', harness: 'claude', project: 'agentistics', startedAt: Date.now() - 3 * 60 * 60_000 },
+  { id: 'f00d02', label: 'invoice export', harness: 'codex', project: 'prontuario', startedAt: Date.now() - 3 * 60 * 60_000 },
+  { id: 'f00d03', label: 'rewrite the CSV importer so it stops guessing the encoding', harness: 'kimi', project: 'embark', startedAt: Date.now() - 4 * 60 * 60_000 },
+  { id: 'f00d04', label: 'no start time on record', harness: 'claude', project: 'aipe' },
 ]
 
 const FAKE_FLEET: ControlSessions = {

--- a/packages/tui/scripts/preview.tsx
+++ b/packages/tui/scripts/preview.tsx
@@ -383,7 +383,7 @@ function fakeHost(opts: Options): ControlHost {
     // nothing: the questions are what a layout check needs to see, and the preview must never send
     // a keystroke anywhere.
     promptSession: done,
-    approveSession: done,
+    answerSession: done,
     reopenFell: done,
   }
 }
@@ -442,17 +442,49 @@ const FAKE_FLEET: ControlSessions = {
       // The dialog, at the width a real one is drawn at — which is the point: the confirmation has
       // to fit it into a pane that is often much narrower, and a fixture of short lines would never
       // show that.
-      canApprove: true,
+      // A THREE-way choice, which is what a claude permission prompt actually is — the case the
+      // picker exists for. `canApprove` is deliberately absent: there is no approving here.
+      canChoose: true,
+      dialogOptions: [
+        { number: 1, label: 'Yes', selected: true },
+        { number: 2, label: 'Yes, allow all edits during this session (shift+tab)', selected: false },
+        { number: 3, label: 'No', selected: false },
+      ],
       approvalLines: [
         '│ Bash command                                                    │',
         '│   bun run db:migrate --env production                           │',
         '│                                                                 │',
         '│ Do you want to proceed?                                         │',
         '│ ❯ 1. Yes                                                        │',
-        '│   2. No, and tell Claude what to do differently                 │',
-        '│ Enter to confirm · Esc to cancel                                │',
+        '│   2. Yes, allow all edits during this session (shift+tab)       │',
+        '│   3. No                                                         │',
+        '│ Esc to cancel · Tab to amend                                    │',
       ],
       startedAt: Date.now() - 22 * 60_000, attached: false,
+    },
+    // A dialog whose options ARE readable but whose harness nobody has verified a way to pick on.
+    // The one row that must draw a REFUSAL naming why, rather than a picker that would confirm the
+    // highlighted row on the user's behalf.
+    {
+      id: 'c0de01', title: 'promote to prod', harness: 'gemini',
+      cwd: '/home/dev/embark', project: 'embark',
+      state: 'waiting-approval', stateLabel: 'needs approval', actionable: true,
+      dialogOptions: [
+        { number: 1, label: 'Só o meu fix, isolado', selected: true },
+        { number: 2, label: 'Promover dev→main inteiro', selected: false },
+        { number: 3, label: 'Parar em dev por enquanto', selected: false },
+        { number: 4, label: 'Type something.', selected: false },
+      ],
+      approvalLines: [
+        'Como promover pra prod? O merge dev→main levaria junto ID-100, ID-81 e ID-54.',
+        '❯ 1. Só o meu fix, isolado',
+        '  2. Promover dev→main inteiro',
+        '  3. Parar em dev por enquanto',
+        '  4. Type something.',
+        'Enter to select · ↑/↓ to navigate · Esc to cancel',
+      ],
+      chooseBlind: 'this dialog is a choice, and nobody has verified how to pick an option on gemini — attach to answer it there.',
+      startedAt: Date.now() - 8 * 60_000, attached: false,
     },
     // The two the machine took together. `lost`, named, and carrying their task — which is what a
     // reboot leaves behind and what "reopen what fell" puts back.

--- a/packages/tui/src/control/i18n.ts
+++ b/packages/tui/src/control/i18n.ts
@@ -272,6 +272,12 @@ export interface ControlStrings {
   sessionsApproveCaveat: string
   /** Heading over the dialog lines carried into the confirmation. */
   sessionsApproveWhat: string
+  /** Marks the option the dialog itself is highlighting, inside the picker. */
+  sessionsChoiceHighlighted: string
+  /** Fallback for a harness with no verified way to pick — the host normally supplies its own. */
+  sessionsChooseBlind: string
+  /** What DOES work when the options cannot be picked from here. */
+  sessionsChooseAttach: string
   asideProjects: string
   asideAllProjects: string
   toggleDone: string
@@ -673,6 +679,9 @@ const EN: ControlStrings = {
   sessionsApproveCaveat:
     'it takes whichever option the dialog above has highlighted — read it first.',
   sessionsApproveWhat: 'on its screen right now',
+  sessionsChoiceHighlighted: '(its default)',
+  sessionsChooseBlind: 'this dialog is a choice, and agentop cannot pick an option on this harness.',
+  sessionsChooseAttach: 'o attaches to the session, where you can answer it — esc goes back.',
   asideProjects: 'PROJECTS',
   asideAllProjects: 'every project',
   toggleDone: 'finished tasks',
@@ -1057,6 +1066,9 @@ const PT: ControlStrings = {
   sessionsApproveCaveat:
     'ela pega a opção que o diálogo acima está destacando — leia antes.',
   sessionsApproveWhat: 'na tela dela agora',
+  sessionsChoiceHighlighted: '(o padrão dela)',
+  sessionsChooseBlind: 'esse diálogo é uma escolha, e o agentop não sabe selecionar uma opção neste harness.',
+  sessionsChooseAttach: 'o anexa na sessão, onde dá para responder — esc volta.',
   asideProjects: 'PROJETOS',
   asideAllProjects: 'todos os projetos',
   toggleDone: 'tarefas finalizadas',

--- a/packages/tui/src/control/i18n.ts
+++ b/packages/tui/src/control/i18n.ts
@@ -235,12 +235,16 @@ export interface ControlStrings {
   sessionsPaneDetail: string
   sessionsPaneAsk: string
   sessionsPaneKeys: string
+  sessionsPaneRestore: string
+  restoreTitle: (n: number) => string
+  restoreAnswer: string
   /** What each key on the sessions screen does — the one list `ctrl+h` prints. */
   sessionsKeyWhat: {
     move: string; open: string; attach: string; menu: string; section: string
     newSession: string; search: string; clear: string; kill: string; rename: string
     note: string; task: string; mark: string; onlyActive: string; closed: string
-    exited: string; unfiled: string; group: string; detail: string; reset: string
+    exited: string; unfiled: string; group: string; detail: string; menuFold: string
+    reset: string
     tabs: string; help: string; quit: string
     approve: string; prompt: string; reopenFell: string
   }
@@ -315,6 +319,10 @@ export interface ControlStrings {
   keySessionsActions: string
   keySessionsApprove: string
   keySessionsPrompt: string
+  /** The menu fold — the plain letter, because tmux's default prefix never arrives inside a tmux. */
+  keySessionsFold: string
+  /** The two keys the restore offer answers, and nothing else. */
+  keyRestoreAnswer: string
   /** The visible action row — the same verbs the letters run, spelled out and clickable. */
   actSessions: {
     attach: string
@@ -609,6 +617,10 @@ const EN: ControlStrings = {
   sessionsPaneDetail: 'detail',
   sessionsPaneAsk: 'question',
   sessionsPaneKeys: 'keys',
+  sessionsPaneRestore: 'last time',
+  restoreTitle: (n: number) =>
+    n === 1 ? 'Your last session was this one:' : `Your last ${n} sessions were these:`,
+  restoreAnswer: 'enter starts them in the background · esc leaves them closed',
   sessionsKeyWhat: {
     move: 'move the cursor',
     open: 'switch between the menu and the list',
@@ -629,6 +641,7 @@ const EN: ControlStrings = {
     unfiled: 'show sessions under no task',
     group: 'change the grouping',
     detail: 'hide the detail pane',
+    menuFold: 'fold the menu away — any digit brings it back',
     reset: 'back to how the app opens',
     tabs: 'change screen',
     help: 'this list',
@@ -709,6 +722,8 @@ const EN: ControlStrings = {
   keySessionsActions: 'tab actions',
   keySessionsApprove: 'y approve',
   keySessionsPrompt: 'p send',
+  keySessionsFold: 'b menu',
+  keyRestoreAnswer: 'enter start · esc leave closed',
   actSessions: {
     attach: 'Attach',
     resume: 'Reopen',
@@ -987,6 +1002,10 @@ const PT: ControlStrings = {
   sessionsPaneDetail: 'detalhe',
   sessionsPaneAsk: 'pergunta',
   sessionsPaneKeys: 'teclas',
+  sessionsPaneRestore: 'da última vez',
+  restoreTitle: (n: number) =>
+    n === 1 ? 'Sua última sessão foi esta:' : `Suas últimas ${n} sessões foram estas:`,
+  restoreAnswer: 'enter inicia em background · esc deixa fechadas',
   sessionsKeyWhat: {
     move: 'move o cursor',
     open: 'alterna entre o menu e a lista',
@@ -1007,6 +1026,7 @@ const PT: ControlStrings = {
     unfiled: 'mostra sessões sem tarefa',
     group: 'muda o agrupamento',
     detail: 'oculta o painel de detalhe',
+    menuFold: 'recolhe o menu — qualquer dígito traz de volta',
     reset: 'volta para como o app abre',
     tabs: 'muda de tela',
     help: 'esta lista',
@@ -1086,6 +1106,8 @@ const PT: ControlStrings = {
   keySessionsActions: 'tab ações',
   keySessionsApprove: 'y aprovar',
   keySessionsPrompt: 'p enviar',
+  keySessionsFold: 'b menu',
+  keyRestoreAnswer: 'enter inicia · esc deixa fechadas',
   actSessions: {
     attach: 'Anexar',
     resume: 'Reabrir',

--- a/packages/tui/src/control/index.ts
+++ b/packages/tui/src/control/index.ts
@@ -169,6 +169,7 @@ export type {
   SpawnSessionRequest,
   SpawnSessionResult,
   ProjectOption,
+  RestoreCandidate,
   ResumeSessionRequest,
   StartHow,
   StartOption,

--- a/packages/tui/src/control/sessions.test.ts
+++ b/packages/tui/src/control/sessions.test.ts
@@ -5,7 +5,7 @@ import {
   sessionColumns, sessionsCockpit, asideRows, asideSelectable, projectCounts, projectColumns,
   projectPickRows, groupProjects, asideSections, asideFold, scrollBar, THUMB, TRACK, sessionNamed,
   sessionHandle, worktreeName, sessionRunning, asideRowKey, resolveAsideCursor,
-  sessionAge, sessionKeyHelp, keyHelpColumn,
+  sessionAge, sessionKeyHelp, keyHelpColumn, closeCellWidth, canClose,
   DEFAULT_ORDER, usageOf, planSubmit,
   cardGrid, cardPages, pageOfCard, CARD_PAGE_MAX, CARD_MIN_WIDTH, CARD_GAP, CARD_LINES,
   cardBadges, cardLines, fitCardLines, cardStateCells, cardLabelWidth, CARD_VALUE_MIN,
@@ -1233,7 +1233,7 @@ describe('sessionKeyHelp', () => {
   const words = Object.fromEntries(
     ['move', 'open', 'attach', 'menu', 'section', 'newSession', 'search', 'clear', 'kill',
       'rename', 'note', 'task', 'mark', 'onlyActive', 'closed', 'exited', 'unfiled', 'group',
-      'detail', 'reset', 'tabs', 'help', 'quit',
+      'detail', 'menuFold', 'reset', 'tabs', 'help', 'quit',
       'approve', 'prompt', 'reopenFell'].map(k => [k, `does ${k}`]),
   ) as Parameters<typeof sessionKeyHelp>[0]
 
@@ -2114,5 +2114,31 @@ describe('the wizard name step', () => {
     // harness and the folder. An empty string is not a name called "".
     const plan = planSubmit({ draft: { harness, cwd: '/r', label: '' }, hasSpawn: true, attach: false })
     if (plan.ok) expect('label' in plan.req).toBe(false)
+  })
+})
+
+describe('the per-row close control', () => {
+  const live = session('a', { state: 'waiting' as SessionState })
+  const closed = session('b', { state: 'closed' as SessionState, actionable: false })
+  const gone = session('c', { state: 'exited' as SessionState })
+
+  it('is offered only on a row agentop can actually stop', () => {
+    // An external process is someone else's to stop, and a closed conversation has nothing running
+    // to end. A control that is visible and refuses is worse than one that is absent.
+    expect(canClose(live)).toBe(true)
+    expect(canClose(closed)).toBe(false)
+    expect(canClose(gone)).toBe(false)
+    expect(canClose(session('d', { state: 'unknown' as SessionState, actionable: false }))).toBe(false)
+  })
+
+  it('costs nothing when nothing on screen can be closed', () => {
+    expect(closeCellWidth([closed, gone], 120)).toBe(0)
+    expect(closeCellWidth([live], 120)).toBe(2)
+  })
+
+  it('gives up on a narrow list rather than squeezing the table for a button', () => {
+    // The keyboard's `x` still works there, and a table squeezed to make room is the worse trade.
+    expect(closeCellWidth([live], 30)).toBe(0)
+    expect(closeCellWidth([live], 40)).toBe(2)
   })
 })

--- a/packages/tui/src/control/sessions.ts
+++ b/packages/tui/src/control/sessions.ts
@@ -925,11 +925,13 @@ export function sessionsCockpit(o: {
   asideLabel: number
   /** Rows the detail pane is asking for, `0` when there is nothing selected to describe. */
   detailWanted: number
+  /** Folded away by the user — the list takes the whole width, whatever it would have fitted. */
+  hideAside?: boolean
 }): CockpitLayout {
   const width = Math.max(1, o.width)
   const height = Math.max(1, o.height)
 
-  const aside = width >= ASIDE_NEEDS
+  const aside = o.hideAside ? 0 : width >= ASIDE_NEEDS
     // `+ 4` rather than `+ 2`: the rows carry a cursor, a state dot and — for a task or a project —
     // a trailing count, and sizing to the label alone truncated every long verb in the menu.
     ? Math.min(ASIDE_MAX, Math.max(ASIDE_MIN, o.asideLabel + 4))
@@ -1614,8 +1616,8 @@ export function sessionKeyHelp(w: {
   move: string; open: string; attach: string; menu: string; section: string
   newSession: string; search: string; clear: string; kill: string; rename: string
   note: string; task: string; mark: string; onlyActive: string; closed: string
-  exited: string; unfiled: string; group: string; detail: string; reset: string
-  tabs: string; help: string; quit: string
+  exited: string; unfiled: string; group: string; detail: string; menuFold: string
+  reset: string; tabs: string; help: string; quit: string
   approve: string; prompt: string; reopenFell: string
 }): KeyHelp[] {
   return [
@@ -1642,6 +1644,9 @@ export function sessionKeyHelp(w: {
     { keys: 'u', what: w.unfiled },
     { keys: 'v', what: w.group },
     { keys: 'd', what: w.detail },
+    // `b` leads: `ctrl+b` is tmux's default prefix, so inside a tmux the chord never reaches this
+    // app at all. The plain letter is the one that always works, and the one the footer names.
+    { keys: 'b / ctrl+b', what: w.menuFold },
     { keys: 'ctrl+r', what: w.reset },
     { keys: '[ ]', what: w.tabs },
     { keys: '?', what: w.help },
@@ -2298,4 +2303,38 @@ export function pagerHit(cells: PagerCells, x: number): 'prev' | 'next' | null {
   if (cells.prev !== '' && x === cells.prevAt) return 'prev'
   if (cells.next !== '' && x === cells.nextAt) return 'next'
   return null
+}
+
+// ---------------------------------------------------------------------------
+// closing a session from its own row
+// ---------------------------------------------------------------------------
+
+/** The glyph that closes a session from its own row. */
+export const CLOSE_CELL = '✕'
+
+/**
+ * Columns reserved at the right edge of the list for the per-row close control — PURE.
+ *
+ * Two: a gap and the glyph. Reserved from the width BEFORE the columns are measured, because a
+ * control drawn after a table that already spent the full width is a control drawn on top of the
+ * last cell.
+ *
+ * Zero when nothing on screen can be closed, and zero on a list too narrow to spare it — the
+ * keyboard's `x` still works there, and a table squeezed to make room for a button is a worse
+ * trade than a button that is only on the wider terminal.
+ */
+export function closeCellWidth(rows: readonly ControlSession[], width: number): number {
+  const NEEDS = 40
+  return width >= NEEDS && rows.some(canClose) ? 2 : 0
+}
+
+/**
+ * Can this row be closed at all?
+ *
+ * Only a session agentop HOSTS: an external process is someone else's to stop, and a closed
+ * conversation has nothing running to end. A row that cannot take it draws no glyph — a control
+ * that is visible and refuses is worse than one that is absent.
+ */
+export function canClose(s: ControlSession): boolean {
+  return s.actionable && s.state !== 'closed' && s.state !== 'exited'
 }

--- a/packages/tui/src/control/sessions.ts
+++ b/packages/tui/src/control/sessions.ts
@@ -509,9 +509,15 @@ export function fitApprovalPreview(lines: readonly string[], rows: number): stri
  * own numbered options, the confirmation under it has two of its own, and without a line saying
  * which is which the pane is two menus stacked on top of each other.
  */
-export function askRows(o: { preview: number; detail: number }): number {
+export function askRows(o: { preview: number; detail: number; choices?: number }): number {
   const preview = Math.max(0, Math.min(o.preview, APPROVAL_PREVIEW_MAX))
-  return Math.max(QUESTION_ROWS + (preview > 0 ? preview + 1 : 0), Math.max(0, o.detail))
+  // A picker draws one row per option instead of the two a yes/no carries, and it is budgeted for
+  // the same reason the evidence is: Ink composites what does not fit, so an unbudgeted list does
+  // not scroll, it draws over whatever is under the pane. `QUESTION_ROWS` stays the floor — a
+  // two-option dialog must not end up with less room than a confirmation would have had.
+  const choices = Math.max(0, o.choices ?? 0)
+  const body = choices > 1 ? Math.max(QUESTION_ROWS, choices) : QUESTION_ROWS
+  return Math.max(body + (preview > 0 ? preview + 1 : 0), Math.max(0, o.detail))
 }
 
 
@@ -582,7 +588,15 @@ export function sessionActions(
     // exists. The host decides `canApprove`, and it is true only when the session is genuinely
     // asking AND somebody has read this harness's dialog — a keystroke sent into a session that is
     // not asking is a blank turn, or an option taken out of a menu nobody was looking at.
-    { action: 'approve', enabled: Boolean(selected?.canApprove) },
+    // Enabled wherever there is something to ANSWER: a plain confirmation, a pickable option list,
+    // or an option list this harness cannot pick from — that last one opens a refusal that names why
+    // and points at attaching, which is information rather than an inert key.
+    {
+      action: 'approve',
+      enabled: Boolean(selected?.canApprove)
+        || Boolean(selected?.canChoose)
+        || (selected?.dialogOptions?.length ?? 0) > 1,
+    },
     // Typing into a session needs it to be RUNNING and nothing more: a session that is working will
     // read what it was handed when it gets there. The one case that must not go through is a
     // session sitting on a dialog, where the prompt is a menu — and that is refused by the HOST,

--- a/packages/tui/src/control/tabs/Sessions.tsx
+++ b/packages/tui/src/control/tabs/Sessions.tsx
@@ -48,6 +48,10 @@ function ScrollBar({ cells }: { cells: readonly string[] }) {
   )
 }
 import { ConfirmPrompt, TextPrompt } from '../Prompt'
+import { Menu } from '../Menu'
+// Aliased: this file has its own `Question` component, which is the whole question PANE. This one
+// is the shared wrapped-sentence primitive `ConfirmPrompt` draws its label with.
+import { Question as WrappedText } from '../Surface'
 import { SessionWizard } from './SessionWizard'
 import { TaskChoice } from '../TaskChoice'
 import {
@@ -400,8 +404,11 @@ export function Sessions({
   // the answers: Ink composites what does not fit, so an unbudgeted preview would not crowd the two
   // answers, it would draw over whatever sits under them.
   const askPreview = ask?.kind === 'approve' ? (ask.session.approvalLines?.length ?? 0) : 0
+  // A picker needs a row per option on top of the evidence, or the answers are composited over
+  // whatever sits under the pane — the same reason the evidence itself is budgeted.
+  const askChoices = ask?.kind === 'approve' ? (ask.session.dialogOptions?.length ?? 0) : 0
   const detailWanted = ask
-    ? askRows({ preview: askPreview, detail: detail.length })
+    ? askRows({ preview: askPreview, detail: detail.length, choices: askChoices })
     : layout === 'cards' || hideDetail ? 0 : detail.length
 
   /**
@@ -633,7 +640,13 @@ export function Sessions({
     // working is a reasonable thing to try, and the answer is "it is not asking anything", which is
     // information. Two different refusals, because they are two different facts — the harness's
     // dialog was never read, or this row is not blocked at all.
-    if (a === 'approve' && !selected.canApprove) {
+    // `y` opens the ANSWER question wherever there is something to answer — a bare confirm on a
+    // plain dialog, the option picker on a numbered one. It refuses only where there is genuinely
+    // nothing: a session that is not blocked at all, or one whose harness nobody has read.
+    if (a === 'approve' && !selected.canApprove && !selected.canChoose) {
+      // A dialog whose options are readable but unpickable is a refusal that NAMES why and points
+      // at attaching, which works — so it opens the question rather than swallowing the keypress.
+      if ((selected.dialogOptions?.length ?? 0) > 1) return actOn('approve')
       const why = selected.approveBlind ?? s.sessionsNotAsking
       void run(async () => ({ ok: false, message: why }))
       return
@@ -1035,7 +1048,7 @@ export function Sessions({
               // Named only where the key actually does something on the selected row. The footer is
               // the only documentation this screen has, and a hint for an inert key is the one bug
               // it exists to prevent.
-              ...(selected?.canApprove ? [s.keySessionsApprove] : []),
+              ...(selected?.canApprove || selected?.canChoose ? [s.keySessionsApprove] : []),
               ...(canPrompt ? [s.keySessionsPrompt] : []),
               s.keySessionsSearch, s.keySessionsNew, s.keySessionsGroup, s.keySessionsClosed,
               ...(grouping === 'task' ? [s.keySessionsNoTask] : []),
@@ -1047,7 +1060,7 @@ export function Sessions({
             ],
           })
   }, [isActive, onChrome, s, ask, actionsFocused, focus, cockpit.aside, grouping,
-      selected?.canApprove, canPrompt, menuHidden, restoring])
+      selected?.canApprove, selected?.canChoose, canPrompt, menuHidden, restoring])
 
   usePointer(p => {
     const wheel = wheelDelta(p.button)
@@ -2180,25 +2193,83 @@ function Question({
   /**
    * Answering the dialog a session is blocked on — the only question here that shows EVIDENCE.
    *
-   * The dialog is drawn ABOVE the confirmation, and the caveat under it says in words what the
-   * keystroke actually does: it takes whichever option is highlighted. Nothing in this product can
-   * read which option that is, so the screen showing the dialog is not a nicety, it IS the check.
+   * Two shapes, because the dialogs are two shapes:
+   *
+   *  - **It offers OPTIONS.** They are listed and one is picked, and the picked one is what gets
+   *    sent. There is no "approve" here to offer: a session asking "only my fix / promote
+   *    everything / stop in dev / type something" has four answers that do different work, and a key
+   *    that took the highlighted row would be choosing between them for the user. That was the
+   *    defect, and it was reported by somebody looking at exactly that dialog.
+   *  - **It offers nothing to choose between** — codex's `Press enter to continue`. Then it really
+   *    is a confirmation, and the dialog is shown above it because the confirm key still takes
+   *    whatever is on the screen.
    */
   if (ask.kind === 'approve') {
-    // What is left for the dialog once the confirmation has taken its rows. Cut from the TOP, so
-    // the options and the footer — the part being answered — are what survives a short pane.
+    const options = session.dialogOptions ?? []
+    // What is left for the dialog once the question has taken its rows. Cut from the TOP, so the
+    // options and the footer — the part being answered — are what survives a short pane.
     const room = Math.max(0, rows - QUESTION_ROWS - 1)
     const preview = fitApprovalPreview(session.approvalLines ?? [], room)
+    const evidence = preview.length > 0 ? (
+      <>
+        <Text dimColor>{truncate(s.sessionsApproveWhat, width)}</Text>
+        {preview.map((line, i) => (
+          <Text key={`ap${i}`} wrap="truncate" color={COLORS.text}>{truncate(line, width)}</Text>
+        ))}
+      </>
+    ) : null
+
+    if (options.length > 1) {
+      // No verified way to pick on this harness. Refused in WORDS, naming what does work — a
+      // refusal you can act on beats a verb that silently answers for you.
+      if (!session.canChoose) {
+        return (
+          <Box flexDirection="column" width={width}>
+            {evidence}
+            {/* WRAPPED, not truncated: this is the whole content of the answer, and a refusal cut
+                off at "nobody has verified how to pick an option on ge…" tells nobody anything.
+                Bounded so it cannot grow over the rows the pane was given. */}
+            <WrappedText
+              text={session.chooseBlind ?? s.sessionsChooseBlind}
+              width={width}
+              maxRows={Math.max(1, rows - preview.length - 2)}
+            />
+            <Text dimColor wrap="truncate">{truncate(s.sessionsChooseAttach, width)}</Text>
+          </Box>
+        )
+      }
+      return (
+        <Box flexDirection="column" width={width}>
+          {evidence}
+          <Menu
+            // `Menu` numbers its own rows from 1, and the parser guarantees the options ARE `1..n`
+            // in order — so the number beside a row here is the same number the session printed
+            // beside it. Adding the option's number to the label would print it twice.
+            items={options.map(o => ({
+              label: o.label,
+              value: String(o.number),
+              ...(o.selected ? { hint: s.sessionsChoiceHighlighted } : {}),
+            }))}
+            width={width}
+            // The row the dialog is highlighting, so pressing enter straight away does what
+            // attaching and pressing enter would have done — and nothing else does.
+            initialIndex={Math.max(0, options.findIndex(o => o.selected))}
+            height={Math.max(2, rows - preview.length - (preview.length > 0 ? 1 : 0))}
+            isActive
+            onCancel={onClose}
+            onSelect={value => {
+              const answer = host.answerSession
+              if (!answer) return onClose()
+              onRun(() => answer.call(host, session.id, Number(value)), s.actSessions.approve)
+            }}
+          />
+        </Box>
+      )
+    }
+
     return (
       <Box flexDirection="column" width={width}>
-        {preview.length > 0 ? (
-          <>
-            <Text dimColor>{truncate(s.sessionsApproveWhat, width)}</Text>
-            {preview.map((line, i) => (
-              <Text key={`ap${i}`} wrap="truncate" color={COLORS.text}>{truncate(line, width)}</Text>
-            ))}
-          </>
-        ) : null}
+        {evidence}
         <ConfirmPrompt
           label={`${s.sessionsApproveConfirm(session.title)} ${s.sessionsApproveCaveat}`}
           yesLabel={s.yes}
@@ -2207,9 +2278,9 @@ function Question({
           height={Math.max(QUESTION_ROWS, rows - preview.length - (preview.length > 0 ? 1 : 0))}
           onCancel={onClose}
           onAnswer={(yes: boolean) => {
-            const approve = host.approveSession
-            if (!yes || !approve) return onClose()
-            onRun(() => approve.call(host, session.id), s.actSessions.approve)
+            const answer = host.answerSession
+            if (!yes || !answer) return onClose()
+            onRun(() => answer.call(host, session.id), s.actSessions.approve)
           }}
         />
       </Box>

--- a/packages/tui/src/control/tabs/Sessions.tsx
+++ b/packages/tui/src/control/tabs/Sessions.tsx
@@ -15,8 +15,8 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Box, Text, useInput } from 'ink'
 import type {
-  ActionResult, ControlExit, ControlHost, ControlSession, ControlSessions, SessionState,
-  SessionViewPrefs,
+  ActionResult, ControlExit, ControlHost, ControlSession, ControlSessions, RestoreCandidate,
+  SessionState, SessionViewPrefs,
 } from '../types'
 import type { ControlStrings } from '../i18n'
 import type { TabChrome } from '../ControlCenter'
@@ -57,7 +57,7 @@ import {
   enabledActionIndexes, filterSessions,
   sessionActions, sessionsCockpit, summaryCells, sessionColumns, padCell,
   taskCounts, projectCounts, sessionMetric, sessionHandle, worktreeName, sessionRunning,
-  sessionAge, sessionKeyHelp, keyHelpColumn,
+  sessionAge, sessionKeyHelp, keyHelpColumn, closeCellWidth, canClose, CLOSE_CELL,
   DEFAULT_ORDER, ACTIVE_STATES, type SessionOrder, type SessionLayout,
   cardGrid, cardPages, pageOfCard, cardBadges, cardLines, fitCardLines, cardStateCells, cardBand,
   cardHit, cardStep, cardPageRows, cardLabelWidth, CARD_LABEL_GAP, pagerCells, pagerHit,
@@ -216,6 +216,17 @@ export function Sessions({
    */
   const [marked, setMarked] = useState<ReadonlySet<string>>(new Set(view?.marked ?? []))
   /**
+   * Whether the menu is folded away entirely, for when the list is what you came to read.
+   *
+   * NOT persisted, unlike every other part of the arrangement: it is a gesture you make to look at
+   * something, not a setting. A menu that was still hidden three days later would be a feature
+   * nobody could find their way back out of — and the keys that open it (`1`-`9`) are the same ones
+   * that jump to a section, so opening it is never a thing you have to remember how to do.
+   */
+  const [menuHidden, setMenuHidden] = useState(false)
+  /** Ids the user has already been asked about this run, so the offer is made once. */
+  const [restoreAsked, setRestoreAsked] = useState(false)
+  /**
    * Whether the visible action row has the keyboard.
    *
    * The row is there so the screen can be used WITHOUT knowing any letters — every verb is spelled
@@ -335,6 +346,17 @@ export function Sessions({
   // The detail pane asks for exactly what it has to say, and the list absorbs the difference. A
   // pane sized to a constant leaves dead rows under it — air under a pane is a fault, and a list
   // with room to grow is not air, it is a list.
+  /**
+   * Whether the "start these again?" offer is the thing on screen.
+   *
+   * Decided HERE rather than beside the render below, because the FOOTER has to know: the offer owns
+   * the keyboard, and while it is up every hint the list would print names a key that does nothing.
+   * That is the one bug this footer exists to prevent, and it shipped — the offer drew over the list
+   * while the strip underneath still advertised `o attach`, `y approve` and `tab actions`.
+   */
+  const restorable = fleet?.restorable ?? []
+  const restoring = !restoreAsked && restorable.length > 0 && Boolean(host.restoreSessions)
+
   /** Whether typing into the selected row is a thing that can work — the same rule
    *  `sessionActions` applies, read once so the footer and the verb cannot disagree. */
   const canPrompt = Boolean(selected)
@@ -478,11 +500,14 @@ export function Sessions({
   // narrow to carry the menu — where it is the only menu there is — and whether that is the case
   // depends on the width alone, so one extra call settles it without either budget guessing at the
   // other. A row taken without being paid for is composited over the one under it.
-  const probe = sessionsCockpit({ width, height, asideLabel, detailWanted })
+  // `hideAside` is passed to BOTH, or the probe answers with an aside the real layout will not draw
+  // and the action row is budgeted against a menu that is not there.
+  const fold = { asideLabel, hideAside: menuHidden }
+  const probe = sessionsCockpit({ width, height, detailWanted, ...fold })
   const actionRows = probe.aside > 0 ? 0 : height >= 12 ? 2 : height >= 8 ? 1 : 0
   const cockpit = actionRows === 0
     ? probe
-    : sessionsCockpit({ width, height: Math.max(1, height - actionRows), asideLabel, detailWanted })
+    : sessionsCockpit({ width, height: Math.max(1, height - actionRows), detailWanted, ...fold })
 
   // The grid, decided HERE rather than beside the list's own arithmetic further down: both input
   // handlers read it, and a value declared under them reads as "used before its declaration" to
@@ -753,9 +778,11 @@ export function Sessions({
     // The DIGITS jump straight to a menu section, from the list as well as from the menu — every
     // section wears its number, so this is a key the screen documents itself rather than one you
     // have to be told about. They work where the arrows are not available at all.
-    if (cockpit.aside > 0 && input >= '1' && input <= '9') {
+    // A digit brings the menu BACK as well as jumping to a section: the keys that reach the menu
+    // are the way out of having hidden it, so there is nothing extra to remember.
+    if (input >= '1' && input <= '9') {
       const n = Number(input) - 1
-      if (n < sections.length) { gotoSection(n); return }
+      if (n < sections.length) { setMenuHidden(false); gotoSection(n); return }
     }
 
     if (focus === 'aside' && cockpit.aside > 0) {
@@ -819,6 +846,18 @@ export function Sessions({
     // duplication here: `l` is what the footer has room to name, and a chord is what someone
     // reaches for without having read the footer at all.
     if (key.ctrl && input === 'a') { setOnlyActive(v => !v); setCursor(0); return }
+    // Folding the menu answers TWO keys, and the second one is not a convenience.
+    //
+    // `ctrl+b` is tmux's DEFAULT PREFIX. Run in a plain terminal the cockpit receives it and this
+    // works — measured through the preview, which writes the real 0x02 byte. Run inside the user's
+    // own tmux it never arrives at all: intercepting the prefix is what a prefix IS, so the client
+    // consumes it and the pane is never told. This app already knows that, which is why it reads
+    // the real prefix from `show-options -g prefix` to tell people how to detach.
+    //
+    // A chord that silently does nothing for everyone who works inside tmux is exactly the "the
+    // command to hide the aside menu is not working" this was reported as. So plain `b` does it
+    // too, and it is the one the footer and the key list name.
+    if (input === 'b' || (key.ctrl && input === 'b')) { setMenuHidden(v => !v); return }
     // `?` is the key, and `ctrl+h` is accepted where the terminal can tell it apart from backspace.
     // It usually cannot: `ctrl+h` IS ASCII 8, which is the backspace byte, so Ink reports it as
     // `key.backspace` and a binding on it would either never fire or fire on backspace. Measured
@@ -969,7 +1008,11 @@ export function Sessions({
     if (!isActive) return
     // While a question is open the global keys stand down and the footer says only what works —
     // a hint for a key that does nothing is the one bug this footer exists to prevent.
-    onChrome(ask
+    onChrome(restoring
+      // The offer owns the keyboard and answers exactly two keys. It says so on the pane itself;
+      // the footer must not contradict it with a strip of verbs that do nothing.
+      ? { capture: true, hints: [s.keyRestoreAnswer] }
+      : ask
       ? { capture: true, hints: [s.keyBack] }
       : focus === 'aside' && cockpit.aside > 0
         // The menu is a vertical list, so it answers ↑↓ and enter — and `esc` is the way back to the
@@ -996,11 +1039,15 @@ export function Sessions({
               ...(canPrompt ? [s.keySessionsPrompt] : []),
               s.keySessionsSearch, s.keySessionsNew, s.keySessionsGroup, s.keySessionsClosed,
               ...(grouping === 'task' ? [s.keySessionsNoTask] : []),
+              // Named only while the menu is THERE to fold: on a narrow terminal the aside is
+              // dropped anyway, and a hint for a key with nothing to act on is the one bug this
+              // footer exists to prevent.
+              ...(cockpit.aside > 0 || menuHidden ? [s.keySessionsFold] : []),
               s.keySessionsReset,
             ],
           })
   }, [isActive, onChrome, s, ask, actionsFocused, focus, cockpit.aside, grouping,
-      selected?.canApprove, canPrompt])
+      selected?.canApprove, canPrompt, menuHidden, restoring])
 
   usePointer(p => {
     const wheel = wheelDelta(p.button)
@@ -1103,10 +1150,21 @@ export function Sessions({
         if (index !== null && index < selectable.length) setCursor(index)
         return
       }
-      const row = offset + (y - (cockpit.summary ? 1 : 0))
+      // The column HEADER is paid for as well as the summary row. Without it every click in the
+      // list answered with the row ABOVE the one under the pointer — the grid branch above returns
+      // first, and cards draw no header, so this is the list path's arithmetic alone.
+      const row = offset + (y - (cockpit.summary ? 1 : 0) - (cockpit.header ? 1 : 0))
       if (row < 0 || row >= rows.length) return
       const found = selectable.indexOf(row)
-      if (found >= 0) setCursor(found)
+      if (found < 0) return
+      setCursor(found)
+      // The X at the right edge. It SELECTS the row first and then asks — so the confirmation names
+      // the session under the pointer, never the one that happened to be selected before.
+      const entry = rows[row]
+      const onClose = closeCell > 0 && p.x >= listX + PANE_EDGE_X + listBody - 1
+      if (onClose && entry?.kind === 'session' && canClose(entry.session)) {
+        setAsk({ kind: 'kill', session: entry.session })
+      }
       return
     }
 
@@ -1180,6 +1238,12 @@ export function Sessions({
   // full pane and then drawn beside a bar is a table truncated by one character on every row.
   const listBar = scrollBar({ offset, total: rows.length, rows: cockpit.listRows })
   const listBody = paneBody(cockpit.list) - (listBar.length > 0 ? 1 : 0)
+  // Reserved BEFORE the columns are measured: a control drawn after a table that already spent the
+  // full width is a control drawn on top of the last cell.
+  const closeCell = closeCellWidth(
+    visible.flatMap(r => (r.kind === 'session' ? [r.session] : [])),
+    listBody,
+  )
 
   // Slicing from zero would leave the view switches below the fold on a short terminal — invisible,
   // and still the thing `enter` would act on.
@@ -1199,15 +1263,15 @@ export function Sessions({
       visible.flatMap(r => (r.kind === 'session' ? [r.session] : [])),
       // The CONTENT width, not the pane's: measuring against the frame made every column four
       // characters wider than the row it was drawn into, and the table survived only because Ink
-      // truncated it.
-      listBody,
+      // truncated it. Minus whatever the close control took.
+      listBody - closeCell,
       {
         groupedByTask: grouping === 'task',
         ages,
         ...(cockpit.header ? { headings: s.sessionsCols } : {}),
       },
     ),
-    [visible, listBody, grouping, cockpit.header, ages, s],
+    [visible, listBody, closeCell, grouping, cockpit.header, ages, s],
   )
 
   // The wizard takes the WHOLE screen rather than the detail strip: it is six questions with a
@@ -1228,6 +1292,34 @@ export function Sessions({
           onShowClosed={v => { setShowClosed(v); setCursor(0) }}
           onHideEmptyTask={v => { setHideEmptyTask(v); setCursor(0) }}
           onClose={() => setAsk(null)}
+        />
+      </Box>
+    )
+  }
+
+  /**
+   * The offer, made ONCE and only when there is something to offer.
+   *
+   * It comes before the list because it is about the list: after a crash the fleet you are looking
+   * at is not the one you left, and finding that out by noticing what is missing is worse than
+   * being told. Declining retires those rows, so the same modal never greets you twice.
+   */
+  if (restoring) {
+    return (
+      <Box flexDirection="column" width={width} flexShrink={0}>
+        <RestoreOffer
+          rows={restorable}
+          strings={s}
+          width={width}
+          height={height}
+          isActive={isActive}
+          onAnswer={accept => {
+            setRestoreAsked(true)
+            const restore = host.restoreSessions
+            if (!restore) return
+            void run(() => restore.call(host, restorable.map(r => r.id), accept))
+              .then(onRefreshFleet)
+          }}
         />
       </Box>
     )
@@ -1478,6 +1570,7 @@ export function Sessions({
                 ages={ages}
                 columns={columns}
                 width={listBody}
+                closeCell={closeCell}
               />
             )
           })}
@@ -1653,7 +1746,7 @@ function SummaryRow({
   )
 }
 
-function SessionRowView({ session, selected, marked, ages, columns, width }: {
+function SessionRowView({ session, selected, marked, ages, columns, width, closeCell }: {
   session: ControlSession
   selected: boolean
   /** Already-localized ages by session id — this component owns no clock and no strings. */
@@ -1662,6 +1755,8 @@ function SessionRowView({ session, selected, marked, ages, columns, width }: {
   marked: boolean
   columns: SessionColumns
   width: number
+  /** Columns reserved at the right edge for the close control — `0` when there is none. */
+  closeCell: number
 }) {
   // `harness` is a plain string here because it can be EMPTY — a session the registry has
   // forgotten runs a harness nobody recorded. An empty one simply gets no colour.
@@ -1727,7 +1822,62 @@ function SessionRowView({ session, selected, marked, ages, columns, width }: {
       {columns.where > 0 ? (
         <Text dimColor>{gap + padCell(session.projectGroup || session.project, columns.where)}</Text>
       ) : null}
+      {/* The close control, at the right edge and only on a row that can take it. It asks before
+          it acts — the same confirmation `x` opens, because a one-click stop on a list that
+          re-sorts under the pointer every five seconds is a session ended by accident. */}
+      {closeCell > 0 ? (
+        <Text color={canClose(session) ? COLORS.danger : undefined}>
+          {' ' + (canClose(session) ? CLOSE_CELL : ' ')}
+        </Text>
+      ) : null}
     </Text>
+  )
+}
+
+/**
+ * "Your last sessions were these — start them again?"
+ *
+ * Every row is NAMED, because the answer is a decision about specific work and a count is not
+ * enough to make it with: three sessions in a repository you have finished with and one you were
+ * in the middle of are the same "4" on screen.
+ */
+function RestoreOffer({ rows, strings: s, width, height, isActive, onAnswer }: {
+  rows: readonly RestoreCandidate[]
+  strings: ControlStrings
+  width: number
+  height: number
+  isActive: boolean
+  onAnswer: (accept: boolean) => void
+}) {
+  useInput((_i, key) => {
+    if (key.return) return onAnswer(true)
+    if (key.escape) return onAnswer(false)
+  }, { isActive })
+
+  const now = Date.now()
+  // Two rows of chrome above and two below; what is left is the list, and a list longer than that
+  // says how many it could not show rather than drawing over the answer.
+  const page = Math.max(1, height - 5)
+
+  return (
+    <Pane title={s.sessionsPaneRestore} focused width={width} height={height}>
+      <Text bold wrap="truncate">{truncate(s.restoreTitle(rows.length), paneBody(width))}</Text>
+      <Text> </Text>
+      {rows.slice(0, page).map(r => (
+        <Text key={r.id} wrap="truncate">
+          <Text color={COLORS.accent}>{'  ' + r.label}</Text>
+          <Text dimColor>{`  ${r.harness}  ${r.project}`}</Text>
+          {r.startedAt !== undefined ? (
+            <Text dimColor>
+              {`  ${s.sessionsAgo(Math.max(0, Math.round((now - r.startedAt) / 1000)))}`}
+            </Text>
+          ) : null}
+        </Text>
+      ))}
+      {rows.length > page ? <Text dimColor>{`  … +${rows.length - page}`}</Text> : null}
+      <Text> </Text>
+      <Text wrap="truncate">{truncate(s.restoreAnswer, paneBody(width))}</Text>
+    </Pane>
   )
 }
 

--- a/packages/tui/src/control/types.ts
+++ b/packages/tui/src/control/types.ts
@@ -527,6 +527,30 @@ export const DEFAULT_SESSION_VIEW: SessionViewPrefs = {
   layout: 'list',
 }
 
+/**
+ * A session the machine lost that could be started again — see `planRestore`.
+ *
+ * Offered ONCE, on the run after everything went down, and never while anything is still running:
+ * a machine with live sessions did not lose everything, and a modal that greets an ordinary restart
+ * is a modal people learn to dismiss without reading.
+ */
+export interface RestoreCandidate {
+  id: string
+  /** Already-composed name: the user's own when there is one, else the conversation's. */
+  label: string
+  harness: string
+  /** The last path segment, for a list that has to stay narrow. */
+  project: string
+  /**
+   * When it started, epoch ms — absent when the registry's timestamp is unreadable.
+   *
+   * An instant rather than a duration, like every other time this contract carries: the screen
+   * repaints far more often than the poll runs, so a duration computed here would freeze at
+   * whatever it was when the host last looked.
+   */
+  startedAt?: number
+}
+
 export interface ControlSessions {
   sessions: ControlSession[]
   /** How many are waiting on a person. Drives the header counter, from every tab. */
@@ -564,6 +588,24 @@ export interface ControlSessions {
    * legitimate thing to offer, and an offer that does not say when reads as one that just happened.
    */
   fell?: { count: number; atMs: number }
+  /**
+   * The SAME fall, named row by row, for the offer made on the way in.
+   *
+   * `fell` is the count and the instant — enough for the summary row, the section heading and the
+   * menu verb. This is the list a person reads to DECIDE, and a count cannot be decided on: three
+   * sessions in a repository you have finished with and one you were in the middle of are the same
+   * "4" on screen.
+   *
+   * Both come from ONE selection (`planCrashGroup`), and that is the point of them being two fields
+   * rather than two questions: a second answer to "what fell" is a second set of rules, which is
+   * the bug `task-reopen.ts` exists to have fixed once.
+   *
+   * Narrower than `fell` by exactly one rule: a row whose conversation does not resolve is dropped
+   * here, because this list is CLICKABLE and a row that cannot be reopened is a button that fails.
+   * It stays inside `fell`, where the reopen counts it as skipped rather than pretending it never
+   * fell.
+   */
+  restorable?: RestoreCandidate[]
 }
 
 export type TeamMode = 'solo' | 'central' | 'member'
@@ -808,6 +850,16 @@ export interface ControlHost {
    * way the moment two things happen between polls.
    */
   finishTask?(task: string, done: boolean): Promise<ActionResult>
+
+  /**
+   * Start the offered sessions again, detached, or decline them.
+   *
+   * DECLINING is not a no-op: it retires the rows it was offered (`endedAt`), because "no" here
+   * means the work is over. Without that the same modal greets you on the next run and the run
+   * after, which is how a prompt becomes something people clear without reading — and the rows
+   * stay listed and individually reopenable either way, so nothing is destroyed by saying no.
+   */
+  restoreSessions?(ids: string[], accept: boolean): Promise<ActionResult>
 
   /**
    * The harnesses this machine can actually START, with what each of them accepts.

--- a/packages/tui/src/control/types.ts
+++ b/packages/tui/src/control/types.ts
@@ -388,6 +388,26 @@ export interface ControlSession {
    */
   canApprove?: boolean
   /**
+   * The OPTIONS the dialog is offering, when its screen could be read with confidence.
+   *
+   * Present only on a blocked row, and ABSENT rather than invented when the screen cannot be
+   * parsed. Its presence changes what "answering" means: with options there is no such thing as
+   * approving, only choosing one of them, and the UI must show them and send the one picked.
+   *
+   * The case this exists for is real and was reported: a session asking "how should I promote to
+   * prod?" with four different answers, in front of a key called `approve` that would have silently
+   * taken whichever was highlighted.
+   */
+  dialogOptions?: Array<{ number: number; label: string; selected: boolean }>
+  /**
+   * Whether the user may pick one of `dialogOptions` from here.
+   *
+   * False when this harness has no verified way to select an option by number (`approval-spec.ts`).
+   * There is deliberately NO fallback to the confirm key in that case: confirming the highlighted
+   * row on a dialog somebody is being shown four answers to is choosing for them.
+   */
+  canChoose?: boolean
+  /**
    * Why approving is unavailable HERE, already localized — present only when the session is blocked
    * and nobody has read this harness's dialog.
    *
@@ -395,6 +415,14 @@ export interface ControlSession {
    * and a verb that vanished without a word reads as the feature being broken.
    */
   approveBlind?: string
+  /**
+   * Why the options on screen cannot be answered from here, already localized — present only when
+   * there ARE options and this harness has no verified way to pick one.
+   *
+   * A refusal that names its reason is usable: it tells someone to attach, which works. A verb that
+   * quietly picks for them is not.
+   */
+  chooseBlind?: string
   /**
    * This session was taken by the machine along with the others, and comes back with them.
    *
@@ -788,17 +816,20 @@ export interface ControlHost {
   promptSession?(id: string, text: string): Promise<ActionResult>
 
   /**
-   * Press the key that takes the option this session's dialog is HIGHLIGHTING.
+   * Answer the dialog this session is blocked on.
    *
-   * Not "approve", and the contract says so on purpose: no CLI here reports which option is
-   * selected, so what this sends is a keystroke and what it confirms is whatever is on the screen.
-   * That is why `ControlSession.approvalLines` exists and why the confirmation must show it.
+   * `choice` is the option NUMBER to pick, and it is the whole point of this signature: a dialog
+   * offering "only my fix / promote everything / stop here / type something" has no approval, and a
+   * verb that took the highlighted row would be choosing between four different outcomes on the
+   * user's behalf. Omitted only for a dialog with no readable options — the codex-shaped
+   * `Press enter to continue`, where there genuinely is nothing to choose between — and the host
+   * then sends the confirm key.
    *
    * The host re-reads the frame immediately before sending and refuses when the session is no longer
-   * asking — a snapshot is up to five seconds old, and an unconditional Enter into a session that
-   * has moved on is a blank turn at best.
+   * asking, or when the options on screen no longer match what the user was shown. A snapshot is up
+   * to five seconds old, and an answer to a question that has changed is worse than no answer.
    */
-  approveSession?(id: string): Promise<ActionResult>
+  answerSession?(id: string, choice?: number): Promise<ActionResult>
 
   /**
    * Reopen every session of the last fall, in the background.


### PR DESCRIPTION
Supersedes **#102** (`feat/session-restore`), reconciled against `dev` as it now stands, plus two user-reported defects in what is live in v1.13.1.

Opened as a new branch rather than force-pushing `feat/session-restore`, which has another session's worktree checked out on it — CLAUDE.md forbids rebasing a branch a live session holds. **Merge this and close #102.**

---

## 1 · #102 reconciled — one selection, not two

`dev` and #102 each implemented "what to offer back after the machine took everything", written by two sessions that could not see each other. Merging both would have shipped both: the drift `task-reopen.ts` was extracted to end, one level up.

**`planCrashGroup` survives.** The two agreed about `endedAt` and about claiming a conversation once, and disagreed about the thing that decides whether the feature is usable: `planRestore` had no evidence a row had ever been **alive**, so it offered every resolvable `lost` row — on a machine with months of history, exactly the "sessões lixo" complaint the feature exists to answer. `session-restore.ts` is deleted.

**What #102 had that survives, because it was right:**

| kept | why |
|---|---|
| newest-first, bounded, resolvable-only | kept as the pure `planFellOffer` *beside* the selection. It is a **presentation** rule: an unresolvable row is a button that fails and has no place in a clickable list, but it still fell — so it stays in `fell`, where the count describes the event and `reopenEntries` reports it as skipped. Folding it into the selection would have quietly shrunk the number. |
| the offer, and retire-on-decline | "no" means the work is over; without it the modal becomes furniture. `endedAt` is also what keeps those rows out of the *next* crash group, so the two features agree without either knowing about the other. |
| accepting = `reopenEntries` | it arrived with its own copy of that loop, which would have been the third. |
| the click off-by-one | #102 also fixed it: the hit test paid for the summary row and not the column header, so every click answered with the row *above* the pointer. |
| the `session-view.ts` coverage bug | **the most valuable thing in #102 and not in dev** — a live row covered its conversation via `conversationForProcess`, which answers with the *first* conversation in a directory, so four live sessions in one repo all covered the same one, three stayed in history as `closed` rows for conversations that were open, and the first vanished although nobody was running it. |

**Folding the menu answers `b` as well as `ctrl+b`** — and that is the fix for *"o comando pra abrir e ocultar o menu aside n ta funcionando"*. `ctrl+b` is tmux's **default prefix**: in a plain terminal it arrives (measured through the preview, which writes the real `0x02`), and inside the user's own tmux it never can, because intercepting the prefix is what a prefix *is*. This app already reads the real prefix from `show-options -g prefix` to tell people how to detach.

Two things #102 shipped without: the offer had **no preview coverage** (`--restore` now draws it), and its footer advertised `o attach` / `y approve` / `tab actions` while the offer owned the keyboard and answered only enter/esc — the one bug that footer exists to prevent.

## 2 · Most dialogs are not yes/no

A user was shown a session asking how to promote to prod — *only my fix* / *promote dev→main whole* / *stop in dev* / *type something* — with a key called **approve** in front of it. `approveSession(id)` could not name an option, so all it could do was confirm whichever row was highlighted: choosing, silently, between four things that do different work to somebody's repository.

Separating yes/no from choice **by footer does not survive the data** — claude's permission prompt is itself a numbered list (`1. Yes / 2. Yes, always / 3. No`), where option 2 grants standing permission and "Yes first" is a convention. The footer answers *is a dialog open*; only the options answer *what would I be choosing*.

So `dialog-choice.ts` reads the options off the screen (bottom-up, stopping at `1.`, refusing unless they come out exactly `1..n` — half-read options are worse than none because they get **offered**), the UI lists them, and the **picked** one is sent. `ApprovalSpec.choice` says how to select by number and exists **only for claude**, verified live; everywhere else a numbered dialog is refused in words naming what does work (attach), because falling back to the confirm key *is* the defect. The bare confirm survives only where there is genuinely nothing to choose between (codex's `Press enter to continue`).

A **third claude footer** came out of this: `AskUserQuestion` draws `Enter to select · ↑/↓ to navigate · Esc to cancel`, which no probed rule matched — so those sessions read as plain `waiting`. Three components, three footers.

## 3 · A footer is the bottom of the screen

A session was reported as needing approval while it was visibly **working** — spinner running, `esc to interrupt` in its footer. It had spent the morning editing `attention-rules.ts`, so `Esc to cancel · Tab to amend` was on its screen as source code, and the rule matched anywhere in a 60-line capture. **In this repository that is guaranteed, not unlikely: agentop is developed with agentop.**

Footers are now matched in the last few lines only, and a frame whose **footer** carries the working marker is never `waiting-approval`. The veto is checked in the footer and *not* over the whole frame on purpose: claude prints `esc to interrupt` whenever anything is interruptible, background subagents included, so a whole-frame veto would suppress a **real** permission prompt on a busy session. Suppressing a real block is the one error worse than this one. Both the false positive and that trap are pinned by tests.

## Verification

- `bun tsc --noEmit` clean; `bun test` **3665 pass / 0 fail**.
- Preview swept **60/130/190 columns × 12/20/30/44 rows × EN/PT**, with the option picker, the refusal, the folded menu and the restore offer each on screen.
- **Proven on a live claude 2.1.232, not only in tests:** the options were parsed off a real `AskUserQuestion`, option **3** was sent while option **1** was highlighted, and the session recorded `→ Canário / gradual`. Sending `3` at a real Write permission prompt produced `User rejected write` and no file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016iGuSq9Sg5uEotxJ2Vwiq4