### PR TITLE
fix(cockpit): name a second server that is running and serving nothing

### DIFF
--- a/packages/server/server/cli-i18n.ts
+++ b/packages/server/server/cli-i18n.ts
@@ -89,6 +89,8 @@ export interface CliStrings {
    * the services row can say least, a red line that named one runtime.
    */
   svcConflict: (runtimes: string[]) => string
+  /** A second copy under the SAME runtime, serving nothing. Names the pid — see ControlService.idle. */
+  svcIdleServer: (pids: number[]) => string
   /** A stop/restart named something that is not running. */
   svcNotRunning: string
 
@@ -404,6 +406,9 @@ const EN: CliStrings = {
   svcAgentistics: 'agentistics',
   svcCentral: 'agentistics central',
   svcConflict: (runtimes) => `conflict: ${runtimes.join(' + ')} both running — stop one`,
+  svcIdleServer: pids => pids.length === 1
+    ? `a second server (pid ${pids[0]}) is running and serving nothing — kill ${pids[0]}`
+    : `${pids.length} extra servers are running and serving nothing — kill ${pids.join(' ')}`,
   svcNotRunning: 'that service is not running.',
 
   sessState: {
@@ -643,6 +648,9 @@ const PT: CliStrings = {
   svcAgentistics: 'agentistics',
   svcCentral: 'agentistics central',
   svcConflict: (runtimes) => `conflito: ${runtimes.join(' + ')} rodando juntos — pare um`,
+  svcIdleServer: pids => pids.length === 1
+    ? `um segundo servidor (pid ${pids[0]}) está rodando sem servir nada — encerre ${pids[0]}`
+    : `${pids.length} servidores extras rodando sem servir nada — encerre ${pids.join(' ')}`,
   svcNotRunning: 'esse serviço não está rodando.',
 
   sessState: {

--- a/packages/server/server/cli-start.ts
+++ b/packages/server/server/cli-start.ts
@@ -107,6 +107,7 @@ import { needsChoice, parseDialogOptions } from './sessions/dialog-choice'
 import { rulesFor } from './sessions/attention-rules'
 import { planCrashGroup, planFellOffer } from './sessions/crash-group'
 import { loadHarnessSessions } from './sessions/harness-sessions'
+import { idleServers, isServerCommand } from './idle-servers'
 // The lock on the door: one conversation, one live session. See `conversation-claim.ts` for the
 // measurement that made it necessary, and `live-claims.ts` for the evidence it is allowed to use.
 import { conversationHeldBy } from './sessions/conversation-claim'
@@ -511,6 +512,8 @@ export function buildService(
     bootOptions?: BootOption[]
     rebuild?: RebuildAbility
     centralPlan?: CentralStartPlan
+    /** Pids of extra copies of this service that hold no port — see `idle-servers.ts`. */
+    idlePids?: number[]
   } = {},
 ): ControlService {
   const up = runtimes.filter(r => r.state === 'up')
@@ -529,6 +532,9 @@ export function buildService(
     bootOptions: facts.bootOptions ?? [],
     // Named, not merely coloured, and never reduced to whichever copy we happened to find first.
     conflict: up.length > 1 ? s.svcConflict(up.map(r => r.kind)) : undefined,
+    // Two processes of the ONE runtime — invisible to every runtime probe, because they all ask
+    // which pid holds the port. See `idle-servers.ts` for the seventy-minute incident.
+    idle: facts.idlePids?.length ? s.svcIdleServer(facts.idlePids) : undefined,
     reason,
     // The single most important line in the model: while anything is up there is nothing to start.
     startOptions: up.length > 0
@@ -746,6 +752,31 @@ async function nativeServerFacts(): Promise<ProcessFacts> {
   const pid = Number((await listeningServerPids())[0])
   if (!Number.isInteger(pid) || pid <= 0) return {}
   return { pid, startedAt: await processStartedAt(pid) }
+}
+
+/**
+ * Server processes that hold NO port — the copies every runtime probe is blind to.
+ *
+ * `lsof -sTCP:LISTEN` can only ever find the process that won the port, so a second server is
+ * invisible to `nativeServerFacts` by construction while it burns a core on the file watcher. This
+ * asks the process table instead and subtracts the listener and ourselves.
+ *
+ * Empty on any failure, including a platform with no `ps`: an unreadable process table is "cannot
+ * tell", and a warning invented out of one would appear on machines nobody could ask.
+ */
+async function idleServerPids(): Promise<number[]> {
+  try {
+    const ps = await sh(['ps', '-eo', 'pid=,args='])
+    const processes = ps.out.split('\n')
+      .map(line => /^\s*(\d+)\s+(.*)$/.exec(line.trim()))
+      .filter((m): m is RegExpExecArray => m !== null)
+      .map(m => ({ pid: Number(m[1]), command: m[2]! }))
+      .filter(p => isServerCommand(p.command))
+    const listening = (await listeningServerPids()).map(Number).filter(n => Number.isInteger(n) && n > 0)
+    return idleServers({ processes, listening, self: process.pid }).idle.map(p => p.pid)
+  } catch {
+    return []
+  }
 }
 
 async function stopLocal(s: CliStrings): Promise<void> {
@@ -1611,6 +1642,10 @@ function createControlHost(initialLang: CliLang, altScreen: Suspendable): StartH
       // native start option even exists (see `StartFacts.centralPlan`).
       centralStartPlan(),
     ])
+    // Asked whatever the runtime state says: the case this exists for is a second server running
+    // while the row reads perfectly healthy, so gating it on `local` would skip exactly the machine
+    // that needs it — and it is worth asking even when nothing holds the port at all.
+    const idlePids = await idleServerPids()
     const [nativeFacts, centralFacts, machineFacts] = await Promise.all([
       local ? nativeServerFacts() : Promise.resolve<ProcessFacts>({}),
       central.state === 'up' ? containerFacts(CENTRAL_FILTER) : Promise.resolve<ContainerFacts>({}),
@@ -1685,6 +1720,7 @@ function createControlHost(initialLang: CliLang, altScreen: Suspendable): StartH
           },
         ], s, bootSupported, s.svcAgentistics),
         rebuild: { local: repo, machine: machineCompose },
+        idlePids,
       }),
       // The central's rebuild always works: `central.sh up` inside a checkout, and the published
       // image outside one — `cli-central.ts` picks between them, and a central that is RUNNING

--- a/packages/server/server/idle-servers.test.ts
+++ b/packages/server/server/idle-servers.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'bun:test'
+import { idleServers, isServerCommand } from './idle-servers'
+
+describe('isServerCommand', () => {
+  it('matches both forms that actually collided', () => {
+    // Verbatim from the machine where two servers ran for seventy minutes. They look nothing alike,
+    // which is exactly why the match is on the SUBCOMMAND and not on the binary's name.
+    expect(isServerCommand('/home/mithrandir/.local/bin/agentop server')).toBe(true)
+    expect(isServerCommand('bun packages/server/bin/cli.ts server')).toBe(true)
+    expect(isServerCommand('/home/x/.volta/tools/image/packages/bun/bin/bun packages/server/bin/cli.ts server')).toBe(true)
+  })
+
+  it('does not match the other agentop verbs', () => {
+    expect(isServerCommand('agentop session ls')).toBe(false)
+    expect(isServerCommand('agentop check-update')).toBe(false)
+    expect(isServerCommand('agentop central up')).toBe(false)
+  })
+
+  it('does not match a command line that merely mentions it', () => {
+    // A `grep` in somebody's pipeline is not a server, and reporting it would train people to
+    // ignore the warning — which is the only way this feature can fail.
+    expect(isServerCommand('grep agentop server')).toBe(false)
+    expect(isServerCommand('server')).toBe(false)
+    expect(isServerCommand('vim notes-about-agentop-server.md')).toBe(false)
+  })
+})
+
+describe('idleServers', () => {
+  const listener = { pid: 517, command: '/home/x/.local/bin/agentop server' }
+  const orphan = { pid: 3189270, command: 'bun packages/server/bin/cli.ts server' }
+
+  it('names the one that is running and serving nothing', () => {
+    const r = idleServers({ processes: [listener, orphan], listening: [517], self: 999 })
+    expect(r.idle.map(p => p.pid)).toEqual([3189270])
+    expect(r.listener).toBe(517)
+  })
+
+  it('never reports the listener', () => {
+    expect(idleServers({ processes: [listener], listening: [517], self: 999 }).idle).toEqual([])
+  })
+
+  it('never reports ITSELF', () => {
+    // The cockpit runs inside an `agentop`. A rule without this reports a conflict on every healthy
+    // machine, which is worse than reporting nothing at all.
+    const me = { pid: 4242, command: '/home/x/.local/bin/agentop server' }
+    expect(idleServers({ processes: [listener, me], listening: [517], self: 4242 }).idle).toEqual([])
+  })
+
+  it('reports a server running while NOBODY holds the port', () => {
+    // Still waste, and still worth naming: it is doing the watcher's work and answering no request.
+    const r = idleServers({ processes: [orphan], listening: [], self: 999 })
+    expect(r.idle.map(p => p.pid)).toEqual([3189270])
+    expect(r.listener).toBeUndefined()
+  })
+})

--- a/packages/server/server/idle-servers.ts
+++ b/packages/server/server/idle-servers.ts
@@ -1,0 +1,93 @@
+/**
+ * idle-servers.ts — PURE. A second `agentop server` that is running and serving NOTHING.
+ *
+ * ## The incident this exists for
+ *
+ * Two `agentop server` processes ran side by side for seventy minutes on a real machine:
+ *
+ * ```
+ * 517      ~/.local/bin/agentop server            ← systemd, holding 47291/47292
+ * 3189270  bun packages/server/bin/cli.ts server  ← started by hand from the checkout
+ * ```
+ *
+ * The second could not bind the ports and **kept working anyway**: the file watcher does not depend
+ * on a listening socket, so it held 2367 inotify watches and recomputed the whole API response on
+ * every transcript write from twelve sessions — 72% of a core and 1.1 GB, serving nobody.
+ *
+ * Nothing in the product could see it. The conflict model knows `native` versus `docker` and merges
+ * the two into one row, and **a compiled binary and `bun run` from a checkout are both native**, so
+ * two servers collapsed into one line that said everything was fine. And the runtime probe asks
+ * `lsof -sTCP:LISTEN`, which by construction can only ever find the one that WON the port.
+ *
+ * ## The rule
+ *
+ * A server process that is not the listener is not a second opinion, it is waste. There is no case
+ * where two of them is what somebody wanted: they read the same files, write the same caches and
+ * fight over the same port. So it is reported as a fault with the pid, and the pid is the whole
+ * point — "something is wrong" that cannot be acted on is a worse message than none.
+ *
+ * The listener itself is never reported. Nor is THIS process: the cockpit runs inside `agentop`, and
+ * a rule that flagged its own pid would report a conflict on every healthy machine.
+ */
+
+/** One process claiming to be an agentop server. */
+export interface ServerProcess {
+  pid: number
+  /** The command line, for the report — a user has to be able to tell which one to kill. */
+  command: string
+}
+
+export interface IdleServers {
+  /** Running, not listening, not us. Waste, every one of them. */
+  idle: ServerProcess[]
+  /** The pid holding the port, when there is one. */
+  listener?: number
+}
+
+/**
+ * Which server processes are doing nothing — PURE.
+ *
+ * `listening` is the set holding the port (usually one). `self` is this process, excluded because
+ * the cockpit is itself an `agentop` and would otherwise report itself forever.
+ */
+export function idleServers(o: {
+  processes: readonly ServerProcess[]
+  listening: readonly number[]
+  self: number
+}): IdleServers {
+  const holding = new Set(o.listening)
+  const idle = o.processes.filter(p => p.pid !== o.self && !holding.has(p.pid))
+  return { idle, ...(o.listening[0] !== undefined ? { listener: o.listening[0] } : {}) }
+}
+
+/**
+ * Whether a command line is an agentop SERVER — PURE.
+ *
+ * Matched on the `server` subcommand rather than on the binary's name, because the two forms that
+ * collided look nothing alike: `~/.local/bin/agentop server` and
+ * `bun packages/server/bin/cli.ts server`. Both end in the verb, and the verb is the thing that
+ * makes a process a server.
+ *
+ * `agentop server` must not match `agentop session`, `agentop check-update`, or a shell whose
+ * command line merely CONTAINS the phrase — a `grep agentop server` in someone's pipeline is not a
+ * server, and reporting it would train people to ignore this.
+ */
+export function isServerCommand(command: string): boolean {
+  const argv = command.trim().split(/\s+/)
+  const i = argv.indexOf('server')
+  if (i <= 0) return false
+
+  // `server` must be the program's FIRST argument, not merely a token preceded by a plausible word.
+  // Requiring only "the thing before it looks like agentop" matched `grep agentop server`, which is
+  // somebody's pipeline and not a server — and one false positive here trains people to ignore the
+  // warning, which is the only way this feature can fail.
+  const isProgram = (a: string): boolean => /(^|\/)agentop$/.test(a)
+  const isScript = (a: string): boolean => /(^|\/)(cli|index)\.(ts|js)$/.test(a)
+  const isRuntime = (a: string): boolean => /(^|\/)(bun|node|deno)(\.exe)?$/.test(a)
+
+  // `agentop server`
+  if (i === 1 && isProgram(argv[0]!)) return true
+  // `bun packages/server/bin/cli.ts server`
+  if (i === 2 && isRuntime(argv[0]!) && isScript(argv[1]!)) return true
+  return false
+}

--- a/packages/tui/src/control/chrome.test.ts
+++ b/packages/tui/src/control/chrome.test.ts
@@ -806,6 +806,31 @@ describe('detailContent', () => {
     expect(c.alert).toBe('')
   })
 
+  test('names a second copy that is running and serving nothing', () => {
+    // The seventy-minute incident: a second `agentop server` could not bind the ports and kept the
+    // file watcher going anyway, burning a core for nobody. Every runtime probe asks
+    // `lsof -sTCP:LISTEN` and therefore CANNOT see it, so the service row read perfectly healthy.
+    const c = detailContent(
+      service({ idle: 'a second server (pid 3189270) is running and serving nothing — kill 3189270' }),
+      s,
+      NOW,
+    )
+    expect(texts(c).join(' ')).toContain('3189270')
+  })
+
+  test('says the conflict AND the idle copy when both are true', () => {
+    // Different faults with different answers — one asks which runtime to stop, the other names a
+    // pid doing work for nobody. Folding them into one sentence would lose an instruction.
+    const c = detailContent(
+      service({ conflict: 'conflict: native + docker both running — stop one', idle: 'a second server (pid 7) …' }),
+      s,
+      NOW,
+    )
+    const said = texts(c).join(' ')
+    expect(said).toContain('conflict')
+    expect(said).toContain('pid 7')
+  })
+
   test('says nothing about a pid the box would not give up — never `pid 0`', () => {
     const c = detailContent(service(), s, NOW)
     expect(texts(c)).toEqual(['native'])

--- a/packages/tui/src/control/chrome.ts
+++ b/packages/tui/src/control/chrome.ts
@@ -899,6 +899,12 @@ export function detailContent(
   const alert = service.conflict ?? ''
   if (alert) lines.push({ kind: 'text', label: '', value: alert, tone: 'bad' })
 
+  // A second copy under the SAME runtime, holding no port. Its own line rather than folded into the
+  // conflict sentence: the two are different faults with different answers — a conflict asks which
+  // runtime to stop, this one names a pid that is doing work for nobody. Both can be true at once,
+  // and then both are said.
+  if (service.idle) lines.push({ kind: 'text', label: '', value: service.idle, tone: 'bad' })
+
   const summary = summaryOf(service, s, now)
   if (summary) lines.push({ kind: 'text', label: '', value: summary, tone: 'muted' })
 

--- a/packages/tui/src/control/types.ts
+++ b/packages/tui/src/control/types.ts
@@ -297,6 +297,23 @@ export interface ControlService {
    * the flag; pair it with a word as well as a colour, and offer `stopOptions`.
    */
   conflict?: string
+  /**
+   * A SECOND copy of this service running under the SAME runtime, serving nothing — already
+   * localized and naming the pid.
+   *
+   * Deliberately not folded into `conflict`, which is about two RUNTIMES and offers a per-runtime
+   * stop. This one is two processes of the one runtime, and the two cases need different sentences:
+   * "it is running natively and in docker, stop one" is a choice, while "a second one is running and
+   * answering nothing" is waste with a pid on it.
+   *
+   * It exists because the runtime probe cannot see this by construction — it asks
+   * `lsof -sTCP:LISTEN`, which only ever finds the process that WON the port. Measured: two
+   * `agentop server`s ran for seventy minutes, the loser burning 72% of a core and 1.1 GB on the
+   * file watcher, and every screen in the product said the service was healthy.
+   *
+   * The pid is the point. "Something is wrong" that cannot be acted on is a worse message than none.
+   */
+  idle?: string
   /** Why the state is `unknown`, already localized. */
   reason?: string
   /**


### PR DESCRIPTION
Two `agentop server`s ran side by side for seventy minutes on this machine. The loser could not bind the ports and **kept working anyway** — the file watcher does not need a listening socket — so it held 2367 inotify watches and recomputed the API response on every transcript write from twelve sessions: **72% of a core and 1.1 GB, serving nobody**.

Nothing in the product could see it, for two compounding reasons:

- the conflict model knows `native` vs `docker` and merges them into one row — and a **compiled binary and `bun run` from a checkout are both native**, so two servers collapsed into one line that read healthy;
- the runtime probe asks `lsof -sTCP:LISTEN`, which **by construction** can only ever find the process that won the port.

So the process table is asked instead, and a server holding no port is reported as a fault **with its pid** — "something is wrong" that cannot be acted on is a worse message than none. It gets its own field rather than being folded into `conflict`: a conflict asks which runtime to stop, this names a pid doing work for nobody, and both can be true at once (tested).

`isServerCommand` requires `server` to be the program's **first argument**. Matching on "the token before it looks like agentop" also matched `grep agentop server` — and one false positive here trains people to ignore the warning, which is the only way this can fail.

**Honesty about the verification.** The rule is checked against the verbatim command lines from the incident, and against this machine's live process table (one server, correctly reported as the listener, none idle). It is **not** verified against a live duplicate: a second server now exits on `EADDRINUSE` rather than lingering, so this is a net for a case the current build appears to have closed by another route. Worth having — a process can be alive-and-not-listening for other reasons — but not oversold.

`bun tsc --noEmit` clean, `bun test` **4040 pass / 0 fail**, binary compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TBcRtC62Sx18sgJj64r1Np