### PR TITLE
fix(cockpit): one switch for "not running", and a search that applies as you type

### DIFF
--- a/packages/tui/src/control/Prompt.tsx
+++ b/packages/tui/src/control/Prompt.tsx
@@ -33,6 +33,15 @@ export interface TextPromptProps {
   /** Mask the value — the member token is pasted in front of other people. */
   secret?: boolean
   onSubmit: (value: string) => void
+  /**
+   * Called on EVERY keystroke, when the caller wants the answer as it is typed.
+   *
+   * Optional because most of these prompts must not act early: a member token is meaningless until
+   * it is whole, and a rename applied per character would write six labels while somebody types
+   * one. A SEARCH is the opposite — the whole value of it is watching the list narrow — so it is
+   * the caller that decides, not this component.
+   */
+  onChange?: (value: string) => void
   onCancel?: () => void
   width: number
   isActive?: boolean
@@ -44,23 +53,29 @@ export function TextPrompt({
   defaultValue,
   secret,
   onSubmit,
+  onChange,
   onCancel,
   width,
   isActive = true,
 }: TextPromptProps) {
   const [value, setValue] = useState('')
+  // One place that changes the value, so `onChange` cannot be forgotten on a path — and it fires
+  // with the NEW value rather than reading state that has not re-rendered yet.
+  const edit = (next: (v: string) => string): void => {
+    setValue(v => { const n = next(v); onChange?.(n); return n })
+  }
 
   useInput((input, key) => {
     if (key.escape) { onCancel?.(); return }
     if (key.return) { onSubmit(value.trim() || defaultValue || ''); return }
-    if (key.ctrl && input === 'u') { setValue(''); return }
-    if (key.backspace || key.delete) { setValue(v => v.slice(0, -1)); return }
+    if (key.ctrl && input === 'u') { edit(() => ''); return }
+    if (key.backspace || key.delete) { edit(v => v.slice(0, -1)); return }
     if (key.ctrl || key.meta || key.tab || key.upArrow || key.downArrow) return
 
     // A paste arrives as one multi-character chunk; control bytes inside it would corrupt the
     // rendered row, so only printable characters are kept.
     const printable = [...input].filter(ch => ch >= ' ' && ch !== '\x7f').join('')
-    if (printable) setValue(v => v + printable)
+    if (printable) edit(v => v + printable)
   }, { isActive })
 
   const suffix = defaultValue ? ` (${defaultValue})` : ''

--- a/packages/tui/src/control/i18n.ts
+++ b/packages/tui/src/control/i18n.ts
@@ -402,8 +402,8 @@ export interface ControlStrings {
   asideShow: string
   asideTasks: string
   asideAllTasks: string
-  toggleClosed: string
-  toggleExited: string
+  /** ONE switch for "not running". `toggleClosed`/`toggleExited` were two names for one question. */
+  toggleHistory: string
   /**
    * The named-row widening, made visible.
    *
@@ -845,8 +845,7 @@ const EN: ControlStrings = {
   asideShow: 'SHOW',
   asideTasks: 'TASKS',
   asideAllTasks: 'every task',
-  toggleClosed: 'closed conversations',
-  toggleExited: 'finished sessions',
+  toggleHistory: 'not running',
   toggleNamed: 'always keep named sessions',
   keySessionsAside: 'tab menu',
   manageTitle: (title: string) => `Managing "${title}"`,
@@ -1256,8 +1255,7 @@ const PT: ControlStrings = {
   asideShow: 'MOSTRAR',
   asideTasks: 'TAREFAS',
   asideAllTasks: 'todas as tarefas',
-  toggleClosed: 'conversas fechadas',
-  toggleExited: 'sessões encerradas',
+  toggleHistory: 'não estão rodando',
   toggleNamed: 'sempre manter sessões nomeadas',
   keySessionsAside: 'tab menu',
   manageTitle: (title: string) => `Gerenciando "${title}"`,

--- a/packages/tui/src/control/session-dimensions.test.ts
+++ b/packages/tui/src/control/session-dimensions.test.ts
@@ -187,20 +187,25 @@ describe('the status shortcuts', () => {
     expect(shortcutOn(['waiting'], 'active')).toBe(false)
   })
 
-  it('reads the widening switches as membership', () => {
-    expect(shortcutOn([...ACTIVE_STATES, 'closed'], 'closed')).toBe(true)
-    expect(shortcutOn([...ACTIVE_STATES], 'closed')).toBe(false)
-    // Both states, together — a `lost` row is over in the only sense this switch asks about.
-    expect(shortcutOn([...ACTIVE_STATES, 'exited'], 'exited')).toBe(false)
-    expect(shortcutOn([...ACTIVE_STATES, 'exited', 'lost'], 'exited')).toBe(true)
+  it('reads the widening switch as membership, and it takes ALL of history', () => {
+    // There were two switches here and they asked one question. `closed` named a conversation that
+    // is not running and `exited` named a finished session plus `lost`; to the person reading the
+    // list all three are "it is not running", so ticking either while the other was on appeared to
+    // do nothing. One switch, all three states, on together or not at all.
+    expect(shortcutOn([...ACTIVE_STATES, 'closed', 'exited', 'lost'], 'history')).toBe(true)
+    expect(shortcutOn([...ACTIVE_STATES], 'history')).toBe(false)
+    // A PARTIAL selection is not the switch being on: it would draw itself lit over a list missing
+    // two of the three states it claims to include.
+    expect(shortcutOn([...ACTIVE_STATES, 'closed'], 'history')).toBe(false)
+    expect(shortcutOn([...ACTIVE_STATES, 'exited', 'lost'], 'history')).toBe(false)
   })
 
   it('turns `active` OFF by itself when another switch widens past it', () => {
     // The visible consequence, and the whole point: a switch is never lit over a list it does not
     // describe. This is what the old model could not express — the state set silently overrode the
     // switches while they went on drawing themselves as if they decided anything.
-    const widened = applyShortcut([...ACTIVE_STATES], 'closed')
-    expect(shortcutOn(widened, 'closed')).toBe(true)
+    const widened = applyShortcut([...ACTIVE_STATES], 'history')
+    expect(shortcutOn(widened, 'history')).toBe(true)
     expect(shortcutOn(widened, 'active')).toBe(false)
   })
 
@@ -210,7 +215,7 @@ describe('the status shortcuts', () => {
   })
 
   it('never empties the selection', () => {
-    expect(applyShortcut(['closed'], 'closed')).toEqual(['closed'])
+    expect(applyShortcut(['closed', 'exited', 'lost'], 'history').sort()).toEqual(['closed', 'exited', 'lost'])
   })
 })
 

--- a/packages/tui/src/control/session-dimensions.ts
+++ b/packages/tui/src/control/session-dimensions.ts
@@ -326,15 +326,25 @@ export function toggleValue(
 // the status shortcuts — a coarse vocabulary for the same selection
 // ---------------------------------------------------------------------------
 
-export type StatusShortcut = 'active' | 'closed' | 'exited'
+export type StatusShortcut = 'active' | 'history'
 
-/** Which states each shortcut names. `Record`, so a new shortcut cannot be half-declared. */
+/**
+ * Which states each shortcut names. `Record`, so a new shortcut cannot be half-declared.
+ *
+ * **There were three, and two of them asked the same question.** `closed` named a conversation that
+ * is not running; `exited` named a session that finished, plus `lost`, a session the backend can no
+ * longer find. Internally those differ and the difference matters — they carry different verbs, and
+ * `lost` is a fact about the backend rather than about the work. But from the chair of the person
+ * reading the screen all three answer *it is not running*, so the list offered one question twice:
+ * ticking either while the other was on appeared to do nothing, which is a control that lies.
+ *
+ * The vocabulary is now the honest pair — what is RUNNING and what is not. The states keep their
+ * distinction and each row still shows its own; it is the FILTER that stopped pretending two
+ * switches were two questions.
+ */
 export const SHORTCUT_STATES: Record<StatusShortcut, readonly SessionState[]> = {
   active: ACTIVE_STATES,
-  closed: ['closed'],
-  // Two states under one switch: the backend has no idea what happened to a `lost` row, so it is
-  // over in the only sense this switch is asking about.
-  exited: ['exited', 'lost'],
+  history: ['closed', 'exited', 'lost'],
 }
 
 const sameSet = (a: readonly string[], b: readonly string[]): boolean =>
@@ -508,7 +518,10 @@ export function storedFilters(state: SessionFilterState): Partial<SessionViewPre
     marked: [...state.marked],
     states: [...status],
     onlyActive: shortcutOn(status, 'active'),
-    showClosed: shortcutOn(status, 'closed'),
-    showExited: shortcutOn(status, 'exited'),
+    // Both legacy switches are derived from the ONE that replaced them. An older binary reading
+    // this file gets them lifted or lowered together, which is what `history` means there too —
+    // and is strictly better than a downgrade that comes up with half the history hidden.
+    showClosed: shortcutOn(status, 'history'),
+    showExited: shortcutOn(status, 'history'),
   }
 }

--- a/packages/tui/src/control/sessions.test.ts
+++ b/packages/tui/src/control/sessions.test.ts
@@ -592,7 +592,7 @@ describe('asideRows', () => {
     new: 'New', search: 'Search', group: 'Group',
   }
   const groupWords = { repo: 'repo', none: 'flat', task: 'tasks', harness: 'harness', model: 'model', project: 'project', status: 'state', marked: 'marked' }
-  const toggleWords = { closed: 'closed', exited: 'finished', named: 'named', done: 'done tasks', active: 'only active', detail: 'detail' }
+  const toggleWords = { history: 'closed', named: 'named', done: 'done tasks', active: 'only active', detail: 'detail' }
   const headings = { actions: 'ACTIONS', view: 'VIEW', show: 'SHOW' }
 
   const build = (o: Partial<Parameters<typeof asideRows>[0]> = {}) => asideRows({
@@ -600,7 +600,7 @@ describe('asideRows', () => {
     actionWords: words,
     grouping: 'none',
     groupWords,
-    toggles: { closed: false, exited: false, named: false, done: false, active: false, detail: false },
+    toggles: { history: false, named: false, done: false, active: false, detail: false },
     toggleWords,
     headings,
     layout: LAYOUT,
@@ -617,10 +617,10 @@ describe('asideRows', () => {
   })
 
   it('states every row own state, so nothing must be pressed to be discovered', () => {
-    const rows = build({ grouping: 'task', toggles: { closed: true, exited: false, named: false, done: false, active: false, detail: false } })
+    const rows = build({ grouping: 'task', toggles: { history: true, named: false, done: false, active: false, detail: false } })
     expect(rows.find(r => r.kind === 'group' && r.value === 'task')).toMatchObject({ on: true })
     expect(rows.find(r => r.kind === 'group' && r.value === 'none')).toMatchObject({ on: false })
-    expect(rows.find(r => r.kind === 'toggle' && r.toggle === 'closed')).toMatchObject({ on: true })
+    expect(rows.find(r => r.kind === 'toggle' && r.toggle === 'history')).toMatchObject({ on: true })
   })
 
   it('offers the named-row switch under every grouping', () => {
@@ -1094,9 +1094,9 @@ describe('the only-active toggle', () => {
       project: 'project', status: 'state', marked: 'marked',
     },
     layout: LAYOUT,
-    toggles: { closed: false, exited: false, named: false, done: false, active: true, detail: false },
+    toggles: { history: false, named: false, done: false, active: true, detail: false },
     toggleWords: {
-      closed: 'closed', exited: 'finished', named: 'named', done: 'done tasks',
+      history: 'closed', named: 'named', done: 'done tasks',
       active: 'only active', detail: 'detail',
     },
     headings: { actions: 'ACTIONS', view: 'VIEW', show: 'SHOW' },
@@ -1897,9 +1897,9 @@ describe('asideRows — the layout section', () => {
       project: 'project', status: 'state', marked: 'marked',
     },
     layout: { ...LAYOUT, value },
-    toggles: { closed: false, exited: false, named: false, done: false, active: true, detail: false },
+    toggles: { history: false, named: false, done: false, active: true, detail: false },
     toggleWords: {
-      closed: 'closed', exited: 'exited', named: 'named', done: 'done', active: 'active',
+      history: 'closed', named: 'named', done: 'done', active: 'active',
       detail: 'detail',
     },
     headings: { actions: 'ACTIONS', view: 'VIEW', show: 'SHOW' },

--- a/packages/tui/src/control/sessions.ts
+++ b/packages/tui/src/control/sessions.ts
@@ -1189,7 +1189,13 @@ export type AsideRow =
  * `named` replaces it, and is the opposite kind of change — it makes an EXISTING hidden behaviour
  * visible. A row the user named used to survive the history switches unconditionally, unwritten.
  */
-export type SessionToggle = 'closed' | 'exited' | 'named' | 'done' | 'active' | 'detail'
+/**
+ * The switches the menu draws.
+ *
+ * `closed` and `exited` were two of these and asked ONE question — "is it not running" — so ticking
+ * either while the other was on appeared to do nothing. They are now `history`.
+ */
+export type SessionToggle = 'history' | 'named' | 'done' | 'active' | 'detail'
 
 /**
  * The aside's rows, in reading order — PURE, so what is drawn and what a click resolves against are
@@ -1279,7 +1285,7 @@ export function asideRows(o: {
   // so ticking `closed` while `active` is on widens the list and turns `active` off — a switch is
   // never lit over a list it does not describe. `named` sits with them because it is the same kind
   // of thing, and because it used to be the one widening nobody could see.
-  const toggles: SessionToggle[] = ['active', 'closed', 'exited', 'named', 'done', 'detail']
+  const toggles: SessionToggle[] = ['active', 'history', 'named', 'done', 'detail']
   for (const t of toggles) {
     rows.push({ kind: 'toggle', toggle: t, label: o.toggleWords[t], on: o.toggles[t] })
   }

--- a/packages/tui/src/control/tabs/Sessions.tsx
+++ b/packages/tui/src/control/tabs/Sessions.tsx
@@ -241,8 +241,9 @@ export function Sessions({
   // describes is a switch that can disagree with the list.
   const status = filters.status ?? ACTIVE_STATES
   const onlyActive = shortcutOn(status, 'active')
-  const showClosed = shortcutOn(status, 'closed')
-  const showExited = shortcutOn(status, 'exited')
+  // ONE switch, because there was one question. `closed` and `exited` both meant "it is not
+  // running", so ticking either while the other was on appeared to do nothing.
+  const showHistory = shortcutOn(status, 'history')
   const taskFilter = filters.task?.[0] ?? null
   const projectFilter = filters.project?.[0] ?? null
   const pressShortcut = useCallback((k: StatusShortcut) => {
@@ -461,11 +462,11 @@ export function Sessions({
     groupWords: s.sessionsGroupings,
     layout: { heading: s.asideLayout, words: s.sessionsLayouts, value: layout },
     toggles: {
-      closed: showClosed, exited: showExited, done: showDone,
+      history: showHistory, done: showDone,
       active: onlyActive, named: showNamed, detail: !hideDetail,
     },
     toggleWords: {
-      closed: s.toggleClosed, exited: s.toggleExited, done: s.toggleDone,
+      history: s.toggleHistory, done: s.toggleDone,
       active: s.toggleActive, named: s.toggleNamed, detail: s.toggleDetail,
     },
     headings: { actions: s.asideActions, view: s.asideView, show: s.asideShow },
@@ -500,7 +501,7 @@ export function Sessions({
       allLabel: s.asideAllProjects,
     },
   }), [
-    actions, grouping, layout, showClosed, showExited, showDone, onlyActive, showNamed, hideDetail,
+    actions, grouping, layout, showHistory, showDone, onlyActive, showNamed, hideDetail,
     status, stateCounts, order, taskFilter,
     projectFilter, fleet?.sessions, fleet?.finishedTasks, s,
   ])
@@ -770,8 +771,7 @@ export function Sessions({
       return
     }
     if (row.kind !== 'toggle') return
-    if (row.toggle === 'closed') return pressShortcut('closed')
-    if (row.toggle === 'exited') return pressShortcut('exited')
+    if (row.toggle === 'history') return pressShortcut('history')
     if (row.toggle === 'active') return pressShortcut('active')
     setCursor(0)
     if (row.toggle === 'done') return setShowDone(v => !v)
@@ -889,8 +889,8 @@ export function Sessions({
     // here, not assumed. `?` has no such collision and is what every list-shaped TUI already uses.
     if (input === '?' || (key.ctrl && input === 'h')) { setAsk({ kind: 'keys' }); return }
     if (input === 'v') return runAction('group')
-    if (input === 'c') { pressShortcut('closed'); return }
-    if (input === 'e') { pressShortcut('exited'); return }
+    // One key, because there is one switch. `c` and `e` toggled two halves of the same question.
+    if (input === 'c' || input === 'e') { pressShortcut('history'); return }
     if (input === 'l') { pressShortcut('active'); return }
     if (input === 'd') { setHideDetail(v => !v); return }
     // `ctrl+g` for the GRID, not `g`: `g` is "top of the list" two lines down and in
@@ -1319,13 +1319,13 @@ export function Sessions({
         <ViewOptions
           strings={s}
           grouping={grouping}
-          showClosed={showClosed}
+          showHistory={showHistory}
           showNamed={showNamed}
           width={width}
           height={height}
           isActive={isActive}
           onGrouping={g => { setGrouping(g); setCursor(0) }}
-          onShowClosed={() => pressShortcut('closed')}
+          onShowClosed={() => pressShortcut('history')}
           onShowNamed={() => { setShowNamed(v => !v); setCursor(0) }}
           onClose={() => setAsk(null)}
         />
@@ -1493,7 +1493,7 @@ export function Sessions({
           grouping={grouping}
           strings={s}
           width={listBody}
-          showClosed={showClosed}
+          showHistory={showHistory}
           showNamed={showNamed}
           onlyActive={onlyActive}
           // How many rows are ON SCREEN, counted from the very list being drawn. The header used to
@@ -1697,13 +1697,13 @@ export function Sessions({
  * to state the answer, so a glance tells you why the list looks the way it does.
  */
 function SummaryRow({
-  fleet, grouping, strings: s, width, showClosed, showNamed, onlyActive, shown, query, scope, fell,
+  fleet, grouping, strings: s, width, showHistory, showNamed, onlyActive, shown, query, scope, fell,
 }: {
   fleet: ControlSessions | null | undefined
   grouping: SessionGrouping
   strings: ControlStrings
   width: number
-  showClosed: boolean
+  showHistory: boolean
   /** The one widening on this block — stated because it changes what a strict filter means. */
   showNamed: boolean
   /** The strict selection: exactly the states that mean something is alive. */
@@ -1737,7 +1737,7 @@ function SummaryRow({
   // still matters, and `showNamed` is named whenever it is on because it is the one thing that puts
   // rows BACK into a list the sentence above says is strict.
   if (onlyActive) hiding.push(s.viewActiveOn)
-  else if (!showClosed) hiding.push(s.viewClosedOn)
+  else if (!showHistory) hiding.push(s.viewClosedOn)
   if (showNamed) hiding.push(s.toggleNamed)
 
   // MEASURED, never left to Yoga: a row that wraps takes two of the screen's rows while its budget
@@ -2517,12 +2517,12 @@ function Question({
  * squeezing it under the list is what made it unreadable the first time.
  */
 function ViewOptions({
-  strings: s, grouping, showClosed, showNamed, width, height, isActive,
+  strings: s, grouping, showHistory, showNamed, width, height, isActive,
   onGrouping, onShowClosed, onShowNamed, onClose,
 }: {
   strings: ControlStrings
   grouping: SessionGrouping
-  showClosed: boolean
+  showHistory: boolean
   showNamed: boolean
   width: number
   height: number
@@ -2583,7 +2583,7 @@ function ViewOptions({
         // The dot means ON, always — for every row on this panel.
         const on = row.kind === 'group'
           ? row.value === grouping
-          : row.kind === 'closed' ? showClosed : showNamed
+          : row.kind === 'closed' ? showHistory : showNamed
         const label = row.kind === 'group'
           ? s.sessionsGroupings[row.value]
           : row.kind === 'closed' ? s.viewClosedOn

--- a/packages/tui/src/control/tabs/Sessions.tsx
+++ b/packages/tui/src/control/tabs/Sessions.tsx
@@ -1660,7 +1660,11 @@ export function Sessions({
               }}
               host={host}
               query={query}
-              onQuery={setQuery}
+              // The cursor goes home on every change. That is the actual answer to the objection
+              // that stopped this being live: a narrowing list moves rows out from under the
+              // selection, so keeping the old index points at whatever slid into that slot. Row 0
+              // is the best match to look at anyway.
+              onQuery={q => { setQuery(q); setCursor(0) }}
               fleet={fleet}
             />
           ) : (
@@ -2205,8 +2209,13 @@ function Question({
         placeholder={query}
         width={width}
         onCancel={onClose}
-        // Applied on submit rather than per keystroke: the list under it is re-grouped and re-sorted
-        // on every change, and a cursor that jumps while someone is still typing is unusable.
+        // LIVE, as it is typed. It used to apply on submit, on the reasoning that re-grouping under
+        // a moving cursor is unusable — but that reasoning was about the CURSOR, and the fix for a
+        // jumping cursor is to reset it, not to make the user type blind. A search whose result you
+        // cannot see until you commit is a search you run twice.
+        onChange={value => onQuery(value.trim())}
+        // Enter closes the field and KEEPS what is already applied. Cancel is what undoes it, and
+        // the empty-submit case is why `placeholder` is used above instead of `defaultValue`.
         onSubmit={value => { onQuery(value.trim()); onClose() }}
       />
       </Box>


### PR DESCRIPTION
Two of the three things reported.

## "por que tem opcao de ver conversa fechada ou encerrada sendo que as duas sao exatamente a mesma coisa?"

They were. `closed` named a conversation that is not running; `exited` named a finished session plus `lost`, a session the backend can no longer find. Internally those differ and the difference matters — different verbs, and `lost` is a fact about the backend rather than about the work. But from the chair of the person reading the list **all three answer "it is not running"**, so the menu asked one question twice: ticking either while the other was on appeared to do nothing.

Now `active` / `history`, which is the honest pair. The states keep their distinction and each row still shows its own — it is the **filter** that stopped pretending two switches were two questions. Both `c` and `e` reach it, so no muscle memory breaks. A **partial** selection does not light the switch: it would draw itself on over a list missing two of the three states it claims.

Legacy `showClosed`/`showExited` are still derived on write, both from the one switch, so a downgrade comes up with history shown or hidden together rather than half missing.

## Search applies as you type

The comment defending submit-only said re-grouping under a moving cursor is unusable — and that reasoning was about the **cursor**, not the search. The fix for a jumping cursor is to reset it, not to make the user type blind. A search whose result you cannot see until you commit is a search you run twice.

`TextPrompt` gains an optional `onChange`, fired through the **one** function that edits the value so no input path can forget it. Optional because most of these prompts must **not** act early: a member token is meaningless until whole, and a rename applied per character would write six labels while somebody types one.

The wizard's project search was already reactive; nothing needed doing there.

## NOT in here, and why

The third request — the shortcuts modal in place of the aside menu — is **not included**. I implemented it and it rendered a **blank screen** (34 rows → 1). I could not find the cause within this pass, and shipping a blank cockpit to fix a placement is a bad trade, so it is reverted and stays open.

`bun tsc --noEmit` clean, `bun test` **4060 pass / 0 fail**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TBcRtC62Sx18sgJj64r1Np