### PR TITLE
fix(cockpit): a remount opens on what the host already knows, not on the defaults

### DIFF
--- a/packages/server/server/cli-start.ts
+++ b/packages/server/server/cli-start.ts
@@ -1428,6 +1428,16 @@ function createControlHost(initialLang: CliLang, altScreen: Suspendable): StartH
       .catch(() => { /* offline — the header simply says nothing */ })
   }
 
+  /**
+   * The last status this host produced, kept so a REMOUNT has something true to open on.
+   *
+   * The host outlives the Ink app — `runStart` creates it once and loops around every attach — which
+   * is what makes this possible at all, and `ControlHost.lastStatus` is where the reason is written
+   * down. Every write to it goes through `remember()`, so there is one place that can go stale.
+   */
+  let lastStatus: ControlStatus | null = null
+  const remember = (next: ControlStatus): ControlStatus => (lastStatus = next)
+
   /** Has the archive consent never been answered? Used only to append a hint, so it fails open. */
   const archivePending = async (): Promise<boolean> => {
     try {
@@ -1570,10 +1580,12 @@ function createControlHost(initialLang: CliLang, altScreen: Suspendable): StartH
   return {
     get lang() { return lang },
 
+    lastStatus: () => lastStatus,
+
     async refresh(): Promise<ControlStatus> {
       const s = S()
       const [{ mode, endpoint, connections, mouse }, services] = await Promise.all([loadState(), serviceRows()])
-      return {
+      return remember({
         mode,
         modeLabel: modeSentence(s, mode, connections.length),
         // Every endpoint, not the mirror's first one: the detail pane is where the user checks
@@ -1589,7 +1601,7 @@ function createControlHost(initialLang: CliLang, altScreen: Suspendable): StartH
         archiveMode: await currentArchiveMode(),
         ...(await sessionViewPref()),
         mouse,
-      }
+      })
     },
 
     /**
@@ -1859,6 +1871,12 @@ function createControlHost(initialLang: CliLang, altScreen: Suspendable): StartH
      * run. Losing it across restarts is not worth failing anything for.
      */
     async setSessionView(view: SessionViewPrefs): Promise<void> {
+      // The remembered status has to move with it. This is the ONE thing a user changes that never
+      // goes through an action — so it never triggers a `refresh()` — and a cache left behind would
+      // hand the next remount the arrangement from before the change, undoing it on screen a moment
+      // after it was made. Written even when the file write fails, for the same reason the failure
+      // is swallowed: the arrangement still holds for this run.
+      if (lastStatus) remember({ ...lastStatus, sessionView: view })
       try {
         await writePreferences({ sessionView: view })
       } catch {
@@ -1875,6 +1893,10 @@ function createControlHost(initialLang: CliLang, altScreen: Suspendable): StartH
     // the toggle for this session, because the control center holds the answer itself and only
     // asks us to remember it.
     async setMouse(on: boolean): Promise<void> {
+      // Same reason as `setSessionView`: a preference the user changes with a keypress, answered by
+      // no action and therefore followed by no `refresh()`. Left out, the remembered status would
+      // tell the next remount the mouse is still what it was before the key was pressed.
+      if (lastStatus) remember({ ...lastStatus, mouse: on })
       try { await writePreferences({ mouse: on }) } catch { /* best-effort */ }
     },
 

--- a/packages/tui/src/control/ControlCenter.test.tsx
+++ b/packages/tui/src/control/ControlCenter.test.tsx
@@ -1,0 +1,116 @@
+import React from 'react'
+import { describe, test, expect } from 'bun:test'
+import { render } from 'ink-testing-library'
+import { ControlCenter } from './ControlCenter'
+import type { ControlHost, ControlSessions, ControlStatus } from './types'
+
+/**
+ * What the cockpit draws in the second BEFORE `refresh()` answers.
+ *
+ * `refresh()` shells out to systemd and to docker, so it takes about a second on a real machine —
+ * and every detach REMOUNTS this app, because attach and detach are two halves of one gesture and
+ * the loop lives in `runStart`. Anything the screen cannot know during that second falls back to a
+ * default, and for the sessions list that means the arrangement someone chose is replaced by the
+ * shipped one and then swapped back in front of them: not an incomplete frame but a WRONG one,
+ * about a choice the user made.
+ *
+ * The assertion is on the FIRST frame on purpose. It is the frame that was wrong, and it is the one
+ * that needs nothing to have resolved — which also keeps this test standing in a full `bun test`
+ * run, where `useData.scope.test.ts` has replaced React's hooks process-wide by the time this file
+ * is reached.
+ */
+
+const FLEET: ControlSessions = { sessions: [], attention: 0, rang: [] }
+
+const STORED: ControlStatus = {
+  mode: 'solo',
+  modeLabel: 'solo',
+  services: [],
+  version: '1.0.0',
+  // What the user chose last time: by REPOSITORY, not the shipped default of by project.
+  sessionView: {
+    grouping: 'repo',
+    showClosed: false,
+    showExited: false,
+    showUnfiled: true,
+    showDone: false,
+    onlyActive: true,
+    layout: 'list',
+  },
+}
+
+/**
+ * A host mid-probe: it already knows what it read from disk, and has not finished looking at the
+ * machine. That is the exact state every remount starts in.
+ */
+function probingHost(known: ControlStatus | null): ControlHost {
+  const done = async () => ({ ok: true, message: '' })
+  return {
+    // Never answers — this is the one-second window the frame under test is drawn in.
+    refresh: () => new Promise<ControlStatus>(() => {}),
+    lastStatus: () => known,
+    start: done,
+    connect: done,
+    disconnect: done,
+    restart: done,
+    stop: done,
+    setMode: done,
+    initCentral: done,
+    upgrade: done,
+    pendingArchiveMode: async () => null,
+    setArchiveMode: done,
+    enableBoot: done,
+    setLang: async () => {},
+    setSessionView: async () => {},
+    setMouse: async () => {},
+    onOutput: () => () => {},
+    readLog: async () => [],
+    sessions: async () => FLEET,
+  } as unknown as ControlHost
+}
+
+/** Strip ANSI so assertions read against the visible text. */
+function plain(frame: string | undefined): string {
+  return (frame ?? '').replace(/\[[0-9;]*m/g, '')
+}
+
+const COLS = 100
+const ROWS = 34
+
+/** The first frame the cockpit draws, at a pinned size. */
+function firstFrame(host: ControlHost): string {
+  // `useTerminalSize` reads the REAL `process.stdout` while Ink lays out against the testing
+  // library's own, so both are pinned — exactly as `scripts/preview.tsx` does it. Left to the
+  // ambient size the frame is whatever the previous test file happened to leave behind, and a pane
+  // too narrow to hold a heading proves nothing about which heading it is.
+  const size = { columns: process.stdout.columns, rows: process.stdout.rows }
+  Object.defineProperty(process.stdout, 'columns', { value: COLS, configurable: true })
+  Object.defineProperty(process.stdout, 'rows', { value: ROWS, configurable: true })
+  const { lastFrame, unmount } = render(
+    <ControlCenter host={host} lang="en" initial={{ tab: 'sessions' }} onExit={() => {}} />,
+  )
+  const frame = plain(lastFrame())
+  unmount()
+  Object.defineProperty(process.stdout, 'columns', { value: size.columns, configurable: true })
+  Object.defineProperty(process.stdout, 'rows', { value: size.rows, configurable: true })
+  return frame
+}
+
+describe('ControlCenter — the frame drawn before the probe answers', () => {
+  test('opens the sessions list on the arrangement the host already knows', () => {
+    const frame = firstFrame(probingHost(STORED))
+    expect(frame).toContain('GROUP repository')
+    expect(frame).not.toContain('GROUP project')
+    // The same seed carries the rest of what was already true — the header used to be blank for as
+    // long as the probe ran.
+    expect(frame).toContain('solo')
+    expect(frame).toContain('v1.0.0')
+  })
+
+  test('falls back to the defaults on a first-ever launch, when nothing is known yet', () => {
+    // `null` is not "slow", it is "never looked" — and then the shipped arrangement is the right
+    // answer rather than a placeholder.
+    const frame = firstFrame(probingHost(null))
+    expect(frame).toContain('GROUP project')
+  })
+})

--- a/packages/tui/src/control/ControlCenter.tsx
+++ b/packages/tui/src/control/ControlCenter.tsx
@@ -134,7 +134,12 @@ export function ControlCenter({ host, lang: initialLang, initial, onExit, mouse 
   const s = controlStrings(lang)
 
   const [tab, setTab] = useState<TabId>(initial?.tab ?? 'services')
-  const [status, setStatus] = useState<ControlStatus | null>(null)
+  // Seeded from what the host already knows, so a REMOUNT does not open on the defaults. Detaching
+  // from a session remounts this app, `refresh()` takes about a second to probe systemd and docker,
+  // and for that second the sessions list was drawn with the shipped arrangement instead of the
+  // user's — the screen visibly rearranged itself under them. `null` stays the first-ever launch,
+  // where there is genuinely nothing to know yet.
+  const [status, setStatus] = useState<ControlStatus | null>(host.lastStatus?.() ?? null)
   const [busy, setBusy] = useState(true)
   const [result, setResult] = useState<ActionResult | null>(null)
   const [chrome, setChrome] = useState<ScreenChrome>({ capture: false, hints: [] })

--- a/packages/tui/src/control/types.ts
+++ b/packages/tui/src/control/types.ts
@@ -673,6 +673,21 @@ export interface ActionResult {
 export interface ControlHost {
   /** Re-detect config + services. Must never throw; failures come back as `unknown` services. */
   refresh(): Promise<ControlStatus>
+  /**
+   * What the host ALREADY knows, synchronously, or `null` on the very first look.
+   *
+   * `refresh()` shells out to systemd and to docker, so it takes about a second — and attach and
+   * detach are two halves of one gesture, so every detach REMOUNTS this app and starts that second
+   * over. Whatever the screen cannot know during it is drawn from defaults, and for the sessions
+   * list that means the arrangement someone chose is replaced by the shipped one and then swapped
+   * back in front of them: a frame that is not merely incomplete but WRONG about a choice the user
+   * made. This is the same answer as the fleet poll's — the previous truth beats a confident
+   * default — and `refresh()` runs anyway, on the frame after.
+   *
+   * The host is what survives the remount (`runStart` creates it once, outside the loop), so it is
+   * the only place this can live.
+   */
+  lastStatus?(): ControlStatus | null
 
   /**
    * Start one runtime — normally a `StartOption` handed straight back.

--- a/packages/web/src/hooks/useData.scope.test.ts
+++ b/packages/web/src/hooks/useData.scope.test.ts
@@ -31,12 +31,18 @@ import type { TagDef } from '../lib/tagMatch'
  * Spreading the real React keeps every other export intact and overrides only the hooks this
  * file needs to run the memo body eagerly. The real module is captured by the import above,
  * which is evaluated before this call.
+ *
+ * Every override that stays must still be FAITHFUL to the hook it replaces, for the same reason:
+ * whatever runs after this file gets this React. `useState` ignoring a lazy initializer handed the
+ * component the function itself as its state — `useTerminalSize` does `useState(currentSize)`, so
+ * every Ink surface rendered after this file came out at a width of `undefined`.
  */
 mock.module('react', () => ({
   ...React,
   default: (React as { default?: unknown }).default ?? React,
   useMemo: <T>(fn: () => T) => fn(),
-  useState: <T>(init: T) => [init, () => {}],
+  useState: <T>(init: T | (() => T)) =>
+    [typeof init === 'function' ? (init as () => T)() : init, () => {}],
   useEffect: () => {},
   useCallback: <T>(fn: T) => fn,
   useRef: <T>(init: T) => ({ current: init }),


### PR DESCRIPTION
## The bug

Detaching from a session and coming back showed the sessions list in the wrong arrangement for about
a second, then it visibly rearranged itself into the right one. Reported from a machine whose list is
grouped by repository: it came back grouped by project.

## Root cause

Attach and detach are two halves of one gesture, so `runStart` loops and every detach REMOUNTS the
control center. The whole screen is drawn from `ControlStatus`, which only exists once `refresh()`
answers — and `refresh()` shells out to systemd and to docker, so for about a second there is none.
`Sessions` therefore gets `view: undefined` and falls back to `DEFAULT_SESSION_VIEW`; the stored
arrangement lands a moment later and the restore effect swaps it in, in front of the user.

## The fix

The host outlives the Ink app (`runStart` creates it once, outside the loop), so it is the only thing
that can answer immediately. It now remembers the last status it produced and hands it over
synchronously through the new `ControlHost.lastStatus`, which the cockpit seeds its state from.
`refresh()` still runs on the frame after. `null` stays the first-ever launch, where there genuinely
is nothing to know and the defaults are the right answer rather than a placeholder.

The two preferences a user changes with a keypress — the arrangement and the mouse — are answered by
no action and therefore followed by no refresh, so both write through `remember()` as well. A cache
left behind there would hand the next remount the value from before the key was pressed, undoing the
change on screen a moment after it was made.

## Also

`useData.scope.test.ts` replaces the `react` module for the whole test process, and its `useState`
stub ignored a lazy initializer. `useTerminalSize` does `useState(currentSize)`, so every Ink surface
rendered in a file after that one came out at a width of `undefined` — which is what the new test hit.
The stub now honours the initializer.

## Verification

- `bun tsc --noEmit` clean
- `bun test` — 3806 pass, 0 fail
- `bun run build:binary` compiles; `./release/agentop session list` runs
- `ControlCenter.test.tsx` fails before the fix with `GROUP project` on screen while the host already
  knew `repo` — the reported frame, exactly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0118R5WtsUr6fVr9VWRc9ijn