### PR TITLE
fix(version): an up-to-date verdict expires far sooner than an update-available one

### DIFF
--- a/packages/server/server/version.test.ts
+++ b/packages/server/server/version.test.ts
@@ -9,6 +9,7 @@ import {
   cachedVersionInfo,
   shouldRefreshVersionCache,
   VERSION_CACHE_TTL_MS,
+  VERSION_NEGATIVE_TTL_MS,
   VERSION_RETRY_MS,
 } from './version'
 // The unattended-upgrade lock lives in upgrade.ts, but its pure helpers are part of the
@@ -132,6 +133,33 @@ test('a cached verdict is only reused for the version it was computed against', 
   // A failure-only entry (attempt stamped, never a successful fetch) is not an answer.
   expect(cachedVersionInfo(entry({ fetchedAt: 0, attemptedAt: now }), '1.7.0')).toBeNull()
   expect(isVersionCacheFresh(null, now, '1.7.0')).toBe(false)
+})
+
+test('an "up to date" verdict goes stale far sooner than an "update available" one', () => {
+  // The bug, measured: a machine on 1.13.7 checked at 21:51 and cached `latest: 1.13.7`. v1.14.0
+  // shipped at 00:52 — inside the 3-hour window — and `check-update` stayed SILENT for the rest of
+  // it. Silence is indistinguishable from "checked, nothing new", so the release looked unpublished.
+  const negative = entry({ latest: '1.7.0', hasUpdate: false })
+  const justPastNegative = negative.fetchedAt + VERSION_NEGATIVE_TTL_MS + 1
+
+  expect(isVersionCacheFresh(negative, justPastNegative, '1.7.0')).toBe(false)
+  // …while the positive verdict at the very same age is still good: it names a release that still
+  // exists, keeps saying the same true thing, and clears itself on upgrade.
+  expect(isVersionCacheFresh(entry(), justPastNegative, '1.7.0')).toBe(true)
+
+  // And the refresh path agrees with the read path — one `ttlFor`, so they cannot drift apart.
+  const attempted = { attemptedAt: negative.fetchedAt }
+  expect(shouldRefreshVersionCache({ ...negative, ...attempted }, justPastNegative, '1.7.0')).toBe(true)
+  expect(shouldRefreshVersionCache({ ...entry(), ...attempted }, justPastNegative, '1.7.0')).toBe(false)
+})
+
+test('the shorter negative TTL still cannot become traffic', () => {
+  // The retry floor outranks it: stale at 30 minutes, re-asked at most every 15.
+  const negative = entry({ latest: '1.7.0', hasUpdate: false })
+  const inRetryWindow = negative.fetchedAt + VERSION_RETRY_MS - 1
+  expect(shouldRefreshVersionCache(
+    { ...negative, attemptedAt: negative.fetchedAt }, inRetryWindow, '1.7.0',
+  )).toBe(false)
 })
 
 test('a stale entry is past its TTL but still printable', () => {

--- a/packages/server/server/version.ts
+++ b/packages/server/server/version.ts
@@ -26,9 +26,41 @@ const CACHE_TTL_MS = 60 * 60 * 1000 // 1 hour (in-process)
 export const VERSION_CACHE_FILE = join(AGENTISTICS_DATA_DIR, 'version-cache.json')
 /** How long a successful check stays authoritative before a refresh is due. */
 export const VERSION_CACHE_TTL_MS = 3 * 60 * 60 * 1000 // 3 hours
+/**
+ * How long a "you are up to date" verdict stays authoritative.
+ *
+ * **The two verdicts are not equally safe to cache, and that is the whole point of this constant.**
+ * A stale `hasUpdate: true` costs nothing: the release it names still exists, the banner keeps
+ * saying the same true thing, and it clears itself the moment the user upgrades. A stale
+ * `hasUpdate: false` is the opposite — it is the machine actively telling someone they are current
+ * while a release sits there, and it does it in the SILENT direction, so nobody can tell the
+ * difference between "checked, nothing new" and "not checked".
+ *
+ * Measured, and this is the bug it fixes: a machine on 1.13.7 checked at 21:51 and cached
+ * `latest: 1.13.7`. v1.14.0 shipped at 00:52. For the rest of the 3-hour window `check-update`
+ * printed NOTHING, and the release looked like it had never been published — including to the
+ * person who had just published it.
+ *
+ * Bounded, not free: the refresh is detached and additionally spaced by `VERSION_RETRY_MS`, so a
+ * shorter negative TTL can never turn into hammering — at most one attempt per retry window per
+ * machine, and never in front of a shell prompt.
+ */
+export const VERSION_NEGATIVE_TTL_MS = 30 * 60 * 1000 // 30 minutes
 /** Minimum spacing between refresh ATTEMPTS — stops 20 shells opening at once (or an
  *  offline machine) from firing 20 GitHub calls. */
 export const VERSION_RETRY_MS = 15 * 60 * 1000 // 15 minutes
+
+/**
+ * The TTL that applies to THIS entry — PURE.
+ *
+ * One function so the read path (`isVersionCacheFresh`) and the refresh path
+ * (`shouldRefreshVersionCache`) can never disagree about how long an answer lasts. They did not
+ * disagree before only because there was a single number; the moment there are two, one place
+ * deciding is the difference between a fix and a new bug.
+ */
+export function ttlFor(entry: VersionCacheEntry, ttlMs: number, negativeTtlMs: number): number {
+  return entry.hasUpdate ? ttlMs : Math.min(ttlMs, negativeTtlMs)
+}
 
 export interface VersionCacheEntry {
   /** The installed version this verdict was computed against. */
@@ -71,9 +103,10 @@ export function isVersionCacheFresh(
   now: number,
   current: string,
   ttlMs: number = VERSION_CACHE_TTL_MS,
+  negativeTtlMs: number = VERSION_NEGATIVE_TTL_MS,
 ): boolean {
   if (!entry || entry.current !== current || entry.fetchedAt <= 0) return false
-  return now - entry.fetchedAt < ttlMs
+  return now - entry.fetchedAt < ttlFor(entry, ttlMs, negativeTtlMs)
 }
 
 /**
@@ -96,11 +129,14 @@ export function shouldRefreshVersionCache(
   current: string,
   ttlMs: number = VERSION_CACHE_TTL_MS,
   retryMs: number = VERSION_RETRY_MS,
+  negativeTtlMs: number = VERSION_NEGATIVE_TTL_MS,
 ): boolean {
   if (!entry || entry.current !== current) return true
   const attempted = entry.attemptedAt ?? entry.fetchedAt
+  // The retry floor still applies, and it is what keeps the shorter negative TTL from becoming
+  // traffic: an up-to-date verdict goes stale at 30 minutes but is re-asked at most every 15.
   if (now - attempted < retryMs) return false
-  return now - entry.fetchedAt >= ttlMs
+  return now - entry.fetchedAt >= ttlFor(entry, ttlMs, negativeTtlMs)
 }
 
 /** Reads the shared cache file. Never throws. */


### PR DESCRIPTION
A user on an old build is told they are current for up to three hours after a release, and told it **silently** — which is indistinguishable from not having checked at all.

The two verdicts are not equally safe to cache:

- a stale `hasUpdate: true` costs nothing — the release it names still exists, the banner keeps saying the same true thing, and it clears itself the moment the user upgrades;
- a stale `hasUpdate: false` hides a release, in the direction nobody can notice.

Measured on a real machine: it checked at 21:51 and cached `latest: 1.13.7`. v1.14.0 shipped at 00:52 — inside the 3-hour TTL — and `check-update` printed nothing for the rest of the window. The release looked unpublished **to the person who had just published it**.

Negative verdicts now expire in 30 minutes. Bounded, not free: `VERSION_RETRY_MS` still floors the attempts, so it is at most one detached call per 15 minutes per machine, and never in front of a shell prompt — `check-update` stays the non-blocking shell-hook path it was designed to be.

One `ttlFor` serves both the read path (`isVersionCacheFresh`) and the refresh path (`shouldRefreshVersionCache`). They agreed before only because there was a single number; with two, one place deciding is the difference between a fix and a new bug. A test asserts they agree.

Verified: `bun tsc --noEmit` clean, `bun test` **4021 pass / 0 fail**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TBcRtC62Sx18sgJj64r1Np