### PR TITLE
feat(sessions): rename lands in both places, and a lost session is taken back

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -254,7 +254,52 @@ packages/server/server/          — server-side modules (never bundled by Vite)
   │                          thing drawing a row) and `session-table.ts` is the pure renderer behind
   │                          `agentop session ls` — including `emptyReason`, which keeps "the poll
   │                          failed", "there is nothing" and "the filter withheld it" three different
-  │                          sentences. See docs/session-manager.md
+  │                          sentences.
+  │                          **A RENAME lands in BOTH places a session can be named.** The reverse
+  │                          direction always worked (`pickTitle` reads the harness's own record);
+  │                          only agentop→harness was missing, so a row renamed here kept whatever
+  │                          the harness went on calling itself and lost to it on recency. The pure
+  │                          `rename-spec.ts` is `Record<HarnessId, RenameSpec|null>` and holds ONE
+  │                          entry — claude's `/rename`, read from its own command table
+  │                          (`immediate: true`, so it costs the session no turn). The other five
+  │                          nulls are FINDINGS, each with its sentence: copilot and kimi HAVE a
+  │                          rename and expose it only in-process (an SDK method, a UI call over
+  │                          `state.json`); codex, gemini and agy have none at all. Two routes were
+  │                          tried against claude 2.1.233 and REJECTED BY MEASUREMENT, not by taste:
+  │                          the messaging socket carries a `{subtype:'rename_session'}` control
+  │                          request that belongs to the SDK's stdio transport and is IGNORED there
+  │                          (sent with a valid token and a distinct title, the record did not
+  │                          change), and there is no CLI subcommand. Writing the harness's own file
+  │                          is refused on principle: a live process rewrites it on every status
+  │                          change, so our bytes would vanish while the session showed the old name
+  │                          — a rename reporting success and doing nothing. So it is a TYPED LINE,
+  │                          which means it needs a pane: an `external` or non-running row keeps its
+  │                          agentop label alone. **The label is written on every path** — refusing
+  │                          outright would make a `lost` row unnameable, which is most of what the
+  │                          verb is for — and what became of the harness half is SAID in words
+  │                          (`renameMessage`, one sentence per reason). It REFUSES on an open
+  │                          dialog, like `promptSession`: a `/rename` typed into a permission
+  │                          prompt goes into the dialog's filter and the submit takes the
+  │                          highlighted option. `rename.ts` is the one implementation both
+  │                          `agentop session rename` and the cockpit's verb call — one gesture
+  │                          implemented twice is the bug `task-reopen.ts` exists to have fixed once.
+  │                          **A RUNNING session whose registry record is GONE is taken back**
+  │                          (`session-adopt.ts`, pure). `registry.ts` serialises writes within ONE
+  │                          process and says so; agentop runs as several (cockpit, daemon, every
+  │                          one-shot command) all read-modify-writing one file, and a record added
+  │                          by a short-lived one has been observed ERASED by a longer-lived one.
+  │                          Measured 2026-08-15: `agentop session attach <conversation-id>` took
+  │                          over a conversation, spawned `agentop-a2b569c123`, and the file that
+  │                          survived did not hold it while nine sibling rows were intact — leaving
+  │                          the user sitting in a session that was `unregistered`, filed under
+  │                          `GONE_PROJECT_KEY`, and beyond every verb (they all resolve against the
+  │                          registry). Adoption never INVENTS: the link is the harness's own record
+  │                          naming our tmux session (`byManagedId`), a row with no such record or no
+  │                          `cwd` stays visible and unregistered rather than being filed under a
+  │                          guessed directory, and a `derived` name is never adopted as a label. The
+  │                          takeover additionally READS ITS WRITE BACK and retries once, saying so
+  │                          when the record still cannot be kept — the loss is otherwise invisible
+  │                          at the moment it happens. See docs/session-manager.md
   ├── cli-start.ts         → the control center's HOST (`ControlHost`): service detection, start/stop/restart, connect/disconnect, boot service, archive consent, language — every action returns an already-localized `ActionResult` instead of printing
   ├── cli-stream.ts        → the control center's OUTPUT CHANNEL: subscribers + `streamCommand` (both pipes captured, never `inherit`) → lines via the pure `@agentistics/tui/control/stream`
   ├── cli-ui.ts            → dependency-free arrow-key select/confirm/input/pause + clearScreen (bundles clean into the binary; no node_modules to resolve)

--- a/packages/server/server/cli-i18n.ts
+++ b/packages/server/server/cli-i18n.ts
@@ -182,6 +182,29 @@ export interface CliStrings {
   sessTaskReopened: (task: string) => string
   sessKillUnconfirmed: (id: string) => string
   sessRenamed: string
+  /**
+   * A rename that landed in BOTH places — agentop's label and the harness's own name.
+   *
+   * Separate from `sessRenamed` because the two claims differ, and the difference is the feature:
+   * one says a row was relabelled, the other says the session now calls itself that too.
+   */
+  sessRenamedBoth: string
+  /**
+   * The agentop label was written and the harness was NOT told — with the reason, in words.
+   *
+   * The label is never withheld over this: a rename that refuses outright would make a `lost` row
+   * unnameable, and naming those rows is most of what the verb is for. But a rename that only half
+   * happened and says nothing is indistinguishable from one that failed, which is the complaint this
+   * whole feature answers in reverse.
+   */
+  sessRenamedLocalOnly: (why: string) => string
+  /** A fact about the TOOL, not about this session: it publishes no rename channel at all. */
+  sessRenameWhyUnsupported: (harness: string) => string
+  sessRenameWhyExternal: string
+  sessRenameWhyNotRunning: string
+  sessRenameWhyDialog: string
+  sessRenameWhyUntypable: string
+  sessRenameWhyFailed: string
   /** Printed on the way into an attach, with the REAL detach key. */
   sessAttaching: (title: string, detach: string) => string
   sessNoted: string
@@ -483,6 +506,18 @@ const EN: CliStrings = {
   sessKillUnconfirmed: (id: string) =>
     `could not confirm ${id} was stopped — it may still be running, so its record was kept.`,
   sessRenamed: 'session renamed.',
+  sessRenamedBoth: 'renamed here and inside the session.',
+  sessRenamedLocalOnly: (why: string) => `renamed in agentop only — ${why}`,
+  sessRenameWhyUnsupported: (harness: string) =>
+    `${harness} publishes no way to rename a session from outside, so it keeps its own name.`,
+  sessRenameWhyExternal:
+    'agentop did not start this session, so there is no pane to type into — it keeps its own name.',
+  sessRenameWhyNotRunning:
+    'nothing is running, so the harness could not be told — it will keep the name it had.',
+  sessRenameWhyDialog:
+    'that session has a question open, and typing now would answer it. Answer it, then rename again to carry the name across.',
+  sessRenameWhyUntypable: 'the name has a line break, which cannot be typed as a single command.',
+  sessRenameWhyFailed: 'the session did not take the keystroke — it may have just ended.',
   sessAttaching: (title: string, detach: string) =>
     `Attaching to ${title}. To leave it running and come back here, press ${detach}.`,
   sessNoted: 'note saved.',
@@ -733,6 +768,18 @@ const PT: CliStrings = {
   sessKillUnconfirmed: (id: string) =>
     `não deu para confirmar que ${id} foi encerrada — ela pode continuar rodando, então o registro dela foi mantido.`,
   sessRenamed: 'sessão renomeada.',
+  sessRenamedBoth: 'renomeada aqui e dentro da sessão.',
+  sessRenamedLocalOnly: (why: string) => `renomeada só no agentop — ${why}`,
+  sessRenameWhyUnsupported: (harness: string) =>
+    `o ${harness} não publica nenhuma forma de renomear uma sessão de fora, então ele mantém o nome dele.`,
+  sessRenameWhyExternal:
+    'o agentop não iniciou essa sessão, então não há painel onde digitar — ela mantém o nome dela.',
+  sessRenameWhyNotRunning:
+    'não há nada rodando, então não deu para avisar o harness — ele vai manter o nome que tinha.',
+  sessRenameWhyDialog:
+    'essa sessão está com uma pergunta aberta, e digitar agora responderia ela. Responda e renomeie de novo para levar o nome adiante.',
+  sessRenameWhyUntypable: 'o nome tem quebra de linha, o que não dá para digitar como um comando só.',
+  sessRenameWhyFailed: 'a sessão não aceitou a tecla — ela pode ter acabado de terminar.',
   sessAttaching: (title: string, detach: string) =>
     `Anexando a ${title}. Para deixá-la rodando e voltar aqui, aperte ${detach}.`,
   sessNoted: 'nota salva.',

--- a/packages/server/server/cli-start.ts
+++ b/packages/server/server/cli-start.ts
@@ -103,6 +103,9 @@ import { recordedRepo, repoFacts } from './sessions/repo-facts'
 import { toControlSession } from './sessions/control-session'
 import { planTaskReopen, taskReopenSucceeded, type TaskReopenPlan } from './sessions/task-reopen'
 import { approvalFor, choiceKey } from './sessions/approval-spec'
+// Carrying a rename through to the harness. Shared with `agentop session rename` — one gesture, one
+// implementation, for the reason `task-reopen.ts` exists.
+import { renameInHarness, renameMessage } from './sessions/rename'
 import { needsChoice, parseDialogOptions } from './sessions/dialog-choice'
 import { rulesFor } from './sessions/attention-rules'
 import { planCrashGroup, planFellOffer } from './sessions/crash-group'
@@ -1336,6 +1339,9 @@ async function ensureSessionsPoller(): Promise<SessionsPoller> {
     // Written once per session, not once per poll — the poller only calls this when the harness's
     // own record disagrees with the registry.
     recordConversation: (id, conversationId) => patchSession(id, { conversationId }),
+    // Take back a running session whose registry record was lost. Called only with a non-empty
+    // list, so a healthy fleet never writes. See `session-adopt.ts` for what may be adopted.
+    adoptSessions: async records => { for (const r of records) await addSession(r) },
   })
   return sessionsPoller
 }
@@ -2355,13 +2361,33 @@ function createControlHost(initialLang: CliLang, altScreen: Suspendable): StartH
       return { ok: true, message: s.sessTaskDeleted(task, plan.clear.length) }
     },
 
+    /**
+     * Rename a session in BOTH places it can be named — agentop's registry and the harness itself.
+     *
+     * The registry write comes first and is unconditional: it is the one that always works, and a
+     * rename that refused because the harness could not be reached would leave every `lost` row
+     * unnameable. The harness half is then attempted through the shared `renameInHarness`, and
+     * whatever became of it is SAID — see `renameMessage`.
+     */
     async renameSession(id: string, label: string): Promise<ActionResult> {
       const s = S()
+      const managed = (await readRegistry()).find(m => m.id === id)
       // The INSTANT goes down with the name. A session can also be renamed from inside the harness,
       // and recency is the only non-arbitrary way to settle a disagreement between the two — a
       // stored name with no timestamp cannot take part in that. See `pickTitle`.
       const ok = await patchSession(id, { label, labelSince: Date.now() })
-      return ok ? { ok: true, message: s.sessRenamed } : { ok: false, message: s.sessNoRegistryEntry }
+      if (!ok || !managed) return ok
+        ? { ok: true, message: s.sessRenamed }
+        : { ok: false, message: s.sessNoRegistryEntry }
+
+      const backend = await resolveBackend()
+      // A backend that cannot run at all is not a failed rename — the label is written and the row
+      // reads correctly. It is the harness half that did not happen, and it is reported as such.
+      const blocked = await backend.unavailable()
+      const outcome = blocked
+        ? ({ kind: 'skipped', reason: 'not-running' } as const)
+        : await renameInHarness({ id, harness: managed.harness }, label.trim(), backend)
+      return { ok: true, message: renameMessage(outcome, managed.harness, s) }
     },
 
     async noteSession(id: string, text: string): Promise<ActionResult> {

--- a/packages/server/server/sessions/cli-session.ts
+++ b/packages/server/server/sessions/cli-session.ts
@@ -20,6 +20,8 @@ import { toControlSession } from './control-session'
 import { recordedRepo, repoFacts } from './repo-facts'
 import { emptyReason, renderSessionTable, resolveWidth } from './session-table'
 import { SPAWN_SPECS, planSpawn } from './spawn-spec'
+// The harness half of a rename. Shared with the cockpit's Rename verb — see `rename.ts`.
+import { renameInHarness, renameMessage } from './rename'
 import { reconcileSessions, resolveSessionRef, type ReconciledSession, type RefCandidate } from './session-ref'
 import { addSession, newSessionId, patchSession, readRegistry, removeSession } from './registry'
 import { conversationForProcess, loadConversations } from './conversations'
@@ -33,7 +35,7 @@ import { liveConversationHolders } from './live-claims'
 import { POLL_MS, SETTLE_MS, spawnOutcome } from './spawn-outcome'
 import { parseHarnessAgents } from './harness-agents'
 import { planTakeover, type TakeoverRefusal } from './takeover'
-import type { SessionBackend, SpawnPlanError } from './types'
+import type { ManagedSession, SessionBackend, SpawnPlanError } from './types'
 
 /** Derived from the specs, never a second hand-written list — the two could not then disagree. */
 const STARTABLE: HarnessId[] = HARNESS_ORDER.filter(h => SPAWN_SPECS[h] !== null)
@@ -118,7 +120,22 @@ export async function runSession(argv: string[]): Promise<number> {
     // typed and however recently. Measured on this machine: every one of twelve live rows had
     // `labelSince: undefined`, because the cockpit's rename verb stamped it and this one did not.
     // The comparison had therefore never once run in production, and the harness took every row.
-    case 'rename': return patch(cmd.ref, { label: cmd.label, labelSince: Date.now() }, 'renamed', backend)
+    // A rename lands in BOTH places a session can be named: the registry, and the harness's own
+    // record. The second half is the shared `renameInHarness` — the cockpit's Rename verb runs the
+    // very same function, because one gesture implemented twice is the bug `task-reopen.ts` exists
+    // to have fixed once. It never blocks the registry write: whatever became of the harness half is
+    // reported in a sentence instead.
+    case 'rename': return patch(
+      cmd.ref,
+      { label: cmd.label, labelSince: Date.now() },
+      'renamed',
+      backend,
+      async session => {
+        const s = cliStrings(await resolveLang())
+        const outcome = await renameInHarness(session, cmd.label.trim(), backend)
+        return `${session.id} ${renameMessage(outcome, session.harness, s)}`
+      },
+    )
     case 'note': return patch(cmd.ref, { note: cmd.text }, 'annotated', backend)
   }
 }
@@ -673,13 +690,43 @@ async function takeOver(ref: string, backend: SessionBackend): Promise<number | 
   const died = await spawnFailure(backend, id)
   if (died) { console.error(died); await backend.kill(id).catch(() => {}); return 1 }
 
-  await addSession({
+  const record: ManagedSession = {
     id, harness: live.harness, cwd: plan.cwd, createdAt: new Date().toISOString(),
     ...(live.name ? { label: live.name, labelSince: Date.now() } : {}),
     conversationId: plan.conversationId,
     ...(await recordedRepo(plan.cwd)),
-  })
+  }
+  // The write is READ BACK, and that is not belt-and-braces — it is the failure this path actually
+  // had. `registry.ts` serialises writes within ONE process; agentop runs as several (the cockpit,
+  // the daemon, every one-shot command), all read-modify-writing the same file. A record added here
+  // was observed erased by a longer-lived process that had read the file just before, and the
+  // session it lost was the one the user was about to sit in: running, unregistered, and beyond
+  // every verb the cockpit offers. One retry closes the ordinary interleaving; a loss that survives
+  // it is SAID rather than left for the user to discover when a rename stops working.
+  if (!await addVerified(record)) {
+    console.error(
+      `${id} is running but its registry record could not be kept — another agentop process is `
+      + 'writing the same registry. The cockpit will take it back on its next poll; if it does not, '
+      + `run \`agentop session attach ${id}\` again.`,
+    )
+  }
   return execAttach(id, backend)
+}
+
+/**
+ * Add a session and confirm it survived. `false` when it did not, after one retry.
+ *
+ * Deliberately not inside `registry.ts`: the retry is a statement about CONCURRENCY between
+ * processes, and the registry module's own contract ("one in-process writer") is honest about not
+ * covering that. Hiding a cross-process retry inside `add` would make every caller believe a
+ * guarantee that still does not exist.
+ */
+async function addVerified(record: ManagedSession): Promise<boolean> {
+  for (let attempt = 0; attempt < 2; attempt++) {
+    await addSession(record)
+    if ((await readRegistry()).some(s => s.id === record.id)) return true
+  }
+  return false
 }
 
 /** Already-localized refusal — the harness's limitation said in words, never a silent no-op. */
