### PR TITLE
fix(control): age a closed session from when it ENDED, and name the three off states

### DIFF
--- a/packages/server/server/cli-i18n.ts
+++ b/packages/server/server/cli-i18n.ts
@@ -740,9 +740,9 @@ const PT: CliStrings = {
     // keeps `waiting`: there it is already the intransitive answer, and "waiting for a reply" would
     // be longer without saying more.
     waiting: 'aguardando resposta',
-    exited: 'desligada',
-    lost: 'desligada',
-    closed: 'desligada',
+    exited: 'encerrada',
+    lost: 'desconectada',
+    closed: 'fechada',
     external: 'externa',
   },
   sessApprovalBlind: (harness: string) =>

--- a/packages/server/server/sessions/control-session.ts
+++ b/packages/server/server/sessions/control-session.ts
@@ -112,6 +112,7 @@ export function toControlSession(
       ? { approvalBlind: s.sessApprovalBlind(harness) }
       : {}),
     ...(v.createdMs !== undefined ? { startedAt: v.createdMs } : {}),
+    ...(v.endedMs !== undefined ? { endedAt: v.endedMs } : {}),
     ...(v.task ? { task: v.task } : {}),
     // Marked BY THE USER — a label, a note or a task. `title` cannot answer this: it always has a
     // value, because the host derives one whenever there is no label. A name typed INSIDE the

--- a/packages/server/server/sessions/session-view.ts
+++ b/packages/server/server/sessions/session-view.ts
@@ -132,6 +132,7 @@ export interface SessionView {
    */
   recordedRepo?: RepoFacts
   createdMs?: number
+  endedMs?: number
   attached: boolean
   /**
    * The conversation this row could REOPEN, when there is one.
@@ -393,6 +394,11 @@ export function buildSessionViews(o: {
       ...(r.backend
         ? { createdMs: r.backend.createdMs }
         : registryCreatedMs(r.managed?.createdAt)),
+      ...(r.managed?.endedAt && Number.isFinite(Date.parse(r.managed.endedAt))
+        ? { endedMs: Date.parse(r.managed.endedAt) }
+        : r.backend?.lastActivityMs && (finished || r.status === 'exited' || r.status === 'lost')
+          ? { endedMs: r.backend.lastActivityMs }
+          : {}),
       // Reopening a finished session is the whole reason its row is kept. Resolved the same way an
       // external process's conversation is — by harness and directory — and absent when nothing
       // can be resolved, rather than offering a verb with no target.
@@ -599,6 +605,7 @@ export function buildSessionViews(o: {
       status: 'closed' as const,
       label: named ?? c.title,
       createdMs: c.lastActivityMs,
+      endedMs: c.lastActivityMs,
       attached: false,
       approvalDetection: false,
       ...(c.resumable ? { resume: { sessionId: c.sessionId, title: c.title } } : {}),

--- a/packages/tui/src/control/i18n.ts
+++ b/packages/tui/src/control/i18n.ts
@@ -1238,9 +1238,9 @@ const PT: ControlStrings = {
     // `aguardando resposta` under a band called `aguardando`.
     waiting: 'aguardando resposta',
     working: 'trabalhando',
-    exited: 'desligada',
-    lost: 'desligada',
-    closed: 'desligada',
+    exited: 'encerrada',
+    lost: 'desconectada',
+    closed: 'fechada',
     unknown: 'externa',
   },
   sessionsSearching: q => `busca: ${q} · esc limpa`,

--- a/packages/tui/src/control/sessions.test.ts
+++ b/packages/tui/src/control/sessions.test.ts
@@ -1400,6 +1400,11 @@ describe('sessionAge', () => {
     const down = session('a', { state: 'exited' as SessionState, startedAt: 90_000 })
     expect(sessionAge(down, 60_000, ago)).toBe('0s')
   })
+
+  it('uses endedAt when available for a closed row', () => {
+    const closed = session('a', { state: 'closed' as SessionState, startedAt: 0, endedAt: 40_000 })
+    expect(sessionAge(closed, 60_000, ago)).toBe('20s')
+  })
 })
 
 describe('sessionKeyHelp', () => {

--- a/packages/tui/src/control/sessions.ts
+++ b/packages/tui/src/control/sessions.ts
@@ -832,8 +832,10 @@ export interface SessionColumns {
  * make the column's width depend on the second it was measured in.
  */
 export function sessionAge(s: ControlSession, now: number, ago: (seconds: number) => string): string {
-  if (sessionRunning(s) || s.startedAt === undefined) return ''
-  return ago(Math.max(0, Math.round((now - s.startedAt) / 1000)))
+  if (sessionRunning(s)) return ''
+  const t = s.endedAt ?? s.startedAt
+  if (t === undefined) return ''
+  return ago(Math.max(0, Math.round((now - t) / 1000)))
 }
 
 /** How much of a session id a row shows. Enough to be unambiguous in practice, and to type. */

--- a/packages/tui/src/control/types.ts
+++ b/packages/tui/src/control/types.ts
@@ -625,6 +625,10 @@ export interface ControlSession {
   approvalBlind?: string
   /** When it started, epoch ms. An instant rather than a duration — see `ServiceRuntimeState`. */
   startedAt?: number
+  /** When it ENDED, epoch ms. Absent while the session runs, and absent on a row whose end nothing
+   *  recorded — `sessionAge` then falls back to the start, which is the older, wronger answer, so
+   *  absence must stay distinguishable from zero. */
+  endedAt?: number
   attached: boolean
   /** Process ID for live process monitoring. */
   pid?: number


### PR DESCRIPTION
## Recovered work, not new

Built on 2026-08-15 in an antigravity session and **never committed**. Rebuilt from that session's own edit payloads and reconciled against `dev`.

A commit whose title describes exactly this feature does exist — `17f440e fix(control): report endedAt age for closed sessions and differentiate off states` — and `git show --stat` on it gives two unrelated web notification files, 4 lines. The session was closed believing that title. That is how the loss stayed invisible.

## What it fixes

A row that is not running reported the time since it **started**. On a session opened yesterday and closed a minute ago that read as a day old — the one number the row exists to give you, and the only one it could not give.

`endedAt` now reaches the TUI:
- `session-view.ts` prefers the registry's own `endedAt`, falling back to the backend's last activity **only for a row that actually finished** (`exited` / `lost` / finished); a closed conversation takes its last-activity stamp directly.
- `sessionAge` prefers it and keeps the start as the fallback, so a row whose end nothing recorded degrades to the old answer rather than to a blank.

The three off states also stopped being one word. `exited`, `lost` and `closed` all printed `desligada`, flattening the only distinction that matters when deciding what to do about a row — it finished, it was disconnected, or you closed it. Now `encerrada`, `desconectada`, `fechada`, in both i18n tables.

## Deliberately left out

Two of the original patches import a `statusKey` from `sessions.ts` that the session **referenced and never wrote** — its intent for grouping the state counts cannot be recovered without inventing it. That refinement is separate from this fix and should be designed on its own rather than guessed at here.

## Verification

- `bun tsc --noEmit` clean
- `bun test` — 4221 pass, 0 fail (including the session's own recovered test: `endedAt` 40s into a 60s window reads `20s`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C1s5zM6ZYbwUWFrZ5rFVfJ