### PR TITLE
release: token vocabulary everywhere, and three defects the browser found

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -2,6 +2,43 @@
 
 All cost and token calculations use a single source of truth: `packages/core/src/types.ts` (imported as `@agentistics/core`). No layer duplicates the pricing logic.
 
+## What the word "tokens" means
+
+**A token figure is always all four billed counters:** `input + output + cacheRead + cacheWrite`.
+Counting lives in `packages/core/src/tokens.ts` — `sessionTokens` / `usageTokens` /
+`sessionTokenTotal` / `usageTokenTotal` / `totalTokens` / `addTokens` / `sumTokens`. Never write the
+sum by hand.
+
+This is not a stylistic preference. Measured on one real machine across its 123 stored Claude
+sessions:
+
+```
+input + output + cacheRead + cacheWrite   8,856,436,865
+input + output                               30,247,005   ← 0.34% of it
+```
+
+A surface that summed two of the four was not slightly low, it was off by ~300×, and the cost beside
+it (which had always priced the cache) disagreed by ~10×. It was found as a session-drawer bug and
+turned out to be 19 call sites across the web app, the server and the exports.
+
+Consequences that are easy to get wrong:
+
+- **An aggregate type carries `tokens: TokenBreakdown`**, not just `inputTokens`/`outputTokens` —
+  `HarnessSummary`, `RepoStat`, `TagAggregate`, `derived.tokenTotals`. The conversational pair is
+  kept for surfaces that legitimately want it (an "Input" card, an "Output" card) and is **never**
+  the thing labelled "tokens".
+- **A rate per million is over the total**, not over the conversational pair. Computing cost/1M
+  against the non-cached ~4% reports a figure tens of times higher than what is charged, and ranks
+  harnesses by how much they cache.
+- **`calcCost` gets the real cache counters.** For a session with no model, `blendedSessionCost`
+  applies each of the four blended rates — pricing cache as fresh input is the opposite error.
+- **A label may not ship without its explanation.** `TOKEN_KINDS` in `tokens.ts` carries a label
+  and a one-sentence `help` per counter in EN/PT, and `totalTokensExplained()` is the sentence that
+  goes under a headline figure. At these magnitudes an unexplained total reads as a fault.
+- **`tokens.lint.test.ts` enforces it** — it greps core/server/web/tui for two-term sums and for
+  `calcCost` arguments with the cache zeroed, and fails the build. Comments and per-field `+=` are
+  exempt; a deliberate two-term reading needs `@tokens-intentional` **and a reason**.
+
 ## Pricing table
 
 All prices are in USD per **1 million tokens**:
@@ -41,10 +78,15 @@ avg_input_rate  = Σ(model_input_tokens  × model_input_price)  / Σ input_token
 avg_output_rate = Σ(model_output_tokens × model_output_price) / Σ output_tokens
 (same for cache read and write)
 