@@ -755,6 +802,13 @@ async function patch(
   fields: { label?: string; labelSince?: number; note?: string },
   verb: string,
   backend: SessionBackend,
+  /**
+   * What to print once the registry write has landed, when the plain `<id> <verb>.` is not the whole
+   * story. `rename` uses it to report what became of the HARNESS half; `note` has no second half and
+   * passes nothing. It runs only after `patchSession` succeeded, so it can never announce work done
+   * on a session the write did not find.
+   */
+  then?: (session: ManagedSession) => Promise<string>,
 ): Promise<number> {
   const registry = await readRegistry()
   const found = resolveSessionRef(registry, ref)
@@ -780,7 +834,7 @@ async function patch(
   // remove the session in between, so the patch itself is the only source of truth on success.
   const applied = await patchSession(found.session.id, fields)
   if (!applied) { console.error(refError(ref, 'not-found', [])); return 1 }
-  console.log(`${found.session.id} ${verb}.`)
+  console.log(then ? await then(found.session) : `${found.session.id} ${verb}.`)
   return 0
 }
 

--- a/packages/server/server/sessions/rename-spec.test.ts
+++ b/packages/server/server/sessions/rename-spec.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, test } from 'bun:test'
+import { HARNESS_ORDER, type HarnessId } from '@agentistics/core'
+import {
+  RENAME_SPECS,
+  harnessRenameSupported,
+  planHarnessRename,
+  renameSpecFor,
+  typableTitle,
+  type RenamePlanInput,
+} from './rename-spec'
+
+/** Everything true, so each test can name the ONE thing it is changing. */
+function input(over: Partial<RenamePlanInput> = {}): RenamePlanInput {
+  return { harness: 'claude', title: 'nome novo', managed: true, running: true, dialogOpen: false, ...over }
+}
+
+describe('RENAME_SPECS', () => {
+  test('covers every harness — a new one must be decided, not defaulted', () => {
+    for (const h of HARNESS_ORDER) expect(h in RENAME_SPECS).toBe(true)
+    expect(Object.keys(RENAME_SPECS).sort()).toEqual([...HARNESS_ORDER].sort())
+  })
+
+  test('claude renames with the command its own table publishes', () => {
+    expect(RENAME_SPECS.claude?.line('cockpit rename')).toBe('/rename cockpit rename')
+  })
+
+  test('every spec records where it was read from', () => {
+    for (const spec of Object.values(RENAME_SPECS)) {
+      if (spec) expect(spec.verified).toMatch(/\d{4}-\d{2}-\d{2}/)
+    }
+  })
+
+  test('claude is the only harness with a verified channel', () => {
+    const supported = HARNESS_ORDER.filter(h => harnessRenameSupported(h))
+    expect(supported).toEqual(['claude'])
+  })
+
+  test('an unknown harness has no spec rather than throwing', () => {
+    expect(renameSpecFor(undefined)).toBeNull()
+    expect(renameSpecFor('nope' as HarnessId)).toBeNull()
+  })
+})
+
+describe('planHarnessRename', () => {
+  test('sends the harness command on a live, unblocked, supported session', () => {
+    expect(planHarnessRename(input())).toEqual({ kind: 'send', line: '/rename nome novo' })
+  })
+
+  test('a harness with no channel is skipped as unsupported, whatever else is true', () => {
+    for (const h of HARNESS_ORDER.filter(x => x !== 'claude')) {
+      expect(planHarnessRename(input({ harness: h }))).toEqual({ kind: 'skip', reason: 'unsupported' })
+    }
+  })
+
+  test('unsupported outranks not-running — restarting a codex session would not help', () => {
+    expect(planHarnessRename(input({ harness: 'codex', running: false })))
+      .toEqual({ kind: 'skip', reason: 'unsupported' })
+  })
+
+  test('a session agentop does not host has no pane to type into', () => {
+    expect(planHarnessRename(input({ managed: false }))).toEqual({ kind: 'skip', reason: 'external' })
+  })
+
+  test('a row that is not running keeps its agentop label alone', () => {
+    expect(planHarnessRename(input({ running: false }))).toEqual({ kind: 'skip', reason: 'not-running' })
+  })
+
+  test('REFUSES while a dialog is open — the text would answer it, not rename anything', () => {
+    expect(planHarnessRename(input({ dialogOpen: true }))).toEqual({ kind: 'skip', reason: 'dialog' })
+  })
+
+  test('a multi-line title is never typed — half of it would rename and half would be a prompt', () => {
+    expect(planHarnessRename(input({ title: 'primeira\nsegunda' })))
+      .toEqual({ kind: 'skip', reason: 'untypable' })
+    expect(planHarnessRename(input({ title: 'primeira\r\nsegunda' })))
+      .toEqual({ kind: 'skip', reason: 'untypable' })
+  })
+
+  test('an empty title is untypable — bare /rename is a different command', () => {
+    expect(planHarnessRename(input({ title: '   ' }))).toEqual({ kind: 'skip', reason: 'untypable' })
+  })
+
+  test('a title the harness would read oddly is still sent verbatim', () => {
+    // Sanitising somebody's chosen name silently is worse than letting it land as typed.
+    expect(planHarnessRename(input({ title: '/help me' })))
+      .toEqual({ kind: 'send', line: '/rename /help me' })
+  })
+})
+
+describe('typableTitle', () => {
+  test('accepts an ordinary single-line name, including accents and punctuation', () => {
+    expect(typableTitle('sessões: revisão · 2')).toBe(true)
+  })
+
+  test('rejects blank and multi-line', () => {
+    expect(typableTitle('')).toBe(false)
+    expect(typableTitle('\n')).toBe(false)
+    expect(typableTitle('a\nb')).toBe(false)
+  })
+})

