### PR TITLE
release: one word for off, an id on every row, and the machine in the header

### DIFF
--- a/packages/core/src/team.ts
+++ b/packages/core/src/team.ts
@@ -36,6 +36,15 @@ export interface TeamConnection {
   /** Display name resolved from GET /api/team/whoami — never user-typed. Per connection,
    *  because each central mints its own token and resolves its own name. */
   user: string
+  /**
+   * What the CENTRAL calls this machine, resolved from `whoami` alongside `user`.
+   *
+   * Per connection, for the same reason `user` is: each central mints its own token and names the
+   * machine itself. Optional because an older central does not send one and a connection that has
+   * never completed a handshake has not learned it yet — absent means unknown, never a hostname
+   * substituted for it.
+   */
+  machineName?: string
   /** Bearer secret (never logged). May be '' against an open/legacy central. */
   token: string
   /** LEGACY MIRROR of `sources`, DERIVED on every write by `normalizeTeamConfig` — never edited

--- a/packages/server/server/cli-start.ts
+++ b/packages/server/server/cli-start.ts
@@ -1680,7 +1680,7 @@ function createControlHost(initialLang: CliLang, altScreen: Suspendable): StartH
    * deliberately does not try to price the whole machine — `MemAvailable` already accounts for
    * everything else, and RESERVED_BYTES holds room back for it.
    */
-  const memoryStatus = async (): Promise<{ memory?: { used: number; max: number; red: boolean } }> => {
+  const memoryStatus = async (): Promise<Pick<ControlStatus, 'memory'>> => {
     try {
       const sample = await readMemory()
       if (!sample) return {}
@@ -1690,10 +1690,40 @@ function createControlHost(initialLang: CliLang, altScreen: Suspendable): StartH
         .map(f => f.pid!)
       const { bytes, read } = await readRss(pids)
       const b = memoryBudget({ sample, sessionBytes: bytes, sessions: read })
-      return { memory: { used: b.used, max: b.max, red: b.red } }
+      return { memory: { used: b.used, max: b.max, red: b.red, percent: b.percent } }
     } catch {
       // Best-effort, exactly like every other reader on this object: a gauge that throws must not
       // take the whole status down with it.
+      return {}
+    }
+  }
+
+  /**
+   * The machine's name on its central and the last push's round trip, or `{}`.
+   *
+   * Read from the LOCAL server's `/api/team/status`, which is the process that actually pushes —
+   * this one only draws. Best-effort and short-timeout on purpose: the cockpit must open on a
+   * machine whose server is down, and a header fact is never worth a hang. Absent beats wrong here
+   * as everywhere: no name is drawn rather than a hostname standing in for one.
+   */
+  const centralIdentity = async (): Promise<Pick<ControlStatus, 'machineName' | 'pushMs'>> => {
+    try {
+      const res = await fetch(`http://localhost:${PORT}/api/team/status`, {
+        signal: AbortSignal.timeout(1200),
+      })
+      if (!res.ok) return {}
+      const body = await res.json() as {
+        connections?: Array<{ machineName?: unknown; latencyMs?: unknown }>
+      }
+      // The FIRST connection: a machine with several centrals has one name per central, and a header
+      // cell cannot carry a list. The connection card shows them all.
+      const first = body.connections?.[0]
+      const name = typeof first?.machineName === 'string' && first.machineName ? first.machineName : undefined
+      const ms = typeof first?.latencyMs === 'number' && Number.isFinite(first.latencyMs)
+        ? Math.max(0, Math.round(first.latencyMs))
+        : undefined
+      return { ...(name ? { machineName: name } : {}), ...(ms !== undefined ? { pushMs: ms } : {}) }
+    } catch {
       return {}
     }
   }
@@ -1896,6 +1926,12 @@ function createControlHost(initialLang: CliLang, altScreen: Suspendable): StartH
         services,
         version: CURRENT_VERSION,
         latestVersion,
+        // WHICH machine this is on its central, and how long the last push took. Both come from the
+        // running server's own status route rather than being re-derived here: the uploader already
+        // resolves the name from `whoami` and already times its round trips, and a second
+        // implementation of either would be a second answer that can disagree with the one the
+        // connection card shows.
+        ...(await centralIdentity()),
         // The parallel-sessions budget. Computed HERE and not in the TUI, like every other decision
         // on this object: the arithmetic lives in the pure `memory-budget.ts` and the two `/proc`
         // reads in `memory-probe.ts`, and the answer arrives already decided — including `red`,

--- a/packages/server/server/sessions/memory-budget.test.ts
+++ b/packages/server/server/sessions/memory-budget.test.ts
@@ -46,6 +46,41 @@ describe('parseMeminfo', () => {
   })
 })
 
