### PR TITLE
fix: token-only member connect, and a rotation that produces one machine

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,8 +207,9 @@ once**, with different sharing rules for each.
 # host a central
 agentop central init && agentop central up
 
-# join one
-agentop member connect --endpoint http://<central-host>:48080 --token <token>
+# join one — a token minted by a central with a public URL carries it,
+# so the token alone is enough (--endpoint only for a bare token)
+agentop member connect --token <token>
 ```
 
 ### Accounts, teams and roles

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -378,6 +378,10 @@ agentop setup
 Non-interactive equivalent:
 
 ```bash
+# a token minted by a central with a public URL carries that URL
+agentop member connect --token <minted-token> [--org <org>]
+
+# a bare token needs the address beside it
 agentop member connect --endpoint http://<central-host>:48080 --token <minted-token> [--org <org>]
 ```
 
@@ -385,9 +389,10 @@ agentop member connect --endpoint http://<central-host>:48080 --token <minted-to
 anything — a bad token never leaves a half-written config. On success it prints
 `connected as <name>` (the name comes from the central).
 
-> Use the central's reachable address for `--endpoint`. Inside a tailnet this is the central's
-> Tailscale IP (e.g. `http://100.x.y.z:48080`). The bearer token is stored locally and never
-> logged.
+> Set the central's **public URL** (Settings → Machines) and the tokens it mints embed it, which is
+> what makes the panel's copy-paste command work. Otherwise use the central's reachable address for
+> `--endpoint`: inside a tailnet that is the central's Tailscale IP (e.g. `http://100.x.y.z:48080`).
+> The bearer token is stored locally and never logged.
 
 ### 3. Check / leave
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -345,7 +345,7 @@ machine's display name is assigned by the central (baked into the minted token)
 and resolved via `/api/team/whoami`; there is no name field on the machine.
 
 ```bash
-agentop member connect --endpoint <url> --token <token> [--org <org>]
+agentop member connect --token <token> [--endpoint <url>] [--org <org>]
 agentop member leave
 agentop member status
 ```
@@ -356,13 +356,22 @@ Verifies the token against the central's `whoami` endpoint, then saves the membe
 config. On a bad token it prints an actionable error and writes **nothing** (no
 half-configured state).
 
+**The token usually carries the URL.** A central with a public URL configured mints a
+composite token (`act1_<base64 url>.<secret>`), which is what the Machines panel copies
+into a ready-to-paste command — so pasting that one command connects the machine.
+`--endpoint` is needed only for a bare token, or to override the embedded URL.
+
 | Flag | Required | Description |
 |------|----------|-------------|
-| `--endpoint <url>` | yes | Central base url, e.g. `http://host:48080` |
-| `--token <token>` | yes | Token minted for this machine in the central's Team Manager |
+| `--token <token>` | yes | Token minted for this machine in the central's Machines panel |
+| `--endpoint <url>` | only for a bare token | Central base url, e.g. `http://host:48080` |
 | `--org <org>` | no | Org override; defaults to the org on the token |
 
 ```bash
+# the copy-paste form: the token carries the central's URL
+agentop member connect --token act1_aHR0cHM6Ly9jZW50cmFsLmV4YW1wbGU.abc123
+
+# a bare token needs the URL beside it
 agentop member connect --endpoint http://100.64.0.2:48080 --token abc123
 ```
 

--- a/packages/server/bin/cli.ts
+++ b/packages/server/bin/cli.ts
@@ -138,9 +138,11 @@ Central:
     e-mail-based reset, so this is how a locked-out last owner gets back in.
 
 Member (a machine may belong to several centrals at once):
-  agentop member connect --endpoint <url> --token <token> [--org <org>] [--label <name>]
+  agentop member connect --token <token> [--endpoint <url>] [--org <org>] [--label <name>]
     Verify the token against the central, then add a new connection or UPDATE an existing
     one keyed by its endpoint (a token rotation on a known central updates in place).
+    A token minted by a central with a public URL configured carries that URL, so the token
+    alone is enough — --endpoint is only needed for a bare token.
   agentop member list
     List every connection this machine has, with its live sync state. ('status' is an alias.)
   agentop member status [--endpoint <url>]
@@ -208,6 +210,7 @@ Examples:
   agentop tui
   agentop watch
   agentop central up
+  agentop member connect --token act1_aHR0cHM6Ly9jZW50cmFsLmV4YW1wbGU.abc123
   agentop member connect --endpoint http://host:48080 --token abc123
   agentop member connect --endpoint http://other:48080 --token def456 --label "Client B"
   agentop member list