--- a/packages/server/server/sessions/rename-spec.ts
+++ b/packages/server/server/sessions/rename-spec.ts
@@ -1,0 +1,186 @@
+/**
+ * rename-spec.ts — PURE. How to rename a session INSIDE its harness, and when that may be tried.
+ *
+ * A session can be named in two places. `pickTitle` (`harness-session-file.ts`) already settles a
+ * disagreement between them; this module is the other half of the same story — making the two
+ * AGREE, by carrying a rename typed in agentop through to the harness itself.
+ *
+ * The reverse direction has always worked: a `/rename` inside the session is written to the
+ * harness's own record and read back by `harness-sessions.ts`. Only the agentop-to-harness
+ * direction was missing, so a row renamed here kept whatever the harness went on calling itself,
+ * and the harness's name won the moment it was the more recent of the two.
+ *
+ * ## Why this is a typed line and not an API call
+ *
+ * Three routes were tried against claude 2.1.233 on 2026-08-15 and two were REJECTED by measurement,
+ * not by preference:
+ *
+ *   - **The messaging socket** (`messagingSocketPath` in `~/.claude/sessions/<pid>.json`, the one
+ *     `events/peer-client.ts` already authenticates to). The binary does carry a control request
+ *     `{subtype: 'rename_session', title}`, and it is in the accepted-subtype set — but that set
+ *     belongs to the SDK's stdio transport. Sent over the peer socket with a valid token and a
+ *     distinct title, the session's own record did not change: no response, no rename. That is the
+ *     route this module would prefer, and it is not open.
+ *   - **A CLI subcommand.** `claude --help` lists no session-rename command in 2.1.233.
+ *   - **Writing the harness's own record.** Rejected on principle as well as on odds: it is another
+ *     tool's private, undocumented state file, held open and rewritten by a live process on every
+ *     status change, so our bytes would be overwritten within seconds while the running session went
+ *     on showing the old name — a rename that reports success and did nothing.
+ *
+ * What is left is the interface the harness actually publishes to its user: the slash command. Read
+ * from claude 2.1.233's own command table, not from memory of what it prints:
+ *
+ *   `name: "rename", aliases: ["name"], description: "Rename the current conversation",
+ *    immediate: true, argumentHint: "[name]"`
+ *
+ * `immediate` is the load-bearing word — the command runs on submit rather than becoming a turn, so
+ * this costs the session nothing and does not appear as work it was asked to do.
+ *
+ * ## Consequences of that route, stated rather than hidden
+ *
+ * Typing is only possible into a session agentop HOSTS. An `external` row — a harness someone
+ * started beside agentop — has no pane to type into, so its harness half is skipped and SAID to be
+ * skipped. Same for a row that is not running: `lost` and `exited` rows keep their agentop label and
+ * nothing else, because there is no process left to tell.
+ *
+ * `Record<HarnessId, … | null>` and not a `Partial`: a harness added to `HarnessId` must fail the
+ * build until someone decides, the same rule `SPAWN_SPECS`, `ATTENTION_RULES`, `APPROVAL_SPECS` and
+ * `HARNESS_CAPABILITIES` follow. `null` is that decision, and the five nulls here are findings —
+ * each was looked for on 2026-08-15 and the result recorded on its row.
+ */
+
+import type { HarnessId } from '@agentistics/core'
+
+export interface RenameSpec {
+  /**
+   * The line to type into a live session to rename it, given the title the user chose.
+   *
+   * A LINE, not a key: the backend's `sendText` types it and submits it, which is exactly what a
+   * person does. Nothing here presses anything else.
+   */
+  line(title: string): string
+  /** Where this was read from — the CLI version and the date, as `attention-rules.ts` records its patterns. */
+  verified: string
+}
+
+/**
+ * How to rename inside each harness. `null` means nobody has found a way, and the row then keeps
+ * the agentop label alone and says so.
+ *
+ * Every entry below was probed on 2026-08-15 against the installed CLI:
+ *
+ *   claude       `/rename [name]` — in the command table, `immediate`, aliased `name`.  ✔
+ *   copilot      `renameSession(name)` exists, but as an in-process SDK method on the session
+ *                object. There is no channel from outside to call it, and no slash command was
+ *                found in the bundle. Its file (`workspace.yaml`) is written by the live process,
+ *                so the file route is the one rejected above.
+ *   kimi         `state.json` carries `title` + `isCustomTitle`, and `renameSession()` exists —
+ *                again as its own UI's internal call over that file. No external channel.
+ *   codex        No rename anywhere in the CLI, and a rollout file records no user-facing name at
+ *                all: there is nothing in codex for a rename to change.
+ *   gemini       Nothing matching `rename` in the bundle.
+ *   antigravity  Nothing matching `rename` in the binary.
+ *
+ * Four of those five are "the harness has no such thing"; copilot and kimi are "it has one and does
+ * not expose it". The distinction is why each carries its own sentence rather than a shared `null`
+ * with no explanation — the day one of them opens a channel, the row says what to look for.
+ */
+export const RENAME_SPECS: Record<HarnessId, RenameSpec | null> = {
+  claude: { line: title => `/rename ${title}`, verified: 'claude 2.1.233, probed 2026-08-15' },
+  codex: null,
+  gemini: null,
+  copilot: null,
+  kimi: null,
+  antigravity: null,
+}
+
+/** The spec for a harness, or `null` when there is none — including for an unknown harness id. */
+export function renameSpecFor(harness: HarnessId | undefined): RenameSpec | null {
+  return harness ? RENAME_SPECS[harness] ?? null : null
+}
+
+/** Whether renaming inside the harness is possible AT ALL for this harness. Drives what the UI offers. */
+export function harnessRenameSupported(harness: HarnessId | undefined): boolean {
+  return renameSpecFor(harness) !== null
+}
+
+/**
+ * Why the harness half of a rename did not happen.
+ *
+ * Each is a DIFFERENT sentence to the user, which is the whole reason this is an enum and not a
+ * boolean: "this harness cannot be renamed from outside" and "your session is sitting on a
+ * permission prompt" send someone to two different places, and collapsing them into "could not
+ * rename" sends them to neither.
+ */
+export type RenameSkipReason =
+  /** The harness publishes no way to rename from outside. Permanent, and about the TOOL. */
+  | 'unsupported'
+  /** agentop did not start this session, so there is no pane to type into. */
+  | 'external'
+  /** Nothing is running — a `lost`, `exited` or `finished` row. */
+  | 'not-running'
+  /** A dialog is open. Typing now would answer it. See below. */
+  | 'dialog'
+  /** The title cannot be typed as one line, so it cannot be sent as one command. */
+  | 'untypable'
+
+export type RenamePlan =
+  | { kind: 'send'; line: string }
+  | { kind: 'skip'; reason: RenameSkipReason }
+
+export interface RenamePlanInput {
+  harness: HarnessId | undefined
+  /** The title the user typed, already trimmed by the caller. */
+  title: string
+  /** Whether agentop hosts this session — i.e. whether there is a pane at all. */
+  managed: boolean
+  /** Whether the backend reports it alive RIGHT NOW, not whether a poll once did. */
+  running: boolean
+  /**
+   * Whether the screen, re-read at this instant, is showing a blocking dialog.
+   *
+   * The caller decides this with `rulesFor(harness).approval` over a fresh capture, exactly as
+   * `promptSession` does. It is passed in rather than derived here so this module stays pure and the
+   * two paths cannot drift into two different readings of "is a dialog open".
+   */
+  dialogOpen: boolean
+}
+
+/**
+ * What to do about the harness half of a rename.
+ *
+ * The order of the checks is the order of the sentences worth saying. `unsupported` comes first
+ * because it is a fact about the harness that holds whatever the session is doing — telling someone
+ * their codex session is "not running" would send them to restart it in the hope of a rename that
+ * can never work.
+ *
+ * The dialog check is last and is the one that must never be dropped. A `/rename` typed into an open
+ * permission prompt does not rename anything: the text goes into the dialog's own filter and the
+ * submit takes whichever option is highlighted. That is the accident this codebase has already had
+ * once, from the other direction, and it is why `promptSession` refuses on a dialog too.
+ */
+export function planHarnessRename(input: RenamePlanInput): RenamePlan {
+  const spec = renameSpecFor(input.harness)
+  if (!spec) return { kind: 'skip', reason: 'unsupported' }
+  if (!input.managed) return { kind: 'skip', reason: 'external' }
+  if (!input.running) return { kind: 'skip', reason: 'not-running' }
+  if (!typableTitle(input.title)) return { kind: 'skip', reason: 'untypable' }
+  if (input.dialogOpen) return { kind: 'skip', reason: 'dialog' }
+  return { kind: 'send', line: spec.line(input.title) }
+}
+
+/**
+ * Whether a title can be typed as ONE command line.
+ *
+ * A newline would submit the command early and leave the remainder sitting in the composer as a
+ * prompt nobody wrote — the harness would be renamed to half the title and then asked a question. A
+ * carriage return does the same. Empty is refused because `/rename` with no argument is a different
+ * command (it opens the harness's own prompt), and an empty agentop label is refused upstream anyway.
+ *
+ * Everything else is allowed through, including a leading `/`: the harness gets what the user typed,
+ * and inventing a sanitiser that silently changes somebody's chosen name is worse than the rename
+ * landing verbatim.
+ */
+export function typableTitle(title: string): boolean {
+  return title.trim().length > 0 && !/[\r\n]/.test(title)
+}

