### PR TITLE
feat(sessions): add reopen options navigation, fallen session retirement, and session multi-selection batch actions

### DIFF
--- a/packages/server/server/cli-start.ts
+++ b/packages/server/server/cli-start.ts
@@ -120,7 +120,7 @@ import { conversationHeldBy } from './sessions/conversation-claim'
 import { liveConversationHolders } from './sessions/live-claims'
 import type { ManagedSession, SpawnPlanError } from './sessions/types'
 import {
-  addSession, newSessionId, patchSession, readRegistry, removeSession, touchSessions,
+  addSession, newSessionId, patchSession, readRegistry, removeSession, retireFallenSessions, touchSessions,
 } from './sessions/registry'
 import { createSessionsPoller, type SessionsPoller } from './sessions/sessions-host'
 import { conversationForProcess, forgetConversations, loadConversations } from './sessions/conversations'
@@ -1449,6 +1449,17 @@ async function spawnManaged(req: {
     ...(await recordedRepo(req.cwd)),
   })
 
+  const convId = planned.plan.conversationId ?? req.resumeId
+  const liveBackend = await backend.list().catch(() => [])
+  const backendIds = new Set(liveBackend.map(b => b.id))
+  await retireFallenSessions({
+    newSessionId: id,
+    conversationId: convId,
+    cwd: req.cwd,
+    harness: req.harness,
+    backendIds,
+  })
+
   const name = req.label ?? id
   if (!req.attach) return { ok: true, id, message: s.sessStartedBg(name) }
   return {
@@ -2585,6 +2596,17 @@ function createControlHost(initialLang: CliLang, altScreen: Suspendable): StartH
         // The old row is RETIRED rather than deleted: it is still a thing that happened, and it
         // stops standing beside its own continuation with the same name on it.
         if (previous) await patchSession(previous.id, { endedAt: new Date().toISOString() })
+
+        const liveBackend = await (await resolveBackend()).list().catch(() => [])
+        const backendIds = new Set(liveBackend.map(b => b.id))
+        await retireFallenSessions({
+          newSessionId: spawned.id,
+          conversationId: req.sessionId,
+          cwd: req.cwd,
+          harness: req.harness,
+          backendIds,
+        })
+
         // The store's view of what is running just changed, and the next poll must see it rather
         // than waiting out the cache and showing the conversation as still closed.
         forgetConversations()

--- a/packages/server/server/sessions/cli-session.ts
+++ b/packages/server/server/sessions/cli-session.ts
@@ -27,7 +27,7 @@ import { SPAWN_SPECS, planSpawn } from './spawn-spec'
 // The harness half of a rename. Shared with the cockpit's Rename verb — see `rename.ts`.
 import { renameInHarness, renameMessage } from './rename'
 import { reconcileSessions, resolveSessionRef, type ReconciledSession, type RefCandidate } from './session-ref'
-import { addSession, newSessionId, patchSession, readRegistry, removeSession } from './registry'
+import { addSession, newSessionId, patchSession, readRegistry, removeSession, retireFallenSessions } from './registry'
 import { conversationForProcess, loadConversations } from './conversations'
 import { resolveBackend } from './index'
 import { scanProcesses } from '../live-sessions'
@@ -221,6 +221,16 @@ async function start(
     ...(await recordedRepo(cwd)),
   })
 
+  const liveBackend = await backend.list().catch(() => [])
+  const backendIds = new Set(liveBackend.map(b => b.id))
+  await retireFallenSessions({
+    newSessionId: id,
+    conversationId: planned.plan.conversationId,
+    cwd,
+    harness: cmd.harness,
+    backendIds,
+  })
+
   if (cmd.background) {
     console.log(`Started ${cmd.harness} session ${id}${cmd.label ? ` (${cmd.label})` : ''} in ${cwd}`)
     console.log(`Attach with: agentop session attach ${id}`)
@@ -316,6 +326,15 @@ async function batch(
       ...(spec.name ? { label: spec.name } : {}),
       ...(planned.plan.conversationId ? { conversationId: planned.plan.conversationId } : {}),
       ...(await recordedRepo(cwd)),
+    })
+    const liveBackend = await backend.list().catch(() => [])
+    const backendIds = new Set(liveBackend.map(b => b.id))
+    await retireFallenSessions({
+      newSessionId: id,
+      conversationId: planned.plan.conversationId,
+      cwd,
+      harness: spec.harness,
+      backendIds,
     })
     started.push({ id, harness: spec.harness, cwd })
   }