@@ -431,15 +434,16 @@ if (command === 'member') {
 
   if (sub === 'connect') {
     const { memberConnect } = await import('../server/cli-member.ts')
-    const endpoint = readFlag('--endpoint')
-    const token = readFlag('--token')
-    const org = readFlag('--org')
-    const label = readFlag('--label')
-    if (!endpoint || !token) {
-      console.error('Usage: agentop member connect --endpoint <url> --token <token> [--org <org>] [--label <name>]\n')
+    const { parseMemberConnectArgs } = await import('../server/member-connect-args.ts')
+    // Only the token is required: a composite `act1_…` token carries the central's URL, and
+    // demanding --endpoint here refused the very command the central prints. See
+    // member-connect-args.ts — resolving the endpoint is memberConnect's job, not the gate's.
+    const parsed = parseMemberConnectArgs(rest)
+    if (!parsed.ok) {
+      console.error(`${parsed.usage}\n`)
       process.exit(1)
     }
-    const code = await memberConnect({ endpoint, token, org, label })
+    const code = await memberConnect(parsed.opts)
     process.exit(code)
   }
   if (sub === 'leave') {

--- a/packages/server/server/cli-member.ts
+++ b/packages/server/server/cli-member.ts
@@ -35,7 +35,9 @@ import { cliStrings, resolveLang, type CliStrings } from './cli-i18n'
 // ---------------------------------------------------------------------------
 
 export interface MemberConnectOptions {
-  endpoint: string
+  /** Optional: a composite `act1_…` token carries the central's URL (see `unpackConnectToken`), so
+   *  the token alone connects a machine. Only a bare secret needs this. */
+  endpoint?: string
   token: string
   org?: string
   label?: string

--- a/packages/server/server/iam-handlers.ts
+++ b/packages/server/server/iam-handlers.ts
@@ -1029,7 +1029,10 @@ export async function handleMachines(req: Request, ip = 'unknown'): Promise<Resp
       if (!machine) return json({ error: 'machine not found' }, 404)
       if (!canManageMachine(principal, machine)) return json({ error: 'forbidden' }, 403)
       const rotated = await rotateToken(rotateId)
-      if (rotated === null) return json({ error: 'machine not found' }, 404)
+      // `null` also covers "another rotation of this machine won the race" (rotate-claim.ts) — from
+      // here the two are the same fact: this id no longer names a machine. Reported as 409 rather
+      // than 404 so the caller can say "it was just rotated, reload" instead of "no such machine".
+      if (rotated === null) return json({ error: 'machine_rotated_or_missing' }, 409)
       // The audit says what MOVED and what was lost: `envelopesDropped` is undelivered sealed mail
       // that no id can open again (the recipient is inside the seal), so it is destroyed by the
       // rotation, not migrated by it. An audit that only recorded the happy half would be a

--- a/packages/server/server/member-connect-args.test.ts
+++ b/packages/server/server/member-connect-args.test.ts
@@ -1,0 +1,78 @@
+/**
+ * member-connect-args.test.ts — the argv gate for `agentop member connect`.
+ *
+ * The regression these pin: the CLI demanded `--endpoint` even for a composite `act1_…` token that
+ * already carries the URL, so the exact command the central's Machines panel prints (and the one
+ * shown after a token rotation) was answered with a usage line and exit 1.
+ */
+
+import { describe, expect, test } from 'bun:test'
+import { packConnectToken } from '@agentistics/core'
+import { parseMemberConnectArgs } from './member-connect-args'
+
+const SECRET = 'a09e195366d8f472a7cb8001d482819957b12f4887d4896056d6a7911899f226'
+const CENTRAL = 'https://central.blpsoares.dev'
+const COMPOSITE = packConnectToken(SECRET, CENTRAL)
+
+describe('parseMemberConnectArgs', () => {
+  test('accepts the composite token ALONE — the command the central tells you to paste', () => {
+    const parsed = parseMemberConnectArgs(['--token', COMPOSITE])
+    expect(parsed.ok).toBe(true)
+    if (!parsed.ok) return
+    expect(parsed.opts.token).toBe(COMPOSITE)
+    // The endpoint is NOT resolved here: `memberConnect` unpacks the token and owns that rule.
+    // What matters is that the gate no longer invents a requirement the token already satisfies.
+    expect(parsed.opts.endpoint).toBeUndefined()
+  })
+
+  test('a raw secret with --endpoint still works (the pre-composite form)', () => {
+    const parsed = parseMemberConnectArgs(['--endpoint', 'http://host:48080', '--token', SECRET])
+    expect(parsed.ok).toBe(true)
+    if (!parsed.ok) return
+    expect(parsed.opts.endpoint).toBe('http://host:48080')
+    expect(parsed.opts.token).toBe(SECRET)
+  })
+
+  test('a raw secret with NO endpoint is still accepted by the gate — memberConnect refuses it, in words', () => {
+    // The gate must not be the place that decides whether an endpoint can be resolved: it cannot
+    // see inside the token. Passing it through is what lets the user read an actionable message
+    // ("needs --endpoint <url> (or a token with the URL embedded)") instead of a usage block.
+    const parsed = parseMemberConnectArgs(['--token', SECRET])
+    expect(parsed.ok).toBe(true)
+  })
+
+  test('no token at all → usage, and the usage names the token-only form', () => {
+    const parsed = parseMemberConnectArgs(['--endpoint', 'http://host:48080'])
+    expect(parsed.ok).toBe(false)
+    if (parsed.ok) return
+    expect(parsed.usage).toContain('--token')
+    expect(parsed.usage).toContain('agentop member connect --token')
+  })
+
+  test('--token with no value is a missing token, not an empty one', () => {
+    const parsed = parseMemberConnectArgs(['--token'])
+    expect(parsed.ok).toBe(false)
+  })
+
+  test('org and label are passed through; absent flags stay undefined, never empty strings', () => {
+    const parsed = parseMemberConnectArgs(['--token', COMPOSITE, '--org', 'acme', '--label', 'Client B'])
+    expect(parsed.ok).toBe(true)
+    if (!parsed.ok) return
+    expect(parsed.opts.org).toBe('acme')
+    expect(parsed.opts.label).toBe('Client B')
+
+    const bare = parseMemberConnectArgs(['--token', COMPOSITE])
+    expect(bare.ok).toBe(true)
+    if (!bare.ok) return
+    expect(bare.opts.org).toBeUndefined()
+    expect(bare.opts.label).toBeUndefined()
+  })
+
+  test('flag order does not matter', () => {
+    const parsed = parseMemberConnectArgs(['--label', 'Laptop', '--token', COMPOSITE, '--org', 'acme'])
+    expect(parsed.ok).toBe(true)
+    if (!parsed.ok) return
+    expect(parsed.opts.token).toBe(COMPOSITE)
+    expect(parsed.opts.label).toBe('Laptop')
+  })
+})

--- a/packages/server/server/member-connect-args.ts
+++ b/packages/server/server/member-connect-args.ts
@@ -1,0 +1,52 @@
+/**
+ * member-connect-args.ts — **pure**: the argv gate for `agentop member connect`.
+ *
+ * It lives here rather than inline in `bin/cli.ts` because the gate ITSELF was the bug. The central
+ * mints a composite token (`act1_<base64 url>.<secret>`, see `packConnectToken`) precisely so that
+ * pasting one command connects a machine, and both the Machines panel and the post-rotation drawer
+ * print exactly `agentop member connect --token act1_…`. The CLI meanwhile refused anything without
+ * `--endpoint` — before `memberConnect`, which has always unpacked the URL out of the token, was
+ * ever reached. The advertised fast path answered a usage line and exit 1.
+ *
+ * So the gate requires ONLY the token. Whether an endpoint can be resolved AT ALL stays where it
+ * can actually be answered — `memberConnect` unpacks the token and, when neither the flag nor the
+ * token carries a URL, says so in a sentence naming both ways to supply one. Two places enforcing
+ * one rule is how they drift; this one just collects flags.
+ */
+
+export interface MemberConnectArgs {
+  endpoint?: string
+  token: string
+  org?: string
+  label?: string
+}
+
+export type ParsedMemberConnect =
+  | { ok: true; opts: MemberConnectArgs }
+  | { ok: false; usage: string }
+
+/** The token-only form leads, because it is the one the central actually prints. */
+export const MEMBER_CONNECT_USAGE =
+  'Usage: agentop member connect --token <token> [--endpoint <url>] [--org <org>] [--label <name>]\n'
+  + '  A token from the central carries its URL — --endpoint is only needed for a bare token.'
+
+/** `--flag value`. A flag whose value is missing is the flag being absent — never an empty string,
+ *  which downstream would read as "the user asked for an empty label". */
+function readFlag(argv: string[], name: string): string | undefined {
+  const idx = argv.indexOf(name)
+  return idx !== -1 && argv[idx + 1] ? argv[idx + 1] : undefined
+}
+
+export function parseMemberConnectArgs(argv: string[]): ParsedMemberConnect {
+  const token = readFlag(argv, '--token')
+  if (!token) return { ok: false, usage: MEMBER_CONNECT_USAGE }
+  return {
+    ok: true,
+    opts: {
+      token,
+      endpoint: readFlag(argv, '--endpoint'),
+      org: readFlag(argv, '--org'),
+      label: readFlag(argv, '--label'),
+    },
+  }
+}

--- a/packages/server/server/rotate-claim.test.ts
+++ b/packages/server/server/rotate-claim.test.ts
@@ -1,0 +1,115 @@
+/**
+ * rotate-claim.test.ts — a token rotation must produce ONE machine, whatever the click count.
+ *
+ * The regression: `rotateToken` read the old token doc, migrated everything, and only THEN wrote
+ * the new doc and deleted the old one. Two rotations of the same machine overlapping (the Rotate
+ * button had no confirm and no in-flight guard, so a double-click sent two) both found the old doc
+ * and both inserted their own replacement — one machine became two, and the extra one owned no
+ * sessions and no token anybody held. Twenty clicks, twenty machines.
+ *
+ * `claimRotation` moves the id swap to the FRONT and makes it a race exactly one caller can win.
+ */
+
+import { describe, expect, test } from 'bun:test'
+import { claimRotation, type RotationClaimStore } from './rotate-claim'
+
+interface Doc { _id: string; label: string; teamIds?: string[] }
+
+/** An in-memory stand-in for the tokens collection. Every method awaits before touching the map,
+ *  so two concurrent claims genuinely interleave — and `takeIfPresent`'s read+delete run in one
+ *  synchronous step afterwards, which is the atomicity Mongo's `findOneAndDelete` provides. */
+function fakeStore(initial: Doc[]) {
+  const docs = new Map(initial.map(d => [d._id, d]))
+  const store: RotationClaimStore<Doc> = {
+    async findOne(id) { await Promise.resolve(); return docs.get(id) ?? null },
+    async insert(doc) {
+      await Promise.resolve()
+      if (docs.has(doc._id)) throw new Error(`duplicate key: ${doc._id}`)
+      docs.set(doc._id, doc)
+    },
+    async takeIfPresent(id) {
+      await Promise.resolve()
+      const found = docs.get(id)
+      if (!found) return null
+      docs.delete(id)
+      return found
+    },
+    async remove(id) { await Promise.resolve(); docs.delete(id) },
+  }
+  return { store, docs }
+}
+
+const MACHINE: Doc = { _id: 'old', label: "Alice's laptop", teamIds: ['t1'] }
+
+describe('claimRotation', () => {
+  test('a single rotation replaces the doc under the new id, keeping its metadata', async () => {
+    const { store, docs } = fakeStore([MACHINE])
+    const claim = await claimRotation(store, 'old', 'new')
+    expect(claim.won).toBe(true)
+    if (!claim.won) return
+    expect(claim.doc).toEqual({ _id: 'new', label: "Alice's laptop", teamIds: ['t1'] })
+    expect([...docs.keys()]).toEqual(['new'])
+  })
+
+  test('TWO concurrent rotations of the same machine leave exactly ONE machine', async () => {
+    const { store, docs } = fakeStore([MACHINE])
+    const [a, b] = await Promise.all([
+      claimRotation(store, 'old', 'newA'),
+      claimRotation(store, 'old', 'newB'),
+    ])
+    expect([a.won, b.won].filter(Boolean)).toHaveLength(1)
+    expect(docs.size).toBe(1)
+    const winner = a.won ? 'newA' : 'newB'
+    expect([...docs.keys()]).toEqual([winner])
+  })
+
+  test('twenty concurrent rotations still leave exactly one machine — the reported symptom', async () => {
+    const { store, docs } = fakeStore([MACHINE])
+    const claims = await Promise.all(
+      Array.from({ length: 20 }, (_, i) => claimRotation(store, 'old', `new${i}`)),
+    )
+    expect(claims.filter(c => c.won)).toHaveLength(1)
+    expect(docs.size).toBe(1)
+  })
+
+  test('the loser leaves NOTHING behind — its own replacement is rolled back', async () => {
+    const { store, docs } = fakeStore([MACHINE])
+    const [a, b] = await Promise.all([
+      claimRotation(store, 'old', 'newA'),
+      claimRotation(store, 'old', 'newB'),
+    ])
+    const loser = a.won ? 'newB' : 'newA'
+    expect(docs.has(loser)).toBe(false)
+  })
+
+  test('rotating an id that no longer exists loses, and writes nothing', async () => {
+    const { store, docs } = fakeStore([MACHINE])
+    const claim = await claimRotation(store, 'gone', 'new')
+    expect(claim.won).toBe(false)
+    expect([...docs.keys()]).toEqual(['old'])
+  })
+
+  test('a second, SEQUENTIAL rotation of an already-rotated id loses — the stale row in a list', async () => {
+    const { store, docs } = fakeStore([MACHINE])
+    await claimRotation(store, 'old', 'new1')
+    const again = await claimRotation(store, 'old', 'new2')
+    expect(again.won).toBe(false)
+    expect([...docs.keys()]).toEqual(['new1'])
+  })
+
+  test('the machine is never absent between the two writes — a crash cannot lose it', async () => {
+    // The insert happens BEFORE the old doc is taken, so at every observable moment at least one
+    // row exists for this machine. The opposite order (take, then insert) has a window where a
+    // crash leaves a machine with no token doc at all — unrecoverable, where a duplicate is not.
+    const { store, docs } = fakeStore([MACHINE])
+    const seen: number[] = []
+    const watched: RotationClaimStore<Doc> = {
+      findOne: id => store.findOne(id),
+      async insert(doc) { await store.insert(doc); seen.push(docs.size) },
+      async takeIfPresent(id) { const r = await store.takeIfPresent(id); seen.push(docs.size); return r },
+      remove: id => store.remove(id),
+    }
+    await claimRotation(watched, 'old', 'new')
+    expect(seen.every(n => n >= 1)).toBe(true)
+  })
+})

--- a/packages/server/server/rotate-claim.ts
+++ b/packages/server/server/rotate-claim.ts
@@ -1,0 +1,64 @@
+/**
+ * rotate-claim.ts — **pure**: the one step of a token rotation that MUST NOT race.
+ *
+ * A machine's identity IS the hash of its token (`memberId = sha256(token)`), so rotating means
+ * swapping one id for another and dragging every collection keyed by it along (see
+ * `rotate-identity.ts` for that enumeration). `rotateToken` used to do the swap LAST: read the old
+ * doc, migrate sessions/stats/workflows/tags/keys, then insert the new doc and delete the old one.
+ * Two overlapping rotations of the same machine therefore both read the same old doc and both
+ * inserted a replacement — ONE machine became TWO, the second owning nothing and holding a token
+ * only the person who double-clicked ever saw. The Rotate button had no confirm and no in-flight
+ * guard, so overlapping rotations were one impatient click away, and the fleet list grew a row per
+ * click.
+ *
+ * So the swap moves to the FRONT and becomes a claim exactly one caller can win. The order is
+ * insert-then-take, not take-then-insert, deliberately:
+ *   - insert → take: a crash between the two leaves a DUPLICATE, which an operator can see and
+ *     delete.
+ *   - take → insert: a crash between the two leaves the machine with NO token doc at all — its
+ *     sessions still keyed by an id nothing points at, and no way to reconstruct the metadata.
+ * A visible extra row beats a silently missing machine, and the window is one round-trip wide.
+ *
+ * The loser rolls its own replacement back and reports a loss; the caller treats that exactly like
+ * "no such machine", because that is what it is by the time it looked.
+ */
+
+/** The minimal tokens-collection surface a claim needs. Declared as an interface so the ordering
+ *  above is a property of a tested function rather than of a comment — this suite has no Mongo. */
+export interface RotationClaimStore<D extends { _id: string }> {
+  findOne(id: string): Promise<D | null>
+  insert(doc: D): Promise<void>
+  /** MUST be atomic: of N concurrent callers, exactly one may receive the document.
+   *  Mongo's `findOneAndDelete` is. A `findOne` followed by a `deleteOne` is NOT. */
+  takeIfPresent(id: string): Promise<D | null>
+  remove(id: string): Promise<void>
+}
+
+export type RotationClaim<D> =
+  /** This caller owns the rotation; `doc` is the machine, already stored under its new id. */
+  | { won: true; doc: D }
+  /** Someone else got there first, or the machine is gone. Nothing of this caller's remains. */
+  | { won: false }
+
+export async function claimRotation<D extends { _id: string }>(
+  store: RotationClaimStore<D>,
+  oldId: string,
+  newId: string,
+): Promise<RotationClaim<D>> {
+  const doc = await store.findOne(oldId)
+  if (!doc) return { won: false }
+
+  const replacement = { ...doc, _id: newId }
+  await store.insert(replacement)
+
+  // The one atomic step. Whoever removes the old row owns the rotation and everything keyed by it.
+  const taken = await store.takeIfPresent(oldId)
+  if (!taken) {
+    // Lost: another rotation already claimed this machine and is migrating its history to ITS new
+    // id. Leaving this replacement in place is exactly the duplicate machine being fixed here.
+    await store.remove(newId).catch(() => { /* best-effort; a stray row is visible and deletable */ })
+    return { won: false }
+  }
+
+  return { won: true, doc: replacement }
+}

--- a/packages/server/server/team-tokens.ts
+++ b/packages/server/server/team-tokens.ts
@@ -24,6 +24,7 @@ import type { Collection } from 'mongodb'
 import { getMongoDb } from './mongo'
 import { fromBsonDate, fromBsonDateOrNull } from './mongo-dates'
 import { teamDocId, type TeamSessionDoc } from './team-store'
+import { claimRotation } from './rotate-claim'
 import { accountTeamsMap, resolveMachineTeams } from '@agentistics/core'
 
 // ---------------------------------------------------------------------------
@@ -213,18 +214,31 @@ export interface RotationResult {
  *   - `tags`         — a `machine` source stores this id; re-pointed, or the tag empties.
  *   - `machineKeys`  — the machine's published envelope key moves with it.
  *   - `envelopes`    — inbound mail is dropped (undeliverable), outbound is left sealed.
- *   - `tokens`       — the token doc is replaced (new hash id, same metadata).
+ *   - `tokens`       — the token doc is replaced (new hash id, same metadata). This happens
+ *                      FIRST, as an atomic claim (`rotate-claim.ts`), not last: it is what makes
+ *                      concurrent rotations of one machine settle into one machine instead of
+ *                      several, and `null` therefore also means "another rotation got here first".
  *
  * `rotate-identity.ts` holds the full enumeration of what is keyed by the machine id, what is
  * only keyed by something that LOOKS like it, and why sibling pins are deliberately not carried.
  */
 export async function rotateToken(oldId: string): Promise<RotationResult | null> {
   const col = await getTokensCollection()
-  const doc = await col.findOne({ _id: oldId })
-  if (!doc) return null
 
   const token = randomBytes(32).toString('hex')
   const newId = hashToken(token)
+
+  // CLAIM FIRST, migrate after. Two overlapping rotations of one machine used to both read the old
+  // doc and both write a replacement, so a double-clicked Rotate button turned one machine into
+  // several — see rotate-claim.ts. Exactly one caller can win this; a loser wrote nothing and is
+  // answered like a machine that no longer exists, because by the time it looked, it did not.
+  const claim = await claimRotation<TokenDoc>({
+    findOne: id => col.findOne({ _id: id }),
+    insert: async d => { await col.insertOne(d) },
+    takeIfPresent: id => col.findOneAndDelete({ _id: id }),
+    remove: async id => { await col.deleteOne({ _id: id }) },
+  }, oldId, newId)
+  if (!claim.won) return null
 
   const db = await getMongoDb()
 
@@ -259,13 +273,8 @@ export async function rotateToken(oldId: string): Promise<RotationResult | null>
       .catch(() => ({ keyMoved: false, envelopesDropped: 0 })),
   ])
 
-  // Replace the token doc (new hash id, same metadata) — preserve team + owner assignment so
-  // rotating a machine's token keeps its teams/owners (previously these were silently dropped).
-  await col.insertOne({
-    ...doc,
-    _id: newId,
-  })
-  await col.deleteOne({ _id: oldId })
+  // The token doc itself moved at the top, in the claim: it carries the same metadata under the
+  // new hash id, so a rotation keeps the machine's teams and owners (they used to be dropped).
 
   return {
     token,

--- a/packages/web/src/pages/settings/MachinesSettings.tsx
+++ b/packages/web/src/pages/settings/MachinesSettings.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useCallback } from 'react'
 import { useOutletContext } from 'react-router-dom'
-import { Plus, Copy, Check, RotateCw, Trash2, Pencil, X } from 'lucide-react'
+import { Plus, Copy, Check, RotateCw, Trash2, Pencil, X, Loader2 } from 'lucide-react'
 import type { AppContext } from '../../lib/app-context'
 import { ConnectionsPanel } from '../../components/team/ConnectionsPanel'
 import { SectionHeader, Section, Select, Checkbox, ConfirmModal, RecordCard, RecordCardAction, SaveBar, runSaveSteps } from './primitives'
@@ -120,7 +120,15 @@ function CentralMachinesView({ pt }: { pt: boolean }) {
   const [copied, setCopied] = useState<string | null>(null)
   const [copyFailed, setCopyFailed] = useState<string | null>(null)
 
-  // Rotate state
+  // Rotate state.
+  // `rotateConfirmId` gates the act (a rotation invalidates the token the machine is using RIGHT
+  // NOW — that is a question, not a toolbar toggle) and `rotatingId` is the in-flight guard. The
+  // button used to fire on click with no confirmation and no visible state, so an impatient second
+  // click sent a second rotation of the same machine — which the central then turned into a second
+  // MACHINE. The server refuses the overlap now (rotate-claim.ts); this is what stops it being
+  // asked in the first place.
+  const [rotateConfirmId, setRotateConfirmId] = useState<string | null>(null)
+  const [rotatingId, setRotatingId] = useState<string | null>(null)
   const [rotateId, setRotateId] = useState<string | null>(null)
   const [rotatedToken, setRotatedToken] = useState<string | null>(null)
 
@@ -355,20 +363,37 @@ function CentralMachinesView({ pt }: { pt: boolean }) {
     }
   }
 
+  /** One rotation at a time, and never two of the same machine: a rotation mints a NEW identity
+   *  (the machine id is the token's hash), so a second one fired before the first answered is a
+   *  second identity for one machine — which is exactly how the fleet list grew duplicate rows. */
   async function rotateMachine(id: string) {
+    if (rotatingId) return
+    setRotatingId(id)
+    setErr(null)
     try {
       const res = await fetch('/api/iam/machines', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ rotateId: id }),
       })
-      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      if (!res.ok) {
+        // 409 is the central saying this id was rotated out from under us (another tab, another
+        // admin) — a stale row, not a failure of the machine, so it asks for a reload by name.
+        if (res.status === 409) {
+          throw new Error(pt
+            ? 'Esta máquina já foi rotacionada em outro lugar. Recarregue a lista e tente de novo.'
+            : 'This machine was already rotated elsewhere. Reload the list and try again.')
+        }
+        throw new Error(`HTTP ${res.status}`)
+      }
       const d = await res.json() as { token: string }
       setRotateId(id)
       setRotatedToken(d.token)
       void load()
     } catch (e) {
-      setErr(String(e))
+      setErr(e instanceof Error ? e.message : String(e))
+    } finally {
+      setRotatingId(null)
     }
   }
 
@@ -748,8 +773,14 @@ function CentralMachinesView({ pt }: { pt: boolean }) {
                           <Pencil size={14} /> {pt ? 'Editar' : 'Edit'}
                         </RecordCardAction>
                       )}