--- a/packages/server/server/sessions/rename.ts
+++ b/packages/server/server/sessions/rename.ts
@@ -1,0 +1,104 @@
+/**
+ * rename.ts — carrying a rename typed in agentop through into the harness itself.
+ *
+ * The decision is the pure `rename-spec.ts`; this is the part that has to touch a backend. It exists
+ * as ONE function rather than as code at each call site for the reason `task-reopen.ts` exists: the
+ * CLI's `agentop session rename` and the cockpit's Rename verb are the same gesture, and the last
+ * time this codebase implemented one gesture twice the two drifted and only one of them was right.
+ *
+ * The screen is RE-READ here rather than trusted from a poll, exactly as `promptSession` does, and
+ * for exactly the same reason: a session that was idle five seconds ago may be sitting on a
+ * permission prompt now, where the input line is a menu and a typed `/rename` is an answer to a
+ * question nobody read.
+ */
+
+import type { HarnessId } from '@agentistics/core'
+import type { CliStrings } from '../cli-i18n'
+import { rulesFor } from './attention-rules'
+import { planHarnessRename, renameSpecFor, type RenameSkipReason } from './rename-spec'
+import type { SessionBackend } from './types'
+
+/** What became of the harness half. The agentop label is written by the caller either way. */
+export type HarnessRenameResult =
+  /** The command was typed and submitted. */
+  | { kind: 'sent' }
+  /** It was never attempted, and this is why — one reason, one sentence. */
+  | { kind: 'skipped'; reason: RenameSkipReason }
+  /** It was attempted and the backend refused to type it. */
+  | { kind: 'failed' }
+
+/** How much of the screen to read before typing. The same window `promptSession` uses. */
+const CAPTURE_LINES = 60
+
+/**
+ * Rename a session inside its harness, if that is possible at this instant.
+ *
+ * NEVER throws and never reports a rename it did not perform: a backend that cannot be listed or a
+ * capture that fails leaves the session's state unknown, and an unknown state is treated as a
+ * blocking dialog — the one reading that cannot cause a keystroke to land somewhere it should not.
+ *
+ * The harness spec is checked FIRST, before the backend is touched at all. Five of the six harnesses
+ * have no rename channel, and asking tmux to list sessions in order to discover that would spend a
+ * process to learn something the table already knew.
+ */
+export async function renameInHarness(
+  session: { id: string; harness: HarnessId },
+  title: string,
+  backend: SessionBackend,
+): Promise<HarnessRenameResult> {
+  if (!renameSpecFor(session.harness)) return { kind: 'skipped', reason: 'unsupported' }
+
+  const live = (await backend.list().catch(() => [])).find(b => b.id === session.id)
+  const running = live?.alive === true
+
+  // A failed capture is not an empty screen. `promptSession` can treat it as one because its own
+  // rules then simply fail to match; here the same shortcut would mean "no dialog", which is the
+  // permissive answer. So a capture that throws is read as a dialog being open, and the rename is
+  // skipped and said to be skipped.
+  let dialogOpen = false
+  if (running) {
+    const frame = await backend.capture(session.id, CAPTURE_LINES).catch(() => null)
+    if (frame === null) dialogOpen = true
+    else {
+      const rules = rulesFor(session.harness)
+      dialogOpen = rules ? rules.approval.some(re => re.test(frame.join('\n'))) : false
+    }
+  }
+
+  const plan = planHarnessRename({
+    harness: session.harness,
+    title,
+    // Reached only with a registry entry in hand, which is what "agentop hosts this" means.
+    managed: true,
+    running,
+    dialogOpen,
+  })
+  if (plan.kind === 'skip') return { kind: 'skipped', reason: plan.reason }
+
+  return (await backend.sendText(session.id, plan.line).catch(() => false))
+    ? { kind: 'sent' }
+    : { kind: 'failed' }
+}
+
+/**
+ * What to TELL the user about a rename, given what became of the harness half. PURE.
+ *
+ * One sentence per outcome, and deliberately not one sentence with a boolean in it: "renamed here
+ * and inside the session" and "renamed in agentop only, because that session has a question open"
+ * send someone to two different places, and a shared "renamed (partially)" sends them to neither.
+ *
+ * The agentop label is written on every path that reaches here, so every sentence is a SUCCESS
+ * sentence with a different amount of reach — never an error. A rename that refused outright would
+ * leave a `lost` row unnameable, and naming those rows is most of what the verb is for.
+ */
+export function renameMessage(result: HarnessRenameResult, harness: HarnessId, s: CliStrings): string {
+  if (result.kind === 'sent') return s.sessRenamedBoth
+  if (result.kind === 'failed') return s.sessRenamedLocalOnly(s.sessRenameWhyFailed)
+  switch (result.reason) {
+    case 'unsupported': return s.sessRenamedLocalOnly(s.sessRenameWhyUnsupported(harness))
+    case 'external': return s.sessRenamedLocalOnly(s.sessRenameWhyExternal)
+    case 'not-running': return s.sessRenamedLocalOnly(s.sessRenameWhyNotRunning)
+    case 'dialog': return s.sessRenamedLocalOnly(s.sessRenameWhyDialog)
+    case 'untypable': return s.sessRenamedLocalOnly(s.sessRenameWhyUntypable)
+  }
+}