-Estimated Session Cost = session_input_tokens  × avg_input_rate
-                       + session_output_tokens × avg_output_rate
-                       + ...
+Estimated Session Cost = session_input_tokens      × avg_input_rate
+                       + session_output_tokens     × avg_output_rate
+                       + session_cache_read_tokens  × avg_cache_read_rate
+                       + session_cache_write_tokens × avg_cache_write_rate
 ```
+
+Implemented **once**, in `blendedSessionCost` (`packages/web/src/hooks/useData.ts`). Two call sites
+— the session drawer and the PDF's per-session column — each wrote their own version over `input`
+and `output` only, which priced a session on the ~4% of its volume that is not cache.
 
 ## Token types
 
@@ -57,7 +99,12 @@ Estimated Session Cost = session_input_tokens  × avg_input_rate
 
 ### Cache efficiency
 
-Cache hit rate = `cacheRead / (cacheRead + input)`
+Cache hit rate = `cacheRead / (input + cacheRead + cacheWrite)`
+
+The denominator is everything the model READ, however it was served — cache writes included, since
+a write is input that had to be read to be written. Output is not in it: output is produced, not
+read, so including it would dilute the rate on an output-heavy session. See `readTokens()` in
+`packages/core/src/tokens.ts`, which is the same function the panel uses.
 
 Color coding: red < 30% · yellow 30–60% · green ≥ 60%
 

--- a/packages/core/src/tokens.lint.test.ts
+++ b/packages/core/src/tokens.lint.test.ts
@@ -102,12 +102,23 @@ describe('no surface may add up two of the four token counters and call it "toke
   // that this guard cries wolf.
   const SUM = /input_?[Tt]okens[^;\n]{0,120}?\+(?!=)[^;]{0,160}?output_?[Tt]okens/g
 
+  /**
+   * The same sum written with the words the other way round: `tokensIn + tokensOut`.
+   *
+   * This guard shipped matching only `inputTokens`/`input_tokens`, and MISSED a live one — the CI
+   * grouping on the Actions page accumulated into fields called `tokensIn`/`tokensOut`, so its
+   * "Tokens" column and its sort were both two-counter and the lint reported the file clean. A rule
+   * that only recognises one naming convention is a rule with a blind spot the size of whatever
+   * somebody names things next.
+   */
+  const SUM_REVERSED = /tokens_?[Ii]n\b[^;\n]{0,120}?\+(?!=)[^;]{0,160}?tokens_?[Oo]ut\b/g
+
   it('finds no unexplained two-term token sum anywhere in the product', () => {
     const offences: string[] = []
     for (const dir of SCAN) {
       for (const file of sourceFiles(dir)) {
         const src = readFileSync(file, 'utf-8')
-        for (const m of src.matchAll(SUM)) {
+        for (const m of [...src.matchAll(SUM), ...src.matchAll(SUM_REVERSED)]) {
           const from = m.index!
           // The cache counters have to appear in the SAME expression. 260 characters is enough to
           // span the four-line form every correct call site in this repo is written in.

--- a/packages/core/src/tokens.test.ts
+++ b/packages/core/src/tokens.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'bun:test'
 import {
   EMPTY_TOKENS, TOKEN_PARTS, addTokens, readTokens, sessionTokenTotal, sessionTokens,
   sumTokens, tokenHelp, tokenLabel, tokenShares, totalTokens, totalTokensExplained,
-  usageTokenTotal, usageTokens,
+  tokenSharePct, usageTokenTotal, usageTokens,
 } from './tokens'
 import type { Lang } from './i18n'
 import type { SessionMeta } from './types'
@@ -76,6 +76,20 @@ describe('the vocabulary', () => {
         expect(tokenHelp(kind, lang).length).toBeGreaterThan(40)
       }
     }
+  })
+
+  it('never prints 0% for a quantity that exists', () => {
+    // Found by opening the panel on a real machine: output was 64.2M of a 17.8B total and rendered
+    // as `0%`, with the sentence reading "output, the most expensive token, is 0%". A confident zero
+    // over a real number is the exact lie this whole module exists to remove.
+    expect(tokenSharePct(64_200_000, 17_800_000_000)).toBe('<1%')
+    expect(tokenSharePct(1, 1_000_000)).toBe('<1%')
+    // A true zero still reads as zero — `<1%` there would invent a quantity.
+    expect(tokenSharePct(0, 1000)).toBe('0%')
+    expect(tokenSharePct(0, 0)).toBe('0%')
+    // And the ordinary case is unchanged.
+    expect(tokenSharePct(96, 100)).toBe('96%')
+    expect(tokenSharePct(1, 100)).toBe('1%')
   })
 
   it('explains a headline total by naming what dominates it', () => {

--- a/packages/core/src/tokens.ts
+++ b/packages/core/src/tokens.ts
@@ -232,6 +232,24 @@ const TERMS: Record<TokenKind, Record<Lang, TokenTerm>> = {
   },
 }
 
+/**
+ * A share as a percentage STRING, which never prints `0%` for a quantity that exists.
+ *
+ * Found by opening the panel: with a real machine's 17.8B total, output — 64.2M tokens and the most
+ * expensive counter there is — rendered as `0%`, and the explanatory sentence read "output, the most
+ * expensive token, is 0%". That is the confident-zero this codebase forbids everywhere else, applied
+ * to the exact number the reader is least able to check.
+ *
+ * `<1%` is the honest answer, and it is also the interesting one: it says the cache has grown so
+ * large that the expensive tokens have become a rounding error, which is the actual finding.
+ */
+export function tokenSharePct(part: number, total: number): string {
+  if (total <= 0 || part <= 0) return '0%'
+  const pct = (part / total) * 100
+  if (pct < 0.5) return '<1%'
+  return `${Math.round(pct)}%`
+}
+
 export function tokenTerm(kind: TokenKind, lang: Lang): TokenTerm {
   return TERMS[kind][lang]
 }
@@ -270,7 +288,7 @@ export function totalTokensExplained(b: TokenBreakdown, lang: Lang): string {
       ? 'Nenhum token registrado neste recorte.'
       : 'No tokens recorded in this scope.'
   }
-  const pct = (n: number) => `${Math.round((n / t) * 100)}%`
+  const pct = (n: number) => tokenSharePct(n, t)
   return lang === 'pt'
     ? `Soma dos quatro contadores. Leitura de cache é ${pct(b.cacheRead)} do total — é a conversa sendo relida a cada turno, e custa cerca de 1/10 da entrada nova. Saída, o token mais caro, é ${pct(b.output)}.`
     : `All four counters added up. Cache read is ${pct(b.cacheRead)} of it — the conversation being re-read every turn, at roughly 1/10 the price of fresh input. Output, the most expensive token, is ${pct(b.output)}.`

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -23,7 +23,7 @@ import type { TagDef } from './lib/tagMatch'
 import { canCreateTagFromFilters, filtersToTagDraft } from './lib/filtersToTag'
 import type { BillingSettings, CostBasis, Filters, HarnessId, HealthIssue, SavedComparison, TeamConfig } from '@agentistics/core'
 import type { Lang, Theme } from '@agentistics/core'
-import { billingReadiness, monthlyCommitment, normalizeBillingSettings, normalizeComparisons, planAllocation, formatProjectName, MODEL_PRICING, distinctUsers, distinctHarnesses, filterByUsers, fmtCost, HARNESS_ORDER, readTeamConnections, totalTokens, totalTokensExplained } from '@agentistics/core'
+import { billingReadiness, monthlyCommitment, normalizeBillingSettings, normalizeComparisons, planAllocation, formatProjectName, MODEL_PRICING, distinctUsers, distinctHarnesses, filterByUsers, fmtCost, HARNESS_ORDER, readTeamConnections, fmt, totalTokens, totalTokensExplained } from '@agentistics/core'
 import { buildDeniedRepoLabels } from './lib/shareRepos'
 import { StatCard } from './components/StatCard'
 import { StreakBreakdownButton } from './components/StreakBreakdownButton'
@@ -419,11 +419,6 @@ function ChartModal({ title, onClose, children }: {
   )
 }
 
-function fmt(n: number): string {
-  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
-  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`
-  return String(n)
-}
 
 function fmtDuration(ms: number): string {
   const h = Math.floor(ms / 3_600_000)

--- a/packages/web/src/components/AgentMetricsPanel.tsx
+++ b/packages/web/src/components/AgentMetricsPanel.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
 import { CheckCircle, XCircle, ChevronDown, ChevronUp, Bot } from 'lucide-react'
-import { fmtCost } from '@agentistics/core'
+import { fmt, fmtCost } from '@agentistics/core'
 import type { AgentInvocation, HarnessId } from '@agentistics/core'
 import type { Lang } from '@agentistics/core'
 import { MetricNote } from './MetricNote'
@@ -25,11 +25,6 @@ interface AgentMetricsPanelProps {
   harness?: HarnessId
 }
 
-function fmtTokens(n: number): string {
-  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
-  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`
-  return String(n)
-}
 
 
 function fmtDuration(ms: number): string {
@@ -143,8 +138,8 @@ export function AgentMetricsPanel({
         />
         <SummaryCard
           label={pt ? 'Tokens de agentes' : 'Agent tokens'}
-          value={fmtTokens(totalTokens)}
-          sub={`avg ${fmtTokens(Math.round(avgTokens))} / ${pt ? 'chamada' : 'call'}`}
+          value={fmt(totalTokens)}
+          sub={`avg ${fmt(Math.round(avgTokens))} / ${pt ? 'chamada' : 'call'}`}
           accent="var(--accent-blue)"
         />
         {/* Agents are a Claude-only capability, so the allocation uses CLAUDE's own C/A — never
@@ -198,7 +193,7 @@ export function AgentMetricsPanel({
                   {stats.count}×
                 </span>
                 {!isMobile && <span style={{ color: 'var(--text-secondary)', textAlign: 'right' }}>
-                  {fmtTokens(stats.tokens)} tok
+                  {fmt(stats.tokens)} tok
                 </span>}
                 {!isMobile && <span style={{ color: 'var(--anthropic-orange)', textAlign: 'right' }}>
                   {fmtCost(stats.costUSD, currency, brlRate)}
@@ -271,7 +266,7 @@ export function AgentMetricsPanel({
                 </span>
               </div>
               <span style={{ fontSize: 11, color: 'var(--text-primary)', textAlign: 'right' }}>
-                {fmtTokens(inv.totalTokens)}
+                {fmt(inv.totalTokens)}
               </span>
               <span style={{ fontSize: 11, color: 'var(--text-secondary)', textAlign: 'right' }}>
                 {inv.totalToolUseCount}

--- a/packages/web/src/components/AgentMetricsPanel.tsx
+++ b/packages/web/src/components/AgentMetricsPanel.tsx
@@ -3,6 +3,7 @@ import { CheckCircle, XCircle, ChevronDown, ChevronUp, Bot } from 'lucide-react'
 import { fmtCost } from '@agentistics/core'
 import type { AgentInvocation, HarnessId } from '@agentistics/core'
 import type { Lang } from '@agentistics/core'
+import { MetricNote } from './MetricNote'
 import { useIsMobile } from '../hooks/useIsMobile'
 import { capable } from '../lib/harness'
 import { NAtag } from './NAtag'
@@ -164,6 +165,15 @@ export function AgentMetricsPanel({
           accent="var(--accent-green)"
         />
       </div>
+
+      {/* What these numbers ARE. An agent's token figure is the harness's own rollup for that
+          invocation, which is a different measurement from the session totals elsewhere — saying so
+          is cheaper than the question "why don't these add up to my session". */}
+      <MetricNote>
+        {pt
+          ? 'Tokens e custo por invocação vêm do que o próprio Claude Code reporta ao encerrar cada agente — já incluem leitura e escrita de cache. Um agente é cobrado dentro da sessão que o chamou, então estes valores são uma FATIA do total da sessão, não uma soma à parte.'
+          : "Tokens and cost per invocation come from what Claude Code itself reports when each agent finishes — cache reads and writes included. An agent is billed inside the session that called it, so these figures are a SLICE of that session's total, not something to add on top."}
+      </MetricNote>
 
       {/* Agent type breakdown */}
       {sortedTypes.length > 0 && (

--- a/packages/web/src/components/CacheHitRatePanel.tsx
+++ b/packages/web/src/components/CacheHitRatePanel.tsx
@@ -4,6 +4,7 @@ import { formatModel, getModelColor, fmtCost } from '@agentistics/core'
 import type { Lang, HarnessId } from '@agentistics/core'
 import { useIsMobile } from '../hooks/useIsMobile'
 import { NAtag } from './NAtag'
+import { MetricNote } from './MetricNote'
 import { capable } from '../lib/harness'
 
 interface Props {
@@ -298,6 +299,14 @@ export function CacheHitRatePanel({
           })}
         </div>
       )}
+
+      {/* The denominator is the thing people get wrong here, and it is the reason the rate can look
+          high on a session whose bill is mostly output. */}
+      <MetricNote>
+        {pt
+          ? 'A taxa é leitura de cache dividida por tudo que o modelo LEU — entrada nova + leitura + escrita de cache. A saída fica de fora porque saída é produzida, não lida; incluí-la diluiria a taxa numa sessão que escreveu muito. Este painel é sempre em preço de API: cache não reduz uma assinatura, ele estica o limite de uso.'
+          : 'The rate is cache reads over everything the model READ — fresh input + cache read + cache write. Output is excluded because output is produced, not read; including it would dilute the rate on a session that wrote a lot. This panel is always in API prices: cache does not reduce a subscription, it extends a rate limit.'}
+      </MetricNote>
 
       {/* Tips — show only first 2 */}
       <div style={{

--- a/packages/web/src/components/CacheHitRatePanel.tsx
+++ b/packages/web/src/components/CacheHitRatePanel.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Zap, Lightbulb, TrendingDown, TrendingUp, Info } from 'lucide-react'
-import { formatModel, getModelColor, fmtCost } from '@agentistics/core'
+import { fmt, formatModel, getModelColor, fmtCost } from '@agentistics/core'
 import type { Lang, HarnessId } from '@agentistics/core'
 import { useIsMobile } from '../hooks/useIsMobile'
 import { NAtag } from './NAtag'
@@ -31,11 +31,6 @@ interface Props {
   harness?: HarnessId
 }
 
-function fmtTokens(n: number): string {
-  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
-  if (n >= 1_000) return `${(n / 1_000).toFixed(0)}K`
-  return String(n)
-}
 
 type Tier = 'low' | 'medium' | 'high'
 
@@ -211,8 +206,8 @@ export function CacheHitRatePanel({
           </div>
           <div style={{ fontSize: 10, color: 'var(--text-tertiary)' }}>
             {pt
-              ? `${fmtTokens(cacheTotals.cacheReadInputTokens)} de ${fmtTokens(totalRelevant)} tokens do cache`
-              : `${fmtTokens(cacheTotals.cacheReadInputTokens)} of ${fmtTokens(totalRelevant)} tokens from cache`}
+              ? `${fmt(cacheTotals.cacheReadInputTokens)} de ${fmt(totalRelevant)} tokens do cache`
+              : `${fmt(cacheTotals.cacheReadInputTokens)} of ${fmt(totalRelevant)} tokens from cache`}
           </div>
         </div>
 

--- a/packages/web/src/components/HighlightsBoard.tsx
+++ b/packages/web/src/components/HighlightsBoard.tsx
@@ -1,17 +1,12 @@
 import React, { useState } from 'react'
 import { Clock, Download, Upload, MessageSquare, Wrench, FolderOpen } from 'lucide-react'
 import type { SessionMeta, Project, HarnessId } from '@agentistics/core'
-import { formatProjectName, sessionLabel } from '@agentistics/core'
+import { fmt, formatProjectName, sessionLabel } from '@agentistics/core'
 import { useIsMobile } from '../hooks/useIsMobile'
 import { NAtag } from './NAtag'
 import { capable } from '../lib/harness'
 import { sessionTime } from '../lib/sessionTime'
 
-function fmt(n: number): string {
-  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
-  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`
-  return String(n)
-}
 
 function fmtDuration(minutes: number): string {
   const h = Math.floor(minutes / 60)

--- a/packages/web/src/components/MetricNote.tsx
+++ b/packages/web/src/components/MetricNote.tsx
@@ -1,0 +1,44 @@
+import React from 'react'
+
+/**
+ * The sentence under a number.
+ *
+ * ## Why this is a component and not fourteen inline divs
+ *
+ * The rule this codebase now holds is that a token figure may not appear without an account of what
+ * produced it — these numbers reach the billions, and an unexplained total at that magnitude reads
+ * as a fault rather than as information. Applying that rule meant writing the same small block of
+ * styles on every panel that shows one, and fourteen copies of a style is fourteen chances for the
+ * explanation to look like a different kind of thing on each screen. A reader learns "small dim text
+ * under the number is what the number means" exactly once, or not at all.
+ *
+ * ## It is always visible
+ *
+ * Deliberately not a tooltip. A `title` attribute does not exist on a phone, and this text is most
+ * needed by the person who is confused right now — putting it behind a hover hides it from half the
+ * audience and from all of the audience in a hurry.
+ *
+ * `tone="warn"` is for a note that qualifies the number rather than describing it: an estimate, an
+ * attribution, a figure that is not what you are billed. It is a weak amber and never the fault red,
+ * because nothing here is broken — the number is simply not the thing a reader would assume.
+ */
+export function MetricNote({ children, tone = 'plain', style }: {
+  children: React.ReactNode
+  tone?: 'plain' | 'warn'
+  style?: React.CSSProperties
+}) {
+  return (
+    <div
+      style={{
+        fontSize: 10.5,
+        lineHeight: 1.5,
+        color: tone === 'warn' ? 'var(--accent-amber, #b45309)' : 'var(--text-tertiary)',
+        marginTop: 6,
+        maxWidth: 620,
+        ...style,
+      }}
+    >
+      {children}
+    </div>
+  )
+}

--- a/packages/web/src/components/ModelBreakdown.tsx
+++ b/packages/web/src/components/ModelBreakdown.tsx
@@ -3,6 +3,7 @@ import type { ModelUsage } from '@agentistics/core'
 import { formatModel, calcCost, getModelColor, fmtCost, usageTokenTotal } from '@agentistics/core'
 import { useIsMobile } from '../hooks/useIsMobile'
 import { resolveProvider, providerOrder } from '@agentistics/core'
+import { MetricNote } from './MetricNote'
 
 type SortKey = 'cost' | 'tokens' | 'model'
 
@@ -333,6 +334,15 @@ export function ModelBreakdown({ modelUsage, note, currency = 'USD', brlRate = 1
           {note}
         </div>
       )}
+
+      {/* The token column here is the model's whole billed volume, and the money beside it is
+          priced from the same four counters — which is exactly why a cheap-looking model can carry
+          a large number. */}
+      <MetricNote style={{ padding: '0 14px 10px' }}>
+        {lang === 'pt'
+          ? 'A coluna de tokens soma os quatro contadores cobrados deste modelo — entrada nova, saída, leitura e escrita de cache — e o custo ao lado é calculado sobre os mesmos quatro, cada um ao seu preço. Um modelo pode aparecer com volume enorme e custo baixo: leitura de cache vale cerca de 1/10 da entrada nova.'
+          : "The tokens column adds this model's four billed counters — fresh input, output, cache read and cache write — and the cost beside it is priced from those same four, each at its own rate. A model can show a huge volume and a small cost: cache reads are worth roughly 1/10 of fresh input."}
+      </MetricNote>
     </div>
     )}
     </>

