### PR TITLE
feat(cockpit): how many assistants this machine can hold, in the header

### DIFF
--- a/packages/server/server/cli-start.ts
+++ b/packages/server/server/cli-start.ts
@@ -107,6 +107,8 @@ import { needsChoice, parseDialogOptions } from './sessions/dialog-choice'
 import { rulesFor } from './sessions/attention-rules'
 import { planCrashGroup, planFellOffer } from './sessions/crash-group'
 import { loadHarnessSessions } from './sessions/harness-sessions'
+import { memoryBudget } from './sessions/memory-budget'
+import { readMemory, readRss } from './sessions/memory-probe'
 // The lock on the door: one conversation, one live session. See `conversation-claim.ts` for the
 // measurement that made it necessary, and `live-claims.ts` for the evidence it is allowed to use.
 import { conversationHeldBy } from './sessions/conversation-claim'
@@ -1570,6 +1572,35 @@ function createControlHost(initialLang: CliLang, altScreen: Suspendable): StartH
     }
   }
 
+  /**
+   * The parallel-sessions budget, or `{}` when this machine cannot be measured.
+   *
+   * Spread into the status, so an unreadable machine contributes NO `memory` key at all and the
+   * header draws no gauge — the same absence-is-absence rule as `ControlService.boot`. A zero here
+   * would read as "no room left" on precisely the machines that could not be asked.
+   *
+   * The pids come from the harness records, which is the set this budget is about: assistants. It
+   * deliberately does not try to price the whole machine — `MemAvailable` already accounts for
+   * everything else, and RESERVED_BYTES holds room back for it.
+   */
+  const memoryStatus = async (): Promise<{ memory?: { used: number; max: number; red: boolean } }> => {
+    try {
+      const sample = await readMemory()
+      if (!sample) return {}
+      const index = await loadHarnessSessions()
+      const pids = [...index.byConversation.values()]
+        .filter(f => f.alive === true && f.pid !== undefined)
+        .map(f => f.pid!)
+      const { bytes, read } = await readRss(pids)
+      const b = memoryBudget({ sample, sessionBytes: bytes, sessions: read })
+      return { memory: { used: b.used, max: b.max, red: b.red } }
+    } catch {
+      // Best-effort, exactly like every other reader on this object: a gauge that throws must not
+      // take the whole status down with it.
+      return {}
+    }
+  }
+
   /** The setting in force, for the Setup tab to state. `undefined` while it is still unanswered. */
   const currentArchiveMode = async (): Promise<ArchiveMode | undefined> => {
     try {
@@ -1749,6 +1780,11 @@ function createControlHost(initialLang: CliLang, altScreen: Suspendable): StartH
         services,
         version: CURRENT_VERSION,
         latestVersion,
+        // The parallel-sessions budget. Computed HERE and not in the TUI, like every other decision
+        // on this object: the arithmetic lives in the pure `memory-budget.ts` and the two `/proc`
+        // reads in `memory-probe.ts`, and the answer arrives already decided — including `red`,
+        // which depends on swap pressure the screen has no way to know about.
+        ...(await memoryStatus()),
         archiveMode: await currentArchiveMode(),
         // The setup wizard is a question the cockpit asks, so what it may offer is decided here,
         // beside the very service states that decide it. `central` is the only mode that

--- a/packages/server/server/sessions/memory-budget.test.ts
+++ b/packages/server/server/sessions/memory-budget.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'bun:test'
+import {
+  memoryBudget, parseMeminfo, ASSUMED_SESSION_BYTES, RED_WITHIN, SWAP_ALARM_FRACTION,
+} from './memory-budget'
+
+const GB = 1024 * 1024 * 1024
+const MB = 1024 * 1024
+
+const sample = (over: Partial<ReturnType<typeof base>> = {}) => ({ ...base(), ...over })
+const base = () => ({ total: 16 * GB, available: 10 * GB, swapTotal: 4 * GB, swapUsed: 0 })
+
+describe('parseMeminfo', () => {
+  it('reads the real shape of /proc/meminfo', () => {
+    // Verbatim from this machine on 2026-08-15.
+    const s = parseMeminfo([
+      'MemTotal:       16127932 kB',
+      'MemFree:         6000536 kB',
+      'MemAvailable:   10217372 kB',
+      'Buffers:          444092 kB',
+      'SwapTotal:       4194304 kB',
+      'SwapFree:        3576832 kB',
+    ].join('\n'))
+    expect(s).not.toBeNull()
+    expect(s!.available).toBe(10217372 * 1024)
+    expect(s!.swapUsed).toBe((4194304 - 3576832) * 1024)
+  })
+
+  it('takes MemAvailable, never MemFree', () => {
+    // Measured at one moment here: free 5.7 GB against available 9.7 GB. Reading MemFree would
+    // declare a machine with 4 GB of headroom nearly out, and every later warning becomes noise.
+    const s = parseMeminfo('MemTotal: 16127932 kB\nMemFree: 6000536 kB\nMemAvailable: 10217372 kB')
+    expect(s!.available).not.toBe(6000536 * 1024)
+  })
+
+  it('returns null rather than a gauge built on a zero', () => {
+    expect(parseMeminfo('')).toBeNull()
+    expect(parseMeminfo('MemTotal: 16127932 kB')).toBeNull()   // no MemAvailable
+    expect(parseMeminfo('nonsense')).toBeNull()
+  })
+
+  it('treats a machine with no swap as having none, not as having failed', () => {
+    const s = parseMeminfo('MemTotal: 100 kB\nMemAvailable: 50 kB')
+    expect(s).not.toBeNull()
+    expect(s!.swapTotal).toBe(0)
+    expect(s!.swapUsed).toBe(0)
+  })
+})
+
+describe('memoryBudget', () => {
+  it('measures the cost from what is running, rather than assuming', () => {
+    const b = memoryBudget({ sample: sample(), sessionBytes: 1200 * MB, sessions: 4 })
+    expect(b.cost.basis).toBe('measured')
+    expect(b.cost.bytes).toBe(300 * MB)
+  })
+
+  it('falls back to the declared default and SAYS it is assumed', () => {
+    const b = memoryBudget({ sample: sample(), sessionBytes: 0, sessions: 0 })
+    expect(b.cost).toEqual({ bytes: ASSUMED_SESSION_BYTES, basis: 'assumed' })
+  })
+
+  it('counts what the sessions already hold as part of the room', () => {
+    // Otherwise the total shrinks as you use the machine correctly: four sessions running would
+    // report a smaller ceiling than the same machine with none.
+    const withNone = memoryBudget({ sample: sample(), sessionBytes: 0, sessions: 0 }).max
+    const withFour = memoryBudget({
+      sample: sample({ available: 10 * GB - 1000 * MB }),
+      sessionBytes: 1000 * MB,
+      sessions: 4,
+      assumedBytes: 250 * MB,
+    }).max
+    expect(withFour).toBe(withNone)
+  })
+
+  it('turns red by DISTANCE, not by percentage', () => {
+    // Three left of thirty is comfortable; three left of fourteen is the last warning. A fraction
+    // makes those the same number, and what gets spent is one session at a time.
+    const tight = memoryBudget({
+      sample: sample({ available: 2 * GB + 3 * 250 * MB }),
+      sessionBytes: 11 * 250 * MB, sessions: 11, assumedBytes: 250 * MB,
+    })
+    expect(tight.left).toBe(RED_WITHIN)
+    expect(tight.red).toBe(true)
+    expect(tight.alarm).toBe('sessions')
+
+    const roomy = memoryBudget({
+      sample: sample({ available: 2 * GB + 10 * 250 * MB }),
+      sessionBytes: 4 * 250 * MB, sessions: 4, assumedBytes: 250 * MB,
+    })
+    expect(roomy.left).toBeGreaterThan(RED_WITHIN)
+    expect(roomy.red).toBe(false)
+    expect(roomy.alarm).toBeUndefined()
+  })
+
+  it('alarms on SWAP even when the RAM figure looks fine', () => {
+    // The freeze this exists to prevent: RAM read 3.6 GB free while swap sat at 97%, and it is the
+    // swap thrash that stops the machine responding. A RAM-only budget said everything was fine at
+    // the exact moment the laptop locked up.
+    const b = memoryBudget({
+      sample: sample({ available: 8 * GB, swapUsed: 4 * GB * SWAP_ALARM_FRACTION }),
+      sessionBytes: 250 * MB, sessions: 1,
+    })
+    expect(b.left).toBeGreaterThan(RED_WITHIN)  // by sessions alone this is comfortable
+    expect(b.red).toBe(true)
+    expect(b.alarm).toBe('swap')                // …and the reason is named, because the action differs
+  })
+
+  it('never reports a ceiling below what is already running', () => {
+    // An over-committed machine is a real state, and reporting `max: 2` while four are up would be
+    // a number nobody can act on. It says 4 of 4, none left.
+    const b = memoryBudget({
+      sample: sample({ available: 0 }), sessionBytes: 4 * GB, sessions: 4,
+    })
+    expect(b.max).toBeGreaterThanOrEqual(4)
+    expect(b.left).toBe(0)
+    expect(b.red).toBe(true)
+  })
+})

--- a/packages/server/server/sessions/memory-budget.ts
+++ b/packages/server/server/sessions/memory-budget.ts
@@ -1,0 +1,154 @@
+/**
+ * memory-budget.ts — PURE. How much room this machine has left, and how many assistants fit in it.
+ *
+ * The question this answers is not "how much RAM is used" — every OS already has a tool for that.
+ * It is **"can I open another session"**, which is a different question with a different unit, and
+ * the only one anybody actually asks before opening one.
+ *
+ * ## Why the answer is a DISTANCE and not a percentage
+ *
+ * The colour is decided by how many sessions are left, never by a fraction. Three left out of
+ * thirty is comfortable; three left out of fourteen is the last warning you get. Percentages
+ * collapse those into the same number, and the thing being spent is a session at a time.
+ *
+ * ## Two numbers that are easy to confuse, and only one of them is right
+ *
+ * `MemAvailable` is what the kernel says can be handed out without swapping — it counts the page
+ * cache the kernel would happily drop. `MemFree` counts only untouched pages. Measured on this
+ * machine at one moment: free 5.7 GB, available 9.7 GB. Using `MemFree` would declare a machine
+ * with 4 GB of headroom to be nearly out, and every warning after that is noise the user learns to
+ * ignore. So: available, always.
+ *
+ * ## Swap is part of the answer, not a footnote
+ *
+ * The freeze this feature exists to prevent was not a RAM shortage: RAM looked fine at 3.6 GB free
+ * while SWAP sat at 97% used, and it is the swap thrash that stops a machine responding. A budget
+ * that only reads RAM would have said everything was fine at the exact moment the laptop locked up.
+ */
+
+/** What the platform could read. Every field is in BYTES. */
+export interface MemorySample {
+  total: number
+  /** `MemAvailable` — reclaimable cache included. Never `MemFree`; see the header. */
+  available: number
+  swapTotal: number
+  swapUsed: number
+}
+
+/** One session's measured cost, and how it was arrived at. */
+export interface SessionCost {
+  bytes: number
+  /**
+   * `measured` — averaged over the sessions actually running here.
+   * `assumed` — nothing was running, so the declared default was used, and the UI must SAY so.
+   */
+  basis: 'measured' | 'assumed'
+}
+
+/**
+ * What one assistant costs when none is running to measure.
+ *
+ * The median of the claude processes on this machine on 2026-08-15, which ranged 162–442 MB. It is
+ * a starting point that gets replaced by measurement the moment there is anything to measure, and
+ * `basis: 'assumed'` exists so no surface can present it as a reading.
+ */
+export const ASSUMED_SESSION_BYTES = 250 * 1024 * 1024
+
+/**
+ * Held back for everything that is not an assistant — the desktop, the browser, the server, a build.
+ *
+ * A budget that lets sessions consume every last byte is arithmetically correct and useless: the
+ * machine dies before the last one starts. This is the floor the count is computed above.
+ */
+export const RESERVED_BYTES = 2 * 1024 * 1024 * 1024
+
+/** Swap this full means the machine is already thrashing, whatever the RAM figure says. */
+export const SWAP_ALARM_FRACTION = 0.85
+
+/** How many sessions may remain before the number turns red. Three, two, one, none — see header. */
+export const RED_WITHIN = 3
+
+export interface MemoryBudget {
+  /** How many sessions this machine can hold in total, at the measured cost. */
+  max: number
+  /** How many are running now. */
+  used: number
+  /** `max - used`, floored at zero. */
+  left: number
+  cost: SessionCost
+  /** True once `left` is inside `RED_WITHIN`, or the swap alarm has tripped. */
+  red: boolean
+  /**
+   * Why the budget is alarming, or `undefined` when it is not. Distinguished because they call for
+   * different actions: `sessions` means close one, `swap` means the machine is ALREADY struggling
+   * and closing one may not be enough.
+   */
+  alarm?: 'sessions' | 'swap'
+}
+
+/**
+ * The budget — PURE.
+ *
+ * `sessionBytes` is the total RSS of the assistant processes, and `sessions` how many there were.
+ * Both come from the caller because reading them is a platform act.
+ */
+export function memoryBudget(o: {
+  sample: MemorySample
+  sessionBytes: number
+  sessions: number
+  reservedBytes?: number
+  assumedBytes?: number
+}): MemoryBudget {
+  const reserved = o.reservedBytes ?? RESERVED_BYTES
+  const cost: SessionCost = o.sessions > 0 && o.sessionBytes > 0
+    ? { bytes: Math.round(o.sessionBytes / o.sessions), basis: 'measured' }
+    : { bytes: o.assumedBytes ?? ASSUMED_SESSION_BYTES, basis: 'assumed' }
+
+  // What the sessions ALREADY hold is part of the room for sessions: they are the thing being
+  // counted. Measuring only what is free would report a ceiling that shrinks as the machine is used
+  // correctly — four sessions running would claim a smaller total than the same machine with none.
+  //
+  // So `room` is the whole envelope and `floor(room / cost)` is the TOTAL, not the remainder. Adding
+  // `sessions` on top of it was double counting, caught by the test above: the same machine reported
+  // 32 empty and 36 with four running.
+  const room = o.sample.available + o.sessionBytes - reserved
+  // Never below what is already up: an over-committed machine is a real state, and "2 of 4" is a
+  // number nobody can act on. It says 4 of 4, none left.
+  const max = Math.max(o.sessions, Math.floor(room / Math.max(1, cost.bytes)))
+  const left = Math.max(0, max - o.sessions)
+
+  const swapping = o.sample.swapTotal > 0
+    && o.sample.swapUsed / o.sample.swapTotal >= SWAP_ALARM_FRACTION
+  // Swap is named FIRST when both trip: it is the more urgent fact and the one closing a session
+  // may not fix.
+  const alarm = swapping ? 'swap' as const : left <= RED_WITHIN ? 'sessions' as const : undefined
+  return { max, used: o.sessions, left, cost, red: alarm !== undefined, ...(alarm ? { alarm } : {}) }
+}
+
+/**
+ * `MemAvailable` and friends out of `/proc/meminfo` — PURE over the text.
+ *
+ * Returns `null` when the required fields are not all present, which is how a non-Linux machine and
+ * a truncated read reach the same honest answer: **no gauge**, rather than a gauge built on a zero.
+ * Same rule as `ControlService.boot` and `HARNESS_CAPABILITIES` — an absent measurement is shown as
+ * absent, never as a confident number.
+ */
+export function parseMeminfo(text: string): MemorySample | null {
+  const kb = (key: string): number | undefined => {
+    const m = new RegExp(`^${key}:\\s+(\\d+) kB$`, 'm').exec(text)
+    return m ? Number(m[1]) * 1024 : undefined
+  }
+  const total = kb('MemTotal')
+  const available = kb('MemAvailable')
+  const swapTotal = kb('SwapTotal')
+  const swapFree = kb('SwapFree')
+  if (total === undefined || available === undefined) return null
+  // Swap is optional: a machine with none is not a machine that failed to report. It reads as zero
+  // of zero, and `memoryBudget` guards the division.
+  return {
+    total,
+    available,
+    swapTotal: swapTotal ?? 0,
+    swapUsed: swapTotal !== undefined && swapFree !== undefined ? swapTotal - swapFree : 0,
+  }
+}

--- a/packages/server/server/sessions/memory-probe.ts
+++ b/packages/server/server/sessions/memory-probe.ts
@@ -1,0 +1,69 @@
+/**
+ * memory-probe.ts — the impure half of the memory budget: reading this machine.
+ *
+ * Split from `memory-budget.ts` for the usual reason — the arithmetic is tested and the syscalls are
+ * not — and kept deliberately small: two reads and a sum.
+ *
+ * **Where it cannot read, it returns `null` and the whole gauge is absent.** Not zero, not a
+ * placeholder. `/proc` exists on Linux and on WSL; it does not on macOS or Windows, and a machine
+ * that cannot be measured must show no gauge rather than a confident wrong one — the same rule
+ * `ControlService.boot` follows for systemd and `HARNESS_CAPABILITIES` for metrics.
+ */
+
+import { readFile, readdir } from 'node:fs/promises'
+import type { MemorySample } from './memory-budget'
+import { parseMeminfo } from './memory-budget'
+
+/** The machine's memory, or `null` where it cannot be read. */
+export async function readMemory(): Promise<MemorySample | null> {
+  try {
+    return parseMeminfo(await readFile('/proc/meminfo', 'utf8'))
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Total resident bytes of a set of pids, and how many were actually readable.
+ *
+ * `VmRSS` from `/proc/<pid>/status` rather than `statm`, because it is already in kB and labelled —
+ * no page-size arithmetic to get wrong.
+ *
+ * **RSS of processes that share pages does not sum exactly.** It over-counts shared libraries, so
+ * this figure is an upper bound. That is the right direction for this use — a budget that errs
+ * toward "fewer sessions fit" fails safe — but it is stated here rather than left for someone to
+ * discover, and it is why the surface says "recommended" and not "available".
+ */
+export async function readRss(pids: readonly number[]): Promise<{ bytes: number; read: number }> {
+  let bytes = 0
+  let read = 0
+  for (const pid of pids) {
+    try {
+      const status = await readFile(`/proc/${pid}/status`, 'utf8')
+      const m = /^VmRSS:\s+(\d+) kB$/m.exec(status)
+      if (!m) continue
+      bytes += Number(m[1]) * 1024
+      read++
+    } catch {
+      // Gone between listing and reading, or a uid that may not look. Skipped, and the count says so.
+    }
+  }
+  return { bytes, read }
+}
+
+/**
+ * Every pid under a tmux session's process tree is NOT what this needs — the harness process is.
+ *
+ * The caller passes the pids it already knows about (from the harness records and from the process
+ * scan), so this module never has to decide what an assistant is. It exists as a named export
+ * because the alternative — each caller writing its own `/proc` read — is how two surfaces end up
+ * disagreeing about the same number.
+ */
+export async function procPidsExist(): Promise<boolean> {
+  try {
+    await readdir('/proc/self')
+    return true
+  } catch {
+    return false
+  }
+}

--- a/packages/tui/scripts/preview.tsx
+++ b/packages/tui/scripts/preview.tsx
@@ -289,6 +289,9 @@ function fakeStatus(opts: Options, apiUrl?: string): ControlStatus {
     services: services(opts.mode, s, apiUrl),
     version: '1.7.3',
     latestVersion: '1.7.4',
+    // The parallel-sessions budget, so the width sweep exercises the header WITH it. A calm one:
+    // the red case gives way later than this does, so a frame that fits this fits that too.
+    memory: { used: 3, max: 17, red: false },
     archiveMode: 'consolidate',
     // The wizard's blocked row, stated whenever the fake central is up: it is the case the fold
     // exists for, and a preview that only ever drew three selectable modes would never show it.

--- a/packages/tui/src/control/Chrome.tsx
+++ b/packages/tui/src/control/Chrome.tsx
@@ -92,6 +92,20 @@ function HeaderTag({ meta }: { meta: HeaderMeta }) {
     <Text>
       <Text dimColor>{meta.text}</Text>
       {meta.alert ? <Text color={COLORS.accent} bold>{` · ${meta.alert}`}</Text> : null}
+      {/* The parallel-sessions budget. Dim while there is room, `danger` once the ceiling is close
+          or the machine is already swapping — but the NUMBERS are always drawn, so a reader who
+          cannot tell the two shades apart still has the whole message. Colour never carries it. */}
+      {meta.memory
+        ? (
+          <Text
+            color={meta.memoryRed ? COLORS.danger : undefined}
+            dimColor={!meta.memoryRed}
+            bold={meta.memoryRed}
+          >
+            {` · ${meta.memory}`}
+          </Text>
+        )
+        : null}
       {/* Glyph plus version, in accent: the dot alone would carry the whole message in color. */}
       {meta.update ? <Text color={COLORS.accent}>{` · ${meta.update}`}</Text> : null}
     </Text>

--- a/packages/tui/src/control/ControlCenter.tsx
+++ b/packages/tui/src/control/ControlCenter.tsx
@@ -365,6 +365,10 @@ export function ControlCenter({ host, lang: initialLang, initial, onExit, mouse 
     // Drawn in the header so it is readable from every tab — a counter you have to navigate to in
     // order to see cannot tell you to navigate there.
     attention: fleet?.attention ?? 0,
+    // Absent on a machine whose memory cannot be read, and then no gauge is drawn at all — never a
+    // zero. The host decides `red`, from the distance to the ceiling AND from swap pressure; the
+    // TUI owns no logic here either.
+    ...(status?.memory ? { memory: status.memory } : {}),
     width,
   })
   const height = bodyHeight(rows, header.rows)

--- a/packages/tui/src/control/chrome.test.ts
+++ b/packages/tui/src/control/chrome.test.ts
@@ -215,6 +215,42 @@ describe('headerMeta', () => {
     expect(meta.update).toBe('● 1.7.4')
   })
 
+  test('draws the parallel-sessions budget, and NOTHING when it could not be measured', () => {
+    const with_ = headerMeta({
+      mode: 'solo', version: '1.7.4', memory: { used: 3, max: 17, red: false }, width: 60,
+    })
+    expect(with_.memory).toBe('▤ 3/17')
+    expect(with_.memoryRed).toBe(false)
+    // A machine whose memory cannot be read draws no gauge at all — never a zero, which would read
+    // as "no room left" on precisely the machines nobody could ask.
+    expect(headerMeta({ mode: 'solo', version: '1.7.4', width: 60 }).memory).toBe('')
+  })
+
+  test('a RED budget outranks the version under width pressure', () => {
+    // The pieces drop least-actionable-first, and a budget about to run out is the most actionable
+    // thing on the row. Dropping the warning to keep a version number would be the wrong trade at
+    // exactly the moment it matters — the version is one `agentop --version` away.
+    const narrow = { mode: 'solo', version: '1.7.4', latestVersion: '1.9.0', attention: 2 }
+    const red = headerMeta({ ...narrow, memory: { used: 14, max: 15, red: true }, width: 22 })
+    expect(red.memory).toBe('▤ 14/15')
+    expect(red.text).toBe('solo')            // the version went first
+    // …while a calm budget gives way instead, because it is only informational.
+    const calm = headerMeta({ ...narrow, memory: { used: 3, max: 17, red: false }, width: 22 })
+    expect(calm.memory).toBe('')
+  })
+
+  test('the waiting counter still outlives the budget', () => {
+    // Ordering pinned end to end: update, then a calm budget, then the version, and the counter is
+    // the last thing standing after the mode token.
+    const meta = headerMeta({
+      mode: 'solo', version: '1.7.4', latestVersion: '1.9.0', attention: 2,
+      memory: { used: 3, max: 17, red: false }, width: 12,
+    })
+    expect(meta.alert).toBe('⏳ 2')
+    expect(meta.memory).toBe('')
+    expect(meta.update).toBe('')
+  })
+
   test('says nothing about an update when the running version IS the latest', () => {
     expect(headerMeta({ mode: 'solo', version: '1.7.4', latestVersion: '1.7.4', width: 60 }).update).toBe('')
     expect(headerMeta({ mode: 'solo', version: '1.7.4', width: 60 }).update).toBe('')

--- a/packages/tui/src/control/chrome.ts
+++ b/packages/tui/src/control/chrome.ts
@@ -184,6 +184,14 @@ export interface HeaderMetaInput {
    * cannot tell you to navigate there.
    */
   attention?: number
+  /**
+   * How many assistants are up out of how many this MACHINE can hold, when it could be measured.
+   *
+   * Absent means nobody could read the memory (not Linux, no `/proc`) and the gauge is simply not
+   * drawn. `red` is decided by the host, from the distance to the ceiling and from swap pressure —
+   * the TUI owns no logic, here as everywhere.
+   */
+  memory?: { used: number; max: number; red: boolean }
   width: number
 }
 
@@ -197,12 +205,23 @@ export interface HeaderMeta {
   /** The waiting-sessions counter, e.g. `⏳ 2`. */
   alert: string
   update: string
+  /**
+   * The parallel-sessions budget, e.g. `▤ 3/17` — how many assistants are up, out of how many this
+   * MACHINE can hold. Empty where memory could not be read at all.
+   *
+   * It answers the question actually asked before opening one, which "10 GB used" does not. The
+   * glyph is there so it cannot be misread as a session count on its own.
+   */
+  memory: string
+  /** True when the budget is inside its warning distance — the caller colours it. */
+  memoryRed?: boolean
 }
 
 /** What the pieces cost together, separators included — the number the caller budgets against. */
 export function headerMetaWidth(meta: HeaderMeta): number {
   return meta.text.length
     + (meta.alert ? SEP.length + meta.alert.length : 0)
+    + (meta.memory ? SEP.length + meta.memory.length : 0)
     + (meta.update ? SEP.length + meta.update.length : 0)
 }
 
@@ -222,25 +241,41 @@ export function headerMetaWidth(meta: HeaderMeta): number {
  * and it is the piece that must survive a narrow terminal.
  */
 export function headerMeta(input: HeaderMetaInput): HeaderMeta {
-  const { mode, version, latestVersion, attention, width } = input
-  if (width <= 0) return { text: '', alert: '', update: '' }
+  const { mode, version, latestVersion, attention, memory, width } = input
+  if (width <= 0) return { text: '', alert: '', update: '', memory: '' }
 
   const outdated = Boolean(latestVersion && latestVersion !== version)
   const text = version ? `${mode}${SEP}v${version}` : mode
   const alert = attention && attention > 0 ? `⏳ ${attention}` : ''
   const update = outdated ? `● ${latestVersion}` : ''
+  // Absent memory renders nothing at all — a machine whose `/proc` cannot be read shows no gauge
+  // rather than a zero, the same rule the boot row and the harness capabilities follow.
+  const mem = memory ? `▤ ${memory.used}/${memory.max}` : ''
+  const red = memory?.red === true
 
-  const full = { text, alert, update }
+  const full = { text, alert, update, memory: mem, memoryRed: red }
   if (headerMetaWidth(full) <= width) return full
 
-  const withoutUpdate = { text, alert, update: '' }
+  // Dropped least-actionable first, exactly as before. The budget sits between the update notice
+  // and the version: it is more actionable than "there is a new release" and less than the waiting
+  // counter, which stays the last thing standing after the mode token.
+  const withoutUpdate = { ...full, update: '' }
   if (headerMetaWidth(withoutUpdate) <= width) return withoutUpdate
 
-  const withoutVersion = { text: mode, alert, update: '' }
+  // …unless it is RED. A budget about to run out is the most actionable thing on the row, so it
+  // outranks the version and keeps its place — dropping the warning to keep a version number would
+  // be the wrong trade at exactly the moment it matters.
+  const withoutMemory = { ...full, update: '', memory: red ? mem : '' }
+  if (headerMetaWidth(withoutMemory) <= width) return withoutMemory
+
+  const withoutVersion = { text: mode, alert, update: '', memory: red ? mem : '', memoryRed: red }
   if (headerMetaWidth(withoutVersion) <= width) return withoutVersion
 
-  if (mode.length <= width) return { text: mode, alert: '', update: '' }
-  return { text: truncate(mode, width), alert: '', update: '' }
+  const modeAndAlert = { text: mode, alert, update: '', memory: '' }
+  if (headerMetaWidth(modeAndAlert) <= width) return modeAndAlert
+
+  if (mode.length <= width) return { text: mode, alert: '', update: '', memory: '' }
+  return { text: truncate(mode, width), alert: '', update: '', memory: '' }
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/tui/src/control/types.ts
+++ b/packages/tui/src/control/types.ts
@@ -819,6 +819,21 @@ export interface ControlStatus {
   version: string
   /** Set when a newer release exists; drives the update dot in the header. */
   latestVersion?: string
+  /**
+   * How many assistants are running out of how many this MACHINE can hold — the header's `▤ 3/17`.
+   *
+   * **This is about the SYSTEM, not about agentop**, and the surface has to say so: a number in the
+   * corner of a window is read as belonging to that window, and someone would otherwise conclude
+   * agentop eats 10 GB. Measured: agentop's own server was 578 MB of a 4 GB total, and the rest was
+   * one Node process per assistant CLI.
+   *
+   * **Absent when the memory could not be read at all** (not Linux, no `/proc`), and then no gauge
+   * is drawn — never a zero. `red` is the host's decision, taken from the DISTANCE to the ceiling
+   * rather than a percentage (three left of thirty is comfortable, three of fourteen is the last
+   * warning) and from swap pressure, which is what actually freezes a machine: the incident this
+   * exists for read 3.6 GB of free RAM while swap sat at 97%.
+   */
+  memory?: { used: number; max: number; red: boolean }
   /** The history-preservation setting in force, or `undefined` while it is still unanswered. */
   archiveMode?: ArchiveMode
   /**


### PR DESCRIPTION
The requested memory gauge, built as the question people actually ask: **`▤ 3/17`** — how many assistants are up, out of how many fit — rather than "10 GB used", which nobody can act on.

Three decisions, each from something measured on this machine:

**`MemAvailable`, never `MemFree`.** At one moment here: free 5.7 GB against available 9.7 GB. `MemFree` would call a machine with 4 GB of headroom nearly out, and every warning after that is noise a user learns to ignore.

**Swap is part of the answer.** The freeze this exists to prevent read 3.6 GB of free RAM while swap sat at **97%** — a RAM-only budget would have said everything was fine at the moment the laptop locked up. The alarm names which of the two tripped, because closing a session fixes one and may not fix the other.

**Red by DISTANCE, not percentage.** Three left of thirty is comfortable; three of fourteen is the last warning, and what gets spent is one session at a time. A red budget also **outranks the version** under width pressure — dropping the warning to keep a version number is the wrong trade at exactly the moment it matters.

Honesty rules kept:

- the cost per session is **measured** from what is running (548 MB here, against the 250 MB default), and `basis: 'assumed'` exists so no surface can present the fallback as a reading;
- a machine whose memory cannot be read draws **no gauge** — not a zero, which would say "no room" on precisely the machines nobody could ask;
- the label is about the **system**, not agentop: a number in a window's corner is read as belonging to that window, and agentop's own server was 578 MB of a 4 GB total;
- RSS over-counts shared pages, so the figure is an upper bound — stated in the module rather than left to be discovered, and why the wording is "recommended".

Verified: `bun tsc --noEmit` clean, `bun test` **4044 pass / 0 fail**, binary compiles, and the width sweep at 60/80/90/100/130/190 columns has **zero** rows overflowing with the gauge present. Against the real machine it reports `3/17` at a measured 548 MB/session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TBcRtC62Sx18sgJj64r1Np