### PR TITLE
fix(events): the daemon's PATH is not the shell's, and it cost the whole desktop channel

### DIFF
--- a/packages/server/server/events/desktop.ts
+++ b/packages/server/server/events/desktop.ts
@@ -14,7 +14,7 @@
  * they have spent a week trusting them.
  */
 
-import { existsSync } from 'node:fs'
+import { existsSync, readFileSync } from 'node:fs'
 import { readdir } from 'node:fs/promises'
 import { join } from 'node:path'
 import { HOME_DIR } from '../config'
@@ -48,18 +48,61 @@ async function findCcnScript(): Promise<string | undefined> {
   return undefined
 }
 
-/** What this machine actually has. */
-export async function probeDesktop(): Promise<DesktopProbe> {
+/**
+ * Is this WSL? Only then is it worth looking for Windows programs under `/mnt`.
+ *
+ * Read from `/proc/version`, which carries the kernel's own build string — the same signal
+ * `live-sessions.ts` uses to decide what this machine can be asked about.
+ */
+function isWsl(): boolean {
+  try {
+    return /microsoft/i.test(readFileSync('/proc/version', 'utf8'))
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Where `powershell.exe` is, PATH or no PATH.
+ *
+ * **A daemon's PATH is not the shell's, and this cost the whole desktop channel.** WSL puts the
+ * Windows directories on the PATH of an interactive shell through interop; a systemd user service
+ * gets `/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:…` and nothing else. So
+ * `Bun.which('powershell.exe')` answered YES to a person typing `agentop events status` and NO to
+ * the daemon that actually does the notifying — the daemon skipped ccn (which needs it), fell
+ * through to `notify-send`, and that failed on every event for hours while `status` in a terminal
+ * cheerfully reported ccn. Measured from the service's own log.
+ *
+ * The absolute path is checked second, exactly as `SCRIPT_HARNESS` in `live-sessions.ts` looks past
+ * a name that does not resolve: what is on PATH is a fact about the caller's environment, not about
+ * the machine.
+ */
+const WSL_POWERSHELL_PATHS = [
+  '/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe',
+  '/mnt/c/Windows/system32/WindowsPowerShell/v1.0/powershell.exe',
+]
+
+export function findPowershell(): string | undefined {
+  const onPath = Bun.which('powershell.exe')
+  if (onPath) return onPath
+  if (!isWsl()) return undefined
+  return WSL_POWERSHELL_PATHS.find(p => existsSync(p))
+}
+
+/** What this machine actually has. `failed` is carried in by the caller — see `DesktopProbe`. */
+export async function probeDesktop(failed: readonly DesktopChannel[] = []): Promise<DesktopProbe> {
   const ccnScript = await findCcnScript()
+  const powershell = findPowershell()
   return {
     ...(ccnScript !== undefined ? { ccnScript } : {}),
     hasJq: !!Bun.which('jq'),
-    hasPowershell: !!Bun.which('powershell.exe'),
+    hasPowershell: powershell !== undefined,
     hasNotifySend: !!Bun.which('notify-send'),
     hasTty: process.stdout.isTTY === true,
     // Absent reads as ENABLED here — unlike `chatAllowed`, because this switch turns off a
     // notification rather than opening a door. Only an explicit `0` disables it.
     disabled: process.env.AGENTISTICS_EVENTS_DESKTOP === '0',
+    ...(failed.length > 0 ? { failed } : {}),
   }
 }
 
@@ -68,10 +111,26 @@ export interface DesktopSetup {
   decision: DesktopDecision
 }
 
+/**
+ * Channels that were chosen and then failed, for this process.
+ *
+ * Module-level rather than threaded through every caller because it is a fact about THIS MACHINE's
+ * channels, not about any one notification, and because the producer holds a `DesktopSetup` for its
+ * whole lifetime — a memory it could not see would leave it retrying a dead channel every five
+ * seconds forever, which is exactly what happened.
+ */
+const failedChannels = new Set<DesktopChannel>()
+
+/** For `status` and the tests: what has stopped working since this process started. */
+export function failedDesktopChannels(): DesktopChannel[] {
+  return [...failedChannels]
+}
+
 /** Probe once, decide once. A caller that notifies repeatedly holds this rather than re-reading the
- *  filesystem on every event. */
+ *  filesystem on every event — but see `failedChannels`: a held setup is re-planned when the channel
+ *  it names has since failed. */
 export async function desktopSetup(): Promise<DesktopSetup> {
-  const probe = await probeDesktop()
+  const probe = await probeDesktop([...failedChannels])
   return { probe, decision: planDesktopChannel(probe) }
 }
 
@@ -83,11 +142,16 @@ export type DesktopResult =
   | { ok: true; channel: DesktopChannel }
   | { ok: false; channel: DesktopChannel; message: string }
 
-async function run(cmd: string[], stdin?: string): Promise<{ code: number; err: string }> {
+async function run(
+  cmd: string[],
+  stdin?: string,
+  env?: Record<string, string>,
+): Promise<{ code: number; err: string }> {
   const proc = Bun.spawn(cmd, {
     stdin: stdin === undefined ? 'ignore' : new TextEncoder().encode(stdin),
     stdout: 'pipe',
     stderr: 'pipe',
+    ...(env ? { env: { ...process.env, ...env } } : {}),
   })
   const timer = setTimeout(() => { try { proc.kill() } catch { /* already gone */ } }, NOTIFY_TIMEOUT_MS)
   try {
@@ -100,22 +164,36 @@ async function run(cmd: string[], stdin?: string): Promise<{ code: number; err: 
 }
 
 /**
- * Show one notification through whichever channel this machine has.
+ * The environment `claude-code-notifications` needs to do anything at all.
  *
- * `cwd` is passed because ccn derives its title and its footer from the directory — it is what
- * makes a toast say which project, for the five harnesses that have no Claude transcript to read.
+ * Its script opens with `command -v powershell.exe >/dev/null 2>&1 || exit 0` and calls `reg.exe`
+ * and `wscript.exe` besides. Under a daemon whose PATH holds no Windows directory that guard fires
+ * and the script **exits 0 having done nothing** — which this module would then report as a
+ * delivered notification. A silent success is the one outcome worse than a loud failure here, so
+ * the Windows system directory is put on the child's PATH explicitly rather than inherited and
+ * hoped for.
  */
-export async function notifyDesktop(
+function ccnEnv(): Record<string, string> | undefined {
+  const ps = findPowershell()
+  if (!ps) return undefined
+  const dir = ps.slice(0, ps.lastIndexOf('/'))
+  // System32 as well as PowerShell's own directory: `reg.exe` and `wscript.exe` live there.
+  const system32 = dir.replace(/\/WindowsPowerShell\/v1\.0$/i, '')
+  const extra = [dir, system32].filter((v, i, a) => a.indexOf(v) === i).join(':')
+  return { PATH: `${process.env.PATH ?? ''}:${extra}` }
+}
+
+/** One attempt through one channel. Split out so `notifyDesktop` can fall through on failure. */
+async function deliverVia(
+  chosen: DesktopSetup,
   text: DesktopText,
   cwd: string,
-  setup?: DesktopSetup,
 ): Promise<DesktopResult> {
-  const chosen = setup ?? await desktopSetup()
   const d = chosen.decision
   try {
     switch (d.channel) {
       case 'ccn': {
-        const r = await run(['bash', chosen.probe.ccnScript!], ccnPayload({ ...text, cwd }))
+        const r = await run(['bash', chosen.probe.ccnScript!], ccnPayload({ ...text, cwd }), ccnEnv())
         return r.code === 0
           ? { ok: true, channel: 'ccn' }
           : { ok: false, channel: 'ccn', message: `claude-code-notifications exited ${r.code}${r.err ? `: ${r.err}` : ''}` }
@@ -127,7 +205,7 @@ export async function notifyDesktop(
           : { ok: false, channel: 'notify-send', message: `notify-send exited ${r.code}${r.err ? `: ${r.err}` : ''}` }
       }
       case 'powershell': {
-        const r = await run(['powershell.exe', '-NoProfile', '-NonInteractive', '-Command', powershellToast(text)])
+        const r = await run([findPowershell() ?? 'powershell.exe', '-NoProfile', '-NonInteractive', '-Command', powershellToast(text)])
         return r.code === 0
           ? { ok: true, channel: 'powershell' }
           : { ok: false, channel: 'powershell', message: `powershell.exe exited ${r.code}${r.err ? `: ${r.err}` : ''}` }
@@ -142,6 +220,37 @@ export async function notifyDesktop(
   } catch (e) {
     return { ok: false, channel: d.channel, message: e instanceof Error ? e.message : String(e) }
   }
+}
+
+/**
+ * Show one notification through whichever channel this machine has, falling through on failure.
+ *
+ * `cwd` is passed because ccn derives its title and its footer from the directory — it is what
+ * makes a toast say which project, for the five harnesses that have no Claude transcript to read.
+ *
+ * A channel that fails is REMEMBERED and the next one down is tried for this same notification, so
+ * a machine whose first choice cannot deliver still gets the event AND stops paying for the dead
+ * channel on every event after it. Bounded by the number of channels: this cannot loop.
+ */
+export async function notifyDesktop(
+  text: DesktopText,
+  cwd: string,
+  setup?: DesktopSetup,
+): Promise<DesktopResult> {
+  // A held setup naming a channel that has since failed is stale, whoever is holding it.
+  let chosen = setup && !failedChannels.has(setup.decision.channel) ? setup : await desktopSetup()
+  let last: DesktopResult = { ok: false, channel: 'none', message: chosen.decision.reason }
+
+  for (let attempt = 0; attempt < 4; attempt++) {
+    last = await deliverVia(chosen, text, cwd)
+    if (last.ok || last.channel === 'none') return last
+    failedChannels.add(last.channel)
+    chosen = await desktopSetup()
+    if (chosen.decision.channel === 'none') {
+      return { ok: false, channel: 'none', message: `${last.message} — ${chosen.decision.reason}` }
+    }
+  }
+  return last
 }
 
 /**

--- a/packages/server/server/events/events-parse.test.ts
+++ b/packages/server/server/events/events-parse.test.ts
@@ -203,9 +203,52 @@ describe('planDesktopChannel', () => {
     expect(d.reason).toContain('inbox')
   })
 
+  test('a channel that FAILED is skipped, and the reason names it', () => {
+    // Measured from the daemon's own log: notify-send is installed on essentially every Linux
+    // image including WSL, where nothing serves org.freedesktop.Notifications. It was chosen, it
+    // exited 1, and it kept being chosen every five seconds.
+    const d = planDesktopChannel({ hasNotifySend: true, hasPowershell: true, failed: ['notify-send'] })
+    expect(d.channel).toBe('powershell')
+    expect(d.reason).toContain('notify-send')
+  })
+
+  test('the cascade keeps falling through as channels fail', () => {
+    const probe = { ccnScript: '/p/notify.sh', hasJq: true, hasPowershell: true, hasNotifySend: true, hasTty: true }
+    expect(planDesktopChannel(probe).channel).toBe('ccn')
+    expect(planDesktopChannel({ ...probe, failed: ['ccn'] }).channel).toBe('notify-send')
+    expect(planDesktopChannel({ ...probe, failed: ['ccn', 'notify-send'] }).channel).toBe('powershell')
+    expect(planDesktopChannel({ ...probe, failed: ['ccn', 'notify-send', 'powershell'] }).channel).toBe('bell')
+    expect(planDesktopChannel({ ...probe, failed: ['ccn', 'notify-send', 'powershell', 'bell'] }).channel).toBe('none')
+  })
+
+  test('every channel having failed still yields a SENTENCE, never a silent nothing', () => {
+    const d = planDesktopChannel({
+      hasNotifySend: true, hasTty: true, failed: ['notify-send', 'bell'],
+    })
+    expect(d.channel).toBe('none')
+    expect(d.reason).toContain('inbox')
+    expect(d.reason).toContain('notify-send')
+  })
+
   test('switched off is its own reason, not confused with unavailable', () => {
     const d = planDesktopChannel({ disabled: true, hasNotifySend: true })
     expect(d.channel).toBe('none')
     expect(d.reason).toContain('switched off')
+  })
+})
+
+describe('findPowershell — a daemon PATH is not a shell PATH', () => {
+  test('what is on PATH is a fact about the CALLER, so the absolute WSL path is checked too', async () => {
+    // The whole desktop channel was lost to this: a systemd user service gets
+    // /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin and nothing else, while an
+    // interactive WSL shell has the Windows directories through interop. `agentop events status`
+    // in a terminal said `ccn` while the daemon doing the notifying could not find powershell.exe,
+    // skipped ccn, and failed on notify-send for hours.
+    const { findPowershell } = await import('./desktop')
+    const found = findPowershell()
+    if (found === undefined) return // not WSL and no powershell on PATH — nothing to assert
+    expect(found.endsWith('powershell.exe')).toBe(true)
+    // Whatever the caller's PATH is, the answer is usable as an argv[0].
+    expect(found.length).toBeGreaterThan(0)
   })
 })

--- a/packages/server/server/events/notify-plan.ts
+++ b/packages/server/server/events/notify-plan.ts
@@ -44,6 +44,20 @@ export interface DesktopProbe {
   hasTty?: boolean
   /** The user turned the desktop step off for this machine. */
   disabled?: boolean
+  /**
+   * Channels that were chosen and then FAILED to deliver, so the cascade skips them.
+   *
+   * **Present on PATH is not evidence a channel can deliver, and this is where that is admitted.**
+   * `notify-send` is installed on essentially every Linux image including WSL, where there is no
+   * `org.freedesktop.Notifications` service behind it — so it is chosen, it exits 1, and it keeps
+   * being chosen every five seconds forever. Measured on this machine from the daemon's log.
+   *
+   * Probing D-Bus up front would answer only that one case, and only at the moment of asking. A
+   * channel that FAILED is the general signal: it also covers one that breaks later, a plugin that
+   * is uninstalled, a display that goes away. So the decision stays pure and the caller carries the
+   * memory of what did not work.
+   */
+  failed?: readonly DesktopChannel[]
 }
 
 export interface DesktopDecision {
@@ -62,27 +76,32 @@ export function planDesktopChannel(p: DesktopProbe): DesktopDecision {
   if (p.disabled) {
     return { channel: 'none', reason: 'desktop notifications are switched off for this machine (AGENTISTICS_EVENTS_DESKTOP=0).' }
   }
-  if (p.ccnScript && p.hasJq && p.hasPowershell) {
-    return { channel: 'ccn', reason: `claude-code-notifications (${p.ccnScript}) — Windows toast with sound, from WSL.` }
+  const dead = new Set(p.failed ?? [])
+  // Named in every reason below, so "why is it not using X" is answerable from `status` alone.
+  const note = dead.size > 0 ? ` Skipped after failing to deliver: ${[...dead].join(', ')}.` : ''
+
+  if (p.ccnScript && p.hasJq && p.hasPowershell && !dead.has('ccn')) {
+    return { channel: 'ccn', reason: `claude-code-notifications (${p.ccnScript}) — Windows toast with sound, from WSL.${note}` }
   }
-  if (p.hasNotifySend) {
+  if (p.hasNotifySend && !dead.has('notify-send')) {
     const ccnNote = p.ccnScript
       ? ' (claude-code-notifications is installed but cannot run here: it needs both jq and powershell.exe)'
       : ''
-    return { channel: 'notify-send', reason: `notify-send${ccnNote}.` }
+    return { channel: 'notify-send', reason: `notify-send${ccnNote}.${note}` }
   }
-  if (p.hasPowershell) {
+  if (p.hasPowershell && !dead.has('powershell')) {
     const ccnNote = p.ccnScript && !p.hasJq
       ? ' claude-code-notifications is installed but jq is missing, so it is skipped.'
       : ''
-    return { channel: 'powershell', reason: `powershell.exe — a plain Windows toast from WSL, no sound and no click target.${ccnNote}` }
+    return { channel: 'powershell', reason: `powershell.exe — a plain Windows toast from WSL, no sound and no click target.${ccnNote}${note}` }
   }
-  if (p.hasTty) {
-    return { channel: 'bell', reason: 'the terminal bell — no notify-send, no powershell.exe, no claude-code-notifications on this machine.' }
+  if (p.hasTty && !dead.has('bell')) {
+    return { channel: 'bell', reason: `the terminal bell — no notify-send, no powershell.exe, no claude-code-notifications on this machine.${note}` }
   }
   return {
     channel: 'none',
-    reason: 'no desktop channel on this machine — none of claude-code-notifications, notify-send or powershell.exe is usable, and there is no terminal to ring. Events are still written to the inbox.',
+    reason: 'no desktop channel on this machine — none of claude-code-notifications, notify-send or powershell.exe is usable, and there is no terminal to ring. Events are still written to the inbox.'
+      + note,
   }
 }
 


### PR DESCRIPTION
## How it was found

By the channel's own rule that a delivery which failed says so — in the service log, hours after it
started failing, on a machine where `agentop events status` in a terminal was reporting everything
was fine:

```
[events] desktop notification failed (notify-send): notify-send exited 1:
GDBus.Error:org.freedesktop.DBus.Error.ServiceUnknown: The name
org.freedesktop.Notifications was not provided by any .service files
```

Every desktop notification since the channel shipped had been going nowhere.

---

## Three defects, one shape: *present* is not *works*

### 1. A daemon's PATH is not a shell's

`Bun.which('powershell.exe')` answers **yes** to a person typing `agentop events status` and **no**
to the daemon that actually does the notifying.

WSL puts the Windows directories on an interactive shell's PATH through interop. A systemd user
service gets `/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin` and nothing else. So the
daemon could not see `powershell.exe`, skipped `ccn` (which needs it), and fell through to
`notify-send` — while a terminal cheerfully reported `ccn`. **The one surface that could report the
problem was the one surface that could not see it.**

`findPowershell` now checks the absolute WSL location after PATH, guarded on `/proc/version` so a
plain Linux box never probes `/mnt`. Same reasoning as `live-sessions.ts` looking past a name that
does not resolve: what is on PATH is a fact about the *caller's environment*, not about the machine.

### 2. ccn would have exited 0 having done nothing

Its script opens with `command -v powershell.exe >/dev/null 2>&1 || exit 0`, and also calls
`reg.exe` and `wscript.exe`. Under that same minimal PATH the guard fires and the script exits **0**
— which this module would have reported as a **delivered** notification.

A silent success is the one outcome worse than a loud failure here, so the Windows system directory
is now put on the child's PATH explicitly rather than inherited and hoped for. This one would have
bitten the moment defect 1 was fixed naively.

### 3. An installed channel is not a working channel

`notify-send` ships on essentially every Linux image **including WSL**, where nothing serves
`org.freedesktop.Notifications`. It was chosen, it exited 1, and it kept being chosen every five
seconds.

So a channel that **fails** is remembered, the next one down is tried **for that same
notification**, and the cascade stops paying for the dead channel on every event after it.

Probing D-Bus up front would have answered only that one case, at only that one moment. A failed
delivery is the general signal — it also covers a channel that breaks later, a plugin that gets
uninstalled, a display that goes away.

The decision stays **pure**: `planDesktopChannel` takes the failed set as an input and names it in
the reason, so `agentop events status` can answer "why is it not using ccn". The memory of what
failed lives at the IO edge, module-level, because a `DesktopSetup` held by the long-running
producer is exactly the thing that would otherwise keep retrying a dead channel forever.

---

## Verified

Under the daemon's **exact** PATH (`env -i PATH=/usr/local/sbin:…:/bin`), which is the case that was
broken:

```
desktop   channel: ccn — claude-code-notifications (…/notify.sh) — Windows toast with sound, from WSL.
desktop   shown
```

Before this change the same command chose `notify-send` and failed.

`bun tsc --noEmit` clean · `bun test` **3755 pass, 0 fail**.

New tests cover the fallthrough as each channel dies in turn, the "everything failed" case still
producing a sentence rather than silence, and `findPowershell` resolving off-PATH.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DTuii7nSqHYKVk8tV7mt7j
