### PR TITLE
feat(sessions): read the harness's own usage-limit banner, and when it lifts

### DIFF
--- a/packages/server/server/sessions/limit.test.ts
+++ b/packages/server/server/sessions/limit.test.ts
@@ -1,0 +1,243 @@
+import { describe, expect, it } from 'bun:test'
+import { HARNESS_ORDER } from '@agentistics/core'
+import {
+  HALF_DAY_MS,
+  LIMIT_RULES,
+  detectLimit,
+  limitCleared,
+  limitRuleFor,
+  parseResetAt,
+} from './limit'
+
+// ── Lines below are VERBATIM from live panes, 2026-08-14, claude 2.1.231. ────────────────────────
+//
+// Captured with `tmux capture-pane -p -S -5000` and re-read through `cat -A`, which is the only way
+// the two bytes that matter are visible at all:
+//
+//   `  M-bM-^NM-? M-BM- You've hit your session limit M-BM-7 resets 6:30pm (America/Sao_Paulo)$`
+//
+// `M-BM- ` is C2 A0 — a NON-BREAKING space before `You've`. `M-BM-7` is C2 B7 — a MIDDLE DOT, not a
+// hyphen and not an asterisk. `FIXTURE BYTES` below fails the build if either is ever normalised
+// away by an editor or a well-meaning cleanup, because a fixture quietly rewritten in ASCII would
+// let a pattern written in ASCII pass while matching nothing on a real screen.
+
+/** The tool-result form, both lines, exactly as the pane drew them. */
+const CLAUDE_BANNER = [
+  "  ⎿  You've hit your session limit · resets 6:30pm (America/Sao_Paulo)",
+  '     /upgrade to increase your usage limit.',
+]
+
+/**
+ * The same event reported through a SUBAGENT failure, from the pane next door.
+ *
+ * The limit belongs to the account rather than to the agent that reached it first, so the parent's
+ * next request fails identically — in the pane this came from, both forms were on screen together.
+ */
+const CLAUDE_AGENT_ERROR =
+  '● Agent "Re-review Task 11 after fix" failed: Agent terminated early due to an API error: ' +
+  "You've hit your session limit · resets 6:30pm (America/Sao_Paulo)"
+
+/** A tail from a session that is simply talking — nothing here may be read as a limit. */
+const ORDINARY_TAIL = [
+  '● Ran 2 shell commands',
+  '  ⎿  Read 40 lines',
+  '● The parser now folds every agent of a session into it.',
+]
+
+/** Local wall clock on a date with no DST transition anywhere, so the arithmetic is portable. */
+const at = (hour: number, minute = 0, day = 14) =>
+  new Date(2026, 7, day, hour, minute, 0, 0).getTime()
+
+const claude = () => limitRuleFor('claude')
+
+describe('FIXTURE BYTES', () => {
+  it('still carries the non-breaking space and the middle dot that were captured', () => {
+    // Guarding the FIXTURE, not the rule. If this line is ever retyped in plain ASCII the tests
+    // below keep passing while the feature stops seeing a single real frame.
+    expect(CLAUDE_BANNER[0]).toContain(' ')
+    expect(CLAUDE_BANNER[0]).toContain('·')
+    expect(CLAUDE_AGENT_ERROR).toContain('·')
+  })
+
+  it('would not be matched by the pattern anyone would have guessed', () => {
+    // The point of capturing instead of remembering: the obvious pattern, written with an ASCII
+    // space and an ASCII separator, matches none of this.
+    expect(/session limit - resets/.test(CLAUDE_BANNER[0]!)).toBe(false)
+    expect(/limit \* resets/.test(CLAUDE_BANNER[0]!)).toBe(false)
+  })
+})
+
+describe('LIMIT_RULES', () => {
+  it('declares an entry for every harness, so a new one cannot be forgotten', () => {
+    for (const h of HARNESS_ORDER) {
+      expect(LIMIT_RULES).toHaveProperty(h)
+    }
+  })
+
+  it('leaves every unprobed harness null rather than guessing a banner for it', () => {
+    for (const h of HARNESS_ORDER) {
+      if (h === 'claude') continue
+      expect(LIMIT_RULES[h]).toBeNull()
+      expect(limitRuleFor(h)).toBeUndefined()
+    }
+  })
+
+  it('never uses the g flag, which would make .test() alternate', () => {
+    for (const h of HARNESS_ORDER) {
+      const r = LIMIT_RULES[h]
+      if (!r) continue
+      for (const re of [...r.banner, ...(r.resetAt ? [r.resetAt] : [])]) {
+        expect(re.global).toBe(false)
+      }
+    }
+  })
+
+  it('records provenance for every harness that has rules', () => {
+    for (const h of HARNESS_ORDER) {
+      const r = LIMIT_RULES[h]
+      if (!r) continue
+      expect(r.probed).toMatch(/\d{4}-\d{2}-\d{2}/)
+    }
+  })
+
+  it('spells every gap `\\s+` and never a literal space', () => {
+    // THE regression guard the whole module is written around. A pattern retyped with an ordinary
+    // space still looks correct in review and matches nothing on a screen whose separator is a
+    // non-breaking space — it does not throw, it reports every blocked session as fine.
+    for (const h of HARNESS_ORDER) {
+      const r = LIMIT_RULES[h]
+      if (!r) continue
+      for (const re of [...r.banner, ...(r.resetAt ? [r.resetAt] : [])]) {
+        expect(re.source).not.toContain(' ')
+        expect(re.source).not.toContain(' ')
+        expect(re.source).not.toContain('·')
+      }
+    }
+  })
+})
+
+describe('detectLimit', () => {
+  it('reads the captured banner, non-breaking space and middle dot included', () => {
+    const hit = detectLimit({ tail: CLAUDE_BANNER, rule: claude(), nowMs: at(18, 37) })
+    expect(hit).toBeDefined()
+    expect(hit!.resetsAtText).toBe('6:30pm')
+    expect(hit!.resetsAtMs).toBe(at(18, 30))
+  })
+
+  it('quotes the line that SAYS something, not the newer one that says /upgrade', () => {
+    // The bug this pins: `/upgrade to increase your usage limit.` is printed BELOW the banner, so a
+    // newest-first scan meets it first. Taking the reset off that same line came back with none —
+    // and an absent reset counts as cleared, so every blocked session read as ready to resume.
+    const hit = detectLimit({ tail: CLAUDE_BANNER, rule: claude(), nowMs: at(18, 0) })
+    expect(hit!.raw).toContain('hit your session limit')
+    expect(hit!.raw).not.toContain('/upgrade')
+    expect(hit!.resetsAtMs).toBe(at(18, 30))
+  })
+
+  it('still sees a limit when the tail cut between the two lines', () => {
+    const hit = detectLimit({ tail: [CLAUDE_BANNER[1]!], rule: claude(), nowMs: at(18, 0) })
+    expect(hit).toBeDefined()
+    expect(hit!.resetsAtMs).toBeUndefined()
+    // Documented, and deliberately the forgiving direction: one wasted prompt beats a row that
+    // nothing can ever clear.
+    expect(limitCleared(hit, at(18, 0))).toBe(true)
+  })
+
+  it('reads the subagent failure form too', () => {
+    const hit = detectLimit({ tail: [CLAUDE_AGENT_ERROR], rule: claude(), nowMs: at(18, 0) })
+    expect(hit).toBeDefined()
+    expect(hit!.resetsAtMs).toBe(at(18, 30))
+  })
+
+  it('takes the NEWEST banner when a session hit the limit twice', () => {
+    // Synthetic — nobody caught one pane hitting the limit twice inside one tail. The banner text is
+    // the captured one; only the second reset time is invented, and it is labelled here rather than
+    // left to read as another capture.
+    const tail = [
+      "  ⎿  You've hit your session limit · resets 1:30pm (America/Sao_Paulo)",
+      '● Kept going for a while.',
+      "  ⎿  You've hit your session limit · resets 6:30pm (America/Sao_Paulo)",
+    ]
+    const hit = detectLimit({ tail, rule: claude(), nowMs: at(18, 37) })
+    expect(hit!.resetsAtText).toBe('6:30pm')
+  })
+
+  it('says nothing about an ordinary tail', () => {
+    expect(detectLimit({ tail: ORDINARY_TAIL, rule: claude(), nowMs: at(18, 0) })).toBeUndefined()
+    expect(detectLimit({ tail: [], rule: claude(), nowMs: at(18, 0) })).toBeUndefined()
+  })
+
+  it('detects nothing at all for a harness nobody probed', () => {
+    // Not "this harness has no limits" — "we have never seen one", which the UI states in words.
+    expect(detectLimit({ tail: CLAUDE_BANNER, rule: limitRuleFor('codex'), nowMs: at(18, 0) }))
+      .toBeUndefined()
+  })
+})
+
+describe('parseResetAt', () => {
+  it('reads a reset that already passed as TODAY, never tomorrow', () => {
+    // The acceptance case, and the one worth being loudest about: 18:30 read at 18:37 is OVER.
+    // Rolling it forward a day parks the whole fleet at the exact instant the resume should fire.
+    expect(parseResetAt('6:30pm', at(18, 37))).toBe(at(18, 30));
+    expect(limitCleared({ raw: '', resetsAtMs: parseResetAt('6:30pm', at(18, 37)) }, at(18, 37)))
+      .toBe(true)
+  })
+
+  it('reads a reset still to come as today', () => {
+    expect(parseResetAt('6:30pm', at(18, 0))).toBe(at(18, 30))
+    expect(limitCleared({ raw: '', resetsAtMs: at(18, 30) }, at(18, 0))).toBe(false)
+  })
+
+  it('rolls a reset across MIDNIGHT into tomorrow', () => {
+    // The mirror of the case above, and the one the first cut of this module got wrong: a banner
+    // printed at 23:50 saying `resets 1:00am` means the 1am one hour away. Read as today's it lands
+    // 23 hours in the past, and a hard-blocked session reports itself free to resume.
+    expect(parseResetAt('1:00am', at(23, 50))).toBe(at(1, 0, 15))
+  })
+
+  it('rolls a late-evening reset read after midnight back to yesterday', () => {
+    expect(parseResetAt('11:00pm', at(0, 10))).toBe(at(23, 0, 13))
+  })
+
+  it('never lands further than half a day from the moment it is read', () => {
+    for (const hour of [0, 3, 6, 9, 12, 15, 18, 21]) {
+      for (const text of ['12am', '1:15am', '6:30am', '12pm', '1:15pm', '6:30pm', '11:45pm']) {
+        const now = at(hour, 20)
+        const ms = parseResetAt(text, now)
+        expect(ms).toBeDefined()
+        expect(Math.abs(ms! - now)).toBeLessThanOrEqual(HALF_DAY_MS)
+      }
+    }
+  })
+
+  it('reads 12am as midnight and 12pm as noon', () => {
+    expect(parseResetAt('12am', at(1, 0))).toBe(at(0, 0))
+    expect(parseResetAt('12pm', at(13, 0))).toBe(at(12, 0))
+  })
+
+  it('accepts the bare-hour and spaced forms the banner could print', () => {
+    expect(parseResetAt('6pm', at(18, 37))).toBe(at(18, 0))
+    expect(parseResetAt('6 PM', at(18, 37))).toBe(at(18, 0))
+  })
+
+  it('refuses anything it cannot read, rather than inventing an instant', () => {
+    for (const junk of ['', 'soon', '25pm', '6:99pm', '0am', '18:30', '6:30']) {
+      expect(parseResetAt(junk, at(12, 0))).toBeUndefined()
+    }
+  })
+})
+
+describe('limitCleared', () => {
+  it('treats no hit at all as cleared', () => {
+    expect(limitCleared(undefined, at(12, 0))).toBe(true)
+  })
+
+  it('treats an unknown reset as cleared', () => {
+    expect(limitCleared({ raw: 'blocked' }, at(12, 0))).toBe(true)
+  })
+
+  it('clears exactly AT the reset, not a millisecond later', () => {
+    expect(limitCleared({ raw: '', resetsAtMs: at(18, 30) }, at(18, 30))).toBe(true)
+    expect(limitCleared({ raw: '', resetsAtMs: at(18, 30) }, at(18, 30) - 1)).toBe(false)
+  })
+})

