### PR TITLE
fix(sessions): say where a session is, and where it continues from

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -200,6 +200,41 @@ packages/server/server/          — server-side modules (never bundled by Vite)
   │                          falling back to the COMMON git dir's parent (`--show-toplevel` would
   │                          answer with the worktree, which is the one name that must not become
   │                          the key). Memoized by directory: the poll runs every five seconds.
+  │                          **A directory that is GONE is not a directory outside a repository**,
+  │                          and the discriminator is whether it EXISTS, never whether git answered.
+  │                          `ExitWorktree --remove` leaves the session registered at a path that
+  │                          names nothing, every `git -C` fails, and the grouping fell through to the
+  │                          last path segment — so the removed worktree `member-connect-rotate`
+  │                          appeared as a PROJECT standing beside `Agentistics`, the project it was
+  │                          a worktree of. A folder name is a guess there, and inventing one from a
+  │                          path that resolves to nothing is the same error as a confident `0` for a
+  │                          metric nobody can produce. So `ManagedSession.repo` records the facts AT
+  │                          SPAWN — the one moment the directory is provably there — the pure
+  │                          `resolveRepoFacts` prefers live git, then the record, then says
+  │                          `missing`, and `groupSessions` files a row with nothing left to name it
+  │                          under ONE bucket said in words (`GONE_PROJECT_KEY`, unreachable as a real
+  │                          key because every project key is a single path SEGMENT). The MEMO also
+  │                          caches POSITIVE answers only: a negative one is a fact about the moment,
+  │                          not about the directory, and caching it for the life of the process left
+  │                          a cwd first probed while its worktree was deleted repo-less forever, even
+  │                          after `agentop session open` put it back. Negatives expire
+  │                          (`NEGATIVE_TTL_MS`); a MISSING directory never spawns git at all.
+  │                          **The conversation link is recorded at SPAWN wherever the CLI accepts an
+  │                          id** — `SpawnSpec.assignId`, `claude --session-id <uuid>` and
+  │                          `copilot --session-id <uuid>`, both verified by running them and
+  │                          checking that the file the adapter reads back carries that very id.
+  │                          Before this it existed only for a REOPENED row plus, for claude alone,
+  │                          whatever `harness-sessions.ts` could read out of `~/.claude/sessions/
+  │                          <pid>.json` while the process lived — so a session started with the
+  │                          cockpit closed had nothing but the harness-and-directory guess, which
+  │                          gives every session of one repository the same conversation. Gemini
+  │                          accepts a UUID and is deliberately EXCLUDED: its id in this product is
+  │                          synthetic (`${dir}/${file}`), so a recorded UUID would resolve to
+  │                          nothing while LOOKING like an exact link. Where no link can ever exist
+  │                          (codex, kimi, gemini, agy) `conversationLinkable` is false and the row
+  │                          SAYS so. And a row that knows its conversation never falls back to the
+  │                          guess even when the store has not caught up: "not yet" and "some other
+  │                          conversation in this directory" are different answers.
   │                          **A MANAGED row now carries the conversation's metrics too** — tokens,
   │                          cost and the CONTEXT GAUGE. Only `external` and `closed` rows read them
   │                          from the store before, so on a machine whose whole fleet is

--- a/docs/session-manager.md
+++ b/docs/session-manager.md
@@ -184,6 +184,33 @@ says which checkout it is. Keying on the directory name filed three checkouts of
 three projects, which is the split the repository dimension exists to avoid — and since this is the
 default grouping, it was the first thing anyone saw.
 
+**A directory that no longer exists** is its own case, and not the same one as a directory outside a
+repository. Removing a worktree leaves the session registered at a path that names nothing: git
+cannot be asked anything about it, so the grouping used to fall back to the last segment of that path
+and a removed `member-connect-rotate` appeared as a project of its own, standing next to
+`Agentistics` — the project it was a worktree of. A folder name is a guess when the path resolves to
+nothing, so two things happen instead. The repository is **recorded when the session starts**, which
+is the one moment the directory is provably there, and a row whose worktree is later removed keeps
+the project it belonged to. Where nothing was recorded — a row from an older build, or a conversation
+the store remembers without a registry entry — the row is filed under **"directory no longer exists"**
+and says so on its detail pane, which is also the answer to why reopening it will fail. The folder
+cell still names the directory, because that *is* where the session was.
+
+### Where a session continues from
+
+A row can name the conversation it is writing, and that is what `--resume` takes. It is **recorded,
+never inferred**: agentop hands the id to the CLI when it starts the session (`claude --session-id`,
+`copilot --session-id`) or when it reopens one, so there is nothing left to guess. Claude also writes
+its own record while the process lives, which is read as well.
+
+For codex, kimi, gemini and antigravity no such link can exist — those CLIs invent an id and never
+report it — so the row says so rather than showing a guess. The fallback everything else uses matches
+by harness and directory, which gives *every* session of one repository the same conversation: good
+enough to offer a reopen you confirm by its title, not good enough to be presented as the conversation
+you are in. A row that does know its conversation never falls back to that guess, even in the minutes
+before the transcript exists: "not written yet" and "some other conversation in this directory" are
+different answers.
+
 ### Tasks
 
 A task is whatever you say it is: a free string, chosen while starting a session or added later, and

--- a/packages/server/server/cli-i18n.ts
+++ b/packages/server/server/cli-i18n.ts
@@ -105,6 +105,22 @@ export interface CliStrings {
   /** Said on a session whose harness has no probed approval markers. */
   sessApprovalBlind: (harness: string) => string
   /**
+   * Said on a row whose recorded DIRECTORY no longer exists on this machine.
+   *
+   * A removed worktree is the ordinary way to get here, and the row is still worth having — it
+   * carries the name, the note and the task. What it cannot carry is a project derived from a path
+   * that resolves to nothing, and this is the sentence that says so instead.
+   */
+  sessDirGone: string
+  /**
+   * Said on a hosted row whose harness can never report which conversation it is writing.
+   *
+   * Not "no conversation was found": the point is that none can be, so what the reopen verb offers
+   * for this harness is inferred from the directory rather than recorded. See
+   * `conversationLinkable`.
+   */
+  sessConversationBlind: (harness: string) => string
+  /**
    * Said on a session that IS visibly blocked, but whose dialog nobody has read.
    *
    * A different fact from `sessApprovalBlind`, which is about not being able to SEE the block. This
@@ -364,6 +380,9 @@ const EN: CliStrings = {
   },
   sessApprovalBlind: (harness: string) =>
     `agentop has no verified screen markers for ${harness}, so a blocking question here shows as "waiting" like any other pause.`,
+  sessDirGone: 'this directory no longer exists — a removed worktree, most likely. Reopening will not work until it is back.',
+  sessConversationBlind: (harness: string) =>
+    `${harness} never reports which conversation a session it started is writing, so agentop cannot record the link — anything offered to reopen here is inferred from the directory.`,
   sessApproveBlind: (harness: string) =>
     `nobody has read ${harness}'s dialog, so agentop does not know which key answers it — attach to this session to answer it there.`,
   sessPrompted: (id: string) => `sent to ${id}.`,
@@ -586,6 +605,9 @@ const PT: CliStrings = {
   },
   sessApprovalBlind: (harness: string) =>
     `o agentop não tem marcadores de tela verificados para ${harness}, então uma pergunta bloqueante aqui aparece como "aguardando", como qualquer outra pausa.`,
+  sessDirGone: 'este diretório não existe mais — provavelmente uma worktree removida. Reabrir não vai funcionar enquanto ele não voltar.',
+  sessConversationBlind: (harness: string) =>
+    `o ${harness} nunca informa qual conversa uma sessão iniciada por ele está escrevendo, então o agentop não consegue registrar o vínculo — o que for oferecido para reabrir aqui é inferido pelo diretório.`,
   sessApproveBlind: (harness: string) =>
     `ninguém leu o diálogo do ${harness}, então o agentop não sabe qual tecla responde — anexe na sessão para responder lá.`,
   sessPrompted: (id: string) => `enviado para ${id}.`,

--- a/packages/server/server/cli-start.ts
+++ b/packages/server/server/cli-start.ts
@@ -29,6 +29,7 @@
  */
 
 import { spawn } from 'node:child_process'
+import { randomUUID } from 'node:crypto'
 import { writeSync } from 'node:fs'
 import { join } from 'node:path'
 import { homedir, platform } from 'node:os'
@@ -89,7 +90,7 @@ import { resolveBackend } from './sessions'
 import { SPAWN_SPECS, planSpawn } from './sessions/spawn-spec'
 import { findProjects } from './sessions/project-source'
 import { candidatePath } from './sessions/project-search'
-import { repoFacts } from './sessions/repo-facts'
+import { recordedRepo, repoFacts } from './sessions/repo-facts'
 // The `SessionView` -> `ControlSession` mapping, extracted so `agentop session ls` draws the same
 // rows from the same decision rather than mapping the fleet a second time.
 import { toControlSession } from './sessions/control-session'
@@ -1261,6 +1262,9 @@ async function spawnManaged(req: {
     ...(req.prompt ? { prompt: req.prompt } : {}),
     ...(req.model ? { model: req.model } : {}),
     ...(req.effort ? { effort: req.effort } : {}),
+    // Offered for a FRESH session; `planSpawn` applies it only where the CLI accepts one and reports
+    // back what it actually did. A resume ignores it — that conversation already has an id.
+    conversationId: randomUUID(),
   })
   if (!planned.ok) return { ok: false, message: explainSpawnError(planned.error, s) }
 
@@ -1289,6 +1293,15 @@ async function spawnManaged(req: {
     ...(req.effort ? { effort: req.effort } : {}),
     ...(req.label ? { label: req.label } : {}),
     ...(req.task ? { task: req.task } : {}),
+    // Recorded at the one moment it is certain — the harness was just handed this id, or we asked
+    // it to reopen this conversation. Without it a fresh session's link exists only while the
+    // harness's own record does (`harness-sessions.ts`, claude alone), so a session started with
+    // the cockpit closed had nothing to fall back on but the harness-and-directory guess.
+    ...(planned.plan.conversationId ? { conversationId: planned.plan.conversationId } : {}),
+    // Which repository this directory is in, while the directory is provably there. See
+    // `ManagedSession.repo`: a worktree removed later leaves a path that names nothing, and the
+    // grouping fell through to its last path segment as though it were a project.
+    ...(await recordedRepo(req.cwd)),
   })
 
   const name = req.label ?? id
@@ -1925,8 +1938,10 @@ function createControlHost(initialLang: CliLang, altScreen: Suspendable): StartH
       const finishedTasks = (await readPreferences()).finishedTasks ?? []
       // Resolved per session and MEMOIZED by directory: a directory does not change repository, and
       // this poll runs every five seconds over the whole fleet — asking git three times per session
-      // per tick would be a hundred processes a minute to learn the same thing.
-      const facts = await Promise.all(snap.sessions.map(v => repoFacts(v.cwd)))
+      // per tick would be a hundred processes a minute to learn the same thing. What the registry
+      // recorded at spawn is handed over with it, so a worktree somebody has since removed keeps
+      // the project it belongs to instead of becoming one.
+      const facts = await Promise.all(snap.sessions.map(v => repoFacts(v.cwd, v.recordedRepo)))
       // What the machine LOST and could start again — named row by row for the offer, from the
       // SAME selection the count below reports. Read off the snapshot the poll already produced
       // rather than recomputed, so the screen cannot be shown two answers to one question while a

--- a/packages/server/server/sessions/cli-session.ts
+++ b/packages/server/server/sessions/cli-session.ts
@@ -6,6 +6,7 @@
  * `reconcileSessions` says what exists. This file does I/O and prints.
  */
 
+import { randomUUID } from 'node:crypto'
 import { resolve } from 'node:path'
 import { HARNESS_ORDER, type HarnessId } from '@agentistics/core'
 import { sessionRunning } from '@agentistics/tui/control/sessions'
@@ -16,7 +17,7 @@ import { cliStrings } from '../cli-i18n'
 import { resolveLang } from '../cli-lang'
 import { readPreferences } from '../preferences'
 import { toControlSession } from './control-session'
-import { repoFacts } from './repo-facts'
+import { recordedRepo, repoFacts } from './repo-facts'
 import { emptyReason, renderSessionTable, resolveWidth } from './session-table'
 import { SPAWN_SPECS, planSpawn } from './spawn-spec'
 import { reconcileSessions, resolveSessionRef, type ReconciledSession, type RefCandidate } from './session-ref'
@@ -123,6 +124,7 @@ async function start(
   const cwd = cmd.cwd ? resolve(cmd.cwd) : process.cwd()
   const planned = planSpawn({
     harness: cmd.harness, cwd, prompt: cmd.prompt, model: cmd.model, effort: cmd.effort,
+    conversationId: randomUUID(),
   })
   if (!planned.ok) { console.error(explainPlanError(planned.error)); return 1 }
 
@@ -143,6 +145,8 @@ async function start(
     ...(cmd.effort ? { effort: cmd.effort } : {}),
     ...(cmd.label ? { label: cmd.label } : {}),
     ...(cmd.task ? { task: cmd.task } : {}),
+    ...(planned.plan.conversationId ? { conversationId: planned.plan.conversationId } : {}),
+    ...(await recordedRepo(cwd)),
   })
 
   if (cmd.background) {
@@ -206,6 +210,7 @@ async function batch(
       ...(spec.prompt ? { prompt: spec.prompt } : {}),
       ...(spec.model ? { model: spec.model } : {}),
       ...(spec.effort ? { effort: spec.effort } : {}),
+      conversationId: randomUUID(),
     })
     if (!planned.ok) { failed.push({ harness: spec.harness, reason: explainPlanError(planned.error) }); continue }
 
@@ -228,6 +233,8 @@ async function batch(
       ...(spec.model ? { model: spec.model } : {}),
       ...(spec.effort ? { effort: spec.effort } : {}),
       ...(spec.name ? { label: spec.name } : {}),
+      ...(planned.plan.conversationId ? { conversationId: planned.plan.conversationId } : {}),
+      ...(await recordedRepo(cwd)),
     })
     started.push({ id, harness: spec.harness, cwd })
   }