--- a/packages/server/server/sessions/session-adopt.test.ts
+++ b/packages/server/server/sessions/session-adopt.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from 'bun:test'
+import type { HarnessSessionFile } from './harness-session-file'
+import { planAdoptions } from './session-adopt'
+
+const NOW = '2026-08-15T20:00:00.000Z'
+
+function file(over: Partial<HarnessSessionFile> = {}): HarnessSessionFile {
+  return { cwd: '/home/u/proj', sessionId: 'conv-1', name: 'renomeada', ...over }
+}
+
+function plan(
+  rows: { id: string; status: string }[],
+  entries: [string, HarnessSessionFile][] = [],
+) {
+  return planAdoptions({
+    rows,
+    byManagedId: new Map(entries),
+    harness: 'claude',
+    nowIso: NOW,
+  })
+}
+
+describe('planAdoptions', () => {
+  test('takes back a running session whose record is gone', () => {
+    expect(plan([{ id: 'a2b569c123', status: 'unregistered' }], [['a2b569c123', file()]])).toEqual([{
+      id: 'a2b569c123',
+      harness: 'claude',
+      cwd: '/home/u/proj',
+      createdAt: NOW,
+      label: 'renomeada',
+      conversationId: 'conv-1',
+    }])
+  })
+
+  test('leaves every other status alone — adoption is not reconciliation', () => {
+    for (const status of ['running', 'exited', 'lost']) {
+      expect(plan([{ id: 'x', status }], [['x', file()]])).toEqual([])
+    }
+  })
+
+  test('an unregistered row with no harness record is left visible, never invented', () => {
+    // No exact link. Filing it would mean guessing a directory, which is the error `repo-facts.ts`
+    // exists to have stopped.
+    expect(plan([{ id: 'orphan', status: 'unregistered' }])).toEqual([])
+  })
+
+  test('a harness record naming no directory is not enough', () => {
+    expect(plan([{ id: 'x', status: 'unregistered' }], [['x', file({ cwd: undefined })]])).toEqual([])
+    expect(plan([{ id: 'x', status: 'unregistered' }], [['x', file({ cwd: '' })]])).toEqual([])
+  })
+
+  test('a DERIVED name is never adopted as a label', () => {
+    // `aipe-46` is not a name a person chose, and the registry outlives the process that invented it.
+    const [rec] = plan(
+      [{ id: 'x', status: 'unregistered' }],
+      [['x', file({ name: 'aipe-46', nameSource: 'derived' })]],
+    )
+    expect(rec?.label).toBeUndefined()
+    expect(rec?.cwd).toBe('/home/u/proj')
+  })
+
+  test('a record with no conversation id still adopts — the link is the tmux name', () => {
+    const [rec] = plan([{ id: 'x', status: 'unregistered' }], [['x', file({ sessionId: undefined })]])
+    expect(rec?.conversationId).toBeUndefined()
+    expect(rec?.id).toBe('x')
+  })
+
+  test('nothing to do yields an empty list, so the caller can skip the write', () => {
+    expect(plan([{ id: 'a', status: 'running' }, { id: 'b', status: 'lost' }])).toEqual([])
+  })
+
+  test('adopts several at once and only the linked ones', () => {
+    const out = plan(
+      [
+        { id: 'linked', status: 'unregistered' },
+        { id: 'orphan', status: 'unregistered' },
+        { id: 'alive', status: 'running' },
+      ],
+      [['linked', file()], ['alive', file()]],
+    )
+    expect(out.map(r => r.id)).toEqual(['linked'])
+  })
+
+  test('createdAt is the moment of adoption, not the harness process start', () => {
+    // The harness record's own timestamps describe the process holding the conversation NOW, which
+    // after a takeover or a resume is not when the work began.
+    const [rec] = plan([{ id: 'x', status: 'unregistered' }], [['x', file({ nameSince: 1 })]])
+    expect(rec?.createdAt).toBe(NOW)
+  })
+})

