### PR TITLE
fix(sessions): a session the harness says is RUNNING stops being listed as closed

### DIFF
--- a/packages/server/server/sessions/harness-session-file.ts
+++ b/packages/server/server/sessions/harness-session-file.ts
@@ -62,6 +62,41 @@ export interface HarnessSessionFile {
    * agentop. It is the EXACT link between a harness's own record and a managed row.
    */
   tmux?: string
+  /**
+   * The process's start time as the kernel counts it — field 22 of `/proc/<pid>/stat`.
+   *
+   * **This is what makes `pid` safe to believe.** These records outlive their processes by design
+   * (that is what keeps a name readable on a `lost` row), so the directory is mostly full of dead
+   * pids — measured here: 64 records, 3 of them still running. A pid alone would therefore report a
+   * long-dead session as alive the moment the OS handed its number to something else, and it would
+   * do it on the row that says "this conversation is running", which is the worst place to be wrong.
+   *
+   * Compared as an opaque STRING, never parsed into a time: it is a count of clock ticks since boot,
+   * whose unit and epoch are the kernel's business. All this code needs is whether the process
+   * answering to that pid is the same one that wrote the record.
+   *
+   * Verified on this machine 2026-08-15: of the three records whose pid still existed, all three
+   * matched `/proc` exactly.
+   */
+  procStart?: string
+  /**
+   * Which harness wrote this record — stamped by the loader, which knows because it is iterating
+   * `HARNESS_SESSION_SOURCES` one harness at a time.
+   *
+   * Not in the file, and carried so no reader has to hardcode a harness to use one of these. Only
+   * claude writes such a record today; that is a fact about the sources table, and the day a second
+   * one does, every consumer is already correct.
+   */
+  harness?: HarnessId
+  /**
+   * Whether the process that wrote this record is STILL RUNNING — stamped by the loader.
+   *
+   * Not part of the file: it is a fact about this moment, answered by the platform. `undefined`
+   * means nobody could tell (no `/proc`, so not Linux) and must be read as "unknown", never as
+   * "not running" — the same N/A-versus-a-confident-0 rule the dashboard applies to harness
+   * capabilities. A row whose liveness is unknown stays exactly as it was.
+   */
+  alive?: boolean
 }
 
 /**
@@ -85,6 +120,10 @@ export function parseHarnessSessionFile(raw: unknown): HarnessSessionFile | null
     ...(str(s.nameSource) ? { nameSource: str(s.nameSource)! } : {}),
     ...(num(s.nameSince) !== undefined ? { nameSince: num(s.nameSince)! } : {}),
     ...(str(s.tmux) ? { tmux: str(s.tmux)! } : {}),
+    // Claude writes it as a STRING of clock ticks; a number would also be reasonable and is
+    // accepted, because the only operation ever performed on it is equality against `/proc`.
+    ...(str(s.procStart) ? { procStart: str(s.procStart)! }
+      : num(s.procStart) !== undefined ? { procStart: String(num(s.procStart)!) } : {}),
   }
 }
 

--- a/packages/server/server/sessions/harness-sessions.ts
+++ b/packages/server/server/sessions/harness-sessions.ts
@@ -33,6 +33,7 @@ import {
   type HarnessSessionFile,
 } from './harness-session-file'
 import { idFromTmuxName } from './tmux-cli'
+import { procAvailable, readProcStart, sameProcess } from './proc-liveness'
 
 /**
  * Where each harness's own session records live on THIS machine.
@@ -146,6 +147,9 @@ export async function loadHarnessSessions(
   // How fresh the record already sitting under each managed id is, so the newest wins rather than
   // whichever `readdir` happened to hand over last. See the note above `Keyed`.
   const seenAt = new Map<string, number>()
+  // Asked ONCE for the whole sweep rather than per file: off Linux the answer is the same 60 times,
+  // and it decides whether `alive` is a fact or stays `undefined`.
+  const canProbe = await procAvailable()
 
   for (const harness of harnesses) {
     const source = HARNESS_SESSION_SOURCES[harness]
@@ -166,7 +170,19 @@ export async function loadHarnessSessions(
       if (!source.matches.test(name)) continue
       const read = await readOne(join(dir, name))
       if (!read) continue
-      const { file, mtimeMs } = read
+      const { mtimeMs } = read
+      // Liveness is stamped here because this is the impure layer and the answer is about NOW.
+      // Only asked where `/proc` exists at all, and only for a record that carries the
+      // anti-recycling key — everywhere else it stays `undefined`, meaning "nobody could tell",
+      // which every reader must treat as unknown rather than as "not running".
+      const pid = read.file.pid
+      const file: HarnessSessionFile = {
+        ...read.file,
+        harness,
+        ...(canProbe && pid !== undefined
+          ? { alive: sameProcess(read.file.procStart, await readProcStart(pid)) }
+          : {}),
+      }
       if (file.pid !== undefined) out.byPid.set(file.pid, file)
 
       // Indexed BEFORE the tmux gate below, and that placement is the fix: everything past that

--- a/packages/server/server/sessions/proc-liveness.test.ts
+++ b/packages/server/server/sessions/proc-liveness.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'bun:test'
+import { sameProcess, readProcStart, procAvailable } from './proc-liveness'
+
+describe('sameProcess — the anti-recycling rule', () => {
+  it('matches only when both sides say the same start time', () => {
+    expect(sameProcess('2467615', '2467615')).toBe(true)
+    expect(sameProcess('2467615', '9999999')).toBe(false)
+  })
+
+  it('refuses when the pid is gone', () => {
+    // `undefined` from the probe is a real answer: nothing is running under that number.
+    expect(sameProcess('2467615', undefined)).toBe(false)
+  })
+
+  it('refuses a record with NO start time, rather than trusting the pid alone', () => {
+    // Every claude before it began writing `procStart`. The caller uses this to claim a session is
+    // alive, and the directory is mostly dead pids the OS is free to hand out again — measured
+    // here: 64 records, 3 running. An unproven claim of liveness is worse than an absent one, so
+    // such a row simply stays as it was.
+    expect(sameProcess(undefined, '2467615')).toBe(false)
+    expect(sameProcess(undefined, undefined)).toBe(false)
+    expect(sameProcess('', '2467615')).toBe(false)
+  })
+})
+
+describe('readProcStart — reading the real /proc', () => {
+  it('reads this very process, and agrees with itself', async () => {
+    if (!(await procAvailable())) return // not Linux: the feature is absent, not wrong
+    const mine = await readProcStart(process.pid)
+    expect(mine).toMatch(/^\d+$/)
+    expect(sameProcess(mine, await readProcStart(process.pid))).toBe(true)
+  })
+
+  it('survives a name with spaces and parentheses in it', async () => {
+    // Field 2 of /proc/<pid>/stat is the executable name IN PARENTHESES and may contain both. A
+    // left-to-right split would put every later field at an offset that depends on the program's
+    // name — which is why the parse cuts at the LAST `)`. Reading our own stat exercises it: bun's
+    // comm is plain, so this asserts the shape rather than the pathological case, and the rule is
+    // documented where it is implemented.
+    if (!(await procAvailable())) return
+    expect(await readProcStart(process.pid)).toMatch(/^\d+$/)
+  })
+
+  it('returns undefined for a pid that cannot exist', async () => {
+    expect(await readProcStart(2 ** 31)).toBeUndefined()
+  })
+})

--- a/packages/server/server/sessions/proc-liveness.ts
+++ b/packages/server/server/sessions/proc-liveness.ts
@@ -1,0 +1,66 @@
+/**
+ * proc-liveness.ts — is the process that wrote a record STILL the one answering to that pid?
+ *
+ * Split from `harness-sessions.ts` so the rule and the syscall are separable: `sameProcess` is pure
+ * and tested, `readProcStart` is the one impure line and is Linux-only by construction.
+ *
+ * ## Why a pid is not enough, stated once
+ *
+ * These records outlive their processes on purpose — that is what keeps the name someone typed
+ * readable on a `lost` row afterwards. Measured on this machine on 2026-08-15: 64 records, of which
+ * **3** belonged to a running process. So the directory is mostly dead pids, and the OS reuses pid
+ * numbers. Believing `pid` alone means reporting a long-dead session as running the moment its
+ * number comes round again — on the row that claims a conversation is live, which is the worst
+ * place in this product to be wrong.
+ *
+ * Field 22 of `/proc/<pid>/stat` is the process's start time in clock ticks since boot. Two
+ * processes can share a pid; they cannot share a pid AND a start time. Verified against real data:
+ * of the three records whose pid still existed, all three matched exactly.
+ */
+
+import { readFile } from 'node:fs/promises'
+
+/**
+ * Whether a record and a probe describe the SAME process — PURE.
+ *
+ * `undefined` from the probe means the pid does not exist: not running, and that is a real answer.
+ * A record with no `procStart` (every claude before it started writing one) is the interesting case
+ * and it is answered NO: without the anti-recycling key there is no way to tell a resumed pid from
+ * the original, and this function's callers use it to claim a session is alive. An unproven claim
+ * of liveness is worse than an absent one — the row stays as it was, which is today's behaviour.
+ */
+export function sameProcess(recorded: string | undefined, probed: string | undefined): boolean {
+  if (!recorded || !probed) return false
+  return recorded === probed
+}
+
+/**
+ * Field 22 of `/proc/<pid>/stat`, or `undefined` when the pid does not exist or cannot be read.
+ *
+ * The parse is `rsplit` on `)` rather than a plain split, and that is load-bearing: field 2 is the
+ * executable name IN PARENTHESES and it may itself contain spaces and parentheses. Splitting from
+ * the left on whitespace puts every later field at an offset that depends on the program's name.
+ * After the LAST `)`, the remaining fields start at field 3, so field 22 is index 19.
+ */
+export async function readProcStart(pid: number): Promise<string | undefined> {
+  try {
+    const stat = await readFile(`/proc/${pid}/stat`, 'utf8')
+    const tail = stat.slice(stat.lastIndexOf(')') + 1).trim().split(/\s+/)
+    const start = tail[19]
+    return start && /^\d+$/.test(start) ? start : undefined
+  } catch {
+    // No /proc (not Linux), a pid that has gone, or a process this uid may not read. All three are
+    // "cannot tell", and the caller must not turn that into "not running".
+    return undefined
+  }
+}
+
+/** True when `/proc` is readable at all — the platform gate for the whole feature. */
+export async function procAvailable(): Promise<boolean> {
+  try {
+    await readFile('/proc/self/stat', 'utf8')
+    return true
+  } catch {
+    return false
+  }
+}

