### PR TITLE
fix(cockpit): the boot row names EVERY unit that will bring the service back

### DIFF
--- a/packages/server/server/cli-start.ts
+++ b/packages/server/server/cli-start.ts
@@ -1696,12 +1696,26 @@ function createControlHost(initialLang: CliLang, altScreen: Suspendable): StartH
 
     return [
       buildService('agentistics', s.svcAgentistics, [nativeRuntime, machineRuntime], s, {
-        // Two distinct boot mechanisms now exist for this one service (native `agentop-server` vs
-        // Docker `agentop-machine`); the detail pane can only state one, so it states the one that
-        // matches whichever runtime is actually up — the native unit otherwise, matching this
-        // field's behavior before the Docker runtime had a boot mechanism of its own at all.
-        boot: machine.state === 'up' ? bootMachine : bootAgentistics,
-        bootUnit: unitName(machine.state === 'up' ? 'machine' : 'server'),
+        // Two distinct boot mechanisms exist for this ONE service — the native `agentop-server` and
+        // the Docker `agentop-machine` — and BOTH can be registered at once. The row used to name
+        // whichever matched the runtime that happened to be up, so on a machine that had registered
+        // both, the other one was invisible: something would bring the service back after a reboot
+        // and the pane named a unit that was not it. That is the same class of half-truth
+        // `ControlService.conflict` exists to prevent for the running state.
+        //
+        // So: registered if EITHER is, and the unit cell names every one that actually is. `boot`
+        // stays `undefined` when the host could not tell at all (no user systemd) — absence is
+        // absence, and a row with no answer draws nothing rather than claiming `off`.
+        boot: bootAgentistics === undefined && bootMachine === undefined
+          ? undefined
+          : bootAgentistics === 'on' || bootMachine === 'on' ? 'on' : 'off',
+        bootUnit: [
+          bootAgentistics === 'on' ? unitName('server') : '',
+          bootMachine === 'on' ? unitName('machine') : '',
+        ].filter(Boolean).join(' + ')
+          // Nothing registered: name the unit the switch on this row would WRITE, so "off" still
+          // says what it is off about.
+          || unitName(machine.state === 'up' ? 'machine' : 'server'),
         // BOTH mechanisms get a verb, whichever runtime happens to be up: the row states one and
         // the switch has to reach either, or a machine that registered the container at boot could
         // never turn that off while running natively.


### PR DESCRIPTION
Closes #136.

Two boot mechanisms exist for one service — the native `agentop-server` and the Docker `agentop-machine` — and **both can be registered at once**. The row named whichever matched the runtime that happened to be up, so on a machine with both registered the other was **invisible**: something would bring the service back after a reboot and the pane named a unit that was not it.

Same class of half-truth `ControlService.conflict` exists to prevent for the running state, and the answer is the same — say both rather than pick one.

- registered if **either** is, and the cell names every one that actually is;
- `boot` stays `undefined` where the host cannot tell at all (no user systemd) — absence is absence, and a row with no answer draws nothing rather than claiming `off`;
- with nothing registered the cell still names the unit this row's switch would **write**, so `off` says what it is off about.

`bun tsc --noEmit` clean, `bun test` **4044 pass / 0 fail**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TBcRtC62Sx18sgJj64r1Np