### PR TITLE
fix(sessions): one conversation, one live session — lock the reopen door

### DIFF
--- a/packages/server/server/cli-i18n.ts
+++ b/packages/server/server/cli-i18n.ts
@@ -139,8 +139,15 @@ export interface CliStrings {
   sessAnswered: (label: string) => string
   /** Nothing fell, or everything that did has already been picked back up. */
   sessNoFell: string
-  sessFellOpened: (opened: number, skipped: number) => string
+  sessFellOpened: (opened: number, skipped: number, held: number) => string
   sessFellNoneOpened: (skipped: number) => string
+  /**
+   * Refusing to open a conversation a live session already has, and NAMING that session.
+   *
+   * The name is the whole message. "Already open" leaves someone hunting for it; the twins this
+   * prevents were only found by reading two screens side by side and noticing identical text.
+   */
+  sessResumeInUse: (holder: string) => string
   /** The fallback title for a session the user never named. */
   sessUntitled: (harness: string, project: string) => string
   sessKilled: (id: string) => string
@@ -158,7 +165,7 @@ export interface CliStrings {
   sessNoted: string
   sessTasked: string
   sessTaskEmpty: (task: string) => string
-  sessTaskOpened: (task: string, opened: number, skipped: number) => string
+  sessTaskOpened: (task: string, opened: number, skipped: number, held: number) => string
   sessTaskNoneOpened: (task: string, skipped: number) => string
   /** A session the backend hosts but the registry never recorded has no metadata to patch. */
   sessNoRegistryEntry: string
@@ -386,12 +393,14 @@ const EN: CliStrings = {
     `agentop has no verified way to pick an option on ${harness}, and will not confirm the highlighted one for you — attach to answer it there.`,
   sessAnswered: (label: string) => `answered: ${label}`,
   sessNoFell: 'nothing fell — no session was lost with the machine still on record.',
-  sessFellOpened: (opened: number, skipped: number) =>
-    skipped > 0
-      ? `reopened ${opened} of the session(s) that fell — ${skipped} could not be reopened.`
-      : `reopened ${opened} session(s) that fell.`,
+  sessFellOpened: (opened: number, skipped: number, held: number) =>
+    `reopened ${opened} session(s) that fell.`
+    + (held > 0 ? ` ${held} already open in another session.` : '')
+    + (skipped > 0 ? ` ${skipped} could not be reopened.` : ''),
   sessFellNoneOpened: (skipped: number) =>
     `none of the ${skipped} session(s) that fell could be reopened.`,
+  sessResumeInUse: (holder: string) =>
+    `that conversation is already open in ${holder} — open it there instead of starting a second assistant in it.`,
   sessUntitled: (harness: string, project: string) => (project ? `${harness} in ${project}` : harness),
   sessKilled: (id: string) => `stopped ${id}.`,
   sessRestoreNone: 'those sessions are no longer in the registry.',
@@ -412,10 +421,10 @@ const EN: CliStrings = {
   sessNoted: 'note saved.',
   sessTasked: 'task set.',
   sessTaskEmpty: (task: string) => `no sessions are filed under "${task}".`,
-  sessTaskOpened: (task: string, opened: number, skipped: number) =>
-    skipped > 0
-      ? `reopened ${opened} session(s) of "${task}" — ${skipped} could not be reopened.`
-      : `reopened ${opened} session(s) of "${task}".`,
+  sessTaskOpened: (task: string, opened: number, skipped: number, held: number) =>
+    `reopened ${opened} session(s) of "${task}".`
+    + (held > 0 ? ` ${held} already open in another session.` : '')
+    + (skipped > 0 ? ` ${skipped} could not be reopened.` : ''),
   sessTaskNoneOpened: (task: string, skipped: number) =>
     `none of the ${skipped} session(s) of "${task}" could be reopened.`,
   sessNoRegistryEntry: 'that session has no record to update — it was not started by agentop.',
@@ -608,12 +617,14 @@ const PT: CliStrings = {
     `o agentop não tem forma verificada de escolher uma opção no ${harness}, e não vai confirmar a destacada por você — anexe para responder lá.`,
   sessAnswered: (label: string) => `respondido: ${label}`,
   sessNoFell: 'nada caiu — nenhuma sessão foi perdida com registro de que estava viva.',
-  sessFellOpened: (opened: number, skipped: number) =>
-    skipped > 0
-      ? `${opened} sessão(ões) que caíram reabertas — ${skipped} não puderam ser reabertas.`
-      : `${opened} sessão(ões) que caíram reabertas.`,
+  sessFellOpened: (opened: number, skipped: number, held: number) =>
+    `${opened} sessão(ões) que caíram reabertas.`
+    + (held > 0 ? ` ${held} já estava(m) aberta(s) em outra sessão.` : '')
+    + (skipped > 0 ? ` ${skipped} não puderam ser reabertas.` : ''),
   sessFellNoneOpened: (skipped: number) =>
     `nenhuma das ${skipped} sessão(ões) que caíram pôde ser reaberta.`,
+  sessResumeInUse: (holder: string) =>
+    `essa conversa já está aberta em ${holder} — abra ela por lá, em vez de colocar um segundo assistente dentro dela.`,
   sessUntitled: (harness: string, project: string) => (project ? `${harness} em ${project}` : harness),
   sessKilled: (id: string) => `${id} encerrada.`,
   sessRestoreNone: 'essas sessões não estão mais no registro.',
@@ -634,10 +645,10 @@ const PT: CliStrings = {
   sessNoted: 'nota salva.',
   sessTasked: 'tarefa definida.',
   sessTaskEmpty: (task: string) => `nenhuma sessão está na tarefa "${task}".`,
-  sessTaskOpened: (task: string, opened: number, skipped: number) =>
-    skipped > 0
-      ? `${opened} sessão(ões) de "${task}" reabertas — ${skipped} não puderam ser reabertas.`
-      : `${opened} sessão(ões) de "${task}" reabertas.`,
+  sessTaskOpened: (task: string, opened: number, skipped: number, held: number) =>
+    `${opened} sessão(ões) de "${task}" reabertas.`
+    + (held > 0 ? ` ${held} já estava(m) aberta(s) em outra sessão.` : '')
+    + (skipped > 0 ? ` ${skipped} não puderam ser reabertas.` : ''),
   sessTaskNoneOpened: (task: string, skipped: number) =>
     `nenhuma das ${skipped} sessão(ões) de "${task}" pôde ser reaberta.`,
   sessNoRegistryEntry: 'essa sessão não tem registro para atualizar — não foi o agentop que iniciou ela.',

--- a/packages/server/server/cli-start.ts
+++ b/packages/server/server/cli-start.ts
@@ -99,6 +99,10 @@ import { needsChoice, parseDialogOptions } from './sessions/dialog-choice'
 import { rulesFor } from './sessions/attention-rules'
 import { planCrashGroup, planFellOffer } from './sessions/crash-group'
 import { loadHarnessSessions } from './sessions/harness-sessions'
+// The lock on the door: one conversation, one live session. See `conversation-claim.ts` for the
+// measurement that made it necessary, and `live-claims.ts` for the evidence it is allowed to use.
+import { conversationHeldBy } from './sessions/conversation-claim'
+import { liveConversationHolders } from './sessions/live-claims'
 import type { ManagedSession, SpawnPlanError } from './sessions/types'
 import {
   addSession, newSessionId, patchSession, readRegistry, removeSession, touchSessions,
@@ -1320,6 +1324,10 @@ async function reopenEntries(
   const live = new Set(
     (await backend.list().catch(() => [])).filter(b => b.alive).map(b => b.id),
   )
+  // What is already being driven, so a task reopen cannot put a second assistant into a conversation
+  // that has one. `live` above cannot answer this: it is keyed by ROW, and the twin case is a row
+  // that is down while another row drives its conversation.
+  const inUse = await liveConversationHolders(backend)
 
   // CLAIMED, one per row: the harness+directory match cannot tell two sessions of one repository
   // apart, so a set of five rows used to start five copies of one conversation. A row that RECORDED
@@ -1328,6 +1336,7 @@ async function reopenEntries(
   const plan = planTaskReopen({
     entries,
     liveIds: live,
+    inUse,
     conversationFor: entry => {
       const own = entry.conversationId
         ? conversations.find(c => c.sessionId === entry.conversationId)
@@ -2081,6 +2090,17 @@ function createControlHost(initialLang: CliLang, altScreen: Suspendable): StartH
       const previous = req.replaces
         ? (await readRegistry()).find(m => m.id === req.replaces)
         : undefined
+      // THE LOCK ON THE DOOR. Refused before anything is spawned, and NAMING the session that
+      // already has this conversation, because a refusal the user cannot act on is a dead end: the
+      // next thing they want is to go and look at it. This is the cheapest defence there is against
+      // the worst thing this feature has done — two assistants typing into one transcript and one
+      // working tree — and it is deliberately a refusal rather than a tidy-up afterwards.
+      const holder = conversationHeldBy(
+        await liveConversationHolders(await resolveBackend()),
+        req.sessionId,
+        req.replaces,
+      )
+      if (holder) return { ok: false, message: s.sessResumeInUse(holder.label) }
       const spawned = await spawnManaged({
         harness: req.harness as HarnessId,
         cwd: req.cwd,
@@ -2121,7 +2141,7 @@ function createControlHost(initialLang: CliLang, altScreen: Suspendable): StartH
       // with `reopenFell` below, which is the same gesture over a set chosen a different way.
       const { plan, opened, skipped } = await reopenEntries(wanted, s)
       return taskReopenSucceeded(plan, opened)
-        ? { ok: true, message: s.sessTaskOpened(task, opened, skipped) }
+        ? { ok: true, message: s.sessTaskOpened(task, opened, skipped, plan.heldElsewhere.length) }
         : { ok: false, message: s.sessTaskNoneOpened(task, skipped) }
     },
 
@@ -2145,7 +2165,7 @@ function createControlHost(initialLang: CliLang, altScreen: Suspendable): StartH
 
       const { plan, opened, skipped } = await reopenEntries(group.entries, s)
       return taskReopenSucceeded(plan, opened)
-        ? { ok: true, message: s.sessFellOpened(opened, skipped) }
+        ? { ok: true, message: s.sessFellOpened(opened, skipped, plan.heldElsewhere.length) }
         : { ok: false, message: s.sessFellNoneOpened(skipped) }
     },
 

--- a/packages/server/server/sessions/cli-session.ts
+++ b/packages/server/server/sessions/cli-session.ts
@@ -28,6 +28,7 @@ import { loadHarnessSessions } from './harness-sessions'
 import { createSessionsPoller, type SessionSnapshot } from './sessions-host'
 import { needsAttention, type SessionView } from './session-view'
 import { planTaskReopen, taskReopenSucceeded } from './task-reopen'
+import { liveConversationHolders } from './live-claims'
 import type { SessionBackend, SpawnPlanError } from './types'
 
 /** Derived from the specs, never a second hand-written list — the two could not then disagree. */
@@ -252,15 +253,34 @@ async function openTask(task: string, json: boolean, backend: SessionBackend): P
   }
   const conversations = await loadConversations()
   const live = new Set((await backend.list().catch(() => [])).filter(b => b.alive).map(b => b.id))
+  // What is already being driven, so this cannot put a second assistant into a conversation that has
+  // one. `live` above cannot answer it: it is keyed by ROW, and the twin case is a row that is down
+  // while a DIFFERENT row drives its conversation. Same collector the cockpit's verb uses.
+  const inUse = await liveConversationHolders(backend)
+  // Claimed within this batch too. The cockpit's copy of this loop has had this set for a while and
+  // this one never did, so `conversationForProcess` — which matches on harness and directory, and
+  // therefore answers with the FIRST conversation of a repository — handed the same one to every row
+  // of a task filed in that repository. The drift `planTaskReopen` was extracted to end, met again
+  // one layer out.
+  const taken = new Set<string>()
   // The DECISION is the pure `planTaskReopen`, shared with the cockpit's verb. The two used to be
   // separate implementations and had drifted: only one retired the row it replaced, so the same
   // gesture left a different registry depending on where you pressed it.
   const plan = planTaskReopen({
     entries: wanted,
     liveIds: live,
+    inUse,
     conversationFor: m => {
-      const conv = conversationForProcess(conversations, { harness: m.harness, cwd: m.cwd })
-      return conv?.resumable ? { sessionId: conv.sessionId, title: conv.title } : null
+      const own = m.conversationId
+        ? conversations.find(c => c.sessionId === m.conversationId)
+        : undefined
+      const conv = own ?? conversationForProcess(
+        conversations.filter(c => !taken.has(c.sessionId)),
+        { harness: m.harness, cwd: m.cwd },
+      )
+      if (!conv?.resumable) return null
+      taken.add(conv.sessionId)
+      return { sessionId: conv.sessionId, title: conv.title }
     },
   })
 
@@ -287,13 +307,22 @@ async function openTask(task: string, json: boolean, backend: SessionBackend): P
   }
 
   if (json) {
-    console.log(JSON.stringify({ task, started, skipped, already: plan.already }, null, 2))
+    console.log(JSON.stringify({
+      task, started, skipped, already: plan.already,
+      // Each one NAMES the session that already has the conversation, because a machine reader is
+      // exactly who needs to be told where the work is rather than that something did not happen.
+      heldElsewhere: plan.heldElsewhere.map(h => ({ id: h.id, heldBy: h.holder.id, label: h.holder.label })),
+    }, null, 2))
   } else {
     for (const id of started) console.log(id)
     // Reported, never silent: a partial reopen presented as a success leaves someone believing they
     // have their whole task back.
+    for (const h of plan.heldElsewhere) {
+      console.log(`${h.id}\talready open in ${h.holder.label}`)
+    }
     const alreadyUp = plan.already.length ? `, ${plan.already.length} already running` : ''
-    console.log(`\n${started.length} reopened${skipped.length ? `, ${skipped.length} could not be` : ''}${alreadyUp}.`)
+    const held = plan.heldElsewhere.length ? `, ${plan.heldElsewhere.length} already open elsewhere` : ''
+    console.log(`\n${started.length} reopened${skipped.length ? `, ${skipped.length} could not be` : ''}${alreadyUp}${held}.`)
   }
   return taskReopenSucceeded(plan, started.length) ? 0 : 1
 }

--- a/packages/server/server/sessions/conversation-claim.test.ts
+++ b/packages/server/server/sessions/conversation-claim.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'bun:test'
+import {
+  conversationHeldBy,
+  conversationsInUse,
+  duplicateConversations,
+  type ClaimingSession,
+} from './conversation-claim'
+
+/**
+ * The real pairs, from `~/.agentistics/managed-sessions.json` on 2026-08-14.
+ *
+ * Five conversations were each recorded against two to four NOT-ENDED rows. Reading two of the
+ * screens side by side showed identical text — one conversation, two assistants typing into it — and
+ * Claude Code itself was printing "another Claude Code on this machine already has Remote Control
+ * for this conversation". The pair below is kept verbatim because the DIRECTORIES are the tell: they
+ * differ, so nothing matched these two rows by directory. Both carried the same recorded
+ * conversation id, which is exactly the evidence this module is built on.
+ */
+const TWINS: ClaimingSession[] = [
+  {
+    id: '44d649269a',
+    alive: true,
+    conversationId: 'cd118e71-3708-420e-8c7f-c578cf59900f',
+    label: 'Avaliar armazenamento de dados em SQLite local',
+  },
+  {
+    id: '1da098e5cb',
+    alive: true,
+    conversationId: 'cd118e71-3708-420e-8c7f-c578cf59900f',
+    label: 'Possivel implementacao de SQLite no agentistics local',
+  },
+]
+
+describe('conversationsInUse', () => {
+  it('names the live session driving a conversation', () => {
+    const held = conversationsInUse([
+      { id: 'a', alive: true, conversationId: 'c1', label: 'the auth work' },
+    ])
+    expect(held.get('c1')).toEqual({ id: 'a', label: 'the auth work' })
+  })
+
+  it('ignores a session that is not alive, however well recorded', () => {
+    // THE rule that keeps this a lock rather than a wall. The harness leaves its record behind when
+    // the process goes — 53 files on this machine against about a dozen live ones — so counting a
+    // record as a claim would refuse to reopen anything that had ever run, which is every row the
+    // reopen verb exists for.
+    const held = conversationsInUse([{ id: 'a', alive: false, conversationId: 'c1' }])
+    expect(held.size).toBe(0)
+  })
+
+  it('ignores a live session whose conversation is unknown', () => {
+    // Absent is "we do not know", never "it holds nothing" — but there is nothing to lock either,
+    // and inventing a claim from a directory guess is what `conversation-claim.ts` refuses to do.
+    expect(conversationsInUse([{ id: 'a', alive: true }]).size).toBe(0)
+  })
+
+  it('falls back to the id when a session has no name, so a refusal always names something', () => {
+    const held = conversationsInUse([{ id: 'a', alive: true, conversationId: 'c1' }])
+    expect(held.get('c1')?.label).toBe('a')
+    const blank = conversationsInUse([{ id: 'b', alive: true, conversationId: 'c2', label: '  ' }])
+    expect(blank.get('c2')?.label).toBe('b')
+  })
+
+  it('names ONE holder even when the fleet already has twins', () => {
+    // The point is to send someone to a session they can look at, not to enumerate a mess.
+    const held = conversationsInUse(TWINS)
+    expect(held.size).toBe(1)
+    expect(held.get('cd118e71-3708-420e-8c7f-c578cf59900f')?.id).toBe('44d649269a')
+  })
+})
+
+describe('conversationHeldBy', () => {
+  const held = conversationsInUse([{ id: 'a', alive: true, conversationId: 'c1', label: 'A' }])
+
+  it('reports the holder', () => {
+    expect(conversationHeldBy(held, 'c1')?.id).toBe('a')
+  })
+
+  it('says nothing about a conversation nobody has', () => {
+    expect(conversationHeldBy(held, 'c2')).toBeUndefined()
+    expect(conversationHeldBy(held, undefined)).toBeUndefined()
+  })
+
+  it('never refuses a row on account of ITSELF', () => {
+    // Reopening a row onto its own conversation is the ordinary gesture. It is normally not alive at
+    // that point, but a finished row can keep a lingering backend pane — and a lock that refuses the
+    // very thing it exists to protect is a lock people learn to work around.
+    expect(conversationHeldBy(held, 'c1', 'a')).toBeUndefined()
+  })
+})
+
+describe('duplicateConversations', () => {
+  it('finds the pair that was actually on this machine', () => {
+    const dupes = duplicateConversations(TWINS)
+    expect(dupes).toHaveLength(1)
+    expect(dupes[0]!.conversationId).toBe('cd118e71-3708-420e-8c7f-c578cf59900f')
+    expect(dupes[0]!.holders.map(h => h.id)).toEqual(['44d649269a', '1da098e5cb'])
+  })
+
+  it('reports nothing when every conversation has one live session', () => {
+    expect(duplicateConversations([
+      { id: 'a', alive: true, conversationId: 'c1' },
+      { id: 'b', alive: true, conversationId: 'c2' },
+    ])).toEqual([])
+  })
+
+  it('does not count a dead twin as a twin', () => {
+    // Two ROWS on one conversation is a tidy-up; two LIVE rows is lost work. Only the second is a
+    // finding, and calling the first one would make the report noise nobody reads.
+    expect(duplicateConversations([
+      { id: 'a', alive: true, conversationId: 'c1' },
+      { id: 'b', alive: false, conversationId: 'c1' },
+    ])).toEqual([])
+  })
+
+  it('is ordered by conversation, so two reads agree', () => {
+    const dupes = duplicateConversations([
+      { id: 'a', alive: true, conversationId: 'z' },
+      { id: 'b', alive: true, conversationId: 'z' },
+      { id: 'c', alive: true, conversationId: 'm' },
+      { id: 'd', alive: true, conversationId: 'm' },
+    ])
+    expect(dupes.map(d => d.conversationId)).toEqual(['m', 'z'])
+  })
+})

--- a/packages/server/server/sessions/conversation-claim.ts
+++ b/packages/server/server/sessions/conversation-claim.ts
@@ -1,0 +1,134 @@
+/**
+ * conversation-claim.ts — PURE. Which conversations are being driven RIGHT NOW, and by what.
+ *
+ * This exists because of the worst thing the session manager has done: it opened the SAME
+ * CONVERSATION in two terminals at once. Measured on this machine on 2026-08-14 — five conversations
+ * were recorded against two to four not-ended registry rows each, one of them four times:
+ *
+ *   cd118e71…  44d649269a  .../worktrees/parse-cache-sqlite
+ *              1da098e5cb  /home/mithrandir/agentistics
+ *   03fa293a…  1ec25fc3d1  .../worktrees/cockpit-remount-flash
+ *              e477d4e628  /home/mithrandir/agentistics
+ *
+ * Reading the two screens side by side showed identical text: one conversation, two assistants
+ * typing into it. Claude Code itself notices and says so —
+ *
+ *   Remote Control not started here · another Claude Code on this machine
+ *   (started 16s ago) already has Remote Control for this conversation
+ *
+ * — so the HARNESS knew and agentop, which started both, did not. It is not a display problem: the
+ * two write to one transcript and to one working tree. The parse-cache session stopped itself, wrote
+ * that somebody else was editing the same files, and declined to dispatch its next agent. It was
+ * right, and the somebody was its own twin.
+ *
+ * ## Only EXACT evidence counts, and that is the whole design
+ *
+ * There are three ways to say which conversation a row drives, and they are not interchangeable:
+ *
+ *  1. the harness's own record (`~/.claude/sessions/<pid>.json`, matched by tmux session name or by
+ *     pid) — a FACT, written by the process about itself;
+ *  2. the id the registry stored while the session was up — a recollection, but an exact one;
+ *  3. harness-and-directory inference — a GUESS, and the one that cannot tell two sessions of one
+ *     repository apart.
+ *
+ * A lock built on (3) is a lock that jams: every session in a repository resolves to the same
+ * conversation, so the second reopen in any repo would be refused forever, and people would learn to
+ * work around the door rather than through it. So only (1) and (2) are ever admitted here — the same
+ * line `session-view.ts` already draws between `metricsOf` (exact only) and `claimResume` (may
+ * guess). The cost is stated plainly: a twin created without either kind of record is invisible to
+ * this module and is not prevented. Refusing on a guess would be worse.
+ *
+ * ## Alive, not merely known
+ *
+ * The harness's records OUTLIVE their processes — 53 files on this machine against about a dozen live
+ * ones. A conversation is therefore in use only when the row holding it is ALIVE, and the caller says
+ * which those are. Reading the records alone would refuse to reopen anything that ever ran.
+ */
+
+/** A live session, as much of it as a refusal needs to name. */
+export interface ClaimingSession {
+  /** The row id — a managed session id, or an external row's id. */
+  id: string
+  /**
+   * Whether this session is running NOW.
+   *
+   * Load-bearing: a harness record left behind by a finished process would otherwise lock its
+   * conversation out of ever being reopened, which is the one thing the reopen verb is for.
+   */
+  alive: boolean
+  /**
+   * The conversation it drives, from an EXACT source only — the harness's own record, or the id the
+   * registry stored. Never a harness-and-directory inference. See the module header.
+   */
+  conversationId?: string
+  /** What to call it when refusing, already display-ready. */
+  label?: string
+}
+
+/** Who is holding a conversation. */
+export interface ConversationHolder {
+  /** The live row driving it. */
+  id: string
+  /** Its name, or its id when it has none — a refusal that names nothing cannot be acted on. */
+  label: string
+}
+
+/**
+ * Conversation id → the live session driving it — PURE.
+ *
+ * FIRST alive holder wins, so the map is stable regardless of how many twins already exist: the
+ * point is to name ONE session the user can go and look at, not to enumerate a mess.
+ */
+export function conversationsInUse(
+  sessions: readonly ClaimingSession[],
+): Map<string, ConversationHolder> {
+  const held = new Map<string, ConversationHolder>()
+  for (const s of sessions) {
+    if (!s.alive || !s.conversationId) continue
+    if (held.has(s.conversationId)) continue
+    held.set(s.conversationId, { id: s.id, label: s.label?.trim() || s.id })
+  }
+  return held
+}
+
+/**
+ * The live session already driving `conversationId`, or `undefined` — PURE.
+ *
+ * `exclude` is the row being replaced. Reopening a row onto its own conversation is the ordinary
+ * case and must never be refused by the row itself: it is normally not alive at that point (that is
+ * why it is being reopened), but a finished row can keep a lingering backend pane, and a lock that
+ * refuses the very gesture it exists to protect is a lock nobody keeps.
+ */
+export function conversationHeldBy(
+  held: ReadonlyMap<string, ConversationHolder>,
+  conversationId: string | undefined,
+  exclude?: string,
+): ConversationHolder | undefined {
+  if (!conversationId) return undefined
+  const holder = held.get(conversationId)
+  if (!holder || holder.id === exclude) return undefined
+  return holder
+}
+
+/**
+ * Conversations this machine is driving from more than one live session — PURE.
+ *
+ * Not used by the lock, which only ever asks about one conversation. This answers the OTHER half of
+ * the same fact: the fleet that already has twins, from before the door was locked. Sorted by
+ * conversation id so a report of it is stable between reads.
+ */
+export function duplicateConversations(
+  sessions: readonly ClaimingSession[],
+): { conversationId: string; holders: ConversationHolder[] }[] {
+  const byConv = new Map<string, ConversationHolder[]>()
+  for (const s of sessions) {
+    if (!s.alive || !s.conversationId) continue
+    const list = byConv.get(s.conversationId) ?? []
+    list.push({ id: s.id, label: s.label?.trim() || s.id })
+    byConv.set(s.conversationId, list)
+  }
+  return [...byConv.entries()]
+    .filter(([, holders]) => holders.length > 1)
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+    .map(([conversationId, holders]) => ({ conversationId, holders }))
+}

--- a/packages/server/server/sessions/live-claims.ts
+++ b/packages/server/server/sessions/live-claims.ts
@@ -1,0 +1,76 @@
+/**
+ * live-claims.ts — the I/O behind `conversation-claim.ts`: which conversations this machine is
+ * driving RIGHT NOW.
+ *
+ * It lives in its own module, and is used by both `cli-start.ts` (the cockpit) and `cli-session.ts`
+ * (the command line), for the reason `task-reopen.ts` was extracted: those two are the SAME gesture
+ * written twice, and every time a rule has been added to one of them it has been missing from the
+ * other. A lock with a second unlocked entrance is not a lock.
+ *
+ * The DECISION — what counts as driving a conversation — is the pure `conversationsInUse`. This only
+ * gathers the evidence, and only the EXACT kinds of it. See that module's header for why a
+ * harness-and-directory guess may never be admitted here.
+ */
+
+import { scanProcesses } from '../live-sessions'
+import { conversationsInUse, type ClaimingSession, type ConversationHolder } from './conversation-claim'
+import { emptyHarnessSessionIndex, loadHarnessSessions } from './harness-sessions'
+import { readRegistry } from './registry'
+import { externalId } from './session-view'
+import type { ManagedSession, SessionBackend } from './types'
+
+/**
+ * Conversation id → the live session driving it.
+ *
+ * Three reads, each contributing something the others cannot:
+ *
+ *  - the BACKEND says which managed rows are alive. Nothing else does: a harness record OUTLIVES its
+ *    process (53 files on this machine against about a dozen live ones), so "there is a record" is
+ *    not "it is running" — locking on the records alone would refuse to reopen anything that had
+ *    ever run, which is every row this verb exists for.
+ *  - the HARNESS's own files say which conversation a live session drives, matched by tmux session
+ *    name for one we host and by pid for one we merely see. It is the only source that is a fact
+ *    rather than a recollection, and the only one that can see an assistant started OUTSIDE agentop
+ *    sitting in the very conversation someone is about to reopen.
+ *  - the REGISTRY's `conversationId` covers a live row whose harness record cannot be read.
+ *
+ * Every read is best-effort and every failure degrades to "we do not know", never to a refusal: this
+ * guard exists to prevent lost work, not to become a new way of losing the verb.
+ */
+export async function liveConversationHolders(
+  backend: SessionBackend,
+): Promise<Map<string, ConversationHolder>> {
+  const [registry, backendSessions, harnessSessions, procs] = await Promise.all([
+    readRegistry().catch(() => [] as ManagedSession[]),
+    backend.list().catch(() => []),
+    loadHarnessSessions().catch(() => emptyHarnessSessionIndex()),
+    scanProcesses().then(r => r.procs).catch(() => []),
+  ])
+  const alive = new Set(backendSessions.filter(b => b.alive).map(b => b.id))
+
+  const claims: ClaimingSession[] = []
+  for (const m of registry) {
+    // A retired row drives nothing, whatever pane the backend still holds for it.
+    if (m.endedAt) continue
+    const exact = harnessSessions.byManagedId.get(m.id)?.sessionId
+    const conversationId = exact ?? m.conversationId
+    if (!conversationId) continue
+    claims.push({
+      id: m.id,
+      alive: alive.has(m.id),
+      conversationId,
+      ...(m.label ? { label: m.label } : {}),
+    })
+  }
+  // An assistant running BESIDE agentop holds its conversation just as hard as one we started, and
+  // it is the case the registry is blind to by construction. `/proc` only reports processes that
+  // exist, so these are alive by definition.
+  for (const p of procs) {
+    const conversationId = p.pid !== undefined
+      ? harnessSessions.byPid.get(p.pid)?.sessionId
+      : undefined
+    if (!conversationId) continue
+    claims.push({ id: externalId(p), alive: true, conversationId, label: p.cwd })
+  }
+  return conversationsInUse(claims)
+}

--- a/packages/server/server/sessions/session-view.ts
+++ b/packages/server/server/sessions/session-view.ts
@@ -175,7 +175,7 @@ function rankOf(v: SessionView): number {
  * in one directory (harness + cwd alone would collapse them into a single row), and unlike a list
  * index it does not change when an unrelated process appears or exits.
  */
-function externalId(p: HarnessProcess): string {
+export function externalId(p: HarnessProcess): string {
   return `external:${p.harness}:${p.cwd}:${p.startedMs ?? 0}`
 }
 

--- a/packages/server/server/sessions/task-reopen.test.ts
+++ b/packages/server/server/sessions/task-reopen.test.ts
@@ -64,3 +64,71 @@ describe('planTaskReopen', () => {
     expect(plan.reopen.map(r => r.entry.id)).toEqual(['a', 'b', 'c'])
   })
 })
+
+describe('a conversation another live session already has', () => {
+  it('is not opened a second time, and the row NAMES what has it', () => {
+    // The measured defect: `liveIds` is keyed by ROW, so a row that is down while a DIFFERENT row
+    // drives its conversation passed every check here — and the reopen put a second assistant into
+    // a live transcript and a live working tree. Five conversations were in that state on this
+    // machine on 2026-08-14.
+    const plan = planTaskReopen({
+      entries: [entry('a')],
+      liveIds: new Set(),
+      conversationFor: conv('c1'),
+      inUse: new Map([['c1', { id: 'twin', label: 'the one already running it' }]]),
+    })
+    expect(plan.reopen).toEqual([])
+    expect(plan.skipped).toEqual([])
+    expect(plan.heldElsewhere).toEqual([
+      { id: 'a', holder: { id: 'twin', label: 'the one already running it' } },
+    ])
+  })
+
+  it('counts as the task being up, not as a failure', () => {
+    // Nothing is missing after such a reopen: the work is on screen under another row. Reporting it
+    // as a failure sends someone looking for a problem the refusal just prevented.
+    const plan = planTaskReopen({
+      entries: [entry('a')],
+      liveIds: new Set(),
+      conversationFor: conv('c1'),
+      inUse: new Map([['c1', { id: 'twin', label: 'twin' }]]),
+    })
+    expect(taskReopenSucceeded(plan, 0)).toBe(true)
+  })
+
+  it('is judged on the conversation the RESOLVER picked, not the one the row remembers', () => {
+    // The resolver decides which conversation this reopen would actually open — a row's recorded id
+    // may be stale, and locking on it would refuse a reopen of something else entirely.
+    const plan = planTaskReopen({
+      entries: [entry('a', { conversationId: 'stale' })],
+      liveIds: new Set(),
+      conversationFor: conv('c1'),
+      inUse: new Map([['stale', { id: 'twin', label: 'twin' }]]),
+    })
+    expect(plan.reopen.map(r => r.resumeId)).toEqual(['c1'])
+    expect(plan.heldElsewhere).toEqual([])
+  })
+
+  it('never refuses a row because of its own id', () => {
+    const plan = planTaskReopen({
+      entries: [entry('a')],
+      liveIds: new Set(),
+      conversationFor: conv('c1'),
+      inUse: new Map([['c1', { id: 'a', label: 'itself' }]]),
+    })
+    expect(plan.reopen.map(r => r.entry.id)).toEqual(['a'])
+    expect(plan.heldElsewhere).toEqual([])
+  })
+
+  it('degrades to the old behaviour when nothing could be established', () => {
+    // Absent is "we do not know", never "everything is free" — but a caller that cannot look must
+    // still be able to reopen, or an unreadable registry would take the verb down with it.
+    const plan = planTaskReopen({
+      entries: [entry('a')],
+      liveIds: new Set(),
+      conversationFor: conv('c1'),
+    })
+    expect(plan.reopen.map(r => r.entry.id)).toEqual(['a'])
+    expect(plan.heldElsewhere).toEqual([])
+  })
+})

--- a/packages/server/server/sessions/task-reopen.ts
+++ b/packages/server/server/sessions/task-reopen.ts
@@ -17,8 +17,17 @@
  *    as a success leaves someone believing they have their whole task back.
  *  - Everything reopened RETIRES its old row. Without it a laptop closed and opened twice leaves the
  *    task holding two dead twins and one live session, all wearing the same name.
+ *  - **A conversation ANOTHER live session is already driving is not opened a second time.** The
+ *    rules above are all about ROWS, and rows are not the thing that gets corrupted: two rows are a
+ *    tidy-up, two assistants typing into one transcript and one working tree is lost work. Measured
+ *    on 2026-08-14 — five conversations were each open under two to four not-ended rows, the harness
+ *    itself was printing "another Claude Code on this machine already has Remote Control for this
+ *    conversation", and one of the twins stopped itself because it could see files changing under
+ *    it. `liveIds` cannot see this: it is keyed by ROW, so a row that is `lost` while a DIFFERENT
+ *    row drives its conversation passes every check here.
  */
 
+import { conversationHeldBy, type ConversationHolder } from './conversation-claim'
 import type { ManagedSession } from './types'
 
 export interface TaskReopenRow {
@@ -29,6 +38,14 @@ export interface TaskReopenRow {
   label: string
 }
 
+/** A row left alone because its conversation is open somewhere else. */
+export interface TaskReopenHeld {
+  /** The row that was not reopened. */
+  id: string
+  /** The live session already driving that row's conversation. */
+  holder: ConversationHolder
+}
+
 export interface TaskReopenPlan {
   /** In registry order, so a task comes back in the order it was built. */
   reopen: TaskReopenRow[]
@@ -36,6 +53,16 @@ export interface TaskReopenPlan {
   already: string[]
   /** Ids that could not be reopened at all, and are reported as such. */
   skipped: string[]
+  /**
+   * Rows whose conversation another LIVE session is already driving, each NAMING that session.
+   *
+   * Its own bucket rather than another `skipped`, because the two ask for different things from the
+   * person reading them: a skip is "this could not be done", and this is "this is already done, over
+   * there" — and it is only useful if it says WHERE. It is also not `already`, which means the row
+   * itself is up; here the row is down and its conversation is up under another name, which is
+   * precisely the case no counter could previously express.
+   */
+  heldElsewhere: TaskReopenHeld[]
 }
 
 export function planTaskReopen(o: {
@@ -44,20 +71,39 @@ export function planTaskReopen(o: {
   liveIds: ReadonlySet<string>
   /** The conversation to resume for a row, or `null` when none can be resolved. */
   conversationFor: (entry: ManagedSession) => { sessionId: string; title: string } | null
+  /**
+   * Conversation id → the live session driving it, from `conversationsInUse`.
+   *
+   * Optional so a caller with no way to establish it degrades to the old behaviour rather than
+   * locking every conversation it cannot see. Absent is "we do not know", never "nothing is live".
+   */
+  inUse?: ReadonlyMap<string, ConversationHolder>
 }): TaskReopenPlan {
-  const plan: TaskReopenPlan = { reopen: [], already: [], skipped: [] }
+  const plan: TaskReopenPlan = { reopen: [], already: [], skipped: [], heldElsewhere: [] }
+  const inUse = o.inUse ?? new Map<string, ConversationHolder>()
   for (const entry of o.entries) {
     // Ending a session is a decision; "open the task" must not quietly undo every one of them.
     if (entry.endedAt) continue
     if (o.liveIds.has(entry.id)) { plan.already.push(entry.id); continue }
     const conv = o.conversationFor(entry)
     if (!conv) { plan.skipped.push(entry.id); continue }
+    // Checked AFTER the conversation is resolved, and against THAT conversation rather than the
+    // row's recorded one: the resolver is what decides which conversation this reopen would
+    // actually open, so it is the only id whose being taken means anything.
+    const holder = conversationHeldBy(inUse, conv.sessionId, entry.id)
+    if (holder) { plan.heldElsewhere.push({ id: entry.id, holder }); continue }
     plan.reopen.push({ entry, resumeId: conv.sessionId, label: entry.label ?? conv.title })
   }
   return plan
 }
 
-/** Whether the whole thing worked out: something came back, or something was already up. */
+/**
+ * Whether the whole thing worked out: something came back, or something was already up.
+ *
+ * A conversation already open elsewhere counts as up. Nothing is missing after such a reopen — the
+ * work is on screen, under another row — and reporting the gesture as a FAILURE would send someone
+ * looking for a problem that the refusal just prevented.
+ */
 export function taskReopenSucceeded(plan: TaskReopenPlan, started: number): boolean {
-  return started > 0 || plan.already.length > 0
+  return started > 0 || plan.already.length > 0 || plan.heldElsewhere.length > 0
 }


### PR DESCRIPTION
Spec item **2.1** of `docs/specs/2026-08-14-session-limit-and-fleet-hygiene.md` — the one item that
**corrupts work** rather than merely looking wrong, which is why it went first.

## What was happening

Reopening could put a SECOND assistant into a conversation that already had one. Measured on this
machine on 2026-08-14, straight out of `managed-sessions.json`: five conversations were each
recorded against two to four **not-ended** rows, one of them four times.

| conversation | rows |
|---|---|
| `cd118e71…` | `44d649269a` (`…/worktrees/parse-cache-sqlite`), `1da098e5cb` (`/home/mithrandir/agentistics`) |
| `03fa293a…` | `1ec25fc3d1` (`…/worktrees/cockpit-remount-flash`), `e477d4e628` (`/home/mithrandir/agentistics`) |
| `1b06e4cb…` | four rows |

Reading two of the screens side by side showed **identical text**, and Claude Code itself was
printing `another Claude Code on this machine already has Remote Control for this conversation`.
The harness knew; agentop, which had started both, did not.

Not a display problem: the two write to one transcript and one working tree. The parse-cache session
stopped itself, wrote that somebody was editing the same files underneath it, and declined to
dispatch its next agent. It was right, and the somebody was its own twin.

## Why nothing caught it

`liveIds` is keyed by **ROW**, so a row that is down while a *different* row drives its conversation
passes every check in `planTaskReopen`. And the measured pair sat in **different directories**, so
nothing matched them by directory either — both simply carried the same recorded conversation id.

## The lock

- **`conversation-claim.ts` (pure, new)** — which conversations are being driven right now, and by
  what. It admits **exact evidence only**: the harness's own `~/.claude/sessions/<pid>.json` and the
  id the registry stored. Never the harness-and-directory inference, which cannot tell two sessions
  of one repository apart and would therefore refuse the second reopen in any repo *forever* — the
  same line `session-view.ts` already draws between `metricsOf` and `claimResume`. Stated cost: a
  twin created with neither kind of record is not prevented. Refusing on a guess would be worse.
- **`live-claims.ts` (new)** — the I/O, shared by the cockpit's verb and `agentop session open`,
  because those are one gesture written twice and a lock with a second unlocked entrance is not a
  lock. Aliveness comes from the **backend**: the harness's records outlive their processes (53
  files here against about a dozen live ones), so locking on records alone would refuse to reopen
  anything that had ever run. Every read is best-effort; failure degrades to "we do not know", never
  to a refusal.
- **`planTaskReopen` gains `heldElsewhere`** — its own bucket, not another `skipped`. A skip says
  "this could not be done"; this says "this is already done, over there", which is only useful if it
  **names where**. It counts as the task being up, since nothing is missing afterwards.
- **`resumeSession` refuses before spawning**, naming the holder (EN + PT).

## Also fixed on the way

`agentop session open` had **no intra-batch claiming at all**. `conversationForProcess` answers with
the first conversation of a repository, so one task filed in one repo handed every row the same
conversation. The cockpit's copy of that loop has had the `taken` set for a while; this one never
did — the same drift `task-reopen.ts` was extracted to end, one layer out.

## Verification

`bun tsc --noEmit` clean · `bun test` **3882 pass, 0 fail** · built with `bun run build:binary` and
run against the real fleet:

```
$ ./release/agentop session open "Agentistics"
24ea447b01	already open in Principal
bfa0f4c6b0	already open in Principal
cbe9320135	already open in Principal

0 reopened, 1 already running, 3 already open elsewhere.
```

Before this change that command would have started **three** assistants inside the conversation
`cbf341b8c8` is driving.

## Deliberately not in scope

- Existing twins are not cleaned up. The spec's call, and the right one: *"uma trava na porta vale
  mais que uma limpeza depois"*. `duplicateConversations` is exported and tested so a report or a
  row marker can be built on it without a second implementation.
- The "reopen what fell" **offer** still lists a row whose conversation is live; `reopenEntries` then
  refuses it and says so by name. The offer is about the fall, the lock is about the door, and a
  truthful refusal beats a silently shortened list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sw2w1GAZRB5SE4Xp1qcpCQ