### PR TITLE
fix(sessions): a name typed into agentop stops losing to the harness

### DIFF
--- a/packages/server/server/sessions/cli-session.ts
+++ b/packages/server/server/sessions/cli-session.ts
@@ -109,7 +109,13 @@ export async function runSession(argv: string[]): Promise<number> {
     case 'ls': return ls(cmd, backend)
     case 'attach': return attach(cmd.ref, backend)
     case 'kill': return kill(cmd.ref, backend)
-    case 'rename': return patch(cmd.ref, { label: cmd.label }, 'renamed', backend)
+    // `labelSince` travels WITH the label, always. `pickTitle` settles a disagreement between the
+    // name typed here and the one the harness holds by RECENCY, and it can only do that when both
+    // sides say when — so a rename written without a timestamp can never win, whatever the user
+    // typed and however recently. Measured on this machine: every one of twelve live rows had
+    // `labelSince: undefined`, because the cockpit's rename verb stamped it and this one did not.
+    // The comparison had therefore never once run in production, and the harness took every row.
+    case 'rename': return patch(cmd.ref, { label: cmd.label, labelSince: Date.now() }, 'renamed', backend)
     case 'note': return patch(cmd.ref, { note: cmd.text }, 'annotated', backend)
   }
 }
@@ -562,7 +568,9 @@ async function kill(ref: string, backend: SessionBackend): Promise<number> {
 
 async function patch(
   ref: string,
-  fields: { label?: string; note?: string },
+  // `labelSince` is here rather than stamped inside because it belongs to `label` and to nothing
+  // else — a note carries no timestamp and must not acquire one by passing through this helper.
+  fields: { label?: string; labelSince?: number; note?: string },
   verb: string,
   backend: SessionBackend,
 ): Promise<number> {

--- a/packages/server/server/sessions/harness-session-file.test.ts
+++ b/packages/server/server/sessions/harness-session-file.test.ts
@@ -106,6 +106,28 @@ describe('pickTitle', () => {
       .toEqual({ title: 'principal do cockpit', source: 'harness' })
   })
 
+  it('prefers the typed name over a COLLISION of that same name', () => {
+    // Measured on a real machine on 2026-08-15: the row labelled `Principal` was listed as
+    // `principal do cockpit-zippy-conway`. A collision name is the user's own with a suffix the
+    // harness appended, so handing the row to the harness shows a mangled copy in preference to the
+    // original — which is the whole of the complaint "the real name still isn't prevailing".
+    expect(pickTitle({
+      label: 'Principal',
+      file: { name: 'principal do cockpit-zippy-conway', nameSource: 'collision' },
+      fallback,
+    })).toEqual({ title: 'Principal', source: 'label', other: 'principal do cockpit-zippy-conway' })
+  })
+
+  it('still lets a real /rename inside the session win when neither side is dated', () => {
+    // The mirror complaint, and the reason the collision rule above is narrow rather than a flipped
+    // default: a name typed with `/rename` carries NO `nameSource`, so it is untouched.
+    expect(pickTitle({
+      label: 'Principal',
+      file: { name: 'renamed inside the session' },
+      fallback,
+    })).toEqual({ title: 'renamed inside the session', source: 'harness', other: 'Principal' })
+  })
+
   it('ignores a name the harness invented, whatever else is true', () => {
     expect(pickTitle({ file: { name: 'aipe-c9', nameSource: 'derived' }, fallback }))
       .toEqual({ title: fallback, source: 'derived' })

--- a/packages/server/server/sessions/harness-session-file.ts
+++ b/packages/server/server/sessions/harness-session-file.ts
@@ -184,6 +184,15 @@ export function pickTitle(o: {
       ? { title: label, source: 'label', other: harness }
       : { title: harness, source: 'harness', other: label }
   }
+
+  // A `collision` name is not a competing name. It is the user's OWN name with a suffix the harness
+  // appended because two sessions asked for the same one — `Principal` came back as
+  // `principal do cockpit-zippy-conway`. With no timestamps to compare, handing the row to the
+  // harness shows a mangled copy in preference to the original, which is exactly the complaint:
+  // "the real name still isn't prevailing in the listing". A genuine `/rename` inside the session
+  // carries NO `nameSource` at all, so it is untouched by this and still wins below.
+  if (o.file?.nameSource === 'collision') return { title: label, source: 'label', other: harness }
+
   return { title: harness, source: 'harness', other: label }
 }
 


### PR DESCRIPTION
Reported: the real session name still is not prevailing in the listing.

Two defects, and the first is why the second was never visible.

**`agentop session rename` wrote `label` with no `labelSince`.** `pickTitle` settles a disagreement between the typed name and the harness's by RECENCY, and can only do that when both sides say when — so a rename from the CLI could never win, whatever was typed and however recently. Measured on this machine: **all twelve live rows had `labelSince: undefined`**, so that comparison had never once run in production and the harness took every row. The cockpit's rename verb stamped it; the CLI's did not.

**With that fixed, the undated fallback still handed the row to the harness** — and a `collision` name is not a competing name. It is the user's own with a suffix the harness appended when two sessions asked for the same one: `Principal` was being listed as `principal do cockpit-zippy-conway`. Showing the mangled copy in preference to the original is the complaint itself.

The rule is deliberately narrow rather than a flipped default: a real `/rename` inside the session carries no `nameSource` at all, so it still wins. That is the mirror complaint the fallback was written for, and both are now answered — with a test each.

**Renaming is still LOCAL and does not reach the harness.** That is the rest of the request and it is #141: a `Record<HarnessId, RenameSpec | null>` so the name agentop shows IS the session's name, with nothing left to arbitrate.

Verified: `bun tsc --noEmit` clean, `bun test` **4019 pass / 0 fail**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TBcRtC62Sx18sgJj64r1Np