--- a/packages/server/server/sessions/limit.ts
+++ b/packages/server/server/sessions/limit.ts
@@ -1,0 +1,242 @@
+/**
+ * limit.ts — PURE. When a session stopped because the HARNESS cut it off, and when it may go again.
+ *
+ * This is a different kind of stop from every other state in `attention.ts`, and the difference is
+ * the whole reason it gets its own module rather than another `approval` pattern:
+ *
+ *  - A `waiting-approval` session is blocked on a person, and answering it costs a keystroke.
+ *  - A `limit-blocked` session is blocked on a CLOCK. Nothing anyone types moves it, and a "continue"
+ *    sent before the reset is not merely useless — it burns the first request of the new window on a
+ *    prompt whose only content is the word continue, and the harness answers it with the same error.
+ *
+ * So the banner is only half of what this module reads. The other half is the RESET TIME the banner
+ * carries, because a fleet-wide resume that ignores it is a button that reliably fails on every row
+ * it touches.
+ *
+ * ## The pattern was captured, never written from memory
+ *
+ * Same rule as `attention-rules.ts`, and for the same reason: a plausible pattern that never matches
+ * fails silently. Captured on 2026-08-14 from three live panes (`agentop-6b23834c1a`,
+ * `agentop-d41dc788ef`, `agentop-cbf341b8c8`) with `tmux capture-pane -p`, claude 2.1.231, and
+ * re-read byte by byte through `cat -A`:
+ *
+ * ```
+ *   ⎿ ␣You've hit your session limit · resets 6:30pm (America/Sao_Paulo)
+ *      /upgrade to increase your usage limit.
+ * ```
+ *
+ * Two things in there would have been guessed wrong. The space before `You've` is a NON-BREAKING
+ * space (U+00A0, `M-BM- ` under `cat -A`) and the separator is a MIDDLE DOT (U+00B7, `M-BM-7`) — a
+ * pattern written with an ASCII space and an ASCII `-` matches neither. The patterns below therefore
+ * anchor on the WORDS and spell every gap `\s+`, which is what makes them survive both the nbsp and
+ * the tool-result indent; `limit.test.ts` fails the build if a literal space is ever typed into one.
+ * The apostrophe in `You've` really is ASCII (`cat -A` left it alone), and is matched as a character
+ * class anyway so a future curly one does not silently switch the feature off.
+ *
+ * The same sentence also arrives inside a SUBAGENT failure, captured verbatim from the third pane:
+ *
+ * ```
+ *   ● Agent "…" failed: Agent terminated early due to an API error: You've hit your session limit · resets 6:30pm (America/Sao_Paulo)
+ * ```
+ *
+ * That line is matched too, deliberately. The limit belongs to the ACCOUNT, not to the subagent that
+ * happened to reach it first, so the parent's very next request fails the same way — and in the pane
+ * it was read from, both forms were on screen together.
+ *
+ * ## Why the tail and not the frame
+ *
+ * The banner is transcript CONTENT, not chrome. It scrolls with the conversation and stays on screen
+ * long after the session has resumed and done more work — so "the banner appears in the frame" would
+ * pin a working session to `limit-blocked` until the text happened to scroll off. This is the exact
+ * shape of the `esc to interrupt` bug that `MARKER_STALE_MS` exists to correct, met a second time.
+ * `detectLimit` is therefore fed the frame TAIL — the last few meaningful lines, the same ones
+ * `frameTail` already computes for the detail pane — so the banner counts only while it is still the
+ * last thing that happened.
+ *
+ * The tail is also the only answer to the other way this pattern can misfire, and it is not
+ * hypothetical here: agentop is developed with agentop, so a session editing THIS FILE has the
+ * banner's words on its screen as source code. `attention-rules.ts` learned that the hard way with
+ * `Esc to cancel · Tab to amend`. A quotation sits in the middle of a screen; the thing that just
+ * stopped the session sits at the end of it.
+ */
+
+import type { HarnessId } from '@agentistics/core'
+
+/** One harness's limit banner, read from real frames. */
+export interface LimitRule {
+  /** A tail line matching one of these is the harness refusing to continue. */
+  banner: RegExp[]
+  /**
+   * Pulls the reset time out of the banner line.
+   *
+   * Optional because a harness may refuse without saying when it will stop refusing, and inventing a
+   * time would be worse than having none: `limitCleared` treats an unknown reset as "may as well
+   * try", while a wrong one blocks a resume that would have worked.
+   */
+  resetAt?: RegExp
+  /** Provenance — the exact CLI version the frames came from, and the date. */
+  probed: string
+}
+
+/**
+ * `Record<HarnessId, … | null>` and not a `Partial`, exactly as `ATTENTION_RULES` and `SPAWN_SPECS`:
+ * adding a harness must fail the build until someone decides. `null` IS the decision — "never seen
+ * this harness hit a limit" — and the UI reports it as detection being unavailable rather than as
+ * the harness having no limits.
+ */
+export const LIMIT_RULES: Record<HarnessId, LimitRule | null> = {
+  claude: {
+    probed: 'claude 2.1.231, 2026-08-14',
+    banner: [
+      // The tool-result form (`⎿ …`) and the subagent `API error: …` form are the same event
+      // rendered in two places; both were on screen in the captured panes, and this one sentence is
+      // the part they share.
+      /(?:You|you)['’]ve\s+hit\s+your\s+session\s+limit/,
+      // The second line of the banner. Kept even though the first line is almost always in the tail
+      // beside it: `frameTail` cuts at a fixed number of MEANINGFUL lines, so a cut can land between
+      // the two, and a limit read one line late is a row that never clears on its own. It carries no
+      // reset time, which is exactly why the reset is looked up across the whole tail below.
+      /\/upgrade\s+to\s+increase\s+your\s+usage\s+limit/,
+    ],
+    // `resets 6:30pm (America/Sao_Paulo)`. The zone is captured but deliberately NOT used to convert:
+    // see `parseResetAt`.
+    resetAt: /resets\s+(\d{1,2}(?::\d{2})?\s*(?:am|pm))/i,
+  },
+  // Not probed. A limit was never observed on these under agentop, and a pattern nobody has seen a
+  // frame of is a guess — the one thing this file exists to refuse.
+  codex: null,
+  gemini: null,
+  copilot: null,
+  antigravity: null,
+  kimi: null,
+}
+
+/** The rules for a harness, or `undefined` when it was never probed. */
+export function limitRuleFor(harness: HarnessId): LimitRule | undefined {
+  return LIMIT_RULES[harness] ?? undefined
+}
+
+/** What a limit banner said. */
+export interface LimitHit {
+  /** The banner line itself, trimmed — what the UI quotes so the state is never only a colour. */
+  raw: string
+  /**
+   * The reset time as the banner WROTE it (`6:30pm`), not a timestamp.
+   *
+   * Absent when the banner named none, or when the harness has no `resetAt` rule.
+   */
+  resetsAtText?: string
+  /** The same instant in epoch ms, when it could be resolved against `nowMs`. See `parseResetAt`. */
+  resetsAtMs?: number
+}
+
+/**
+ * The banner in a frame tail, or `undefined` — PURE.
+ *
+ * `tail` must be the MEANINGFUL last lines (what `frameTail` returns), never the raw frame — see the
+ * module header.
+ *
+ * **The banner is TWO lines, and the newer one is the one that says nothing.** `/upgrade to increase
+ * your usage limit.` is printed BELOW `You've hit your session limit · resets 6:30pm`, so a
+ * newest-first scan meets it first — and reading the reset off that matched line alone came back with
+ * no reset at all. An absent reset counts as cleared, so every genuinely blocked session would have
+ * read as ready to resume and the mass resume would have burned the new window's first request on all
+ * of them: a bug in the reassuring direction, at the one moment the feature is meant to fire.
+ *
+ * So the line that CARRIES the reset is preferred for both jobs — it is the reset, and it is also the
+ * sentence worth quoting on the row, `/upgrade …` being an instruction to the user rather than a
+ * statement about the session. The bare newest match is only the fallback, for the tail that cut
+ * between the two lines.
+ */
+export function detectLimit(o: {
+  tail: readonly string[]
+  rule?: LimitRule
+  nowMs: number
+}): LimitHit | undefined {
+  const rule = o.rule
+  if (!rule) return undefined
+
+  let newest: string | undefined
+  let withReset: { line: string; text: string } | undefined
+  // Newest first: when a session hit the limit twice, the recent one is the one still in force.
+  for (let i = o.tail.length - 1; i >= 0; i--) {
+    const line = (o.tail[i] ?? '').trim()
+    if (!rule.banner.some(re => re.test(line))) continue
+    if (newest === undefined) newest = line
+    if (withReset === undefined && rule.resetAt) {
+      const found = rule.resetAt.exec(line)?.[1]
+      if (found) withReset = { line, text: found.trim() }
+    }
+    if (newest !== undefined && withReset !== undefined) break
+  }
+
+  if (newest === undefined) return undefined
+  const hit: LimitHit = { raw: withReset?.line ?? newest }
+  if (withReset) {
+    hit.resetsAtText = withReset.text
+    const ms = parseResetAt(withReset.text, o.nowMs)
+    if (ms !== undefined) hit.resetsAtMs = ms
+  }
+  return hit
+}
+
+/**
+ * Half a day, and the whole of the calendar rule below.
+ *
+ * A banner names a wall-clock time and no date, so `6:30pm` describes three instants — yesterday's,
+ * today's and tomorrow's. The one it means is the one NEAREST the moment it is being read, which is
+ * the same thing as saying it lands within twelve hours either side of now.
+ */
+export const HALF_DAY_MS = 12 * 60 * 60 * 1000
+
+const DAY_MS = 24 * 60 * 60 * 1000
+
+/**
+ * `6:30pm` against a reference instant → epoch ms, in the LOCAL clock — PURE.
+ *
+ * Two decisions here are deliberate:
+ *
+ *  - **The banner's zone is ignored.** It names the zone the HARNESS is reporting in, and agentop
+ *    runs on the same machine as the session that printed it, so the local clock already agrees.
+ *    Converting a wall-clock time into a zone with no date is arithmetic that goes wrong twice a year
+ *    and buys nothing here — and getting it wrong pushes the reset into the future, which is the
+ *    direction that leaves the whole fleet parked.
+ *  - **The nearest reading of the clock wins, in BOTH directions.** A time that already passed today
+ *    is TODAY's, never tomorrow's: a limit that reset at 18:30 and is read at 18:37 is over, and
+ *    rolling it forward 24 hours would be the single worst answer this function can give, since it
+ *    describes the exact moment the feature is supposed to fire. The mirror case is just as real and
+ *    was missing — a banner printed at 23:50 saying `resets 1:00am` means the 1am AN HOUR AWAY, and
+ *    reading it as today's 1am puts the reset 23 hours in the PAST, which reports a hard-blocked
+ *    session as free to resume. Both are the same rule: take the candidate within half a day of now.
+ */
+export function parseResetAt(text: string, nowMs: number): number | undefined {
+  const m = /^(\d{1,2})(?::(\d{2}))?\s*(am|pm)$/i.exec(text.trim())
+  if (!m) return undefined
+  const rawHour = Number(m[1])
+  const minute = m[2] ? Number(m[2]) : 0
+  if (rawHour < 1 || rawHour > 12 || minute > 59) return undefined
+  const pm = (m[3] ?? '').toLowerCase() === 'pm'
+  const hour = rawHour === 12 ? (pm ? 12 : 0) : pm ? rawHour + 12 : rawHour
+
+  const at = new Date(nowMs)
+  at.setHours(hour, minute, 0, 0)
+  let ms = at.getTime()
+  // More than half a day ahead means the banner belongs to YESTERDAY's reading of this clock; more
+  // than half a day behind means TOMORROW's. Anything in between — including a time already past by
+  // minutes, which is the case the whole feature turns on — is today's.
+  if (ms - nowMs > HALF_DAY_MS) ms -= DAY_MS
+  else if (nowMs - ms > HALF_DAY_MS) ms += DAY_MS
+  return ms
+}
+
+/**
+ * Whether the window this hit describes is OVER — PURE.
+ *
+ * An unknown reset counts as over. The alternative is a row nothing can ever clear, and the cost of
+ * being wrong is one wasted prompt against the cost of a session parked forever.
+ */
+export function limitCleared(hit: LimitHit | undefined, nowMs: number): boolean {
+  if (!hit) return true
+  if (hit.resetsAtMs === undefined) return true
+  return nowMs >= hit.resetsAtMs
+}


### PR DESCRIPTION
Spec item **2** of `docs/specs/2026-08-14-session-limit-and-fleet-hygiene.md` — the original ask, and
the thing that stops the fleet parking itself again.

An initial `limit.ts` existed on the spec branch **without tests**. This is that module reviewed
against the live panes it was written from, corrected, and pinned.

## Why it is its own module and not another approval rule

A session that stopped because the harness cut it off is **not blocked on a person, it is blocked on
a clock**. `waiting-approval` is the wrong shape: a keystroke does not move it, and a `continue` sent
before the reset burns the first request of the new window on a prompt whose only content is the word
continue — the harness answers it with the same error. So the banner is only half of what this reads;
the other half is the **reset time** it carries.

## The pattern was captured, never remembered

Read from three live panes on 2026-08-14 (claude 2.1.231) and re-read through `cat -A`:

```
  M-bM-^NM-? M-BM- You've hit your session limit M-BM-7 resets 6:30pm (America/Sao_Paulo)
     /upgrade to increase your usage limit.
```

`M-BM- ` is **U+00A0**, a non-breaking space before `You've`. `M-BM-7` is **U+00B7**, a middle dot —
not a hyphen and not an asterisk. So the rules anchor on the WORDS and spell every gap `\s+`. Two
tests defend that: one asserts the fixture still carries both bytes (an ASCII cleanup would otherwise
leave the rules passing while matching nothing on a real screen), and one asserts **no pattern in
`LIMIT_RULES` contains a literal space**.

The subagent form is matched too — `Agent … terminated early due to an API error: You've hit your
session limit · resets 6:30pm` — because the limit belongs to the ACCOUNT, not to the agent that
reached it first.

## Two defects found in the initial cut, both failing in the reassuring direction

1. **The banner is two lines and the newer one says nothing.** `/upgrade to increase your usage
   limit.` sits *below* the sentence carrying `resets 6:30pm`, so a newest-first scan met it first,
   and reading the reset off that same matched line yielded none. An unknown reset counts as cleared
   — so every genuinely blocked session read as free to resume, and a mass resume would have burned
   the new window's first request on all of them. The line that carries the reset is now preferred
   for both jobs, since it is also the sentence worth quoting on a row.
2. **`parseResetAt` only ever rolled the clock backward.** A banner printed at 23:50 saying
   `resets 1:00am` means the 1am an hour away; read as today's it lands 23 hours in the past, and a
   hard-blocked session reports itself free. Both directions are one rule — the candidate within half
   a day of now — so the forward roll was simply missing. The acceptance case is pinned: **18:30 read
   at 18:37 is TODAY and over**, never tomorrow, because that is the exact instant the feature is
   supposed to fire.

## Reading discipline

Pure, and fed the frame **TAIL**, never the whole frame. The banner is transcript content and stays
on screen long after the session resumed — that is the `esc to interrupt` bug `MARKER_STALE_MS`
exists to correct, met a second time. It is also the only defence against this repository's own
sessions, which have these exact words on screen as source code all day.

`Record<HarnessId, LimitRule | null>`, claude only. The other five are `null` — "never seen one",
not "has no limits" — because a pattern nobody has a frame of is a guess.

## Scope

Detection only. Nothing is wired to it yet: the `limit-blocked` state, the row marking and the mass
resume (spec §1.1–1.4) follow in their own PRs.

## Verification

`bun tsc --noEmit` clean · `bun test` **3940 pass, 0 fail** (25 of them new) · rebased onto
`origin/dev` after #126/#127/#128.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sw2w1GAZRB5SE4Xp1qcpCQ