--- a/packages/server/server/sessions/session-adopt.ts
+++ b/packages/server/server/sessions/session-adopt.ts
@@ -1,0 +1,103 @@
+/**
+ * session-adopt.ts — PURE. Taking a running session BACK into the registry when its record is gone.
+ *
+ * `reconcileSessions` already has a name for this row: `unregistered` — the backend is running
+ * `agentop-<id>` and the registry holds nothing by that id. Until now that was where the story
+ * ended, and the row showed up with no harness, no directory, no label and no task, filed under
+ * `GONE_PROJECT_KEY` ("no registered directory"). Every verb the cockpit offers resolves against the
+ * registry, so such a row cannot be attached, renamed, filed or killed: it is visible and inert.
+ *
+ * ## Why a row can be running and unregistered at all
+ *
+ * The registry serialises writes with an IN-PROCESS queue (`registry.ts`), which is exactly as much
+ * as it can promise: `agentop` runs as several processes at once — the cockpit, the daemon, and
+ * every one-shot `agentop session …` — and they all read-modify-write one file. A record added by a
+ * short-lived CLI process can therefore be erased by a longer-lived one that had read the file just
+ * before. Measured on this machine on 2026-08-15: a takeover (`agentop session attach` on a
+ * conversation id) spawned `agentop-a2b569c123`, wrote its record, and the file that survived did
+ * not contain it — while nine other sessions in the same registry were intact.
+ *
+ * The write path is being hardened separately, and that is worth doing. It is not sufficient on its
+ * own: a lost write is invisible at the moment it happens, and the session it loses is the one the
+ * user is sitting in. Adoption is what makes the loss recoverable rather than permanent, and it also
+ * covers the cases no write-path fix can — a registry restored from a backup, a `--corrupt`
+ * quarantine, a second agentop build with its own registry.
+ *
+ * ## What may be adopted, and what may never be invented
+ *
+ * The link is the harness's OWN record naming our tmux session (`tmux: "agentop-<id>:@w.%p"` in
+ * `~/.claude/sessions/<pid>.json`), which `harness-sessions.ts` indexes as `byManagedId`. That is an
+ * EXACT link, not a guess by harness-and-directory — the same distinction the rest of this module
+ * family is built on.
+ *
+ * So a row is adopted only when such a record exists AND names a directory. Everything else is left
+ * `unregistered`, deliberately: a row whose directory nobody can state would be adopted into the
+ * registry as a permanent record with an invented `cwd`, and an invented cwd is what `repo-facts.ts`
+ * exists to have stopped. A row left unregistered is visible and says what it is; a row adopted with
+ * a made-up directory is filed under a project it was never in, and nothing on screen says so.
+ *
+ * The name is taken only when the harness says a PERSON chose it. A `derived` name (`aipe-46`) is
+ * not a name — `harness-session-file.ts` measured 24 of 40 — and adopting one would write a label
+ * the user never typed into a registry that outlives the process, where `pickTitle` would then have
+ * to treat it as a deliberate choice forever.
+ */
+
+import type { HarnessId } from '@agentistics/core'
+import { chosenName } from './harness-session-file'
+import type { HarnessSessionFile } from './harness-session-file'
+import type { ManagedSession } from './types'
+
+/** The one status this module acts on. Kept as a literal so a caller cannot pass the wrong rows. */
+export const ADOPTABLE_STATUS = 'unregistered' as const
+
+export interface AdoptInput {
+  /** The reconciled fleet. Only `unregistered` rows are even looked at. */
+  rows: readonly { id: string; status: string }[]
+  /**
+   * The harness's own records keyed by OUR managed id — `HarnessSessionIndex.byManagedId`.
+   *
+   * Claude-only today, because it is the only harness that writes such a file. A harness that never
+   * appears here is never adopted, which is the correct outcome and not a gap: without its own
+   * record there is no exact link, and an inexact one is what this module refuses.
+   */
+  byManagedId: ReadonlyMap<string, HarnessSessionFile>
+  /** The harness every record in `byManagedId` belongs to. */
+  harness: HarnessId
+  /** `createdAt` for the records written. The caller's clock, so a test can pin it. */
+  nowIso: string
+}
+
+/**
+ * The registry records that should be written to take running sessions back.
+ *
+ * Empty whenever there is nothing to do, which is the ordinary case — the caller can then skip the
+ * write entirely rather than touching the registry on every poll.
+ *
+ * `createdAt` is the moment of ADOPTION, not of the session's birth, and that is honest rather than
+ * lossy: the harness record carries `startedAt`, but it is the start of the process now holding the
+ * conversation, which after a takeover or a resume is not when the work began. A field that would be
+ * wrong in the interesting case is better left saying what it can defend.
+ */
+export function planAdoptions(input: AdoptInput): ManagedSession[] {
+  const out: ManagedSession[] = []
+  for (const row of input.rows) {
+    if (row.status !== ADOPTABLE_STATUS) continue
+    const file = input.byManagedId.get(row.id)
+    // No exact link, or a link that names no directory: leave it visible and unregistered rather
+    // than filing it under a directory nobody can state.
+    if (!file?.cwd) continue
+    const label = chosenName(file)
+    out.push({
+      id: row.id,
+      harness: input.harness,
+      cwd: file.cwd,
+      createdAt: input.nowIso,
+      // Only a name a PERSON chose. `chosenName` already drops a derived one.
+      ...(label ? { label } : {}),
+      // The exact conversation, straight from the harness's own record — the whole reason this row
+      // is adoptable at all.
+      ...(file.sessionId ? { conversationId: file.sessionId } : {}),
+    })
+  }
+  return out
+}

