### PR TITLE
feat(tui): blue underline highlight for focused session row and harness column placement

### DIFF
--- a/packages/tui/src/control/tabs/Sessions.tsx
+++ b/packages/tui/src/control/tabs/Sessions.tsx
@@ -112,6 +112,8 @@ const CONTEXT_COLOR: Record<ContextLevel, string | undefined> = {
   full: COLORS.danger,
 }
 
+const SESSION_FOCUS_ACCENT = COLORS.info
+
 /** The colour each state wears. Paired with a WORD everywhere it is drawn — a fleet state announced
  *  in colour alone is unreadable on a terminal with a flattened palette, and this is the one screen
  *  whose whole purpose is that single fact. */
@@ -1551,15 +1553,15 @@ export function Sessions({
           same measured widths so the heading can never sit over the wrong column. */}
       {cockpit.header && rows.length > 0 && !grid ? (
         <Text dimColor wrap="truncate">
-          {'  ' + (columns.id > 0 ? padCell(s.sessionsCols.id, columns.id) + '  ' : '')
-            + padCell(s.sessionsCols.state, columns.state)}
+          {'  ' + (columns.id > 0 ? padCell(s.sessionsCols.id, columns.id) + '  ' : '')}
+          {columns.harness > 0 ? padCell(s.sessionsCols.harness, columns.harness) + '  ' : ''}
+          {padCell(s.sessionsCols.state, columns.state)}
           {columns.title > 0 ? '  ' + padCell(s.sessionsCols.title, columns.title) : ''}
           {columns.age > 0 ? '  ' + padCell(s.sessionsCols.age, columns.age) : ''}
           {columns.worktree > 0 ? '  ' + padCell(s.sessionsCols.worktree, columns.worktree) : ''}
           {columns.task > 0 ? '  ' + padCell(s.sessionsCols.task, columns.task) : ''}
           {columns.metrics > 0 ? '  ' + padCell(s.sessionsCols.metrics, columns.metrics) : ''}
           {columns.context > 0 ? '  ' + padCell(s.sessionsCols.context, columns.context) : ''}
-          {columns.harness > 0 ? '  ' + padCell(s.sessionsCols.harness, columns.harness) : ''}
           {columns.where > 0 ? '  ' + padCell(s.sessionsCols.where, columns.where) : ''}
         </Text>
       ) : null}
@@ -1856,7 +1858,7 @@ function SessionRowView({ session, selected, marked, ages, columns, width, close
           the one moment you are looking straight at it. The bar is `info` rather than the accent
           on purpose — the accent means focus everywhere else in this app, and a highlight that
           wore it would read as "this is selected" on four rows at once. */}
-      <Text color={selected ? COLORS.accent : undefined}>{selected ? '❯' : ' '}</Text>
+      <Text color={selected ? COLORS.info : undefined} underline={selected}>{selected ? '❯' : ' '}</Text>
       <Text color={marked ? COLORS.info : undefined} bold={marked}>{marked ? '▌' : ' '}</Text>
       {/* Colour AND word, always paired — and PADDED, so every title starts in the same column.
           Two spaces between unpadded cells is what made this read as a jumble of words: the state
@@ -1864,19 +1866,27 @@ function SessionRowView({ session, selected, marked, ages, columns, width, close
       {/* The HANDLE. `agentop session attach 3f5f` takes a prefix, so this is the one thing on the
           row that names the session to anything but this screen. */}
       {columns.id > 0 ? (
-        <Text color={selected ? COLORS.accent : undefined} dimColor={!selected}>
+        <Text color={selected ? COLORS.info : undefined} underline={selected} dimColor={!selected} bold={selected}>
           {padCell(sessionHandle(session), columns.id) + gap}
         </Text>
       ) : null}
+      {/* Harness column is placed right after id, and retains its harness color when selected while taking underline. */}
+      {columns.harness > 0 ? (
+        <Text color={harnessColor} underline={selected} bold={selected}>
+          {padCell(session.harness, columns.harness) + gap}
+        </Text>
+      ) : null}
       <Text
-        color={selected ? COLORS.accent : STATE_COLOR[session.state]}
+        color={selected ? COLORS.info : STATE_COLOR[session.state]}
+        underline={selected}
         bold={selected || session.state === 'waiting-approval'}
       >
         {padCell(session.stateLabel, columns.state)}
       </Text>
       {columns.title > 0 ? (
         <Text
-          color={selected ? COLORS.accent : marked ? COLORS.info : undefined}
+          color={selected ? COLORS.info : marked ? COLORS.info : undefined}
+          underline={selected}
           bold={selected || marked}
         >
           {gap + padCell(session.title, columns.title)}
@@ -1885,7 +1895,7 @@ function SessionRowView({ session, selected, marked, ages, columns, width, close
       {/* How long ago it started, on rows that are NOT running — the age is most of the "reopen
           this or not" decision, and it lived only in the detail pane. */}
       {columns.age > 0 ? (
-        <Text color={selected ? COLORS.accent : undefined} dimColor={!selected}>
+        <Text color={selected ? COLORS.info : undefined} underline={selected} dimColor={!selected}>
           {gap + padCell(ages.get(session.id) ?? '', columns.age)}
         </Text>
       ) : null}
@@ -1894,14 +1904,14 @@ function SessionRowView({ session, selected, marked, ages, columns, width, close
           The word, never a glyph alone — a distinction announced in a symbol is one that has to be
           taught before the screen can be read. */}
       {columns.worktree > 0 ? (
-        <Text color={selected ? COLORS.accent : COLORS.secondary} bold={selected}>{gap + padCell(worktreeName(session), columns.worktree)}</Text>
+        <Text color={selected ? COLORS.info : COLORS.secondary} underline={selected} bold={selected}>{gap + padCell(worktreeName(session), columns.worktree)}</Text>
       ) : null}
       {/* The TASK, right of the name. Filing a session under a task and then not being able to see
           which task it is in is the feature not working — the fact only existed in the detail pane
           and in a grouping you had to switch to. `sessionColumns` drops the cell while grouping BY
           task, where the heading over the row already says it. */}
       {columns.task > 0 ? (
-        <Text color={selected ? COLORS.accent : COLORS.secondary} bold={selected}>
+        <Text color={selected ? COLORS.info : COLORS.secondary} underline={selected} bold={selected}>
           {gap + padCell(session.task ?? '', columns.task)}
         </Text>
       ) : null}
@@ -1909,7 +1919,7 @@ function SessionRowView({ session, selected, marked, ages, columns, width, close
           a row you are deciding whether to close is one whose cost you want beside its name rather
           than one selection away in the detail pane. */}
       {columns.metrics > 0 ? (
-        <Text color={selected ? COLORS.accent : COLORS.secondary} bold={selected}>{gap + padCell(sessionMetric(session), columns.metrics)}</Text>
+        <Text color={selected ? COLORS.info : COLORS.secondary} underline={selected} bold={selected}>{gap + padCell(sessionMetric(session), columns.metrics)}</Text>
       ) : null}
       {/* How full the context window is. Beside the usage because it is the same kind of fact and
           the opposite reading of it: usage is what this session has spent, this is what it has
@@ -1918,20 +1928,16 @@ function SessionRowView({ session, selected, marked, ages, columns, width, close
       {columns.context > 0 ? (
         <Text
           color={selected
-            ? COLORS.accent
+            ? COLORS.info
             : session.context ? CONTEXT_COLOR[contextLevel(session.context.fraction)] : undefined}
+          underline={selected}
           dimColor={!selected && (!session.context || contextLevel(session.context.fraction) === 'ok')}
         >
           {gap + padCell(sessionContext(session), columns.context)}
         </Text>
       ) : null}
-      {columns.harness > 0 ? (
-        <Text color={selected ? COLORS.accent : harnessColor} bold={selected}>
-          {gap + padCell(session.harness, columns.harness)}
-        </Text>
-      ) : null}
       {columns.where > 0 ? (
-        <Text dimColor>{gap + padCell(session.projectGroup || session.project, columns.where)}</Text>
+        <Text color={selected ? COLORS.info : undefined} underline={selected} dimColor={!selected}>{gap + padCell(session.projectGroup || session.project, columns.where)}</Text>
       ) : null}
       {/* The close control, at the right edge and only on a row that can take it. It asks before
           it acts — the same confirmation `x` opens, because a one-click stop on a list that
@@ -2150,7 +2156,7 @@ function CardLineView({ line, width, labelWidth, marked, selected, stateColor, b
   }
   if (line.kind === 'title') {
     return (
-      <Text wrap="truncate" color={selected ? COLORS.accent : marked ? COLORS.info : undefined} bold>
+      <Text wrap="truncate" color={selected ? SESSION_FOCUS_ACCENT : marked ? COLORS.info : undefined} bold>
         {truncate(line.text, width)}
       </Text>
     )

--- a/packages/web/src/lib/sessionNotifications.ts
+++ b/packages/web/src/lib/sessionNotifications.ts
@@ -252,29 +252,29 @@ export function handleSessionStateTransitions(
 
     if (nextState === 'waiting-approval') {
       title = lang === 'pt'
-        ? `🔴 Precisa de Aprovação: ${sessionSubject}`
-        : `🔴 Needs Approval: ${sessionSubject}`
+        ? `[Precisa de Aprovação] ${sessionSubject}`
+        : `[Needs Approval] ${sessionSubject}`
       body = lang === 'pt'
         ? `A sessão "${sessionSubject}"${locationInfo} está aguardando sua autorização para continuar.`
         : `Session "${sessionSubject}"${locationInfo} is waiting for your authorization to proceed.`
     } else if (nextState === 'waiting') {
       title = lang === 'pt'
-        ? `🟡 Aguardando Resposta: ${sessionSubject}`
-        : `🟡 Waiting Input: ${sessionSubject}`
+        ? `[Aguardando Resposta] ${sessionSubject}`
+        : `[Waiting Input] ${sessionSubject}`
       body = lang === 'pt'
         ? `A sessão "${sessionSubject}"${locationInfo} concluiu o turno e aguarda sua resposta.`
         : `Session "${sessionSubject}"${locationInfo} finished its turn and is waiting for your response.`
     } else if (nextState === 'working') {
       title = lang === 'pt'
-        ? `🟢 Em Andamento: ${sessionSubject}`
-        : `🟢 Working: ${sessionSubject}`
+        ? `[Em Andamento] ${sessionSubject}`
+        : `[Working] ${sessionSubject}`
       body = lang === 'pt'
         ? `A sessão "${sessionSubject}"${locationInfo} iniciou o processamento.`
         : `Session "${sessionSubject}"${locationInfo} started working.`
     } else if (nextState === 'exited') {
       title = lang === 'pt'
-        ? `⚪ Sessão Encerrada: ${sessionSubject}`
-        : `⚪ Session Closed: ${sessionSubject}`
+        ? `[Sessão Encerrada] ${sessionSubject}`
+        : `[Session Closed] ${sessionSubject}`
       body = lang === 'pt'
         ? `A sessão "${sessionSubject}"${locationInfo} foi finalizada.`
         : `Session "${sessionSubject}"${locationInfo} was closed.`

--- a/packages/web/src/lib/sessionNotifications.ts
+++ b/packages/web/src/lib/sessionNotifications.ts
@@ -18,6 +18,12 @@ export interface NotificationSettings {
     'working': boolean
     'exited': boolean
   }
+  eventSounds?: {
+    'waiting-approval': SoundPreset
+    'waiting': SoundPreset
+    'working': SoundPreset
+    'exited': SoundPreset
+  }
   soundEnabled: boolean
   soundPreset: SoundPreset
   soundVolume: number // 0.0 to 1.0
@@ -33,6 +39,12 @@ export const DEFAULT_NOTIFICATION_SETTINGS: NotificationSettings = {
     'waiting': true,
     'working': false,
     'exited': true,
+  },
+  eventSounds: {
+    'waiting-approval': 'alert',
+    'waiting': 'chime',
+    'working': 'soft',
+    'exited': 'ping',
   },
   soundEnabled: true,
   soundPreset: 'chime',
@@ -50,6 +62,10 @@ export function getNotificationSettings(): NotificationSettings {
       events: {
         ...DEFAULT_NOTIFICATION_SETTINGS.events,
         ...(parsed.events || {}),
+      },
+      eventSounds: {
+        ...DEFAULT_NOTIFICATION_SETTINGS.eventSounds,
+        ...(parsed.eventSounds || {}),
       },
     }
   } catch {

--- a/packages/web/src/pages/SessionsPage.tsx
+++ b/packages/web/src/pages/SessionsPage.tsx
@@ -97,7 +97,7 @@ export default function SessionsPage() {
 
     if (perm === 'granted') {
       triggerSessionNotification({
-        title: pt ? '🔔 Notificações Ativadas' : '🔔 Notifications Enabled',
+        title: pt ? 'Notificações Ativadas' : 'Notifications Enabled',
         body: pt
           ? 'Você receberá alertas em tempo real sobre o andamento das suas live sessions.'
           : 'You will receive real-time alerts on your live sessions progress.',

--- a/packages/web/src/pages/settings/NotificationsSettings.tsx
+++ b/packages/web/src/pages/settings/NotificationsSettings.tsx
@@ -8,6 +8,7 @@ import {
   getBrowserNotificationPermission,
   playNotificationSound,
   triggerSessionNotification,
+  DEFAULT_NOTIFICATION_SETTINGS,
   type NotificationSettings,
   type SoundPreset,
 } from '../../lib/sessionNotifications'
@@ -34,6 +35,11 @@ export default function NotificationsSettings() {
   function updateEvent(eventKey: keyof NotificationSettings['events'], value: boolean) {
     const nextEvents = { ...settings.events, [eventKey]: value }
     update({ events: nextEvents })
+  }
+
+  function updateEventSound(eventKey: keyof NotificationSettings['eventSounds'], value: SoundPreset) {
+    const nextSounds = { ...(settings.eventSounds || DEFAULT_NOTIFICATION_SETTINGS.eventSounds), [eventKey]: value }
+    update({ eventSounds: nextSounds })
   }
 
   async function handleRequestPermission() {
@@ -70,6 +76,53 @@ export default function NotificationsSettings() {
     { key: 'soft', labelPt: 'Suave / Discreto', labelEn: 'Soft / Subtle', descPt: 'Pulso duplo de baixa frequência', descEn: 'Double low-frequency pulse' },
     { key: 'alert', labelPt: 'Alerta / Destaque', labelEn: 'Alert Tone', descPt: 'Tom triplo de atenção em E5', descEn: 'Triple attention tone in E5' },
     { key: 'ping', labelPt: 'Ping de Cristal', labelEn: 'Crystal Ping', descPt: 'Sino agudo de alta clareza', descEn: 'High clarity bell' },
+  ]
+
+  const EVENT_CONFIGS: {
+    key: keyof NotificationSettings['events']
+    titlePt: string
+    titleEn: string
+    color: string
+    icon: React.ReactNode
+    descPt: string
+    descEn: string
+  }[] = [
+    {
+      key: 'waiting-approval',
+      titlePt: 'Precisa de Aprovação',
+      titleEn: 'Needs Approval',
+      color: '#ef4444',
+      icon: <AlertCircle size={15} style={{ color: '#ef4444' }} />,
+      descPt: 'Quando a sessão é pausada aguardando confirmação ou autorização do usuário',
+      descEn: 'When session is paused waiting for user confirmation or tool authorization',
+    },
+    {
+      key: 'waiting',
+      titlePt: 'Aguardando Resposta',
+      titleEn: 'Waiting Response',
+      color: 'var(--anthropic-orange)',
+      icon: <Clock size={15} style={{ color: 'var(--anthropic-orange)' }} />,
+      descPt: 'Quando a IA concluiu a resposta e aguarda sua nova mensagem/comando',
+      descEn: 'When AI completes its turn and awaits your input/command',
+    },
+    {
+      key: 'working',
+      titlePt: 'Trabalhando',
+      titleEn: 'Working',
+      color: '#22c55e',
+      icon: <Activity size={15} style={{ color: '#22c55e' }} />,
+      descPt: 'Quando a sessão retoma a execução / geração de código',
+      descEn: 'When session resumes execution / code generation',
+    },
+    {
+      key: 'exited',
+      titlePt: 'Sessão Encerrada',
+      titleEn: 'Session Exited',
+      color: 'var(--text-secondary)',
+      icon: <XCircle size={15} style={{ color: 'var(--text-tertiary)' }} />,
+      descPt: 'Quando o processo de uma sessão ao vivo é finalizado',
+      descEn: 'When a live session process exits or terminates',
+    },
   ]
 
   return (
@@ -167,152 +220,118 @@ export default function NotificationsSettings() {
 
       <Divider />
 
-      {/* Event Types / Filter Section */}
-      <SectionHeader label={pt ? 'Eventos para Notificar' : 'Notification Events'} />
+      {/* Event Types & Per-Status Sound Customization */}
+      <SectionHeader label={pt ? 'Eventos e Toques por Status' : 'Events & Per-Status Tones'} />
       <div style={{ fontSize: 12, color: 'var(--text-tertiary)', marginBottom: 14 }}>
         {pt
-          ? 'Escolha em quais momentos das suas live sessions você deseja receber alertas:'
-          : 'Choose when you want to be notified during live session progress:'}
+          ? 'Escolha em quais momentos notificar e defina o toque específico para cada status:'
+          : 'Choose when to notify and select a specific sound chime for each status:'}
       </div>
 
       <div style={{ display: 'flex', flexDirection: 'column', gap: 10, marginBottom: 20 }}>
-        {/* Waiting Approval */}
-        <div
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'space-between',
-            padding: '12px 14px',
-            borderRadius: 8,
-            border: '1px solid var(--border-subtle)',
-            background: 'var(--bg-elevated)',
-          }}
-        >
-          <div>
-            <div style={{ fontSize: 13, fontWeight: 600, color: '#ef4444', display: 'flex', alignItems: 'center', gap: 6 }}>
-              <AlertCircle size={15} style={{ color: '#ef4444' }} />
-              <span>{pt ? 'Precisa de Aprovação' : 'Needs Approval'}</span>
-              <span style={{ fontSize: 11, fontWeight: 400, color: 'var(--text-tertiary)', marginLeft: 4 }}>
-                (waiting-approval)
-              </span>
-            </div>
-            <div style={{ fontSize: 11, color: 'var(--text-tertiary)', marginTop: 2 }}>
-              {pt
-                ? 'Quando a sessão é pausada aguardando confirmação ou autorização do usuário'
-                : 'When session is paused waiting for user confirmation or tool authorization'}
-            </div>
-          </div>
-          <Toggle
-            on={settings.events['waiting-approval']}
-            onToggle={() => updateEvent('waiting-approval', !settings.events['waiting-approval'])}
-          />
-        </div>
+        {EVENT_CONFIGS.map(evt => {
+          const events = settings.events || DEFAULT_NOTIFICATION_SETTINGS.events
+          const eventSounds = settings.eventSounds || DEFAULT_NOTIFICATION_SETTINGS.eventSounds
+          const enabled = events[evt.key] ?? true
+          const currentSound = eventSounds[evt.key] ?? 'chime'
 
-        {/* Waiting Input */}
-        <div
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'space-between',
-            padding: '12px 14px',
-            borderRadius: 8,
-            border: '1px solid var(--border-subtle)',
-            background: 'var(--bg-elevated)',
-          }}
-        >
-          <div>
-            <div style={{ fontSize: 13, fontWeight: 600, color: 'var(--anthropic-orange)', display: 'flex', alignItems: 'center', gap: 6 }}>
-              <Clock size={15} style={{ color: 'var(--anthropic-orange)' }} />
-              <span>{pt ? 'Aguardando Resposta' : 'Waiting Response'}</span>
-              <span style={{ fontSize: 11, fontWeight: 400, color: 'var(--text-tertiary)', marginLeft: 4 }}>
-                (waiting)
-              </span>
-            </div>
-            <div style={{ fontSize: 11, color: 'var(--text-tertiary)', marginTop: 2 }}>
-              {pt
-                ? 'Quando a IA concluiu a resposta e aguarda sua nova mensagem/comando'
-                : 'When AI completes its turn and awaits your input/command'}
-            </div>
-          </div>
-          <Toggle
-            on={settings.events['waiting']}
-            onToggle={() => updateEvent('waiting', !settings.events['waiting'])}
-          />
-        </div>
+          return (
+            <div
+              key={evt.key}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                padding: '12px 14px',
+                borderRadius: 8,
+                border: '1px solid var(--border-subtle)',
+                background: 'var(--bg-elevated)',
+                gap: 12,
+                flexWrap: 'wrap',
+              }}
+            >
+              <div style={{ flex: 1, minWidth: 220 }}>
+                <div style={{ fontSize: 13, fontWeight: 600, color: evt.color, display: 'flex', alignItems: 'center', gap: 6 }}>
+                  {evt.icon}
+                  <span>{pt ? evt.titlePt : evt.titleEn}</span>
+                  <span style={{ fontSize: 11, fontWeight: 400, color: 'var(--text-tertiary)', marginLeft: 4 }}>
+                    ({evt.key})
+                  </span>
+                </div>
+                <div style={{ fontSize: 11, color: 'var(--text-tertiary)', marginTop: 2 }}>
+                  {pt ? evt.descPt : evt.descEn}
+                </div>
+              </div>
 
-        {/* Working */}
-        <div
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'space-between',
-            padding: '12px 14px',
-            borderRadius: 8,
-            border: '1px solid var(--border-subtle)',
-            background: 'var(--bg-elevated)',
-          }}
-        >
-          <div>
-            <div style={{ fontSize: 13, fontWeight: 600, color: '#22c55e', display: 'flex', alignItems: 'center', gap: 6 }}>
-              <Activity size={15} style={{ color: '#22c55e' }} />
-              <span>{pt ? 'Trabalhando' : 'Working'}</span>
-              <span style={{ fontSize: 11, fontWeight: 400, color: 'var(--text-tertiary)', marginLeft: 4 }}>
-                (working)
-              </span>
-            </div>
-            <div style={{ fontSize: 11, color: 'var(--text-tertiary)', marginTop: 2 }}>
-              {pt
-                ? 'Quando a sessão retoma a execução / geração de código'
-                : 'When session resumes execution / code generation'}
-            </div>
-          </div>
-          <Toggle
-            on={settings.events['working']}
-            onToggle={() => updateEvent('working', !settings.events['working'])}
-          />
-        </div>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 10, flexShrink: 0 }}>
+                {/* Per-Status Sound Dropdown */}
+                {settings.soundEnabled && (
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+                    <select
+                      value={currentSound}
+                      onChange={e => updateEventSound(evt.key, e.target.value as SoundPreset)}
+                      disabled={!enabled}
+                      style={{
+                        padding: '5px 8px',
+                        borderRadius: 6,
+                        border: '1px solid var(--border-subtle)',
+                        background: 'var(--bg-surface)',
+                        color: enabled ? 'var(--text-primary)' : 'var(--text-tertiary)',
+                        fontSize: 11,
+                        fontFamily: 'inherit',
+                        cursor: enabled ? 'pointer' : 'not-allowed',
+                        opacity: enabled ? 1 : 0.6,
+                      }}
+                    >
+                      {SOUND_PRESETS.map(p => (
+                        <option key={p.key} value={p.key}>
+                          {pt ? p.labelPt : p.labelEn}
+                        </option>
+                      ))}
+                    </select>
 
-        {/* Exited */}
-        <div
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'space-between',
-            padding: '12px 14px',
-            borderRadius: 8,
-            border: '1px solid var(--border-subtle)',
-            background: 'var(--bg-elevated)',
-          }}
-        >
-          <div>
-            <div style={{ fontSize: 13, fontWeight: 600, color: 'var(--text-secondary)', display: 'flex', alignItems: 'center', gap: 6 }}>
-              <XCircle size={15} style={{ color: 'var(--text-tertiary)' }} />
-              <span>{pt ? 'Sessão Encerrada' : 'Session Exited'}</span>
-              <span style={{ fontSize: 11, fontWeight: 400, color: 'var(--text-tertiary)', marginLeft: 4 }}>
-                (exited)
-              </span>
+                    <button
+                      onClick={() => playNotificationSound(currentSound, settings.soundVolume)}
+                      disabled={!enabled}
+                      title={pt ? 'Ouvir toque deste status' : 'Play sound'}
+                      style={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        width: 28,
+                        height: 28,
+                        borderRadius: 6,
+                        border: '1px solid var(--border-subtle)',
+                        background: 'var(--bg-surface)',
+                        color: enabled ? 'var(--anthropic-orange)' : 'var(--text-tertiary)',
+                        cursor: enabled ? 'pointer' : 'not-allowed',
+                        padding: 0,
+                        opacity: enabled ? 1 : 0.6,
+                      }}
+                    >
+                      <Volume2 size={13} />
+                    </button>
+                  </div>
+                )}
+
+                <Toggle
+                  on={enabled}
+                  onToggle={() => updateEvent(evt.key, !enabled)}
+                />
+              </div>
             </div>
