### PR TITLE
fix: agentistics' own token was the one its redactor did not know

### DIFF
--- a/packages/core/src/redact.test.ts
+++ b/packages/core/src/redact.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test'
-import { redactSecrets, containsSecret } from './redact'
+import { redactSecrets, containsSecret, redactSessionText, REDACTION } from './redact'
 
 const R = '[REDACTED]'
 
@@ -158,5 +158,56 @@ describe('behavior', () => {
     const dirty = 'mongodb+srv://u:pw12345678@h/db'
     expect(containsSecret(dirty)).toBe(true)
     expect(containsSecret(redactSecrets(dirty))).toBe(false)
+  })
+})
+
+describe("agentistics' own connect token", () => {
+  /**
+   * The composite form `packConnectToken` produces and the UI tells people to paste: `act1_` +
+   * base64url of the central URL + `.` + the hex secret. Shaped like the real one that was found in
+   * a session's `first_prompt`; the secret here is random hex typed for this test.
+   */
+  const TOKEN = 'act1_aHR0cHM6Ly9jZW50cmFsLmV4YW1wbGUuY29t'
+    + '.1f3c9a7e5b2d4068af91c3e7d5b8402619ac7f3e0d2b5849c6ef1a3b7d90c254'
+
+  test('redacts the token this product mints, which is the one it kept missing', () => {
+    // Every other vendor's format was on the STRONG list and ours was not. It was found in
+    // plaintext in `first_prompt` — the field this module exists to protect.
+    expect(redactSecrets(TOKEN)).toBe(REDACTION)
+    expect(containsSecret(TOKEN)).toBe(true)
+  })
+
+  test('redacts it inside the prose somebody actually pastes', () => {
+    const out = redactSecrets(`agentop member connect --token ${TOKEN} nao funciona`)
+    expect(out).not.toContain(TOKEN)
+    // The sentence still says what the session was ABOUT, which is the whole value of a label.
+    expect(out).toContain('agentop member connect')
+    expect(out).toContain('nao funciona')
+  })
+
+  test('scrubs it out of a session the way the push boundary does', () => {
+    const session = { first_prompt: `here is my token: ${TOKEN}`, title: 'connect fails' }
+    const out = redactSessionText(session)
+    expect(out.first_prompt).not.toContain(TOKEN)
+    expect(out.title).toBe('connect fails')
+  })
+
+  test('leaves a bare SHA-256 alone — 64 hex is a hash, not a namespace', () => {
+    // The deliberate limit. `hashToken` output, git objects and content hashes are all this shape,
+    // and a rule for it would redact labels that merely quote one. A noisy redactor gets switched
+    // off, which costs more than it saves.
+    const sha = 'a'.repeat(64)
+    expect(redactSecrets(`the id is ${sha}`)).toContain(sha)
+  })
+
+  test('still catches a bare secret when it is pasted WITH context', () => {
+    const secret = '1f3c9a7e5b2d4068af91c3e7d5b8402619ac7f3e0d2b5849c6ef1a3b7d90c254'
+    expect(redactSecrets(`--token=${secret}`)).not.toContain(secret)
+    expect(redactSecrets(`Authorization: Bearer ${secret}`)).not.toContain(secret)
+  })
+
+  test('does not fire on the prefix alone, or on prose that merely mentions it', () => {
+    expect(redactSecrets('paste your act1_ token here')).toBe('paste your act1_ token here')
+    expect(redactSecrets('the act1_ format embeds the endpoint')).toBe('the act1_ format embeds the endpoint')
   })
 })

--- a/packages/core/src/redact.ts
+++ b/packages/core/src/redact.ts
@@ -60,7 +60,29 @@ const STRONG: RegExp[] = [
   /\bAIza[A-Za-z0-9\-_]{35}/g,
   /\bAKIA[0-9A-Z]{16}\b/g,
   /\beyJ[A-Za-z0-9\-_]{8,}\.eyJ[A-Za-z0-9\-_]{8,}\.[A-Za-z0-9\-_]{8,}/g, // JWT
+  // OUR OWN connect token — `act1_<base64url endpoint>.<hex secret>`, from `packConnectToken`.
+  //
+  // This list carried GitHub's, Anthropic's, OpenAI's, Slack's, Google's, AWS's and a JWT before it
+  // carried agentistics'. The gap was found the way these are: a real one, pasted as a session's
+  // opening message, sitting in plaintext in `first_prompt` in the local store — the exact field
+  // this module exists to protect, and the one that travels to a central.
+  //
+  // Unguarded like its neighbours, because `act1_` is a namespace this product mints: nothing else
+  // produces it, so there is no prose to protect from a false positive.
+  /\bact1_[A-Za-z0-9\-_]+\.[A-Za-z0-9]{16,}/g,
 ]
+
+/**
+ * NOT in the list above, deliberately: the BARE secret half, 64 hex characters (96 for a repo/CI
+ * token — see `mintToken`).
+ *
+ * It carries no namespace, and 64 hex is exactly the shape of a SHA-256 — which this product prints
+ * constantly and legitimately, `hashToken`'s own output included. A rule for it would redact any
+ * session label that merely quotes a hash, and the first thing anyone does with a noisy redactor is
+ * switch it off. A bare secret pasted WITH context is already covered: `ASSIGNMENT` catches
+ * `token=<hex>` and `BEARER` catches `Bearer <hex>`. Pasted entirely alone it is indistinguishable
+ * from a hash, and this module's stated rule is to leave text alone when in doubt.
+ */
 
 /**
  * The password inside a `scheme://user:password@host` URI.


### PR DESCRIPTION
`redactSecrets` carried GitHub's token format, Anthropic's, OpenAI's, Slack's, Google's, AWS's and a JWT — and not the one this product mints.

It was found the way these are: a real `act1_…` connect token, pasted as a session's opening message, sitting in plaintext in `first_prompt` in the local store. That is the exact field this module exists to protect, and the one that travels to a central and into Mongo.

The pattern is unguarded like its neighbours: `act1_` is a namespace this product mints, so nothing else produces it and there is no prose to protect from a false positive.

**The bare secret half is deliberately not matched** — 64 hex characters, 96 for a repo token. A rule that broad would eat commit hashes, checksums and file digests out of the very prompts these fields exist to label, and `redactSecrets` is documented as precise rather than exhaustive for exactly that reason: a redactor that makes labels useless is a redactor people switch off.

This is a safety net for the accidental paste and **not a substitute for rotating** a token that has already been on disk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019vBSuKQLuyLhWZS4zbiu2s