@@ -279,6 +286,15 @@ async function openTask(task: string, json: boolean, backend: SessionBackend): P
       id, harness: m.harness, cwd: m.cwd, createdAt: new Date().toISOString(), task,
       label: row.label,
       ...(m.note ? { note: m.note } : {}),
+      // The conversation is known EXACTLY here — we just handed its id to the CLI. The cockpit's
+      // reopen verb has recorded it since it was written; this path had not, so the same gesture
+      // left a row that knew which conversation it drove or one that did not, depending on where it
+      // was pressed. `planTaskReopen` exists to stop precisely that kind of drift.
+      ...(planned.plan.conversationId ? { conversationId: planned.plan.conversationId } : {}),
+      // The REPLACEMENT re-measures rather than copying `m.repo`: a reopen is the moment to notice
+      // that the worktree came back, and copying a recorded value would carry one stale answer
+      // through every session ever reopened from it.
+      ...(await recordedRepo(m.cwd)),
     })
     // The old row is RETIRED, not deleted: it is still a thing that happened, and it stops standing
     // beside its own continuation with the same name on it.
@@ -312,6 +328,11 @@ function fleetJson(snap: SessionSnapshot): unknown {
       label: v.label ?? null,
       task: v.task ?? null,
       resumeId: v.resume?.sessionId ?? null,
+      // The RECORDED conversation, kept apart from `resumeId` above rather than folded into it.
+      // They answer different questions: this one is what the row provably drives, that one is a
+      // target the reopen verb OFFERS and will fall back to a harness-and-directory guess for. A
+      // caller reading one field could not tell which of the two it had been given.
+      conversationId: v.conversationId ?? null,
     })),
     attention: snap.attention,
     unavailable: snap.unavailable ?? null,