-                      <RecordCardAction label="Rotate token" onClick={() => void rotateMachine(m.id)}>
-                        <RotateCw size={14} /> {pt ? 'Rotacionar' : 'Rotate'}
+                      <RecordCardAction
+                        label="Rotate token"
+                        disabled={rotatingId !== null}
+                        onClick={() => setRotateConfirmId(m.id)}
+                      >
+                        {rotatingId === m.id
+                          ? <><Loader2 size={14} style={{ animation: 'spin 1s linear infinite' }} /> {pt ? 'Rotacionando…' : 'Rotating…'}</>
+                          : <><RotateCw size={14} /> {pt ? 'Rotacionar' : 'Rotate'}</>}
                       </RecordCardAction>
                       <RecordCardAction label="Revoke machine" danger onClick={() => setRevokeConfirmId(m.id)}>
                         <Trash2 size={14} /> {pt ? 'Revogar' : 'Revoke'}
@@ -850,11 +881,20 @@ function CentralMachinesView({ pt }: { pt: boolean }) {
                           </button>
                         )}
                         <button
-                          style={{ ...ghostBtn, padding: '4px 8px' }}
-                          onClick={e => { e.stopPropagation(); void rotateMachine(m.id) }}
-                          title={pt ? 'Rotacionar token' : 'Rotate token'}
+                          style={{
+                            ...ghostBtn, padding: '4px 8px',
+                            cursor: rotatingId ? 'not-allowed' : 'pointer', opacity: rotatingId ? 0.5 : 1,
+                          }}
+                          disabled={rotatingId !== null}
+                          aria-busy={rotatingId === m.id || undefined}
+                          onClick={e => { e.stopPropagation(); setRotateConfirmId(m.id) }}
+                          title={rotatingId === m.id
+                            ? (pt ? 'Rotacionando…' : 'Rotating…')
+                            : (pt ? 'Rotacionar token' : 'Rotate token')}
                         >
