### PR TITLE
feat(sessions): the highlight survives, gets its own band, and the keys stop lying

### DIFF
--- a/packages/server/server/cli-i18n.ts
+++ b/packages/server/server/cli-i18n.ts
@@ -648,14 +648,18 @@ const PT: CliStrings = {
   sessState: {
     working: 'trabalhando',
     waitingApproval: 'precisa de aprovação',
-    waiting: 'aguardando',
+    // "aguardando" alone does not say aguardando WHAT, and the state next to it is
+    // `waitingApproval` — with both spelled out the pair reads as the distinction it is. English
+    // keeps `waiting`: there it is already the intransitive answer, and "waiting for a reply" would
+    // be longer without saying more.
+    waiting: 'aguardando resposta',
     exited: 'encerrada',
     lost: 'perdida',
     external: 'externa',
     closed: 'fechada',
   },
   sessApprovalBlind: (harness: string) =>
-    `o agentop não tem marcadores de tela verificados para ${harness}, então uma pergunta bloqueante aqui aparece como "aguardando", como qualquer outra pausa.`,
+    `o agentop não tem marcadores de tela verificados para ${harness}, então uma pergunta bloqueante aqui aparece como "aguardando resposta", como qualquer outra pausa.`,
   sessDirGone: 'este diretório não existe mais — provavelmente uma worktree removida. Reabrir não vai funcionar enquanto ele não voltar.',
   sessConversationBlind: (harness: string) =>
     `o ${harness} nunca informa qual conversa uma sessão iniciada por ele está escrevendo, então o agentop não consegue registrar o vínculo — o que for oferecido para reabrir aqui é inferido pelo diretório.`,
@@ -733,7 +737,7 @@ const PT: CliStrings = {
     waiting: (n: number, names: string) =>
       `${n} ${n === 1 ? 'sessão esperando' : 'sessões esperando'} por você: ${names}`,
     blind: (harnesses: string) =>
-      `Detecção de aprovação não está disponível para: ${harnesses} — essas sessões aparecem como "aguardando" de qualquer jeito.`,
+      `Detecção de aprovação não está disponível para: ${harnesses} — essas sessões aparecem como "aguardando resposta" de qualquer jeito.`,
   },
 
   dockerMissing: 'docker não instalado',

--- a/packages/tui/src/control/i18n.ts
+++ b/packages/tui/src/control/i18n.ts
@@ -272,7 +272,7 @@ export interface ControlStrings {
     move: string; open: string; attach: string; menu: string; section: string
     newSession: string; search: string; clear: string; kill: string; rename: string
     note: string; task: string; mark: string; onlyActive: string; closed: string
-    exited: string; unfiled: string; group: string; detail: string; menuFold: string
+    exited: string; group: string; layout: string; detail: string; menuFold: string
     reset: string
     tabs: string; help: string; quit: string
     approve: string; prompt: string; reopenFell: string
@@ -711,7 +711,7 @@ const EN: ControlStrings = {
     onlyActive: 'show only what is running',
     closed: 'show closed conversations',
     exited: 'show sessions that ended',
-    unfiled: 'show sessions under no task',
+    layout: 'list or cards',
     group: 'change the grouping',
     detail: 'hide the detail pane',
     menuFold: 'fold the menu away — any digit brings it back',
@@ -761,7 +761,7 @@ const EN: ControlStrings = {
   sessionsShowing: (shown, total) => `${shown} of ${total}`,
   sessionsCardAttached: 'attached',
   sessionsCardBlind: 'approval unknown',
-  keySessionsLayout: 'f list/cards',
+  keySessionsLayout: 'ctrl+g list/cards',
   keySessionsCard: '←→ card',
   keySessionsPage: 'pgup/pgdn page',
   asideSort: 'ORDER',
@@ -794,7 +794,7 @@ const EN: ControlStrings = {
   keySessionsRename: 'n name',
   keySessionsNote: 't note',
   keySessionsNew: 'a new',
-  keySessionsSearch: '/ search',
+  keySessionsSearch: 'ctrl+f search',
   keySessionsActions: 'tab actions',
   keySessionsApprove: 'y approve',
   keySessionsPrompt: 'p send',
@@ -1119,7 +1119,7 @@ const PT: ControlStrings = {
     onlyActive: 'mostra só o que está rodando',
     closed: 'mostra conversas fechadas',
     exited: 'mostra sessões encerradas',
-    unfiled: 'mostra sessões sem tarefa',
+    layout: 'lista ou cards',
     group: 'muda o agrupamento',
     detail: 'oculta o painel de detalhe',
     menuFold: 'recolhe o menu — qualquer dígito traz de volta',
@@ -1168,7 +1168,7 @@ const PT: ControlStrings = {
   sessionsShowing: (shown, total) => `${shown} de ${total}`,
   sessionsCardAttached: 'anexada',
   sessionsCardBlind: 'aprovação incerta',
-  keySessionsLayout: 'f lista/cards',
+  keySessionsLayout: 'ctrl+g lista/cards',
   keySessionsCard: '←→ card',
   keySessionsPage: 'pgup/pgdn página',
   asideSort: 'ORDENAR',
@@ -1178,7 +1178,11 @@ const PT: ControlStrings = {
   },
   sessionsStates: {
     'waiting-approval': 'precisa aprovação',
-    waiting: 'aguardando',
+    // The same word the state COLUMN shows (`cli-i18n.ts`'s `sessState.waiting`). Two tables of one
+    // vocabulary, and the sessions screen draws from both at once — the column from the host, the
+    // band heading and the filter row from here. They have to say the same thing or the row reads
+    // `aguardando resposta` under a band called `aguardando`.
+    waiting: 'aguardando resposta',
     working: 'trabalhando',
     exited: 'encerrada',
     lost: 'perdida',
@@ -1201,7 +1205,7 @@ const PT: ControlStrings = {
   keySessionsRename: 'n nomear',
   keySessionsNote: 't nota',
   keySessionsNew: 'a nova',
-  keySessionsSearch: '/ buscar',
+  keySessionsSearch: 'ctrl+f buscar',
   keySessionsActions: 'tab ações',
   keySessionsApprove: 'y aprovar',
   keySessionsPrompt: 'p enviar',

--- a/packages/tui/src/control/session-dimensions.test.ts
+++ b/packages/tui/src/control/session-dimensions.test.ts
@@ -20,7 +20,7 @@ import {
   toggleValue,
   type SessionDimensionId,
 } from './session-dimensions'
-import { groupSessions } from './sessions'
+import { groupSessions, sessionRows } from './sessions'
 import type { ControlSession, SessionState } from './types'
 
 const session = (id: string, over: Partial<ControlSession> = {}): ControlSession => ({
@@ -293,22 +293,123 @@ describe('migrateSessionFilters', () => {
 
 describe('storedFilters', () => {
   it('round-trips every dimension, empty selections included', () => {
-    const state = { filters: { status: ['closed'], task: [UNFILED] }, showNamed: true }
+    const state = { filters: { status: ['closed'], task: [UNFILED] }, showNamed: true, marked: ['a'] }
     expect(migrateSessionFilters(storedFilters(state))).toEqual(state)
+  })
+
+  it('round-trips the MARKS, and the empty set is a value', () => {
+    // The reported bug: the component wrote `...(marked.size > 0 ? { marked: [...marked] } : {})`,
+    // so unmarking everything removed the key rather than writing an empty list — and the next
+    // restore read absence, fell back, and resurrected the marks that had just been cleared. A
+    // conditional spread cannot express "the answer is nothing", which is why this seam always
+    // writes the field.
+    const withMarks = { filters: { status: ['closed'] }, showNamed: false, marked: ['a', 'b'] }
+    expect(migrateSessionFilters(storedFilters(withMarks)).marked).toEqual(['a', 'b'])
+
+    const cleared = { ...withMarks, marked: [] }
+    const stored = storedFilters(cleared)
+    expect(stored.marked).toEqual([])
+    expect(migrateSessionFilters(stored).marked).toEqual([])
+
+    // And the clearing SURVIVES a second trip, which is where the old bug actually bit: the first
+    // write looked fine and the read after it brought the old marks back.
+    expect(migrateSessionFilters(storedFilters(migrateSessionFilters(stored))).marked).toEqual([])
+  })
+
+  it('reads absence as no marks, never as not-loaded', () => {
+    expect(migrateSessionFilters({}).marked).toEqual([])
+    expect(migrateSessionFilters(undefined).marked).toEqual([])
   })
 
   it('writes the legacy switches so an older binary still comes up filtered', () => {
     // Derived on write and never read back except by the migration — same pattern, and the same
     // reason, as `deniedRepos` in the sharing rules. A downgrade must not lift every filter.
-    const stored = storedFilters({ filters: { status: [...ACTIVE_STATES] }, showNamed: false })
+    const stored = storedFilters({ filters: { status: [...ACTIVE_STATES] }, showNamed: false, marked: [] })
     expect(stored.onlyActive).toBe(true)
     expect(stored.showClosed).toBe(false)
     expect(stored.showExited).toBe(false)
     expect(stored.states).toEqual([...ACTIVE_STATES])
 
-    const wide = storedFilters({ filters: { status: [...SESSION_STATES] }, showNamed: false })
+    const wide = storedFilters({ filters: { status: [...SESSION_STATES] }, showNamed: false, marked: [] })
     expect(wide.onlyActive).toBe(false)
     expect(wide.showClosed).toBe(true)
     expect(wide.showExited).toBe(true)
+  })
+})
+
+describe('the marked band', () => {
+  const band = (grouping: 'none' | SessionDimensionId, ids: string[]) => sessionRows(
+    groupSessions(FLEET, grouping, WORDS, [], undefined, CTX),
+    'closed', 'finished', undefined,
+    ids.length > 0 ? { ids: new Set(ids), label: 'marked' } : undefined,
+  )
+  const sessionsUnder = (rows: ReturnType<typeof band>, heading: string) => {
+    const at = rows.findIndex(r => r.kind === 'heading' && r.label === heading)
+    if (at < 0) return null
+    const out: string[] = []
+    for (let i = at + 1; i < rows.length; i++) {
+      const r = rows[i]!
+      if (r.kind !== 'session') break
+      out.push(r.session.id)
+    }
+    return out.sort()
+  }
+
+  it('leads the list, whatever the arrangement', () => {
+    // Marking is the user's and outranks the grouping — `none` included, which is the case a band
+    // built inside a group could not have covered.
+    for (const grouping of ['none', ...DIMENSION_ORDER] as const) {
+      const rows = band(grouping, ['a', 'g'])
+      const first = rows.find(r => r.kind === 'heading')
+      expect(first).toMatchObject({ label: 'marked', count: 2 })
+      expect(sessionsUnder(rows, 'marked')).toEqual(['a', 'g'])
+    }
+  })
+
+  it('puts a marked row in the band and NOWHERE ELSE', () => {
+    // The whole point. The same session in two places is the reason someone was hunting for it in
+    // the first place, and a band that merely COPIES the rows makes the list longer and no easier.
+    for (const grouping of ['none', ...DIMENSION_ORDER] as const) {
+      const rows = band(grouping, ['a', 'g'])
+      const appearances = rows.filter(r => r.kind === 'session' && (r.session.id === 'a' || r.session.id === 'g'))
+      expect(appearances).toHaveLength(2)
+      // And nothing else was dropped on the way.
+      expect(rows.filter(r => r.kind === 'session')).toHaveLength(FLEET.length)
+    }
+  })
+
+  it('takes a marked row out of HISTORY too, not just out of the live block', () => {
+    // `c` is closed and `e` is lost. Both would otherwise sit under the history heading, which is
+    // exactly where a marked row is hardest to find.
+    const rows = band('project', ['c', 'e'])
+    expect(sessionsUnder(rows, 'marked')).toEqual(['c', 'e'])
+    // A history band still exists — `d` is exited and unmarked — so the assertion is about WHERE
+    // the marked two ended up, not about the band being gone.
+    const closedHeadings = rows
+      .map((r, i) => (r.kind === 'heading' && r.label.includes('closed') ? i : -1))
+      .filter(i => i >= 0)
+    expect(closedHeadings.length).toBeGreaterThan(0)
+    for (const at of closedHeadings) {
+      for (let i = at + 1; i < rows.length; i++) {
+        const r = rows[i]!
+        if (r.kind !== 'session') break
+        expect(['c', 'e']).not.toContain(r.session.id)
+      }
+    }
+  })
+
+  it('does not exist at all when nothing is marked', () => {
+    // Not an empty band — no band. A heading with no rows under it is a box with a name in it.
+    const rows = band('project', [])
+    expect(rows.some(r => r.kind === 'heading' && r.label === 'marked')).toBe(false)
+    expect(rows.filter(r => r.kind === 'session')).toHaveLength(FLEET.length)
+  })
+
+  it('leaves a group EMPTIED by the band drawing nothing, rather than a bare heading', () => {
+    // `f` is the only session in project `solo`; marking it must not leave `solo` standing with a
+    // count of zero.
+    const rows = band('project', ['f'])
+    expect(rows.some(r => r.kind === 'heading' && r.label === 'solo')).toBe(false)
+    expect(sessionsUnder(rows, 'marked')).toEqual(['f'])
   })
 })

--- a/packages/tui/src/control/session-dimensions.ts
+++ b/packages/tui/src/control/session-dimensions.ts
@@ -392,6 +392,19 @@ export const FILTERS_VERSION = 2
 export interface SessionFilterState {
   filters: SessionFilters
   showNamed: boolean
+  /**
+   * The session ids the user MARKED, so a row can be found again without searching for it.
+   *
+   * Persisted here with the filters rather than beside them, because the bug it fixes was exactly a
+   * hand-written persist: the component wrote `...(marked.size > 0 ? { marked: [...marked] } : {})`,
+   * so UNMARKING EVERYTHING removed the key instead of writing an empty list — and the next restore
+   * read absence, fell back to whatever was stored before, and resurrected marks the user had just
+   * cleared. A conditional spread cannot express "the answer is nothing".
+   *
+   * So this is always written and always read, and the empty set is a value. `session-dimensions.
+   * test.ts` round-trips it INCLUDING empty, which is the case that was broken.
+   */
+  marked: string[]
 }
 
 /**
@@ -412,6 +425,14 @@ export const DEFAULT_FILTERS: SessionFilters = { status: [...ACTIVE_STATES] }
  * did not name, and the screen said "only active" over 62 of 65 sessions.
  */
 export const DEFAULT_SHOW_NAMED = false
+
+/**
+ * Nothing is marked on a machine that has never chosen — an empty LIST, never `undefined`.
+ *
+ * Stated here so absence has one meaning. It is the half of the round-trip that was missing: with
+ * no default, "no marks" and "not loaded yet" were the same value.
+ */
+export const DEFAULT_MARKED: string[] = []
 
 const knownStates = (values: readonly string[]): string[] =>
   values.filter(v => (SESSION_STATES as readonly string[]).includes(v))
@@ -439,6 +460,7 @@ export function migrateSessionFilters(
 ): SessionFilterState {
   const p = prefs ?? {}
   const showNamed = p.showNamed ?? DEFAULT_SHOW_NAMED
+  const marked = [...(p.marked ?? DEFAULT_MARKED)]
 
   if (p.filtersVersion === FILTERS_VERSION && p.filters) {
     const filters: SessionFilters = {}
@@ -450,18 +472,18 @@ export function migrateSessionFilters(
     // A status selection that survived nothing recognisable is not a filter, it is a list that shows
     // nothing — and the never-empty rule applies to a file just as it applies to a keypress.
     if (!filters.status || filters.status.length === 0) filters.status = [...ACTIVE_STATES]
-    return { filters, showNamed }
+    return { filters, showNamed, marked }
   }
 
   // Absent switches read as the default arrangement's own answer: only active. Stated as a literal
   // here rather than read off `DEFAULT_SESSION_VIEW`, which is now DERIVED from this module and
   // cannot be imported back without a value cycle.
-  if (p.onlyActive ?? true) return { filters: { status: [...ACTIVE_STATES] }, showNamed }
+  if (p.onlyActive ?? true) return { filters: { status: [...ACTIVE_STATES] }, showNamed, marked }
 
   const status = [...ACTIVE_STATES]
   if (p.showClosed) status.push('closed')
   if (p.showExited) status.push('exited', 'lost')
-  return { filters: { status }, showNamed }
+  return { filters: { status }, showNamed, marked }
 }
 
 /**
@@ -482,6 +504,8 @@ export function storedFilters(state: SessionFilterState): Partial<SessionViewPre
     filtersVersion: FILTERS_VERSION,
     filters,
     showNamed: state.showNamed,
+    // ALWAYS written, empty list included — see `SessionFilterState.marked`.
+    marked: [...state.marked],
     states: [...status],
     onlyActive: shortcutOn(status, 'active'),
     showClosed: shortcutOn(status, 'closed'),

--- a/packages/tui/src/control/sessions.test.ts
+++ b/packages/tui/src/control/sessions.test.ts
@@ -15,6 +15,7 @@ import {
   type CardBand, type CardLine, type SessionRow,
   dimensionWordBook,
   GROUPINGS,
+  CLOSE_CELL,
 } from './sessions'
 import type { ControlSession, SessionState } from './types'
 import { PANE_FRAME_Y } from './chrome.ts'
@@ -1299,7 +1300,7 @@ describe('sessionAge', () => {
 describe('sessionKeyHelp', () => {
   const words = Object.fromEntries(
     ['move', 'open', 'attach', 'menu', 'section', 'newSession', 'search', 'clear', 'kill',
-      'rename', 'note', 'task', 'mark', 'onlyActive', 'closed', 'exited', 'unfiled', 'group',
+      'rename', 'note', 'task', 'mark', 'onlyActive', 'closed', 'exited', 'group', 'layout',
       'detail', 'menuFold', 'reset', 'tabs', 'help', 'quit',
       'approve', 'prompt', 'reopenFell'].map(k => [k, `does ${k}`]),
   ) as Parameters<typeof sessionKeyHelp>[0]
@@ -2391,14 +2392,24 @@ describe('the per-row close control', () => {
     expect(canClose(session('d', { state: 'unknown' as SessionState, actionable: false }))).toBe(false)
   })
 
+  it('is measurable ASCII, because this package counts code units and not columns', () => {
+    // `truncate` counts `s.length` — UTF-16 code UNITS — and nothing here measures display width.
+    // A wastebasket is a surrogate pair (`.length === 2`) whose column width is 1 or 2 depending on
+    // the terminal, so it cannot be reserved correctly; the reservation would be wrong by one and
+    // shear every row under it. Bracketed ASCII is three of each.
+    expect(CLOSE_CELL).toBe('[x]')
+    expect([...CLOSE_CELL].length).toBe(CLOSE_CELL.length)
+    expect(CLOSE_CELL.codePointAt(0)!).toBeLessThan(128)
+  })
+
   it('costs nothing when nothing on screen can be closed', () => {
     expect(closeCellWidth([closed, gone], 120)).toBe(0)
-    expect(closeCellWidth([live], 120)).toBe(2)
+    expect(closeCellWidth([live], 120)).toBe(CLOSE_CELL.length + 1)
   })
 
   it('gives up on a narrow list rather than squeezing the table for a button', () => {
     // The keyboard's `x` still works there, and a table squeezed to make room is the worse trade.
     expect(closeCellWidth([live], 30)).toBe(0)
-    expect(closeCellWidth([live], 40)).toBe(2)
+    expect(closeCellWidth([live], 40)).toBe(CLOSE_CELL.length + 1)
   })
 })

--- a/packages/tui/src/control/sessions.ts
+++ b/packages/tui/src/control/sessions.ts
@@ -21,7 +21,8 @@ import type { ControlSession, SessionState } from './types'
 // rest of the control center imports from, and moving a name is not a reason to touch nine files.
 export {
   ACTIVE_STATES, SESSION_STATES, SESSION_DIMENSIONS, DIMENSION_ORDER, GROUPINGS, UNFILED,
-  GONE_PROJECT_KEY, FILTERS_VERSION, DEFAULT_FILTERS, DEFAULT_SHOW_NAMED, SHORTCUT_STATES,
+  GONE_PROJECT_KEY, FILTERS_VERSION, DEFAULT_FILTERS, DEFAULT_MARKED, DEFAULT_SHOW_NAMED,
+  SHORTCUT_STATES,
   applyShortcut, bucketKey, dimensionValueLabel, dimensionWordBook, migrateSessionFilters,
   sessionKept, sessionNamed,
   sessionRunning, shortcutOn, storedFilters, toggleValue,
@@ -250,8 +251,28 @@ export function sessionRows(
    * the reading order, never a change to which rows are listed.
    */
   fellLabel?: string,
+  /**
+   * The rows the user MARKED, and what to call their band.
+   *
+   * Marking a row exists for exactly one purpose — finding it again — and a glyph on a line that
+   * stays wherever the ordering left it does not serve it. So marked rows become a BAND AT THE TOP,
+   * in the same shape as every other band here.
+   *
+   * Three rules, and the third is the one that makes the feature work:
+   *  - the band is absent when nothing is marked (a band with a title and no rows is a box with a
+   *    name in it);
+   *  - it applies under EVERY arrangement, `none` included — marking is the user's, and it outranks
+   *    the grouping;
+   *  - a marked row appears in the band and NOWHERE ELSE. The same session in two places is the
+   *    reason someone was hunting for it.
+   *
+   * It lives here rather than in a component because `cardPages` walks these very rows: the card
+   * grid gets the band for free, and cannot disagree with the list about which group a row is in.
+   */
+  marked?: { ids: ReadonlySet<string>; label: string },
 ): SessionRow[] {
   const out: SessionRow[] = []
+  const isMarked = (s: ControlSession) => marked?.ids.has(s.id) ?? false
 
   const push = (label: string, sessions: readonly ControlSession[], muted?: boolean) => {
     if (sessions.length === 0) return
@@ -273,10 +294,21 @@ export function sessionRows(
   const hasFell = Boolean(fellLabel)
   const isFell = (s: ControlSession) => hasFell && s.fell === true && !isLive(s)
 
+  // The marked band leads, drawn from every group so a mark outranks the arrangement. It is ONE
+  // band rather than the live/fell/closed split the groups get: a marked conversation that is over
+  // is still the one you marked, and filing it under history is putting it back where it was hard
+  // to find.
+  if (marked) {
+    push(marked.label, groups.flatMap(g => g.sessions.filter(isMarked)))
+  }
+
   for (const g of groups) {
-    const live = g.sessions.filter(isLive)
-    const fell = g.sessions.filter(isFell)
-    const closed = g.sessions.filter(s => !isLive(s) && !isFell(s))
+    // Everything the band above took is gone from here — the same row twice is the bug, not the
+    // feature. A group left empty by this simply draws nothing: `push` skips it.
+    const rest = g.sessions.filter(s => !isMarked(s))
+    const live = rest.filter(isLive)
+    const fell = rest.filter(isFell)
+    const closed = rest.filter(s => !isLive(s) && !isFell(s))
     // An empty KEY is an absence ("no task"), not a category, and is drawn as one. A FINISHED task
     // says so in its heading and is muted with it: the sessions are still listed and still
     // attachable, so the screen must say why they are set apart rather than merely dimming them.
@@ -1762,7 +1794,7 @@ export function sessionKeyHelp(w: {
   move: string; open: string; attach: string; menu: string; section: string
   newSession: string; search: string; clear: string; kill: string; rename: string
   note: string; task: string; mark: string; onlyActive: string; closed: string
-  exited: string; unfiled: string; group: string; detail: string; menuFold: string
+  exited: string; group: string; layout: string; detail: string; menuFold: string
   reset: string; tabs: string; help: string; quit: string
   approve: string; prompt: string; reopenFell: string
 }): KeyHelp[] {
@@ -1778,7 +1810,7 @@ export function sessionKeyHelp(w: {
     { keys: 'tab', what: w.open },
     { keys: '1-9 / ← →', what: w.section },
     { keys: 'a', what: w.newSession },
-    { keys: '/', what: w.search },
+    { keys: 'ctrl+f', what: w.search },
     { keys: 'esc', what: w.clear },
     { keys: 'x', what: w.kill },
     { keys: 'n', what: w.rename },
@@ -1787,8 +1819,8 @@ export function sessionKeyHelp(w: {
     { keys: 'ctrl+a / l', what: w.onlyActive },
     { keys: 'c', what: w.closed },
     { keys: 'e', what: w.exited },
-    { keys: 'u', what: w.unfiled },
     { keys: 'v', what: w.group },
+    { keys: 'ctrl+g', what: w.layout },
     { keys: 'd', what: w.detail },
     // `b` leads: `ctrl+b` is tmux's default prefix, so inside a tmux the chord never reaches this
     // app at all. The plain letter is the one that always works, and the one the footer names.
@@ -2480,15 +2512,30 @@ export function pagerHit(cells: PagerCells, x: number): 'prev' | 'next' | null {
 // closing a session from its own row
 // ---------------------------------------------------------------------------
 
-/** The glyph that closes a session from its own row. */
-export const CLOSE_CELL = '✕'
+/**
+ * The control that closes a session from its own row.
+ *
+ * A bare `✕` at the end of a table reads as a TRUNCATION mark, not as a verb — which is what it was
+ * reported as. A wastebasket would say it plainly, and it is what the design asked for, but it
+ * cannot be measured here: `truncate` counts `s.length`, which is UTF-16 code UNITS, and there is no
+ * width dependency anywhere in this package. `🗑` is a surrogate pair, so `.length` is 2, while its
+ * DISPLAY width is 1 or 2 depending on the terminal and on whether it is given emoji presentation.
+ * Neither number is reliably the other, and a glyph whose measure is wrong by one shears every row
+ * under it.
+ *
+ * So it is bracketed ASCII: three characters, `.length === 3`, three columns, on every terminal.
+ * The design named this trade itself — a pretty glyph that shears the table is worse than a plain
+ * one that does not. Revisit it the day this package measures display width.
+ */
+export const CLOSE_CELL = '[x]'
 
 /**
  * Columns reserved at the right edge of the list for the per-row close control — PURE.
  *
- * Two: a gap and the glyph. Reserved from the width BEFORE the columns are measured, because a
- * control drawn after a table that already spent the full width is a control drawn on top of the
- * last cell.
+ * A gap plus the control itself, DERIVED from `CLOSE_CELL` rather than written as a number beside
+ * it: the two were `'✕'` and `2`, and changing the glyph without changing the reservation is how a
+ * control ends up drawn on top of the last cell. Reserved from the width BEFORE the columns are
+ * measured, for the same reason.
  *
  * Zero when nothing on screen can be closed, and zero on a list too narrow to spare it — the
  * keyboard's `x` still works there, and a table squeezed to make room for a button is a worse
@@ -2496,7 +2543,7 @@ export const CLOSE_CELL = '✕'
  */
 export function closeCellWidth(rows: readonly ControlSession[], width: number): number {
   const NEEDS = 40
-  return width >= NEEDS && rows.some(canClose) ? 2 : 0
+  return width >= NEEDS && rows.some(canClose) ? CLOSE_CELL.length + 1 : 0
 }
 
 /**

--- a/packages/tui/src/control/tabs/Sessions.tsx
+++ b/packages/tui/src/control/tabs/Sessions.tsx
@@ -73,6 +73,7 @@ import {
   type AsideRow, type OfferedAction, type SessionColumns, type SessionToggle,
   type DetailLine, type SessionAction, type SessionGrouping, type SessionRow,
   applyShortcut,
+  DEFAULT_MARKED,
   migrateSessionFilters,
   sessionKept,
   shortcutOn,
@@ -265,7 +266,9 @@ export function Sessions({
    * Kept by session id rather than by position, because the list re-sorts under it every five
    * seconds: a mark that meant "the third row" would be on someone else's session by the next poll.
    */
-  const [marked, setMarked] = useState<ReadonlySet<string>>(new Set(view?.marked ?? []))
+  const [marked, setMarked] = useState<ReadonlySet<string>>(
+    () => new Set(migrateSessionFilters(view).marked),
+  )
   /**
    * Whether the menu is folded away entirely, for when the list is what you came to read.
    *
@@ -334,9 +337,11 @@ export function Sessions({
     // The heading is passed only when something ACTUALLY fell. `sessionRows` treats an absent word
     // as "there is no such section", so on an ordinary machine the reading order is unchanged
     // rather than carrying an empty block that exists to say nothing.
-  ), s.sessionsClosedWord, s.sessionsDoneWord, fleet?.fell ? s.sessionsFellWord : undefined), [
+  ), s.sessionsClosedWord, s.sessionsDoneWord, fleet?.fell ? s.sessionsFellWord : undefined,
+     // Absent when nothing is marked, so the band is not merely empty — it does not exist.
+     marked.size > 0 ? { ids: marked, label: s.sessionsMarkedBand } : undefined), [
     fleet?.sessions, fleet?.finishedTasks, fleet?.fell, done, grouping, query, filters, showNamed,
-    showDone, taskFilter, dimensionCtx, order, words,
+    showDone, taskFilter, dimensionCtx, order, words, marked,
   ])
 
   const selectable = useMemo(() => selectableIndexes(rows), [rows])
@@ -735,7 +740,7 @@ export function Sessions({
     setOrder(DEFAULT_ORDER)
     setHideDetail(false)
     setLayout(DEFAULT_SESSION_VIEW.layout ?? 'list')
-    setMarked(new Set())
+    setMarked(new Set(DEFAULT_MARKED))
     setQuery('')
     setCursor(0)
   }, [])
@@ -888,7 +893,11 @@ export function Sessions({
     if (input === 'e') { pressShortcut('exited'); return }
     if (input === 'l') { pressShortcut('active'); return }
     if (input === 'd') { setHideDetail(v => !v); return }
-    if (input === 'f') { setLayout(l => (l === 'list' ? 'cards' : 'list')); return }
+    // `ctrl+g` for the GRID, not `g`: `g` is "top of the list" two lines down and in
+    // `resolveListKey`'s menus, and a key answered by the screen AND by the list does two things at
+    // once. `v` — the design's fallback — is already the grouping picker. The chord keeps the
+    // mnemonic, collides with nothing, and pairs with `ctrl+f` beside it.
+    if (key.ctrl && input === 'g') { setLayout(l => (l === 'list' ? 'cards' : 'list')); return }
     // The HIGHLIGHTER. `space` because it is the mark key of every list that has one, and because
     // it is the only unclaimed key on this screen that a person reaches for without being told.
     if (input === ' ') {
@@ -909,7 +918,9 @@ export function Sessions({
     // the menu, which is what made every other verb reachable, and the cost of that was three
     // keystrokes for the thing this screen is most often opened to do.
     if (input === 'o') return runAction('attach')
-    if (input === '/') return runAction('search')
+    // `ctrl+f` is what people already type for find; `/` stays as an alias for the vi hands, and is
+    // deliberately not in the key help — the footer names ONE key per verb or it stops being read.
+    if ((key.ctrl && input === 'f') || input === '/') return runAction('search')
     // `k` is deliberately NOT the kill key — it is `up` in this list, and a key that moves the
     // cursor on one screen and destroys work on another is the shape of a real accident.
     if (input === 'x') return runAction('kill')
@@ -973,12 +984,15 @@ export function Sessions({
     const restoredFilters = migrateSessionFilters(view)
     setFilters(restoredFilters.filters)
     setShowNamed(restoredFilters.showNamed)
+    // Through the SAME seam, so "nothing is marked" is a value the restore can carry. It used to be
+    // read straight off `view.marked`, whose absence the persist below could not tell apart from an
+    // empty set — see `SessionFilterState.marked`.
+    setMarked(new Set(restoredFilters.marked))
     setOrder((view.sort as SessionOrder | undefined) ?? DEFAULT_ORDER)
     setHideDetail(view.hideDetail ?? false)
     // The DEFAULT, never a literal — same rule, same reason as `onlyActive` above.
     setLayout(view.layout ?? DEFAULT_SESSION_VIEW.layout ?? 'list')
     setCardAnchor(view.cardAnchor)
-    setMarked(new Set(view.marked ?? []))
   }, [view])
 
   /**
@@ -1012,13 +1026,12 @@ export function Sessions({
       grouping,
       // The filters and their derived-on-write copies, in one place — an older binary reading this
       // file still comes up filtered rather than with everything lifted.
-      ...storedFilters({ filters, showNamed }),
+      ...storedFilters({ filters, showNamed, marked: [...marked] }),
       showUnfiled: true,
       showDone,
       hideDetail,
       layout,
       ...(cardAnchor ? { cardAnchor } : {}),
-      ...(marked.size > 0 ? { marked: [...marked] } : {}),
       sort: order,
     } as SessionViewPrefs)
   }, [grouping, filters, showNamed, showDone, hideDetail,
@@ -1181,7 +1194,10 @@ export function Sessions({
       // The X at the right edge. It SELECTS the row first and then asks — so the confirmation names
       // the session under the pointer, never the one that happened to be selected before.
       const entry = rows[row]
-      const onClose = closeCell > 0 && p.x >= listX + PANE_EDGE_X + listBody - 1
+      // The whole control, not its last column: the cell is `CLOSE_CELL` wide, and a hit area of
+      // one column under a three-column button is a button that mostly does nothing.
+      const onClose = closeCell > 0
+        && p.x >= listX + PANE_EDGE_X + listBody - CLOSE_CELL.length
       if (onClose && entry?.kind === 'session' && canClose(entry.session)) {
         setAsk({ kind: 'kill', session: entry.session })
       }

--- a/packages/tui/src/control/types.ts
+++ b/packages/tui/src/control/types.ts
@@ -10,7 +10,7 @@
 import type { CliLang } from './lang'
 // The default ARRANGEMENT is derived from the dimension vocabulary rather than written out beside
 // it. `session-dimensions.ts` imports this file for TYPES only, so this is the one value direction.
-import { DEFAULT_FILTERS, DEFAULT_SHOW_NAMED, storedFilters } from './session-dimensions'
+import { DEFAULT_FILTERS, DEFAULT_MARKED, DEFAULT_SHOW_NAMED, storedFilters } from './session-dimensions'
 
 export type TabId =
   | 'services'
@@ -718,7 +718,7 @@ export interface SessionViewPrefs {
  */
 export const DEFAULT_SESSION_VIEW: SessionViewPrefs = {
   grouping: 'project',
-  ...storedFilters({ filters: DEFAULT_FILTERS, showNamed: DEFAULT_SHOW_NAMED }),
+  ...storedFilters({ filters: DEFAULT_FILTERS, showNamed: DEFAULT_SHOW_NAMED, marked: DEFAULT_MARKED }),
   showDone: false,
   layout: 'list',
   // Derived-on-write, like the three `storedFilters` writes above: only an older binary reads it.


### PR DESCRIPTION
Spec items **2.5, 2.6, 2.7, 2.8** of `docs/specs/2026-08-14-session-limit-and-fleet-hygiene.md`, in
one PR: they are one screen's daily friction, and 2.6 had to wait for the dimension table (#134).

## 2.5 — the highlight vanished on its own

`SessionViewPrefs` already declared `marked`, so the spec's lead was the *other* end of it. The
persist wrote:

```ts
...(marked.size > 0 ? { marked: [...marked] } : {}),
```

A conditional spread cannot express "the answer is nothing". Unmarking everything **removed the
key** instead of writing an empty list; the next restore read absence, fell back, and resurrected
the marks that had just been cleared. Detaching remounts this screen, so that restore happens
constantly.

Marks now travel through the same pure seam as the filters (`migrateSessionFilters` /
`storedFilters`), which always writes the field and always reads it. `DEFAULT_MARKED` states what
absence means — an empty list, not `undefined`.

> Round-tripped by test **including the empty set**, and a second time through: the old bug looked
> fine on the first write and bit on the read after it.

## 2.6 — a marked row is its own band

The `▌` was a glyph on a line that stayed wherever the ordering left it, which does not serve the
one thing marking is for. Marked rows are now a band at the **top**, decided in `sessionRows` — so
`cardPages` walks the very same rows and the card grid gets it for free.

- applies under **every** arrangement, `none` included — marking is the user's and outranks the
  grouping
- the band **does not exist** when nothing is marked
- a marked row appears there and **nowhere else**
- it is **one** band, not the live/fell/closed split the groups get: a marked conversation that is
  over is still the one you marked, and filing it under history puts it back where it was hard to
  find
- a group emptied by the band draws nothing rather than a bare heading

Verified in both layouts through `preview.tsx`.

## 2.7 — "aguardando resposta"

The spec named one line. There were **four**: the word, the two sentences that quote it, and a
**second state table** in `tui/src/control/i18n.ts`. The sessions screen draws from both at once —
the column from the host, the band heading and the filter row from the TUI — so changing one would
have left a row reading `aguardando resposta` under a band called `aguardando`. English keeps
`waiting`.

## 2.8 — the glyph and the keys

**`✕` → `[x]`, not a wastebasket.** `truncate` counts `s.length` — UTF-16 code **units** — and there
is no width dependency in this package. `🗑` is a surrogate pair (`.length === 2`) whose column width
is 1 or 2 depending on the terminal and its presentation; a reservation wrong by one shears every
row under it. The spec named this trade itself, and a test pins that the cell is measurable ASCII.
`closeCellWidth` now **derives** from `CLOSE_CELL.length` instead of a `2` written beside a `'✕'`,
and the pointer hit area covers the whole control rather than its last column.

**Search is `ctrl+f`**, with `/` kept as an undocumented alias.

**The grid moves off `f` to `ctrl+g`.** Both of the spec's suggestions were taken: `g` is "top of the
list" on this very screen *and* inside `resolveListKey`'s menus, and `v` is already the grouping
picker. The chord keeps the mnemonic and pairs with the `ctrl+f` beside it.

Also removed a key-help row for `u`, which #134 left citing a switch it had deleted.

## Verification

- `bun tsc --noEmit` clean
- `bun test` **4017 pass, 0 fail**
- `bun run build:binary`, then `preview.tsx`: band renders in the list **and** the cards grid,
  `ctrl+g` switches layout, `ctrl+f` opens search, key help shows both and no stale `u`
- **80 columns**, every menu section opened, both layouts — no row over the width

## Still open

Defect 2 of the filters design (`covered()` is a bucket test, not a pairing — one managed session
hides every other assistant in its directory) is not in this PR. Groundwork done while investigating
it: `claude daemon` **is** documented, by `claude daemon --help` rather than the top-level help, and
there are **four** non-interactive forms live on this machine, not one — `daemon run`, two
`bg-pty-host`, and `bg-spare`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sw2w1GAZRB5SE4Xp1qcpCQ