### PR TITLE
fix(sessions): being LISTED is not being alive — reopen works again

### DIFF
--- a/packages/server/server/sessions/cli-session.ts
+++ b/packages/server/server/sessions/cli-session.ts
@@ -31,6 +31,8 @@ import { needsAttention, type SessionView } from './session-view'
 import { planTaskReopen, taskReopenSucceeded } from './task-reopen'
 import { liveConversationHolders } from './live-claims'
 import { POLL_MS, SETTLE_MS, spawnOutcome } from './spawn-outcome'
+import { parseHarnessAgents } from './harness-agents'
+import { planTakeover, type TakeoverRefusal } from './takeover'
 import type { SessionBackend, SpawnPlanError } from './types'
 
 /** Derived from the specs, never a second hand-written list — the two could not then disagree. */
@@ -600,8 +602,127 @@ async function list(backend: SessionBackend, json = false): Promise<number> {
 async function attach(ref: string, backend: SessionBackend): Promise<number> {
   const reconciled = reconcileSessions(await readRegistry(), await backend.list())
   const found = resolveSessionRef(reconciled.map(toRefCandidate), ref)
-  if (!found.ok) { console.error(refError(ref, found.reason, found.matches)); return 1 }
-  return execAttach(found.session.id, backend)
+  if (found.ok) return execAttach(found.session.id, backend)
+
+  // Not a row agentop hosts — but it may be a conversation that is RUNNING somewhere, and the user
+  // asked to get into it. This is the case the product had no answer for: it refused with "open it
+  // where it already is", which names a place that for a background agent does not exist.
+  //
+  // The answer is to CLOSE the assistant holding it and reopen the conversation here. The lock
+  // exists to stop two assistants in one conversation, and closing the first satisfies it exactly;
+  // refusing satisfies it by leaving the user with none. The decision is the pure `planTakeover` —
+  // it checks that the harness can resume by id BEFORE anything is killed.
+  const took = await takeOver(ref, backend)
+  if (took !== null) return took
+
+  console.error(refError(ref, found.reason, found.matches))
+  return 1
+}
+
+/**
+ * Close whatever is holding a live conversation and reopen it under agentop.
+ *
+ * `null` when `ref` names no live conversation — the caller then reports the ordinary lookup error.
+ *
+ * Not claude-specific: the two steps are the same everywhere, and `planSpawn` already knows which
+ * harnesses can resume by id at all. Today only claude publishes a live-session list to search
+ * (`claude agents --json`); the day another does, it joins the search and nothing else changes.
+ */
+async function takeOver(ref: string, backend: SessionBackend): Promise<number | null> {
+  const live = await liveAgentFor(ref)
+  if (!live) return null
+
+  const planned = planSpawn({ harness: live.harness, cwd: live.cwd, resumeId: live.sessionId })
+  const plan = planTakeover({
+    conversationId: live.sessionId,
+    harness: live.harness,
+    resumable: planned.ok,
+    holder: { pid: live.pid, cwd: live.cwd, label: live.name },
+    cwd: live.cwd,
+  })
+
+  if (plan.kind === 'refuse') {
+    console.error(explainTakeover(plan.reason))
+    return 1
+  }
+  if (plan.kind === 'free' || !planned.ok) return null
+
+  // Ending somebody's running assistant loses whatever it was mid-turn, so it is stated before it
+  // happens rather than reported after.
+  console.log(`Closing ${plan.holder.label ?? plan.conversationId.slice(0, 8)} (pid ${plan.holder.pid}) to reopen it here…`)
+  try {
+    process.kill(plan.holder.pid!, 'SIGTERM')
+  } catch (e) {
+    console.error(`Could not close it: ${e instanceof Error ? e.message : String(e)}`)
+    return 1
+  }
+  // Wait for it to actually go. Resuming while the old one is still shutting down is the very race
+  // the harness refuses on, and it would land as another dead row.
+  for (let i = 0; i < 40; i++) {
+    await new Promise(r => setTimeout(r, 100))
+    try { process.kill(plan.holder.pid!, 0) } catch { break }
+  }
+
+  const id = newSessionId()
+  try {
+    await backend.spawn({ id, cwd: plan.cwd, argv: planned.plan.argv })
+  } catch (e) {
+    console.error(`Closed it, but could not reopen: ${e instanceof Error ? e.message : String(e)}`)
+    return 1
+  }
+  const died = await spawnFailure(backend, id)
+  if (died) { console.error(died); await backend.kill(id).catch(() => {}); return 1 }
+
+  await addSession({
+    id, harness: live.harness, cwd: plan.cwd, createdAt: new Date().toISOString(),
+    ...(live.name ? { label: live.name, labelSince: Date.now() } : {}),
+    conversationId: plan.conversationId,
+    ...(await recordedRepo(plan.cwd)),
+  })
+  return execAttach(id, backend)
+}
+
+/** Already-localized refusal — the harness's limitation said in words, never a silent no-op. */
+function explainTakeover(reason: TakeoverRefusal): string {
+  switch (reason.code) {
+    case 'resume-unsupported':
+      return `${reason.harness} cannot reopen a conversation by id, so the assistant holding it was left alone.`
+    case 'holder-unreachable':
+      return `something is holding this conversation${reason.label ? ` (${reason.label})` : ''} and agentop cannot close it.`
+    case 'no-cwd':
+      return 'this conversation has no directory to reopen in — a removed worktree, most likely.'
+  }
+}
+
+/**
+ * The LIVE conversation matching what the user typed, when there is exactly one.
+ *
+ * Matched on a prefix of the conversation id or on the session's NAME, because those are the two
+ * things on screen. Ambiguity resolves to nothing rather than to a guess: taking over the wrong
+ * conversation closes the wrong assistant.
+ */
+async function liveAgentFor(ref: string): Promise<
+  { sessionId: string; harness: HarnessId; cwd: string; pid?: number; name?: string } | null
+> {
+  try {
+    const out = Bun.spawnSync(['claude', 'agents', '--json'])
+    if (!out.success) return null
+    const needle = ref.trim().toLowerCase()
+    const hits = parseHarnessAgents(out.stdout.toString()).filter(a =>
+      a.sessionId.toLowerCase().startsWith(needle)
+      || (a.name ?? '').toLowerCase() === needle)
+    const only = hits.length === 1 ? hits[0]! : undefined
+    if (!only?.cwd) return null
+    return {
+      sessionId: only.sessionId,
+      harness: 'claude',
+      cwd: only.cwd,
+      ...(only.pid !== undefined ? { pid: only.pid } : {}),
+      ...(only.name ? { name: only.name } : {}),
+    }
+  } catch {
+    return null
+  }
 }
 
 async function kill(ref: string, backend: SessionBackend): Promise<number> {

--- a/packages/server/server/sessions/harness-agents.test.ts
+++ b/packages/server/server/sessions/harness-agents.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'bun:test'
+import { agentHeld, indexAgents, needsAgentView, parseHarnessAgents } from './harness-agents'
+
+// Verbatim from `claude agents --json` on this machine, 2026-08-15. The first record is the
+// session that reported "it appeared but I still cannot resume it".
+const REAL = JSON.stringify([
+  {
+    pid: 508665, id: '581deab7', cwd: '/home/mithrandir/agentistics/.claude/worktrees/session-monitor',
+    kind: 'background', startedAt: 1786762198260,
+    sessionId: '581deab7-8aa7-4438-9371-5d4f1668c1ab', name: 'MAIN',
+    status: 'busy', state: 'working',
+  },
+  {
+    id: '1ebeee57', cwd: '/home/mithrandir', kind: 'background',
+    sessionId: '1ebeee57-8336-4689-a391-14caf25c9221', name: 'teste multi sessoes',
+  },
+])
+
+describe('parseHarnessAgents', () => {
+  it('reads what the harness states about itself', () => {
+    const [main] = parseHarnessAgents(REAL)
+    expect(main).toMatchObject({
+      sessionId: '581deab7-8aa7-4438-9371-5d4f1668c1ab',
+      pid: 508665,
+      kind: 'background',
+      // The name the USER typed — recovered without reading a file, matching a pid, or guessing
+      // from a directory, which is what every other source here has had to do.
+      name: 'MAIN',
+      // And the activity, which agentop otherwise derives by capturing the pane.
+      state: 'working',
+    })
+  })
+
+  it('drops a record with no conversation id rather than listing something unactionable', () => {
+    // `sessionId` is the only field every consumer keys on. A row that cannot be correlated would
+    // appear as a session nothing can act on, which is worse than absent.
+    expect(parseHarnessAgents('[{"pid":1,"name":"x"}]')).toEqual([])
+  })
+
+  it('never throws on anything the command might print', () => {
+    for (const junk of ['', 'not json', '{}', 'null', '[1,2,3]', '["a"]', '[[]]']) {
+      expect(parseHarnessAgents(junk)).toEqual([])
+    }
+  })
+})
+
+describe('agentHeld / needsAgentView', () => {
+  const index = indexAgents(parseHarnessAgents(REAL))
+  const alive = () => true
+
+  it('is HELD only when a process is actually running', () => {
+    // Claude refuses to resume a conversation already running, and it refuses AFTER launching — so
+    // without asking first the refusal is discovered by reading a dead pane, which is how three
+    // rows called MAIN happened.
+    expect(agentHeld(index, '581deab7-8aa7-4438-9371-5d4f1668c1ab', alive)).toBe(true)
+    expect(agentHeld(index, 'some-conversation-that-ended', alive)).toBe(false)
+  })
+
+  it('being in the LIST is not being alive — the bug this distinction fixes', () => {
+    // Measured: 8 records, only 2 with a pid. The other six were `background`/`blocked` with no
+    // process at all — conversations the daemon still knows and nothing is running. Treating
+    // presence as alive made the cockpit refuse to reopen a conversation nothing was holding, and
+    // answer "open it where it already is" about a place that did not exist. Those six are
+    // precisely what reopen is FOR.
+    const idle = indexAgents(parseHarnessAgents(JSON.stringify([
+      { sessionId: 'idle-1', kind: 'background', state: 'blocked', name: 'teste multi sessoes' },
+    ])))
+    expect(idle.has('idle-1')).toBe(true)      // it IS in the list…
+    expect(agentHeld(idle, 'idle-1', alive)).toBe(false)  // …and nothing is holding it
+  })
+
+  it('a record can outlive its process, so the pid is confirmed', () => {
+    expect(agentHeld(index, '581deab7-8aa7-4438-9371-5d4f1668c1ab', () => false)).toBe(false)
+  })
+
+  it('marks the sessions that can only be reached through the agent view', () => {
+    // A background agent has no tty and no tmux: no terminal to attach to and no second copy that
+    // may be started. Telling someone to "open it where it already is" names no place.
+    expect(needsAgentView(index.get('581deab7-8aa7-4438-9371-5d4f1668c1ab'))).toBe(true)
+    expect(needsAgentView(undefined)).toBe(false)
+    expect(needsAgentView({ sessionId: 'x', kind: 'interactive' })).toBe(false)
+  })
+})

--- a/packages/server/server/sessions/harness-agents.ts
+++ b/packages/server/server/sessions/harness-agents.ts
@@ -1,0 +1,138 @@
+/**
+ * harness-agents.ts — PURE parsing of what the harness says about its OWN live sessions.
+ *
+ * ## Why this exists, and why it outranks everything beside it
+ *
+ * agentop has been INFERRING which conversations are alive: reading `/proc`, matching pids against
+ * `~/.claude/sessions/<pid>.json`, comparing directories, probing `procStart` so a recycled pid
+ * cannot lie. Every one of those is a workaround for not being able to ask.
+ *
+ * `claude agents --json` is the tool answering directly, and it answers with more than the
+ * inference ever recovered. Measured on this machine on 2026-08-15:
+ *
+ * ```json
+ * {"pid":508665,"id":"581deab7","cwd":"…/worktrees/session-monitor","kind":"background",
+ *  "startedAt":1786762198260,"sessionId":"581deab7-…","name":"MAIN",
+ *  "status":"busy","state":"working"}
+ * ```
+ *
+ * That single record carries the conversation id, the pid, the directory, **the name the user
+ * typed**, and the ACTIVITY — the last of which agentop derives by capturing the pane and matching
+ * screen markers. It also includes BACKGROUND agents, which have no tty and no tmux and were
+ * therefore the sessions the whole inference chain could never see.
+ *
+ * It does not replace the screen probe: `state` here is what the harness knows about itself, and
+ * `waiting-approval` — a session blocked on a permission dialog — is a fact about the SCREEN that
+ * only the screen shows. The two are complementary, and where they disagree the screen wins on the
+ * question it can answer and this wins on identity.
+ *
+ * ## Read like someone else's format, because it is
+ *
+ * Same discipline as `harness-session-file.ts` and `antigravity-protobuf.ts`: every field checked,
+ * a missing or wrong-typed one yields "not known" rather than a throw, and a record that will not
+ * parse is skipped rather than taking the list with it. The command is a CLI whose output shape is
+ * not ours to depend on.
+ */
+
+/** One live session, as the harness describes it. */
+export interface HarnessAgent {
+  /** The conversation id — the exact key everything else here correlates on. */
+  sessionId: string
+  /** OS pid, when stated. */
+  pid?: number
+  cwd?: string
+  /** `background` for an agent with no terminal; absent or something else for an interactive one. */
+  kind?: string
+  /** The name the user gave the session. Absent when it has none. */
+  name?: string
+  /** What the harness says it is doing (`working`, `idle`, …). Never a screen reading. */
+  state?: string
+  startedAt?: number
+}
+
+/**
+ * Parse `claude agents --json` — PURE, total, never a throw.
+ *
+ * A record with no `sessionId` is dropped: it is the only field every consumer keys on, and a row
+ * that cannot be correlated is worse than absent — it would appear as a session nothing can act on.
+ */
+export function parseHarnessAgents(raw: string): HarnessAgent[] {
+  let data: unknown
+  try {
+    data = JSON.parse(raw)
+  } catch {
+    return []
+  }
+  if (!Array.isArray(data)) return []
+
+  const str = (v: unknown): string | undefined =>
+    typeof v === 'string' && v !== '' ? v : undefined
+  const num = (v: unknown): number | undefined =>
+    typeof v === 'number' && Number.isFinite(v) ? v : undefined
+
+  const out: HarnessAgent[] = []
+  for (const item of data) {
+    if (!item || typeof item !== 'object' || Array.isArray(item)) continue
+    const o = item as Record<string, unknown>
+    const sessionId = str(o.sessionId)
+    if (!sessionId) continue
+    out.push({
+      sessionId,
+      ...(num(o.pid) !== undefined ? { pid: num(o.pid)! } : {}),
+      ...(str(o.cwd) ? { cwd: str(o.cwd)! } : {}),
+      ...(str(o.kind) ? { kind: str(o.kind)! } : {}),
+      ...(str(o.name) ? { name: str(o.name)! } : {}),
+      ...(str(o.state) ? { state: str(o.state)! } : {}),
+      ...(num(o.startedAt) !== undefined ? { startedAt: num(o.startedAt)! } : {}),
+    })
+  }
+  return out
+}
+
+/** Indexed by conversation id — the one key every other source can be matched against. */
+export function indexAgents(agents: readonly HarnessAgent[]): Map<string, HarnessAgent> {
+  const byConversation = new Map<string, HarnessAgent>()
+  // Later wins: the list is the harness's own and holds one entry per live session, so a repeat
+  // would be a format surprise rather than history. Taking the last is the same rule the other
+  // readers use, and it is stated so nobody has to guess which.
+  for (const a of agents) byConversation.set(a.sessionId, a)
+  return byConversation
+}
+
+/**
+ * Is this conversation actually HELD by a running assistant?
+ *
+ * **Being in the list is not being alive, and that distinction is the whole bug.** Measured on this
+ * machine on 2026-08-15: `claude agents --json` returned 8 records and only **2** carried a pid.
+ * The other six were `kind: background, state: blocked` with no process at all — conversations the
+ * daemon still knows about and nothing is running.
+ *
+ * Treating presence in the list as "alive" is what made the cockpit refuse to reopen a conversation
+ * that nothing was holding, and answer with "open it where it already is" — a place that did not
+ * exist, because there was no process to be anywhere. Those six are precisely the sessions REOPEN
+ * is for.
+ *
+ * So a conversation is held only when the harness names a pid for it. The caller supplies `running`
+ * to confirm that pid still exists, because a record can outlive its process and this decision
+ * blocks a verb the user is asking for.
+ */
+export function agentHeld(
+  index: ReadonlyMap<string, HarnessAgent>,
+  conversationId: string,
+  running: (pid: number) => boolean,
+): boolean {
+  const pid = index.get(conversationId)?.pid
+  return pid !== undefined && running(pid)
+}
+
+/**
+ * Whether this live session can be reached only through the harness's own agent view.
+ *
+ * A BACKGROUND agent has no tty and no tmux: there is no terminal to attach to and no second copy
+ * that may be started. `claude agents` is the tool's supported way in, and it is the answer the
+ * cockpit must offer instead of a sentence telling someone to "open it where it already is" — which
+ * is exactly the dead end this replaces, because there is no "where".
+ */
+export function needsAgentView(agent: HarnessAgent | undefined): boolean {
+  return agent?.kind === 'background'
+}

--- a/packages/server/server/sessions/live-claims.ts
+++ b/packages/server/server/sessions/live-claims.ts
@@ -17,6 +17,7 @@ import { conversationsInUse, type ClaimingSession, type ConversationHolder } fro
 import { emptyHarnessSessionIndex, loadHarnessSessions } from './harness-sessions'
 import { readRegistry } from './registry'
 import { externalId } from './session-view'
+import { parseHarnessAgents, type HarnessAgent } from './harness-agents'
 import type { ManagedSession, SessionBackend } from './types'
 
 /**
@@ -72,5 +73,38 @@ export async function liveConversationHolders(
     if (!conversationId) continue
     claims.push({ id: externalId(p), alive: true, conversationId, label: p.cwd })
   }
+  // The harness's OWN list of live sessions — the only source that sees a BACKGROUND agent, which
+  // has no tty, no tmux and nothing in the registry.
+  //
+  // A record is a claim only when it names a pid AND that pid exists. Measured on this machine:
+  // `claude agents --json` returned 8 records and only 2 carried one; the other six were
+  // `background`/`blocked` with no process at all — conversations the daemon still knows and
+  // nothing is running. Counting those as held is what made the cockpit refuse to reopen a
+  // conversation nothing was holding, and answer "open it where it already is" about a place that
+  // did not exist. Those six are precisely what reopen is FOR.
+  for (const a of await readHarnessAgents()) {
+    if (a.pid === undefined || !pidAlive(a.pid)) continue
+    claims.push({
+      id: `agent:${a.sessionId}`,
+      alive: true,
+      conversationId: a.sessionId,
+      ...(a.name ? { label: a.name } : {}),
+    })
+  }
   return conversationsInUse(claims)
+}
+
+/** `claude agents --json`, or nothing. Best-effort: a machine without the CLI behaves as before. */
+async function readHarnessAgents(): Promise<HarnessAgent[]> {
+  try {
+    const out = Bun.spawnSync(['claude', 'agents', '--json'])
+    return out.success ? parseHarnessAgents(out.stdout.toString()) : []
+  } catch {
+    return []
+  }
+}
+
+/** Signal 0 asks the kernel whether the pid exists without touching the process. */
+function pidAlive(pid: number): boolean {
+  try { process.kill(pid, 0); return true } catch { return false }
 }

--- a/packages/server/server/sessions/takeover.test.ts
+++ b/packages/server/server/sessions/takeover.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'bun:test'
+import { planTakeover } from './takeover'
+
+const base = { conversationId: 'c1', harness: 'claude' as const, resumable: true }
+
+describe('planTakeover', () => {
+  it('takes over a conversation a live assistant is holding', () => {
+    // The case that produced "abra ela por lá" — a sentence naming a place that, for a background
+    // agent, does not exist. Closing the holder satisfies the one-assistant-per-conversation rule
+    // exactly; refusing satisfies it by leaving the user with none.
+    const plan = planTakeover({
+      ...base,
+      holder: { pid: 508665, cwd: '/repo/wt', label: 'MAIN' },
+    })
+    expect(plan).toEqual({
+      kind: 'takeover',
+      conversationId: 'c1',
+      cwd: '/repo/wt',
+      holder: { pid: 508665, cwd: '/repo/wt', label: 'MAIN' },
+    })
+  })
+
+  it('leaves an unheld conversation to the ordinary reopen', () => {
+    expect(planTakeover(base)).toEqual({ kind: 'free', conversationId: 'c1' })
+  })
+
+  it('refuses BEFORE the kill when the harness cannot resume by id', () => {
+    // The ordering is the point. Ending a session and then discovering the conversation cannot be
+    // reopened loses work for nothing — and it is exactly what a check written after the kill does.
+    const plan = planTakeover({
+      ...base, harness: 'gemini', resumable: false, holder: { pid: 1, cwd: '/repo' },
+    })
+    expect(plan).toEqual({ kind: 'refuse', reason: { code: 'resume-unsupported', harness: 'gemini' } })
+  })
+
+  it('refuses when the holder cannot be closed at all', () => {
+    // Neither a row of ours nor a pid: nothing to act on. Saying so beats a verb that does nothing.
+    const plan = planTakeover({ ...base, holder: { cwd: '/repo', label: 'somebody else' } })
+    expect(plan).toEqual({ kind: 'refuse', reason: { code: 'holder-unreachable', label: 'somebody else' } })
+  })
+
+  it('refuses when there is nowhere to reopen', () => {
+    // A removed worktree. Killing the holder would leave the conversation with no directory to come
+    // back in, which is a worse state than the one it started in.
+    expect(planTakeover({ ...base, holder: { pid: 1 } }))
+      .toEqual({ kind: 'refuse', reason: { code: 'no-cwd' } })
+  })
+
+  it('closes one of ours through the BACKEND, not by signal', () => {
+    // A managed row has a session to end; killing its pid would leave the backend holding a pane
+    // for a process that is gone, which is the `lost` state arriving by our own hand.
+    const plan = planTakeover({ ...base, holder: { sessionId: 'a1b2c', cwd: '/repo' } })
+    expect(plan.kind).toBe('takeover')
+    if (plan.kind !== 'takeover') throw new Error('unreachable')
+    expect(plan.holder.sessionId).toBe('a1b2c')
+    expect(plan.holder.pid).toBeUndefined()
+  })
+})

--- a/packages/server/server/sessions/takeover.ts
+++ b/packages/server/server/sessions/takeover.ts
@@ -1,0 +1,95 @@
+/**
+ * takeover.ts — PURE. Taking a conversation that is ALREADY RUNNING and reopening it under agentop.
+ *
+ * ## What this replaces, and why the previous answer was not one
+ *
+ * A conversation held by a live assistant could not be reopened, and the product said so:
+ *
+ *   "essa conversa já está aberta em …/worktrees/session-monitor — abra ela por lá."
+ *
+ * That sentence is **correct about the fact and useless as an action**. It names a place, and for a
+ * background agent there is no place: no tty, no tmux, no window to go to. The user's answer was the
+ * right one — *find the process, close it, and reopen the conversation here* — and it is right for a
+ * reason worth writing down: the lock exists to stop TWO assistants in one conversation, and closing
+ * the first satisfies it exactly. Refusing satisfies it by leaving the user with none.
+ *
+ * ## It is a destructive act, so it is planned rather than performed
+ *
+ * Ending somebody's running assistant loses whatever it was in the middle of. This module decides
+ * and the caller performs, so the decision can be shown, confirmed and tested without a process
+ * being killed to find out what would happen.
+ *
+ * ## Every harness, not just the one that reported it
+ *
+ * Killing a pid and resuming by id are the same two steps everywhere, so nothing here is
+ * claude-specific: the caller supplies the holder (whatever source found it) and `planSpawn` already
+ * knows which harnesses can resume by id at all. A harness that cannot is refused BEFORE anything is
+ * killed — ending a session to then discover the conversation cannot be reopened would be the worst
+ * possible order, and it is the one a check written after the kill would produce.
+ */
+
+import type { HarnessId } from '@agentistics/core'
+
+/** The assistant currently holding a conversation. */
+export interface ConversationHolder {
+  /** OS pid, when the source could name one. Without it nothing can be closed. */
+  pid?: number
+  /** The agentop row driving it, when it is one of ours — closed through the backend, not a signal. */
+  sessionId?: string
+  /** Where it is running, so the replacement opens in the same place. */
+  cwd?: string
+  /** What to call it while asking. */
+  label?: string
+}
+
+export type TakeoverPlan =
+  /** Close `holder`, then reopen `conversationId` in `cwd`. The only outcome that acts. */
+  | { kind: 'takeover'; conversationId: string; cwd: string; holder: ConversationHolder }
+  /** Nothing is holding it — the ordinary reopen applies, and this module has no business here. */
+  | { kind: 'free'; conversationId: string }
+  /** It cannot be done, and `reason` says which of the ways. */
+  | { kind: 'refuse'; reason: TakeoverRefusal }
+
+export type TakeoverRefusal =
+  /** The harness cannot reopen a conversation by id, so closing the holder would strand it. */
+  | { code: 'resume-unsupported'; harness: HarnessId }
+  /** Something holds it and nothing here can close that something. */
+  | { code: 'holder-unreachable'; label?: string }
+  /** No directory to reopen in — a removed worktree, most likely. */
+  | { code: 'no-cwd' }
+
+/**
+ * Decide — PURE.
+ *
+ * `resumable` is the harness's own capability (from `SPAWN_SPECS`), checked FIRST and before any
+ * thought of closing anything. `holder` is whatever the caller's search turned up: `undefined`
+ * means nothing holds the conversation.
+ */
+export function planTakeover(o: {
+  conversationId: string
+  harness: HarnessId
+  /** Can this harness reopen a conversation by id at all? */
+  resumable: boolean
+  holder?: ConversationHolder
+  /** Where to reopen. The holder's own directory when it has one. */
+  cwd?: string
+}): TakeoverPlan {
+  if (!o.holder) return { kind: 'free', conversationId: o.conversationId }
+  // Before the kill, always. Ending a session and THEN discovering the conversation cannot be
+  // reopened is the one ordering that loses work for nothing.
+  if (!o.resumable) return { kind: 'refuse', reason: { code: 'resume-unsupported', harness: o.harness } }
+
+  // Closable through the backend (a row of ours) or by signal (a pid). With neither there is
+  // nothing to act on, and saying so beats a verb that silently does nothing.
+  if (o.holder.sessionId === undefined && o.holder.pid === undefined) {
+    return {
+      kind: 'refuse',
+      reason: { code: 'holder-unreachable', ...(o.holder.label ? { label: o.holder.label } : {}) },
+    }
+  }
+
+  const cwd = o.cwd ?? o.holder.cwd
+  if (!cwd) return { kind: 'refuse', reason: { code: 'no-cwd' } }
+
+  return { kind: 'takeover', conversationId: o.conversationId, cwd, holder: o.holder }
+}

--- a/packages/tui/src/control/tabs/Sessions.tsx
+++ b/packages/tui/src/control/tabs/Sessions.tsx
@@ -1857,7 +1857,9 @@ function SessionRowView({ session, selected, marked, ages, columns, width, close
           and in a grouping you had to switch to. `sessionColumns` drops the cell while grouping BY
           task, where the heading over the row already says it. */}
       {columns.task > 0 ? (
-        <Text color={COLORS.secondary}>{gap + padCell(session.task ?? '', columns.task)}</Text>
+        <Text color={selected ? COLORS.accent : COLORS.secondary} bold={selected}>
+          {gap + padCell(session.task ?? '', columns.task)}
+        </Text>
       ) : null}
       {/* Usage sits right of the name and left of the harness — it is a number about THIS row, and
           a row you are deciding whether to close is one whose cost you want beside its name rather


### PR DESCRIPTION
Reported: *"mesmo tendo aparecido ele não deixa eu retomar a sessão"*. The cockpit answered:

> essa conversa já está aberta em …/worktrees/session-monitor — abra ela por lá

**Correct about the fact and useless as an action.** It names a place, and for a background agent there is none: no tty, no tmux, no window to go to.

## The cause is sharper than the sentence

`claude agents --json` is the harness's own list of its live sessions — the only source that sees a background agent at all — and **being in it is not the same as running**. Measured here:

```
8 records, 2 with a pid
6 × kind=background state=blocked pid=—   ← no process whatsoever
```

Those six are conversations the daemon still knows and **nothing is driving**. Counting them as held is what refused a reopen for a conversation nothing was holding — and they are precisely what reopen is *for*.

A conversation is now HELD only when the harness names a pid **and that pid exists** (confirmed with signal 0, because a record can outlive its process and this decision blocks a verb the user is asking for).

**Verified against the real machine:** 2 conversations genuinely held, and `Build agentop harness cockpit` — the one in the screenshot — is free again.

## And when something IS holding it, the answer stops being a refusal

`planTakeover` closes the assistant and reopens the conversation here. That is what was asked for, and what the lock actually wants: the rule is *one assistant per conversation*, and closing the first satisfies it exactly — refusing satisfies it by leaving nobody with it.

**Harness-agnostic by construction**: killing a pid and resuming by id are the same two steps everywhere, and `planSpawn` already knows which harnesses can resume at all — checked **before** the kill, because ending a session and then discovering it cannot be reopened is the one ordering that loses work for nothing. (Only claude publishes a live-session list to search today; the day another does, it joins the search and nothing else changes.)

## Also

The **task column** takes the accent on the focused row — the one cell the previous pass missed.

`bun tsc --noEmit` clean, `bun test` **4073 pass / 0 fail**, binary compiles.

**Not verified by execution:** the kill-then-reopen path is covered by unit tests and its decision was checked against the live agent list, but I did not run it against one of your sessions — that would have ended work you did not ask me to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TBcRtC62Sx18sgJj64r1Np