### PR TITLE
fix(cockpit): remove the per-row close control

### DIFF
--- a/packages/tui/src/control/sessions.test.ts
+++ b/packages/tui/src/control/sessions.test.ts
@@ -2402,14 +2402,18 @@ describe('the per-row close control', () => {
     expect(CLOSE_CELL.codePointAt(0)!).toBeLessThan(128)
   })
 
-  it('costs nothing when nothing on screen can be closed', () => {
-    expect(closeCellWidth([closed, gone], 120)).toBe(0)
-    expect(closeCellWidth([live], 120)).toBe(CLOSE_CELL.length + 1)
-  })
-
-  it('gives up on a narrow list rather than squeezing the table for a button', () => {
-    // The keyboard's `x` still works there, and a table squeezed to make room is the worse trade.
-    expect(closeCellWidth([live], 30)).toBe(0)
-    expect(closeCellWidth([live], 40)).toBe(CLOSE_CELL.length + 1)
+  it('costs the table NOTHING, at any width and whatever is on screen', () => {
+    // The control is gone. It did not make sense where it sat: every other verb on this screen is
+    // reached from the menu or a key, and a table's last column is where a VALUE goes — so a button
+    // parked there reads as a truncated cell, and it put the most destructive question on the row
+    // exactly where the eye lands after skimming it.
+    //
+    // Asserted across the whole range rather than at one width, so the reservation cannot creep back
+    // for "just the wide terminal".
+    for (const width of [0, 30, 40, 120, 400]) {
+      expect(closeCellWidth([live], width)).toBe(0)
+      expect(closeCellWidth([closed, gone], width)).toBe(0)
+      expect(closeCellWidth([], width)).toBe(0)
+    }
   })
 })

--- a/packages/tui/src/control/sessions.ts
+++ b/packages/tui/src/control/sessions.ts
@@ -2532,18 +2532,20 @@ export const CLOSE_CELL = '[x]'
 /**
  * Columns reserved at the right edge of the list for the per-row close control — PURE.
  *
- * A gap plus the control itself, DERIVED from `CLOSE_CELL` rather than written as a number beside
- * it: the two were `'✕'` and `2`, and changing the glyph without changing the reservation is how a
- * control ends up drawn on top of the last cell. Reserved from the width BEFORE the columns are
- * measured, for the same reason.
+ * **Always zero: the control is gone.** Kept as a function rather than deleted so the width
+ * arithmetic still has one place that says what the right edge costs, and so a future control there
+ * has somewhere to declare itself instead of being sprinkled through the callers.
  *
- * Zero when nothing on screen can be closed, and zero on a list too narrow to spare it — the
- * keyboard's `x` still works there, and a table squeezed to make room for a button is a worse
- * trade than a button that is only on the wider terminal.
+ * Removed because it did not make sense where it sat. Every other verb on this screen is reached
+ * from the menu or a key, and a table's last column is where a VALUE goes — so a control parked
+ * there reads as a truncated cell until you happen to click it. It also put the most destructive
+ * question on the screen exactly where a reader's eye lands after skimming a row.
+ *
+ * Nothing was taken away but the button: `x` still closes the selected session, and the menu still
+ * offers it in words.
  */
-export function closeCellWidth(rows: readonly ControlSession[], width: number): number {
-  const NEEDS = 40
-  return width >= NEEDS && rows.some(canClose) ? CLOSE_CELL.length + 1 : 0
+export function closeCellWidth(_rows: readonly ControlSession[], _width: number): number {
+  return 0
 }
 
 /**


### PR DESCRIPTION
The `x` at the end of each session row is gone, as requested — and the reason is worth stating.

Every other verb on this screen is reached from the menu or a key. A table's last column is where a **value** goes, so a control parked there reads as a truncated cell until somebody happens to click it. It also put the most destructive question on the screen exactly where the eye lands after skimming a row.

`closeCellWidth` stays as a function returning zero rather than being deleted: the width arithmetic keeps one place that says what the right edge costs, and a future control there has somewhere to declare itself instead of being sprinkled through the callers. The test asserts zero **across the whole width range**, so the reservation cannot creep back for "just the wide terminal".

Nothing was taken away but the button — `x` still closes the selected session, and the menu still offers it in words.

`bun tsc --noEmit` clean, `bun test` **4055 pass / 0 fail**, verified in the compiled binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TBcRtC62Sx18sgJj64r1Np