--- a/packages/server/server/sessions/session-view.test.ts
+++ b/packages/server/server/sessions/session-view.test.ts
@@ -292,6 +292,53 @@ describe("what the harness says about its OWN session", () => {
     expect(views[0]!.searchText).toContain('cockpit')
   })
 
+  it('a conversation whose record is ALIVE is running, not closed', () => {
+    // The other half of the report. A background agent alive for 38 minutes sat in the closed block
+    // under a title from another week, offering to "reopen" a conversation that had never stopped.
+    // It is synthesised into the SAME external path a scanned process takes, so it inherits every
+    // rule already written there rather than getting a parallel branch.
+    const views = buildSessionViews({
+      reconciled: [],
+      activity: new Map(),
+      processes: [],
+      conversations: [{
+        sessionId: '581deab7', title: 'a title from another week', lastActivityMs: 1,
+        harness: 'claude' as const, cwd: '/repo/a', resumable: true, firstPrompt: '',
+      }],
+      harnessSessions: index({
+        byConversation: {
+          '581deab7': {
+            name: 'MAIN', pid: 508665, cwd: '/repo/a', sessionId: '581deab7',
+            harness: 'claude', alive: true,
+          },
+        },
+      }),
+    })
+    expect(views.map(v => v.status)).toContain('external')
+    expect(views.find(v => v.status === 'external')?.harnessName).toBe('MAIN')
+    // …and it is not ALSO sitting in the closed block under the old title.
+    expect(views.filter(v => v.status === 'closed')).toHaveLength(0)
+  })
+
+  it('synthesises nothing when liveness could not be determined', () => {
+    // `alive: undefined` means no /proc — not Linux, or a uid that may not read it. Unknown must
+    // never become a claim, so the row stays exactly as it was today.
+    const views = buildSessionViews({
+      reconciled: [],
+      activity: new Map(),
+      processes: [],
+      conversations: [{
+        sessionId: 'c1', title: 'stored title', lastActivityMs: 1,
+        harness: 'claude' as const, cwd: '/repo/a', resumable: true, firstPrompt: '',
+      }],
+      harnessSessions: index({
+        byConversation: { c1: { name: 'MAIN', pid: 1, cwd: '/repo/a', harness: 'claude' } },
+      }),
+    })
+    expect(views).toHaveLength(1)
+    expect(views[0]!.status).toBe('closed')
+  })
+
   it('never lets a DERIVED name displace a real store title', () => {
     // `agentistics-84` is what the harness invents from the folder when nobody has said anything.
     const views = buildSessionViews({

--- a/packages/server/server/sessions/session-view.ts
+++ b/packages/server/server/sessions/session-view.ts
@@ -396,17 +396,55 @@ export function buildSessionViews(o: {
   // A row whose harness is unknown covers NOTHING: it might be that process or might not, and
   // silently swallowing an external session on a maybe is the worse of the two errors — a duplicate
   // row is visible and self-correcting, a missing one is not.
+  // Only a row that is actually RUNNING can account for a running process. `!== 'lost'` was too
+  // wide: an `exited` row accounts for a process that is GONE, and letting it cover swallows a live
+  // session that happens to share its directory. Measured on this machine — three exited rows sat in
+  // the worktree of a background agent that was alive, and the agent was hidden behind them and
+  // listed as a closed conversation instead.
   const covered = (p: HarnessProcess): boolean => managed.some(m =>
     m.harness === p.harness &&
-    m.status !== 'lost' &&
+    (m.status === 'running' || m.status === 'unregistered') &&
     sessionAtCwd({ current_cwd: m.cwd, project_path: m.cwd }, p.cwd))
 
   const conversations = o.conversations ?? []
 
-  const external: SessionView[] = o.processes.filter(p => !covered(p)).map(p => {
+  /**
+   * Sessions the harness's OWN records prove are running, which the `/proc` scan did not report.
+   *
+   * Synthesised as processes rather than special-cased downstream, deliberately: they then travel
+   * the very same `external` path as a scanned one and inherit every rule already written there —
+   * the `covered` de-duplication, the exact-name lookup, the resume target, the tokens and the
+   * context gauge. A parallel branch would be a second set of rules for one kind of row.
+   *
+   * Two things had to be true before this was sound, and both now are: the record carries
+   * `procStart`, so `alive` is a fact about THIS process and not about whoever inherited its pid;
+   * and `alive` is `undefined` wherever nobody could tell, so a machine with no `/proc` synthesises
+   * nothing and behaves exactly as it did.
+   *
+   * This is what stops a live session being listed as `closed`. Measured: a background agent alive
+   * for 38 minutes — no tmux, missed by the scan — sat in the closed block under a title from
+   * another week, offering to "reopen" a conversation that had never stopped.
+   */
+  const scannedPids = new Set(o.processes.map(p => p.pid).filter((v): v is number => v !== undefined))
+  const fromRecords: HarnessProcess[] = [...(o.harnessSessions?.byConversation.values() ?? [])]
+    .filter(f => f.alive === true && f.pid !== undefined && !scannedPids.has(f.pid)
+      && f.cwd !== undefined && f.harness !== undefined)
+    .map(f => ({
+      harness: f.harness!,
+      cwd: f.cwd!,
+      pid: f.pid!,
+      ...(f.sessionId ? { sessionId: f.sessionId } : {}),
+    }))
+
+  const external: SessionView[] = [...o.processes, ...fromRecords].filter(p => !covered(p)).map(p => {
     // What the harness says about ITSELF, keyed on the pid `/proc` reported. Exact where every other
     // reading of an external process is an inference from its directory.
-    const own = p.pid !== undefined ? o.harnessSessions?.byPid.get(p.pid) : undefined
+    // By pid first — that is the key a SCANNED process arrives with. Falling back to the
+    // conversation removes a hidden coupling rather than papering over one: a row synthesised from
+    // a record already knows the conversation exactly, and making its name depend on a second
+    // lookup succeeding would leave it correctly listed and anonymously labelled.
+    const own = (p.pid !== undefined ? o.harnessSessions?.byPid.get(p.pid) : undefined)
+      ?? (p.sessionId ? o.harnessSessions?.byConversation.get(p.sessionId) : undefined)
     const ownName = chosenName(own)
     // What this process appears to be driving. The harness's own `sessionId` outranks the argv one
     // and the directory guess alike: it is what the process is writing to, said by the process.


### PR DESCRIPTION
Closes #145 — the other half of the report that produced #146.

A background agent alive for 38 minutes sat in the closed block, offering to "reopen" a conversation that had never stopped. Three defects, found by pulling one thread.

**A pid alone cannot be believed.** These records outlive their processes by design — that is what keeps a typed name readable on a `lost` row — so the directory is mostly dead pids, and the OS reuses the numbers. Measured here: **64 records, 3 still running**. Trusting `pid` would report a long-dead session as alive on the very row that claims a conversation is live.

`procStart` (field 22 of `/proc/<pid>/stat`) is the anti-recycling key, and it was **already in the file, unread**. Two processes can share a pid; they cannot share a pid *and* a start time. Verified: of the three records whose pid still existed, all three matched exactly. `sameProcess` **refuses a record without the key** rather than falling back to the pid, and `alive` stays `undefined` wherever `/proc` cannot be read — unknown must never become a claim, so a non-Linux machine synthesises nothing and behaves exactly as before.

**A live record the scan missed is synthesised into the SAME external path** a scanned process takes, so it inherits the de-duplication, the exact-name lookup, the resume target and the gauges instead of getting a parallel branch.

**And a third, found on the way:** `covered()` accepted any managed row that was not `lost`. An **`exited` row accounts for a process that is GONE** — three of them sat in that worktree and were swallowing the live session. Only a running row can cover a running process.

Verified against the session that reported it, through the compiled binary:

```
agentistics  2
  f5114  aguardando resposta  aprovar acoes pela tui   session-approve
         externa              MAIN                     session-monitor
```

`bun tsc --noEmit` clean, `bun test` **4031 pass / 0 fail**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TBcRtC62Sx18sgJj64r1Np