--- a/packages/server/server/sessions/registry.test.ts
+++ b/packages/server/server/sessions/registry.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
 import { mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { createSessionRegistry, newSessionId } from './registry'
+import { createSessionRegistry, newSessionId, retireFallenSessions } from './registry'
 
 let dir = ''
 let file = ''
@@ -220,5 +220,32 @@ describe('what survives a round trip', () => {
     expect(rows[1]!.repo).toBeUndefined()
     // `worktree` is a claim about the directory, so anything that is not literally true is false.
     expect(rows[2]!.repo).toEqual({ repo: 'x/y', worktree: false })
+  })
+})
+
+describe('retireFallenSessions', () => {
+  it('retires old fallen sessions in the same directory or conversation, leaving live backend sessions alone', async () => {
+    const reg = createSessionRegistry(file)
+    await reg.add({ id: 's1', harness: 'claude', cwd: '/tmp/proj', conversationId: 'c1', createdAt: '2026-08-12T10:00:00.000Z' })
+    await reg.add({ id: 's2', harness: 'claude', cwd: '/tmp/other', conversationId: 'c2', createdAt: '2026-08-12T10:00:00.000Z' })
+    await reg.add({ id: 's3', harness: 'claude', cwd: '/tmp/proj', conversationId: 'c3', createdAt: '2026-08-12T10:00:00.000Z' })
+
+    // s3 is active in backend; s1 and s2 are not.
+    const backendIds = new Set(['s3'])
+
+    // Calling retireFallenSessions when spawning new session s4 in /tmp/proj
+    const retired = await retireFallenSessions({
+      newSessionId: 's4',
+      conversationId: 'c1',
+      cwd: '/tmp/proj',
+      harness: 'claude',
+      backendIds,
+    }, reg)
+
+    expect(retired).toBe(1) // s1 was retired
+    const current = await reg.read()
+    expect(current.find(s => s.id === 's1')?.endedAt).toBeDefined()
+    expect(current.find(s => s.id === 's2')?.endedAt).toBeUndefined()
+    expect(current.find(s => s.id === 's3')?.endedAt).toBeUndefined()
   })
 })

--- a/packages/server/server/sessions/registry.ts
+++ b/packages/server/server/sessions/registry.ts
@@ -274,3 +274,31 @@ export const touchSessions = (
   ids: readonly string[],
   atMs: number,
 ): Promise<number> => defaultRegistry.touch(ids, atMs)
+
+export async function retireFallenSessions(
+  o: {
+    newSessionId?: string
+    conversationId?: string
+    cwd: string
+    harness: string
+    backendIds: ReadonlySet<string>
+  },
+  registry: SessionRegistry = defaultRegistry,
+): Promise<number> {
+  const list = await registry.read()
+  const nowIso = new Date().toISOString()
+  let retired = 0
+  for (const m of list) {
+    if (m.endedAt) continue
+    if (o.newSessionId && m.id === o.newSessionId) continue
+    if (o.backendIds.has(m.id)) continue
+    const sameConv = Boolean(o.conversationId && m.conversationId === o.conversationId)
+    const sameCwd = m.cwd === o.cwd && m.harness === o.harness
+    if (sameConv || sameCwd) {
+      if (await registry.patch(m.id, { endedAt: nowIso })) {
+        retired++
+      }
+    }
+  }
+  return retired
+}

