### PR TITLE
release: the session list stops lying, and the duplication is fixed at the source

### DIFF
--- a/packages/server/server/cli-i18n.ts
+++ b/packages/server/server/cli-i18n.ts
@@ -415,10 +415,15 @@ const EN: CliStrings = {
     working: 'working',
     waitingApproval: 'needs approval',
     waiting: 'waiting',
-    exited: 'exited',
-    lost: 'lost',
+    // ONE word for every way a session is not running. `exited`, `lost` and `closed` are three
+    // internal facts and were three words on the row — but a reader has one question here ("is it
+    // running?") and one move available ("reopen it"), so three answers to it was noise dressed as
+    // precision. The distinction still exists in the state and is still said by the DETAIL pane;
+    // the column stops spending three vocabularies on one bit.
+    exited: 'off',
+    lost: 'off',
+    closed: 'off',
     external: 'external',
-    closed: 'closed',
   },
   sessApprovalBlind: (harness: string) =>
     `agentop has no verified screen markers for ${harness}, so a blocking question here shows as "waiting" like any other pause.`,
@@ -661,10 +666,10 @@ const PT: CliStrings = {
     // keeps `waiting`: there it is already the intransitive answer, and "waiting for a reply" would
     // be longer without saying more.
     waiting: 'aguardando resposta',
-    exited: 'encerrada',
-    lost: 'perdida',
+    exited: 'desligada',
+    lost: 'desligada',
+    closed: 'desligada',
     external: 'externa',
-    closed: 'fechada',
   },
   sessApprovalBlind: (harness: string) =>
     `o agentop não tem marcadores de tela verificados para ${harness}, então uma pergunta bloqueante aqui aparece como "aguardando resposta", como qualquer outra pausa.`,