--- a/packages/server/server/sessions/sessions-host.ts
+++ b/packages/server/server/sessions/sessions-host.ts
@@ -16,6 +16,8 @@ import type { HarnessProcess } from '../live-sessions'
 import { rulesFor } from './attention-rules'
 import { approvalTail, attentionOf, digestFrame, frameTail } from './attention'
 import { parseDialogOptions, type DialogOption } from './dialog-choice'
+// Taking a running session back when its registry record is gone. See `session-adopt.ts`.
+import { planAdoptions } from './session-adopt'
 import { loadConversations, type Conversation } from './conversations'
 import { HEARTBEAT_MS, planCrashGroup, type CrashGroup } from './crash-group'
 import { emptyHarnessSessionIndex, type HarnessSessionIndex } from './harness-sessions'
@@ -112,6 +114,14 @@ export function createSessionsPoller(o: {
    * conversation.
    */
   recordConversation?: (id: string, conversationId: string) => Promise<unknown>
+  /**
+   * Write registry records for sessions the backend is running and the registry has lost.
+   *
+   * Injected and optional for the same reason the two above are: it writes to disk. Called only with
+   * a non-empty list, so a fleet with nothing to adopt — the ordinary case — never touches the file.
+   * What may be adopted at all is the pure `planAdoptions`.
+   */
+  adoptSessions?: (records: readonly ManagedSession[]) => Promise<unknown>
   now?: () => number
   captureLines?: number
   /** Overridable so a test can drive several heartbeats without waiting a minute for each. */
@@ -167,6 +177,24 @@ export function createSessionsPoller(o: {
 
       const reconciled = reconcileSessions(registry, backendSessions)
       const harnessOf = new Map(registry.map(r => [r.id, r.harness]))
+
+      // Take back any session the backend is running that the registry has lost. It is not a
+      // theoretical case: the registry's write queue is per PROCESS, several agentop processes write
+      // the same file, and a record added by a short-lived one has been observed erased by a
+      // longer-lived one — leaving the user sitting in a session the cockpit could no longer name,
+      // attach to, rename or kill. Adoption never invents anything: see `session-adopt.ts`. It is
+      // idempotent by construction (an adopted row stops being `unregistered`), so it writes once.
+      if (o.adoptSessions) {
+        const adopt = planAdoptions({
+          rows: reconciled,
+          byManagedId: harnessSessions.byManagedId,
+          harness: 'claude',
+          nowIso: new Date(nowMs).toISOString(),
+        })
+        // Best effort, exactly like the heartbeat: a registry that cannot be written costs the
+        // adoption, never the fleet on screen.
+        if (adopt.length > 0) await o.adoptSessions(adopt).catch(() => undefined)
+      }
 
       const nextDigest = new Map<string, string>()
       const activity = new Map<string, SessionActivity>()


### PR DESCRIPTION
## O problema

Um rename feito no agentop nunca chegava ao harness. A linha renomeada aqui mantinha o nome que o harness continuava usando — e **perdia** para ele por recência, já que `pickTitle` resolve o desempate por `nameSince`. A direção inversa (`/rename` dentro da sessão) sempre funcionou, o que fazia a lacuna parecer um rename que falhou em silêncio.

## O que foi feito

### Rename bidirecional

`rename-spec.ts` (puro) é `Record<HarnessId, RenameSpec | null>` e tem **uma** entrada: o `/rename` do claude, lido da tabela de comandos do próprio binário (`immediate: true`, então não custa turno à sessão). Os outros cinco `null` são **achados**, cada um com sua frase — copilot e kimi *têm* rename e só o expõem in-process (método de SDK, chamada de UI sobre `state.json`); codex, gemini e agy não têm nenhum.

Duas rotas foram testadas contra claude 2.1.233 e **descartadas por medição**, não por preferência:

- **O socket de mensagens.** O binário carrega um control request `{subtype: 'rename_session', title}` e ele está no set de subtypes aceitos — mas esse set pertence ao transporte stdio do SDK. Enviado pelo socket peer com token válido e um título distinto, o registro da sessão não mudou.
- **Subcomando de CLI.** `claude --help` não lista nenhum em 2.1.233.

Escrever o arquivo do próprio harness foi recusado por princípio: é estado privado e não documentado de outra ferramenta, reescrito por um processo vivo a cada mudança de status — nossos bytes sumiriam em segundos enquanto a sessão seguiria mostrando o nome antigo. Um rename que reporta sucesso e não fez nada.

Sobra a interface que o harness realmente publica ao usuário: o slash command. E isso tem consequências, ditas em vez de escondidas — digitar exige um pane, então uma linha `external` ou parada fica só com o label do agentop.

**O label é gravado em todo caminho.** Recusar por inteiro deixaria uma linha `lost` impossível de nomear, que é a maior parte do que o verbo serve. O que aconteceu com a metade do harness é dito em uma frase por motivo (`renameMessage`).

Ele **recusa com diálogo aberto**, igual ao `promptSession`: um `/rename` digitado num prompt de permissão vai para o filtro do diálogo e o submit leva a opção destacada.

`rename.ts` é a implementação única que `agentop session rename` e o verbo do cockpit chamam — um gesto implementado duas vezes é o bug que o `task-reopen.ts` existe para ter corrigido de vez.

### Adoção de sessão órfã

`session-adopt.ts` (puro) traz de volta uma sessão que está rodando e cujo registro sumiu.

O `registry.ts` serializa escritas dentro de **um** processo, e diz isso explicitamente; o agentop roda como vários (cockpit, daemon, cada comando one-shot), todos fazendo read-modify-write no mesmo arquivo. Medido em 2026-08-15: um takeover (`agentop session attach <id-de-conversa>`) subiu `agentop-a2b569c123`, escreveu o registro, e o arquivo que sobreviveu não o continha — enquanto nove linhas irmãs ficaram intactas. O usuário ficou sentado numa sessão `unregistered`, arquivada sob `GONE_PROJECT_KEY` e fora do alcance de todo verbo, já que todos resolvem contra o registry.

A adoção **não inventa nada**: o vínculo é o registro do próprio harness nomeando nossa sessão tmux (`byManagedId`). Uma linha sem esse registro, ou sem `cwd`, continua visível e não-registrada em vez de ser arquivada sob um diretório chutado — o erro que o `repo-facts.ts` existe para ter parado. Um nome `derived` nunca é adotado como label.

O takeover além disso **relê a própria escrita** e tenta uma vez mais, dizendo quando o registro ainda não pôde ser mantido: uma perda dessas é invisível no momento em que acontece.

## Verificação

Contra uma sessão viva, não só em teste:

- o registro do harness passou de `"erro ao fazer upgrade da cli"` para o nome novo, com `nameSince` fresco, e o label do registry bate;
- os dois caminhos de skip reportam a frase certa (`não há nada rodando…`, `o antigravity não publica nenhuma forma de renomear…`);
- a sessão órfã foi readotada com cwd real, `conversationId` e o nome escolhido pelo usuário.

`bun tsc --noEmit` limpo · **4103 pass / 0 fail** · 25 testes novos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015gQSpz5h8DotRaCN9yF46W