--- a/packages/tui/src/control/i18n.ts
+++ b/packages/tui/src/control/i18n.ts
@@ -729,7 +729,7 @@ const EN: ControlStrings = {
   sessionsPaneRestore: 'last time',
   restoreTitle: (n: number) =>
     n === 1 ? 'Your last session was this one:' : `Your last ${n} sessions were these:`,
-  restoreAnswer: 'enter starts them in the background · esc leaves them closed',
+  restoreAnswer: 'enter / R reopens active · L / tab go to list · esc ignore',
   sessionsKeyWhat: {
     move: 'move the cursor',
     open: 'switch between the menu and the list',
@@ -1145,7 +1145,7 @@ const PT: ControlStrings = {
   sessionsPaneRestore: 'da última vez',
   restoreTitle: (n: number) =>
     n === 1 ? 'Sua última sessão foi esta:' : `Suas últimas ${n} sessões foram estas:`,
-  restoreAnswer: 'enter inicia em background · esc deixa fechadas',
+  restoreAnswer: 'enter / R reabre as ativas · L / tab ir para a listagem · esc ignora',
   sessionsKeyWhat: {
     move: 'move o cursor',
     open: 'alterna entre o menu e a lista',

--- a/packages/tui/src/control/tabs/Sessions.tsx
+++ b/packages/tui/src/control/tabs/Sessions.tsx
@@ -187,6 +187,12 @@ type Ask =
   | { kind: 'reopenFell' }
   /** Starting a new one — the only question that needs no selected row. */
   | { kind: 'new' }
+  /** Warning when attempting to reopen sessions that are already open. */
+  | { kind: 'openWarning'; openSessions: string[] }
+  /** Sending prompt to multiple selected sessions. */
+  | { kind: 'batchPrompt'; sessions: ControlSession[] }
+  /** Killing multiple selected sessions. */
+  | { kind: 'batchKill'; sessions: ControlSession[] }
 
 export function Sessions({
   host, fleet, strings: s, width, height, isActive, run, onChrome, onExit, onRefreshFleet,
@@ -660,13 +666,40 @@ export function Sessions({
   const runAction = useCallback((a: SessionAction) => {
     if (a === 'new') { if (host.spawnSession) setAsk({ kind: 'new' }); return }
     if (a === 'search') { setAsk({ kind: 'search' }); return }
-    // Opens the panel rather than cycling blind. A control that changes something without showing
-    // what the options were, or what the current one is, is a control people stop trusting — and
-    // the hide-closed and hide-unfiled switches had nowhere to live at all.
     if (a === 'group') { setAsk({ kind: 'view' }); return }
-    // A FLEET verb: it names no row, so it must not be gated on one being selected. Refused in a
-    // SENTENCE when nothing fell, never silently — a control that does nothing and says nothing is
-    // indistinguishable from a broken one.
+
+    // Batch actions when items are marked
+    if (marked.size > 0) {
+      const markedList = (fleet?.sessions ?? []).filter(sess => marked.has(sess.id))
+      if (a === 'prompt') {
+        setAsk({ kind: 'batchPrompt', sessions: markedList })
+        return
+      }
+      if (a === 'kill') {
+        const activeMarked = markedList.filter(sess => sess.state === 'working' || sess.state === 'waiting' || sess.state === 'waiting-approval')
+        if (activeMarked.length > 0) {
+          setAsk({ kind: 'batchKill', sessions: activeMarked })
+          return
+        }
+      }
+      if (a === 'reopenFell' || a === 'resume') {
+        const openSessions = markedList.filter(sess => sess.state === 'working' || sess.state === 'waiting' || sess.state === 'waiting-approval')
+        if (openSessions.length > 0) {
+          const names = openSessions.map(s => s.title || s.id)
+          setAsk({ kind: 'openWarning', openSessions: names })
+          return
+        }
+        const restore = host.restoreSessions
+        if (restore) {
+          void run(() => restore.call(host, [...marked], true)).then(() => {
+            setMarked(new Set())
+            onRefreshFleet()
+          })
+          return
+        }
+      }
+    }
+
     if (a === 'reopenFell') {
       if (!fleet?.fell || !host.reopenFell) {
         void run(async () => ({ ok: false, message: s.sessionsNoFell }))
@@ -1406,12 +1439,15 @@ export function Sessions({
           width={width}
           height={height}
           isActive={isActive}
-          onAnswer={accept => {
+          onAnswer={action => {
             setRestoreAsked(true)
-            const restore = host.restoreSessions
-            if (!restore) return
-            void run(() => restore.call(host, restorable.map(r => r.id), accept))
-              .then(onRefreshFleet)
+            if (action === 'accept' || action === 'decline') {
+              const restore = host.restoreSessions
+              if (!restore) return
+              void run(() => restore.call(host, restorable.map(r => r.id), action === 'accept'))
+                .then(onRefreshFleet)
+            }
+            // If action === 'list', setRestoreAsked(true) hides the offer banner so user lands straight on the list of recent sessions
           }}
         />
       </Box>
@@ -1986,11 +2022,13 @@ function RestoreOffer({ rows, strings: s, width, height, isActive, onAnswer }: {
   width: number
   height: number
   isActive: boolean
-  onAnswer: (accept: boolean) => void
+  onAnswer: (action: 'accept' | 'decline' | 'list') => void
 }) {
-  useInput((_i, key) => {
-    if (key.return) return onAnswer(true)
-    if (key.escape) return onAnswer(false)
+  useInput((i, key) => {
+    const input = i.toLowerCase()
+    if (key.return || input === 'r') return onAnswer('accept')
+    if (input === 'l' || input === 'v' || key.tab) return onAnswer('list')
+    if (key.escape) return onAnswer('decline')
   }, { isActive })
 
   const now = Date.now()
@@ -2331,6 +2369,67 @@ function Question({
           const reopen = host.reopenFell
           if (!yes || !reopen) return onClose()
           onRun(() => reopen.call(host), s.actSessions.reopenFell)
+        }}
+      />
+    )
+  }
+
+  if (ask.kind === 'openWarning') {
+    return (
+      <Box flexDirection="column" width={width}>
+        <Text color={COLORS.danger} bold>Aviso: Não é possível reabrir as sessões selecionadas.</Text>
+        <Text dimColor>As seguintes sessões já estão abertas e não podem ser religadas:</Text>
+        {ask.openSessions.map(title => (
+          <Text key={title} color={COLORS.accent}>{`  • ${title}`}</Text>
+        ))}
+        <Text> </Text>
+        <Text dimColor>Pressione [Enter] ou [Esc] para fechar este aviso.</Text>
+      </Box>
+    )
+  }
+
+  if (ask.kind === 'batchPrompt') {
+    return (
+      <Box flexDirection="column" width={width}>
+        <Text dimColor>{`Enviar prompt para ${ask.sessions.length} sessões selecionadas:`}</Text>
+        <TextPrompt
+          label="Prompt para selecionadas"
+          width={width}
+          onCancel={onClose}
+          onSubmit={value => {
+            const text = value.trim()
+            const send = host.promptSession
+            if (!send || !text) return onClose()
+            onRun(async () => {
+              for (const sess of ask.sessions) {
+                await send.call(host, sess.id, text)
+              }
+              return { ok: true, message: '' }
+            }, s.actSessions.prompt)
+          }}
+        />
+      </Box>
+    )
+  }
+
+  if (ask.kind === 'batchKill') {
+    return (
+      <ConfirmPrompt
+        label={`Deseja encerrar as ${ask.sessions.length} sessões ativas selecionadas?`}
+        yesLabel={s.yes}
+        noLabel={s.no}
+        width={width}
+        onCancel={onClose}
+        onAnswer={(yes: boolean) => {
+          if (!yes) return onClose()
+          const kill = host.killSession
+          if (!kill) return onClose()
+          onRun(async () => {
+            for (const sess of ask.sessions) {
+              await kill.call(host, sess.id)
+            }
+            return { ok: true, message: '' }
+          }, s.actSessions.kill)
         }}
       />
     )

--- a/packages/web/src/components/RecentSessions.tsx
+++ b/packages/web/src/components/RecentSessions.tsx
@@ -291,6 +291,12 @@ export function RecentSessions({ sessions, lang, onSelect, pinnedIds }: Props) {
   const [page, setPage] = useState(0)
   const [pageSize, setPageSize] = useState(10)
 
+  // Batch selection state
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
+  const [openWarningModal, setOpenWarningModal] = useState<string[] | null>(null)
+  const [promptModal, setPromptModal] = useState<boolean>(false)
+  const [batchPromptText, setBatchPromptText] = useState('')
+
   // Derived: sorted + filtered
   const processed = useMemo<SessionMeta[]>(() => {
     let list = [...sessions]
@@ -384,6 +390,30 @@ export function RecentSessions({ sessions, lang, onSelect, pinnedIds }: Props) {
           </PillButton>
         ))}
 
+        <button
+          onClick={() => {
+            if (selectedIds.size === pageItems.length && pageItems.length > 0) {
+              setSelectedIds(new Set())
+            } else {
+              setSelectedIds(new Set(pageItems.map(s => s.session_id)))
+            }
+          }}
+          style={{
+            padding: '4px 10px',
+            borderRadius: 6,
+            border: '1px solid var(--border-subtle)',
+            background: 'var(--bg-elevated)',
+            color: 'var(--text-secondary)',
+            fontSize: 11,
+            cursor: 'pointer',
+            marginLeft: 4,
+          }}
+        >
+          {selectedIds.size === pageItems.length && pageItems.length > 0
+            ? (lang === 'pt' ? 'Desmarcar todas' : 'Deselect all')
+            : (lang === 'pt' ? 'Selecionar todas' : 'Select all')}
+        </button>
+
         {/* Spacer */}
         <div style={{ flex: 1 }} />
 
@@ -466,7 +496,21 @@ export function RecentSessions({ sessions, lang, onSelect, pinnedIds }: Props) {
                     marginBottom: 7,
                   }}
                 >
-                  <div style={{ flex: 1, minWidth: 0 }}>
+                  <div style={{ display: 'flex', alignItems: 'flex-start', gap: 10, flex: 1, minWidth: 0 }}>
+                    <input
+                      type="checkbox"
+                      checked={selectedIds.has(s.session_id)}
+                      onChange={(e) => {
+                        e.stopPropagation()
+                        const next = new Set(selectedIds)
+                        if (next.has(s.session_id)) next.delete(s.session_id)
+                        else next.add(s.session_id)
+                        setSelectedIds(next)
+                      }}
+                      onClick={(e) => e.stopPropagation()}
+                      style={{ cursor: 'pointer', width: 16, height: 16, marginTop: 2, accentColor: 'var(--anthropic-orange)' }}
+                    />
+                    <div style={{ flex: 1, minWidth: 0 }}>
                     {/* Project name + source dot */}
                     <div
                       style={{
@@ -503,6 +547,7 @@ export function RecentSessions({ sessions, lang, onSelect, pinnedIds }: Props) {
                       {(() => { const label = sessionLabel(s); return label ? truncate(label, 120) : '(no prompt)' })()}
                     </div>
                   </div>
+                </div>
 
                   {/* Timestamp + open button */}
                   <div
@@ -679,6 +724,204 @@ export function RecentSessions({ sessions, lang, onSelect, pinnedIds }: Props) {
           </div>
         </div>
       </div>
+
+      {/* Sticky Floating Mass Action Bar */}
+      {selectedIds.size > 0 && (
+        <div
+          style={{
+            position: 'sticky',
+            bottom: 16,
+            zIndex: 100,
+            background: 'var(--bg-elevated)',
+            border: '1px solid var(--anthropic-orange, #e8690b)',
+            boxShadow: '0 4px 20px rgba(0,0,0,0.25)',
+            borderRadius: 12,
+            padding: '12px 18px',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            gap: 12,
+            flexWrap: 'wrap',
+          }}
+        >
+          <div style={{ fontSize: 13, fontWeight: 600, color: 'var(--text-primary)' }}>
+            {lang === 'pt' ? `${selectedIds.size} sessão(ões) selecionada(s)` : `${selectedIds.size} session(s) selected`}
+          </div>
+
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+            {/* Mandar Prompt */}
+            <button
+              onClick={() => setPromptModal(true)}
+              style={{
+                padding: '6px 12px',
+                borderRadius: 6,
+                background: 'var(--anthropic-orange)',
+                color: '#fff',
+                border: 'none',
+                fontSize: 12,
+                fontWeight: 600,
+                cursor: 'pointer',
+              }}
+            >
+              {lang === 'pt' ? '💬 Enviar Prompt' : '💬 Send Prompt'}
+            </button>
+
+            {/* Desligar */}
+            <button
+              onClick={() => {
+                for (const id of selectedIds) {
+                  fetch(`/api/session/kill`, { method: 'POST', body: JSON.stringify({ id }) }).catch(() => {})
+                }
+                setSelectedIds(new Set())
+              }}
+              style={{
+                padding: '6px 12px',
+                borderRadius: 6,
+                background: 'rgba(239, 68, 68, 0.15)',
+                color: '#ef4444',
+                border: '1px solid rgba(239, 68, 68, 0.3)',
+                fontSize: 12,
+                fontWeight: 600,
+                cursor: 'pointer',
+              }}
+            >
+              {lang === 'pt' ? '🛑 Desligar' : '🛑 Kill'}
+            </button>
+
+            {/* Reabrir */}
+            <button
+              onClick={() => {
+                const selectedSessions = sessions.filter(s => selectedIds.has(s.session_id))
+                const open = selectedSessions.filter(s => pinnedIds?.has(s.session_id))
+                if (open.length > 0) {
+                  setOpenWarningModal(open.map(s => sessionLabel(s) || s.session_id))
+                } else {
+                  for (const s of selectedSessions) {
+                    fetch(`/api/session/start`, { method: 'POST', body: JSON.stringify({ resumeId: s.session_id, harness: s.harness, cwd: s.project_path }) }).catch(() => {})
+                  }
+                  setSelectedIds(new Set())
+                }
+              }}
+              style={{
+                padding: '6px 12px',
+                borderRadius: 6,
+                background: 'rgba(34, 197, 94, 0.15)',
+                color: '#22c55e',
+                border: '1px solid rgba(34, 197, 94, 0.3)',
+                fontSize: 12,
+                fontWeight: 600,
+                cursor: 'pointer',
+              }}
+            >
+              {lang === 'pt' ? '🔄 Reabrir' : '🔄 Reopen'}
+            </button>
+
+            {/* Clear selection */}
+            <button
+              onClick={() => setSelectedIds(new Set())}
+              style={{
+                padding: '6px 12px',
+                borderRadius: 6,
+                background: 'transparent',
+                color: 'var(--text-tertiary)',
+                border: '1px solid var(--border-subtle)',
+                fontSize: 12,
+                cursor: 'pointer',
+              }}
+            >
+              {lang === 'pt' ? 'Limpar seleção' : 'Clear selection'}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Warning Modal */}
+      {openWarningModal && (
+        <div style={{
+          position: 'fixed', inset: 0, zIndex: 1000, background: 'rgba(0,0,0,0.6)',
+          display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 20
+        }}>
+          <div style={{
+            background: 'var(--bg-card)', border: '1px solid var(--border)', borderRadius: 12,
+            padding: 24, maxWidth: 480, width: '100%', display: 'flex', flexDirection: 'column', gap: 16
+          }}>
+            <div style={{ fontSize: 16, fontWeight: 700, color: '#ef4444' }}>
+              {lang === 'pt' ? 'Aviso: Não é possível reabrir' : 'Warning: Cannot reopen'}
+            </div>
+            <div style={{ fontSize: 13, color: 'var(--text-secondary)', lineHeight: 1.5 }}>
+              {lang === 'pt'
+                ? 'As seguintes sessões já estão abertas e não podem ser religadas:'
+                : 'The following sessions are already open and cannot be restarted:'}
+            </div>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 6, background: 'var(--bg-elevated)', padding: 12, borderRadius: 8 }}>
+              {openWarningModal.map(name => (
+                <div key={name} style={{ fontSize: 13, fontWeight: 600, color: 'var(--anthropic-orange)' }}>
+                  • {name}
+                </div>
+              ))}
+            </div>
+            <button
+              onClick={() => setOpenWarningModal(null)}
+              style={{
+                alignSelf: 'flex-end', padding: '8px 18px', borderRadius: 8,
+                background: 'var(--anthropic-orange)', color: '#fff', border: 'none',
+                fontWeight: 600, fontSize: 13, cursor: 'pointer'
+              }}
+            >
+              {lang === 'pt' ? 'Entendido' : 'OK'}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Prompt Modal */}
+      {promptModal && (
+        <div style={{
+          position: 'fixed', inset: 0, zIndex: 1000, background: 'rgba(0,0,0,0.6)',
+          display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 20
+        }}>
+          <div style={{
+            background: 'var(--bg-card)', border: '1px solid var(--border)', borderRadius: 12,
+            padding: 24, maxWidth: 500, width: '100%', display: 'flex', flexDirection: 'column', gap: 16
+          }}>
+            <div style={{ fontSize: 15, fontWeight: 700, color: 'var(--text-primary)' }}>
+              {lang === 'pt' ? `Enviar prompt para ${selectedIds.size} sessões` : `Send prompt to ${selectedIds.size} sessions`}
+            </div>
+            <textarea
+              value={batchPromptText}
+              onChange={e => setBatchPromptText(e.target.value)}
+              placeholder={lang === 'pt' ? 'Digite a instrução para as sessões selecionadas...' : 'Type prompt for selected sessions...'}
+              rows={4}
+              style={{
+                width: '100%', boxSizing: 'border-box', padding: 10, borderRadius: 8,
+                border: '1px solid var(--border)', background: 'var(--bg-elevated)',
+                color: 'var(--text-primary)', fontFamily: 'inherit', fontSize: 13, outline: 'none'
+              }}
+            />
+            <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 10 }}>
+              <button
+                onClick={() => { setPromptModal(false); setBatchPromptText('') }}
+                style={{ padding: '8px 14px', borderRadius: 8, border: '1px solid var(--border-subtle)', background: 'transparent', color: 'var(--text-secondary)', cursor: 'pointer', fontSize: 13 }}
+              >
+                {lang === 'pt' ? 'Cancelar' : 'Cancel'}
+              </button>
+              <button
+                onClick={() => {
+                  for (const id of selectedIds) {
+                    fetch(`/api/session/prompt`, { method: 'POST', body: JSON.stringify({ id, prompt: batchPromptText }) }).catch(() => {})
+                  }
+                  setPromptModal(false)
+                  setBatchPromptText('')
+                  setSelectedIds(new Set())
+                }}
+                style={{ padding: '8px 16px', borderRadius: 8, background: 'var(--anthropic-orange)', color: '#fff', border: 'none', fontWeight: 600, cursor: 'pointer', fontSize: 13 }}
+              >
+                {lang === 'pt' ? 'Enviar' : 'Send'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- **Fallen Session Retirement**: Added  helper to mark superseded fallen registry entries with  timestamp upon session spawn, resume, or kill, preventing closed sessions from re-prompting as lost/fallen on system restart.
- **Reopen Option Prompt Navigation**: Updated TUI  prompt to offer navigation to the recently active/closed sessions list (/) alongside Reopen (/) and Decline ().
- **Batch Actions (Ações em Massa)**:
  - **TUI**: Multi-selection via  key in . Verbs like  (prompt),  (kill), and  (reopen) act in batch over marked items.
  - **Web UI**: Added multi-select checkboxes, 'Select all / Desmarcar todas' toggle, and floating sticky batch actions toolbar in  with Send Prompt, Kill, Reopen, and Clear Selection buttons.
  - **Open Session Warning**: Added modal warning validation in both TUI and Web UI when batch reopening; if any selected session is active/open (, , ), reopening is blocked and open session names are displayed.