+describe('memoryBudget — how loaded the machine is', () => {
+  it('reports RAM and SWAP as one pool', () => {
+    // Two readings are wanted and neither implies the other: `used/max` answers "can I open
+    // another one", this answers "how close is this box to the edge". Two of seventeen is
+    // comfortable; two of seventeen while swapping is not.
+    const half = memoryBudget({
+      sample: { total: 8 * GB, available: 4 * GB, swapTotal: 0, swapUsed: 0 },
+      sessionBytes: 0, sessions: 0,
+    })
+    expect(half.percent).toBe(50)
+  })
+
+  it('counts swap as USED, so a full swap cannot hide behind free RAM', () => {
+    // The freeze this exists for: 3.6 GB of free RAM at 97% swap. Reading RAM alone called that
+    // machine healthy at the moment it stopped responding.
+    const swapping = memoryBudget({
+      sample: { total: 16 * GB, available: 3.6 * GB, swapTotal: 4 * GB, swapUsed: 3.9 * GB },
+      sessionBytes: 0, sessions: 0,
+    })
+    const ramOnly = Math.round((1 - 3.6 / 16) * 100)
+    expect(swapping.percent).toBeGreaterThan(ramOnly)
+  })
+
+  it('is bounded, and answers 0 for a machine it could not measure', () => {
+    const none = memoryBudget({
+      sample: { total: 0, available: 0, swapTotal: 0, swapUsed: 0 }, sessionBytes: 0, sessions: 0,
+    })
+    expect(none.percent).toBe(0)
+    const over = memoryBudget({
+      sample: { total: 1 * GB, available: 0, swapTotal: 0, swapUsed: 0 }, sessionBytes: 0, sessions: 0,
+    })
+    expect(over.percent).toBeLessThanOrEqual(100)
+  })
+})
+
 describe('memoryBudget', () => {
   it('measures the cost from what is running, rather than assuming', () => {
     const b = memoryBudget({ sample: sample(), sessionBytes: 1200 * MB, sessions: 4 })

--- a/packages/server/server/sessions/memory-budget.ts
+++ b/packages/server/server/sessions/memory-budget.ts
@@ -76,6 +76,18 @@ export interface MemoryBudget {
   /** `max - used`, floored at zero. */
   left: number
   cost: SessionCost
+  /**
+   * How much of the machine is IN USE, 0-100 — RAM and swap together.
+   *
+   * Asked for and missing from the first cut, which shipped only `used/max`. That number answers
+   * "can I open another one" and says nothing about how close the machine is to the edge: two
+   * sessions of the seventeen it can hold is comfortable, and two of seventeen on a box already
+   * swapping is not. Both readings are wanted and neither implies the other.
+   *
+   * Swap counts as used, because a page that had to be swapped out is pressure whatever the RAM
+   * figure says — the freeze this whole feature exists for read 3.6 GB of free RAM at 97% swap.
+   */
+  percent: number
   /** True once `left` is inside `RED_WITHIN`, or the swap alarm has tripped. */
   red: boolean
   /**
@@ -122,7 +134,18 @@ export function memoryBudget(o: {
   // Swap is named FIRST when both trip: it is the more urgent fact and the one closing a session
   // may not fix.
   const alarm = swapping ? 'swap' as const : left <= RED_WITHIN ? 'sessions' as const : undefined
-  return { max, used: o.sessions, left, cost, red: alarm !== undefined, ...(alarm ? { alarm } : {}) }
+
+  // RAM and swap as ONE pool: everything the machine has, minus everything still free. A box whose
+  // RAM is nominally fine while its swap is full is not a box with room, and reporting the two
+  // separately lets the calm half of the pair carry the headline.
+  const capacity = o.sample.total + o.sample.swapTotal
+  const free = Math.max(0, o.sample.available) + Math.max(0, o.sample.swapTotal - o.sample.swapUsed)
+  const percent = capacity > 0 ? Math.min(100, Math.max(0, Math.round((1 - free / capacity) * 100))) : 0
+
+  return {
+    max, used: o.sessions, left, cost, percent,
+    red: alarm !== undefined, ...(alarm ? { alarm } : {}),
+  }
 }
 
 /**

--- a/packages/server/server/team-connections.ts
+++ b/packages/server/server/team-connections.ts
@@ -898,6 +898,11 @@ export function buildConnectionStatusEntry(
     endpoint: conn.endpoint,
     org: conn.org,
     user: conn.user,
+    // The name the CENTRAL gave this machine. Already resolved from `whoami` and already stored on
+    // the connection; it simply had no way out of this process. The cockpit's header draws it so
+    // two SSH'd terminals running identical cockpits can be told apart — which was reported as
+    // impossible, and was.
+    ...(conn.machineName ? { machineName: conn.machineName } : {}),
     ...(conn.label ? { label: conn.label } : {}),
     lastSuccessAt: uploaderStatus.lastSuccessAt,
     errKind,

--- a/packages/tui/scripts/preview.tsx
+++ b/packages/tui/scripts/preview.tsx
@@ -287,11 +287,14 @@ function fakeStatus(opts: Options, apiUrl?: string): ControlStatus {
     modeLabel: opts.mode === 'member' ? s.configMemberBare : opts.mode === 'central' ? s.configCentral : s.configSolo,
     endpoint: opts.mode === 'member' ? LONG_ENDPOINT : undefined,
     services: services(opts.mode, s, apiUrl),
+    // A member machine carries a NAME and a latency; the sweep has to see the header at its widest,
+    // or the fit is only ever checked in the shape that happens to be shortest.
+    ...(opts.mode === 'member' ? { machineName: 'wsl-mithrandir', pushMs: 468 } : {}),
     version: '1.7.3',
     latestVersion: '1.7.4',
     // The parallel-sessions budget, so the width sweep exercises the header WITH it. A calm one:
     // the red case gives way later than this does, so a frame that fits this fits that too.
-    memory: { used: 3, max: 17, red: false },
+    memory: { used: 3, max: 17, red: false, percent: 62 },
     archiveMode: 'consolidate',
     // The wizard's blocked row, stated whenever the fake central is up: it is the case the fold
     // exists for, and a preview that only ever drew three selectable modes would never show it.

--- a/packages/tui/src/control/Chrome.tsx
+++ b/packages/tui/src/control/Chrome.tsx
@@ -91,6 +91,10 @@ function HeaderTag({ meta }: { meta: HeaderMeta }) {
   return (
     <Text>
       <Text dimColor>{meta.text}</Text>
+      {/* WHICH machine, and whether its link is alive. In `secondary` rather than dim: it is the
+          thing a person scans for when two terminals look identical, so it has to be findable at a
+          glance without competing with the waiting counter's accent. */}
+      {meta.machine ? <Text color={COLORS.secondary}>{` · ${meta.machine}`}</Text> : null}
       {meta.alert ? <Text color={COLORS.accent} bold>{` · ${meta.alert}`}</Text> : null}
       {/* The parallel-sessions budget. Dim while there is room, `danger` once the ceiling is close
           or the machine is already swapping — but the NUMBERS are always drawn, so a reader who

--- a/packages/tui/src/control/Chrome.tsx
+++ b/packages/tui/src/control/Chrome.tsx
@@ -87,6 +87,19 @@ export function Header({ layout, width }: { layout: HeaderLayout; width: number 
  * version: a bare accent-coloured digit beside a dim one says nothing on a terminal that drops
  * colour, and this is the piece a user is meant to act on.
  */
+/**
+ * The load bar's colours, by level.
+ *
+ * `undefined` for `ok` so a healthy machine stays DIM like the rest of the tag — a permanently
+ * green bar in the corner is a light nobody looks at, and the whole value of this cell is that a
+ * change in it is noticeable.
+ */
+const LOAD_COLOR: Record<'ok' | 'warn' | 'full', string | undefined> = {
+  ok: undefined,
+  warn: COLORS.accent,
+  full: COLORS.danger,
+}
+
 function HeaderTag({ meta }: { meta: HeaderMeta }) {
   return (
     <Text>
@@ -99,12 +112,18 @@ function HeaderTag({ meta }: { meta: HeaderMeta }) {
       {/* The parallel-sessions budget. Dim while there is room, `danger` once the ceiling is close
           or the machine is already swapping — but the NUMBERS are always drawn, so a reader who
           cannot tell the two shades apart still has the whole message. Colour never carries it. */}
+      {/* Coloured by how FULL the machine is, htop-style — green while there is room, amber as it
+          tightens, red near the top. The session-budget alarm (`memoryRed`) still wins when it
+          trips, because "no room for another assistant" is the more actionable of the two and they
+          are genuinely different facts: a box can sit at 95% with room for three more sessions, or
+          have room for none at 40% because the ones running are enormous. The NUMBERS are always
+          drawn, so colour never carries the message alone. */}
       {meta.memory
         ? (
           <Text
-            color={meta.memoryRed ? COLORS.danger : undefined}
-            dimColor={!meta.memoryRed}
-            bold={meta.memoryRed}
+            color={meta.memoryRed ? COLORS.danger : LOAD_COLOR[meta.memoryLevel ?? 'ok']}
+            dimColor={!meta.memoryRed && (meta.memoryLevel ?? 'ok') === 'ok'}
+            bold={meta.memoryRed || meta.memoryLevel === 'full'}
           >
             {` · ${meta.memory}`}
           </Text>

--- a/packages/tui/src/control/ControlCenter.tsx
+++ b/packages/tui/src/control/ControlCenter.tsx
@@ -369,6 +369,10 @@ export function ControlCenter({ host, lang: initialLang, initial, onExit, mouse 
     // zero. The host decides `red`, from the distance to the ceiling AND from swap pressure; the
     // TUI owns no logic here either.
     ...(status?.memory ? { memory: status.memory } : {}),
+    // WHICH machine, and whether its link is alive. Absent in solo mode and on a machine that has
+    // never completed a handshake — no name is drawn rather than a hostname standing in for one.
+    ...(status?.machineName ? { machineName: status.machineName } : {}),
+    ...(status?.pushMs !== undefined ? { pushMs: status.pushMs } : {}),
     width,
   })
   const height = bodyHeight(rows, header.rows)

--- a/packages/tui/src/control/chrome.test.ts
+++ b/packages/tui/src/control/chrome.test.ts
@@ -21,6 +21,11 @@ import {
   headerLayout,
   headerMeta,
   headerMetaWidth,
+  loadBar,
+  loadLevel,
+  LOAD_BAR,
+  LOAD_WARN,
+  LOAD_HIGH,
   HINT_SEP,
   LEFT_MAX_SHARE,
   LEFT_MIN,
@@ -208,6 +213,33 @@ describe('footerHints', () => {
   })
 })
 
+describe('the load bar', () => {
+  test('fills in proportion, and rounds DOWN like the number beside it', () => {
+    // A bar showing full while the label says 99% is one of them being wrong, and it would be the
+    // bar — the shape is what gets believed at a glance.
+    expect(loadBar(0)).toBe('░'.repeat(LOAD_BAR))
+    expect(loadBar(100)).toBe('█'.repeat(LOAD_BAR))
+    expect(loadBar(50)).toBe('████░░░░')
+    expect(loadBar(99)).not.toBe('█'.repeat(LOAD_BAR))
+  })
+
+  test('is bounded by a machine that reports nonsense', () => {
+    expect(loadBar(-5)).toBe('░'.repeat(LOAD_BAR))
+    expect(loadBar(9999)).toBe('█'.repeat(LOAD_BAR))
+  })
+
+  test('changes level as it climbs — the whole point of the colour', () => {
+    // The thresholds are the MEMORY's, not the context window's: a context window at 80% is worth
+    // noticing, a machine at 80% is already slow and one at 90% is minutes from swapping.
+    expect(loadLevel(10)).toBe('ok')
+    expect(loadLevel(LOAD_WARN - 1)).toBe('ok')
+    expect(loadLevel(LOAD_WARN)).toBe('warn')
+    expect(loadLevel(LOAD_HIGH - 1)).toBe('warn')
+    expect(loadLevel(LOAD_HIGH)).toBe('full')
+    expect(loadLevel(100)).toBe('full')
+  })
+})
+
 describe('headerMeta', () => {
   test('states the mode, the version and the update dot when there is room', () => {
     const meta = headerMeta({ mode: 'member', version: '1.7.3', latestVersion: '1.7.4', width: 60 })
@@ -222,7 +254,9 @@ describe('headerMeta', () => {
     // Sessions AND load: `3/17` says how many more fit, `62%` says how hard the box is already
     // working. A machine at 90% for reasons unrelated to agentop reads comfortable on the ratio
     // alone, which is why the percentage was asked for after the first pass shipped only the ratio.
-    expect(with_.memory).toBe('ram 3/17 62%')
+    // A BAR, like htop, because a bare `62%` does not say what is 62% full. Both are drawn: the
+    // shape is what gets read at a glance, the number is what gets acted on.
+    expect(with_.memory).toBe('ram ████░░░░ 62% · 3/17')
     expect(with_.memoryRed).toBe(false)
     // A machine whose memory cannot be read draws no gauge at all — never a zero, which would read
     // as "no room left" on precisely the machines nobody could ask.
@@ -254,11 +288,12 @@ describe('headerMeta', () => {
     const narrow = { mode: 'solo', version: '1.7.4', latestVersion: '1.9.0', attention: 2 }
     // Widened with the cell: it now carries the percentage too, so the row it has to survive on is
     // wider than it was. The ASSERTION is the ordering, not the number of columns.
-    const red = headerMeta({ ...narrow, memory: { used: 14, max: 15, red: true, percent: 91 }, width: 30 })
-    expect(red.memory).toBe('ram 14/15 91%')
+    // Wider than before, because the cell now carries a bar too. The ASSERTION is the ordering.
+    const red = headerMeta({ ...narrow, memory: { used: 14, max: 15, red: true, percent: 91 }, width: 44 })
+    expect(red.memory).toContain('91%')
     expect(red.text).toBe('solo')            // the version went first
     // …while a calm budget gives way instead, because it is only informational.
-    const calm = headerMeta({ ...narrow, memory: { used: 3, max: 17, red: false, percent: 62 }, width: 30 })
+    const calm = headerMeta({ ...narrow, memory: { used: 3, max: 17, red: false, percent: 62 }, width: 44 })
     expect(calm.memory).toBe('')
   })
 

--- a/packages/tui/src/control/chrome.test.ts
+++ b/packages/tui/src/control/chrome.test.ts
@@ -217,9 +217,12 @@ describe('headerMeta', () => {
 
   test('draws the parallel-sessions budget, and NOTHING when it could not be measured', () => {
     const with_ = headerMeta({
-      mode: 'solo', version: '1.7.4', memory: { used: 3, max: 17, red: false }, width: 60,
+      mode: 'solo', version: '1.7.4', memory: { used: 3, max: 17, red: false, percent: 62 }, width: 60,
     })
-    expect(with_.memory).toBe('ram 3/17')
+    // Sessions AND load: `3/17` says how many more fit, `62%` says how hard the box is already
+    // working. A machine at 90% for reasons unrelated to agentop reads comfortable on the ratio
+    // alone, which is why the percentage was asked for after the first pass shipped only the ratio.
+    expect(with_.memory).toBe('ram 3/17 62%')
     expect(with_.memoryRed).toBe(false)
     // A machine whose memory cannot be read draws no gauge at all — never a zero, which would read
     // as "no room left" on precisely the machines nobody could ask.
@@ -236,7 +239,7 @@ describe('headerMeta', () => {
     // memory here and owns no row in the list) while the list counts ROWS after its filter. The
     // label is the only thing that can say so, so the label is pinned.
     const meta = headerMeta({
-      mode: 'solo', version: '1.7.4', memory: { used: 5, max: 18, red: false }, width: 60,
+      mode: 'solo', version: '1.7.4', memory: { used: 5, max: 18, red: false, percent: 62 }, width: 60,
     })
     expect(meta.memory).toContain('ram')
     expect(meta.memory).not.toContain('▤')
@@ -249,11 +252,13 @@ describe('headerMeta', () => {
     // thing on the row. Dropping the warning to keep a version number would be the wrong trade at
     // exactly the moment it matters — the version is one `agentop --version` away.
     const narrow = { mode: 'solo', version: '1.7.4', latestVersion: '1.9.0', attention: 2 }
-    const red = headerMeta({ ...narrow, memory: { used: 14, max: 15, red: true }, width: 22 })
-    expect(red.memory).toBe('ram 14/15')
+    // Widened with the cell: it now carries the percentage too, so the row it has to survive on is
+    // wider than it was. The ASSERTION is the ordering, not the number of columns.
+    const red = headerMeta({ ...narrow, memory: { used: 14, max: 15, red: true, percent: 91 }, width: 30 })
+    expect(red.memory).toBe('ram 14/15 91%')
     expect(red.text).toBe('solo')            // the version went first
     // …while a calm budget gives way instead, because it is only informational.
-    const calm = headerMeta({ ...narrow, memory: { used: 3, max: 17, red: false }, width: 22 })
+    const calm = headerMeta({ ...narrow, memory: { used: 3, max: 17, red: false, percent: 62 }, width: 30 })
     expect(calm.memory).toBe('')
   })
 
@@ -262,7 +267,7 @@ describe('headerMeta', () => {
     // the last thing standing after the mode token.
     const meta = headerMeta({
       mode: 'solo', version: '1.7.4', latestVersion: '1.9.0', attention: 2,
-      memory: { used: 3, max: 17, red: false }, width: 12,
+      memory: { used: 3, max: 17, red: false, percent: 62 }, width: 12,
     })
     expect(meta.alert).toBe('⏳ 2')
     expect(meta.memory).toBe('')

--- a/packages/tui/src/control/chrome.ts
+++ b/packages/tui/src/control/chrome.ts
@@ -191,7 +191,11 @@ export interface HeaderMetaInput {
    * drawn. `red` is decided by the host, from the distance to the ceiling and from swap pressure —
    * the TUI owns no logic, here as everywhere.
    */
-  memory?: { used: number; max: number; red: boolean }
+  memory?: { used: number; max: number; red: boolean; percent: number }
+  /** What this machine is called on its central, when it has one. */
+  machineName?: string
+  /** Round trip of the last successful push, ms. */
+  pushMs?: number
   width: number
 }
 
@@ -219,11 +223,20 @@ export interface HeaderMeta {
   memory: string
   /** True when the budget is inside its warning distance — the caller colours it. */
   memoryRed?: boolean
+  /**
+   * The machine's name on its central, and the last push's round trip.
+   *
+   * One cell, because they are one fact: WHICH machine this is and whether its link is alive.
+   * Split in two they would compete for the same corner and drop independently, leaving a latency
+   * belonging to no named machine.
+   */
+  machine: string
 }
 
 /** What the pieces cost together, separators included — the number the caller budgets against. */
 export function headerMetaWidth(meta: HeaderMeta): number {
   return meta.text.length
+    + (meta.machine ? SEP.length + meta.machine.length : 0)
     + (meta.alert ? SEP.length + meta.alert.length : 0)
     + (meta.memory ? SEP.length + meta.memory.length : 0)
     + (meta.update ? SEP.length + meta.update.length : 0)
@@ -245,8 +258,8 @@ export function headerMetaWidth(meta: HeaderMeta): number {
  * and it is the piece that must survive a narrow terminal.
  */
 export function headerMeta(input: HeaderMetaInput): HeaderMeta {
-  const { mode, version, latestVersion, attention, memory, width } = input
-  if (width <= 0) return { text: '', alert: '', update: '', memory: '' }
+  const { mode, version, latestVersion, attention, memory, machineName, pushMs, width } = input
+  if (width <= 0) return { text: '', machine: '', alert: '', update: '', memory: '' }
 
   const outdated = Boolean(latestVersion && latestVersion !== version)
   const text = version ? `${mode}${SEP}v${version}` : mode
@@ -262,10 +275,18 @@ export function headerMeta(input: HeaderMetaInput): HeaderMeta {
   // process and no row of its own) while the list counts ROWS after its filter — so no arithmetic
   // fix is available or wanted. What was missing is that the gauge never said what it measures. A
   // word costs one column over the glyph and is the same in both languages.
-  const mem = memory ? `ram ${memory.used}/${memory.max}` : ''
+  // Sessions AND load, because they answer different questions: `3/17` is how many more assistants
+  // fit, `62%` is how hard the box is already working — a machine at 90% for reasons unrelated to
+  // agentop reads comfortable on the ratio alone. Reported as missing after the first pass.
+  const mem = memory ? `ram ${memory.used}/${memory.max} ${memory.percent}%` : ''
   const red = memory?.red === true
+  // Which machine this is, and whether its link is alive. Two SSH'd terminals running identical
+  // cockpits are otherwise indistinguishable — the name already existed and was simply never shown.
+  const machine = machineName
+    ? (pushMs !== undefined ? `${machineName} ${pushMs}ms` : machineName)
+    : ''
 
-  const full = { text, alert, update, memory: mem, memoryRed: red }
+  const full = { text, machine, alert, update, memory: mem, memoryRed: red }
   if (headerMetaWidth(full) <= width) return full
 
   // Dropped least-actionable first, exactly as before. The budget sits between the update notice
@@ -280,14 +301,23 @@ export function headerMeta(input: HeaderMetaInput): HeaderMeta {
   const withoutMemory = { ...full, update: '', memory: red ? mem : '' }
   if (headerMetaWidth(withoutMemory) <= width) return withoutMemory
 
-  const withoutVersion = { text: mode, alert, update: '', memory: red ? mem : '', memoryRed: red }
+  // The version goes before the machine NAME: a version is one `agentop --version` away, while the
+  // name is the answer to "which box am I looking at" — the whole reason it is on the row, and
+  // unanswerable from anywhere else in a terminal SSH'd into somewhere.
+  const withoutVersion = { text: mode, machine, alert, update: '', memory: red ? mem : '', memoryRed: red }
   if (headerMetaWidth(withoutVersion) <= width) return withoutVersion
 
-  const modeAndAlert = { text: mode, alert, update: '', memory: '' }
+  // Then the latency, keeping the bare name. Knowing WHICH machine survives longer than knowing how
+  // fast it answered.
+  const bareName = machineName ?? ''
+  const withoutLatency = { text: mode, machine: bareName, alert, update: '', memory: red ? mem : '', memoryRed: red }
+  if (headerMetaWidth(withoutLatency) <= width) return withoutLatency
+
+  const modeAndAlert = { text: mode, machine: '', alert, update: '', memory: '' }
   if (headerMetaWidth(modeAndAlert) <= width) return modeAndAlert
 
-  if (mode.length <= width) return { text: mode, alert: '', update: '', memory: '' }
-  return { text: truncate(mode, width), alert: '', update: '', memory: '' }
+  if (mode.length <= width) return { text: mode, machine: '', alert: '', update: '', memory: '' }
+  return { text: truncate(mode, width), machine: '', alert: '', update: '', memory: '' }
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/tui/src/control/chrome.ts
+++ b/packages/tui/src/control/chrome.ts
@@ -16,6 +16,9 @@ import type { ControlStrings } from './i18n'
 // the function that turns a `CockpitLayout` into one, beside the function that produced the layout.
 import type { Rect } from './hit'
 import { truncate } from '../components/Primitives'
+// The SAME bar the session rows draw for the context window. One gauge shape per application: two
+// drawn differently read as two different kinds of measurement.
+import { contextBar } from './sessions'
 import { MARK_WIDTH, WORDMARK_ART, WORDMARK_WIDTH } from '../components/Wordmark'
 
 export interface TabSpec {
@@ -224,6 +227,15 @@ export interface HeaderMeta {
   /** True when the budget is inside its warning distance — the caller colours it. */
   memoryRed?: boolean
   /**
+   * How full the machine is, as a LEVEL — what the caller colours the bar by.
+   *
+   * Separate from `memoryRed`, which is the SESSION budget's alarm ("no room for another
+   * assistant"). A machine can be at 95% with room for three more sessions, and it can have room
+   * for none while sitting at 40% because the sessions running are enormous. Two facts, two
+   * colours, and collapsing them would make one of the two lie.
+   */
+  memoryLevel?: 'ok' | 'warn' | 'full'
+  /**
    * The machine's name on its central, and the last push's round trip.
    *
    * One cell, because they are one fact: WHICH machine this is and whether its link is alive.
@@ -234,6 +246,35 @@ export interface HeaderMeta {
 }
 
 /** What the pieces cost together, separators included — the number the caller budgets against. */
+/**
+ * Columns the load bar takes. Short on purpose: it shares a row with the mode, the version, the
+ * machine, the waiting counter and the update notice, and every column it takes is one of theirs.
+ * Eight is enough to read a half from a quarter at a glance, which is all a bar has to do.
+ */
+export const LOAD_BAR = 8
+
+/** How full the machine is, as a bar — the same shape the context gauge uses. */
+export function loadBar(percent: number): string {
+  return contextBar(Math.max(0, Math.min(100, percent)) / 100, LOAD_BAR)
+}
+
+/**
+ * What the bar is SAYING, so the caller can colour it — the same three-level vocabulary the context
+ * gauge uses, and for the same reason: a machine at 90% and a context window at 90% are the same
+ * warning to the person reading them.
+ *
+ * The thresholds are the memory's own, not the context window's. A context window at 80% is worth
+ * noticing; a machine at 80% is already slow, and one at 90% is minutes from swapping.
+ */
+export const LOAD_WARN = 75
+export const LOAD_HIGH = 90
+
+export function loadLevel(percent: number): 'ok' | 'warn' | 'full' {
+  if (percent >= LOAD_HIGH) return 'full'
+  if (percent >= LOAD_WARN) return 'warn'
+  return 'ok'
+}
+
 export function headerMetaWidth(meta: HeaderMeta): number {
   return meta.text.length
     + (meta.machine ? SEP.length + meta.machine.length : 0)
@@ -278,7 +319,13 @@ export function headerMeta(input: HeaderMetaInput): HeaderMeta {
   // Sessions AND load, because they answer different questions: `3/17` is how many more assistants
   // fit, `62%` is how hard the box is already working — a machine at 90% for reasons unrelated to
   // agentop reads comfortable on the ratio alone. Reported as missing after the first pass.
-  const mem = memory ? `ram ${memory.used}/${memory.max} ${memory.percent}%` : ''
+  // A BAR, like htop, because a bare `62%` does not say what is 62% full. The shape is what gets
+  // read at a glance and the number is what gets acted on, so both are drawn — and the bar is the
+  // SAME `contextBar` the session rows use for the context window rather than a second one: two
+  // gauges drawn differently in one application read as two different kinds of measurement.
+  const mem = memory
+    ? `ram ${loadBar(memory.percent)} ${memory.percent}% · ${memory.used}/${memory.max}`
+    : ''
   const red = memory?.red === true
   // Which machine this is, and whether its link is alive. Two SSH'd terminals running identical
   // cockpits are otherwise indistinguishable — the name already existed and was simply never shown.
@@ -286,7 +333,11 @@ export function headerMeta(input: HeaderMetaInput): HeaderMeta {
     ? (pushMs !== undefined ? `${machineName} ${pushMs}ms` : machineName)
     : ''
 
-  const full = { text, machine, alert, update, memory: mem, memoryRed: red }
+  const level = memory ? loadLevel(memory.percent) : undefined
+  const full = {
+    text, machine, alert, update, memory: mem, memoryRed: red,
+    ...(level ? { memoryLevel: level } : {}),
+  }
   if (headerMetaWidth(full) <= width) return full
 
   // Dropped least-actionable first, exactly as before. The budget sits between the update notice
@@ -304,13 +355,13 @@ export function headerMeta(input: HeaderMetaInput): HeaderMeta {
   // The version goes before the machine NAME: a version is one `agentop --version` away, while the
   // name is the answer to "which box am I looking at" — the whole reason it is on the row, and
   // unanswerable from anywhere else in a terminal SSH'd into somewhere.
-  const withoutVersion = { text: mode, machine, alert, update: '', memory: red ? mem : '', memoryRed: red }
+  const withoutVersion = { text: mode, machine, alert, update: '', memory: red ? mem : '', memoryRed: red, ...(level ? { memoryLevel: level } : {}) }
   if (headerMetaWidth(withoutVersion) <= width) return withoutVersion
 
   // Then the latency, keeping the bare name. Knowing WHICH machine survives longer than knowing how
   // fast it answered.
   const bareName = machineName ?? ''
-  const withoutLatency = { text: mode, machine: bareName, alert, update: '', memory: red ? mem : '', memoryRed: red }
+  const withoutLatency = { text: mode, machine: bareName, alert, update: '', memory: red ? mem : '', memoryRed: red, ...(level ? { memoryLevel: level } : {}) }
   if (headerMetaWidth(withoutLatency) <= width) return withoutLatency
 
   const modeAndAlert = { text: mode, machine: '', alert, update: '', memory: '' }

--- a/packages/tui/src/control/types.ts
+++ b/packages/tui/src/control/types.ts
@@ -850,7 +850,43 @@ export interface ControlStatus {
    * warning) and from swap pressure, which is what actually freezes a machine: the incident this
    * exists for read 3.6 GB of free RAM while swap sat at 97%.
    */
-  memory?: { used: number; max: number; red: boolean }
+  memory?: {
+    used: number
+    max: number
+    red: boolean
+    /**
+     * How much of the MACHINE is in use, 0-100.
+     *
+     * Beside `used/max` rather than instead of it: they answer different questions, and the first
+     * alone was not enough. `3/17` says how many more assistants fit; it says nothing about a box
+     * already at 90% for reasons that have nothing to do with agentop. Reported as missing after
+     * the first pass shipped only the ratio.
+     *
+     * Counts SWAP as used, like the alarm does — the freeze this warns about read 3.6 GB of free
+     * RAM at 97% swap, so a RAM-only figure would print a comfortable number at the worst moment.
+     */
+    percent: number
+  }
+  /**
+   * What this machine is CALLED on the central it pushes to.
+   *
+   * Reported: "uso 1 computador e acesso mais 1 via ssh, e daí não lembro qual agentop é de qual
+   * máquina". Two identical cockpits in two terminals are indistinguishable, and the name already
+   * exists — the central mints it onto the token and the member reads it back from `whoami`. It was
+   * simply never shown.
+   *
+   * Absent in solo mode: there is no central to have named it, and substituting a hostname would be
+   * a different fact wearing the same label.
+   */
+  machineName?: string
+  /**
+   * Round trip of the last successful contact with the central, in milliseconds.
+   *
+   * `undefined` before the first one and wherever nothing is pushed — never `0`, which would read
+   * as an instant round trip rather than as no measurement. It is the number that says the link is
+   * WORKING rather than merely configured.
+   */
+  pushMs?: number
   /** The history-preservation setting in force, or `undefined` while it is still unanswered. */
   archiveMode?: ArchiveMode
   /**


### PR DESCRIPTION
Everything merged into `dev` since v1.15.0.

## The list stops offering the same choice three times

`encerrada` / `perdida` / `fechada` became one word — and then one **row**. The first pass collapsed only the label, which left three menu entries all reading `desligada`: worse than three different words, because one choice was offered three times with nothing on screen saying why. The BUCKET collapses now, not just its name, and the legacy preference migration goes through the same bucket so a stored `showExited` cannot filter for states that no longer key to themselves.

## Reopen works again

Being in `claude agents --json` is not being alive. Measured: 8 records, **2 with a pid** — the other six were `background`/`blocked` with no process at all, and counting them as held is what refused a reopen for a conversation nothing was holding. And when something *is* holding it, the answer is no longer a refusal naming a place that does not exist: `planTakeover` closes the assistant and reopens the conversation, harness-agnostic, checking that the harness can resume **before** anything is killed.

## The header answers three questions it could not

```
member · v1.7.3 · wsl-mithrandir 468ms · ⏳ 2 · ram ████░░░░ 62% · 3/17 · ● 1.7.4
```

- **which machine** — the name already existed (the central mints it, `whoami` returns it) and had no way out of the uploader's process. Two SSH'd terminals running identical cockpits were indistinguishable;
- **whether the link is alive** — the round trip was already measured and never shown;
- **how loaded the box is** — a bar, htop-style, reusing the context gauge's renderer rather than a second one. Coloured by a level whose thresholds are the memory's own, and deliberately not the same flag as the session-budget alarm: a box can sit at 95% with room for three more sessions, or have none at 40%.

## Also

An id on every row including external ones; the focused row entirely in the accent; the per-row `[x]` gone; a row written only for a session that actually started; task deletion that keeps the sessions and removes only the label.

## Verification

On dev at f58d360: `bun tsc --noEmit` clean, `bun test` **4123 pass / 0 fail**, binary compiles, width sweep at 80/110/150/190 columns with zero rows overflowing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TBcRtC62Sx18sgJj64r1Np