--- a/packages/server/server/cli-i18n.ts
+++ b/packages/server/server/cli-i18n.ts
@@ -89,6 +89,8 @@ export interface CliStrings {
    * the services row can say least, a red line that named one runtime.
    */
   svcConflict: (runtimes: string[]) => string
+  /** A second copy under the SAME runtime, serving nothing. Names the pid — see ControlService.idle. */
+  svcIdleServer: (pids: number[]) => string
   /** A stop/restart named something that is not running. */
   svcNotRunning: string
 
@@ -404,6 +406,9 @@ const EN: CliStrings = {
   svcAgentistics: 'agentistics',
   svcCentral: 'agentistics central',
   svcConflict: (runtimes) => `conflict: ${runtimes.join(' + ')} both running — stop one`,
+  svcIdleServer: pids => pids.length === 1
+    ? `a second server (pid ${pids[0]}) is running and serving nothing — kill ${pids[0]}`
+    : `${pids.length} extra servers are running and serving nothing — kill ${pids.join(' ')}`,
   svcNotRunning: 'that service is not running.',
 
   sessState: {
@@ -643,6 +648,9 @@ const PT: CliStrings = {
   svcAgentistics: 'agentistics',
   svcCentral: 'agentistics central',
   svcConflict: (runtimes) => `conflito: ${runtimes.join(' + ')} rodando juntos — pare um`,
+  svcIdleServer: pids => pids.length === 1
+    ? `um segundo servidor (pid ${pids[0]}) está rodando sem servir nada — encerre ${pids[0]}`
+    : `${pids.length} servidores extras rodando sem servir nada — encerre ${pids.join(' ')}`,
   svcNotRunning: 'esse serviço não está rodando.',
 
   sessState: {

--- a/packages/server/server/cli-start.ts
+++ b/packages/server/server/cli-start.ts
@@ -1696,12 +1696,26 @@ function createControlHost(initialLang: CliLang, altScreen: Suspendable): StartH
 
     return [
       buildService('agentistics', s.svcAgentistics, [nativeRuntime, machineRuntime], s, {
-        // Two distinct boot mechanisms now exist for this one service (native `agentop-server` vs
-        // Docker `agentop-machine`); the detail pane can only state one, so it states the one that
-        // matches whichever runtime is actually up — the native unit otherwise, matching this
-        // field's behavior before the Docker runtime had a boot mechanism of its own at all.
-        boot: machine.state === 'up' ? bootMachine : bootAgentistics,
-        bootUnit: unitName(machine.state === 'up' ? 'machine' : 'server'),
+        // Two distinct boot mechanisms exist for this ONE service — the native `agentop-server` and
+        // the Docker `agentop-machine` — and BOTH can be registered at once. The row used to name
+        // whichever matched the runtime that happened to be up, so on a machine that had registered
+        // both, the other one was invisible: something would bring the service back after a reboot
+        // and the pane named a unit that was not it. That is the same class of half-truth
+        // `ControlService.conflict` exists to prevent for the running state.
+        //
+        // So: registered if EITHER is, and the unit cell names every one that actually is. `boot`
+        // stays `undefined` when the host could not tell at all (no user systemd) — absence is
+        // absence, and a row with no answer draws nothing rather than claiming `off`.
+        boot: bootAgentistics === undefined && bootMachine === undefined
+          ? undefined
+          : bootAgentistics === 'on' || bootMachine === 'on' ? 'on' : 'off',
+        bootUnit: [
+          bootAgentistics === 'on' ? unitName('server') : '',
+          bootMachine === 'on' ? unitName('machine') : '',
+        ].filter(Boolean).join(' + ')
+          // Nothing registered: name the unit the switch on this row would WRITE, so "off" still
+          // says what it is off about.
+          || unitName(machine.state === 'up' ? 'machine' : 'server'),
         // BOTH mechanisms get a verb, whichever runtime happens to be up: the row states one and
         // the switch has to reach either, or a machine that registered the container at boot could
         // never turn that off while running natively.

--- a/packages/server/server/cli-start.ts
+++ b/packages/server/server/cli-start.ts
@@ -107,6 +107,7 @@ import { needsChoice, parseDialogOptions } from './sessions/dialog-choice'
 import { rulesFor } from './sessions/attention-rules'
 import { planCrashGroup, planFellOffer } from './sessions/crash-group'
 import { loadHarnessSessions } from './sessions/harness-sessions'
+import { idleServers, isServerCommand } from './idle-servers'
 // The lock on the door: one conversation, one live session. See `conversation-claim.ts` for the
 // measurement that made it necessary, and `live-claims.ts` for the evidence it is allowed to use.
 import { conversationHeldBy } from './sessions/conversation-claim'
@@ -511,6 +512,8 @@ export function buildService(
     bootOptions?: BootOption[]
     rebuild?: RebuildAbility
     centralPlan?: CentralStartPlan
+    /** Pids of extra copies of this service that hold no port — see `idle-servers.ts`. */
+    idlePids?: number[]
   } = {},
 ): ControlService {
   const up = runtimes.filter(r => r.state === 'up')
@@ -529,6 +532,9 @@ export function buildService(
     bootOptions: facts.bootOptions ?? [],
     // Named, not merely coloured, and never reduced to whichever copy we happened to find first.
     conflict: up.length > 1 ? s.svcConflict(up.map(r => r.kind)) : undefined,
+    // Two processes of the ONE runtime — invisible to every runtime probe, because they all ask
+    // which pid holds the port. See `idle-servers.ts` for the seventy-minute incident.
+    idle: facts.idlePids?.length ? s.svcIdleServer(facts.idlePids) : undefined,
     reason,
     // The single most important line in the model: while anything is up there is nothing to start.
     startOptions: up.length > 0
@@ -746,6 +752,31 @@ async function nativeServerFacts(): Promise<ProcessFacts> {
   const pid = Number((await listeningServerPids())[0])
   if (!Number.isInteger(pid) || pid <= 0) return {}
   return { pid, startedAt: await processStartedAt(pid) }
+}
+
+/**
+ * Server processes that hold NO port — the copies every runtime probe is blind to.
+ *
+ * `lsof -sTCP:LISTEN` can only ever find the process that won the port, so a second server is
+ * invisible to `nativeServerFacts` by construction while it burns a core on the file watcher. This
+ * asks the process table instead and subtracts the listener and ourselves.
+ *
+ * Empty on any failure, including a platform with no `ps`: an unreadable process table is "cannot
+ * tell", and a warning invented out of one would appear on machines nobody could ask.
+ */
+async function idleServerPids(): Promise<number[]> {
+  try {
+    const ps = await sh(['ps', '-eo', 'pid=,args='])
+    const processes = ps.out.split('\n')
+      .map(line => /^\s*(\d+)\s+(.*)$/.exec(line.trim()))
+      .filter((m): m is RegExpExecArray => m !== null)
+      .map(m => ({ pid: Number(m[1]), command: m[2]! }))
+      .filter(p => isServerCommand(p.command))
+    const listening = (await listeningServerPids()).map(Number).filter(n => Number.isInteger(n) && n > 0)
+    return idleServers({ processes, listening, self: process.pid }).idle.map(p => p.pid)
+  } catch {
+    return []
+  }
 }
 
 async function stopLocal(s: CliStrings): Promise<void> {
@@ -1611,6 +1642,10 @@ function createControlHost(initialLang: CliLang, altScreen: Suspendable): StartH
       // native start option even exists (see `StartFacts.centralPlan`).
       centralStartPlan(),
     ])
+    // Asked whatever the runtime state says: the case this exists for is a second server running
+    // while the row reads perfectly healthy, so gating it on `local` would skip exactly the machine
+    // that needs it — and it is worth asking even when nothing holds the port at all.
+    const idlePids = await idleServerPids()
     const [nativeFacts, centralFacts, machineFacts] = await Promise.all([
       local ? nativeServerFacts() : Promise.resolve<ProcessFacts>({}),
       central.state === 'up' ? containerFacts(CENTRAL_FILTER) : Promise.resolve<ContainerFacts>({}),
@@ -1685,6 +1720,7 @@ function createControlHost(initialLang: CliLang, altScreen: Suspendable): StartH
           },
         ], s, bootSupported, s.svcAgentistics),
         rebuild: { local: repo, machine: machineCompose },
+        idlePids,
       }),
       // The central's rebuild always works: `central.sh up` inside a checkout, and the published
       // image outside one — `cli-central.ts` picks between them, and a central that is RUNNING

--- a/packages/server/server/cli-start.ts
+++ b/packages/server/server/cli-start.ts
@@ -107,6 +107,8 @@ import { needsChoice, parseDialogOptions } from './sessions/dialog-choice'
 import { rulesFor } from './sessions/attention-rules'
 import { planCrashGroup, planFellOffer } from './sessions/crash-group'
 import { loadHarnessSessions } from './sessions/harness-sessions'
+import { memoryBudget } from './sessions/memory-budget'
+import { readMemory, readRss } from './sessions/memory-probe'
 // The lock on the door: one conversation, one live session. See `conversation-claim.ts` for the
 // measurement that made it necessary, and `live-claims.ts` for the evidence it is allowed to use.
 import { conversationHeldBy } from './sessions/conversation-claim'
@@ -1570,6 +1572,35 @@ function createControlHost(initialLang: CliLang, altScreen: Suspendable): StartH
     }
   }
 
+  /**
+   * The parallel-sessions budget, or `{}` when this machine cannot be measured.
+   *
+   * Spread into the status, so an unreadable machine contributes NO `memory` key at all and the
+   * header draws no gauge — the same absence-is-absence rule as `ControlService.boot`. A zero here
+   * would read as "no room left" on precisely the machines that could not be asked.
+   *
+   * The pids come from the harness records, which is the set this budget is about: assistants. It
+   * deliberately does not try to price the whole machine — `MemAvailable` already accounts for
+   * everything else, and RESERVED_BYTES holds room back for it.
+   */
+  const memoryStatus = async (): Promise<{ memory?: { used: number; max: number; red: boolean } }> => {
+    try {
+      const sample = await readMemory()
+      if (!sample) return {}
+      const index = await loadHarnessSessions()
+      const pids = [...index.byConversation.values()]
+        .filter(f => f.alive === true && f.pid !== undefined)
+        .map(f => f.pid!)
+      const { bytes, read } = await readRss(pids)
+      const b = memoryBudget({ sample, sessionBytes: bytes, sessions: read })
+      return { memory: { used: b.used, max: b.max, red: b.red } }
+    } catch {
+      // Best-effort, exactly like every other reader on this object: a gauge that throws must not
+      // take the whole status down with it.
+      return {}
+    }
+  }
+
   /** The setting in force, for the Setup tab to state. `undefined` while it is still unanswered. */
   const currentArchiveMode = async (): Promise<ArchiveMode | undefined> => {
     try {
@@ -1749,6 +1780,11 @@ function createControlHost(initialLang: CliLang, altScreen: Suspendable): StartH
         services,
         version: CURRENT_VERSION,
         latestVersion,
+        // The parallel-sessions budget. Computed HERE and not in the TUI, like every other decision
+        // on this object: the arithmetic lives in the pure `memory-budget.ts` and the two `/proc`
+        // reads in `memory-probe.ts`, and the answer arrives already decided — including `red`,
+        // which depends on swap pressure the screen has no way to know about.
+        ...(await memoryStatus()),
         archiveMode: await currentArchiveMode(),
         // The setup wizard is a question the cockpit asks, so what it may offer is decided here,
         // beside the very service states that decide it. `central` is the only mode that

--- a/packages/server/server/idle-servers.test.ts
+++ b/packages/server/server/idle-servers.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'bun:test'
+import { idleServers, isServerCommand } from './idle-servers'
+
+describe('isServerCommand', () => {
+  it('matches both forms that actually collided', () => {
+    // Verbatim from the machine where two servers ran for seventy minutes. They look nothing alike,
+    // which is exactly why the match is on the SUBCOMMAND and not on the binary's name.
+    expect(isServerCommand('/home/mithrandir/.local/bin/agentop server')).toBe(true)
+    expect(isServerCommand('bun packages/server/bin/cli.ts server')).toBe(true)
+    expect(isServerCommand('/home/x/.volta/tools/image/packages/bun/bin/bun packages/server/bin/cli.ts server')).toBe(true)
+  })
+
+  it('does not match the other agentop verbs', () => {
+    expect(isServerCommand('agentop session ls')).toBe(false)
+    expect(isServerCommand('agentop check-update')).toBe(false)
+    expect(isServerCommand('agentop central up')).toBe(false)
+  })
+
+  it('does not match a command line that merely mentions it', () => {
+    // A `grep` in somebody's pipeline is not a server, and reporting it would train people to
+    // ignore the warning — which is the only way this feature can fail.
+    expect(isServerCommand('grep agentop server')).toBe(false)
+    expect(isServerCommand('server')).toBe(false)
+    expect(isServerCommand('vim notes-about-agentop-server.md')).toBe(false)
+  })
+})
+
+describe('idleServers', () => {
+  const listener = { pid: 517, command: '/home/x/.local/bin/agentop server' }
+  const orphan = { pid: 3189270, command: 'bun packages/server/bin/cli.ts server' }
+
+  it('names the one that is running and serving nothing', () => {
+    const r = idleServers({ processes: [listener, orphan], listening: [517], self: 999 })
+    expect(r.idle.map(p => p.pid)).toEqual([3189270])
+    expect(r.listener).toBe(517)
+  })
+
+  it('never reports the listener', () => {
+    expect(idleServers({ processes: [listener], listening: [517], self: 999 }).idle).toEqual([])
+  })
+
+  it('never reports ITSELF', () => {
+    // The cockpit runs inside an `agentop`. A rule without this reports a conflict on every healthy
+    // machine, which is worse than reporting nothing at all.
+    const me = { pid: 4242, command: '/home/x/.local/bin/agentop server' }
+    expect(idleServers({ processes: [listener, me], listening: [517], self: 4242 }).idle).toEqual([])
+  })
+
+  it('reports a server running while NOBODY holds the port', () => {
+    // Still waste, and still worth naming: it is doing the watcher's work and answering no request.
+    const r = idleServers({ processes: [orphan], listening: [], self: 999 })
+    expect(r.idle.map(p => p.pid)).toEqual([3189270])
+    expect(r.listener).toBeUndefined()
+  })
+})

--- a/packages/server/server/idle-servers.ts
+++ b/packages/server/server/idle-servers.ts
@@ -1,0 +1,93 @@
+/**
+ * idle-servers.ts — PURE. A second `agentop server` that is running and serving NOTHING.
+ *
+ * ## The incident this exists for
+ *
+ * Two `agentop server` processes ran side by side for seventy minutes on a real machine:
+ *
+ * ```
+ * 517      ~/.local/bin/agentop server            ← systemd, holding 47291/47292
+ * 3189270  bun packages/server/bin/cli.ts server  ← started by hand from the checkout
+ * ```
+ *
+ * The second could not bind the ports and **kept working anyway**: the file watcher does not depend
+ * on a listening socket, so it held 2367 inotify watches and recomputed the whole API response on
+ * every transcript write from twelve sessions — 72% of a core and 1.1 GB, serving nobody.
+ *
+ * Nothing in the product could see it. The conflict model knows `native` versus `docker` and merges
+ * the two into one row, and **a compiled binary and `bun run` from a checkout are both native**, so
+ * two servers collapsed into one line that said everything was fine. And the runtime probe asks
+ * `lsof -sTCP:LISTEN`, which by construction can only ever find the one that WON the port.
+ *
+ * ## The rule
+ *
+ * A server process that is not the listener is not a second opinion, it is waste. There is no case
+ * where two of them is what somebody wanted: they read the same files, write the same caches and
+ * fight over the same port. So it is reported as a fault with the pid, and the pid is the whole
+ * point — "something is wrong" that cannot be acted on is a worse message than none.
+ *
+ * The listener itself is never reported. Nor is THIS process: the cockpit runs inside `agentop`, and
+ * a rule that flagged its own pid would report a conflict on every healthy machine.
+ */
+
+/** One process claiming to be an agentop server. */
+export interface ServerProcess {
+  pid: number
+  /** The command line, for the report — a user has to be able to tell which one to kill. */
+  command: string
+}
+
+export interface IdleServers {
+  /** Running, not listening, not us. Waste, every one of them. */
+  idle: ServerProcess[]
+  /** The pid holding the port, when there is one. */
+  listener?: number
+}
+
+/**
+ * Which server processes are doing nothing — PURE.
+ *
+ * `listening` is the set holding the port (usually one). `self` is this process, excluded because
+ * the cockpit is itself an `agentop` and would otherwise report itself forever.
+ */
+export function idleServers(o: {
+  processes: readonly ServerProcess[]
+  listening: readonly number[]
+  self: number
+}): IdleServers {
+  const holding = new Set(o.listening)
+  const idle = o.processes.filter(p => p.pid !== o.self && !holding.has(p.pid))
+  return { idle, ...(o.listening[0] !== undefined ? { listener: o.listening[0] } : {}) }
+}
+
+/**
+ * Whether a command line is an agentop SERVER — PURE.
+ *
+ * Matched on the `server` subcommand rather than on the binary's name, because the two forms that
+ * collided look nothing alike: `~/.local/bin/agentop server` and
+ * `bun packages/server/bin/cli.ts server`. Both end in the verb, and the verb is the thing that
+ * makes a process a server.
+ *
+ * `agentop server` must not match `agentop session`, `agentop check-update`, or a shell whose
+ * command line merely CONTAINS the phrase — a `grep agentop server` in someone's pipeline is not a
+ * server, and reporting it would train people to ignore this.
+ */
+export function isServerCommand(command: string): boolean {
+  const argv = command.trim().split(/\s+/)
+  const i = argv.indexOf('server')
+  if (i <= 0) return false
+
+  // `server` must be the program's FIRST argument, not merely a token preceded by a plausible word.
+  // Requiring only "the thing before it looks like agentop" matched `grep agentop server`, which is
+  // somebody's pipeline and not a server — and one false positive here trains people to ignore the
+  // warning, which is the only way this feature can fail.
+  const isProgram = (a: string): boolean => /(^|\/)agentop$/.test(a)
+  const isScript = (a: string): boolean => /(^|\/)(cli|index)\.(ts|js)$/.test(a)
+  const isRuntime = (a: string): boolean => /(^|\/)(bun|node|deno)(\.exe)?$/.test(a)
+
+  // `agentop server`
+  if (i === 1 && isProgram(argv[0]!)) return true
+  // `bun packages/server/bin/cli.ts server`
+  if (i === 2 && isRuntime(argv[0]!) && isScript(argv[1]!)) return true
+  return false
+}

--- a/packages/server/server/live-sessions.test.ts
+++ b/packages/server/server/live-sessions.test.ts
@@ -289,6 +289,52 @@ test('an old process with nothing on disk is idle, not starting up', () => {
 
 // --- identifying the process itself --------------------------------------------------------------
 
+test('an install named after its VERSION is still recognised', () => {
+  // Measured on 2026-08-15, and the reason this is a bug and not a tidy-up: two processes running
+  // THE SAME executable, one listed and one invisible.
+  //
+  //   pid 3137032  comm=claude    exe=…/share/claude/versions/2.1.233   ← listed
+  //   pid  508665  comm=2.1.233   exe=…/share/claude/versions/2.1.233   ← invisible
+  //
+  // Claude Code installs to `~/.local/share/claude/versions/<version>`, so comm and the exe
+  // basename can BOTH be a version string — in no table, and different every release. The
+  // directory is the identity that survives an upgrade.
+  const exe = '/home/mithrandir/.local/share/claude/versions/2.1.233'
+  expect(harnessOf('2.1.233', exe)).toBe('claude')
+  expect(harnessOf('claude', exe)).toBe('claude')
+  // Specific enough that a directory merely containing the word cannot match.
+  expect(harnessOf('2.1.233', '/home/u/projects/claude/versions/2.1.233')).toBeUndefined()
+  expect(harnessOf('2.1.233', '/home/u/.local/share/claude/versions/2.1.233/extra/thing')).toBeUndefined()
+})
+
+test('the harness PLUMBING is not a session', () => {
+  // Recognising the install path found the invisible session and brought its infrastructure with
+  // it — the daemon and the pty hosts run the same binary. All argvs verbatim from /proc.
+  const exe = '/home/mithrandir/.local/share/claude/versions/2.1.233'
+  // The pty host rewrote its own argv[0] to a single string CONTAINING the verb — there is no
+  // argv[1] to look at, which is exactly what a first attempt at this rule missed.
+  expect(harnessOfProcess('2.1.233', exe, [
+    'claude bg-pty-host', '--bg-pty-host', '/tmp/cc-daemon-1000/8c5bc785/pty/581deab7.sock', '252',
+  ])).toBeUndefined()
+  expect(harnessOfProcess('2.1.233', exe, [
+    'claude bg-spare', '--bg-spare', '/tmp/cc-daemon-1000/8c5bc785/spare/3aa44d79.claim.sock',
+  ])).toBeUndefined()
+  expect(harnessOfProcess('claude', '/home/mithrandir/.local/bin/claude', [
+    '/home/mithrandir/.local/bin/claude', 'daemon', 'run', '--json-path', '/home/u/.claude/daemon.json',
+  ])).toBeUndefined()
+  // …and the real session is untouched.
+  expect(harnessOfProcess('2.1.233', exe, ['claude'])).toBe('claude')
+})
+
+test('the plumbing gate never eats a session because of what it SAYS', () => {
+  // The trap this gate is written around: a `bg-pty-host` argv carries the session id of the REAL
+  // conversation it serves, so "drop what carries a session id" keeps the helper and hides the
+  // session. The VERB is what separates them — and a prompt that merely mentions one must not match.
+  const exe = '/home/mithrandir/.local/share/claude/versions/2.1.233'
+  expect(harnessOfProcess('claude', exe, ['claude', '-p', 'restart the daemon please'])).toBe('claude')
+  expect(harnessOfProcess('claude', exe, ['claude', '--resume', 'a-uuid', '-p', 'bg-pty-host'])).toBe('claude')
+})
+
 test('a harness is recognised by its executable when comm is not its name', () => {
   // `gh copilot` runs its binary with the thread name MainThread, so comm-only matching missed
   // Copilot entirely and it never appeared as live.

--- a/packages/server/server/live-sessions.ts
+++ b/packages/server/server/live-sessions.ts
@@ -83,7 +83,116 @@ export function harnessOf(comm: string, exePath: string | undefined): HarnessId 
   if (byComm) return byComm
   if (!exePath) return undefined
   const base = exePath.slice(exePath.lastIndexOf('/') + 1)
-  return PROCESS_HARNESS[base]
+  const byBase = PROCESS_HARNESS[base]
+  if (byBase) return byBase
+  return harnessOfPath(exePath)
+}
+
+/**
+ * Install PATHS whose executable is named after the VERSION rather than the tool.
+ *
+ * Claude Code installs to `~/.local/share/claude/versions/<version>`, so both `comm` and the exe
+ * basename can come back as `2.1.233` — a string in no table, and one that changes every release.
+ *
+ * Measured on this machine on 2026-08-15, and this is why it is a real bug rather than a tidy-up:
+ * TWO processes running THAT VERY BINARY, one seen and one not.
+ *
+ * ```
+ * pid 3137032  comm=claude    exe=…/share/claude/versions/2.1.233   ← listed
+ * pid  508665  comm=2.1.233   exe=…/share/claude/versions/2.1.233   ← invisible
+ * ```
+ *
+ * Same executable, same install, and the only difference is what the process happened to set `comm`
+ * to. Matching the DIRECTORY is the identity that survives an upgrade; the basename never could.
+ *
+ * A `Record`, so a harness added to `HarnessId` fails the build until somebody decides. `null` is
+ * "this one is not installed that way", which is the ordinary case.
+ */
+const VERSIONED_INSTALL: Record<HarnessId, RegExp | null> = {
+  // Anchored on the whole segment run, not a bare `includes`: `/share/claude/versions/` is specific
+  // enough that a user directory happening to contain the word `claude` cannot match it.
+  claude: /(^|\/)\.local\/share\/claude\/versions\/[^/]+$/,
+  codex: null,
+  gemini: null,
+  copilot: null,
+  antigravity: null,
+  kimi: null,
+}
+
+/** The harness an executable PATH belongs to, for installs named after their version — PURE. */
+export function harnessOfPath(exePath: string): HarnessId | undefined {
+  for (const [id, re] of Object.entries(VERSIONED_INSTALL) as [HarnessId, RegExp | null][]) {
+    if (re && re.test(exePath)) return id
+  }
+  return undefined
+}
+
+/**
+ * A harness process that is INFRASTRUCTURE rather than a conversation — PURE.
+ *
+ * Recognising the versioned install path (above) correctly found the session that was invisible,
+ * and dragged in its plumbing with it. Measured on this machine, all running the same binary:
+ *
+ * ```
+ * claude daemon run --json-path …/daemon.json      ← the daemon
+ * claude bg-pty-host --bg-pty-host …/581deab7.sock ← a pty host for a session
+ * claude bg-pty-host --bg-pty-host …/spare/…       ← a pre-warmed spare
+ * ```
+ *
+ * None is a session, and listing them as assistants is the false positive that teaches people to
+ * ignore this list.
+ *
+ * **The gate is on the SUBCOMMAND, and that is the whole care in it.** The obvious rule — "drop
+ * what carries a session id" — is exactly backwards: a `bg-pty-host` argv carries the id of the
+ * REAL session it serves, so that rule keeps the helper and hides the conversation. What separates
+ * them is the verb, which says what the process IS.
+ *
+ * Absent from the table means "not known to be infrastructure", so a harness nobody has looked at
+ * behaves exactly as it does today rather than being filtered on a guess.
+ */
+const NOT_A_SESSION: Record<HarnessId, readonly string[] | null> = {
+  claude: ['daemon', 'bg-pty-host', 'bg-spare'],
+  codex: null,
+  gemini: null,
+  copilot: null,
+  antigravity: null,
+  kimi: null,
+}
+
+/**
+ * How many leading tokens may name a subcommand.
+ *
+ * Bounded on purpose: a socket path, a flag value or a PROMPT later in the argv may legitimately
+ * contain any of these words, and a session whose first message mentioned "daemon" must not vanish
+ * from the list. Three is enough for `claude daemon run` and one token more.
+ */
+const SUBCOMMAND_TOKENS = 3
+
+/**
+ * Whether this argv is the harness's plumbing rather than a session — PURE.
+ *
+ * **`argv[0]` is split on whitespace, and that is not a nicety.** Measured: a pty host's first argv
+ * element is the single string `"claude bg-pty-host"` — the process rewrote its own `argv[0]` to a
+ * descriptive label, so there is no argv[1] subcommand to find. A rule that looked only past
+ * `argv[0]` (the first thing written here) matched the daemon and missed every pty host, which is
+ * the majority of the plumbing.
+ *
+ * ```
+ * argv[0]="claude daemon run"?  no — ['claude','daemon','run']       three elements
+ * argv[0]="claude bg-pty-host"  yes — one element, verb inside it
+ * ```
+ *
+ * So the head is TOKENISED rather than indexed, and the flag form is skipped: `--bg-pty-host` is a
+ * flag on that very process, and matching flags would be a second way to say the same thing that
+ * could disagree with the first.
+ */
+export function isHarnessInfrastructure(harness: HarnessId, argv: readonly string[]): boolean {
+  const verbs = NOT_A_SESSION[harness]
+  if (!verbs) return false
+  const head = argv.slice(0, SUBCOMMAND_TOKENS).join(' ').split(/\s+/).filter(Boolean)
+  // argv[0]'s own first token is the program name; everything after it, up to the bound, may be a
+  // subcommand. Flags are skipped rather than matched — see the header.
+  return head.slice(1, SUBCOMMAND_TOKENS).some(t => !t.startsWith('-') && verbs.includes(t))
 }
 
 /** Interpreters a harness may be installed as a script for. Their `comm` and their exe basename
@@ -123,7 +232,11 @@ export function harnessOfProcess(
   argv: readonly string[],
 ): HarnessId | undefined {
   const direct = harnessOf(comm, exePath)
-  if (direct) return direct
+  // Identified, but is it a CONVERSATION? Recognising the versioned install path found the session
+  // that was invisible and brought its plumbing with it — the daemon and the pty hosts run the same
+  // binary. See `isHarnessInfrastructure` for why the gate is on the subcommand and not on the
+  // session id the plumbing also carries.
+  if (direct) return isHarnessInfrastructure(direct, argv) ? undefined : direct
   const exeBase = exePath ? exePath.slice(exePath.lastIndexOf('/') + 1) : ''
   if (!JS_RUNTIMES.has(comm) && !JS_RUNTIMES.has(exeBase)) return undefined
   // argv[0] is the runtime; the script is what follows. Scan the rest so a `node --flag script`

--- a/packages/server/server/sessions/cli-session.ts
+++ b/packages/server/server/sessions/cli-session.ts
@@ -30,6 +30,7 @@ import { createSessionsPoller, type SessionSnapshot } from './sessions-host'
 import { needsAttention, type SessionView } from './session-view'
 import { planTaskReopen, taskReopenSucceeded } from './task-reopen'
 import { liveConversationHolders } from './live-claims'
+import { POLL_MS, SETTLE_MS, spawnOutcome } from './spawn-outcome'
 import type { SessionBackend, SpawnPlanError } from './types'
 
 /** Derived from the specs, never a second hand-written list — the two could not then disagree. */
@@ -120,6 +121,37 @@ export async function runSession(argv: string[]): Promise<number> {
   }
 }
 
+/**
+ * Whether the session we just started is already GONE, and what it said on the way out.
+ *
+ * Returns the sentence to show, or `undefined` when it is running. One helper for all three spawn
+ * sites — `start`, `batch` and the reopen — because the failure is identical at each and a check in
+ * only one of them is the same bug surviving in the other two.
+ *
+ * The deadline is `SETTLE_MS`, and it is MEASURED rather than guessed — see that constant. The
+ * first version waited 700ms on the reasoning that a refusal must be immediate; the real one lands
+ * between 1.5s and 3s, so that check would have reported "started" for the very session it exists
+ * to catch.
+ */
+async function spawnFailure(backend: SessionBackend, id: string): Promise<string | undefined> {
+  // POLLED, not slept. Measured: the refusal lands between 1.5s and 3s — the harness loads and
+  // resolves the conversation before deciding — so a fixed short wait reports "started" for a
+  // session that is about to die. Polling ends the moment it dies, so a refusal costs what it
+  // costs and only a healthy session waits out the deadline.
+  const deadline = Date.now() + SETTLE_MS
+  let outcome = spawnOutcome([])
+  while (Date.now() < deadline) {
+    await new Promise(r => setTimeout(r, POLL_MS))
+    outcome = spawnOutcome(await backend.capture(id, 40).catch(() => [] as string[]))
+    if (outcome.died) break
+  }
+  if (!outcome.died) return undefined
+  // The harness's own words, because they are the only actionable part. A status with no message is
+  // still better than "it did not start".
+  return outcome.message
+    || `the session exited immediately${outcome.status !== undefined ? ` (status ${outcome.status})` : ''}`
+}
+
 async function start(
   cmd: Extract<SessionCommand, { kind: 'start' }>,
   backend: SessionBackend,
@@ -140,6 +172,16 @@ async function start(
     await backend.spawn({ id, cwd, argv: planned.plan.argv, ...(planned.plan.sendKeys ? { sendKeys: planned.plan.sendKeys } : {}) })
   } catch (e) {
     console.error(`Could not start the session: ${e instanceof Error ? e.message : String(e)}`)
+    return 1
+  }
+
+  // `spawn` returning is not evidence anything is RUNNING — tmux's contract is "I made you a
+  // session". A harness that refuses its arguments has already exited by now, and registering a row
+  // for it is what produced three dead rows called MAIN. See `spawn-outcome.ts`.
+  const failed = await spawnFailure(backend, id)
+  if (failed) {
+    console.error(failed)
+    await backend.kill(id).catch(() => {})
     return 1
   }
 
@@ -231,6 +273,15 @@ async function batch(
       failed.push({ harness: spec.harness, reason: e instanceof Error ? e.message : String(e) })
       continue
     }
+    // Same check as `start`: a harness that refused its arguments is already gone, and a batch that
+    // reports N started when N exited is worse than one that reports the refusal — the whole point
+    // of a batch is that nobody is watching each one come up.
+    const died = await spawnFailure(backend, id)
+    if (died) {
+      failed.push({ harness: spec.harness, reason: died })
+      await backend.kill(id).catch(() => {})
+      continue
+    }
     await addSession({
       id,
       harness: spec.harness,
@@ -308,6 +359,16 @@ async function openTask(task: string, json: boolean, backend: SessionBackend): P
     try {
       await backend.spawn({ id, cwd: m.cwd, argv: planned.plan.argv })
     } catch { skipped.push(m.id); continue }
+    // The path the report came from. Claude refuses to resume a conversation that is already open
+    // as a background agent, and the refusal is instant — so this reopen wrote a row for a process
+    // that no longer existed, and pressing it again wrote another. The old row must NOT be retired
+    // either: retiring it on a reopen that failed would lose the only row that still names the work.
+    const died = await spawnFailure(backend, id)
+    if (died) {
+      skipped.push(m.id)
+      await backend.kill(id).catch(() => {})
+      continue
+    }
     await addSession({
       id, harness: m.harness, cwd: m.cwd, createdAt: new Date().toISOString(), task,
       label: row.label,

--- a/packages/server/server/sessions/harness-session-file.ts
+++ b/packages/server/server/sessions/harness-session-file.ts
@@ -62,6 +62,41 @@ export interface HarnessSessionFile {
    * agentop. It is the EXACT link between a harness's own record and a managed row.
    */
   tmux?: string
+  /**
+   * The process's start time as the kernel counts it — field 22 of `/proc/<pid>/stat`.
+   *
+   * **This is what makes `pid` safe to believe.** These records outlive their processes by design
+   * (that is what keeps a name readable on a `lost` row), so the directory is mostly full of dead
+   * pids — measured here: 64 records, 3 of them still running. A pid alone would therefore report a
+   * long-dead session as alive the moment the OS handed its number to something else, and it would
+   * do it on the row that says "this conversation is running", which is the worst place to be wrong.
+   *
+   * Compared as an opaque STRING, never parsed into a time: it is a count of clock ticks since boot,
+   * whose unit and epoch are the kernel's business. All this code needs is whether the process
+   * answering to that pid is the same one that wrote the record.
+   *
+   * Verified on this machine 2026-08-15: of the three records whose pid still existed, all three
+   * matched `/proc` exactly.
+   */
+  procStart?: string
+  /**
+   * Which harness wrote this record — stamped by the loader, which knows because it is iterating
+   * `HARNESS_SESSION_SOURCES` one harness at a time.
+   *
+   * Not in the file, and carried so no reader has to hardcode a harness to use one of these. Only
+   * claude writes such a record today; that is a fact about the sources table, and the day a second
+   * one does, every consumer is already correct.
+   */
+  harness?: HarnessId
+  /**
+   * Whether the process that wrote this record is STILL RUNNING — stamped by the loader.
+   *
+   * Not part of the file: it is a fact about this moment, answered by the platform. `undefined`
+   * means nobody could tell (no `/proc`, so not Linux) and must be read as "unknown", never as
+   * "not running" — the same N/A-versus-a-confident-0 rule the dashboard applies to harness
+   * capabilities. A row whose liveness is unknown stays exactly as it was.
+   */
+  alive?: boolean
 }
 
 /**
@@ -85,6 +120,10 @@ export function parseHarnessSessionFile(raw: unknown): HarnessSessionFile | null
     ...(str(s.nameSource) ? { nameSource: str(s.nameSource)! } : {}),
     ...(num(s.nameSince) !== undefined ? { nameSince: num(s.nameSince)! } : {}),
     ...(str(s.tmux) ? { tmux: str(s.tmux)! } : {}),
+    // Claude writes it as a STRING of clock ticks; a number would also be reasonable and is
+    // accepted, because the only operation ever performed on it is equality against `/proc`.
+    ...(str(s.procStart) ? { procStart: str(s.procStart)! }
+      : num(s.procStart) !== undefined ? { procStart: String(num(s.procStart)!) } : {}),
   }
 }
 

--- a/packages/server/server/sessions/harness-sessions.ts
+++ b/packages/server/server/sessions/harness-sessions.ts
@@ -33,6 +33,7 @@ import {
   type HarnessSessionFile,
 } from './harness-session-file'
 import { idFromTmuxName } from './tmux-cli'
+import { procAvailable, readProcStart, sameProcess } from './proc-liveness'
 
 /**
  * Where each harness's own session records live on THIS machine.
@@ -146,6 +147,9 @@ export async function loadHarnessSessions(
   // How fresh the record already sitting under each managed id is, so the newest wins rather than
   // whichever `readdir` happened to hand over last. See the note above `Keyed`.
   const seenAt = new Map<string, number>()
+  // Asked ONCE for the whole sweep rather than per file: off Linux the answer is the same 60 times,
+  // and it decides whether `alive` is a fact or stays `undefined`.
+  const canProbe = await procAvailable()
 
   for (const harness of harnesses) {
     const source = HARNESS_SESSION_SOURCES[harness]
@@ -166,7 +170,19 @@ export async function loadHarnessSessions(
       if (!source.matches.test(name)) continue
       const read = await readOne(join(dir, name))
       if (!read) continue
-      const { file, mtimeMs } = read
+      const { mtimeMs } = read
+      // Liveness is stamped here because this is the impure layer and the answer is about NOW.
+      // Only asked where `/proc` exists at all, and only for a record that carries the
+      // anti-recycling key — everywhere else it stays `undefined`, meaning "nobody could tell",
+      // which every reader must treat as unknown rather than as "not running".
+      const pid = read.file.pid
+      const file: HarnessSessionFile = {
+        ...read.file,
+        harness,
+        ...(canProbe && pid !== undefined
+          ? { alive: sameProcess(read.file.procStart, await readProcStart(pid)) }
+          : {}),
+      }
       if (file.pid !== undefined) out.byPid.set(file.pid, file)
 
       // Indexed BEFORE the tmux gate below, and that placement is the fix: everything past that

--- a/packages/server/server/sessions/memory-budget.test.ts
+++ b/packages/server/server/sessions/memory-budget.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'bun:test'
+import {
+  memoryBudget, parseMeminfo, ASSUMED_SESSION_BYTES, RED_WITHIN, SWAP_ALARM_FRACTION,
+} from './memory-budget'
+
+const GB = 1024 * 1024 * 1024
+const MB = 1024 * 1024
+
+const sample = (over: Partial<ReturnType<typeof base>> = {}) => ({ ...base(), ...over })
+const base = () => ({ total: 16 * GB, available: 10 * GB, swapTotal: 4 * GB, swapUsed: 0 })
+
+describe('parseMeminfo', () => {
+  it('reads the real shape of /proc/meminfo', () => {
+    // Verbatim from this machine on 2026-08-15.
+    const s = parseMeminfo([
+      'MemTotal:       16127932 kB',
+      'MemFree:         6000536 kB',
+      'MemAvailable:   10217372 kB',
+      'Buffers:          444092 kB',
+      'SwapTotal:       4194304 kB',
+      'SwapFree:        3576832 kB',
+    ].join('\n'))
+    expect(s).not.toBeNull()
+    expect(s!.available).toBe(10217372 * 1024)
+    expect(s!.swapUsed).toBe((4194304 - 3576832) * 1024)
+  })
+
+  it('takes MemAvailable, never MemFree', () => {
+    // Measured at one moment here: free 5.7 GB against available 9.7 GB. Reading MemFree would
+    // declare a machine with 4 GB of headroom nearly out, and every later warning becomes noise.
+    const s = parseMeminfo('MemTotal: 16127932 kB\nMemFree: 6000536 kB\nMemAvailable: 10217372 kB')
+    expect(s!.available).not.toBe(6000536 * 1024)
+  })
+
+  it('returns null rather than a gauge built on a zero', () => {
+    expect(parseMeminfo('')).toBeNull()
+    expect(parseMeminfo('MemTotal: 16127932 kB')).toBeNull()   // no MemAvailable
+    expect(parseMeminfo('nonsense')).toBeNull()
+  })
+
+  it('treats a machine with no swap as having none, not as having failed', () => {
+    const s = parseMeminfo('MemTotal: 100 kB\nMemAvailable: 50 kB')
+    expect(s).not.toBeNull()
+    expect(s!.swapTotal).toBe(0)
+    expect(s!.swapUsed).toBe(0)
+  })
+})
+
+describe('memoryBudget', () => {
+  it('measures the cost from what is running, rather than assuming', () => {
+    const b = memoryBudget({ sample: sample(), sessionBytes: 1200 * MB, sessions: 4 })
+    expect(b.cost.basis).toBe('measured')
+    expect(b.cost.bytes).toBe(300 * MB)
+  })
+
+  it('falls back to the declared default and SAYS it is assumed', () => {
+    const b = memoryBudget({ sample: sample(), sessionBytes: 0, sessions: 0 })
+    expect(b.cost).toEqual({ bytes: ASSUMED_SESSION_BYTES, basis: 'assumed' })
+  })
+
+  it('counts what the sessions already hold as part of the room', () => {
+    // Otherwise the total shrinks as you use the machine correctly: four sessions running would
+    // report a smaller ceiling than the same machine with none.
+    const withNone = memoryBudget({ sample: sample(), sessionBytes: 0, sessions: 0 }).max
+    const withFour = memoryBudget({
+      sample: sample({ available: 10 * GB - 1000 * MB }),
+      sessionBytes: 1000 * MB,
+      sessions: 4,
+      assumedBytes: 250 * MB,
+    }).max
+    expect(withFour).toBe(withNone)
+  })
+
+  it('turns red by DISTANCE, not by percentage', () => {
+    // Three left of thirty is comfortable; three left of fourteen is the last warning. A fraction
+    // makes those the same number, and what gets spent is one session at a time.
+    const tight = memoryBudget({
+      sample: sample({ available: 2 * GB + 3 * 250 * MB }),
+      sessionBytes: 11 * 250 * MB, sessions: 11, assumedBytes: 250 * MB,
+    })
+    expect(tight.left).toBe(RED_WITHIN)
+    expect(tight.red).toBe(true)
+    expect(tight.alarm).toBe('sessions')
+
+    const roomy = memoryBudget({
+      sample: sample({ available: 2 * GB + 10 * 250 * MB }),
+      sessionBytes: 4 * 250 * MB, sessions: 4, assumedBytes: 250 * MB,
+    })
+    expect(roomy.left).toBeGreaterThan(RED_WITHIN)
+    expect(roomy.red).toBe(false)
+    expect(roomy.alarm).toBeUndefined()
+  })
+
+  it('alarms on SWAP even when the RAM figure looks fine', () => {
+    // The freeze this exists to prevent: RAM read 3.6 GB free while swap sat at 97%, and it is the
+    // swap thrash that stops the machine responding. A RAM-only budget said everything was fine at
+    // the exact moment the laptop locked up.
+    const b = memoryBudget({
+      sample: sample({ available: 8 * GB, swapUsed: 4 * GB * SWAP_ALARM_FRACTION }),
+      sessionBytes: 250 * MB, sessions: 1,
+    })
+    expect(b.left).toBeGreaterThan(RED_WITHIN)  // by sessions alone this is comfortable
+    expect(b.red).toBe(true)
+    expect(b.alarm).toBe('swap')                // …and the reason is named, because the action differs
+  })
+
+  it('never reports a ceiling below what is already running', () => {
+    // An over-committed machine is a real state, and reporting `max: 2` while four are up would be
+    // a number nobody can act on. It says 4 of 4, none left.
+    const b = memoryBudget({
+      sample: sample({ available: 0 }), sessionBytes: 4 * GB, sessions: 4,
+    })
+    expect(b.max).toBeGreaterThanOrEqual(4)
+    expect(b.left).toBe(0)
+    expect(b.red).toBe(true)
+  })
+})

--- a/packages/server/server/sessions/memory-budget.ts
+++ b/packages/server/server/sessions/memory-budget.ts
@@ -1,0 +1,154 @@
+/**
+ * memory-budget.ts — PURE. How much room this machine has left, and how many assistants fit in it.
+ *
+ * The question this answers is not "how much RAM is used" — every OS already has a tool for that.
+ * It is **"can I open another session"**, which is a different question with a different unit, and
+ * the only one anybody actually asks before opening one.
+ *
+ * ## Why the answer is a DISTANCE and not a percentage
+ *
+ * The colour is decided by how many sessions are left, never by a fraction. Three left out of
+ * thirty is comfortable; three left out of fourteen is the last warning you get. Percentages
+ * collapse those into the same number, and the thing being spent is a session at a time.
+ *
+ * ## Two numbers that are easy to confuse, and only one of them is right
+ *
+ * `MemAvailable` is what the kernel says can be handed out without swapping — it counts the page
+ * cache the kernel would happily drop. `MemFree` counts only untouched pages. Measured on this
+ * machine at one moment: free 5.7 GB, available 9.7 GB. Using `MemFree` would declare a machine
+ * with 4 GB of headroom to be nearly out, and every warning after that is noise the user learns to
+ * ignore. So: available, always.
+ *
+ * ## Swap is part of the answer, not a footnote
+ *
+ * The freeze this feature exists to prevent was not a RAM shortage: RAM looked fine at 3.6 GB free
+ * while SWAP sat at 97% used, and it is the swap thrash that stops a machine responding. A budget
+ * that only reads RAM would have said everything was fine at the exact moment the laptop locked up.
+ */
+
+/** What the platform could read. Every field is in BYTES. */
+export interface MemorySample {
+  total: number
+  /** `MemAvailable` — reclaimable cache included. Never `MemFree`; see the header. */
+  available: number
+  swapTotal: number
+  swapUsed: number
+}
+
+/** One session's measured cost, and how it was arrived at. */
+export interface SessionCost {
+  bytes: number
+  /**
+   * `measured` — averaged over the sessions actually running here.
+   * `assumed` — nothing was running, so the declared default was used, and the UI must SAY so.
+   */
+  basis: 'measured' | 'assumed'
+}
+
+/**
+ * What one assistant costs when none is running to measure.
+ *
+ * The median of the claude processes on this machine on 2026-08-15, which ranged 162–442 MB. It is
+ * a starting point that gets replaced by measurement the moment there is anything to measure, and
+ * `basis: 'assumed'` exists so no surface can present it as a reading.
+ */
+export const ASSUMED_SESSION_BYTES = 250 * 1024 * 1024
+
+/**
+ * Held back for everything that is not an assistant — the desktop, the browser, the server, a build.
+ *
+ * A budget that lets sessions consume every last byte is arithmetically correct and useless: the
+ * machine dies before the last one starts. This is the floor the count is computed above.
+ */
+export const RESERVED_BYTES = 2 * 1024 * 1024 * 1024
+
+/** Swap this full means the machine is already thrashing, whatever the RAM figure says. */
+export const SWAP_ALARM_FRACTION = 0.85
+
+/** How many sessions may remain before the number turns red. Three, two, one, none — see header. */
+export const RED_WITHIN = 3
+
+export interface MemoryBudget {
+  /** How many sessions this machine can hold in total, at the measured cost. */
+  max: number
+  /** How many are running now. */
+  used: number
+  /** `max - used`, floored at zero. */
+  left: number
+  cost: SessionCost
+  /** True once `left` is inside `RED_WITHIN`, or the swap alarm has tripped. */
+  red: boolean
+  /**
+   * Why the budget is alarming, or `undefined` when it is not. Distinguished because they call for
+   * different actions: `sessions` means close one, `swap` means the machine is ALREADY struggling
+   * and closing one may not be enough.
+   */
+  alarm?: 'sessions' | 'swap'
+}
+
+/**
+ * The budget — PURE.
+ *
+ * `sessionBytes` is the total RSS of the assistant processes, and `sessions` how many there were.
+ * Both come from the caller because reading them is a platform act.
+ */
+export function memoryBudget(o: {
+  sample: MemorySample
+  sessionBytes: number
+  sessions: number
+  reservedBytes?: number
+  assumedBytes?: number
+}): MemoryBudget {
+  const reserved = o.reservedBytes ?? RESERVED_BYTES
+  const cost: SessionCost = o.sessions > 0 && o.sessionBytes > 0
+    ? { bytes: Math.round(o.sessionBytes / o.sessions), basis: 'measured' }
+    : { bytes: o.assumedBytes ?? ASSUMED_SESSION_BYTES, basis: 'assumed' }
+
+  // What the sessions ALREADY hold is part of the room for sessions: they are the thing being
+  // counted. Measuring only what is free would report a ceiling that shrinks as the machine is used
+  // correctly — four sessions running would claim a smaller total than the same machine with none.
+  //
+  // So `room` is the whole envelope and `floor(room / cost)` is the TOTAL, not the remainder. Adding
+  // `sessions` on top of it was double counting, caught by the test above: the same machine reported
+  // 32 empty and 36 with four running.
+  const room = o.sample.available + o.sessionBytes - reserved
+  // Never below what is already up: an over-committed machine is a real state, and "2 of 4" is a
+  // number nobody can act on. It says 4 of 4, none left.
+  const max = Math.max(o.sessions, Math.floor(room / Math.max(1, cost.bytes)))
+  const left = Math.max(0, max - o.sessions)
+
+  const swapping = o.sample.swapTotal > 0
+    && o.sample.swapUsed / o.sample.swapTotal >= SWAP_ALARM_FRACTION
+  // Swap is named FIRST when both trip: it is the more urgent fact and the one closing a session
+  // may not fix.
+  const alarm = swapping ? 'swap' as const : left <= RED_WITHIN ? 'sessions' as const : undefined
+  return { max, used: o.sessions, left, cost, red: alarm !== undefined, ...(alarm ? { alarm } : {}) }
+}
+
+/**
+ * `MemAvailable` and friends out of `/proc/meminfo` — PURE over the text.
+ *
+ * Returns `null` when the required fields are not all present, which is how a non-Linux machine and
+ * a truncated read reach the same honest answer: **no gauge**, rather than a gauge built on a zero.
+ * Same rule as `ControlService.boot` and `HARNESS_CAPABILITIES` — an absent measurement is shown as
+ * absent, never as a confident number.
+ */
+export function parseMeminfo(text: string): MemorySample | null {
+  const kb = (key: string): number | undefined => {
+    const m = new RegExp(`^${key}:\\s+(\\d+) kB$`, 'm').exec(text)
+    return m ? Number(m[1]) * 1024 : undefined
+  }
+  const total = kb('MemTotal')
+  const available = kb('MemAvailable')
+  const swapTotal = kb('SwapTotal')
+  const swapFree = kb('SwapFree')
+  if (total === undefined || available === undefined) return null
+  // Swap is optional: a machine with none is not a machine that failed to report. It reads as zero
+  // of zero, and `memoryBudget` guards the division.
+  return {
+    total,
+    available,
+    swapTotal: swapTotal ?? 0,
+    swapUsed: swapTotal !== undefined && swapFree !== undefined ? swapTotal - swapFree : 0,
+  }
+}

--- a/packages/server/server/sessions/memory-probe.ts
+++ b/packages/server/server/sessions/memory-probe.ts
@@ -1,0 +1,69 @@
+/**
+ * memory-probe.ts — the impure half of the memory budget: reading this machine.
+ *
+ * Split from `memory-budget.ts` for the usual reason — the arithmetic is tested and the syscalls are
+ * not — and kept deliberately small: two reads and a sum.
+ *
+ * **Where it cannot read, it returns `null` and the whole gauge is absent.** Not zero, not a
+ * placeholder. `/proc` exists on Linux and on WSL; it does not on macOS or Windows, and a machine
+ * that cannot be measured must show no gauge rather than a confident wrong one — the same rule
+ * `ControlService.boot` follows for systemd and `HARNESS_CAPABILITIES` for metrics.
+ */
+
+import { readFile, readdir } from 'node:fs/promises'
+import type { MemorySample } from './memory-budget'
+import { parseMeminfo } from './memory-budget'
+
+/** The machine's memory, or `null` where it cannot be read. */
+export async function readMemory(): Promise<MemorySample | null> {
+  try {
+    return parseMeminfo(await readFile('/proc/meminfo', 'utf8'))
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Total resident bytes of a set of pids, and how many were actually readable.
+ *
+ * `VmRSS` from `/proc/<pid>/status` rather than `statm`, because it is already in kB and labelled —
+ * no page-size arithmetic to get wrong.
+ *
+ * **RSS of processes that share pages does not sum exactly.** It over-counts shared libraries, so
+ * this figure is an upper bound. That is the right direction for this use — a budget that errs
+ * toward "fewer sessions fit" fails safe — but it is stated here rather than left for someone to
+ * discover, and it is why the surface says "recommended" and not "available".
+ */
+export async function readRss(pids: readonly number[]): Promise<{ bytes: number; read: number }> {
+  let bytes = 0
+  let read = 0
+  for (const pid of pids) {
+    try {
+      const status = await readFile(`/proc/${pid}/status`, 'utf8')
+      const m = /^VmRSS:\s+(\d+) kB$/m.exec(status)
+      if (!m) continue
+      bytes += Number(m[1]) * 1024
+      read++
+    } catch {
+      // Gone between listing and reading, or a uid that may not look. Skipped, and the count says so.
+    }
+  }
+  return { bytes, read }
+}
+
+/**
+ * Every pid under a tmux session's process tree is NOT what this needs — the harness process is.
+ *
+ * The caller passes the pids it already knows about (from the harness records and from the process
+ * scan), so this module never has to decide what an assistant is. It exists as a named export
+ * because the alternative — each caller writing its own `/proc` read — is how two surfaces end up
+ * disagreeing about the same number.
+ */
+export async function procPidsExist(): Promise<boolean> {
+  try {
+    await readdir('/proc/self')
+    return true
+  } catch {
+    return false
+  }
+}

--- a/packages/server/server/sessions/proc-liveness.test.ts
+++ b/packages/server/server/sessions/proc-liveness.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'bun:test'
+import { sameProcess, readProcStart, procAvailable } from './proc-liveness'
+
+describe('sameProcess — the anti-recycling rule', () => {
+  it('matches only when both sides say the same start time', () => {
+    expect(sameProcess('2467615', '2467615')).toBe(true)
+    expect(sameProcess('2467615', '9999999')).toBe(false)
+  })
+
+  it('refuses when the pid is gone', () => {
+    // `undefined` from the probe is a real answer: nothing is running under that number.
+    expect(sameProcess('2467615', undefined)).toBe(false)
+  })
+
+  it('refuses a record with NO start time, rather than trusting the pid alone', () => {
+    // Every claude before it began writing `procStart`. The caller uses this to claim a session is
+    // alive, and the directory is mostly dead pids the OS is free to hand out again — measured
+    // here: 64 records, 3 running. An unproven claim of liveness is worse than an absent one, so
+    // such a row simply stays as it was.
+    expect(sameProcess(undefined, '2467615')).toBe(false)
+    expect(sameProcess(undefined, undefined)).toBe(false)
+    expect(sameProcess('', '2467615')).toBe(false)
+  })
+})
+
+describe('readProcStart — reading the real /proc', () => {
+  it('reads this very process, and agrees with itself', async () => {
+    if (!(await procAvailable())) return // not Linux: the feature is absent, not wrong
+    const mine = await readProcStart(process.pid)
+    expect(mine).toMatch(/^\d+$/)
+    expect(sameProcess(mine, await readProcStart(process.pid))).toBe(true)
+  })
+
+  it('survives a name with spaces and parentheses in it', async () => {
+    // Field 2 of /proc/<pid>/stat is the executable name IN PARENTHESES and may contain both. A
+    // left-to-right split would put every later field at an offset that depends on the program's
+    // name — which is why the parse cuts at the LAST `)`. Reading our own stat exercises it: bun's
+    // comm is plain, so this asserts the shape rather than the pathological case, and the rule is
+    // documented where it is implemented.
+    if (!(await procAvailable())) return
+    expect(await readProcStart(process.pid)).toMatch(/^\d+$/)
+  })
+
+  it('returns undefined for a pid that cannot exist', async () => {
+    expect(await readProcStart(2 ** 31)).toBeUndefined()
+  })
+})

--- a/packages/server/server/sessions/proc-liveness.ts
+++ b/packages/server/server/sessions/proc-liveness.ts
@@ -1,0 +1,66 @@
+/**
+ * proc-liveness.ts — is the process that wrote a record STILL the one answering to that pid?
+ *
+ * Split from `harness-sessions.ts` so the rule and the syscall are separable: `sameProcess` is pure
+ * and tested, `readProcStart` is the one impure line and is Linux-only by construction.
+ *
+ * ## Why a pid is not enough, stated once
+ *
+ * These records outlive their processes on purpose — that is what keeps the name someone typed
+ * readable on a `lost` row afterwards. Measured on this machine on 2026-08-15: 64 records, of which
+ * **3** belonged to a running process. So the directory is mostly dead pids, and the OS reuses pid
+ * numbers. Believing `pid` alone means reporting a long-dead session as running the moment its
+ * number comes round again — on the row that claims a conversation is live, which is the worst
+ * place in this product to be wrong.
+ *
+ * Field 22 of `/proc/<pid>/stat` is the process's start time in clock ticks since boot. Two
+ * processes can share a pid; they cannot share a pid AND a start time. Verified against real data:
+ * of the three records whose pid still existed, all three matched exactly.
+ */
+
+import { readFile } from 'node:fs/promises'
+
+/**
+ * Whether a record and a probe describe the SAME process — PURE.
+ *
+ * `undefined` from the probe means the pid does not exist: not running, and that is a real answer.
+ * A record with no `procStart` (every claude before it started writing one) is the interesting case
+ * and it is answered NO: without the anti-recycling key there is no way to tell a resumed pid from
+ * the original, and this function's callers use it to claim a session is alive. An unproven claim
+ * of liveness is worse than an absent one — the row stays as it was, which is today's behaviour.
+ */
+export function sameProcess(recorded: string | undefined, probed: string | undefined): boolean {
+  if (!recorded || !probed) return false
+  return recorded === probed
+}
+
+/**
+ * Field 22 of `/proc/<pid>/stat`, or `undefined` when the pid does not exist or cannot be read.
+ *
+ * The parse is `rsplit` on `)` rather than a plain split, and that is load-bearing: field 2 is the
+ * executable name IN PARENTHESES and it may itself contain spaces and parentheses. Splitting from
+ * the left on whitespace puts every later field at an offset that depends on the program's name.
+ * After the LAST `)`, the remaining fields start at field 3, so field 22 is index 19.
+ */
+export async function readProcStart(pid: number): Promise<string | undefined> {
+  try {
+    const stat = await readFile(`/proc/${pid}/stat`, 'utf8')
+    const tail = stat.slice(stat.lastIndexOf(')') + 1).trim().split(/\s+/)
+    const start = tail[19]
+    return start && /^\d+$/.test(start) ? start : undefined
+  } catch {
+    // No /proc (not Linux), a pid that has gone, or a process this uid may not read. All three are
+    // "cannot tell", and the caller must not turn that into "not running".
+    return undefined
+  }
+}
+
+/** True when `/proc` is readable at all — the platform gate for the whole feature. */
+export async function procAvailable(): Promise<boolean> {
+  try {
+    await readFile('/proc/self/stat', 'utf8')
+    return true
+  } catch {
+    return false
+  }
+}

--- a/packages/server/server/sessions/session-view.test.ts
+++ b/packages/server/server/sessions/session-view.test.ts
@@ -292,6 +292,53 @@ describe("what the harness says about its OWN session", () => {
     expect(views[0]!.searchText).toContain('cockpit')
   })
 
+  it('a conversation whose record is ALIVE is running, not closed', () => {
+    // The other half of the report. A background agent alive for 38 minutes sat in the closed block
+    // under a title from another week, offering to "reopen" a conversation that had never stopped.
+    // It is synthesised into the SAME external path a scanned process takes, so it inherits every
+    // rule already written there rather than getting a parallel branch.
+    const views = buildSessionViews({
+      reconciled: [],
+      activity: new Map(),
+      processes: [],
+      conversations: [{
+        sessionId: '581deab7', title: 'a title from another week', lastActivityMs: 1,
+        harness: 'claude' as const, cwd: '/repo/a', resumable: true, firstPrompt: '',
+      }],
+      harnessSessions: index({
+        byConversation: {
+          '581deab7': {
+            name: 'MAIN', pid: 508665, cwd: '/repo/a', sessionId: '581deab7',
+            harness: 'claude', alive: true,
+          },
+        },
+      }),
+    })
+    expect(views.map(v => v.status)).toContain('external')
+    expect(views.find(v => v.status === 'external')?.harnessName).toBe('MAIN')
+    // …and it is not ALSO sitting in the closed block under the old title.
+    expect(views.filter(v => v.status === 'closed')).toHaveLength(0)
+  })
+
+  it('synthesises nothing when liveness could not be determined', () => {
+    // `alive: undefined` means no /proc — not Linux, or a uid that may not read it. Unknown must
+    // never become a claim, so the row stays exactly as it was today.
+    const views = buildSessionViews({
+      reconciled: [],
+      activity: new Map(),
+      processes: [],
+      conversations: [{
+        sessionId: 'c1', title: 'stored title', lastActivityMs: 1,
+        harness: 'claude' as const, cwd: '/repo/a', resumable: true, firstPrompt: '',
+      }],
+      harnessSessions: index({
+        byConversation: { c1: { name: 'MAIN', pid: 1, cwd: '/repo/a', harness: 'claude' } },
+      }),
+    })
+    expect(views).toHaveLength(1)
+    expect(views[0]!.status).toBe('closed')
+  })
+
   it('never lets a DERIVED name displace a real store title', () => {
     // `agentistics-84` is what the harness invents from the folder when nobody has said anything.
     const views = buildSessionViews({

--- a/packages/server/server/sessions/session-view.ts
+++ b/packages/server/server/sessions/session-view.ts
@@ -396,17 +396,55 @@ export function buildSessionViews(o: {
   // A row whose harness is unknown covers NOTHING: it might be that process or might not, and
   // silently swallowing an external session on a maybe is the worse of the two errors — a duplicate
   // row is visible and self-correcting, a missing one is not.
+  // Only a row that is actually RUNNING can account for a running process. `!== 'lost'` was too
+  // wide: an `exited` row accounts for a process that is GONE, and letting it cover swallows a live
+  // session that happens to share its directory. Measured on this machine — three exited rows sat in
+  // the worktree of a background agent that was alive, and the agent was hidden behind them and
+  // listed as a closed conversation instead.
   const covered = (p: HarnessProcess): boolean => managed.some(m =>
     m.harness === p.harness &&
-    m.status !== 'lost' &&
+    (m.status === 'running' || m.status === 'unregistered') &&
     sessionAtCwd({ current_cwd: m.cwd, project_path: m.cwd }, p.cwd))
 
   const conversations = o.conversations ?? []
 
-  const external: SessionView[] = o.processes.filter(p => !covered(p)).map(p => {
+  /**
+   * Sessions the harness's OWN records prove are running, which the `/proc` scan did not report.
+   *
+   * Synthesised as processes rather than special-cased downstream, deliberately: they then travel
+   * the very same `external` path as a scanned one and inherit every rule already written there —
+   * the `covered` de-duplication, the exact-name lookup, the resume target, the tokens and the
+   * context gauge. A parallel branch would be a second set of rules for one kind of row.
+   *
+   * Two things had to be true before this was sound, and both now are: the record carries
+   * `procStart`, so `alive` is a fact about THIS process and not about whoever inherited its pid;
+   * and `alive` is `undefined` wherever nobody could tell, so a machine with no `/proc` synthesises
+   * nothing and behaves exactly as it did.
+   *
+   * This is what stops a live session being listed as `closed`. Measured: a background agent alive
+   * for 38 minutes — no tmux, missed by the scan — sat in the closed block under a title from
+   * another week, offering to "reopen" a conversation that had never stopped.
+   */
+  const scannedPids = new Set(o.processes.map(p => p.pid).filter((v): v is number => v !== undefined))
+  const fromRecords: HarnessProcess[] = [...(o.harnessSessions?.byConversation.values() ?? [])]
+    .filter(f => f.alive === true && f.pid !== undefined && !scannedPids.has(f.pid)
+      && f.cwd !== undefined && f.harness !== undefined)
+    .map(f => ({
+      harness: f.harness!,
+      cwd: f.cwd!,
+      pid: f.pid!,
+      ...(f.sessionId ? { sessionId: f.sessionId } : {}),
+    }))
+
+  const external: SessionView[] = [...o.processes, ...fromRecords].filter(p => !covered(p)).map(p => {
     // What the harness says about ITSELF, keyed on the pid `/proc` reported. Exact where every other
     // reading of an external process is an inference from its directory.
-    const own = p.pid !== undefined ? o.harnessSessions?.byPid.get(p.pid) : undefined
+    // By pid first — that is the key a SCANNED process arrives with. Falling back to the
+    // conversation removes a hidden coupling rather than papering over one: a row synthesised from
+    // a record already knows the conversation exactly, and making its name depend on a second
+    // lookup succeeding would leave it correctly listed and anonymously labelled.
+    const own = (p.pid !== undefined ? o.harnessSessions?.byPid.get(p.pid) : undefined)
+      ?? (p.sessionId ? o.harnessSessions?.byConversation.get(p.sessionId) : undefined)
     const ownName = chosenName(own)
     // What this process appears to be driving. The harness's own `sessionId` outranks the argv one
     // and the directory guess alike: it is what the process is writing to, said by the process.

--- a/packages/server/server/sessions/spawn-outcome.test.ts
+++ b/packages/server/server/sessions/spawn-outcome.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'bun:test'
+import { spawnOutcome } from './spawn-outcome'
+
+describe('spawnOutcome', () => {
+  it('reads the refusal that produced three dead rows called MAIN', () => {
+    // Captured verbatim from the pane. The conversation was running as a background agent, Claude
+    // refused to resume it, and the process was gone before the spawn call returned — so a row was
+    // written for it. Every press of Reopen made another.
+    const frame = [
+      'Session 581deab7-8aa7-4438-9371-5d4f1668c1ab is currently running as a',
+      'background agent (bg). Use `claude agents` to find and attach to it, or add',
+      '--fork-session to branch off a copy.',
+      'Pane is dead (status 1, Sat Aug 15 01:31:03 2026)',
+    ]
+    const out = spawnOutcome(frame)
+    expect(out.died).toBe(true)
+    expect(out.status).toBe(1)
+    // The words are what make it actionable: "it did not start" is not, "already open elsewhere" is.
+    expect(out.message).toContain('background agent')
+    expect(out.message).toContain('581deab7')
+  })
+
+  it('finds the words even with a pane full of blank rows between', () => {
+    // The shape tmux actually produces, measured: the message on the FIRST row, the notice on the
+    // LAST, and 33 blank rows in between. A fixed window of the lines immediately before the notice
+    // collected nothing, and the user was told only "exited (status 1)" — true, and useless.
+    const frame = [
+      'Session 581deab7-… is currently running as a background agent (bg).',
+      'a copy.',
+      ...Array<string>(33).fill(''),
+      'Pane is dead (status 1, Sat Aug 15 01:59:20 2026)',
+    ]
+    const out = spawnOutcome(frame)
+    expect(out.died).toBe(true)
+    expect(out.message).toContain('background agent')
+    // …and in the order they were printed, not reversed by the upward scan.
+    expect(out.message.indexOf('Session')).toBeLessThan(out.message.indexOf('a copy.'))
+  })
+
+  it('says nothing died when the session is drawing its first frame', () => {
+    const out = spawnOutcome(['', '❯ ', '  ⏵⏵ auto mode on (shift+tab to cycle)'])
+    expect(out.died).toBe(false)
+    expect(out.message).toBe('')
+  })
+
+  it('still reports DEAD when tmux words the notice without a status', () => {
+    // The notice is tmux's and its shape is not ours to depend on. Losing the number is a smaller
+    // error than concluding the program is running.
+    const out = spawnOutcome(['boom', 'Pane is dead'])
+    expect(out.died).toBe(true)
+    expect(out.status).toBeUndefined()
+    expect(out.message).toBe('boom')
+  })
+
+  it('takes the LAST notice, and carries no words when there were none', () => {
+    expect(spawnOutcome(['Pane is dead (status 1)']).message).toBe('')
+    expect(spawnOutcome(['Pane is dead (status 1)', 'x', 'Pane is dead (status 7)']).status).toBe(7)
+  })
+})

--- a/packages/server/server/sessions/spawn-outcome.ts
+++ b/packages/server/server/sessions/spawn-outcome.ts
@@ -1,0 +1,113 @@
+/**
+ * spawn-outcome.ts — PURE. Did the thing we just started actually START?
+ *
+ * ## The bug this exists for, reported and reproduced
+ *
+ * A conversation was showing as `closed` while it was in fact running as a background agent. Every
+ * press of Reopen spawned `claude --resume <id>`, and Claude Code REFUSED — the conversation was
+ * already open elsewhere:
+ *
+ * ```
+ * Session 581deab7-… is currently running as a background agent (bg).
+ * Use `claude agents` to find and attach to it, or add --fork-session to branch off a copy.
+ * Pane is dead (status 1, Sat Aug 15 01:31:03 2026)
+ * ```
+ *
+ * The spawn "succeeded" — tmux created the session, the call returned — so a row was written. The
+ * program inside had already exited. Pressing Reopen again made another one. The user finished with
+ * **three rows called MAIN**, all dead, and the real conversation still not opened.
+ *
+ * **`spawn` returning without throwing is not evidence that anything is running.** tmux's contract
+ * is "I made you a session", not "your program is alive"; with `remain-on-exit on` — which agentop
+ * sets deliberately, so a crash can be read instead of vanishing — a dead pane looks exactly like a
+ * live one to `list()`. The screen is the only thing that knows.
+ *
+ * ## What is read, and what is deliberately not
+ *
+ * `Pane is dead` is tmux's own words for "your program exited", and it carries the status. That is
+ * the DECISION. Everything above it is the program's last words, and they are what the user needs —
+ * "it did not start" is not actionable, "it refused because the conversation is already open" is.
+ *
+ * The message is never interpreted, only carried. A harness may refuse for reasons nobody here has
+ * seen, and inventing a category for each would be a table that goes stale in silence; passing the
+ * words through is correct for every refusal, including the ones that do not exist yet.
+ */
+
+/** What a freshly spawned session's screen says about itself. */
+export interface SpawnOutcome {
+  /** True when tmux reports the program exited. */
+  died: boolean
+  /** The exit status tmux named, when it named one. */
+  status?: number
+  /** The program's own last words, trimmed — what the user is shown. Empty when it said nothing. */
+  message: string
+}
+
+/**
+ * tmux's dead-pane notice, e.g. `Pane is dead (status 1, Sat Aug 15 01:31:03 2026)`.
+ *
+ * The status is optional in the pattern because the notice is tmux's and its shape is not ours to
+ * depend on: a build that words it differently must still be read as DEAD, with the status simply
+ * absent. Losing the number is a smaller error than concluding the program is running.
+ */
+const DEAD_PANE = /Pane is dead(?:\s*\(status\s+(\d+))?/i
+
+/**
+ * Read a just-spawned session's frame — PURE.
+ *
+ * `frame` is the captured pane, newest last.
+ */
+export function spawnOutcome(frame: readonly string[]): SpawnOutcome {
+  let deadAt = -1
+  let status: number | undefined
+  for (let i = frame.length - 1; i >= 0; i--) {
+    const m = DEAD_PANE.exec(frame[i] ?? '')
+    if (!m) continue
+    deadAt = i
+    if (m[1] !== undefined) status = Number(m[1])
+    break
+  }
+  if (deadAt < 0) return { died: false, message: '' }
+
+  // The program's words are the last lines with CONTENT above the notice, however far up they are —
+  // not the lines immediately before it. Measured: tmux leaves the notice on the pane's last row and
+  // the message on its first, with 33 blank rows between, so a fixed window of the preceding lines
+  // collected nothing at all and the user was told only "exited (status 1)".
+  //
+  // Bounded, because a crash can print a whole stack trace and this ends up on one line of a CLI.
+  const said: string[] = []
+  for (let i = deadAt - 1; i >= 0 && said.length < MESSAGE_LINES; i--) {
+    const line = (frame[i] ?? '').trim()
+    if (line) said.push(line)
+  }
+  return { died: true, ...(status !== undefined ? { status } : {}), message: said.reverse().join(' ').trim() }
+}
+
+/** How many lines above the notice count as the program's message. */
+export const MESSAGE_LINES = 6
+
+/**
+ * How long to keep asking before believing a session started — milliseconds.
+ *
+ * **Measured, because the obvious guess was wrong.** The first version of this waited 700ms on the
+ * reasoning that a refusal is immediate — parse the arguments, print, exit. It is not. Timed against
+ * the real refusal on this machine:
+ *
+ * ```
+ *  300ms  pane empty
+ *  700ms  pane empty          ← a 700ms check reports "started" and writes the row
+ * 1500ms  two lines, alive
+ * 3000ms  dead
+ * ```
+ *
+ * The harness loads, resolves the conversation, and only then refuses. A guessed timeout would have
+ * missed the exact case this exists for while looking like it worked.
+ *
+ * Paired with `POLL_MS`: the wait ENDS the moment the pane dies, so a refusal costs about as long as
+ * it takes, and only a healthy session pays the full deadline — which is why `batch` runs its checks
+ * in one parallel pass rather than serially.
+ */
+export const SETTLE_MS = 5_000
+
+/** How often to re-read the pane while waiting. */
+export const POLL_MS = 250

--- a/packages/tui/scripts/preview.tsx
+++ b/packages/tui/scripts/preview.tsx
@@ -289,6 +289,9 @@ function fakeStatus(opts: Options, apiUrl?: string): ControlStatus {
     services: services(opts.mode, s, apiUrl),
     version: '1.7.3',
     latestVersion: '1.7.4',
+    // The parallel-sessions budget, so the width sweep exercises the header WITH it. A calm one:
+    // the red case gives way later than this does, so a frame that fits this fits that too.
+    memory: { used: 3, max: 17, red: false },
     archiveMode: 'consolidate',
     // The wizard's blocked row, stated whenever the fake central is up: it is the case the fold
     // exists for, and a preview that only ever drew three selectable modes would never show it.

--- a/packages/tui/src/control/Chrome.tsx
+++ b/packages/tui/src/control/Chrome.tsx
@@ -92,6 +92,20 @@ function HeaderTag({ meta }: { meta: HeaderMeta }) {
     <Text>
       <Text dimColor>{meta.text}</Text>
       {meta.alert ? <Text color={COLORS.accent} bold>{` · ${meta.alert}`}</Text> : null}
+      {/* The parallel-sessions budget. Dim while there is room, `danger` once the ceiling is close
+          or the machine is already swapping — but the NUMBERS are always drawn, so a reader who
+          cannot tell the two shades apart still has the whole message. Colour never carries it. */}
+      {meta.memory
+        ? (
+          <Text
+            color={meta.memoryRed ? COLORS.danger : undefined}
+            dimColor={!meta.memoryRed}
+            bold={meta.memoryRed}
+          >
+            {` · ${meta.memory}`}
+          </Text>
+        )
+        : null}
       {/* Glyph plus version, in accent: the dot alone would carry the whole message in color. */}
       {meta.update ? <Text color={COLORS.accent}>{` · ${meta.update}`}</Text> : null}
     </Text>

--- a/packages/tui/src/control/ControlCenter.tsx
+++ b/packages/tui/src/control/ControlCenter.tsx
@@ -365,6 +365,10 @@ export function ControlCenter({ host, lang: initialLang, initial, onExit, mouse 
     // Drawn in the header so it is readable from every tab — a counter you have to navigate to in
     // order to see cannot tell you to navigate there.
     attention: fleet?.attention ?? 0,
+    // Absent on a machine whose memory cannot be read, and then no gauge is drawn at all — never a
+    // zero. The host decides `red`, from the distance to the ceiling AND from swap pressure; the
+    // TUI owns no logic here either.
+    ...(status?.memory ? { memory: status.memory } : {}),
     width,
   })
   const height = bodyHeight(rows, header.rows)

--- a/packages/tui/src/control/Prompt.tsx
+++ b/packages/tui/src/control/Prompt.tsx
@@ -33,6 +33,15 @@ export interface TextPromptProps {
   /** Mask the value — the member token is pasted in front of other people. */
   secret?: boolean
   onSubmit: (value: string) => void
+  /**
+   * Called on EVERY keystroke, when the caller wants the answer as it is typed.
+   *
+   * Optional because most of these prompts must not act early: a member token is meaningless until
+   * it is whole, and a rename applied per character would write six labels while somebody types
+   * one. A SEARCH is the opposite — the whole value of it is watching the list narrow — so it is
+   * the caller that decides, not this component.
+   */
+  onChange?: (value: string) => void
   onCancel?: () => void
   width: number
   isActive?: boolean
@@ -44,23 +53,29 @@ export function TextPrompt({
   defaultValue,
   secret,
   onSubmit,
+  onChange,
   onCancel,
   width,
   isActive = true,
 }: TextPromptProps) {
   const [value, setValue] = useState('')
+  // One place that changes the value, so `onChange` cannot be forgotten on a path — and it fires
+  // with the NEW value rather than reading state that has not re-rendered yet.
+  const edit = (next: (v: string) => string): void => {
+    setValue(v => { const n = next(v); onChange?.(n); return n })
+  }
 
   useInput((input, key) => {
     if (key.escape) { onCancel?.(); return }
     if (key.return) { onSubmit(value.trim() || defaultValue || ''); return }
-    if (key.ctrl && input === 'u') { setValue(''); return }
-    if (key.backspace || key.delete) { setValue(v => v.slice(0, -1)); return }
+    if (key.ctrl && input === 'u') { edit(() => ''); return }
+    if (key.backspace || key.delete) { edit(v => v.slice(0, -1)); return }
     if (key.ctrl || key.meta || key.tab || key.upArrow || key.downArrow) return
 
     // A paste arrives as one multi-character chunk; control bytes inside it would corrupt the
     // rendered row, so only printable characters are kept.
     const printable = [...input].filter(ch => ch >= ' ' && ch !== '\x7f').join('')
-    if (printable) setValue(v => v + printable)
+    if (printable) edit(v => v + printable)
   }, { isActive })
 
   const suffix = defaultValue ? ` (${defaultValue})` : ''

--- a/packages/tui/src/control/chrome.test.ts
+++ b/packages/tui/src/control/chrome.test.ts
@@ -806,6 +806,31 @@ describe('detailContent', () => {
     expect(c.alert).toBe('')
   })
 
+  test('names a second copy that is running and serving nothing', () => {
+    // The seventy-minute incident: a second `agentop server` could not bind the ports and kept the
+    // file watcher going anyway, burning a core for nobody. Every runtime probe asks
+    // `lsof -sTCP:LISTEN` and therefore CANNOT see it, so the service row read perfectly healthy.
+    const c = detailContent(
+      service({ idle: 'a second server (pid 3189270) is running and serving nothing — kill 3189270' }),
+      s,
+      NOW,
+    )
+    expect(texts(c).join(' ')).toContain('3189270')
+  })
+
+  test('says the conflict AND the idle copy when both are true', () => {
+    // Different faults with different answers — one asks which runtime to stop, the other names a
+    // pid doing work for nobody. Folding them into one sentence would lose an instruction.
+    const c = detailContent(
+      service({ conflict: 'conflict: native + docker both running — stop one', idle: 'a second server (pid 7) …' }),
+      s,
+      NOW,
+    )
+    const said = texts(c).join(' ')
+    expect(said).toContain('conflict')
+    expect(said).toContain('pid 7')
+  })
+
   test('says nothing about a pid the box would not give up — never `pid 0`', () => {
     const c = detailContent(service(), s, NOW)
     expect(texts(c)).toEqual(['native'])

--- a/packages/tui/src/control/chrome.test.ts
+++ b/packages/tui/src/control/chrome.test.ts
@@ -215,6 +215,42 @@ describe('headerMeta', () => {
     expect(meta.update).toBe('● 1.7.4')
   })
 
+  test('draws the parallel-sessions budget, and NOTHING when it could not be measured', () => {
+    const with_ = headerMeta({
+      mode: 'solo', version: '1.7.4', memory: { used: 3, max: 17, red: false }, width: 60,
+    })
+    expect(with_.memory).toBe('▤ 3/17')
+    expect(with_.memoryRed).toBe(false)
+    // A machine whose memory cannot be read draws no gauge at all — never a zero, which would read
+    // as "no room left" on precisely the machines nobody could ask.
+    expect(headerMeta({ mode: 'solo', version: '1.7.4', width: 60 }).memory).toBe('')
+  })
+
+  test('a RED budget outranks the version under width pressure', () => {
+    // The pieces drop least-actionable-first, and a budget about to run out is the most actionable
+    // thing on the row. Dropping the warning to keep a version number would be the wrong trade at
+    // exactly the moment it matters — the version is one `agentop --version` away.
+    const narrow = { mode: 'solo', version: '1.7.4', latestVersion: '1.9.0', attention: 2 }
+    const red = headerMeta({ ...narrow, memory: { used: 14, max: 15, red: true }, width: 22 })
+    expect(red.memory).toBe('▤ 14/15')
+    expect(red.text).toBe('solo')            // the version went first
+    // …while a calm budget gives way instead, because it is only informational.
+    const calm = headerMeta({ ...narrow, memory: { used: 3, max: 17, red: false }, width: 22 })
+    expect(calm.memory).toBe('')
+  })
+
+  test('the waiting counter still outlives the budget', () => {
+    // Ordering pinned end to end: update, then a calm budget, then the version, and the counter is
+    // the last thing standing after the mode token.
+    const meta = headerMeta({
+      mode: 'solo', version: '1.7.4', latestVersion: '1.9.0', attention: 2,
+      memory: { used: 3, max: 17, red: false }, width: 12,
+    })
+    expect(meta.alert).toBe('⏳ 2')
+    expect(meta.memory).toBe('')
+    expect(meta.update).toBe('')
+  })
+
   test('says nothing about an update when the running version IS the latest', () => {
     expect(headerMeta({ mode: 'solo', version: '1.7.4', latestVersion: '1.7.4', width: 60 }).update).toBe('')
     expect(headerMeta({ mode: 'solo', version: '1.7.4', width: 60 }).update).toBe('')

--- a/packages/tui/src/control/chrome.ts
+++ b/packages/tui/src/control/chrome.ts
@@ -184,6 +184,14 @@ export interface HeaderMetaInput {
    * cannot tell you to navigate there.
    */
   attention?: number
+  /**
+   * How many assistants are up out of how many this MACHINE can hold, when it could be measured.
+   *
+   * Absent means nobody could read the memory (not Linux, no `/proc`) and the gauge is simply not
+   * drawn. `red` is decided by the host, from the distance to the ceiling and from swap pressure —
+   * the TUI owns no logic, here as everywhere.
+   */
+  memory?: { used: number; max: number; red: boolean }
   width: number
 }
 
@@ -197,12 +205,23 @@ export interface HeaderMeta {
   /** The waiting-sessions counter, e.g. `⏳ 2`. */
   alert: string
   update: string
+  /**
+   * The parallel-sessions budget, e.g. `▤ 3/17` — how many assistants are up, out of how many this
+   * MACHINE can hold. Empty where memory could not be read at all.
+   *
+   * It answers the question actually asked before opening one, which "10 GB used" does not. The
+   * glyph is there so it cannot be misread as a session count on its own.
+   */
+  memory: string
+  /** True when the budget is inside its warning distance — the caller colours it. */
+  memoryRed?: boolean
 }
 
 /** What the pieces cost together, separators included — the number the caller budgets against. */
 export function headerMetaWidth(meta: HeaderMeta): number {
   return meta.text.length
     + (meta.alert ? SEP.length + meta.alert.length : 0)
+    + (meta.memory ? SEP.length + meta.memory.length : 0)
     + (meta.update ? SEP.length + meta.update.length : 0)
 }
 
@@ -222,25 +241,41 @@ export function headerMetaWidth(meta: HeaderMeta): number {
  * and it is the piece that must survive a narrow terminal.
  */
 export function headerMeta(input: HeaderMetaInput): HeaderMeta {
-  const { mode, version, latestVersion, attention, width } = input
-  if (width <= 0) return { text: '', alert: '', update: '' }
+  const { mode, version, latestVersion, attention, memory, width } = input
+  if (width <= 0) return { text: '', alert: '', update: '', memory: '' }
 
   const outdated = Boolean(latestVersion && latestVersion !== version)
   const text = version ? `${mode}${SEP}v${version}` : mode
   const alert = attention && attention > 0 ? `⏳ ${attention}` : ''
   const update = outdated ? `● ${latestVersion}` : ''
+  // Absent memory renders nothing at all — a machine whose `/proc` cannot be read shows no gauge
+  // rather than a zero, the same rule the boot row and the harness capabilities follow.
+  const mem = memory ? `▤ ${memory.used}/${memory.max}` : ''
+  const red = memory?.red === true
 
-  const full = { text, alert, update }
+  const full = { text, alert, update, memory: mem, memoryRed: red }
   if (headerMetaWidth(full) <= width) return full
 
-  const withoutUpdate = { text, alert, update: '' }
+  // Dropped least-actionable first, exactly as before. The budget sits between the update notice
+  // and the version: it is more actionable than "there is a new release" and less than the waiting
+  // counter, which stays the last thing standing after the mode token.
+  const withoutUpdate = { ...full, update: '' }
   if (headerMetaWidth(withoutUpdate) <= width) return withoutUpdate
 
-  const withoutVersion = { text: mode, alert, update: '' }
+  // …unless it is RED. A budget about to run out is the most actionable thing on the row, so it
+  // outranks the version and keeps its place — dropping the warning to keep a version number would
+  // be the wrong trade at exactly the moment it matters.
+  const withoutMemory = { ...full, update: '', memory: red ? mem : '' }
+  if (headerMetaWidth(withoutMemory) <= width) return withoutMemory
+
+  const withoutVersion = { text: mode, alert, update: '', memory: red ? mem : '', memoryRed: red }
   if (headerMetaWidth(withoutVersion) <= width) return withoutVersion
 
-  if (mode.length <= width) return { text: mode, alert: '', update: '' }
-  return { text: truncate(mode, width), alert: '', update: '' }
+  const modeAndAlert = { text: mode, alert, update: '', memory: '' }
+  if (headerMetaWidth(modeAndAlert) <= width) return modeAndAlert
+
+  if (mode.length <= width) return { text: mode, alert: '', update: '', memory: '' }
+  return { text: truncate(mode, width), alert: '', update: '', memory: '' }
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/tui/src/control/chrome.ts
+++ b/packages/tui/src/control/chrome.ts
@@ -899,6 +899,12 @@ export function detailContent(
   const alert = service.conflict ?? ''
   if (alert) lines.push({ kind: 'text', label: '', value: alert, tone: 'bad' })
 
+  // A second copy under the SAME runtime, holding no port. Its own line rather than folded into the
+  // conflict sentence: the two are different faults with different answers — a conflict asks which
+  // runtime to stop, this one names a pid that is doing work for nobody. Both can be true at once,
+  // and then both are said.
+  if (service.idle) lines.push({ kind: 'text', label: '', value: service.idle, tone: 'bad' })
+
   const summary = summaryOf(service, s, now)
   if (summary) lines.push({ kind: 'text', label: '', value: summary, tone: 'muted' })
 

--- a/packages/tui/src/control/i18n.ts
+++ b/packages/tui/src/control/i18n.ts
@@ -402,8 +402,8 @@ export interface ControlStrings {
   asideShow: string
   asideTasks: string
   asideAllTasks: string
-  toggleClosed: string
-  toggleExited: string
+  /** ONE switch for "not running". `toggleClosed`/`toggleExited` were two names for one question. */
+  toggleHistory: string
   /**
    * The named-row widening, made visible.
    *
@@ -845,8 +845,7 @@ const EN: ControlStrings = {
   asideShow: 'SHOW',
   asideTasks: 'TASKS',
   asideAllTasks: 'every task',
-  toggleClosed: 'closed conversations',
-  toggleExited: 'finished sessions',
+  toggleHistory: 'not running',
   toggleNamed: 'always keep named sessions',
   keySessionsAside: 'tab menu',
   manageTitle: (title: string) => `Managing "${title}"`,
@@ -1256,8 +1255,7 @@ const PT: ControlStrings = {
   asideShow: 'MOSTRAR',
   asideTasks: 'TAREFAS',
   asideAllTasks: 'todas as tarefas',
-  toggleClosed: 'conversas fechadas',
-  toggleExited: 'sessões encerradas',
+  toggleHistory: 'não estão rodando',
   toggleNamed: 'sempre manter sessões nomeadas',
   keySessionsAside: 'tab menu',
   manageTitle: (title: string) => `Gerenciando "${title}"`,

--- a/packages/tui/src/control/i18n.ts
+++ b/packages/tui/src/control/i18n.ts
@@ -384,6 +384,8 @@ export interface ControlStrings {
   sessionsResumeRunning: string
   sessionsSearchLabel: string
   sessionsSearchEmpty: string
+  /** The word on a HISTORY band. Must agree with `sessionsStates` — a row saying `off` under a
+   *  band called `closed` is the same vocabulary split this collapse exists to remove. */
   sessionsClosedWord: string
   sessionsShowClosed: string
   /** The view panel: one vertical list of every choice about what the list shows. */
@@ -773,9 +775,11 @@ const EN: ControlStrings = {
     'waiting-approval': 'needs approval',
     waiting: 'waiting',
     working: 'working',
-    exited: 'exited',
-    lost: 'lost',
-    closed: 'closed',
+    // ONE word for every way a session is not running — see `cli-i18n.ts`'s `sessState`, which this
+    // table has to agree with or a row reads `off` under a band called `closed`.
+    exited: 'off',
+    lost: 'off',
+    closed: 'off',
     unknown: 'external',
   },
   sessionsSearching: q => `search: ${q} · esc clears`,
@@ -829,7 +833,7 @@ const EN: ControlStrings = {
     'the assistant already running there is NOT stopped — close it first, or you will have two on one conversation.',
   sessionsSearchLabel: 'Search sessions and closed conversations',
   sessionsSearchEmpty: 'nothing matches.',
-  sessionsClosedWord: 'closed',
+  sessionsClosedWord: 'off',
   sessionsShowClosed: 'closed: shown',
   viewTitle: 'What this list shows',
   viewGroupBy: 'Group by',
@@ -1183,9 +1187,9 @@ const PT: ControlStrings = {
     // `aguardando resposta` under a band called `aguardando`.
     waiting: 'aguardando resposta',
     working: 'trabalhando',
-    exited: 'encerrada',
-    lost: 'perdida',
-    closed: 'fechada',
+    exited: 'desligada',
+    lost: 'desligada',
+    closed: 'desligada',
     unknown: 'externa',
   },
   sessionsSearching: q => `busca: ${q} · esc limpa`,
@@ -1239,7 +1243,7 @@ const PT: ControlStrings = {
     'o assistente que já roda ali NÃO é encerrado — feche ele antes, ou você fica com dois na mesma conversa.',
   sessionsSearchLabel: 'Buscar sessões e conversas fechadas',
   sessionsSearchEmpty: 'nada corresponde.',
-  sessionsClosedWord: 'fechada',
+  sessionsClosedWord: 'desligada',
   sessionsShowClosed: 'fechadas: visíveis',
   viewTitle: 'O que esta lista mostra',
   viewGroupBy: 'Agrupar por',

--- a/packages/tui/src/control/session-dimensions.test.ts
+++ b/packages/tui/src/control/session-dimensions.test.ts
@@ -187,20 +187,25 @@ describe('the status shortcuts', () => {
     expect(shortcutOn(['waiting'], 'active')).toBe(false)
   })
 
-  it('reads the widening switches as membership', () => {
-    expect(shortcutOn([...ACTIVE_STATES, 'closed'], 'closed')).toBe(true)
-    expect(shortcutOn([...ACTIVE_STATES], 'closed')).toBe(false)
-    // Both states, together — a `lost` row is over in the only sense this switch asks about.
-    expect(shortcutOn([...ACTIVE_STATES, 'exited'], 'exited')).toBe(false)
-    expect(shortcutOn([...ACTIVE_STATES, 'exited', 'lost'], 'exited')).toBe(true)
+  it('reads the widening switch as membership, and it takes ALL of history', () => {
+    // There were two switches here and they asked one question. `closed` named a conversation that
+    // is not running and `exited` named a finished session plus `lost`; to the person reading the
+    // list all three are "it is not running", so ticking either while the other was on appeared to
+    // do nothing. One switch, all three states, on together or not at all.
+    expect(shortcutOn([...ACTIVE_STATES, 'closed', 'exited', 'lost'], 'history')).toBe(true)
+    expect(shortcutOn([...ACTIVE_STATES], 'history')).toBe(false)
+    // A PARTIAL selection is not the switch being on: it would draw itself lit over a list missing
+    // two of the three states it claims to include.
+    expect(shortcutOn([...ACTIVE_STATES, 'closed'], 'history')).toBe(false)
+    expect(shortcutOn([...ACTIVE_STATES, 'exited', 'lost'], 'history')).toBe(false)
   })
 
   it('turns `active` OFF by itself when another switch widens past it', () => {
     // The visible consequence, and the whole point: a switch is never lit over a list it does not
     // describe. This is what the old model could not express — the state set silently overrode the
     // switches while they went on drawing themselves as if they decided anything.
-    const widened = applyShortcut([...ACTIVE_STATES], 'closed')
-    expect(shortcutOn(widened, 'closed')).toBe(true)
+    const widened = applyShortcut([...ACTIVE_STATES], 'history')
+    expect(shortcutOn(widened, 'history')).toBe(true)
     expect(shortcutOn(widened, 'active')).toBe(false)
   })
 
@@ -210,7 +215,7 @@ describe('the status shortcuts', () => {
   })
 
   it('never empties the selection', () => {
-    expect(applyShortcut(['closed'], 'closed')).toEqual(['closed'])
+    expect(applyShortcut(['closed', 'exited', 'lost'], 'history').sort()).toEqual(['closed', 'exited', 'lost'])
   })
 })
 

--- a/packages/tui/src/control/session-dimensions.ts
+++ b/packages/tui/src/control/session-dimensions.ts
@@ -326,15 +326,25 @@ export function toggleValue(
 // the status shortcuts — a coarse vocabulary for the same selection
 // ---------------------------------------------------------------------------
 
-export type StatusShortcut = 'active' | 'closed' | 'exited'
+export type StatusShortcut = 'active' | 'history'
 
-/** Which states each shortcut names. `Record`, so a new shortcut cannot be half-declared. */
+/**
+ * Which states each shortcut names. `Record`, so a new shortcut cannot be half-declared.
+ *
+ * **There were three, and two of them asked the same question.** `closed` named a conversation that
+ * is not running; `exited` named a session that finished, plus `lost`, a session the backend can no
+ * longer find. Internally those differ and the difference matters — they carry different verbs, and
+ * `lost` is a fact about the backend rather than about the work. But from the chair of the person
+ * reading the screen all three answer *it is not running*, so the list offered one question twice:
+ * ticking either while the other was on appeared to do nothing, which is a control that lies.
+ *
+ * The vocabulary is now the honest pair — what is RUNNING and what is not. The states keep their
+ * distinction and each row still shows its own; it is the FILTER that stopped pretending two
+ * switches were two questions.
+ */
 export const SHORTCUT_STATES: Record<StatusShortcut, readonly SessionState[]> = {
   active: ACTIVE_STATES,
-  closed: ['closed'],
-  // Two states under one switch: the backend has no idea what happened to a `lost` row, so it is
-  // over in the only sense this switch is asking about.
-  exited: ['exited', 'lost'],
+  history: ['closed', 'exited', 'lost'],
 }
 
 const sameSet = (a: readonly string[], b: readonly string[]): boolean =>
@@ -508,7 +518,10 @@ export function storedFilters(state: SessionFilterState): Partial<SessionViewPre
     marked: [...state.marked],
     states: [...status],
     onlyActive: shortcutOn(status, 'active'),
-    showClosed: shortcutOn(status, 'closed'),
-    showExited: shortcutOn(status, 'exited'),
+    // Both legacy switches are derived from the ONE that replaced them. An older binary reading
+    // this file gets them lifted or lowered together, which is what `history` means there too —
+    // and is strictly better than a downgrade that comes up with half the history hidden.
+    showClosed: shortcutOn(status, 'history'),
+    showExited: shortcutOn(status, 'history'),
   }
 }

--- a/packages/tui/src/control/sessions.test.ts
+++ b/packages/tui/src/control/sessions.test.ts
@@ -592,7 +592,7 @@ describe('asideRows', () => {
     new: 'New', search: 'Search', group: 'Group',
   }
   const groupWords = { repo: 'repo', none: 'flat', task: 'tasks', harness: 'harness', model: 'model', project: 'project', status: 'state', marked: 'marked' }
-  const toggleWords = { closed: 'closed', exited: 'finished', named: 'named', done: 'done tasks', active: 'only active', detail: 'detail' }
+  const toggleWords = { history: 'closed', named: 'named', done: 'done tasks', active: 'only active', detail: 'detail' }
   const headings = { actions: 'ACTIONS', view: 'VIEW', show: 'SHOW' }
 
   const build = (o: Partial<Parameters<typeof asideRows>[0]> = {}) => asideRows({
@@ -600,7 +600,7 @@ describe('asideRows', () => {
     actionWords: words,
     grouping: 'none',
     groupWords,
-    toggles: { closed: false, exited: false, named: false, done: false, active: false, detail: false },
+    toggles: { history: false, named: false, done: false, active: false, detail: false },
     toggleWords,
     headings,
     layout: LAYOUT,
@@ -617,10 +617,10 @@ describe('asideRows', () => {
   })
 
   it('states every row own state, so nothing must be pressed to be discovered', () => {
-    const rows = build({ grouping: 'task', toggles: { closed: true, exited: false, named: false, done: false, active: false, detail: false } })
+    const rows = build({ grouping: 'task', toggles: { history: true, named: false, done: false, active: false, detail: false } })
     expect(rows.find(r => r.kind === 'group' && r.value === 'task')).toMatchObject({ on: true })
     expect(rows.find(r => r.kind === 'group' && r.value === 'none')).toMatchObject({ on: false })
-    expect(rows.find(r => r.kind === 'toggle' && r.toggle === 'closed')).toMatchObject({ on: true })
+    expect(rows.find(r => r.kind === 'toggle' && r.toggle === 'history')).toMatchObject({ on: true })
   })
 
   it('offers the named-row switch under every grouping', () => {
@@ -1094,9 +1094,9 @@ describe('the only-active toggle', () => {
       project: 'project', status: 'state', marked: 'marked',
     },
     layout: LAYOUT,
-    toggles: { closed: false, exited: false, named: false, done: false, active: true, detail: false },
+    toggles: { history: false, named: false, done: false, active: true, detail: false },
     toggleWords: {
-      closed: 'closed', exited: 'finished', named: 'named', done: 'done tasks',
+      history: 'closed', named: 'named', done: 'done tasks',
       active: 'only active', detail: 'detail',
     },
     headings: { actions: 'ACTIONS', view: 'VIEW', show: 'SHOW' },
@@ -1897,9 +1897,9 @@ describe('asideRows — the layout section', () => {
       project: 'project', status: 'state', marked: 'marked',
     },
     layout: { ...LAYOUT, value },
-    toggles: { closed: false, exited: false, named: false, done: false, active: true, detail: false },
+    toggles: { history: false, named: false, done: false, active: true, detail: false },
     toggleWords: {
-      closed: 'closed', exited: 'exited', named: 'named', done: 'done', active: 'active',
+      history: 'closed', named: 'named', done: 'done', active: 'active',
       detail: 'detail',
     },
     headings: { actions: 'ACTIONS', view: 'VIEW', show: 'SHOW' },

--- a/packages/tui/src/control/sessions.test.ts
+++ b/packages/tui/src/control/sessions.test.ts
@@ -2402,14 +2402,18 @@ describe('the per-row close control', () => {
     expect(CLOSE_CELL.codePointAt(0)!).toBeLessThan(128)
   })
 
-  it('costs nothing when nothing on screen can be closed', () => {
-    expect(closeCellWidth([closed, gone], 120)).toBe(0)
-    expect(closeCellWidth([live], 120)).toBe(CLOSE_CELL.length + 1)
-  })
-
-  it('gives up on a narrow list rather than squeezing the table for a button', () => {
-    // The keyboard's `x` still works there, and a table squeezed to make room is the worse trade.
-    expect(closeCellWidth([live], 30)).toBe(0)
-    expect(closeCellWidth([live], 40)).toBe(CLOSE_CELL.length + 1)
+  it('costs the table NOTHING, at any width and whatever is on screen', () => {
+    // The control is gone. It did not make sense where it sat: every other verb on this screen is
+    // reached from the menu or a key, and a table's last column is where a VALUE goes — so a button
+    // parked there reads as a truncated cell, and it put the most destructive question on the row
+    // exactly where the eye lands after skimming it.
+    //
+    // Asserted across the whole range rather than at one width, so the reservation cannot creep back
+    // for "just the wide terminal".
+    for (const width of [0, 30, 40, 120, 400]) {
+      expect(closeCellWidth([live], width)).toBe(0)
+      expect(closeCellWidth([closed, gone], width)).toBe(0)
+      expect(closeCellWidth([], width)).toBe(0)
+    }
   })
 })

--- a/packages/tui/src/control/sessions.test.ts
+++ b/packages/tui/src/control/sessions.test.ts
@@ -868,11 +868,24 @@ describe('sessionHandle', () => {
     expect(sessionHandle(session('3f5f4dd461'))).toBe('3f5f4')
   })
 
-  it('is EMPTY for a row agentop did not name', () => {
-    // An external process and a closed conversation are named by the harness. Showing five
-    // characters of a synthetic id offers a handle the CLI cannot resolve.
-    expect(sessionHandle(session('external:claude:/repo:0'))).toBe('')
-    expect(sessionHandle(session('closed:abc-def'))).toBe('')
+  it('names EVERY row, because every session has an id', () => {
+    // This used to be empty for external and closed rows, protecting `attach` from a handle it
+    // cannot resolve. It protected one command at the cost of the column: a table where some rows
+    // have no id reads as data missing, and those rows cannot be referred to at all.
+    //
+    // A row that names a CONVERSATION shows the conversation's id — not attachable, but exactly
+    // what reopening resolves, which is the one verb such a row offers.
+    expect(sessionHandle(session('closed:abcdef-1234', {
+      resume: { sessionId: 'abcdef-1234', title: 'x' },
+    }))).toBe('abcde')
+
+    // With nothing else to go on, the trailing distinguishing part of the synthetic id. It resolves
+    // no command and still tells two rows apart, which is the column's other job — and for two
+    // assistants open in ONE directory the start time is the only thing that does.
+    const a = sessionHandle(session('external:claude:/repo:1786770001'))
+    const b = sessionHandle(session('external:claude:/repo:1786770002'))
+    expect(a).not.toBe('')
+    expect(a).not.toBe(b)
   })
 })
 

--- a/packages/tui/src/control/sessions.ts
+++ b/packages/tui/src/control/sessions.ts
@@ -1189,7 +1189,13 @@ export type AsideRow =
  * `named` replaces it, and is the opposite kind of change — it makes an EXISTING hidden behaviour
  * visible. A row the user named used to survive the history switches unconditionally, unwritten.
  */
-export type SessionToggle = 'closed' | 'exited' | 'named' | 'done' | 'active' | 'detail'
+/**
+ * The switches the menu draws.
+ *
+ * `closed` and `exited` were two of these and asked ONE question — "is it not running" — so ticking
+ * either while the other was on appeared to do nothing. They are now `history`.
+ */
+export type SessionToggle = 'history' | 'named' | 'done' | 'active' | 'detail'
 
 /**
  * The aside's rows, in reading order — PURE, so what is drawn and what a click resolves against are
@@ -1279,7 +1285,7 @@ export function asideRows(o: {
   // so ticking `closed` while `active` is on widens the list and turns `active` off — a switch is
   // never lit over a list it does not describe. `named` sits with them because it is the same kind
   // of thing, and because it used to be the one widening nobody could see.
-  const toggles: SessionToggle[] = ['active', 'closed', 'exited', 'named', 'done', 'detail']
+  const toggles: SessionToggle[] = ['active', 'history', 'named', 'done', 'detail']
   for (const t of toggles) {
     rows.push({ kind: 'toggle', toggle: t, label: o.toggleWords[t], on: o.toggles[t] })
   }

--- a/packages/tui/src/control/sessions.ts
+++ b/packages/tui/src/control/sessions.ts
@@ -2532,18 +2532,20 @@ export const CLOSE_CELL = '[x]'
 /**
  * Columns reserved at the right edge of the list for the per-row close control — PURE.
  *
- * A gap plus the control itself, DERIVED from `CLOSE_CELL` rather than written as a number beside
- * it: the two were `'✕'` and `2`, and changing the glyph without changing the reservation is how a
- * control ends up drawn on top of the last cell. Reserved from the width BEFORE the columns are
- * measured, for the same reason.
+ * **Always zero: the control is gone.** Kept as a function rather than deleted so the width
+ * arithmetic still has one place that says what the right edge costs, and so a future control there
+ * has somewhere to declare itself instead of being sprinkled through the callers.
  *
- * Zero when nothing on screen can be closed, and zero on a list too narrow to spare it — the
- * keyboard's `x` still works there, and a table squeezed to make room for a button is a worse
- * trade than a button that is only on the wider terminal.
+ * Removed because it did not make sense where it sat. Every other verb on this screen is reached
+ * from the menu or a key, and a table's last column is where a VALUE goes — so a control parked
+ * there reads as a truncated cell until you happen to click it. It also put the most destructive
+ * question on the screen exactly where a reader's eye lands after skimming a row.
+ *
+ * Nothing was taken away but the button: `x` still closes the selected session, and the menu still
+ * offers it in words.
  */
-export function closeCellWidth(rows: readonly ControlSession[], width: number): number {
-  const NEEDS = 40
-  return width >= NEEDS && rows.some(canClose) ? CLOSE_CELL.length + 1 : 0
+export function closeCellWidth(_rows: readonly ControlSession[], _width: number): number {
+  return 0
 }
 
 /**

--- a/packages/tui/src/control/sessions.ts
+++ b/packages/tui/src/control/sessions.ts
@@ -834,14 +834,29 @@ export function sessionAge(s: ControlSession, now: number, ago: (seconds: number
 export const ID_CELL = 5
 
 /**
- * The handle: the leading characters of the id, which is what the CLI resolves a prefix against.
+ * The handle: the leading characters of whatever identity this row actually has.
  *
- * Empty for a row that has no id of ours — an external process and a closed conversation are named
- * by the harness, not by agentop, and showing five characters of a synthetic id would offer a
- * handle that `agentop session attach` cannot resolve.
+ * **Every session has an id, so every row shows one.** This returned `''` for external and closed
+ * rows, reasoning that a synthetic id is a handle `agentop session attach` cannot resolve. That
+ * protected one command at the cost of the column: a table where some rows have no id reads as data
+ * missing, and the reader cannot refer to those rows at all — not in a note, not out loud, not to
+ * an assistant.
+ *
+ * The identity is taken in order of how resolvable it is:
+ *
+ *  1. **A row agentop hosts** — its own id. `attach`, `kill` and `rename` take a prefix of it.
+ *  2. **A row naming a CONVERSATION** (`resume`) — the conversation id. Not attachable, but it is
+ *     exactly what reopening resolves, so it is a handle for the one verb the row offers.
+ *  3. **Anything else** — the trailing distinguishing part of the synthetic id. It resolves no
+ *     command and still tells two rows apart, which is the column's other job.
  */
 export function sessionHandle(s: ControlSession): string {
-  return s.id.startsWith('external:') || s.id.startsWith('closed:') ? '' : s.id.slice(0, ID_CELL)
+  if (!s.id.startsWith('external:') && !s.id.startsWith('closed:')) return s.id.slice(0, ID_CELL)
+  const conversation = s.resume?.sessionId
+  if (conversation) return conversation.slice(0, ID_CELL)
+  // `external:<harness>:<cwd>:<startedMs>` — the start time is what separates two assistants open in
+  // one directory, which is precisely the pair a reader needs to tell apart.
+  return s.id.slice(s.id.lastIndexOf(':') + 1).slice(-ID_CELL)
 }
 
 /**

--- a/packages/tui/src/control/tabs/Sessions.tsx
+++ b/packages/tui/src/control/tabs/Sessions.tsx
@@ -241,8 +241,9 @@ export function Sessions({
   // describes is a switch that can disagree with the list.
   const status = filters.status ?? ACTIVE_STATES
   const onlyActive = shortcutOn(status, 'active')
-  const showClosed = shortcutOn(status, 'closed')
-  const showExited = shortcutOn(status, 'exited')
+  // ONE switch, because there was one question. `closed` and `exited` both meant "it is not
+  // running", so ticking either while the other was on appeared to do nothing.
+  const showHistory = shortcutOn(status, 'history')
   const taskFilter = filters.task?.[0] ?? null
   const projectFilter = filters.project?.[0] ?? null
   const pressShortcut = useCallback((k: StatusShortcut) => {
@@ -461,11 +462,11 @@ export function Sessions({
     groupWords: s.sessionsGroupings,
     layout: { heading: s.asideLayout, words: s.sessionsLayouts, value: layout },
     toggles: {
-      closed: showClosed, exited: showExited, done: showDone,
+      history: showHistory, done: showDone,
       active: onlyActive, named: showNamed, detail: !hideDetail,
     },
     toggleWords: {
-      closed: s.toggleClosed, exited: s.toggleExited, done: s.toggleDone,
+      history: s.toggleHistory, done: s.toggleDone,
       active: s.toggleActive, named: s.toggleNamed, detail: s.toggleDetail,
     },
     headings: { actions: s.asideActions, view: s.asideView, show: s.asideShow },
@@ -500,7 +501,7 @@ export function Sessions({
       allLabel: s.asideAllProjects,
     },
   }), [
-    actions, grouping, layout, showClosed, showExited, showDone, onlyActive, showNamed, hideDetail,
+    actions, grouping, layout, showHistory, showDone, onlyActive, showNamed, hideDetail,
     status, stateCounts, order, taskFilter,
     projectFilter, fleet?.sessions, fleet?.finishedTasks, s,
   ])
@@ -770,8 +771,7 @@ export function Sessions({
       return
     }
     if (row.kind !== 'toggle') return
-    if (row.toggle === 'closed') return pressShortcut('closed')
-    if (row.toggle === 'exited') return pressShortcut('exited')
+    if (row.toggle === 'history') return pressShortcut('history')
     if (row.toggle === 'active') return pressShortcut('active')
     setCursor(0)
     if (row.toggle === 'done') return setShowDone(v => !v)
@@ -889,8 +889,8 @@ export function Sessions({
     // here, not assumed. `?` has no such collision and is what every list-shaped TUI already uses.
     if (input === '?' || (key.ctrl && input === 'h')) { setAsk({ kind: 'keys' }); return }
     if (input === 'v') return runAction('group')
-    if (input === 'c') { pressShortcut('closed'); return }
-    if (input === 'e') { pressShortcut('exited'); return }
+    // One key, because there is one switch. `c` and `e` toggled two halves of the same question.
+    if (input === 'c' || input === 'e') { pressShortcut('history'); return }
     if (input === 'l') { pressShortcut('active'); return }
     if (input === 'd') { setHideDetail(v => !v); return }
     // `ctrl+g` for the GRID, not `g`: `g` is "top of the list" two lines down and in
@@ -1319,13 +1319,13 @@ export function Sessions({
         <ViewOptions
           strings={s}
           grouping={grouping}
-          showClosed={showClosed}
+          showHistory={showHistory}
           showNamed={showNamed}
           width={width}
           height={height}
           isActive={isActive}
           onGrouping={g => { setGrouping(g); setCursor(0) }}
-          onShowClosed={() => pressShortcut('closed')}
+          onShowClosed={() => pressShortcut('history')}
           onShowNamed={() => { setShowNamed(v => !v); setCursor(0) }}
           onClose={() => setAsk(null)}
         />
@@ -1493,7 +1493,7 @@ export function Sessions({
           grouping={grouping}
           strings={s}
           width={listBody}
-          showClosed={showClosed}
+          showHistory={showHistory}
           showNamed={showNamed}
           onlyActive={onlyActive}
           // How many rows are ON SCREEN, counted from the very list being drawn. The header used to
@@ -1697,13 +1697,13 @@ export function Sessions({
  * to state the answer, so a glance tells you why the list looks the way it does.
  */
 function SummaryRow({
-  fleet, grouping, strings: s, width, showClosed, showNamed, onlyActive, shown, query, scope, fell,
+  fleet, grouping, strings: s, width, showHistory, showNamed, onlyActive, shown, query, scope, fell,
 }: {
   fleet: ControlSessions | null | undefined
   grouping: SessionGrouping
   strings: ControlStrings
   width: number
-  showClosed: boolean
+  showHistory: boolean
   /** The one widening on this block — stated because it changes what a strict filter means. */
   showNamed: boolean
   /** The strict selection: exactly the states that mean something is alive. */
@@ -1737,7 +1737,7 @@ function SummaryRow({
   // still matters, and `showNamed` is named whenever it is on because it is the one thing that puts
   // rows BACK into a list the sentence above says is strict.
   if (onlyActive) hiding.push(s.viewActiveOn)
-  else if (!showClosed) hiding.push(s.viewClosedOn)
+  else if (!showHistory) hiding.push(s.viewClosedOn)
   if (showNamed) hiding.push(s.toggleNamed)
 
   // MEASURED, never left to Yoga: a row that wraps takes two of the screen's rows while its budget
@@ -2517,12 +2517,12 @@ function Question({
  * squeezing it under the list is what made it unreadable the first time.
  */
 function ViewOptions({
-  strings: s, grouping, showClosed, showNamed, width, height, isActive,
+  strings: s, grouping, showHistory, showNamed, width, height, isActive,
   onGrouping, onShowClosed, onShowNamed, onClose,
 }: {
   strings: ControlStrings
   grouping: SessionGrouping
-  showClosed: boolean
+  showHistory: boolean
   showNamed: boolean
   width: number
   height: number
@@ -2583,7 +2583,7 @@ function ViewOptions({
         // The dot means ON, always — for every row on this panel.
         const on = row.kind === 'group'
           ? row.value === grouping
-          : row.kind === 'closed' ? showClosed : showNamed
+          : row.kind === 'closed' ? showHistory : showNamed
         const label = row.kind === 'group'
           ? s.sessionsGroupings[row.value]
           : row.kind === 'closed' ? s.viewClosedOn

--- a/packages/tui/src/control/tabs/Sessions.tsx
+++ b/packages/tui/src/control/tabs/Sessions.tsx
@@ -1660,7 +1660,11 @@ export function Sessions({
               }}
               host={host}
               query={query}
-              onQuery={setQuery}
+              // The cursor goes home on every change. That is the actual answer to the objection
+              // that stopped this being live: a narrowing list moves rows out from under the
+              // selection, so keeping the old index points at whatever slid into that slot. Row 0
+              // is the best match to look at anyway.
+              onQuery={q => { setQuery(q); setCursor(0) }}
               fleet={fleet}
             />
           ) : (
@@ -2205,8 +2209,13 @@ function Question({
         placeholder={query}
         width={width}
         onCancel={onClose}
-        // Applied on submit rather than per keystroke: the list under it is re-grouped and re-sorted
-        // on every change, and a cursor that jumps while someone is still typing is unusable.
+        // LIVE, as it is typed. It used to apply on submit, on the reasoning that re-grouping under
+        // a moving cursor is unusable — but that reasoning was about the CURSOR, and the fix for a
+        // jumping cursor is to reset it, not to make the user type blind. A search whose result you
+        // cannot see until you commit is a search you run twice.
+        onChange={value => onQuery(value.trim())}
+        // Enter closes the field and KEEPS what is already applied. Cancel is what undoes it, and
+        // the empty-submit case is why `placeholder` is used above instead of `defaultValue`.
         onSubmit={value => { onQuery(value.trim()); onClose() }}
       />
       </Box>

--- a/packages/tui/src/control/tabs/Sessions.tsx
+++ b/packages/tui/src/control/tabs/Sessions.tsx
@@ -1820,9 +1820,14 @@ function SessionRowView({ session, selected, marked, ages, columns, width, close
       {/* The HANDLE. `agentop session attach 3f5f` takes a prefix, so this is the one thing on the
           row that names the session to anything but this screen. */}
       {columns.id > 0 ? (
-        <Text dimColor>{padCell(sessionHandle(session), columns.id) + gap}</Text>
+        <Text color={selected ? COLORS.accent : undefined} dimColor={!selected}>
+          {padCell(sessionHandle(session), columns.id) + gap}
+        </Text>
       ) : null}
-      <Text color={STATE_COLOR[session.state]} bold={session.state === 'waiting-approval'}>
+      <Text
+        color={selected ? COLORS.accent : STATE_COLOR[session.state]}
+        bold={selected || session.state === 'waiting-approval'}
+      >
         {padCell(session.stateLabel, columns.state)}
       </Text>
       {columns.title > 0 ? (
@@ -1836,14 +1841,16 @@ function SessionRowView({ session, selected, marked, ages, columns, width, close
       {/* How long ago it started, on rows that are NOT running — the age is most of the "reopen
           this or not" decision, and it lived only in the detail pane. */}
       {columns.age > 0 ? (
-        <Text dimColor>{gap + padCell(ages.get(session.id) ?? '', columns.age)}</Text>
+        <Text color={selected ? COLORS.accent : undefined} dimColor={!selected}>
+          {gap + padCell(ages.get(session.id) ?? '', columns.age)}
+        </Text>
       ) : null}
       {/* A linked WORKTREE says so, because it changes what the row IS: three rows of one repo in
           three directories are three checkouts, and without the word they read as three projects.
           The word, never a glyph alone — a distinction announced in a symbol is one that has to be
           taught before the screen can be read. */}
       {columns.worktree > 0 ? (
-        <Text color={COLORS.secondary}>{gap + padCell(worktreeName(session), columns.worktree)}</Text>
+        <Text color={selected ? COLORS.accent : COLORS.secondary} bold={selected}>{gap + padCell(worktreeName(session), columns.worktree)}</Text>
       ) : null}
       {/* The TASK, right of the name. Filing a session under a task and then not being able to see
           which task it is in is the feature not working — the fact only existed in the detail pane
@@ -1856,20 +1863,26 @@ function SessionRowView({ session, selected, marked, ages, columns, width, close
           a row you are deciding whether to close is one whose cost you want beside its name rather
           than one selection away in the detail pane. */}
       {columns.metrics > 0 ? (
-        <Text color={COLORS.secondary}>{gap + padCell(sessionMetric(session), columns.metrics)}</Text>
+        <Text color={selected ? COLORS.accent : COLORS.secondary} bold={selected}>{gap + padCell(sessionMetric(session), columns.metrics)}</Text>
       ) : null}
       {/* How full the context window is. Beside the usage because it is the same kind of fact and
           the opposite reading of it: usage is what this session has spent, this is what it has
           left. A row with no reading draws a BLANK of the same width rather than a `0%` — the
           column exists because some rows can answer, not because all of them can. */}
       {columns.context > 0 ? (
-        <Text color={session.context ? CONTEXT_COLOR[contextLevel(session.context.fraction)] : undefined}
-              dimColor={!session.context || contextLevel(session.context.fraction) === 'ok'}>
+        <Text
+          color={selected
+            ? COLORS.accent
+            : session.context ? CONTEXT_COLOR[contextLevel(session.context.fraction)] : undefined}
+          dimColor={!selected && (!session.context || contextLevel(session.context.fraction) === 'ok')}
+        >
           {gap + padCell(sessionContext(session), columns.context)}
         </Text>
       ) : null}
       {columns.harness > 0 ? (
-        <Text color={harnessColor}>{gap + padCell(session.harness, columns.harness)}</Text>
+        <Text color={selected ? COLORS.accent : harnessColor} bold={selected}>
+          {gap + padCell(session.harness, columns.harness)}
+        </Text>
       ) : null}
       {columns.where > 0 ? (
         <Text dimColor>{gap + padCell(session.projectGroup || session.project, columns.where)}</Text>

--- a/packages/tui/src/control/types.ts
+++ b/packages/tui/src/control/types.ts
@@ -819,6 +819,21 @@ export interface ControlStatus {
   version: string
   /** Set when a newer release exists; drives the update dot in the header. */
   latestVersion?: string
+  /**
+   * How many assistants are running out of how many this MACHINE can hold — the header's `▤ 3/17`.
+   *
+   * **This is about the SYSTEM, not about agentop**, and the surface has to say so: a number in the
+   * corner of a window is read as belonging to that window, and someone would otherwise conclude
+   * agentop eats 10 GB. Measured: agentop's own server was 578 MB of a 4 GB total, and the rest was
+   * one Node process per assistant CLI.
+   *
+   * **Absent when the memory could not be read at all** (not Linux, no `/proc`), and then no gauge
+   * is drawn — never a zero. `red` is the host's decision, taken from the DISTANCE to the ceiling
+   * rather than a percentage (three left of thirty is comfortable, three of fourteen is the last
+   * warning) and from swap pressure, which is what actually freezes a machine: the incident this
+   * exists for read 3.6 GB of free RAM while swap sat at 97%.
+   */
+  memory?: { used: number; max: number; red: boolean }
   /** The history-preservation setting in force, or `undefined` while it is still unanswered. */
   archiveMode?: ArchiveMode
   /**

--- a/packages/tui/src/control/types.ts
+++ b/packages/tui/src/control/types.ts
@@ -297,6 +297,23 @@ export interface ControlService {
    * the flag; pair it with a word as well as a colour, and offer `stopOptions`.
    */
   conflict?: string
+  /**
+   * A SECOND copy of this service running under the SAME runtime, serving nothing — already
+   * localized and naming the pid.
+   *
+   * Deliberately not folded into `conflict`, which is about two RUNTIMES and offers a per-runtime
+   * stop. This one is two processes of the one runtime, and the two cases need different sentences:
+   * "it is running natively and in docker, stop one" is a choice, while "a second one is running and
+   * answering nothing" is waste with a pid on it.
+   *
+   * It exists because the runtime probe cannot see this by construction — it asks
+   * `lsof -sTCP:LISTEN`, which only ever finds the process that WON the port. Measured: two
+   * `agentop server`s ran for seventy minutes, the loser burning 72% of a core and 1.1 GB on the
+   * file watcher, and every screen in the product said the service was healthy.
+   *
+   * The pid is the point. "Something is wrong" that cannot be acted on is a worse message than none.
+   */
+  idle?: string
   /** Why the state is `unknown`, already localized. */
   reason?: string
   /**


### PR DESCRIPTION
Twenty commits. The thread that runs through them: a row saying something it cannot back up.

## The duplication (#152)

Reported: MAIN showed closed, every Reopen duplicated it, and the duplicates were dead. Claude Code refuses to resume a conversation already open as a background agent — the spawn *succeeded* (tmux made the session) while the program had already exited, so a row was written for a corpse, and pressing again wrote another.

**`spawn` returning is not evidence anything is running.** Two guesses corrected by measurement: the refusal takes **1.5–3s**, not the 700ms "a refusal must be immediate" assumed (a 700ms check reports "started" for the very session it exists to catch); and tmux puts the message on the pane's **first** row and the death notice on its **last**, 33 blank rows apart, so reading the lines just above the notice collected nothing.

## Finding sessions at all (#151, #147, #146)

Two processes running **the same executable**, one listed and one invisible — Claude installs to `…/versions/<version>`, so `comm` and the exe basename can both be a version string. Recognising the install path found the invisible session and dragged the plumbing in with it; the gate is on the **subcommand**, because a `bg-pty-host` argv carries the session id of the real conversation it serves (so "drop what has a session id" keeps the helper and hides the session).

A record's `pid` is only believable with `procStart` beside it: 64 records here, 3 alive, and the OS reuses pid numbers.

## The list stops lying (#155, #154, #153)

- **three words for one fact** — `encerrada`/`perdida`/`fechada` became one, in both word tables;
- **two filter switches asking one question** became one;
- **an id on every row**, including external ones;
- the **focused row** is entirely in the accent;
- the per-row `[x]` is gone.

## Also

The memory budget (#148) — `▤ 3/17`, red by **distance** not percentage, swap counted because the freeze it exists for showed 3.6 GB free RAM at 97% swap. An idle second server named with its pid (#149). The boot row naming **every** unit (#150). Search applies as you type.

## Verification

On dev at 5fa6866: `bun tsc --noEmit` clean, `bun test` **4060 pass / 0 fail**, binary compiles, width sweep at 80/120/190 columns with **zero** rows overflowing, and the reporting session reads `581de · externa · MAIN`.

**Not included, and stated rather than hidden:** the shortcuts modal in place of the aside menu. Two attempts both rendered a blank cockpit; I could not find the cause and will not trade a working screen for a placement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TBcRtC62Sx18sgJj64r1Np