-                          <RotateCw size={12} />
+                          {rotatingId === m.id
+                            ? <Loader2 size={12} style={{ animation: 'spin 1s linear infinite' }} />
+                            : <RotateCw size={12} />}
                         </button>
                         <button
                           style={{ ...ghostBtn, padding: '4px 8px', color: '#ef4444' }}
@@ -1356,6 +1396,28 @@ function CentralMachinesView({ pt }: { pt: boolean }) {
         </div>
       </Drawer>
 
+      {/* Rotate token confirm — the act is not undoable and it disconnects a working machine, so
+          it is asked rather than fired. Closing on confirm is also the first of the two guards
+          against a second rotation (the second is `rotatingId`, which disables every Rotate). */}
+      <ConfirmModal
+        open={rotateConfirmId !== null}
+        title={pt ? 'Rotacionar o token?' : 'Rotate the token?'}
+        message={(() => {
+          const name = machines.find(m => m.id === rotateConfirmId)?.machineName ?? ''
+          return pt
+            ? `O token atual de "${name}" para de valer imediatamente. A máquina só volta a enviar dados depois de reconectar com o novo token (mostrado uma única vez). O histórico é preservado.`
+            : `The current token for "${name}" stops working immediately. The machine only reports again once it reconnects with the new token (shown once). Its history is preserved.`
+        })()}
+        confirmLabel={pt ? 'Rotacionar' : 'Rotate'}
+        cancelLabel={pt ? 'Cancelar' : 'Cancel'}
+        onConfirm={() => {
+          const id = rotateConfirmId
+          setRotateConfirmId(null)
+          if (id) void rotateMachine(id)
+        }}
+        onCancel={() => setRotateConfirmId(null)}
+      />
+
       {/* Revoke machine confirm */}
       <ConfirmModal
         open={revokeConfirmId !== null}
@@ -1384,6 +1446,8 @@ function CentralMachinesView({ pt }: { pt: boolean }) {
         onConfirm={() => void bulkDelete()}
         onCancel={() => setBulkDeleteConfirm(false)}
       />
+
+      <style>{'@keyframes spin { to { transform: rotate(360deg); } }'}</style>
     </>
   )
 }

