### PR TITLE
release: session identity, version-cache honesty, and the typed name

### DIFF
--- a/packages/server/server/sessions/cli-session.ts
+++ b/packages/server/server/sessions/cli-session.ts
@@ -109,7 +109,13 @@ export async function runSession(argv: string[]): Promise<number> {
     case 'ls': return ls(cmd, backend)
     case 'attach': return attach(cmd.ref, backend)
     case 'kill': return kill(cmd.ref, backend)
-    case 'rename': return patch(cmd.ref, { label: cmd.label }, 'renamed', backend)
+    // `labelSince` travels WITH the label, always. `pickTitle` settles a disagreement between the
+    // name typed here and the one the harness holds by RECENCY, and it can only do that when both
+    // sides say when — so a rename written without a timestamp can never win, whatever the user
+    // typed and however recently. Measured on this machine: every one of twelve live rows had
+    // `labelSince: undefined`, because the cockpit's rename verb stamped it and this one did not.
+    // The comparison had therefore never once run in production, and the harness took every row.
+    case 'rename': return patch(cmd.ref, { label: cmd.label, labelSince: Date.now() }, 'renamed', backend)
     case 'note': return patch(cmd.ref, { note: cmd.text }, 'annotated', backend)
   }
 }
@@ -562,7 +568,9 @@ async function kill(ref: string, backend: SessionBackend): Promise<number> {
 
 async function patch(
   ref: string,
-  fields: { label?: string; note?: string },
+  // `labelSince` is here rather than stamped inside because it belongs to `label` and to nothing
+  // else — a note carries no timestamp and must not acquire one by passing through this helper.
+  fields: { label?: string; labelSince?: number; note?: string },
   verb: string,
   backend: SessionBackend,
 ): Promise<number> {

--- a/packages/server/server/sessions/harness-session-file.test.ts
+++ b/packages/server/server/sessions/harness-session-file.test.ts
@@ -106,6 +106,28 @@ describe('pickTitle', () => {
       .toEqual({ title: 'principal do cockpit', source: 'harness' })
   })
 
+  it('prefers the typed name over a COLLISION of that same name', () => {
+    // Measured on a real machine on 2026-08-15: the row labelled `Principal` was listed as
+    // `principal do cockpit-zippy-conway`. A collision name is the user's own with a suffix the
+    // harness appended, so handing the row to the harness shows a mangled copy in preference to the
+    // original — which is the whole of the complaint "the real name still isn't prevailing".
+    expect(pickTitle({
+      label: 'Principal',
+      file: { name: 'principal do cockpit-zippy-conway', nameSource: 'collision' },
+      fallback,
+    })).toEqual({ title: 'Principal', source: 'label', other: 'principal do cockpit-zippy-conway' })
+  })
+
+  it('still lets a real /rename inside the session win when neither side is dated', () => {
+    // The mirror complaint, and the reason the collision rule above is narrow rather than a flipped
+    // default: a name typed with `/rename` carries NO `nameSource`, so it is untouched.
+    expect(pickTitle({
+      label: 'Principal',
+      file: { name: 'renamed inside the session' },
+      fallback,
+    })).toEqual({ title: 'renamed inside the session', source: 'harness', other: 'Principal' })
+  })
+
   it('ignores a name the harness invented, whatever else is true', () => {
     expect(pickTitle({ file: { name: 'aipe-c9', nameSource: 'derived' }, fallback }))
       .toEqual({ title: fallback, source: 'derived' })

--- a/packages/server/server/sessions/harness-session-file.ts
+++ b/packages/server/server/sessions/harness-session-file.ts
@@ -184,6 +184,15 @@ export function pickTitle(o: {
       ? { title: label, source: 'label', other: harness }
       : { title: harness, source: 'harness', other: label }
   }
+
+  // A `collision` name is not a competing name. It is the user's OWN name with a suffix the harness
+  // appended because two sessions asked for the same one — `Principal` came back as
+  // `principal do cockpit-zippy-conway`. With no timestamps to compare, handing the row to the
+  // harness shows a mangled copy in preference to the original, which is exactly the complaint:
+  // "the real name still isn't prevailing in the listing". A genuine `/rename` inside the session
+  // carries NO `nameSource` at all, so it is untouched by this and still wins below.
+  if (o.file?.nameSource === 'collision') return { title: label, source: 'label', other: harness }
+
   return { title: harness, source: 'harness', other: label }
 }
 

--- a/packages/server/server/sessions/harness-sessions.ts
+++ b/packages/server/server/sessions/harness-sessions.ts
@@ -87,6 +87,21 @@ export interface HarnessSessionIndex {
   byManagedId: Map<string, HarnessSessionFile>
   /** Keyed by OS pid — how an EXTERNAL session found in `/proc` is matched. Exact. */
   byPid: Map<number, HarnessSessionFile>
+  /**
+   * Keyed by the harness's own CONVERSATION id. Exact, and the only key that needs nothing else.
+   *
+   * The other two both require a second fact to be true: `byManagedId` needs the session to have
+   * been started under tmux, and `byPid` needs the `/proc` scan to have surfaced the process. A
+   * session that satisfies neither was invisible — and one that satisfies neither is not exotic, it
+   * is a **background agent**: no tmux, and nothing in the scan.
+   *
+   * Measured on this machine on 2026-08-15: a session alive for 38 minutes, whose record held
+   * `sessionId 581deab7…`, `name 'MAIN'` (typed, `nameSource` absent) and `tmux` NONE, was listed by
+   * agentop as `closed`, under a title from the conversation store that predated the rename by days.
+   * The file naming both the conversation and the live pid was read, indexed, and then never asked
+   * for — because there was no key that fit it.
+   */
+  byConversation: Map<string, HarnessSessionFile>
 }
 
 /**
@@ -109,11 +124,13 @@ interface Keyed {
   mtimeMs: number
 }
 
-const EMPTY: HarnessSessionIndex = { byManagedId: new Map(), byPid: new Map() }
+const EMPTY: HarnessSessionIndex = {
+  byManagedId: new Map(), byPid: new Map(), byConversation: new Map(),
+}
 
 /** An empty index, for a caller that has nothing to look up. */
 export function emptyHarnessSessionIndex(): HarnessSessionIndex {
-  return { byManagedId: new Map(), byPid: new Map() }
+  return { byManagedId: new Map(), byPid: new Map(), byConversation: new Map() }
 }
 
 /**
@@ -151,6 +168,21 @@ export async function loadHarnessSessions(
       if (!read) continue
       const { file, mtimeMs } = read
       if (file.pid !== undefined) out.byPid.set(file.pid, file)
+
+      // Indexed BEFORE the tmux gate below, and that placement is the fix: everything past that
+      // `continue` is skipped for a session that was not started under tmux, which is exactly the
+      // case that had no key at all. Newest-wins for the same reason `byManagedId` needs it — a
+      // conversation resumed several times leaves a record per run, and `readdir` order deciding
+      // which name is current is no decision.
+      const conversation = file.sessionId
+      if (conversation) {
+        const key = `c:${conversation}`
+        if (mtimeMs >= (seenAt.get(key) ?? -Infinity)) {
+          seenAt.set(key, mtimeMs)
+          out.byConversation.set(conversation, file)
+        }
+      }
+
       const tmux = tmuxSessionName(file)
       const managedId = tmux ? idFromTmuxName(tmux) : null
       // `idFromTmuxName` returns null for a tmux session that is not ours, which is the ordinary

--- a/packages/server/server/sessions/session-view.test.ts
+++ b/packages/server/server/sessions/session-view.test.ts
@@ -215,9 +215,11 @@ describe("what the harness says about its OWN session", () => {
   const index = (over: {
     byManagedId?: Record<string, Record<string, unknown>>
     byPid?: Record<number, Record<string, unknown>>
+    byConversation?: Record<string, Record<string, unknown>>
   }) => ({
     byManagedId: new Map(Object.entries(over.byManagedId ?? {})),
     byPid: new Map(Object.entries(over.byPid ?? {}).map(([k, v]) => [Number(k), v])),
+    byConversation: new Map(Object.entries(over.byConversation ?? {})),
   }) as never
 
   const managed = (id: string, o: Partial<ManagedSession> = {}): ManagedSession => ({
@@ -265,6 +267,46 @@ describe("what the harness says about its OWN session", () => {
       harnessSessions: index({ byManagedId: { m1: { sessionId: 'right' } } }),
     })
     expect(v!.resume?.sessionId).toBe('right')
+  })
+
+  it('gives a CLOSED row the name its own session chose, over the store title', () => {
+    // Measured on 2026-08-15. A session renamed to `MAIN` was listed under
+    // `Build agentop harness cockpit with session management` — a title from a different week.
+    // It is a BACKGROUND AGENT: no tmux, so `byManagedId` cannot see it, and the /proc scan
+    // surfaced nothing, so `byPid` was never asked. `byConversation` is the key that needs
+    // neither.
+    const views = buildSessionViews({
+      reconciled: [],
+      activity: new Map(),
+      processes: [],
+      conversations: [{
+        sessionId: '581deab7', title: 'Build agentop harness cockpit with session management',
+        lastActivityMs: 1, harness: 'claude' as const, cwd: '/repo/a', resumable: true,
+        firstPrompt: '',
+      }],
+      harnessSessions: index({ byConversation: { '581deab7': { name: 'MAIN' } } }),
+    })
+    expect(views[0]!.label).toBe('MAIN')
+    // Findable by BOTH: the name it now shows, and the one it used to show.
+    expect(views[0]!.searchText).toContain('main')
+    expect(views[0]!.searchText).toContain('cockpit')
+  })
+
+  it('never lets a DERIVED name displace a real store title', () => {
+    // `agentistics-84` is what the harness invents from the folder when nobody has said anything.
+    const views = buildSessionViews({
+      reconciled: [],
+      activity: new Map(),
+      processes: [],
+      conversations: [{
+        sessionId: 'c1', title: 'a title somebody wrote', lastActivityMs: 1,
+        harness: 'claude' as const, cwd: '/repo/a', resumable: true, firstPrompt: '',
+      }],
+      harnessSessions: index({
+        byConversation: { c1: { name: 'agentistics-84', nameSource: 'derived' } },
+      }),
+    })
+    expect(views[0]!.label).toBe('a title somebody wrote')
   })
 
   it('matches an EXTERNAL process by its pid', () => {

--- a/packages/server/server/sessions/session-view.ts
+++ b/packages/server/server/sessions/session-view.ts
@@ -471,12 +471,30 @@ export function buildSessionViews(o: {
   const closed: SessionView[] = conversations
     .filter(c => !shown.has(c.sessionId))
     .slice(0, o.closedLimit ?? 12)
-    .map(c => ({
+    .map(c => {
+      /**
+       * The name the SESSION gave itself, when its own record can be found by conversation id.
+       *
+       * `c.title` comes from the conversation store, which is written from the transcript and can be
+       * days older than a `/rename`. Measured: a session renamed to `MAIN` was listed here under
+       * `Build agentop harness cockpit with session management` — a title from a different week.
+       *
+       * This is the one lookup that needs nothing else to be true. `byManagedId` requires the
+       * session to have been started under tmux and `byPid` requires the `/proc` scan to have
+       * surfaced it; a background agent satisfies neither, and was therefore shown under whatever
+       * the store last recorded with no way to correct it.
+       *
+       * `chosenName` still rejects a `derived` name, so a harness-invented `agentistics-84` never
+       * displaces a real title.
+       */
+      const own = o.harnessSessions?.byConversation.get(c.sessionId)
+      const named = chosenName(own)
+      return {
       id: `closed:${c.sessionId}`,
       harness: c.harness,
       cwd: c.cwd,
       status: 'closed' as const,
-      label: c.title,
+      label: named ?? c.title,
       createdMs: c.lastActivityMs,
       attached: false,
       approvalDetection: false,
@@ -486,8 +504,12 @@ export function buildSessionViews(o: {
       ...(c.contextTokens !== undefined && c.contextWindow !== undefined
         ? { contextTokens: c.contextTokens, contextWindow: c.contextWindow }
         : {}),
-      searchText: searchTextOf(c.harness, c.cwd, c.title, c.firstPrompt),
-    }))
+      // The typed name goes into the search text TOO, or the row is displayed under a name that
+      // cannot be used to find it — which is the complaint arriving by the other door.
+      searchText: searchTextOf(c.harness, c.cwd, named ?? c.title, c.firstPrompt)
+        + (named && named !== c.title ? ` ${c.title.toLowerCase()}` : ''),
+      }
+    })
 
   return [...managed, ...external, ...closed].sort((a, b) => {
     const byRank = rankOf(a) - rankOf(b)

--- a/packages/server/server/version.test.ts
+++ b/packages/server/server/version.test.ts
@@ -9,6 +9,7 @@ import {
   cachedVersionInfo,
   shouldRefreshVersionCache,
   VERSION_CACHE_TTL_MS,
+  VERSION_NEGATIVE_TTL_MS,
   VERSION_RETRY_MS,
 } from './version'
 // The unattended-upgrade lock lives in upgrade.ts, but its pure helpers are part of the
@@ -132,6 +133,33 @@ test('a cached verdict is only reused for the version it was computed against', 
   // A failure-only entry (attempt stamped, never a successful fetch) is not an answer.
   expect(cachedVersionInfo(entry({ fetchedAt: 0, attemptedAt: now }), '1.7.0')).toBeNull()
   expect(isVersionCacheFresh(null, now, '1.7.0')).toBe(false)
+})
+
+test('an "up to date" verdict goes stale far sooner than an "update available" one', () => {
+  // The bug, measured: a machine on 1.13.7 checked at 21:51 and cached `latest: 1.13.7`. v1.14.0
+  // shipped at 00:52 — inside the 3-hour window — and `check-update` stayed SILENT for the rest of
+  // it. Silence is indistinguishable from "checked, nothing new", so the release looked unpublished.
+  const negative = entry({ latest: '1.7.0', hasUpdate: false })
+  const justPastNegative = negative.fetchedAt + VERSION_NEGATIVE_TTL_MS + 1
+
+  expect(isVersionCacheFresh(negative, justPastNegative, '1.7.0')).toBe(false)
+  // …while the positive verdict at the very same age is still good: it names a release that still
+  // exists, keeps saying the same true thing, and clears itself on upgrade.
+  expect(isVersionCacheFresh(entry(), justPastNegative, '1.7.0')).toBe(true)
+
+  // And the refresh path agrees with the read path — one `ttlFor`, so they cannot drift apart.
+  const attempted = { attemptedAt: negative.fetchedAt }
+  expect(shouldRefreshVersionCache({ ...negative, ...attempted }, justPastNegative, '1.7.0')).toBe(true)
+  expect(shouldRefreshVersionCache({ ...entry(), ...attempted }, justPastNegative, '1.7.0')).toBe(false)
+})
+
+test('the shorter negative TTL still cannot become traffic', () => {
+  // The retry floor outranks it: stale at 30 minutes, re-asked at most every 15.
+  const negative = entry({ latest: '1.7.0', hasUpdate: false })
+  const inRetryWindow = negative.fetchedAt + VERSION_RETRY_MS - 1
+  expect(shouldRefreshVersionCache(
+    { ...negative, attemptedAt: negative.fetchedAt }, inRetryWindow, '1.7.0',
+  )).toBe(false)
 })
 
 test('a stale entry is past its TTL but still printable', () => {

--- a/packages/server/server/version.ts
+++ b/packages/server/server/version.ts
@@ -26,9 +26,41 @@ const CACHE_TTL_MS = 60 * 60 * 1000 // 1 hour (in-process)
 export const VERSION_CACHE_FILE = join(AGENTISTICS_DATA_DIR, 'version-cache.json')
 /** How long a successful check stays authoritative before a refresh is due. */
 export const VERSION_CACHE_TTL_MS = 3 * 60 * 60 * 1000 // 3 hours
+/**
+ * How long a "you are up to date" verdict stays authoritative.
+ *
+ * **The two verdicts are not equally safe to cache, and that is the whole point of this constant.**
+ * A stale `hasUpdate: true` costs nothing: the release it names still exists, the banner keeps
+ * saying the same true thing, and it clears itself the moment the user upgrades. A stale
+ * `hasUpdate: false` is the opposite — it is the machine actively telling someone they are current
+ * while a release sits there, and it does it in the SILENT direction, so nobody can tell the
+ * difference between "checked, nothing new" and "not checked".
+ *
+ * Measured, and this is the bug it fixes: a machine on 1.13.7 checked at 21:51 and cached
+ * `latest: 1.13.7`. v1.14.0 shipped at 00:52. For the rest of the 3-hour window `check-update`
+ * printed NOTHING, and the release looked like it had never been published — including to the
+ * person who had just published it.
+ *
+ * Bounded, not free: the refresh is detached and additionally spaced by `VERSION_RETRY_MS`, so a
+ * shorter negative TTL can never turn into hammering — at most one attempt per retry window per
+ * machine, and never in front of a shell prompt.
+ */
+export const VERSION_NEGATIVE_TTL_MS = 30 * 60 * 1000 // 30 minutes
 /** Minimum spacing between refresh ATTEMPTS — stops 20 shells opening at once (or an
  *  offline machine) from firing 20 GitHub calls. */
 export const VERSION_RETRY_MS = 15 * 60 * 1000 // 15 minutes
+
+/**
+ * The TTL that applies to THIS entry — PURE.
+ *
+ * One function so the read path (`isVersionCacheFresh`) and the refresh path
+ * (`shouldRefreshVersionCache`) can never disagree about how long an answer lasts. They did not
+ * disagree before only because there was a single number; the moment there are two, one place
+ * deciding is the difference between a fix and a new bug.
+ */
+export function ttlFor(entry: VersionCacheEntry, ttlMs: number, negativeTtlMs: number): number {
+  return entry.hasUpdate ? ttlMs : Math.min(ttlMs, negativeTtlMs)
+}
 
 export interface VersionCacheEntry {
   /** The installed version this verdict was computed against. */
@@ -71,9 +103,10 @@ export function isVersionCacheFresh(
   now: number,
   current: string,
   ttlMs: number = VERSION_CACHE_TTL_MS,
+  negativeTtlMs: number = VERSION_NEGATIVE_TTL_MS,
 ): boolean {
   if (!entry || entry.current !== current || entry.fetchedAt <= 0) return false
-  return now - entry.fetchedAt < ttlMs
+  return now - entry.fetchedAt < ttlFor(entry, ttlMs, negativeTtlMs)
 }
 
 /**
@@ -96,11 +129,14 @@ export function shouldRefreshVersionCache(
   current: string,
   ttlMs: number = VERSION_CACHE_TTL_MS,
   retryMs: number = VERSION_RETRY_MS,
+  negativeTtlMs: number = VERSION_NEGATIVE_TTL_MS,
 ): boolean {
   if (!entry || entry.current !== current) return true
   const attempted = entry.attemptedAt ?? entry.fetchedAt
+  // The retry floor still applies, and it is what keeps the shorter negative TTL from becoming
+  // traffic: an up-to-date verdict goes stale at 30 minutes but is re-asked at most every 15.
   if (now - attempted < retryMs) return false
-  return now - entry.fetchedAt >= ttlMs
+  return now - entry.fetchedAt >= ttlFor(entry, ttlMs, negativeTtlMs)
 }
 
 /** Reads the shared cache file. Never throws. */


### PR DESCRIPTION
Ships #142, #144 and #146.

**#146 — a renamed session is findable.** `HarnessSessionIndex` had two keys and both required a second fact to hold: `byManagedId` needs tmux, `byPid` needs the /proc scan. A background agent satisfies neither, so its record — naming the conversation, the live pid and the typed name `MAIN` — was read, indexed and never asked for. `byConversation` needs nothing else. Verified against the live session that reported it.

**#144 — an "up to date" verdict expires in 30 minutes, not 3 hours.** A stale `hasUpdate: true` costs nothing; a stale `hasUpdate: false` hides a release, silently. Measured: a machine checked at 21:51, v1.14.0 shipped at 00:52, and `check-update` said nothing for the rest of the window — the release looked unpublished to the person who published it.

**#142 — the typed name stops losing to the harness.** `agentop session rename` never wrote `labelSince`, so `pickTitle`'s recency comparison had never once run in production.

Verified on dev at e04761f: `bun tsc --noEmit` clean, `bun test` **4023 pass / 0 fail**, binary compiles and lists the reporting session as `MAIN`.

Still open and deliberately not in here: the row says `closed` while the process runs (#145 — the anti-pid-recycling key `procStart` is already in the record), and rename is still one-way (#141).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TBcRtC62Sx18sgJj64r1Np