### PR TITLE
fix(tui): strip the ESC byte too, so a coloured value cannot break an assertion

### DIFF
--- a/packages/tui/src/control/ControlCenter.test.tsx
+++ b/packages/tui/src/control/ControlCenter.test.tsx
@@ -69,9 +69,22 @@ function probingHost(known: ControlStatus | null): ControlHost {
   } as unknown as ControlHost
 }
 
-/** Strip ANSI so assertions read against the visible text. */
+/**
+ * Strip ANSI so assertions read against the visible text.
+ *
+ * The ESC byte is part of the pattern, and that is the whole point. This used to strip `[36m`
+ * while LEAVING the `\x1b` in front of it, which was invisible for as long as no assertion
+ * straddled a colour change: `GROUP repository` was drawn in one style, so the two words sat next
+ * to each other and `toContain` matched. The moment the dimension VALUE got its own colour, a bare
+ * `\x1b` landed between them and every one of these assertions failed against a frame that was
+ * perfectly correct. A half-stripped frame is worse than an unstripped one — it reads as text right
+ * up until it doesn't.
+ *
+ * Matches whole CSI sequences rather than only SGR (`…m`), so a cursor move or an erase cannot
+ * reintroduce the same class of bug.
+ */
 function plain(frame: string | undefined): string {
-  return (frame ?? '').replace(/\[[0-9;]*m/g, '')
+  return (frame ?? '').replace(/\x1b\[[0-9;:?]*[ -/]*[@-~]/g, '')
 }
 
 const COLS = 100


### PR DESCRIPTION
`dev` was red: 2 failing tests in `ControlCenter.test.tsx`, from two PRs (#134, #137) that were each green on their own branch.

The test helper stripped `[36m` while leaving the `\x1b` in front of it. Invisible for as long as no assertion straddled a colour change — `GROUP repository` was drawn in one style, so the words sat next to each other and `toContain` matched. The dimensions table gave the dimension VALUE its own colour, a bare ESC landed between the words, and both assertions failed against a frame that was perfectly correct.

The behaviour under test is right, including the new default of grouping by project. Only the assertion was brittle.

Now matches whole CSI sequences rather than only SGR, so a cursor move or an erase cannot reintroduce the same class of bug.

Verified on this branch: `bun tsc --noEmit` clean, `bun test` **4017 pass / 0 fail**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TBcRtC62Sx18sgJj64r1Np