--- a/packages/web/src/pages/settings/primitives.tsx
+++ b/packages/web/src/pages/settings/primitives.tsx
@@ -178,22 +178,28 @@ export function RecordCard({ title, subtitle, badge, fields, actions, onClick, l
 // RecordCardAction
 // A footer button for RecordCard: equal share of the row, 44px tall, flat against its neighbours
 // (the 1px gaps in the parent's background show through as hairline dividers).
-export function RecordCardAction({ onClick, children, danger, label }: {
+export function RecordCardAction({ onClick, children, danger, label, disabled }: {
   onClick: () => void
   children: React.ReactNode
   danger?: boolean
   label: string
+  /** An action that is already running, or that must wait for one. A disabled control that still
+   *  LOOKS pressable is how an unanswered click becomes a second request. */
+  disabled?: boolean
 }) {
   return (
     <button
       type="button"
       onClick={onClick}
+      disabled={disabled}
       aria-label={label}
+      aria-busy={disabled || undefined}
       style={{
         flex: 1, minHeight: 44, display: 'inline-flex', alignItems: 'center', justifyContent: 'center', gap: 7,
         border: 'none', background: 'var(--bg-card)',
         color: danger ? '#ef4444' : 'var(--text-secondary)',
-        fontSize: 12.5, fontWeight: 600, fontFamily: 'inherit', cursor: 'pointer',
+        fontSize: 12.5, fontWeight: 600, fontFamily: 'inherit',
+        cursor: disabled ? 'not-allowed' : 'pointer', opacity: disabled ? 0.5 : 1,
       }}
     >
       {children}


### PR DESCRIPTION
Two bugs reported from a live central, one on each side of the same token.

## 1. `agentop member connect --token act1_…` was refused

The central mints a composite token (`act1_<base64 url>.<secret>`) precisely so one pasted command connects a machine, and both the Machines panel and the post-rotation drawer print exactly `agentop member connect --token act1_…`. `bin/cli.ts` demanded `--endpoint` **before** `memberConnect` — which has always unpacked the URL out of the token — was ever reached, so the advertised fast path answered a usage line and exit 1.

The gate now requires only the token and lives in the pure, tested `member-connect-args.ts`. Whether an endpoint can be resolved at all stays where it can actually be answered: `memberConnect`, reading inside the token. A bare secret with no `--endpoint` still gets its actionable sentence naming both ways to supply a URL.

Verified against the real CLI in an isolated data dir:

| command | before | after |
|---|---|---|
| `--token act1_…` | usage line, exit 1 | attempts the real connection |
| `--token abc123` (no URL anywhere) | usage line | `needs --endpoint <url> (or a token with the URL embedded)` |
| no `--token` | usage line | usage line, token-only form first |

## 2. Rotate token fired on click, and duplicated machines

Rotate had no confirmation and no in-flight state — nothing on screen said anything was happening — so a second click was one impatient moment away. `rotateToken` then turned it into a second **machine**: it read the old token doc, migrated sessions/stats/workflows/tags/keys, and only *then* wrote the new doc and deleted the old one. Two overlapping rotations both found the same old doc and both inserted a replacement. Twenty clicks, twenty machines — nineteen owning no sessions and holding a token nobody kept.

- **Server** — the id swap moves to the FRONT of the rotation and becomes a claim exactly one caller can win (`rotate-claim.ts`, pure, tested against a concurrent fake: two, then twenty, simultaneous rotations leave one machine). The order is insert-then-take on purpose: a crash between the two writes leaves a visible duplicate an operator can delete, where take-then-insert leaves a machine with NO token doc and no way to reconstruct it. The loser rolls its own replacement back; the route reports it as 409 so the UI can say "it was just rotated, reload" rather than "no such machine".
- **UI** — asks first (the current token stops working immediately: a question, not a toolbar toggle), and while a rotation is in flight every Rotate control is disabled and the running one says so, spinner and all. Desktop row and mobile card both.

## Notes

- Duplicates already in a central's `tokens` collection are not cleaned up by this — it prevents new ones.
- Shipping: the CLI half rides the binary (`bun run bin`), the rotation half the central image (`agentop central up --rebuild`).

## Verification

- `bun test` — 3765 pass, 0 fail (14 new tests across the two pure modules)
- `bun tsc --noEmit` clean
- `bun run build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)