### PR TITLE
fix(sessions): index a harness record by CONVERSATION, so a renamed session is findable

### DIFF
--- a/packages/server/server/sessions/harness-sessions.ts
+++ b/packages/server/server/sessions/harness-sessions.ts
@@ -87,6 +87,21 @@ export interface HarnessSessionIndex {
   byManagedId: Map<string, HarnessSessionFile>
   /** Keyed by OS pid — how an EXTERNAL session found in `/proc` is matched. Exact. */
   byPid: Map<number, HarnessSessionFile>
+  /**
+   * Keyed by the harness's own CONVERSATION id. Exact, and the only key that needs nothing else.
+   *
+   * The other two both require a second fact to be true: `byManagedId` needs the session to have
+   * been started under tmux, and `byPid` needs the `/proc` scan to have surfaced the process. A
+   * session that satisfies neither was invisible — and one that satisfies neither is not exotic, it
+   * is a **background agent**: no tmux, and nothing in the scan.
+   *
+   * Measured on this machine on 2026-08-15: a session alive for 38 minutes, whose record held
+   * `sessionId 581deab7…`, `name 'MAIN'` (typed, `nameSource` absent) and `tmux` NONE, was listed by
+   * agentop as `closed`, under a title from the conversation store that predated the rename by days.
+   * The file naming both the conversation and the live pid was read, indexed, and then never asked
+   * for — because there was no key that fit it.
+   */
+  byConversation: Map<string, HarnessSessionFile>
 }
 
 /**
@@ -109,11 +124,13 @@ interface Keyed {
   mtimeMs: number
 }
 
-const EMPTY: HarnessSessionIndex = { byManagedId: new Map(), byPid: new Map() }
+const EMPTY: HarnessSessionIndex = {
+  byManagedId: new Map(), byPid: new Map(), byConversation: new Map(),
+}
 
 /** An empty index, for a caller that has nothing to look up. */
 export function emptyHarnessSessionIndex(): HarnessSessionIndex {
-  return { byManagedId: new Map(), byPid: new Map() }
+  return { byManagedId: new Map(), byPid: new Map(), byConversation: new Map() }
 }
 
 /**
@@ -151,6 +168,21 @@ export async function loadHarnessSessions(
       if (!read) continue
       const { file, mtimeMs } = read
       if (file.pid !== undefined) out.byPid.set(file.pid, file)
+
+      // Indexed BEFORE the tmux gate below, and that placement is the fix: everything past that
+      // `continue` is skipped for a session that was not started under tmux, which is exactly the
+      // case that had no key at all. Newest-wins for the same reason `byManagedId` needs it — a
+      // conversation resumed several times leaves a record per run, and `readdir` order deciding
+      // which name is current is no decision.
+      const conversation = file.sessionId
+      if (conversation) {
+        const key = `c:${conversation}`
+        if (mtimeMs >= (seenAt.get(key) ?? -Infinity)) {
+          seenAt.set(key, mtimeMs)
+          out.byConversation.set(conversation, file)
+        }
+      }
+
       const tmux = tmuxSessionName(file)
       const managedId = tmux ? idFromTmuxName(tmux) : null
       // `idFromTmuxName` returns null for a tmux session that is not ours, which is the ordinary

--- a/packages/server/server/sessions/session-view.test.ts
+++ b/packages/server/server/sessions/session-view.test.ts
@@ -215,9 +215,11 @@ describe("what the harness says about its OWN session", () => {
   const index = (over: {
     byManagedId?: Record<string, Record<string, unknown>>
     byPid?: Record<number, Record<string, unknown>>
+    byConversation?: Record<string, Record<string, unknown>>
   }) => ({
     byManagedId: new Map(Object.entries(over.byManagedId ?? {})),
     byPid: new Map(Object.entries(over.byPid ?? {}).map(([k, v]) => [Number(k), v])),
+    byConversation: new Map(Object.entries(over.byConversation ?? {})),
   }) as never
 
   const managed = (id: string, o: Partial<ManagedSession> = {}): ManagedSession => ({
@@ -265,6 +267,46 @@ describe("what the harness says about its OWN session", () => {
       harnessSessions: index({ byManagedId: { m1: { sessionId: 'right' } } }),
     })
     expect(v!.resume?.sessionId).toBe('right')
+  })
+
+  it('gives a CLOSED row the name its own session chose, over the store title', () => {
+    // Measured on 2026-08-15. A session renamed to `MAIN` was listed under
+    // `Build agentop harness cockpit with session management` — a title from a different week.
+    // It is a BACKGROUND AGENT: no tmux, so `byManagedId` cannot see it, and the /proc scan
+    // surfaced nothing, so `byPid` was never asked. `byConversation` is the key that needs
+    // neither.
+    const views = buildSessionViews({
+      reconciled: [],
+      activity: new Map(),
+      processes: [],
+      conversations: [{
+        sessionId: '581deab7', title: 'Build agentop harness cockpit with session management',
+        lastActivityMs: 1, harness: 'claude' as const, cwd: '/repo/a', resumable: true,
+        firstPrompt: '',
+      }],
+      harnessSessions: index({ byConversation: { '581deab7': { name: 'MAIN' } } }),
+    })
+    expect(views[0]!.label).toBe('MAIN')
+    // Findable by BOTH: the name it now shows, and the one it used to show.
+    expect(views[0]!.searchText).toContain('main')
+    expect(views[0]!.searchText).toContain('cockpit')
+  })
+
+  it('never lets a DERIVED name displace a real store title', () => {
+    // `agentistics-84` is what the harness invents from the folder when nobody has said anything.
+    const views = buildSessionViews({
+      reconciled: [],
+      activity: new Map(),
+      processes: [],
+      conversations: [{
+        sessionId: 'c1', title: 'a title somebody wrote', lastActivityMs: 1,
+        harness: 'claude' as const, cwd: '/repo/a', resumable: true, firstPrompt: '',
+      }],
+      harnessSessions: index({
+        byConversation: { c1: { name: 'agentistics-84', nameSource: 'derived' } },
+      }),
+    })
+    expect(views[0]!.label).toBe('a title somebody wrote')
   })
 
   it('matches an EXTERNAL process by its pid', () => {

--- a/packages/server/server/sessions/session-view.ts
+++ b/packages/server/server/sessions/session-view.ts
@@ -471,12 +471,30 @@ export function buildSessionViews(o: {
   const closed: SessionView[] = conversations
     .filter(c => !shown.has(c.sessionId))
     .slice(0, o.closedLimit ?? 12)
-    .map(c => ({
+    .map(c => {
+      /**
+       * The name the SESSION gave itself, when its own record can be found by conversation id.
+       *
+       * `c.title` comes from the conversation store, which is written from the transcript and can be
+       * days older than a `/rename`. Measured: a session renamed to `MAIN` was listed here under
+       * `Build agentop harness cockpit with session management` — a title from a different week.
+       *
+       * This is the one lookup that needs nothing else to be true. `byManagedId` requires the
+       * session to have been started under tmux and `byPid` requires the `/proc` scan to have
+       * surfaced it; a background agent satisfies neither, and was therefore shown under whatever
+       * the store last recorded with no way to correct it.
+       *
+       * `chosenName` still rejects a `derived` name, so a harness-invented `agentistics-84` never
+       * displaces a real title.
+       */
+      const own = o.harnessSessions?.byConversation.get(c.sessionId)
+      const named = chosenName(own)
+      return {
       id: `closed:${c.sessionId}`,
       harness: c.harness,
       cwd: c.cwd,
       status: 'closed' as const,
-      label: c.title,
+      label: named ?? c.title,
       createdMs: c.lastActivityMs,
       attached: false,
       approvalDetection: false,
@@ -486,8 +504,12 @@ export function buildSessionViews(o: {
       ...(c.contextTokens !== undefined && c.contextWindow !== undefined
         ? { contextTokens: c.contextTokens, contextWindow: c.contextWindow }
         : {}),
-      searchText: searchTextOf(c.harness, c.cwd, c.title, c.firstPrompt),
-    }))
+      // The typed name goes into the search text TOO, or the row is displayed under a name that
+      // cannot be used to find it — which is the complaint arriving by the other door.
+      searchText: searchTextOf(c.harness, c.cwd, named ?? c.title, c.firstPrompt)
+        + (named && named !== c.title ? ` ${c.title.toLowerCase()}` : ''),
+      }
+    })
 
   return [...managed, ...external, ...closed].sort((a, b) => {
     const byRank = rankOf(a) - rankOf(b)


### PR DESCRIPTION
Reported: *"o título dessa conversa é MAIN, tentei encontrar essa sessão no agentop e não foi, os titles não estão fiéis"*.

The session was listed as `Build agentop harness cockpit with session management` — a title from a different week — and could not be found by the name on its own screen.

`HarnessSessionIndex` had two keys, and **both require a second fact to hold**: `byManagedId` needs the session to have been started under tmux, and `byPid` needs the `/proc` scan to have surfaced the process. A **background agent satisfies neither**. Its record — naming the conversation, the live pid and the typed name `MAIN` — was read, indexed, and then never asked for, because no key fit it.

`byConversation` needs nothing else: the harness writes the conversation id into its own record. It is populated **before** the tmux gate, which is the actual fix — everything past that `continue` was skipped for precisely the sessions that had no other key.

Guards kept:

- `chosenName` still rejects a `derived` name, so `agentistics-84` never displaces a real title (tested).
- Newest-wins, same as `byManagedId`: a resumed conversation leaves a record per run, and readdir order deciding which name is current is no decision.
- The old title stays in `searchText`, or the row is displayed under a name that cannot find it — the same complaint through the other door.

**Verified against the live session that reported it**, through the compiled binary:

```
closed:581deab7-…  closed  claude  MAIN  …/worktrees/session-monitor
```

**Explicitly NOT fixed here:** it still says `closed` while the process is running. That needs a liveness input, and the anti-pid-recycling key already exists in the record (`procStart`). Tracked in #145.

`bun tsc --noEmit` clean, `bun test` **4021 pass / 0 fail**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TBcRtC62Sx18sgJj64r1Np