-            <div style={{ fontSize: 11, color: 'var(--text-tertiary)', marginTop: 2 }}>
-              {pt
-                ? 'Quando o processo de uma sessão ao vivo é finalizado'
-                : 'When a live session process exits or terminates'}
-            </div>
-          </div>
-          <Toggle
-            on={settings.events['exited']}
-            onToggle={() => updateEvent('exited', !settings.events['exited'])}
-          />
-        </div>
+          )
+        })}
       </div>
 
       <Divider />
 
-      {/* Sound Effects Section */}
-      <SectionHeader label={pt ? 'Efeitos Sonoros' : 'Sound Effects'} />
+      {/* General Sound Effects Section */}
+      <SectionHeader label={pt ? 'Efeitos Sonoros Globais' : 'Sound Effects'} />
 
       <PrefRow
         label={pt ? 'Tocar Som nas Notificações' : 'Play Sound on Notifications'}
-        sub={pt ? 'Efeito sonoro synthesized sem arquivos externos' : 'Synthesized audio chime without external asset downloads'}
+        sub={pt ? 'Efeito sonoro sintetizado via Web Audio API sem arquivos externos' : 'Synthesized audio chime via Web Audio API without external downloads'}
       >
         <Toggle on={settings.soundEnabled} onToggle={() => update({ soundEnabled: !settings.soundEnabled })} />
       </PrefRow>