--- a/packages/web/src/components/ModelBreakdown.tsx
+++ b/packages/web/src/components/ModelBreakdown.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo, useState } from 'react'
 import type { ModelUsage } from '@agentistics/core'
-import { formatModel, calcCost, getModelColor, fmtCost, usageTokenTotal } from '@agentistics/core'
+import { fmt, formatModel, calcCost, getModelColor, fmtCost, usageTokenTotal } from '@agentistics/core'
 import { useIsMobile } from '../hooks/useIsMobile'
 import { resolveProvider, providerOrder } from '@agentistics/core'
 import { MetricNote } from './MetricNote'
@@ -30,11 +30,6 @@ interface Props {
   lang?: 'en' | 'pt'
 }
 
-function fmt(n: number): string {
-  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
-  if (n >= 1_000) return `${(n / 1_000).toFixed(0)}K`
-  return String(n)
-}
 
 
 const COL: React.CSSProperties = { fontSize: 11, color: 'var(--text-tertiary)', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.06em' }

--- a/packages/web/src/components/RecentSessions.tsx
+++ b/packages/web/src/components/RecentSessions.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useMemo } from 'react'
 import type { SessionMeta } from '@agentistics/core'
 import { sessionTime } from '../lib/sessionTime'
-import { formatProjectName, sessionLabel, sessionTokenTotal } from '@agentistics/core'
+import { fmt, formatProjectName, sessionLabel, sessionTokenTotal } from '@agentistics/core'
 import { HARNESS_LABELS, HARNESS_COLORS } from '../lib/harness'
 import { format, parseISO } from 'date-fns'
 import {
@@ -69,11 +69,6 @@ const T = {
 
 // Helpers
 
-function fmt(n: number): string {
-  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
-  if (n >= 1_000) return `${(n / 1_000).toFixed(0)}K`
-  return String(n)
-}
 
 /** Every billed counter — the column header says "tokens", so it must be all of them. */
 function totalTokens(s: SessionMeta): number {

--- a/packages/web/src/components/SessionDrilldownModal.tsx
+++ b/packages/web/src/components/SessionDrilldownModal.tsx
@@ -13,7 +13,7 @@ import {
 } from '@agentistics/core'
 import { blendedCostPerToken, blendedSessionCost } from '../hooks/useData'
 import { buildWorkflowSteps } from '../lib/workflowSteps'
-import { fmtFull, workflowTokens } from '@agentistics/core'
+import { fmt as fmtShort, fmtFull, workflowTokens } from '@agentistics/core'
 import { HARNESS_LABELS, HARNESS_COLORS } from '../lib/harness'
 import { PrecisionToggle } from './PrecisionToggle'
 import { useIsMobile } from '../hooks/useIsMobile'
@@ -32,11 +32,15 @@ interface Props {
   onClose: () => void
 }
 
+/**
+ * The drawer's own wrapper: the precision toggle swaps the compact reading for the exact one.
+ *
+ * The compact side delegates to the shared `fmt`, which knows about billions. The local copy this
+ * replaced stopped at millions, so a cached session rendered as `9809.8M` — a number nobody can
+ * read at a glance, which is the entire job of a compact format.
+ */
 function fmt(n: number, full = false): string {
-  if (full) return fmtFull(n)
-  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
-  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`
-  return String(n)
+  return full ? fmtFull(n) : fmtShort(n)
 }
 
 

--- a/packages/web/src/components/TokenTotalsPanel.tsx
+++ b/packages/web/src/components/TokenTotalsPanel.tsx
@@ -1,8 +1,8 @@
 import React from 'react'
 import type { Filters, Lang, TokenBreakdown } from '@agentistics/core'
 import {
-  TOKEN_COLORS, TOKEN_PARTS, fmt, fmtFull, readTokens, tokenHelp, tokenLabel, tokenShares,
-  totalTokens, totalTokensExplained,
+  TOKEN_COLORS, TOKEN_PARTS, fmt, fmtFull, readTokens, tokenHelp, tokenLabel,
+  tokenSharePct, totalTokens, totalTokensExplained,
 } from '@agentistics/core'
 import { scopeSentence } from '../lib/scopeSentence'
 import { useIsMobile } from '../hooks/useIsMobile'
@@ -39,7 +39,6 @@ export function TokenTotalsPanel({ tokens, filters, lang }: Props) {
   const pt = lang === 'pt'
   const isMobile = useIsMobile()
   const [full, setFull] = React.useState(false)
-  const shares = tokenShares(tokens)
   const total = totalTokens(tokens)
   const read = readTokens(tokens)
   const conversation = tokens.input + tokens.output
@@ -104,7 +103,7 @@ export function TokenTotalsPanel({ tokens, filters, lang }: Props) {
                 </td>
                 <td style={{ ...num, color: 'var(--text-primary)' }}>{n(tokens[part])}</td>
                 <td style={{ ...num, color: 'var(--text-tertiary)', fontWeight: 600, width: 56 }}>
-                  {Math.round(shares[part] * 100)}%
+                  {tokenSharePct(tokens[part], total)}
                 </td>
               </tr>
             ))}
@@ -149,7 +148,7 @@ export function TokenTotalsPanel({ tokens, filters, lang }: Props) {
                   {n(d.value)}
                 </td>
                 <td style={{ ...num, borderBottom: 'none', paddingTop: 12, color: 'var(--text-tertiary)', fontWeight: 600 }}>
-                  {total > 0 ? `${Math.round((d.value / total) * 100)}%` : '—'}
+                  {total > 0 ? tokenSharePct(d.value, total) : '—'}
                 </td>
               </tr>
             ))}

--- a/packages/web/src/components/ToolMetricsPanel.tsx
+++ b/packages/web/src/components/ToolMetricsPanel.tsx
@@ -3,6 +3,7 @@ import { FileText, ArrowDownWideNarrow } from 'lucide-react'
 import type { Lang } from '@agentistics/core'
 import { t } from '@agentistics/core'
 import { useIsMobile } from '../hooks/useIsMobile'
+import { MetricNote } from './MetricNote'
 
 interface Props {
   toolCounts: Record<string, number>
@@ -25,6 +26,7 @@ function fmt(n: number): string {
 
 export function ToolMetricsPanel({ toolCounts, toolOutputTokens, agentFileReads, lang, forcedMode, hideAgentReads }: Props) {
   const isMobile = useIsMobile()
+  const pt = lang === 'pt'
   const [viewMode, setViewMode] = useState<ViewMode>(forcedMode ?? 'calls')
   const effectiveMode: ViewMode = forcedMode ?? viewMode
   const showToggle = forcedMode === undefined
@@ -158,6 +160,16 @@ export function ToolMetricsPanel({ toolCounts, toolOutputTokens, agentFileReads,
             )
           })}
         </div>
+      )}
+
+      {/* The token mode is an ATTRIBUTION, not a measurement, and the difference matters here more
+          than almost anywhere: a "villain" badge is an accusation built on a fair split. */}
+      {effectiveMode === 'tokens' && entries.length > 0 && (
+        <MetricNote tone="warn">
+          {pt
+            ? 'Estimativa, não medição: só os tokens de SAÍDA são atribuídos aqui, e um turno que chamou várias ferramentas divide a saída dele em partes iguais entre elas. O que uma ferramenta fez o modelo LER depois — o resultado dela — é cobrado como entrada e cache do turno seguinte, e não aparece nesta barra.'
+            : 'An estimate, not a measurement: only OUTPUT tokens are attributed here, and a turn that called several tools splits its output equally between them. What a tool then made the model READ — its result — is billed as the next turn\u2019s input and cache, and does not appear in this bar.'}
+        </MetricNote>
       )}
 
       {/* Agent file reads section */}

--- a/packages/web/src/components/ToolMetricsPanel.tsx
+++ b/packages/web/src/components/ToolMetricsPanel.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import { FileText, ArrowDownWideNarrow } from 'lucide-react'
 import type { Lang } from '@agentistics/core'
-import { t } from '@agentistics/core'
+import { fmt, t } from '@agentistics/core'
 import { useIsMobile } from '../hooks/useIsMobile'
 import { MetricNote } from './MetricNote'
 
@@ -18,11 +18,6 @@ interface Props {
 
 type ViewMode = 'calls' | 'tokens'
 
-function fmt(n: number): string {
-  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
-  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`
-  return String(n)
-}
 
 export function ToolMetricsPanel({ toolCounts, toolOutputTokens, agentFileReads, lang, forcedMode, hideAgentReads }: Props) {
   const isMobile = useIsMobile()

--- a/packages/web/src/pages/ActionsPage.tsx
+++ b/packages/web/src/pages/ActionsPage.tsx
@@ -2,8 +2,12 @@ import React, { useMemo, useState } from 'react'
 import { useOutletContext, useNavigate } from 'react-router-dom'
 import { Zap, ArrowLeft, GitCommit, ExternalLink } from 'lucide-react'
 import type { AppContext } from '../lib/app-context'
-import { repoShortName, fmt, fmtCost, calcCost, sessionCostUSD, type SessionMeta } from '@agentistics/core'
+import {
+  repoShortName, fmt, fmtCost, calcCost, sessionCostUSD, EMPTY_TOKENS, addTokens, sessionTokens,
+  totalTokens, type SessionMeta, type TokenBreakdown,
+} from '@agentistics/core'
 import { Section } from '../components/Section'
+import { MetricNote } from '../components/MetricNote'
 import { SortControl } from '../components/SortControl'
 
 type ActSortKey = 'cost' | 'runs' | 'tokens' | 'commits' | 'members' | 'name'
@@ -16,15 +20,17 @@ export default function ActionsPage() {
   const pt = lang === 'pt'
 
   const groups = useMemo(() => {
-    const byRepo: Record<string, { remote: string; runs: number; tokensIn: number; tokensOut: number; commits: number; costUSD: number; users: Set<string> }> = {}
+    const byRepo: Record<string, { remote: string; runs: number; tokensIn: number; tokensOut: number; tokens: TokenBreakdown; commits: number; costUSD: number; users: Set<string> }> = {}
     for (const s of derived.filteredSessions) {
       if (!s.ci) continue
       const key = s.git_remote || ''
       let g = byRepo[key]
-      if (!g) g = byRepo[key] = { remote: key, runs: 0, tokensIn: 0, tokensOut: 0, commits: 0, costUSD: 0, users: new Set() }
+      if (!g) g = byRepo[key] = { remote: key, runs: 0, tokensIn: 0, tokensOut: 0, tokens: EMPTY_TOKENS, commits: 0, costUSD: 0, users: new Set() }
       g.runs++
       g.tokensIn += s.input_tokens ?? 0
       g.tokensOut += s.output_tokens ?? 0
+      // Every billed counter — the column says "tok" and the sort ranks by it.
+      g.tokens = addTokens(g.tokens, sessionTokens(s))
       g.commits += s.git_commits ?? 0
       g.costUSD += sessionCost(s)
       if (s.user) g.users.add(s.user)
@@ -39,7 +45,7 @@ export default function ActionsPage() {
       switch (sortKey) {
         case 'cost': return g.costUSD
         case 'runs': return g.runs
-        case 'tokens': return g.tokensIn + g.tokensOut
+        case 'tokens': return totalTokens(g.tokens)
         case 'commits': return g.commits
         case 'members': return g.users.size
         case 'name': return (g.remote ? repoShortName(g.remote) : '').toLowerCase()
@@ -117,7 +123,7 @@ export default function ActionsPage() {
                     {linked && <ExternalLink size={11} color="var(--text-tertiary)" />}
                   </span>
                   <span style={{ fontSize: 12, color: 'var(--text-secondary)' }}>{g.runs} runs</span>
-                  <span style={{ fontSize: 12, color: 'var(--text-tertiary)' }}>{fmt(g.tokensIn + g.tokensOut)} tok</span>
+                  <span style={{ fontSize: 12, color: 'var(--text-tertiary)' }}>{fmt(totalTokens(g.tokens))} tok</span>
                   <span style={{ fontSize: 12, color: 'var(--text-tertiary)', display: 'inline-flex', alignItems: 'center', gap: 3 }}><GitCommit size={11} />{g.commits}</span>
                   <span style={{ fontSize: 12.5, fontWeight: 700, color: 'var(--anthropic-orange)', width: 90, textAlign: 'right' }}>{fmtCost(g.costUSD, currency, brlRate)}</span>
                 </div>
@@ -125,6 +131,11 @@ export default function ActionsPage() {
             })}
           </div>
         )}
+        <MetricNote>
+          {pt
+            ? 'Tokens somam os quatro contadores cobrados — entrada nova, saída, leitura e escrita de cache. Runners de CI são efêmeros e reaproveitam pouco cache entre execuções, então aqui a fatia de leitura de cache costuma ser bem menor que numa sessão sua.'
+            : 'Tokens add all four billed counters — fresh input, output, cache read and cache write. CI runners are ephemeral and reuse little cache between runs, so the cache-read share here is usually far smaller than in one of your own sessions.'}
+        </MetricNote>
       </Section>
     </>
   )

--- a/packages/web/src/pages/ComparePage.tsx
+++ b/packages/web/src/pages/ComparePage.tsx
@@ -8,6 +8,7 @@ import { HARNESS_LABELS, HARNESS_COLORS, capable } from '../lib/harness'
 import { computeFilteredHarnessSummaries } from '../hooks/useData'
 import { fmtDateLocalized } from '../lib/dateFormat'
 import { CompareByFilter } from './compare/CompareByFilter'
+import { MetricNote } from '../components/MetricNote'
 
 interface HarnessAgg {
   harness: HarnessId
@@ -501,8 +502,21 @@ function CompareByHarness() {
         </table>
       </div>
 
+      {/* Three token rows sit above each other and only one of them is the total. Without this the
+          obvious reading is that input + output should equal it, and it is off by ~300x. */}
+      <MetricNote>
+        {lang === 'pt'
+          ? 'A linha de tokens totais soma os quatro contadores cobrados. As linhas de entrada e saída abaixo dela são só dois deles — o resto é leitura e escrita de cache, que costumam ser a maior parte do volume. Por isso entrada + saída NÃO fecha com o total.'
+          : 'The total-tokens row adds all four billed counters. The input and output rows under it are only two of them — the rest is cache read and cache write, usually most of the volume. That is why input + output does NOT add up to the total.'}
+      </MetricNote>
+
       {/* Cost per 1M tokens (blended) — highlights the cheapest harness */}
       <SectionCard title={t('compare.costPerMTokens', lang)}>
+        <MetricNote style={{ marginTop: 0, marginBottom: 12 }}>
+          {lang === 'pt'
+            ? 'Custo dividido por TODOS os tokens cobrados, cache incluído. Dividir só pela conversa daria um valor dezenas de vezes maior que o cobrado, e ordenaria os assistentes por quanto cada um usa cache em vez de por quanto custa.'
+            : 'Cost divided by ALL billed tokens, cache included. Dividing by the conversation alone would report a figure tens of times higher than what is charged, and would rank assistants by how much each one caches rather than by what it costs.'}
+        </MetricNote>
         <div style={{
           display: 'grid',
           gridTemplateColumns: 'repeat(auto-fit, minmax(160px, 1fr))',

--- a/packages/web/src/pages/ComparePage.tsx
+++ b/packages/web/src/pages/ComparePage.tsx
@@ -3,7 +3,7 @@ import { useOutletContext, useSearchParams } from 'react-router-dom'
 import { GitCompare } from 'lucide-react'
 import type { AppContext } from '../lib/app-context'
 import type { HarnessId, Lang, TokenBreakdown } from '@agentistics/core'
-import { EMPTY_TOKENS, fmt, fmtCost, formatModel, t, totalTokens } from '@agentistics/core'
+import { EMPTY_TOKENS, fmt, fmtCost, formatModel, t, tokenSharePct, totalTokens } from '@agentistics/core'
 import { HARNESS_LABELS, HARNESS_COLORS, capable } from '../lib/harness'
 import { computeFilteredHarnessSummaries } from '../hooks/useData'
 import { fmtDateLocalized } from '../lib/dateFormat'
@@ -639,6 +639,12 @@ function CompareByHarness() {
           {aggs.map(a => {
             const totalSessions = aggs.reduce((s, x) => s + x.sessions, 0)
             const pct = totalSessions > 0 ? Math.round((a.sessions / totalSessions) * 100) : 0
+            // A harness with real sessions must never read `0%`. Found in the browser: Codex CLI
+            // and Kimi Code, one session each against 352, both rendered as `0%` beside a bar with
+            // visible width — the label contradicting the chart next to it. The bar keeps the raw
+            // `pct` (a 0-width bar is the honest picture of a rounding error); only the LABEL is
+            // corrected, because a label is read as a claim.
+            const pctLabel = tokenSharePct(a.sessions, totalSessions)
             return (
               <div key={a.harness}>
                 <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 6 }}>
@@ -659,7 +665,7 @@ function CompareByHarness() {
                       {a.sessions.toLocaleString()} {t('compare.sessionsLower', lang)}
                     </span>
                     <span style={{ fontSize: 12, fontWeight: 700, color: colors[a.harness], minWidth: 36, textAlign: 'right', fontVariantNumeric: 'tabular-nums' }}>
-                      {pct}%
+                      {pctLabel}
                     </span>
                   </div>
                 </div>

--- a/packages/web/src/pages/MembersPage.tsx
+++ b/packages/web/src/pages/MembersPage.tsx
@@ -8,6 +8,7 @@ import type { AppContext } from '../lib/app-context'
 import { fmt, fmtCost, formatModel, repoShortName, type HarnessId } from '@agentistics/core'
 import { aggregateMemberMetrics, withStatsCacheTotals, LOCAL_KEY, type MemberGroupBy, type MemberMetrics } from '../lib/member-metrics'
 import { cacheTotalsUsable } from '../lib/topUsage'
+import { MetricNote } from '../components/MetricNote'
 import { HARNESS_LABELS, HARNESS_COLORS } from '../lib/harness'
 import { Section } from '../components/Section'
 import { SortControl } from '../components/SortControl'
@@ -192,6 +193,7 @@ export default function MembersPage() {
         <Kpi label="Tokens" value={fmt(totalTokens)} />
         <Kpi label={pt ? 'Custo' : 'Cost'} value={fmtCost(totalCost, currency, brlRate)} accent />
       </div>
+      <MetricNote>{pt ? 'Tokens somam os quatro contadores cobrados: entrada nova, saída, leitura e escrita de cache. A leitura de cache é a maior fatia do volume na maioria das máquinas — é a conversa relida a cada turno, a cerca de 1/10 do preço da entrada nova.' : 'Tokens add all four billed counters: fresh input, output, cache read and cache write. Cache read is the largest share of the volume on most machines — the conversation re-read every turn, at roughly 1/10 the price of fresh input.'}</MetricNote>
 
       {/* Comparative charts. The cards below rank one row at a time; a chart is what makes the
           SPREAD visible — who is an outlier and by how much. The metric is switchable because

--- a/packages/web/src/pages/RepoDetailPage.tsx
+++ b/packages/web/src/pages/RepoDetailPage.tsx
@@ -20,6 +20,7 @@ import { Section } from '../components/Section'
 import { ModelBreakdown } from '../components/ModelBreakdown'
 import { ActivityChart } from '../components/ActivityChart'
 import { RecentSessions } from '../components/RecentSessions'
+import { MetricNote } from '../components/MetricNote'
 
 type Tab = 'overview' | 'members' | 'compare' | 'actions' | 'sessions' | 'workflows'
 
@@ -221,6 +222,11 @@ export default function RepoDetailPage() {
                 <StatTile label={pt ? 'Tokens' : 'Tokens'} value={fmt(ciSessions.reduce((a, s) => a + sessionTokenTotal(s), 0))} />
                 <StatTile label="Commits" value={String(ciSessions.reduce((a, s) => a + (s.git_commits ?? 0), 0))} />
               </div>
+              <MetricNote style={{ marginTop: 0, marginBottom: 12 }}>
+                {pt
+                  ? 'Tokens somam os quatro contadores cobrados: entrada nova, saída, leitura e escrita de cache.'
+                  : 'Tokens add all four billed counters: fresh input, output, cache read and cache write.'}
+              </MetricNote>
               <RecentSessions sessions={ciSessions} lang={lang} onSelect={setSelectedSession} />
             </>
           )}

--- a/packages/web/src/pages/RepositoriesPage.tsx
+++ b/packages/web/src/pages/RepositoriesPage.tsx
@@ -6,6 +6,7 @@ import type { RepoStat, RepoSortKey } from '../hooks/useData'
 import { sortRepos } from '../hooks/useData'
 import { Section } from '../components/Section'
 import { RepositoriesList } from '../components/RepositoriesList'
+import { MetricNote } from '../components/MetricNote'
 import { SortControl } from '../components/SortControl'
 
 export default function RepositoriesPage() {
@@ -130,6 +131,11 @@ export default function RepositoriesPage() {
           onOpen={openRepo}
           deniedRepoLabels={deniedRepoLabels}
         />
+        <MetricNote>
+          {lang === 'pt'
+            ? 'O número de tokens de cada card soma os quatro contadores cobrados — entrada nova, saída, leitura e escrita de cache — e é por ele que a ordenação por tokens ranqueia. Um repositório com poucas sessões longas pode ter volume maior que um com muitas sessões curtas: cada turno relê a conversa inteira do cache.'
+            : "Each card's token figure adds all four billed counters — fresh input, output, cache read and cache write — and it is what the tokens sort ranks by. A repository with a few long sessions can carry more volume than one with many short ones: every turn re-reads the whole conversation from cache."}
+        </MetricNote>
       </Section>
     </>
   )

--- a/packages/web/src/pages/TagDetailPage.tsx
+++ b/packages/web/src/pages/TagDetailPage.tsx
@@ -8,6 +8,7 @@ import { ArrowLeft, Pencil, Trash2, CalendarRange } from 'lucide-react'
 import { fmt, fmtCost, formatModel, formatProjectName, repoShortName, totalTokens as totalTokensOf } from '@agentistics/core'
 import type { AppContext } from '../lib/app-context'
 import type { TokenBreakdown } from '@agentistics/core'
+import { MetricNote } from '../components/MetricNote'
 import { HARNESS_LABELS } from '../lib/harness'
 import { ConfirmModal, SectionHeader } from './settings/primitives'
 import { useIsMobile } from '../hooks/useIsMobile'
@@ -420,6 +421,13 @@ export default function TagDetailPage() {
           <StatTile label={pt ? 'Membros' : 'Members'} value={(detail?.stats.distinctMembers ?? 0).toLocaleString()} />
           <StatTile label={pt ? 'Máquinas' : 'Machines'} value={(detail?.stats.distinctMachines ?? 0).toLocaleString()} />
         </div>
+        {/* Three token tiles side by side and only the first is the total — without this the
+            obvious reading is that the other two should add up to it. */}
+        <MetricNote>
+          {pt
+            ? '"Tokens" soma os quatro contadores cobrados. As duas caixas ao lado — entrada e saída — são só dois deles; o resto é leitura e escrita de cache, normalmente a maior parte do volume. Por isso entrada + saída não fecha com o total.'
+            : '"Tokens" adds all four billed counters. The two tiles beside it — in and out — are only two of them; the rest is cache read and cache write, usually most of the volume. That is why in + out does not add up to the total.'}
+        </MetricNote>
         {/* A tag whose sources resolve to nothing is a real, common state (a brand-new grouping, or
             one whose machines have not pushed yet) — say so instead of showing five zeros. */}
         {empty && (

--- a/packages/web/src/pages/TopUsagePage.tsx
+++ b/packages/web/src/pages/TopUsagePage.tsx
@@ -4,6 +4,7 @@ import { Trophy, Cpu, Boxes, FolderOpen, GitBranch, Users, Monitor } from 'lucid
 import { fmt, fmtCost, formatProjectName, planAllocation, repoShortName } from '@agentistics/core'
 import type { AppContext } from '../lib/app-context'
 import { Section } from '../components/Section'
+import { MetricNote } from '../components/MetricNote'
 import { HARNESS_COLORS, HARNESS_LABELS } from '../lib/harness'
 import { useIsMobile } from '../hooks/useIsMobile'
 import { rankTop, rankTopFromCaches, cacheTotalsUsable, shareOf, type TopDimension, type TopMetric, type TopEntry } from '../lib/topUsage'
@@ -136,6 +137,16 @@ export default function TopUsagePage() {
           ))}
         </div>
       </div>
+
+      {/* Stated ONCE for the whole page rather than on each of its cards: every board below ranks
+          the same measurement, and repeating the sentence six times would train people to skip it. */}
+      {metric === 'tokens' && (
+        <MetricNote style={{ marginTop: 0, marginBottom: 4 }}>
+          {pt
+            ? 'Tokens aqui são todos os contadores cobrados — entrada nova, saída, leitura e escrita de cache. A leitura de cache costuma ser a maior parte do volume (é a conversa relida a cada turno, a cerca de 1/10 do preço da entrada nova), então o ranking por tokens e o ranking por custo discordam com frequência. É por isso que os dois existem.'
+            : 'Tokens here are every billed counter — fresh input, output, cache read and cache write. Cache read is usually most of the volume (the conversation re-read every turn, at roughly 1/10 the price of fresh input), so ranking by tokens and ranking by cost routinely disagree. That is why both are offered.'}
+        </MetricNote>
+      )}
 
       <div className="ag-grid cols-2">
         {dimensions.map(dim => {


### PR DESCRIPTION
Release PR. Unlike #159, this one carries **only** the work from #160 — three commits, no other author's changes.

## Every token figure now explains itself

The labelling pass from #158 had reached 5 of the ~28 surfaces that print a token number; it now reaches 16, through one `MetricNote` component rather than fourteen inline blocks. Always visible, never a tooltip — `title` does not exist on a phone, and this text is most needed by whoever is confused right now.

Each note says what **its** number is: `ToolMetricsPanel` an attribution rather than a measurement, `AgentMetricsPanel` a slice of its session's total, `CacheHitRatePanel` why output is not in the denominator, Compare and TagDetail why in + out is not meant to equal the total.

`docs/metrics.md` states the four-counter rule, and two formulas it had wrong are corrected.

## A live bug the lint had missed

The Actions page accumulated CI tokens into fields named `tokensIn`/`tokensOut`, so its "Tokens" column and its sort were both two-counter — and the guard reported the file clean, because it only knew `inputTokens`/`input_tokens`. Fixed, and `SUM_REVERSED` now catches the other spelling (verified by reverting the page and watching the lint fail).

## Three defects only the browser could show

Ran under Playwright at 1440px and 390px — the verification the previous two releases shipped without.

- **`0%` over a real quantity.** Output, 64.2M tokens and the most expensive counter there is, rendered as `0%` against a 17.8B total, with the sentence reading "output, the most expensive token, is 0%". Same lie on Compare: Codex CLI and Kimi Code, one session each against 352, labelled `0%` beside a bar with visible width. `tokenSharePct` returns `<1%` for a quantity that exists.
- **An unreadable headline.** The header printed `17861.8M tok`. `fmt` in the core has handled billions for a long time, but **seven components** carried a private copy that stopped at millions — and nothing had exceeded a billion on those surfaces until the counters started including cache. All seven now use the shared one: `17.9B tok`.
- **Mobile, verified at last.** No horizontal page overflow on any of the eight routes; the wide agent table scrolls inside its own container; "Who leads" is a single 328px column; its metric buttons are exactly 44px. Zero console errors.

## Verification

`bun tsc --noEmit` clean, **4117 tests pass**, `bun run build` succeeds, and the dashboard was driven in a real browser at both viewports.
