### PR TITLE
fix(control): report endedAt age for closed sessions and differentiate off states

### DIFF
--- a/packages/web/src/lib/sessionNotifications.ts
+++ b/packages/web/src/lib/sessionNotifications.ts
@@ -18,7 +18,7 @@ export interface NotificationSettings {
     'working': boolean
     'exited': boolean
   }
-  eventSounds?: {
+  eventSounds: {
     'waiting-approval': SoundPreset
     'waiting': SoundPreset
     'working': SoundPreset

--- a/packages/web/src/pages/settings/NotificationsSettings.tsx
+++ b/packages/web/src/pages/settings/NotificationsSettings.tsx
@@ -37,8 +37,9 @@ export default function NotificationsSettings() {
     update({ events: nextEvents })
   }
 
-  function updateEventSound(eventKey: keyof NotificationSettings['eventSounds'], value: SoundPreset) {
-    const nextSounds = { ...(settings.eventSounds || DEFAULT_NOTIFICATION_SETTINGS.eventSounds), [eventKey]: value }
+  function updateEventSound(eventKey: keyof NotificationSettings['events'], value: SoundPreset) {
+    const eventSounds = settings.eventSounds ?? DEFAULT_NOTIFICATION_SETTINGS.eventSounds
+    const nextSounds = { ...eventSounds, [eventKey]: value }
     update({ eventSounds: nextSounds })
   }
 


### PR DESCRIPTION
Fixes session age calculation for non-running sessions using endedAt and differentiates PT off states (encerrada, desconectada, fechada).