@@ -321,7 +340,7 @@ export default function NotificationsSettings() {
         <>
           <div style={{ marginTop: 14, marginBottom: 14 }}>
             <div style={{ fontSize: 12, fontWeight: 600, color: 'var(--text-secondary)', marginBottom: 8 }}>
-              {pt ? 'Estilo do Som' : 'Sound Style'}
+              {pt ? 'Toque Padrão / Fallback' : 'Default Sound Style'}
             </div>
             <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(160px, 1fr))', gap: 8 }}>
               {SOUND_PRESETS.map(preset => {

--- a/packages/web/src/pages/settings/NotificationsSettings.tsx
+++ b/packages/web/src/pages/settings/NotificationsSettings.tsx
@@ -12,7 +12,7 @@ import {
   type SoundPreset,
 } from '../../lib/sessionNotifications'
 import { SectionHeader, Divider, PrefRow, Toggle } from './primitives'
-import { Bell, Volume2, VolumeX, ShieldAlert, Sparkles, CheckCircle2, AlertCircle } from 'lucide-react'
+import { Bell, Volume2, VolumeX, ShieldAlert, Sparkles, CheckCircle2, AlertCircle, Clock, Activity, XCircle } from 'lucide-react'
 
 export default function NotificationsSettings() {
   const ctx = useOutletContext<AppContext>()
@@ -55,7 +55,7 @@ export default function NotificationsSettings() {
 
   function handleTestSoundAndNotification() {
     triggerSessionNotification({
-      title: pt ? '🔔 Notificação de Teste' : '🔔 Test Notification',
+      title: pt ? 'Notificação de Teste' : 'Test Notification',
       body: pt
         ? 'Isso é uma demonstração do alerta sonoro e visual das Live Sessions.'
         : 'This is a test of the Live Sessions visual and sound notification.',
@@ -190,7 +190,7 @@ export default function NotificationsSettings() {
         >
           <div>
             <div style={{ fontSize: 13, fontWeight: 600, color: '#ef4444', display: 'flex', alignItems: 'center', gap: 6 }}>
-              <span>🔴</span>
+              <AlertCircle size={15} style={{ color: '#ef4444' }} />
               <span>{pt ? 'Precisa de Aprovação' : 'Needs Approval'}</span>
               <span style={{ fontSize: 11, fontWeight: 400, color: 'var(--text-tertiary)', marginLeft: 4 }}>
                 (waiting-approval)
@@ -222,7 +222,7 @@ export default function NotificationsSettings() {
         >
           <div>
             <div style={{ fontSize: 13, fontWeight: 600, color: 'var(--anthropic-orange)', display: 'flex', alignItems: 'center', gap: 6 }}>
-              <span>🟡</span>
+              <Clock size={15} style={{ color: 'var(--anthropic-orange)' }} />
               <span>{pt ? 'Aguardando Resposta' : 'Waiting Response'}</span>
               <span style={{ fontSize: 11, fontWeight: 400, color: 'var(--text-tertiary)', marginLeft: 4 }}>
                 (waiting)
@@ -230,7 +230,7 @@ export default function NotificationsSettings() {
             </div>
             <div style={{ fontSize: 11, color: 'var(--text-tertiary)', marginTop: 2 }}>
               {pt
-                ? 'Quando a IA conclui a resposta e aguarda sua nova mensagem/comando'
+                ? 'Quando a IA concluiu a resposta e aguarda sua nova mensagem/comando'
                 : 'When AI completes its turn and awaits your input/command'}
             </div>
           </div>
@@ -254,7 +254,7 @@ export default function NotificationsSettings() {
         >
           <div>
             <div style={{ fontSize: 13, fontWeight: 600, color: '#22c55e', display: 'flex', alignItems: 'center', gap: 6 }}>
-              <span>🟢</span>
+              <Activity size={15} style={{ color: '#22c55e' }} />
               <span>{pt ? 'Trabalhando' : 'Working'}</span>
               <span style={{ fontSize: 11, fontWeight: 400, color: 'var(--text-tertiary)', marginLeft: 4 }}>
                 (working)
@@ -286,7 +286,7 @@ export default function NotificationsSettings() {
         >
           <div>
             <div style={{ fontSize: 13, fontWeight: 600, color: 'var(--text-secondary)', display: 'flex', alignItems: 'center', gap: 6 }}>
-              <span>⚪</span>
+              <XCircle size={15} style={{ color: 'var(--text-tertiary)' }} />
               <span>{pt ? 'Sessão Encerrada' : 'Session Exited'}</span>
               <span style={{ fontSize: 11, fontWeight: 400, color: 'var(--text-tertiary)', marginLeft: 4 }}>
                 (exited)


### PR DESCRIPTION
## Summary
- Reordered the `harness` column in `agentop` CLI TUI list so it immediately follows `id`.
- Updated focused session row styling to use blue text (`COLORS.info`) with `underline` across all cells.
- Preserved the unique brand color of the `harness` column while applying the `underline` effect on focus.
- Resolved TypeScript types in notification settings.