### PR TITLE
release: page the TUI dashboard's list screens

### DIFF
--- a/packages/tui/src/App.tsx
+++ b/packages/tui/src/App.tsx
@@ -35,7 +35,14 @@ export function App({ apiBase, lang }: { apiBase: string; lang: TuiLang }) {
   const { data, connection, refresh } = useAppData(apiBase)
 
   const [help, setHelp] = React.useState(false)
-  const nav = useDashboardNav({ isActive: !help, harnesses: data?.harnesses })
+  // The nav needs both to clamp a page: what is being listed, and how many rows a page holds here.
+  const bodyHeight = Math.max(3, rows - CHROME_ROWS)
+  const nav = useDashboardNav({
+    isActive: !help,
+    harnesses: data?.harnesses,
+    data,
+    height: bodyHeight,
+  })
 
   useInput((input, key) => {
     if (help) {
@@ -64,7 +71,6 @@ export function App({ apiBase, lang }: { apiBase: string; lang: TuiLang }) {
     )
   }
 
-  const bodyHeight = Math.max(3, rows - CHROME_ROWS)
   // The shell adds one column of padding on each side; screens must size against what is left,
   // or a full-width bar/table overflows by exactly those two columns and wraps.
   const bodyWidth = Math.max(20, columns - PADDING_X * 2)

--- a/packages/tui/src/components/Primitives.tsx
+++ b/packages/tui/src/components/Primitives.tsx
@@ -66,6 +66,29 @@ export function Empty({ message }: { message: string }) {
 }
 
 /**
+ * The line under a paged list: where you are, how much there IS, and the keys that move.
+ *
+ * The total is the point. These screens used to slice to whatever the terminal afforded and say
+ * nothing about the rest, so a machine holding hundreds of sessions answered with the twenty-five
+ * that happened to fit — a confident wrong number in the one place a person goes to find out. What
+ * is on screen is a WINDOW, and a window that does not say so is a total.
+ */
+export function Pager({ window: win, total, s }: {
+  window: { page: number; pages: number; from: number; to: number }
+  total: number
+  s: { pageOf: (page: number, pages: number) => string; showing: (from: number, to: number, total: number) => string; pagerHint: string }
+}) {
+  return (
+    <Text dimColor>
+      {s.pageOf(win.page + 1, win.pages)}
+      {'  ·  '}
+      {s.showing(win.from + 1, win.to, total)}
+      {win.pages > 1 ? `  ·  ${s.pagerHint}` : ''}
+    </Text>
+  )
+}
+
+/**
  * Truncates to a visible width with an ellipsis. Terminal cells are the constraint here, and an
  * over-long project path or session title would otherwise wrap and break every row below it.
  */

--- a/packages/tui/src/control/tabs/Dashboard.tsx
+++ b/packages/tui/src/control/tabs/Dashboard.tsx
@@ -55,7 +55,7 @@ export function Dashboard({ status, strings: s, lang, width, height, isActive, n
     nonce,
   })
 
-  const nav = useDashboardNav({ isActive, harnesses: data?.harnesses })
+  const nav = useDashboardNav({ isActive, harnesses: data?.harnesses, data, height })
 
   useEffect(() => {
     if (!isActive) return

--- a/packages/tui/src/dashboard/DashboardView.tsx
+++ b/packages/tui/src/dashboard/DashboardView.tsx
@@ -25,31 +25,20 @@ import { Costs } from '../screens/Costs'
 import { Harnesses } from '../screens/Harnesses'
 import { Hardware } from '../screens/Hardware'
 import { FilterOverlay } from '../overlays/Overlays'
-import { sessionHarness } from '../selectors'
 import { Divider } from '../control/Surface'
 import { fitsBeside, sourceRowText } from '../control/surface.ts'
 import { ACTION_SEP } from '../control/chrome.ts'
 import { COLORS } from '../theme'
 import type { TuiStrings } from '../i18n'
 import type { ConnectionState } from '../data/useAppData'
-import { DASHBOARD_SCREENS, dashboardRows, stripFit } from './view'
+import { applyHarnessFilter, DASHBOARD_SCREENS, dashboardRows, stripFit } from './view'
 import type { DashboardNav } from './useDashboardNav'
 
 /**
- * Restricts an AppData to one harness, so every screen can stay filter-unaware.
- *
- * Claude's totals live in the statsCache and every other harness's live in the session list, so
- * filtering has to act on BOTH: selecting a non-Claude harness must blank the cache, or the
- * Claude numbers would survive the filter and be attributed to the selection.
+ * Kept exported here under its old name: it moved down to the pure view module, beside the paging
+ * that is decided against its result, not out of the product.
  */
-export function applyHarnessFilter(data: AppData, harness: HarnessId | null): AppData {
-  if (!harness) return data
-  return {
-    ...data,
-    harnesses: (data.harnesses ?? []).filter(h => h === harness),
-    sessions: (data.sessions ?? []).filter(s => sessionHarness(s) === harness),
-  }
-}
+export { applyHarnessFilter } from './view'
 
 export interface DashboardViewProps {
   /** `null` while nothing has been read yet — a different sentence from "there is nothing". */
@@ -85,7 +74,7 @@ export function DashboardView({ data, apiBase, s, width, height, nav, connection
       ? <Box marginTop={1}><Text color={COLORS.muted}>{notice}</Text></Box>
       : !view
         ? <Box marginTop={1}><Text color={COLORS.accent}>{s.loading}…</Text></Box>
-        : <Screen id={nav.screen} data={view} apiBase={apiBase} s={s} width={width} height={rows.body} streak={streak} />
+        : <Screen id={nav.screen} data={view} apiBase={apiBase} s={s} width={width} height={rows.body} streak={streak} page={nav.page} />
 
   return (
     // `flexShrink={0}`: the budget above is this view's contract with whatever frames it, and a Box
@@ -110,7 +99,7 @@ export function DashboardView({ data, apiBase, s, width, height, nav, connection
   )
 }
 
-function Screen({ id, data, apiBase, s, width, height, streak }: {
+function Screen({ id, data, apiBase, s, width, height, streak, page }: {
   id: DashboardNav['screen']
   data: AppData
   apiBase?: string | null
@@ -118,12 +107,14 @@ function Screen({ id, data, apiBase, s, width, height, streak }: {
   width: number
   height: number
   streak: number
+  /** The page the three LIST screens are on. The others draw no list and ignore it. */
+  page: number
 }) {
   switch (id) {
     case 'overview': return <Overview data={data} s={s} width={width} height={height} streak={streak} />
-    case 'projects': return <Projects data={data} s={s} width={width} height={height} />
-    case 'history': return <History data={data} s={s} width={width} height={height} />
-    case 'costs': return <Costs data={data} s={s} width={width} height={height} />
+    case 'projects': return <Projects data={data} s={s} width={width} height={height} page={page} />
+    case 'history': return <History data={data} s={s} width={width} height={height} page={page} />
+    case 'costs': return <Costs data={data} s={s} width={width} height={height} page={page} />
     case 'harnesses': return <Harnesses data={data} s={s} width={width} height={height} />
     case 'hardware': return <Hardware data={data} apiBase={apiBase ?? null} s={s} width={width} height={height} />
   }

--- a/packages/tui/src/dashboard/useDashboardNav.ts
+++ b/packages/tui/src/dashboard/useDashboardNav.ts
@@ -12,11 +12,20 @@
  * uses the same flag to hold its own `?`/`q` handler back.
  */
 
-import { useMemo, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { useInput } from 'ink'
-import type { HarnessId } from '@agentistics/core'
+import type { AppData, HarnessId } from '@agentistics/core'
 import { HARNESS_ORDER } from '@agentistics/core'
-import { DASHBOARD_SCREENS, resolveDashboardScreen, type DashboardScreenId } from './view'
+import {
+  applyHarnessFilter,
+  dashboardRows,
+  DASHBOARD_SCREENS,
+  listPlan,
+  pageableTotal,
+  pageWindow,
+  resolveDashboardScreen,
+  type DashboardScreenId,
+} from './view'
 
 export interface DashboardFilter {
   /** `null` is the "all harnesses" entry, always first. */
@@ -33,17 +42,42 @@ export interface DashboardNav {
   filter: DashboardFilter | null
   /** True while the picker owns the keyboard. */
   capture: boolean
+  /** The page the open screen's list is on, 0-based. Clamped where the rows are drawn as well. */
+  page: number
 }
+
+/**
+ * The keys that page a list.
+ *
+ * The ARROWS are not among them, deliberately — see `resolveDashboardScreen`: the control center
+ * answers `←`/`→` for its tabs, and a key answered here as well would do two things at once. `pgup`
+ * and `pgdn` are free everywhere this is drawn, and `,` / `.` are the fallback for the terminals
+ * that keep those two for their own scrollback. Both are named by the pager line itself, which is
+ * the only documentation a screen this dense can afford.
+ */
+const PAGE_BACK = ','
+const PAGE_FORWARD = '.'
 
 export function useDashboardNav(opts: {
   isActive: boolean
   /** The harnesses that actually have data, so the picker never offers an empty one. */
   harnesses: readonly HarnessId[] | undefined
+  /**
+   * What the screens are drawing, so a page can be clamped against the rows that EXIST.
+   *
+   * An unbounded counter takes as many presses to come back as it took to run past the end, and
+   * correcting it where the rows are drawn is one frame too late — that frame is the one the next
+   * key lands on.
+   */
+  data?: AppData | null
+  /** The height `DashboardView` is given, which is what decides how many rows a page holds. */
+  height?: number
 }): DashboardNav {
   const [screen, setScreen] = useState<DashboardScreenId>(DASHBOARD_SCREENS[0]!)
   const [harness, setHarness] = useState<HarnessId | null>(null)
   const [open, setOpen] = useState(false)
   const [index, setIndex] = useState(0)
+  const [page, setPage] = useState(0)
 
   // Keyed on the joined ids rather than the array: `data.harnesses` is a fresh array on every
   // payload, and rebuilding this list each time would reset nothing but would churn every consumer.
@@ -53,6 +87,24 @@ export function useDashboardNav(opts: {
     return [null, ...HARNESS_ORDER.filter(h => present.has(h))]
   }, [key])
 
+  /**
+   * Open a screen — the ONE way, so a click on the strip resets the page exactly as a key does.
+   *
+   * Each screen lists something else, so a page carried across is a position in a list that is not
+   * there any more.
+   */
+  const goto = useCallback((id: DashboardScreenId) => {
+    setScreen(id)
+    setPage(0)
+  }, [])
+
+  // Paging is decided against the FILTERED list, so a page can never name a row the filter removed
+  // and the page count is the count of what the filter left standing.
+  const view = opts.data ? applyHarnessFilter(opts.data, harness) : null
+  const total = pageableTotal(screen, view)
+  const body = dashboardRows(opts.height ?? 0).body
+  const pages = pageWindow(total, listPlan(body, total).size, 0).pages
+
   useInput((input, key2) => {
     if (open) {
       if (key2.escape) { setOpen(false); return }
@@ -60,6 +112,9 @@ export function useDashboardNav(opts: {
       if (key2.downArrow) { setIndex(i => Math.min(options.length - 1, i + 1)); return }
       if (key2.return) {
         setHarness(options[index] ?? null)
+        // A new filter is a new list; keeping the page would land on a window of it that has
+        // nothing to do with where the reader was.
+        setPage(0)
         setOpen(false)
       }
       return
@@ -72,15 +127,22 @@ export function useDashboardNav(opts: {
       return
     }
 
+    if (key2.pageUp || input === PAGE_BACK) { setPage(p => Math.max(0, p - 1)); return }
+    if (key2.pageDown || input === PAGE_FORWARD) {
+      setPage(p => Math.min(pages - 1, p + 1))
+      return
+    }
+
     const next = resolveDashboardScreen({ input, tab: key2.tab, shift: key2.shift }, screen)
-    if (next) setScreen(next)
+    if (next) goto(next)
   }, { isActive: opts.isActive })
 
   return {
     screen,
-    setScreen,
+    setScreen: goto,
     harness,
     filter: open ? { options, index } : null,
     capture: open,
+    page,
   }
 }

--- a/packages/tui/src/dashboard/view.test.ts
+++ b/packages/tui/src/dashboard/view.test.ts
@@ -8,12 +8,16 @@ import {
   costsPlan,
   dashboardRows,
   dashboardSource,
+  listPlan,
   listRows,
   overviewPlan,
+  PAGE_SIZE,
+  pageWindow,
   resolveDashboardScreen,
   stripCells,
   stripFit,
   SHARE_MAX,
+  pageableTotal,
 } from './view'
 
 const key = (over: Partial<Parameters<typeof resolveDashboardScreen>[0]> = {}) =>
@@ -146,7 +150,10 @@ describe('row budgets', () => {
         if (o.empty) expect(n).toBe(0)
 
         const c = costsPlan(height, n)
-        const costSpent = c.table > 0 ? 1 + c.table + (c.share > 0 ? 2 + c.share : 0) : 0
+        // Header + rows + the pager's own line + the share panel's chrome and bars.
+        const costSpent = c.table > 0
+          ? 1 + c.table + (c.pager ? 1 : 0) + (c.share > 0 ? 2 + c.share : 0)
+          : 0
         expect(costSpent).toBeLessThanOrEqual(Math.max(0, height))
         expect(c.share).toBeLessThanOrEqual(Math.min(n, SHARE_MAX))
 
@@ -169,7 +176,7 @@ describe('row budgets', () => {
     expect(tight.share).toBe(0)
     expect(tight.table).toBe(5)
     // One row is the header alone. A result row on top of it is the overflow Ink composites.
-    expect(costsPlan(1, 5)).toEqual({ table: 0, share: 0 })
+    expect(costsPlan(1, 5)).toEqual({ table: 0, share: 0, pager: false })
   })
 
   test('a table asks for one row fewer than its height, because it draws a header', () => {
@@ -177,5 +184,86 @@ describe('row budgets', () => {
     // Never zero: a table with no rows at all says less than a table with one.
     expect(listRows(1)).toBe(1)
     expect(listRows(0)).toBe(1)
+  })
+})
+
+describe('paging', () => {
+  test('pageWindow names the slice of the requested page', () => {
+    expect(pageWindow(355, 15, 0)).toEqual({ page: 0, pages: 24, from: 0, to: 15 })
+    expect(pageWindow(355, 15, 1)).toEqual({ page: 1, pages: 24, from: 15, to: 30 })
+  })
+
+  test('the last page is short, never a slice past the end', () => {
+    // 355 = 23 full pages of 15 plus 10 rows.
+    expect(pageWindow(355, 15, 23)).toEqual({ page: 23, pages: 24, from: 345, to: 355 })
+  })
+
+  test('a page pointing past the end is clamped, never blank', () => {
+    // The list shortens under a remembered page every time the filter changes.
+    expect(pageWindow(20, 15, 9)).toEqual({ page: 1, pages: 2, from: 15, to: 20 })
+    expect(pageWindow(20, 15, -3)).toEqual({ page: 0, pages: 2, from: 0, to: 15 })
+    expect(pageWindow(20, 15, NaN)).toEqual({ page: 0, pages: 2, from: 0, to: 15 })
+  })
+
+  test('an empty list is page 1 of 1, never page 1 of 0', () => {
+    expect(pageWindow(0, 15, 4)).toEqual({ page: 0, pages: 1, from: 0, to: 0 })
+  })
+
+  test('a size below one row is one row, never a division by zero', () => {
+    expect(pageWindow(7, 0, 0)).toEqual({ page: 0, pages: 7, from: 0, to: 1 })
+  })
+
+  test('a list that fits pays for no pager', () => {
+    // A line saying "page 1 of 1" is a row spent stating that nothing was withheld.
+    expect(listPlan(30, 10)).toEqual({ size: PAGE_SIZE, pager: false })
+    expect(listPlan(30, PAGE_SIZE)).toEqual({ size: PAGE_SIZE, pager: false })
+  })
+
+  test('one row held back is what raises the pager', () => {
+    expect(listPlan(30, PAGE_SIZE + 1)).toEqual({ size: PAGE_SIZE, pager: true })
+  })
+
+  test('a short body shortens the PAGE rather than overflowing', () => {
+    // Ink composites what does not fit, so the height is a ceiling on the page and not on nothing.
+    expect(listPlan(10, 100)).toEqual({ size: 8, pager: true })
+    expect(listPlan(3, 100)).toEqual({ size: 1, pager: true })
+    expect(listPlan(1, 100).size).toBe(1)
+  })
+
+  test('a page and its chrome never spend more rows than the body has', () => {
+    for (let height = 1; height <= 40; height++) {
+      for (const total of [0, 1, 7, 15, 16, 355]) {
+        const plan = listPlan(height, total)
+        const rows = Math.min(plan.size, total)
+        const spent = (rows > 0 ? 1 + rows : 0) + (plan.pager ? 1 : 0)
+        // One row of a height of one is the floor this arithmetic is allowed to break, and it is
+        // the same floor `listRows` has always had.
+        if (height > 2) expect(spent).toBeLessThanOrEqual(height)
+        expect(plan.size).toBeLessThanOrEqual(PAGE_SIZE)
+        expect(plan.size).toBeGreaterThanOrEqual(1)
+      }
+    }
+  })
+
+  test('the costs table pages without pushing its share panel off the screen', () => {
+    const many = costsPlan(30, 40)
+    expect(many.pager).toBe(true)
+    expect(many.share).toBe(SHARE_MAX)
+    expect(many.table).toBeLessThanOrEqual(PAGE_SIZE)
+    // Header + page + pager + share chrome + bars, all inside the height.
+    expect(1 + many.table + 1 + 2 + many.share).toBeLessThanOrEqual(30)
+  })
+
+  test('only the three list screens page at all', () => {
+    const data = { sessions: [], projects: [], harnesses: [] } as never
+    for (const id of DASHBOARD_SCREENS) {
+      // overview / harnesses / hardware draw no list, so their pager keys do nothing by arithmetic
+      // rather than by a special case in the keyboard.
+      if (id === 'overview' || id === 'harnesses' || id === 'hardware') {
+        expect(pageableTotal(id, data)).toBe(0)
+      }
+    }
+    // Nothing read yet is not the same as an empty list, and neither can be paged.
+    expect(pageableTotal('history', null)).toBe(0)
   })
 })

--- a/packages/tui/src/dashboard/view.ts
+++ b/packages/tui/src/dashboard/view.ts
@@ -15,9 +15,11 @@
  * which its parts give way.
  */
 
+import type { AppData, HarnessId } from '@agentistics/core'
 import type { NavKey } from '../control/nav'
 import type { ControlService } from '../control/types'
 import { sourceRowFit, type SourceRowFit } from '../control/surface.ts'
+import { modelRows, projectRows, sessionHarness, sessionRows } from '../selectors'
 import type { TuiStrings } from '../i18n'
 
 /**
@@ -221,10 +223,12 @@ export function overviewPlan(height: number, harnesses: number): OverviewPlan {
 }
 
 export interface CostsPlan {
-  /** Model rows under the table header. */
+  /** Model rows under the table header — one page of them once `pager` is set. */
   table: number
   /** Bars in the share panel. `0` means it is not drawn. */
   share: number
+  /** Whether the pager line is drawn, and therefore whether its row was paid for. */
+  pager: boolean
 }
 
 /**
@@ -233,8 +237,23 @@ export interface CostsPlan {
  * The TABLE is the screen: it is every model, priced and ranked, while the share panel re-states the
  * top five as bars. So the panel is what gives way, whole — a share panel showing one of five bars is
  * a proportion the reader cannot use.
+ *
+ * The pager is decided LAST and only once a model would be held back. Its page is `PAGE_SIZE` at
+ * most, like every other list, but it is also bounded by whatever the share panel leaves — the share
+ * panel is a view OF the table's top rows, so a page that pushed it off screen would be paging one
+ * half of the screen by destroying the other.
  */
 export function costsPlan(height: number, models: number): CostsPlan {
+  const whole = costsLayout(height, models)
+  // A pager over a table with no rows at all is a row spent saying nothing can be shown; at that
+  // height the header is the only thing left, and it still says what the columns are.
+  if (whole.table <= 0 || models <= whole.table) return { ...whole, pager: false }
+  const paged = costsLayout(height - PAGER_ROW, models)
+  return { ...paged, table: Math.min(PAGE_SIZE, paged.table), pager: true }
+}
+
+/** The table/share split at a given height, pager already paid for by the caller. */
+function costsLayout(height: number, models: number): { table: number; share: number } {
   // At one row there is only the table's own header, which still says what the columns are. Asking
   // for a result row as well is one row of overflow — and `Math.max(1, …)` is exactly the shape of
   // that bug: it hands out a row that does not exist.
@@ -251,6 +270,123 @@ export function costsPlan(height: number, models: number): CostsPlan {
 /** Result rows a plain table may draw at this height — its header is not free. */
 export function listRows(height: number): number {
   return Math.max(1, height - TABLE_HEADER)
+}
+
+// ---------------------------------------------------------------------------
+// paging
+// ---------------------------------------------------------------------------
+
+/**
+ * Rows a page of a list holds.
+ *
+ * The three list screens used to slice to whatever the terminal afforded and stop there, with no way
+ * to reach anything below the fold: on a 25-row terminal that answered "you have 25 sessions" to a
+ * machine holding hundreds — a confident wrong number, in the one place a person goes to find out.
+ *
+ * It is a FIXED 15 rather than "whatever fits" because the pager states a place, and a place whose
+ * page count changes when you resize the window is not one. The height still bounds it downward: Ink
+ * COMPOSITES what does not fit rather than clipping it, so a page taller than the body paints over
+ * whatever is below.
+ */
+export const PAGE_SIZE = 15
+
+/** The pager line costs a row wherever it is drawn. */
+const PAGER_ROW = 1
+
+export interface PageWindow {
+  /** The page actually in force, clamped into range. */
+  page: number
+  /** At least 1: an empty list is on page 1 of 1, never page 1 of 0. */
+  pages: number
+  /** Slice bounds for `rows.slice(from, to)`. */
+  from: number
+  /** One past the last index, `Math.min`ed against the total — a short last page stays honest. */
+  to: number
+}
+
+/**
+ * Which slice of a list a page names — PURE, and CLAMPED on every call.
+ *
+ * Clamped rather than corrected in an effect, for the same reason the cockpit's cursor is: a filter
+ * that removes rows, or a poll that ends a session, shortens the list under a remembered index, and
+ * a stored page would point past the end for exactly one frame — the frame the user presses a key
+ * on. The cockpit's own `cardPages` is deliberately NOT this function: its pages are bands of
+ * variable height rather than fixed slices, so the two share the idea and nothing else.
+ */
+export function pageWindow(total: number, size: number, page: number): PageWindow {
+  const capacity = Math.max(1, Math.floor(size))
+  const count = Math.max(0, Math.floor(total))
+  const pages = Math.max(1, Math.ceil(count / capacity))
+  const at = clampInt(Math.floor(page), 0, pages - 1)
+  const from = at * capacity
+  return { page: at, pages, from, to: Math.min(count, from + capacity) }
+}
+
+export interface ListPlan {
+  /** Rows one page may draw. */
+  size: number
+  /** Whether the pager line is drawn — and therefore whether it was paid for. */
+  pager: boolean
+}
+
+/**
+ * How a plain list spends its rows: results, and the pager line under them.
+ *
+ * A list that fits pays for NO pager — a pager saying "page 1 of 1" is a row spent stating that
+ * nothing was withheld, on a screen whose rows are the scarce thing. As soon as one row would be
+ * held back the line appears, because that is the moment its absence becomes a lie.
+ */
+export function listPlan(height: number, total: number): ListPlan {
+  const whole = Math.max(1, Math.min(PAGE_SIZE, height - TABLE_HEADER))
+  if (total <= whole) return { size: whole, pager: false }
+  return { size: Math.max(1, Math.min(PAGE_SIZE, height - TABLE_HEADER - PAGER_ROW)), pager: true }
+}
+
+/**
+ * How many rows the screen behind `id` would list — the total a pager counts against.
+ *
+ * It exists so the KEYBOARD can clamp: an unbounded page counter takes as many presses to come back
+ * as it took to run past the end, and correcting it where the rows are drawn is one frame too late.
+ * The screens that page nothing report 0, which reads as a single page and no keys — `overview` and
+ * `hardware` draw no list, and `harnesses` cannot have more rows than there are harnesses.
+ */
+export function pageableTotal(id: DashboardScreenId, data: AppData | null): number {
+  if (!data) return 0
+  switch (id) {
+    case 'history': return sessionRows(data).length
+    case 'projects': return projectRows(data).length
+    case 'costs': return modelRows(data).length
+    default: return 0
+  }
+}
+
+function clampInt(n: number, lo: number, hi: number): number {
+  if (!Number.isFinite(n)) return lo
+  return Math.min(hi, Math.max(lo, n))
+}
+
+// ---------------------------------------------------------------------------
+// the harness filter
+// ---------------------------------------------------------------------------
+
+/**
+ * Restricts an AppData to one harness, so every screen can stay filter-unaware.
+ *
+ * Claude's totals live in the statsCache and every other harness's live in the session list, so
+ * filtering has to act on BOTH: selecting a non-Claude harness must blank the cache, or the
+ * Claude numbers would survive the filter and be attributed to the selection.
+ *
+ * It lives here, beside `pageableTotal`, because paging is decided AGAINST THE FILTERED LIST: the
+ * page count is the count of what the filter left standing, and a page can never name a row the
+ * filter removed.
+ */
+export function applyHarnessFilter(data: AppData, harness: HarnessId | null): AppData {
+  if (!harness) return data
+  return {
+    ...data,
+    harnesses: (data.harnesses ?? []).filter(h => h === harness),
+    sessions: (data.sessions ?? []).filter(s => sessionHarness(s) === harness),
+  }
 }
 
 /**

--- a/packages/tui/src/i18n.ts
+++ b/packages/tui/src/i18n.ts
@@ -80,8 +80,15 @@ export interface TuiStrings {
   filterTitle: string
   filterAll: string
   filterHint: string
+  helpPager: string
 
   days: (n: number) => string
+  /** "page 2 of 24" — the place, said the same way at every terminal size. */
+  pageOf: (page: number, pages: number) => string
+  /** "16-30 of 355" — the window AND the total, because the window alone reads as the total. */
+  showing: (from: number, to: number, total: number) => string
+  /** The keys that page, named on the line itself. */
+  pagerHint: string
 }
 
 const en: TuiStrings = {
@@ -136,8 +143,12 @@ const en: TuiStrings = {
   filterTitle: 'Filter by harness',
   filterAll: 'All harnesses',
   filterHint: '↑↓ choose · enter apply · esc cancel',
+  helpPager: ', .         page through the list (pgup/pgdn)',
 
   days: n => `${n}d`,
+  pageOf: (page, pages) => `page ${page} of ${pages}`,
+  showing: (from, to, total) => `${from}-${to} of ${total}`,
+  pagerHint: ', . page',
 }
 
 const pt: TuiStrings = {
@@ -192,8 +203,12 @@ const pt: TuiStrings = {
   filterTitle: 'Filtrar por assistente',
   filterAll: 'Todos os assistentes',
   filterHint: '↑↓ escolher · enter aplicar · esc cancelar',
+  helpPager: ', .         paginar a lista (pgup/pgdn)',
 
   days: n => `${n}d`,
+  pageOf: (page, pages) => `página ${page} de ${pages}`,
+  showing: (from, to, total) => `${from}-${to} de ${total}`,
+  pagerHint: ', . paginar',
 }
 
 export const TUI_STRINGS: Record<TuiLang, TuiStrings> = { en, pt }

--- a/packages/tui/src/overlays/Overlays.tsx
+++ b/packages/tui/src/overlays/Overlays.tsx
@@ -25,6 +25,7 @@ export function HelpOverlay({ s }: { s: TuiStrings }) {
     <Panel title={s.helpTitle}>
       <Text dimColor>{s.helpNav}</Text>
       <Text dimColor>{s.helpFilter}</Text>
+      <Text dimColor>{s.helpPager}</Text>
       <Text dimColor>{s.helpQuit}</Text>
       <Text dimColor>{s.helpClose}</Text>
       {/* What the numbers MEAN, not just which key does what. The token total is the one figure on

--- a/packages/tui/src/screens/Costs.tsx
+++ b/packages/tui/src/screens/Costs.tsx
@@ -3,16 +3,18 @@ import { Box } from 'ink'
 import type { AppData } from '@agentistics/core'
 import { fmt, fmtCost, formatModel } from '@agentistics/core'
 import { modelRows, type ModelRow } from '../selectors'
-import { DataTable, Empty, BarRow, Section, type Column } from '../components/Primitives'
+import { DataTable, Empty, BarRow, Pager, Section, type Column } from '../components/Primitives'
 import { COLORS } from '../theme'
-import { costsPlan } from '../dashboard/view'
+import { costsPlan, pageWindow } from '../dashboard/view'
 import type { TuiStrings } from '../i18n'
 
-export function Costs({ data, s, width, height }: {
+export function Costs({ data, s, width, height, page }: {
   data: AppData
   s: TuiStrings
   width: number
   height: number
+  /** The requested page, 0-based. Clamped here — the shell may hand over a stale one. */
+  page?: number
 }) {
   const rows = modelRows(data)
   if (rows.length === 0) return <Empty message={s.empty} />
@@ -31,10 +33,12 @@ export function Costs({ data, s, width, height }: {
   // The table is the screen and the share panel re-states its top five as bars, so the panel is what
   // gives way — whole, never partially. See `costsPlan`.
   const plan = costsPlan(height, rows.length)
+  const win = pageWindow(rows.length, plan.table, page ?? 0)
 
   return (
-    <Box flexDirection="column">
-      <DataTable columns={columns} rows={rows.slice(0, plan.table)} keyOf={r => r.model} width={width} />
+    <Box flexDirection="column" flexShrink={0}>
+      <DataTable columns={columns} rows={rows.slice(win.from, win.to)} keyOf={r => r.model} width={width} />
+      {plan.pager && <Pager window={win} total={rows.length} s={s} />}
       {plan.share > 0 && (
         <Section title={s.share}>
           {rows.slice(0, plan.share).map(r => (

--- a/packages/tui/src/screens/History.tsx
+++ b/packages/tui/src/screens/History.tsx
@@ -12,22 +12,31 @@ import { Box } from 'ink'
 import type { AppData } from '@agentistics/core'
 import { fmt, fmtCost } from '@agentistics/core'
 import { sessionRows, type SessionRow } from '../selectors'
-import { DataTable, Empty, type Column } from '../components/Primitives'
+import { DataTable, Empty, Pager, type Column } from '../components/Primitives'
 import { COLORS, HARNESS_COLOR, HARNESS_LABEL } from '../theme'
-import { listRows } from '../dashboard/view'
+import { listPlan, pageWindow } from '../dashboard/view'
 import type { TuiStrings } from '../i18n'
 
-export function History({ data, s, width, height }: {
+export function History({ data, s, width, height, page }: {
   data: AppData
   s: TuiStrings
   width: number
   height: number
+  /** The requested page, 0-based. Clamped here — the shell may hand over a stale one. */
+  page?: number
 }) {
-  // The table spends a row on its header, so the rows it may draw are one fewer than the height it
-  // was given — asking for `height` results and then drawing a header over them is one row of
-  // overflow, which Ink composites onto whatever is below.
-  const rows = sessionRows(data, { limit: listRows(height) })
-  if (rows.length === 0) return <Empty message={s.noSessions} />
+  // The WHOLE list the filter left standing. It used to be sliced to the terminal's height with no
+  // way to reach anything below the fold, so a machine holding hundreds of sessions answered with
+  // the twenty-five that happened to fit.
+  const all = sessionRows(data)
+  if (all.length === 0) return <Empty message={s.noSessions} />
+
+  // The table spends a row on its header and the pager another, so the rows a page may draw are
+  // fewer than the height it was given — drawing over them is overflow, which Ink composites onto
+  // whatever is below.
+  const plan = listPlan(height, all.length)
+  const win = pageWindow(all.length, plan.size, page ?? 0)
+  const rows = all.slice(win.from, win.to)
 
   const labelWidth = 24
   const columns: Column<SessionRow>[] = [
@@ -47,8 +56,9 @@ export function History({ data, s, width, height }: {
   ]
 
   return (
-    <Box flexDirection="column">
+    <Box flexDirection="column" flexShrink={0}>
       <DataTable columns={columns} rows={rows} keyOf={r => r.id} width={width} />
+      {plan.pager && <Pager window={win} total={all.length} s={s} />}
     </Box>
   )
 }

--- a/packages/tui/src/screens/Projects.tsx
+++ b/packages/tui/src/screens/Projects.tsx
@@ -3,19 +3,24 @@ import { Box } from 'ink'
 import type { AppData } from '@agentistics/core'
 import { fmt, fmtCost } from '@agentistics/core'
 import { projectRows, type ProjectRow } from '../selectors'
-import { DataTable, Empty, type Column } from '../components/Primitives'
+import { DataTable, Empty, Pager, type Column } from '../components/Primitives'
 import { COLORS } from '../theme'
-import { listRows } from '../dashboard/view'
+import { listPlan, pageWindow } from '../dashboard/view'
 import type { TuiStrings } from '../i18n'
 
-export function Projects({ data, s, width, height }: {
+export function Projects({ data, s, width, height, page }: {
   data: AppData
   s: TuiStrings
   width: number
   height: number
+  /** The requested page, 0-based. Clamped here — the shell may hand over a stale one. */
+  page?: number
 }) {
-  const rows = projectRows(data)
-  if (rows.length === 0) return <Empty message={s.noProjects} />
+  const all = projectRows(data)
+  if (all.length === 0) return <Empty message={s.noProjects} />
+
+  const plan = listPlan(height, all.length)
+  const win = pageWindow(all.length, plan.size, page ?? 0)
 
   // fitColumns gives the name column whatever the numeric columns leave over.
   const nameWidth = 24
@@ -27,16 +32,18 @@ export function Projects({ data, s, width, height }: {
     { key: 'last', header: s.lastActivity, width: 12, align: 'right', render: r => r.lastActivity.slice(0, 10) },
   ]
 
-  // One row fewer than the height: the table draws a header before the first result, and asking for
-  // `height` results would overflow by exactly that row — which Ink composites rather than clips.
+  // Fewer rows than the height: the table draws a header before the first result and the pager a
+  // line under the last, and asking for `height` results would overflow by exactly those rows —
+  // which Ink composites rather than clips.
   return (
-    <Box flexDirection="column">
+    <Box flexDirection="column" flexShrink={0}>
       <DataTable
         columns={columns}
-        rows={rows.slice(0, listRows(height))}
+        rows={all.slice(win.from, win.to)}
         keyOf={r => r.path}
         width={width}
       />
+      {plan.pager && <Pager window={win} total={all.length} s={s} />}
     </Box>
   )
 }

--- a/packages/tui/src/screens/paging.test.tsx
+++ b/packages/tui/src/screens/paging.test.tsx
@@ -1,0 +1,113 @@
+/**
+ * What the three list screens draw once they page.
+ *
+ * The bug being held down is one a unit test of the arithmetic cannot see: a screen that slices to
+ * whatever the terminal affords and says nothing about the rest ANSWERS with its window. So these
+ * assert the sentence under the table as much as the rows in it.
+ */
+
+import React from 'react'
+import { describe, test, expect } from 'bun:test'
+import { render } from 'ink-testing-library'
+import type { AppData, SessionMeta } from '@agentistics/core'
+import { emptyStatsCache } from '@agentistics/core'
+import { History } from './History'
+import { Projects } from './Projects'
+import { Costs } from './Costs'
+import { PAGE_SIZE } from '../dashboard/view'
+import { strings } from '../i18n'
+
+const s = strings('en')
+
+function session(i: number, over: Partial<SessionMeta> = {}): SessionMeta {
+  return {
+    session_id: `s${String(i).padStart(3, '0')}`,
+    project_path: `/home/u/proj${i % 40}`,
+    start_time: `2026-07-${String(1 + (i % 28)).padStart(2, '0')}T10:00:00Z`,
+    first_prompt: `session ${i}`,
+    model: `model-${i % 40}`,
+    duration_minutes: 5, user_message_count: 1, assistant_message_count: 1,
+    tool_counts: {}, tool_output_tokens: {}, agent_file_reads: {}, languages: [],
+    git_commits: 0, git_pushes: 0, input_tokens: 10, output_tokens: 5,
+    user_interruptions: 0, user_response_times: [], tool_errors: 0,
+    tool_error_categories: {}, uses_task_agent: false, uses_mcp: false,
+    uses_web_search: false, uses_web_fetch: false, lines_added: 0, lines_removed: 0,
+    files_modified: 0, message_hours: [], user_message_timestamps: [],
+    harness: 'codex',
+    ...over,
+  } as SessionMeta
+}
+
+function appData(count: number): AppData {
+  return {
+    statsCache: emptyStatsCache(),
+    sessions: Array.from({ length: count }, (_, i) => session(i)),
+    projects: [], allSessions: [], harnesses: ['codex'],
+  } as unknown as AppData
+}
+
+const frameOf = (el: React.ReactElement) =>
+  (render(el).lastFrame() ?? '').replace(/\x1b\[[0-9;]*m/g, '')
+
+describe('History paging', () => {
+  test('draws one page and states the place and the TOTAL, not the window', () => {
+    const frame = frameOf(<History data={appData(355)} s={s} width={100} height={20} page={0} />)
+    expect(frame).toContain('page 1 of 24')
+    expect(frame).toContain('1-15 of 355')
+    // header + 15 rows + the pager line
+    expect(frame.split('\n').filter(l => l.trim()).length).toBe(2 + PAGE_SIZE)
+  })
+
+  test('a later page names its own slice', () => {
+    const frame = frameOf(<History data={appData(355)} s={s} width={100} height={20} page={3} />)
+    expect(frame).toContain('page 4 of 24')
+    expect(frame).toContain('46-60 of 355')
+  })
+
+  test('the last page is short and still says the total', () => {
+    const frame = frameOf(<History data={appData(355)} s={s} width={100} height={20} page={23} />)
+    expect(frame).toContain('page 24 of 24')
+    expect(frame).toContain('346-355 of 355')
+  })
+
+  test('a page past the end is clamped rather than rendered blank', () => {
+    const frame = frameOf(<History data={appData(20)} s={s} width={100} height={20} page={99} />)
+    expect(frame).toContain('page 2 of 2')
+    expect(frame).toContain('16-20 of 20')
+  })
+
+  test('a list that fits draws no pager at all', () => {
+    const frame = frameOf(<History data={appData(4)} s={s} width={100} height={20} page={0} />)
+    expect(frame).not.toContain('page 1 of 1')
+    expect(frame).not.toContain(s.pagerHint)
+  })
+
+  test('an empty list says so rather than paging nothing', () => {
+    expect(frameOf(<History data={appData(0)} s={s} width={100} height={20} page={0} />))
+      .toContain(s.noSessions)
+  })
+
+  test('the page is a window on the FILTERED list — the screen is handed what the filter left', () => {
+    // `applyHarnessFilter` runs upstream, so a screen given 20 rows can never reach a 21st.
+    expect(frameOf(<History data={appData(20)} s={s} width={100} height={20} page={0} />))
+      .toContain('1-15 of 20')
+  })
+})
+
+describe('Projects paging', () => {
+  test('pages its own list and counts every project', () => {
+    // 40 distinct project paths across the sessions above.
+    const frame = frameOf(<Projects data={appData(200)} s={s} width={100} height={20} page={1} />)
+    expect(frame).toContain('page 2 of 3')
+    expect(frame).toContain('16-30 of 40')
+  })
+})
+
+describe('Costs paging', () => {
+  test('pages the model table while the share panel keeps ranking the whole list', () => {
+    const frame = frameOf(<Costs data={appData(200)} s={s} width={100} height={30} page={1} />)
+    expect(frame).toContain('of 40')
+    // The share panel is a view of the top five OVERALL, so it does not move with the page.
+    expect(frame).toContain(s.share)
+  })
+})


### PR DESCRIPTION
Promotes `dev` to `main`. It carries exactly one change (#175).

## TUI list paging

The dashboard's **History**, **Projects** and **Costs** screens sliced their list to whatever the terminal afforded and stopped there, with no way to reach anything below the fold — so a 25-row terminal answered "you have 25 sessions" to a machine holding hundreds.

They now page **15 rows at a time**, with a line under the table stating the place, the window and the **total**, plus the keys that move it (`,` / `.` and pgup/pgdn — never the arrows, which the control center answers for its tabs).

Full rationale in #175.

## Verification

- `bun tsc --noEmit` clean; 4216 tests pass (35 new); CI green on #175.
- Rendered against real data: 135 sessions → 9 pages, last page short at `121-135`.
- Checked against the compiled binary, not only `bun run`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016NySSwjz8XWTQbrub7hyDr