### PR TITLE
fix(cockpit): two states, an id on every row, and the whole focused row lit

### DIFF
--- a/packages/server/server/cli-i18n.ts
+++ b/packages/server/server/cli-i18n.ts
@@ -415,10 +415,15 @@ const EN: CliStrings = {
     working: 'working',
     waitingApproval: 'needs approval',
     waiting: 'waiting',
-    exited: 'exited',
-    lost: 'lost',
+    // ONE word for every way a session is not running. `exited`, `lost` and `closed` are three
+    // internal facts and were three words on the row — but a reader has one question here ("is it
+    // running?") and one move available ("reopen it"), so three answers to it was noise dressed as
+    // precision. The distinction still exists in the state and is still said by the DETAIL pane;
+    // the column stops spending three vocabularies on one bit.
+    exited: 'off',
+    lost: 'off',
+    closed: 'off',
     external: 'external',
-    closed: 'closed',
   },
   sessApprovalBlind: (harness: string) =>
     `agentop has no verified screen markers for ${harness}, so a blocking question here shows as "waiting" like any other pause.`,
@@ -661,10 +666,10 @@ const PT: CliStrings = {
     // keeps `waiting`: there it is already the intransitive answer, and "waiting for a reply" would
     // be longer without saying more.
     waiting: 'aguardando resposta',
-    exited: 'encerrada',
-    lost: 'perdida',
+    exited: 'desligada',
+    lost: 'desligada',
+    closed: 'desligada',
     external: 'externa',
-    closed: 'fechada',
   },
   sessApprovalBlind: (harness: string) =>
     `o agentop não tem marcadores de tela verificados para ${harness}, então uma pergunta bloqueante aqui aparece como "aguardando resposta", como qualquer outra pausa.`,