@@ -368,7 +389,7 @@ async function ls(
 
   // Resolved per session and memoized by directory — the same read the cockpit does, and what makes
   // three worktrees of one repository group under the project rather than under three names.
-  const facts = await Promise.all(snap.sessions.map(v => repoFacts(v.cwd)))
+  const facts = await Promise.all(snap.sessions.map(v => repoFacts(v.cwd, v.recordedRepo)))
   // A preferences file that cannot be read costs the "finished" mark on a task heading, never the
   // table: the fleet is what the command is for.
   const finishedTasks = await readPreferences().then(p => p.finishedTasks ?? []).catch(() => [])
@@ -422,6 +443,7 @@ async function ls(
         project: c.sessionsUnknownProject,
         task: c.sessionsUnknownTask,
         repo: c.sessionsUnknownRepo,
+        goneProject: c.sessionsGoneProject,
       },
       closed: c.sessionsClosedWord,
       done: c.sessionsDoneWord,

--- a/packages/server/server/sessions/control-session.test.ts
+++ b/packages/server/server/sessions/control-session.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'bun:test'
+import { cliStrings } from '../cli-i18n'
+import { toControlSession } from './control-session'
+import type { ResolvedRepoFacts } from './repo-facts'
+import type { SessionView } from './session-view'
+
+const S = cliStrings('en')
+
+/** The narrowest row this mapper accepts — a session agentop hosts and is running. */
+function view(over: Partial<SessionView> = {}): SessionView {
+  return {
+    id: 'a1',
+    harness: 'claude',
+    cwd: '/home/d/agentistics/.claude/worktrees/member-connect-rotate',
+    status: 'lost',
+    attached: false,
+    approvalDetection: true,
+    searchText: '',
+    ...over,
+  }
+}
+
+const GONE: ResolvedRepoFacts = { worktree: false, missing: true, source: 'none' }
+const RECOVERED: ResolvedRepoFacts = {
+  repo: 'blpsoares/agentistics', root: 'agentistics', worktree: true, missing: true, source: 'recorded',
+}
+const LIVE: ResolvedRepoFacts = {
+  repo: 'blpsoares/agentistics', root: 'agentistics', worktree: true, missing: false, source: 'live',
+}
+
+describe('a directory that no longer exists', () => {
+  it('is NOT filed under the last segment of a path that names nothing', () => {
+    // The reported bug: the removed worktree `member-connect-rotate` became a project group of its
+    // own, standing beside `Agentistics` — the project it was a worktree of. The folder cell still
+    // says where the session was, because that is a fact; the GROUP must not claim it is a project.
+    const c = toControlSession(view(), S, GONE)
+    expect(c.project).toBe('member-connect-rotate')
+    // No group is claimed here: `groupSessions` keys the bucket on `dirGone` instead.
+    expect(c.projectGroup).toBeUndefined()
+    expect(c.dirGone).toBe(S.sessDirGone)
+    expect(c.repo).toBeUndefined()
+  })
+
+  it('groups under the project it belonged to once the repository was recorded at spawn', () => {
+    const c = toControlSession(view(), S, RECOVERED)
+    expect(c.projectGroup).toBe('agentistics')
+    expect(c.repo).toBe('blpsoares/agentistics')
+    // Still said: the row names a path that is not there, which is also why reopening will fail.
+    expect(c.dirGone).toBe(S.sessDirGone)
+  })
+
+  it('says nothing about a directory that is simply there', () => {
+    const c = toControlSession(view(), S, LIVE)
+    expect(c.dirGone).toBeUndefined()
+    expect(c.projectGroup).toBe('agentistics')
+  })
+})
+
+describe('which conversation a row continues from', () => {
+  it('carries a RECORDED id, and only a recorded one', () => {
+    const c = toControlSession(view({ conversationId: 'c-1' }), S, LIVE)
+    expect(c.conversationId).toBe('c-1')
+    expect(c.conversationBlind).toBeUndefined()
+  })
+
+  it('says so where the harness can never report one', () => {
+    // codex invents its own id and never hands it back, so everything downstream falls to the
+    // harness-and-directory guess. That is fine to OFFER and not fine to state as fact.
+    const c = toControlSession(view({ harness: 'codex' }), S, LIVE)
+    expect(c.conversationId).toBeUndefined()
+    expect(c.conversationBlind).toBe(S.sessConversationBlind('codex'))
+  })
+
+  it('stays quiet on a claude row that has not been recorded YET', () => {
+    // claude CAN be linked — the id is assigned at spawn, and the harness's own record names it
+    // besides. An absent id here is "not yet", not "never", and the two must not read alike.
+    const c = toControlSession(view({ harness: 'claude' }), S, LIVE)
+    expect(c.conversationBlind).toBeUndefined()
+  })
+
+  it('claims nothing about a row agentop never started', () => {
+    // An external process and a closed conversation were never ours to record, so the sentence
+    // would be answering a question this screen is not letting anyone ask.
+    for (const status of ['external', 'closed'] as const) {
+      const c = toControlSession(view({ harness: 'codex', status }), S, LIVE)
+      expect(c.conversationBlind).toBeUndefined()
+    }
+  })
+})

--- a/packages/server/server/sessions/control-session.ts
+++ b/packages/server/server/sessions/control-session.ts
@@ -19,8 +19,9 @@ import type { CliStrings } from '../cli-i18n'
 import { approvalFor } from './approval-spec'
 import { needsChoice } from './dialog-choice'
 import { pickTitle } from './harness-session-file'
-import type { RepoFacts } from './repo-facts'
+import type { ResolvedRepoFacts } from './repo-facts'
 import type { SessionView } from './session-view'
+import { conversationLinkable } from './spawn-spec'
 
 /** The state word each session wears, and the machine-readable state beside it. */
 export function sessionState(v: SessionView): SessionState {
@@ -62,7 +63,7 @@ export function toControlSession(
   v: SessionView,
   s: CliStrings,
   /** What repository this session's directory belongs to, already resolved and memoized. */
-  facts: RepoFacts = { worktree: false },
+  facts: ResolvedRepoFacts = { worktree: false, missing: false, source: 'none' },
 ): ControlSession {
   const state = sessionState(v)
   const project = projectName(v.cwd)
@@ -121,7 +122,22 @@ export function toControlSession(
     // Only when it differs: a session in the main checkout groups under its own folder already, and
     // a field repeating what is beside it is one more thing that can disagree.
     ...(facts.root && facts.root !== project ? { projectGroup: facts.root } : {}),
+    // Said wherever it is true, recovered repository or not: the row still names a path, and that
+    // path resolves to nothing on this machine. It is also the answer to "why did reopening fail",
+    // and — when no repository was recorded — it is what `groupSessions` keys the bucket on instead
+    // of `project`, which is then the last segment of a path that names nothing.
+    ...(facts.missing ? { dirGone: s.sessDirGone } : {}),
     ...(facts.worktree ? { worktree: true } : {}),
+    // The conversation this row is KNOWN to be writing — what `--resume` takes, and the only exact
+    // answer to "where does it continue from". Never filled from the harness+directory guess.
+    ...(v.conversationId ? { conversationId: v.conversationId } : {}),
+    // …and where no answer can ever exist, that is stated instead. Only on a row we HOST and only
+    // while it has no id: an `external` or `closed` row was never ours to record, and a claude row
+    // that has not been polled yet is about to have one. Same shape as `approvalBlind`.
+    ...(v.status !== 'external' && v.status !== 'closed' && !v.conversationId && harness
+      && !conversationLinkable(v.harness!)
+      ? { conversationBlind: s.sessConversationBlind(harness) }
+      : {}),
     ...(v.resume ? { resume: v.resume } : {}),
     ...(v.lastLines?.length ? { lastLines: v.lastLines } : {}),
     ...(v.approvalLines?.length ? { approvalLines: v.approvalLines } : {}),

--- a/packages/server/server/sessions/registry.test.ts
+++ b/packages/server/server/sessions/registry.test.ts
@@ -177,4 +177,33 @@ describe('what survives a round trip', () => {
     expect(rows[0]!.lastSeenMs).toBeUndefined()
     expect(rows[1]!.lastSeenMs).toBe(7)
   })
+
+  it('keeps the repository recorded at spawn, which is all a removed worktree leaves behind', async () => {
+    const reg = createSessionRegistry(file)
+    await reg.add({
+      ...session('a'),
+      repo: { repo: 'blpsoares/agentistics', root: 'agentistics', worktree: true },
+    })
+    expect((await reg.read())[0]!.repo)
+      .toEqual({ repo: 'blpsoares/agentistics', root: 'agentistics', worktree: true })
+  })
+
+  it('drops a recorded repo that is not SHAPED like one, keeping the session', async () => {
+    // The one nested object in this file, so it is the one place "the load-bearing fields checked
+    // out, trust the rest" does not hold. A hand-edited string would reach `resolveRepoFacts` with
+    // no `repo` on it and the row would behave as though nothing had been recorded — the failure
+    // this field exists to prevent, arriving silently.
+    await writeFile(file, JSON.stringify([
+      { ...session('a'), repo: 'agentistics' },
+      { ...session('b'), repo: { root: 'agentistics', worktree: true } },
+      { ...session('c'), repo: { repo: 'x/y', worktree: 'yes' } },
+    ]), 'utf-8')
+    const rows = await createSessionRegistry(file).read()
+    expect(rows.map(r => r.id)).toEqual(['a', 'b', 'c'])
+    expect(rows[0]!.repo).toBeUndefined()
+    // No `repo` key means nothing every reader can key on — kept out rather than half-kept.
+    expect(rows[1]!.repo).toBeUndefined()
+    // `worktree` is a claim about the directory, so anything that is not literally true is false.
+    expect(rows[2]!.repo).toEqual({ repo: 'x/y', worktree: false })
+  })
 })

--- a/packages/server/server/sessions/registry.ts
+++ b/packages/server/server/sessions/registry.ts
@@ -113,6 +113,31 @@ function sanitize(raw: unknown): ManagedSession | null {
     ...(typeof s.lastSeenMs === 'number' && Number.isFinite(s.lastSeenMs)
       ? { lastSeenMs: s.lastSeenMs }
       : {}),
+    ...sanitizeRepo(s.repo),
+  }
+}
+
+/**
+ * The recorded repository, kept only if it is SHAPED like one.
+ *
+ * The one nested object in this file, so it is the one field where "the three load-bearing ones
+ * check out, trust the rest" does not hold: a hand-edited `"repo": "agentistics"` would reach
+ * `resolveRepoFacts` as a string, `facts.repo` would be `undefined` on it, and the row would
+ * silently behave as though nothing had been recorded — the exact failure this field exists to
+ * prevent, arriving invisibly. A malformed entry drops the FIELD and keeps the session, because
+ * everything else about that row is still usable.
+ */
+function sanitizeRepo(raw: unknown): { repo?: ManagedSession['repo'] } {
+  if (!raw || typeof raw !== 'object') return {}
+  const r = raw as Record<string, unknown>
+  // `repo` is what every reader keys on; without it the record says nothing worth keeping.
+  if (typeof r.repo !== 'string' || !r.repo) return {}
+  return {
+    repo: {
+      repo: r.repo,
+      ...(typeof r.root === 'string' && r.root ? { root: r.root } : {}),
+      worktree: r.worktree === true,
+    },
   }
 }
 

--- a/packages/server/server/sessions/repo-facts.test.ts
+++ b/packages/server/server/sessions/repo-facts.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'bun:test'
-import { decideRepoFacts } from './repo-facts'
+import {
+  NEGATIVE_TTL_MS, decideRepoFacts, repoFactsFresh, resolveRepoFacts,
+} from './repo-facts'
 
 describe('decideRepoFacts', () => {
   it('reports nothing at all outside a repository', () => {
@@ -51,5 +53,66 @@ describe('decideRepoFacts', () => {
     expect(decideRepoFacts({
       remote: '/some/local/path', gitDir: '/r/.git', commonDir: '/r/.git',
     }).repo).toBe('r')
+  })
+})
+
+describe('resolveRepoFacts', () => {
+  const WT = { repo: 'blpsoares/agentistics', root: 'agentistics', worktree: true }
+
+  it('prefers what git says NOW over anything recorded', () => {
+    const moved = { repo: 'blpsoares/other', root: 'other', worktree: false }
+    expect(resolveRepoFacts({ live: moved, recorded: WT, exists: true }))
+      .toEqual({ ...moved, missing: false, source: 'live' })
+  })
+
+  it('keeps a DELETED worktree filed under the project it was a worktree of', () => {
+    // The bug this exists for: `.claude/worktrees/member-connect-rotate` is removed with the
+    // session still registered, every `git -C` fails, and the last path segment became a project
+    // of its own standing beside the one it belongs to.
+    expect(resolveRepoFacts({ live: { worktree: false }, recorded: WT, exists: false }))
+      .toEqual({ ...WT, missing: true, source: 'recorded' })
+  })
+
+  it('says MISSING rather than naming a repository it cannot name', () => {
+    // No recorded facts (a row written by an older build, or a directory that never was a repo).
+    // The path names nothing, so the folder name at the end of it is a guess — and the caller is
+    // told to say so in words instead of grouping under it.
+    expect(resolveRepoFacts({ live: { worktree: false }, exists: false }))
+      .toEqual({ worktree: false, missing: true, source: 'none' })
+  })
+
+  it('does not call a directory that merely is not a repository missing', () => {
+    // `~/aipe` is a real folder outside git. Its own name IS a real name for it, and grouping by it
+    // is correct — this must not land in the same bucket as a path that resolves to nothing.
+    expect(resolveRepoFacts({ live: { worktree: false }, exists: true }))
+      .toEqual({ worktree: false, missing: false, source: 'none' })
+  })
+
+  it('falls back to the recorded repo when git goes quiet on a directory that is still there', () => {
+    // git not installed in this container, an index lock, a filesystem unmounted mid-poll: none of
+    // those are evidence that the repository recorded at spawn was wrong.
+    expect(resolveRepoFacts({ live: { worktree: false }, recorded: WT, exists: true }))
+      .toEqual({ ...WT, missing: false, source: 'recorded' })
+  })
+
+  it('ignores a recorded entry that names no repository', () => {
+    expect(resolveRepoFacts({ live: { worktree: false }, recorded: { worktree: false }, exists: false }))
+      .toEqual({ worktree: false, missing: true, source: 'none' })
+  })
+})
+
+describe('repoFactsFresh', () => {
+  const positive = { facts: { repo: 'a/b', root: 'b', worktree: false }, atMs: 0 }
+  const negative = { facts: { worktree: false }, atMs: 0 }
+
+  it('reuses a POSITIVE answer forever — a directory does not change repository', () => {
+    expect(repoFactsFresh(positive, NEGATIVE_TTL_MS * 1000)).toBe(true)
+  })
+
+  it('lets a NEGATIVE answer expire, so a recreated worktree is recognised', () => {
+    // The defect: the first poll of a cwd whose worktree was deleted cached "no repository", and
+    // that cwd stayed repo-less for the life of the process even after the worktree came back.
+    expect(repoFactsFresh(negative, NEGATIVE_TTL_MS - 1)).toBe(true)
+    expect(repoFactsFresh(negative, NEGATIVE_TTL_MS)).toBe(false)
   })
 })

--- a/packages/server/server/sessions/repo-facts.ts
+++ b/packages/server/server/sessions/repo-facts.ts
@@ -11,11 +11,36 @@
  * toplevel of a linked worktree is the worktree itself. With no remote it falls back to the
  * COMMON git dir's parent, which is the main checkout even when asked from inside a worktree.
  *
- * Every answer is CACHED for the life of the process. A directory does not change repository, and
- * the fleet poller runs every five seconds over every session — asking git four times per session
- * per tick is a hundred processes a minute to learn the same thing.
+ * ## A directory that is GONE is not a directory that is not in a repository
+ *
+ * `ExitWorktree --remove`, `git worktree remove` and an ordinary `rm -rf` all leave the session
+ * registered at a path that no longer names anything. Every `git -C <gone>` then fails, the facts
+ * come back empty, and the grouping falls through to the last path segment — so the deleted
+ * worktree `.claude/worktrees/member-connect-rotate` appeared on screen as a PROJECT of its own,
+ * standing beside `Agentistics`, which is the project it was a worktree of. A folder name is a
+ * guess, and inventing a project from a path that resolves to nothing is the same error as
+ * reporting a confident `0` for a metric a harness cannot produce.
+ *
+ * So the discriminator is whether the DIRECTORY EXISTS, not whether git answered:
+ *  - it exists and git named a repo  → that, live;
+ *  - the session RECORDED its repo when it started → that, and it is the only fact left;
+ *  - it exists and nothing names a repo → not in a repository, and its own folder name is real;
+ *  - it is gone and nothing was recorded → `missing`, said in WORDS by the UI and never grouped
+ *    under a name derived from the path.
+ *
+ * ## What may be memoized, and what may not
+ *
+ * A POSITIVE answer is permanent: a directory does not change repository, and the fleet poller runs
+ * every five seconds over every session, so asking git three times per session per tick is a hundred
+ * processes a minute to learn the same thing. A NEGATIVE one is not a fact about the directory, it
+ * is a fact about this MOMENT — the worktree had been removed, or git was briefly unavailable — and
+ * caching it for the life of the process meant a cwd probed once while absent stayed repo-less
+ * forever, even after `agentop session open` or `git worktree add` put it back. Negatives therefore
+ * expire (`NEGATIVE_TTL_MS`), which costs one re-probe a minute for a directory genuinely outside a
+ * repository, and nothing at all for one that is missing — that case never spawns git.
  */
 
+import { stat } from 'node:fs/promises'
 import { basename, dirname } from 'node:path'
 import { repoShortName, normalizeGitRemote } from '@agentistics/core'
 
@@ -37,11 +62,90 @@ export interface RepoFacts {
   worktree: boolean
 }
 
+/**
+ * The same facts, plus what could not be learned live — what every CALLER should be reading.
+ *
+ * `RepoFacts` alone cannot distinguish "this directory is not in a repository" from "this directory
+ * is not there any more", and the two must be rendered differently: the first has a real folder
+ * name to group under, the second has only a path that names nothing.
+ */
+export interface ResolvedRepoFacts extends RepoFacts {
+  /** True when the directory itself no longer exists on this machine. */
+  missing: boolean
+  /**
+   * Where the repository above came from.
+   *
+   * `live` — git answered just now. `recorded` — the session wrote it down when it started, which
+   * is the only fact that survives the directory being deleted. `none` — nothing names a repository,
+   * and `repo`/`root` are absent.
+   */
+  source: 'live' | 'recorded' | 'none'
+}
+
 const NONE: RepoFacts = { worktree: false }
 
-const cache = new Map<string, RepoFacts>()
+/**
+ * How long a NEGATIVE answer stands before git is asked again.
+ *
+ * A minute: long enough that a directory genuinely outside a repository is not re-probed on every
+ * five-second poll (12 ticks, not 1), short enough that a worktree recreated by `agentop session
+ * open` is recognised while the person who recreated it is still looking at the screen.
+ */
+export const NEGATIVE_TTL_MS = 60_000
 
-/** Reset the memo. Tests only — a directory's repository does not change while agentop runs. */
+interface CacheEntry {
+  facts: RepoFacts
+  /** When git was asked, epoch ms. */
+  atMs: number
+}
+
+const cache = new Map<string, CacheEntry>()
+
+/**
+ * May a cached answer be reused? — PURE.
+ *
+ * A POSITIVE one always: a directory does not change repository. A NEGATIVE one only inside the
+ * TTL, because it is a statement about a moment rather than about the directory — the whole reason
+ * a cwd first seen while its worktree was deleted no longer stays repo-less for the life of the
+ * process.
+ */
+export function repoFactsFresh(entry: CacheEntry, nowMs: number, ttlMs = NEGATIVE_TTL_MS): boolean {
+  if (entry.facts.repo !== undefined) return true
+  return nowMs - entry.atMs < ttlMs
+}
+
+/**
+ * The answer a caller should render, from the three things that can be known — PURE.
+ *
+ * Order matters and is the whole content of this function:
+ *  1. what git says NOW outranks everything, because it is the only one measured against the
+ *     directory as it is;
+ *  2. what the session RECORDED when it started is next — it was measured the same way, once, and
+ *     it is all that is left of a worktree somebody has since removed;
+ *  3. otherwise there is no repository, and `missing` says which of the two silences this is.
+ *
+ * Step 2 runs even when the directory still EXISTS: git can fail for reasons that are not "no
+ * repository here" (it is not installed in this container, the index is locked, a filesystem is
+ * unmounted mid-poll), and preferring a fact recorded at spawn over a momentary silence is strictly
+ * better than falling back to the folder name. `missing` is reported independently of it, because
+ * the directory being gone is worth saying whether or not the repository could be recovered.
+ */
+export function resolveRepoFacts(o: {
+  /** What git answered just now — `NONE` when it could not be asked or said nothing. */
+  live: RepoFacts
+  /** What the session recorded when it started, if it recorded anything. */
+  recorded?: RepoFacts | undefined
+  /** Whether the directory exists right now. */
+  exists: boolean
+}): ResolvedRepoFacts {
+  if (o.live.repo !== undefined) return { ...o.live, missing: false, source: 'live' }
+  if (o.recorded?.repo !== undefined) {
+    return { ...o.recorded, missing: !o.exists, source: 'recorded' }
+  }
+  return { ...NONE, missing: !o.exists, source: 'none' }
+}
+
+/** Reset the memo. Tests only. */
 export function forgetRepoFacts(): void {
   cache.clear()
 }
@@ -86,17 +190,65 @@ async function git(cwd: string, args: string[]): Promise<string> {
   }
 }
 
-/** The repository a directory belongs to. Memoized; never throws. */
-export async function repoFacts(cwd: string): Promise<RepoFacts> {
-  if (!cwd) return NONE
+/** Does this directory exist right now? Never throws — anything unreadable answers "no". */
+async function dirExists(cwd: string): Promise<boolean> {
+  try {
+    return (await stat(cwd)).isDirectory()
+  } catch {
+    return false
+  }
+}
+
+/**
+ * The repository a directory belongs to, as a caller should render it. Never throws.
+ *
+ * `recorded` is what the session wrote down when it started — pass it and a removed worktree keeps
+ * its project, omit it and the answer is the live one plus whether the directory is still there.
+ *
+ * A MISSING directory never spawns git: three processes to be told a path does not exist is three
+ * processes wasted on every poll, and the `stat` has already answered the question.
+ */
+export async function repoFacts(cwd: string, recorded?: RepoFacts): Promise<ResolvedRepoFacts> {
+  if (!cwd) return { ...NONE, missing: false, source: 'none' }
+
+  const exists = await dirExists(cwd)
+  if (!exists) return resolveRepoFacts({ live: NONE, recorded, exists: false })
+
+  const nowMs = Date.now()
   const hit = cache.get(cwd)
-  if (hit) return hit
+  if (hit && repoFactsFresh(hit, nowMs)) {
+    return resolveRepoFacts({ live: hit.facts, recorded, exists: true })
+  }
+
   const [commonDir, gitDir, remote] = await Promise.all([
     git(cwd, ['rev-parse', '--path-format=absolute', '--git-common-dir']),
     git(cwd, ['rev-parse', '--path-format=absolute', '--git-dir']),
     git(cwd, ['config', '--get', 'remote.origin.url']),
   ])
-  const facts = decideRepoFacts({ remote, gitDir, commonDir })
-  cache.set(cwd, facts)
-  return facts
+  const live = decideRepoFacts({ remote, gitDir, commonDir })
+  cache.set(cwd, { facts: live, atMs: nowMs })
+  return resolveRepoFacts({ live, recorded, exists: true })
+}
+
+/**
+ * What to RECORD on a session being started — shaped to spread straight into `addSession`.
+ *
+ * Only ever the LIVE answer, and only when it names a repository. An empty record would be
+ * indistinguishable from an older build that recorded nothing, while being preferred over a
+ * repository the directory acquires later; and a recorded value copied from another recorded value
+ * would let one stale answer propagate through every session ever reopened from it.
+ *
+ * Never throws — a session must start even when git does not answer. It simply records nothing,
+ * which is what every row written before this existed already does.
+ */
+export async function recordedRepo(cwd: string): Promise<{ repo?: RepoFacts }> {
+  const facts = await repoFacts(cwd).catch(() => undefined)
+  if (facts?.source !== 'live' || facts.repo === undefined) return {}
+  return {
+    repo: {
+      repo: facts.repo,
+      ...(facts.root ? { root: facts.root } : {}),
+      worktree: facts.worktree,
+    },
+  }
 }

--- a/packages/server/server/sessions/session-table.test.ts
+++ b/packages/server/server/sessions/session-table.test.ts
@@ -12,7 +12,7 @@ const STRINGS: SessionTableStrings = {
   },
   unknown: {
     harness: 'harness unknown', model: 'no model recorded', project: 'no directory recorded',
-    task: 'no task', repo: 'no repository',
+    task: 'no task', repo: 'no repository', goneProject: 'directory no longer exists',
   },
   closed: 'closed',
   done: 'finished',

--- a/packages/server/server/sessions/session-table.ts
+++ b/packages/server/server/sessions/session-table.ts
@@ -49,7 +49,14 @@ import type { ControlSession, SessionState } from '@agentistics/tui/control'
  */
 export interface SessionTableStrings {
   cols: Record<keyof SessionColumns, string>
-  unknown: { harness: string; model: string; project: string; task: string; repo: string }
+  unknown: {
+    harness: string
+    model: string
+    project: string
+    task: string
+    repo: string
+    goneProject: string
+  }
   /** Heads the block of conversations that are not running. */
   closed: string
   /** Marks a task the user finished, on its heading. */

--- a/packages/server/server/sessions/session-view.test.ts
+++ b/packages/server/server/sessions/session-view.test.ts
@@ -289,3 +289,68 @@ describe("what the harness says about its OWN session", () => {
     expect(v!.label).toBe('Principal')
   })
 })
+
+describe('a row that KNOWS which conversation it drives', () => {
+  const conv = (sessionId: string, over: Record<string, unknown> = {}) => ({
+    sessionId,
+    harness: 'claude' as const,
+    cwd: '/repo/a',
+    title: sessionId,
+    lastActivityMs: 1,
+    resumable: true,
+    firstPrompt: '',
+    ...over,
+  })
+
+  it('offers exactly that conversation, never the directory guess', () => {
+    const reconciled = [row('a', {
+      status: 'lost',
+      backend: undefined,
+      managed: managed('a', { conversationId: 'mine' }),
+    })]
+    const [v] = buildSessionViews({
+      reconciled,
+      activity: new Map(),
+      processes: [],
+      // `older` is the one the harness+directory guess would pick — same harness, same directory.
+      conversations: [conv('older'), conv('mine')],
+    })
+    expect(v!.resume?.sessionId).toBe('mine')
+  })
+
+  it('offers NOTHING when the store does not hold that conversation yet', () => {
+    // Ordinary now that the id is recorded at SPAWN rather than only at reopen: a session minutes
+    // old has an id and no transcript written under it. Falling through to the guess would hand it
+    // an unrelated conversation from the same directory — the bug that reopened three rows onto one.
+    const reconciled = [row('a', {
+      status: 'lost',
+      backend: undefined,
+      managed: managed('a', { conversationId: 'not-written-yet' }),
+    })]
+    const [v] = buildSessionViews({
+      reconciled,
+      activity: new Map(),
+      processes: [],
+      conversations: [conv('older')],
+    })
+    expect(v!.resume).toBeUndefined()
+  })
+
+  it('still guesses for a row that recorded nothing — the old behaviour, unchanged', () => {
+    const reconciled = [row('a', { status: 'lost', backend: undefined })]
+    const [v] = buildSessionViews({
+      reconciled,
+      activity: new Map(),
+      processes: [],
+      conversations: [conv('older')],
+    })
+    expect(v!.resume?.sessionId).toBe('older')
+  })
+
+  it('carries the repository the registry recorded, for the caller that resolves the facts', () => {
+    const repo = { repo: 'blpsoares/agentistics', root: 'agentistics', worktree: true }
+    const reconciled = [row('a', { managed: managed('a', { repo }) })]
+    const [v] = buildSessionViews({ reconciled, activity: new Map(), processes: [] })
+    expect(v!.recordedRepo).toEqual(repo)
+  })
+})

--- a/packages/server/server/sessions/session-view.ts
+++ b/packages/server/server/sessions/session-view.ts
@@ -14,6 +14,7 @@ import { rulesFor } from './attention-rules'
 import type { DialogOption } from './dialog-choice'
 import { chosenName, type HarnessSessionFile } from './harness-session-file'
 import type { HarnessSessionIndex } from './harness-sessions'
+import type { RepoFacts } from './repo-facts'
 import type { ReconciledSession } from './session-ref'
 import type { Conversation } from './conversations'
 import { conversationForProcess } from './conversations'
@@ -114,6 +115,15 @@ export interface SessionView {
    * event channel deduplicates on. Absent is absent.
    */
   conversationId?: string
+  /**
+   * The repository this row's directory was in when the session STARTED, as the registry recorded
+   * it — carried so the caller that resolves `repo-facts.ts` can hand it over.
+   *
+   * It is here rather than resolved here because resolving means running git, and this module is
+   * pure. Present only on a managed row written by a build that records it; `resolveRepoFacts`
+   * treats absence as "nothing recorded", never as "no repository".
+   */
+  recordedRepo?: RepoFacts
   createdMs?: number
   attached: boolean
   /**
@@ -255,11 +265,19 @@ export function buildSessionViews(o: {
     exactId?: string,
   ): { resume?: { sessionId: string; title: string } } => {
     const pool = o.conversations ?? []
-    const exact = exactId ? pool.find(c => c.sessionId === exactId) : undefined
-    const own = exact ?? (managed?.conversationId
-      ? pool.find(c => c.sessionId === managed.conversationId)
-      : undefined)
-    const conv = own ?? pool.find(c =>
+    const knownId = exactId ?? managed?.conversationId
+    const own = knownId ? pool.find(c => c.sessionId === knownId) : undefined
+    // A row that KNOWS which conversation it drives never falls back to the guess — not even when
+    // the store does not hold that conversation yet. Since the id is recorded at SPAWN (not only at
+    // reopen), that gap is now ordinary: a session minutes old has an id and no transcript written
+    // under it. "Not yet" and "some other conversation in this directory" are not the same answer,
+    // and taking the second is the guess that handed three rows one conversation after a crash.
+    if (knownId) {
+      if (!own?.resumable) return {}
+      claimed.add(own.sessionId)
+      return { resume: { sessionId: own.sessionId, title: own.title } }
+    }
+    const conv = pool.find(c =>
       !claimed.has(c.sessionId)
       && c.harness === harness
       && sessionAtCwd({ current_cwd: c.cwd, project_path: c.cwd }, managed?.cwd ?? ''))
@@ -333,6 +351,7 @@ export function buildSessionViews(o: {
       ...(r.managed?.effort ? { effort: r.managed.effort } : {}),
       ...(r.managed?.task ? { task: r.managed.task } : {}),
       ...(r.managed?.conversationId ? { conversationId: r.managed.conversationId } : {}),
+      ...(r.managed?.repo ? { recordedRepo: r.managed.repo } : {}),
       // The backend's clock when there is a backend, the REGISTRY's when there is not. A row the
       // machine lost has no tmux session left to ask, so it reported no start time at all — and a
       // session you are deciding whether to reopen is one whose age is most of the decision.

--- a/packages/server/server/sessions/spawn-spec.test.ts
+++ b/packages/server/server/sessions/spawn-spec.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'bun:test'
 import { HARNESS_ORDER } from '@agentistics/core'
-import { SPAWN_SPECS, planSpawn } from './spawn-spec'
+import { SPAWN_SPECS, conversationLinkable, planSpawn } from './spawn-spec'
 
 describe('SPAWN_SPECS', () => {
   it('has an entry for every harness', () => {
@@ -96,5 +96,74 @@ describe('planSpawn', () => {
   it('does NOT validate the model against a closed list', () => {
     const r = planSpawn({ harness: 'claude', cwd: '/tmp', model: 'claude-opus-5-some-future-name' })
     expect(r).toEqual({ ok: true, plan: { argv: ['claude', '--model', 'claude-opus-5-some-future-name'] } })
+  })
+})
+
+describe('assigning the conversation id at spawn', () => {
+  it('names the conversation for a harness whose CLI accepts one', () => {
+    // claude: `--session-id <uuid>  Use a specific session ID for the conversation`. Verified on
+    // 2026-08-14 to produce `~/.claude/projects/<enc>/<uuid>.jsonl` — the same id the adapter reads
+    // back, which is what makes recording it worth anything.
+    const r = planSpawn({ harness: 'claude', cwd: '/r', conversationId: 'u-1' })
+    expect(r.ok).toBe(true)
+    if (!r.ok) return
+    expect(r.plan.argv).toEqual(['claude', '--session-id', 'u-1'])
+    expect(r.plan.conversationId).toBe('u-1')
+  })
+
+  it('does the same for copilot, whose single flag both sets and resumes', () => {
+    const r = planSpawn({ harness: 'copilot', cwd: '/r', conversationId: 'u-2' })
+    expect(r.ok).toBe(true)
+    if (!r.ok) return
+    expect(r.plan.argv).toEqual(['copilot', '--session-id', 'u-2'])
+    expect(r.plan.conversationId).toBe('u-2')
+  })
+
+  it('records NOTHING for a harness that invents its own id and never reports it', () => {
+    // codex, kimi, gemini and antigravity. An id recorded here would be one nothing in the store
+    // resolves to, which is worse than none: it LOOKS like an exact link. The UI says so instead —
+    // see `conversationLinkable`.
+    for (const harness of ['codex', 'kimi', 'gemini', 'antigravity'] as const) {
+      const r = planSpawn({ harness, cwd: '/r', conversationId: 'u-3' })
+      expect(r.ok).toBe(true)
+      if (!r.ok) continue
+      expect(r.plan.argv).not.toContain('u-3')
+      expect(r.plan.conversationId).toBeUndefined()
+    }
+  })
+
+  it('never assigns an id beside a resume — that conversation already has one', () => {
+    const r = planSpawn({ harness: 'claude', cwd: '/r', resumeId: 'old', conversationId: 'new' })
+    expect(r.ok).toBe(true)
+    if (!r.ok) return
+    expect(r.plan.argv).toEqual(['claude', '--resume', 'old'])
+    // The conversation this spawn drives is the one it was told to reopen.
+    expect(r.plan.conversationId).toBe('old')
+  })
+
+  it('leaves the argv untouched when no id is offered', () => {
+    const r = planSpawn({ harness: 'claude', cwd: '/r' })
+    expect(r.ok).toBe(true)
+    if (!r.ok) return
+    expect(r.plan.argv).toEqual(['claude'])
+    expect(r.plan.conversationId).toBeUndefined()
+  })
+})
+
+describe('conversationLinkable', () => {
+  it('is true exactly where an EXACT link can exist', () => {
+    // claude on both counts (`--session-id`, and `~/.claude/sessions/<pid>.json` carrying the tmux
+    // session we started it under); copilot on the flag alone.
+    expect(conversationLinkable('claude')).toBe(true)
+    expect(conversationLinkable('copilot')).toBe(true)
+  })
+
+  it('is false where every answer would be a harness-and-directory guess', () => {
+    // The guess gives every session of one repository the same conversation — the bug that reopened
+    // three rows onto one conversation. It is fine to OFFER, and this flag is what stops it being
+    // presented as the conversation the row is in.
+    for (const harness of ['codex', 'kimi', 'gemini', 'antigravity'] as const) {
+      expect(conversationLinkable(harness)).toBe(false)
+    }
   })
 })

--- a/packages/server/server/sessions/spawn-spec.ts
+++ b/packages/server/server/sessions/spawn-spec.ts
@@ -17,6 +17,7 @@
  */
 
 import type { HarnessId } from '@agentistics/core'
+import { HARNESS_SESSION_SOURCES } from './harness-session-file'
 import type { SpawnRequest, SpawnPlanResult, SpawnSpec } from './types'
 
 export const SPAWN_SPECS: Record<HarnessId, SpawnSpec | null> = {
@@ -32,6 +33,11 @@ export const SPAWN_SPECS: Record<HarnessId, SpawnSpec | null> = {
     efforts: ['low', 'medium', 'high', 'xhigh', 'max'],
     // `-r, --resume [value]  Resume a conversation by session ID`
     resume: id => ['--resume', id],
+    // `--session-id <uuid>  Use a specific session ID for the conversation (must be a valid UUID)`.
+    // VERIFIED 2026-08-14 against claude 2.1.x: `claude --session-id <uuid> -p …` in `/tmp/sid-probe`
+    // wrote `~/.claude/projects/-tmp-sid-probe/<uuid>.jsonl` — the same id the adapter reads back as
+    // `SessionMeta.session_id`, which is the only thing that makes the record worth keeping.
+    assignId: id => ['--session-id', id],
   },
 
   // `Usage: codex [OPTIONS] [PROMPT]` / `[PROMPT]  Optional user prompt to start the session`
@@ -71,6 +77,12 @@ export const SPAWN_SPECS: Record<HarnessId, SpawnSpec | null> = {
     modelSuggestions: ['gemini-3-flash-preview', 'gemini-2.5-pro', 'gemini-2.5-flash'],
     // No effort flag exists, and no `resume`: gemini's `-r, --resume` takes "latest" or an index
     // number, never a session id. Offering it would be a verb that reopens the wrong conversation.
+    //
+    // And deliberately NO `assignId`, although `--session-id  Start a new session with a manually
+    // provided UUID` exists: the id agentistics knows a gemini conversation by is SYNTHETIC —
+    // `gemini.ts` builds `${dirName}/${fileBase}` from the chat file's path, because the files
+    // carry no id of their own. A recorded UUID would therefore match no session in the store, and
+    // an id that resolves to nothing is worse than no id at all: it looks like an exact link.
   },
 
   // `-p, --prompt <text>  Execute a prompt in non-interactive mode (exits after completion)` — the
@@ -85,6 +97,12 @@ export const SPAWN_SPECS: Record<HarnessId, SpawnSpec | null> = {
     // `-r, --resume[=value]`, whose `[=value]` form requires the `=` and silently degrades to
     // "resume the most recent" when the id is passed as a separate argument.
     resume: id => ['--session-id', id],
+    // The SAME flag: `--session-id <id>  Resume an existing session or task by ID, **or set the
+    // UUID for a new session**`. VERIFIED 2026-08-14: `copilot --session-id <uuid> -p …` printed
+    // back `Resume  copilot --resume=<that uuid>` and created
+    // `~/.copilot/session-state/<uuid>/events.jsonl` — and that directory name IS the id the
+    // adapter keys sessions by.
+    assignId: id => ['--session-id', id],
   },
 
   // `--prompt-interactive  Run an initial prompt interactively and continue the session`, plus a
@@ -100,6 +118,26 @@ export const SPAWN_SPECS: Record<HarnessId, SpawnSpec | null> = {
     efforts: ['low', 'medium', 'high'],
     resume: id => ['--conversation', id], // `--conversation  Resume a previous conversation by ID`
   },
+}
+
+/**
+ * Can agentop ever know EXACTLY which conversation a fresh session of this harness is writing?
+ *
+ * Two ways exist and this is both of them: we told the CLI which id to use (`assignId`), or the
+ * harness keeps a record of its own live sessions that can be matched back to our row
+ * (`HARNESS_SESSION_SOURCES` — Claude's `~/.claude/sessions/<pid>.json`, which carries the tmux
+ * session name we started it under).
+ *
+ * `false` is the answer for codex, kimi, gemini and antigravity, and it must be SAID rather than
+ * papered over: everything downstream then falls back to `conversationForProcess`, which matches by
+ * harness and directory and therefore gives every session of one repository the same conversation.
+ * That guess is good enough to OFFER a reopen a person confirms by title, and not good enough to be
+ * presented as the conversation this row is in. The same rule `HARNESS_CAPABILITIES` applies to a
+ * metric, applied to a link.
+ */
+export function conversationLinkable(harness: HarnessId): boolean {
+  return SPAWN_SPECS[harness]?.assignId !== undefined
+    || HARNESS_SESSION_SOURCES[harness] !== null
 }
 
 /** Decide the exact argv (and any text to type in) for a requested session. */
@@ -128,6 +166,10 @@ export function planSpawn(req: SpawnRequest): SpawnPlanResult {
   // The resume argv goes FIRST because one of these is a subcommand (`codex resume <id>`), and a
   // subcommand that follows a flag is not a subcommand any more.
   if (req.resumeId && spec.resume) argv.push(...spec.resume(req.resumeId))
+  // A FRESH session may be told which conversation id to write under, where the CLI accepts one.
+  // Never alongside a resume: the conversation already exists and already has an id.
+  const assigned = !req.resumeId && req.conversationId && spec.assignId ? req.conversationId : undefined
+  if (assigned && spec.assignId) argv.push(...spec.assignId(assigned))
   if (req.model && spec.modelFlag) argv.push(spec.modelFlag, req.model)
   if (req.effort && spec.effortFlag) argv.push(spec.effortFlag, req.effort)
 
@@ -138,5 +180,17 @@ export function planSpawn(req: SpawnRequest): SpawnPlanResult {
     else sendKeys = req.prompt
   }
 
-  return { ok: true, plan: sendKeys === undefined ? { argv } : { argv, sendKeys } }
+  // The conversation this spawn is KNOWN to drive: the one we asked to reopen, or the one we just
+  // named. Absent for a fresh session on a CLI that will invent its own id and never report it —
+  // and absent is what makes the UI say so instead of showing a guess.
+  const conversationId = req.resumeId ?? assigned
+
+  return {
+    ok: true,
+    plan: {
+      argv,
+      ...(sendKeys === undefined ? {} : { sendKeys }),
+      ...(conversationId ? { conversationId } : {}),
+    },
+  }
 }

--- a/packages/server/server/sessions/types.ts
+++ b/packages/server/server/sessions/types.ts
@@ -7,6 +7,7 @@
  */
 
 import type { HarnessId } from '@agentistics/core'
+import type { RepoFacts } from './repo-facts'
 
 /**
  * How a harness accepts an initial prompt while starting an INTERACTIVE session.
@@ -45,6 +46,18 @@ export interface SpawnSpec {
    * an index, never an id, so it has none and the verb is simply not offered for it.
    */
   resume?: (id: string) => string[]
+  /**
+   * The argv (after `bin`) that tells a FRESH session which conversation id to write under.
+   *
+   * Absent for every CLI that invents its own and never reports it back, which is most of them —
+   * and absence is load-bearing: it is what makes the cockpit say the link cannot be recorded for
+   * this harness rather than showing the harness-and-directory guess as though it were a fact.
+   *
+   * Only ever set where the id the CLI accepts is EXACTLY the id the adapter reads sessions back
+   * by, verified by running it. Gemini accepts a UUID and is deliberately absent for that reason —
+   * see its entry in `SPAWN_SPECS`.
+   */
+  assignId?: (id: string) => string[]
 }
 
 export interface SpawnRequest {
@@ -57,6 +70,15 @@ export interface SpawnRequest {
    * not refused, because a resumed session accepting an opening line is a reasonable thing to want.
    */
   resumeId?: string
+  /**
+   * A conversation id to ASSIGN to a fresh session — a UUID the caller minted.
+   *
+   * Offered, never imposed: it is used only where `SpawnSpec.assignId` says the CLI accepts one,
+   * and ignored beside `resumeId`, whose conversation already has an id. The caller reads back
+   * `SpawnPlan.conversationId` to learn whether it was actually applied, so nothing is ever
+   * recorded that was not passed to the CLI.
+   */
+  conversationId?: string
   prompt?: string
   model?: string
   effort?: string
@@ -68,6 +90,16 @@ export interface SpawnPlan {
   argv: string[]
   /** Typed into the session once it is up, for a `send-keys` harness. */
   sendKeys?: string
+  /**
+   * The conversation this spawn is KNOWN to drive — the id reopened, or the id assigned.
+   *
+   * This is the whole of what a caller may record. Absent means the harness will invent its own and
+   * never say what it was, and the registry must then hold nothing rather than a plausible guess:
+   * `conversationForProcess` matches by harness and directory, so a guess files every session of
+   * one repository under the same conversation, which is how a crash left one conversation listed
+   * three times under three names.
+   */
+  conversationId?: string
 }
 
 export type SpawnPlanError =
@@ -166,6 +198,22 @@ export interface ManagedSession {
    * the same one, and the fleet came back with a single session listed three times under one name.
    */
   conversationId?: string
+  /**
+   * The repository this session's directory belonged to WHEN IT STARTED.
+   *
+   * Recorded because `repo-facts.ts` can only answer by running git in the directory, and the
+   * directory does not always survive the session: `ExitWorktree --remove` and `git worktree
+   * remove` leave the row registered at a path that names nothing. Every probe then fails, the
+   * grouping falls through to the last path segment, and a removed worktree appears as a PROJECT
+   * of its own beside the project it was a worktree of — a name invented from a path that resolves
+   * to nothing, which is the same error as a confident `0` for a metric nobody can produce.
+   *
+   * Spawn is the one moment the answer is certain, because the directory is provably there — the
+   * session is being started in it. Absent on a row written by a build that predates this, and on
+   * one started outside a repository; `resolveRepoFacts` treats absence as "nothing recorded",
+   * never as "no repository", so an older row simply behaves as it always did.
+   */
+  repo?: RepoFacts
 }
 
 /**

--- a/packages/tui/src/control/i18n.ts
+++ b/packages/tui/src/control/i18n.ts
@@ -229,6 +229,10 @@ export interface ControlStrings {
   sessionsMetrics: string
   /** Detail-pane label for the context gauge spelled out. */
   sessionsContext: string
+  /** Detail-pane label for the conversation id this row continues from. */
+  sessionsConversation: string
+  /** Grouping heading for rows whose recorded directory no longer exists on this machine. */
+  sessionsGoneProject: string
   /** The name that did NOT win, when a session is named in agentop AND inside the harness. */
   sessionsAlsoLabel: string
   sessionsAlsoHarness: string
@@ -639,6 +643,8 @@ const EN: ControlStrings = {
   sessionsTask: 'task',
   sessionsMetrics: 'usage',
   sessionsContext: 'context window',
+  sessionsConversation: 'conversation',
+  sessionsGoneProject: 'directory no longer exists',
   sessionsAlsoLabel: 'named here',
   sessionsAlsoHarness: 'named inside',
   sessionsDetach: 'to detach',
@@ -1035,6 +1041,8 @@ const PT: ControlStrings = {
   sessionsTask: 'tarefa',
   sessionsMetrics: 'uso',
   sessionsContext: 'janela de contexto',
+  sessionsConversation: 'conversa',
+  sessionsGoneProject: 'diretório não existe mais',
   sessionsAlsoLabel: 'nome daqui',
   sessionsAlsoHarness: 'nome de dentro',
   sessionsDetach: 'para sair',

--- a/packages/tui/src/control/sessions.test.ts
+++ b/packages/tui/src/control/sessions.test.ts
@@ -27,6 +27,7 @@ const LAYOUT = {
 
 const UNKNOWN = {
   harness: 'harness unknown', model: 'no model recorded', project: 'no directory', task: 'no task',
+  goneProject: 'directory no longer exists',
   repo: 'no repository',
 }
 
@@ -87,6 +88,47 @@ describe('groupSessions', () => {
     session('b', { harness: 'codex', project: 'x', state: 'waiting-approval' }),
     session('c', { harness: 'claude', model: 'opus', project: 'y', state: 'working' }),
   ]
+
+  it('does not make a PROJECT out of a directory that no longer exists', () => {
+    // Reported from a real machine: the worktree `.claude/worktrees/member-connect-rotate` was
+    // removed with its session still registered, so every `git -C` failed and the row grouped under
+    // the last segment of a path that names nothing — a project of its own, standing beside
+    // `Agentistics`, which is the project it was a worktree of.
+    const gone = [
+      session('w', { project: 'member-connect-rotate', dirGone: 'gone' }),
+      session('v', { project: 'billing-basis', dirGone: 'gone' }),
+      session('m', { project: 'agentistics' }),
+    ]
+    const g = groupSessions(gone, 'project', UNKNOWN)
+    const labels = g.map(x => x.label).sort()
+    expect(labels).toEqual(['agentistics', 'directory no longer exists'])
+    // Both missing rows are in ONE bucket: what they have in common is that nobody knows where
+    // they were, and that is a single fact rather than two project names.
+    expect(g.find(x => x.label === 'directory no longer exists')!.sessions.map(s => s.id).sort())
+      .toEqual(['v', 'w'])
+  })
+
+  it('still groups a gone directory under the project the registry recorded for it', () => {
+    // The recovery case: `ManagedSession.repo` was written at spawn, so the row keeps the project
+    // it belonged to and never reaches the bucket at all.
+    const g = groupSessions(
+      [session('w', { project: 'member-connect-rotate', projectGroup: 'agentistics', dirGone: 'gone' })],
+      'project',
+      UNKNOWN,
+    )
+    expect(g.map(x => x.label)).toEqual(['agentistics'])
+  })
+
+  it('keeps "gone" and "no directory recorded" as two different headings', () => {
+    // A row with no cwd at all is a different absence from a row whose recorded path is not there,
+    // and one heading for both would read as a category that neither of them is.
+    const g = groupSessions(
+      [session('n', { project: '' }), session('w', { project: 'x', dirGone: 'gone' })],
+      'project',
+      UNKNOWN,
+    )
+    expect(g.map(x => x.label).sort()).toEqual(['directory no longer exists', 'no directory'])
+  })
 
   it('returns one unnamed group when grouping is off', () => {
     const g = groupSessions(list, 'none', UNKNOWN)
@@ -211,7 +253,7 @@ describe('detailLines', () => {
   const labels = {
     where: 'where', model: 'model', note: 'note', started: 'started',
     external: 'started outside agentop', closed: 'not running', doing: 'saying', task: 'task', metrics: 'usage',
-    context: 'window',
+    context: 'window', conversation: 'conversation',
     alsoLabel: 'named here', alsoHarness: 'named inside',
   }
   const ago = () => '5m ago'
@@ -312,7 +354,7 @@ describe('detailLines — the two non-actionable rows say different things', () 
   const labels = {
     where: 'where', model: 'model', note: 'note', started: 'started',
     external: 'started outside agentop', closed: 'not running', doing: 'saying',
-    task: 'task', metrics: 'usage', context: 'window',
+    task: 'task', metrics: 'usage', context: 'window', conversation: 'conversation',
     alsoLabel: 'named here', alsoHarness: 'named inside',
   }
   const ago = () => '5m ago'
@@ -2055,7 +2097,7 @@ describe('detailLines — named in two places', () => {
   const labels = {
     where: 'where', model: 'model', note: 'note', started: 'started',
     external: 'external', closed: 'closed', doing: 'saying', task: 'task', metrics: 'usage',
-    context: 'window',
+    context: 'window', conversation: 'conversation',
     alsoLabel: 'named here', alsoHarness: 'named inside',
   }
   const ago = () => '5m ago'
@@ -2250,7 +2292,7 @@ describe('detailLines — the gauge spelled out', () => {
   const labels = {
     where: 'where', model: 'model', note: 'note', started: 'started',
     external: 'external', closed: 'closed', doing: 'saying', task: 'task', metrics: 'usage',
-    context: 'context window',
+    context: 'context window', conversation: 'conversation',
     alsoLabel: 'named here', alsoHarness: 'named inside',
   }
 

--- a/packages/tui/src/control/sessions.ts
+++ b/packages/tui/src/control/sessions.ts
@@ -160,10 +160,35 @@ export interface SessionGroup {
  * blank heading across dimensions: "harness unknown" and "no model recorded" are different facts,
  * and a heading that reads as a category when it is really an absence is how a list starts lying.
  */
+/**
+ * The key rows whose DIRECTORY is gone are filed under, when nothing else names them.
+ *
+ * Unreachable as a real key by construction: every project key is `projectGroup || project`, and
+ * both are single path SEGMENTS — `projectName` splits on the separator, so no value either can
+ * take contains one. A sentinel that a folder could be named would silently merge that folder's
+ * sessions into this bucket.
+ */
+const GONE_PROJECT_KEY = '/gone'
+
 export function groupSessions(
   list: readonly ControlSession[],
   by: SessionGrouping,
-  unknownLabels: { harness: string; model: string; project: string; task: string; repo: string },
+  unknownLabels: {
+    harness: string
+    model: string
+    project: string
+    task: string
+    repo: string
+    /**
+     * Rows whose recorded directory no longer exists AND whose repository was never recorded.
+     *
+     * Its own heading rather than sharing `project`'s: "no directory recorded" and "the directory
+     * is not there any more" are different facts, and the second is the one that must not be
+     * grouped under the last segment of the path — that is how the removed worktree
+     * `member-connect-rotate` became a project standing beside `Agentistics`.
+     */
+    goneProject: string
+  },
   /** The tasks the user marked finished — a statement about the WORK, not about any session. */
   doneTasks: readonly string[] = [],
   order: SessionOrder = DEFAULT_ORDER,
@@ -177,9 +202,13 @@ export function groupSessions(
       : by === 'task' ? (s.task ?? '')
       : by === 'repo' ? (s.repo ?? '')
       // The PROJECT is what the work is called, which for anything in a repository is the main
-      // checkout — never the worktree's own directory, or one project files as three.
-      : (s.projectGroup || s.project)
-    const label = key !== '' ? key : unknownLabels[by]
+      // checkout — never the worktree's own directory, or one project files as three. And never
+      // the folder name of a directory that is GONE: that path resolves to nothing, so its last
+      // segment is a guess, and a group made out of a guess reads exactly like a real project.
+      : (s.projectGroup || (s.dirGone ? GONE_PROJECT_KEY : s.project))
+    const label = key === GONE_PROJECT_KEY ? unknownLabels.goneProject
+      : key !== '' ? key
+      : unknownLabels[by]
     const found = groups.get(key)
     if (found) found.sessions.push(s)
     else {
@@ -394,6 +423,14 @@ export function detailLines(s: ControlSession, labels: {
   /** Heads the spelled-out gauge: `45%  ·  455.4k / 1M`. */
   context: string
   /**
+   * Heads the conversation this row continues from — the id `--resume` takes.
+   *
+   * Worth a row of its own because it is the one fact that turns "this session is somewhere" into
+   * something a person can act on outside agentop, and because it is only ever shown when it was
+   * RECORDED: a row without it is a row where nobody knows, and `conversationBlind` says so.
+   */
+  conversation: string
+  /**
    * Labels for the OTHER name, when a session is named in both places.
    *
    * Two of them, because which one is the other depends on which one won — and a single label
@@ -458,6 +495,10 @@ export function detailLines(s: ControlSession, labels: {
       value: `${s.context.label}  ·  ${s.context.used} / ${s.context.window}`,
     })
   }
+  // Where it continues from. Under the metrics because it is the fact you copy rather than read.
+  if (s.conversationId) {
+    out.push({ key: 'conv', label: labels.conversation, value: s.conversationId })
+  }
   if (s.note) out.push({ key: 'note', label: labels.note, value: s.note })
   if (s.startedAt !== undefined) {
     out.push({ key: 'started', label: labels.started, value: ago(s.startedAt) })
@@ -474,7 +515,13 @@ export function detailLines(s: ControlSession, labels: {
   }
   if (s.state === 'closed') out.push({ key: 'closed', label: '', value: labels.closed, note: true })
   else if (!s.actionable) out.push({ key: 'external', label: '', value: labels.external, note: true })
+  // The directory first: it is the caveat that explains the others — a path that resolves to
+  // nothing is why the project may be a bucket and why reopening will fail.
+  if (s.dirGone) out.push({ key: 'gone', label: '', value: s.dirGone, note: true })
   if (s.approvalBlind) out.push({ key: 'blind', label: '', value: s.approvalBlind, note: true })
+  if (s.conversationBlind) {
+    out.push({ key: 'convblind', label: '', value: s.conversationBlind, note: true })
+  }
   return out
 }
 

--- a/packages/tui/src/control/tabs/Sessions.tsx
+++ b/packages/tui/src/control/tabs/Sessions.tsx
@@ -333,6 +333,7 @@ export function Sessions({
       project: s.sessionsUnknownProject,
       task: s.sessionsUnknownTask,
       repo: s.sessionsUnknownRepo,
+      goneProject: s.sessionsGoneProject,
     },
     fleet?.finishedTasks ?? [],
     order,
@@ -394,6 +395,7 @@ export function Sessions({
     task: s.sessionsTask,
     metrics: s.sessionsMetrics,
     context: s.sessionsContext,
+    conversation: s.sessionsConversation,
     alsoLabel: s.sessionsAlsoLabel,
     alsoHarness: s.sessionsAlsoHarness,
     // Absent when the backend did not report one — an invented keystroke is worse than none, since

--- a/packages/tui/src/control/types.ts
+++ b/packages/tui/src/control/types.ts
@@ -351,8 +351,21 @@ export interface ControlSession {
    * and `agentistics`, which files one project as three. It is a SEPARATE field from `project`
    * because the row must still say which directory it is actually in: with several worktrees open
    * at once, the folder cell is the only thing telling them apart.
+   *
+   * It is also where a row whose directory is GONE and whose repository was never recorded is filed:
+   * the host puts an already-localized sentence here rather than a name, because the alternative is
+   * grouping under the last segment of a path that resolves to nothing — which is how a removed
+   * worktree appeared as a project of its own beside the project it was a worktree of.
    */
   projectGroup?: string
+  /**
+   * Already-localized: this row's directory does not exist on this machine any more.
+   *
+   * Present whether or not the repository was recovered from what the registry recorded, because
+   * the two are different facts — one says which project the work belonged to, this one says the
+   * path is not there, which is also the answer to "why can I not reopen it".
+   */
+  dirGone?: string
   /** True only for a LINKED worktree. Said on the row, because it changes what the row IS. */
   worktree?: boolean
   /**
@@ -367,6 +380,22 @@ export interface ControlSession {
   note?: string
   /** The piece of work this session belongs to, when the user said so. Groups the list. */
   task?: string
+  /**
+   * The harness's own conversation id this row is KNOWN to be writing — what `--resume` takes.
+   *
+   * The exact answer to "where does this continue from", and the only one this screen may state:
+   * it is recorded, never inferred. Absent on a row started before the id could be recorded, and on
+   * every row of a harness that cannot report one — see `conversationBlind`.
+   */
+  conversationId?: string
+  /**
+   * Already-localized: this harness can never report which conversation a session it started is
+   * writing, so no link can be recorded for this row and anything offered to reopen is inferred.
+   *
+   * Present only on a hosted row that has no `conversationId`. Same discipline as `approvalBlind`:
+   * a capability that does not exist is said in words rather than left to look like an absence.
+   */
+  conversationBlind?: string
   /**
    * The conversation this row could REOPEN, when there is one.
    *


### PR DESCRIPTION
Three defects in how the cockpit identifies **where a session is** and **where it stopped**. Each one turned an absence into a confident claim, which is the class of bug this repo already refuses for `HARNESS_CAPABILITIES` and `liveEmptyNotice`.

## 1. A removed worktree became a project of its own

`repo-facts.ts` answers only by running git in the directory, and the directory does not always survive the session — `ExitWorktree --remove` and the `lost`/reopen flow both leave a row registered at a path that names nothing. Every `git -C` then failed, `decideRepoFacts` returned `NONE`, and the grouping fell through to the last path segment.

Observed on this machine: the removed worktree `.claude/worktrees/member-connect-rotate` appeared as its **own project group**, standing beside `Agentistics` — the project it was a worktree of — with the project and repo cells empty.

```
git -C ~/agentistics/.claude/worktrees/session-monitor       rev-parse --git-common-dir
  → /home/mithrandir/agentistics/.git        (groups under Agentistics, correct)
git -C ~/agentistics/.claude/worktrees/member-connect-rotate rev-parse --git-common-dir
  → fatal: cannot change to ... No such file or directory   (its own group, wrong)
```

**The discriminator is whether the DIRECTORY EXISTS, not whether git answered.** Those are different facts and they render differently: a directory outside a repository has a real folder name to group under, a path that resolves to nothing does not.

- `ManagedSession.repo` records the facts **at spawn**, the one moment the directory is provably there.
- The pure `resolveRepoFacts({ live, recorded, exists })` prefers live git, then the record, then reports `missing`. Step 2 runs even when the directory still exists: git can go quiet for reasons that are not "no repository here" (not installed in a container, an index lock, a filesystem unmounted mid-poll), and a fact recorded at spawn beats a momentary silence.
- `groupSessions` files a row with nothing left to name it under **one bucket said in words** (`GONE_PROJECT_KEY`, unreachable as a real key because every project key is a single path *segment*). The folder cell still names the directory — that *is* where the session was — and the detail pane says the path is gone, which is also the answer to why reopening will fail.
- Rows written by older builds carry no record and land in that bucket rather than inventing a project. Degrading honestly was the point.

Verified against the live fleet — `member-connect-rotate` now sits under **"diretório não existe mais"** instead of beside `Agentistics`.

## 2. The `repoFacts` memo never recovered

`cache.set(cwd, facts)` stored the **negative** result too, so a cwd first probed while its worktree was absent (or while git was momentarily unavailable) stayed repo-less for the life of the process — even after `agentop session open` or `git worktree add` put it back.

A positive answer is a fact about the *directory* and stays permanent. A negative one is a fact about the *moment* and now expires (`NEGATIVE_TTL_MS`, 60s — one re-probe a minute instead of one per five-second poll). A **missing** directory never spawns git at all: the `stat` already answered.

## 3. The registry did not know which conversation a session was writing

On `dev` this was known only for a **reopened** row, plus — for claude alone — whatever `harness-sessions.ts` could read out of `~/.claude/sessions/<pid>.json` while the process lived. A session started with the cockpit closed had nothing but `conversationForProcess`, which matches by harness and directory and so gives **every session of one repository the same conversation**.

`SpawnSpec.assignId` hands the CLI an id at spawn wherever it accepts one, and `SpawnPlan.conversationId` reports back what was actually applied so nothing is recorded that was not passed:

| harness | flag | verified |
|---|---|---|
| claude | `--session-id <uuid>` | `claude --session-id U -p …` in `/tmp/sid-probe` wrote `~/.claude/projects/-tmp-sid-probe/U.jsonl` |
| copilot | `--session-id <uuid>` (same flag both sets and resumes) | printed back `Resume copilot --resume=U` and created `~/.copilot/session-state/U/events.jsonl` |

**Gemini accepts a UUID and is deliberately excluded.** Its id in this product is synthetic — `gemini.ts` builds `${dirName}/${fileBase}` because the chat files carry none — so a recorded UUID would resolve to nothing while *looking* like an exact link, which is worse than no id.

Where no link can ever exist (codex, kimi, gemini, antigravity) `conversationLinkable` is `false` and the row **says so** rather than presenting the directory guess as fact. It is stated only on a row agentop hosts that has no id yet: a claude row without one is "not polled yet", not "never", and the two must not read alike.

Also fixed here:

- **`agentop session open` now records the id.** It was the one reopen path that did not, so the same gesture left a row that knew its conversation or one that did not, depending on where it was pressed — the drift `task-reopen.ts` exists to have fixed once.
- **A row that knows its conversation no longer falls back to the guess** when the store has not caught up. That gap is ordinary now the id is recorded at spawn (a session minutes old has an id and no transcript), and "not written yet" is not "some other conversation in this directory" — taking the second is what once handed three `lost` rows one conversation.
- `conversationId` is exposed on the row's detail pane and in `session ls --json` / `session list --json`, kept **separate** from `resumeId`: one is what the row provably drives, the other is a target the verb offers and may have guessed.

## Purity and tests

New pure functions, each with tests: `resolveRepoFacts`, `repoFactsFresh`, `conversationLinkable`, the `planSpawn` assignment, the registry's nested `sanitizeRepo`, `groupSessions`' bucket, and `toControlSession`'s two new sentences (new `control-session.test.ts`).

`bun tsc --noEmit` clean; `bun test` 3896 pass / 0 fail.

## Not in scope

The `agentop member connect --token` gate and the token-rotation race are already fixed upstream in v1.13.4 (`09bf4c5`, `d577127`); the installed binary is v1.13.1 and the central still runs an older build. Those are upgrade/deploy decisions, untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0184MtFmjPpPhW4chiLcy2Cy