--- a/packages/tui/src/control/i18n.ts
+++ b/packages/tui/src/control/i18n.ts
@@ -384,6 +384,8 @@ export interface ControlStrings {
   sessionsResumeRunning: string
   sessionsSearchLabel: string
   sessionsSearchEmpty: string
+  /** The word on a HISTORY band. Must agree with `sessionsStates` — a row saying `off` under a
+   *  band called `closed` is the same vocabulary split this collapse exists to remove. */
   sessionsClosedWord: string
   sessionsShowClosed: string
   /** The view panel: one vertical list of every choice about what the list shows. */
@@ -773,9 +775,11 @@ const EN: ControlStrings = {
     'waiting-approval': 'needs approval',
     waiting: 'waiting',
     working: 'working',
-    exited: 'exited',
-    lost: 'lost',
-    closed: 'closed',
+    // ONE word for every way a session is not running — see `cli-i18n.ts`'s `sessState`, which this
+    // table has to agree with or a row reads `off` under a band called `closed`.
+    exited: 'off',
+    lost: 'off',
+    closed: 'off',
     unknown: 'external',
   },
   sessionsSearching: q => `search: ${q} · esc clears`,
@@ -829,7 +833,7 @@ const EN: ControlStrings = {
     'the assistant already running there is NOT stopped — close it first, or you will have two on one conversation.',
   sessionsSearchLabel: 'Search sessions and closed conversations',
   sessionsSearchEmpty: 'nothing matches.',
-  sessionsClosedWord: 'closed',
+  sessionsClosedWord: 'off',
   sessionsShowClosed: 'closed: shown',
   viewTitle: 'What this list shows',
   viewGroupBy: 'Group by',
@@ -1183,9 +1187,9 @@ const PT: ControlStrings = {
     // `aguardando resposta` under a band called `aguardando`.
     waiting: 'aguardando resposta',
     working: 'trabalhando',
-    exited: 'encerrada',
-    lost: 'perdida',
-    closed: 'fechada',
+    exited: 'desligada',
+    lost: 'desligada',
+    closed: 'desligada',
     unknown: 'externa',
   },
   sessionsSearching: q => `busca: ${q} · esc limpa`,
@@ -1239,7 +1243,7 @@ const PT: ControlStrings = {
     'o assistente que já roda ali NÃO é encerrado — feche ele antes, ou você fica com dois na mesma conversa.',
   sessionsSearchLabel: 'Buscar sessões e conversas fechadas',
   sessionsSearchEmpty: 'nada corresponde.',
-  sessionsClosedWord: 'fechada',
+  sessionsClosedWord: 'desligada',
   sessionsShowClosed: 'fechadas: visíveis',
   viewTitle: 'O que esta lista mostra',
   viewGroupBy: 'Agrupar por',

--- a/packages/tui/src/control/sessions.test.ts
+++ b/packages/tui/src/control/sessions.test.ts
@@ -868,11 +868,24 @@ describe('sessionHandle', () => {
     expect(sessionHandle(session('3f5f4dd461'))).toBe('3f5f4')
   })
 
-  it('is EMPTY for a row agentop did not name', () => {
-    // An external process and a closed conversation are named by the harness. Showing five
-    // characters of a synthetic id offers a handle the CLI cannot resolve.
-    expect(sessionHandle(session('external:claude:/repo:0'))).toBe('')
-    expect(sessionHandle(session('closed:abc-def'))).toBe('')
+  it('names EVERY row, because every session has an id', () => {
+    // This used to be empty for external and closed rows, protecting `attach` from a handle it
+    // cannot resolve. It protected one command at the cost of the column: a table where some rows
+    // have no id reads as data missing, and those rows cannot be referred to at all.
+    //
+    // A row that names a CONVERSATION shows the conversation's id — not attachable, but exactly
+    // what reopening resolves, which is the one verb such a row offers.
+    expect(sessionHandle(session('closed:abcdef-1234', {
+      resume: { sessionId: 'abcdef-1234', title: 'x' },
+    }))).toBe('abcde')
+
+    // With nothing else to go on, the trailing distinguishing part of the synthetic id. It resolves
+    // no command and still tells two rows apart, which is the column's other job — and for two
+    // assistants open in ONE directory the start time is the only thing that does.
+    const a = sessionHandle(session('external:claude:/repo:1786770001'))
+    const b = sessionHandle(session('external:claude:/repo:1786770002'))
+    expect(a).not.toBe('')
+    expect(a).not.toBe(b)
   })
 })
 

--- a/packages/tui/src/control/sessions.ts
+++ b/packages/tui/src/control/sessions.ts
@@ -834,14 +834,29 @@ export function sessionAge(s: ControlSession, now: number, ago: (seconds: number
 export const ID_CELL = 5
 
 /**
- * The handle: the leading characters of the id, which is what the CLI resolves a prefix against.
+ * The handle: the leading characters of whatever identity this row actually has.
  *
- * Empty for a row that has no id of ours — an external process and a closed conversation are named
- * by the harness, not by agentop, and showing five characters of a synthetic id would offer a
- * handle that `agentop session attach` cannot resolve.
+ * **Every session has an id, so every row shows one.** This returned `''` for external and closed
+ * rows, reasoning that a synthetic id is a handle `agentop session attach` cannot resolve. That
+ * protected one command at the cost of the column: a table where some rows have no id reads as data
+ * missing, and the reader cannot refer to those rows at all — not in a note, not out loud, not to
+ * an assistant.
+ *
+ * The identity is taken in order of how resolvable it is:
+ *
+ *  1. **A row agentop hosts** — its own id. `attach`, `kill` and `rename` take a prefix of it.
+ *  2. **A row naming a CONVERSATION** (`resume`) — the conversation id. Not attachable, but it is
+ *     exactly what reopening resolves, so it is a handle for the one verb the row offers.
+ *  3. **Anything else** — the trailing distinguishing part of the synthetic id. It resolves no
+ *     command and still tells two rows apart, which is the column's other job.
  */
 export function sessionHandle(s: ControlSession): string {
-  return s.id.startsWith('external:') || s.id.startsWith('closed:') ? '' : s.id.slice(0, ID_CELL)
+  if (!s.id.startsWith('external:') && !s.id.startsWith('closed:')) return s.id.slice(0, ID_CELL)
+  const conversation = s.resume?.sessionId
+  if (conversation) return conversation.slice(0, ID_CELL)
+  // `external:<harness>:<cwd>:<startedMs>` — the start time is what separates two assistants open in
+  // one directory, which is precisely the pair a reader needs to tell apart.
+  return s.id.slice(s.id.lastIndexOf(':') + 1).slice(-ID_CELL)
 }
 
 /**

--- a/packages/tui/src/control/tabs/Sessions.tsx
+++ b/packages/tui/src/control/tabs/Sessions.tsx
@@ -1820,9 +1820,14 @@ function SessionRowView({ session, selected, marked, ages, columns, width, close
       {/* The HANDLE. `agentop session attach 3f5f` takes a prefix, so this is the one thing on the
           row that names the session to anything but this screen. */}
       {columns.id > 0 ? (
-        <Text dimColor>{padCell(sessionHandle(session), columns.id) + gap}</Text>
+        <Text color={selected ? COLORS.accent : undefined} dimColor={!selected}>
+          {padCell(sessionHandle(session), columns.id) + gap}
+        </Text>
       ) : null}
-      <Text color={STATE_COLOR[session.state]} bold={session.state === 'waiting-approval'}>
+      <Text
+        color={selected ? COLORS.accent : STATE_COLOR[session.state]}
+        bold={selected || session.state === 'waiting-approval'}
+      >
         {padCell(session.stateLabel, columns.state)}
       </Text>
       {columns.title > 0 ? (
@@ -1836,14 +1841,16 @@ function SessionRowView({ session, selected, marked, ages, columns, width, close
       {/* How long ago it started, on rows that are NOT running — the age is most of the "reopen
           this or not" decision, and it lived only in the detail pane. */}
       {columns.age > 0 ? (
-        <Text dimColor>{gap + padCell(ages.get(session.id) ?? '', columns.age)}</Text>
+        <Text color={selected ? COLORS.accent : undefined} dimColor={!selected}>
+          {gap + padCell(ages.get(session.id) ?? '', columns.age)}
+        </Text>
       ) : null}
       {/* A linked WORKTREE says so, because it changes what the row IS: three rows of one repo in
           three directories are three checkouts, and without the word they read as three projects.
           The word, never a glyph alone — a distinction announced in a symbol is one that has to be
           taught before the screen can be read. */}
       {columns.worktree > 0 ? (
-        <Text color={COLORS.secondary}>{gap + padCell(worktreeName(session), columns.worktree)}</Text>
+        <Text color={selected ? COLORS.accent : COLORS.secondary} bold={selected}>{gap + padCell(worktreeName(session), columns.worktree)}</Text>
       ) : null}
       {/* The TASK, right of the name. Filing a session under a task and then not being able to see
           which task it is in is the feature not working — the fact only existed in the detail pane
@@ -1856,20 +1863,26 @@ function SessionRowView({ session, selected, marked, ages, columns, width, close
           a row you are deciding whether to close is one whose cost you want beside its name rather
           than one selection away in the detail pane. */}
       {columns.metrics > 0 ? (
-        <Text color={COLORS.secondary}>{gap + padCell(sessionMetric(session), columns.metrics)}</Text>
+        <Text color={selected ? COLORS.accent : COLORS.secondary} bold={selected}>{gap + padCell(sessionMetric(session), columns.metrics)}</Text>
       ) : null}
       {/* How full the context window is. Beside the usage because it is the same kind of fact and
           the opposite reading of it: usage is what this session has spent, this is what it has
           left. A row with no reading draws a BLANK of the same width rather than a `0%` — the
           column exists because some rows can answer, not because all of them can. */}
       {columns.context > 0 ? (
-        <Text color={session.context ? CONTEXT_COLOR[contextLevel(session.context.fraction)] : undefined}
-              dimColor={!session.context || contextLevel(session.context.fraction) === 'ok'}>
+        <Text
+          color={selected
+            ? COLORS.accent
+            : session.context ? CONTEXT_COLOR[contextLevel(session.context.fraction)] : undefined}
+          dimColor={!selected && (!session.context || contextLevel(session.context.fraction) === 'ok')}
+        >
           {gap + padCell(sessionContext(session), columns.context)}
         </Text>
       ) : null}
       {columns.harness > 0 ? (
-        <Text color={harnessColor}>{gap + padCell(session.harness, columns.harness)}</Text>
+        <Text color={selected ? COLORS.accent : harnessColor} bold={selected}>
+          {gap + padCell(session.harness, columns.harness)}
+        </Text>
       ) : null}
       {columns.where > 0 ? (
         <Text dimColor>{gap + padCell(session.projectGroup || session.project, columns.where)}</Text>


### PR DESCRIPTION
Four things from one screenshot, and the first is the real one.

## Three words for one fact

The column said **`encerrada`, `perdida` and `fechada`** — three internal facts printed as three words. A reader has **one** question here ("is it running?") and **one** move available ("reopen it"), so three answers to it was noise dressed as precision.

The states keep their distinction and the detail pane still says which. The column stops spending three vocabularies on one bit.

**Both word tables changed together** — the row's from `cli-i18n.ts` and the band heading's from `control/i18n.ts`. A row reading `desligada` under a band called `fechada` is that same split arriving by another route, and this screen draws from both tables at once.

## An id on every row

`sessionHandle` returned `''` for external and closed rows, protecting `attach` from a handle it cannot resolve. **That protected one command at the cost of the column**: a table where some rows have no id reads as data missing, and those rows cannot be referred to at all — not in a note, not out loud, not to an assistant.

Now it takes the most resolvable identity available:

1. our own id — what `attach`/`kill`/`rename` resolve;
2. else the **conversation** id — not attachable, but exactly what reopening resolves, which is the one verb such a row offers;
3. else the distinguishing tail of the synthetic id — resolves nothing, and for two assistants in **one directory** it is the only thing that tells them apart.

Your `MAIN` now reads `581de · externa · MAIN`.

## The focused row is entirely in the accent

Not just its title. Finding the cursor meant hunting one orange word among coloured cells.

## The `[x]`

Already removed in #153 — this PR is the rest of that report.

`bun tsc --noEmit` clean, `bun test` **4060 pass / 0 fail**, verified in the compiled binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TBcRtC62Sx18sgJj64r1Np