### PR TITLE
fix(antigravity): recover token/cost totals for orchestrator-only sessions

### DIFF
--- a/packages/server/server/adapters/antigravity-parse.test.ts
+++ b/packages/server/server/adapters/antigravity-parse.test.ts
@@ -601,6 +601,36 @@ test('mergeAntigravityChild: work is folded, invented user activity is not', () 
   expect(merged.end_time).toBe('2026-07-27T18:21:00.000Z')
 })
 
+// Regression: a pure orchestrator (dispatches subagents, generates no gen_metadata rows of its
+// own) must not end up with model === undefined after the merge, or every consumer that keys off
+// `model` first (useData.ts's per-model aggregation, sessionModelUsage's own fallback) silently
+// drops the session's real, merged-in child tokens/cost from every total — while a raw
+// `input_tokens` sum stays correct, so the discrepancy is invisible until totals are compared
+// against a source of truth (measured: 232M tokens on the vendor's own quota panel vs 407K on a
+// harness-filtered agentistics total, for a fleet with several long orchestrator sessions).
+test('mergeAntigravityChild: a parentless model falls back to the dominant merged model', () => {
+  const parentOf = new Map([[CHILD_A, 'parent-1']])
+  const parentTranscript = PARENT_WITH_SUBAGENTS
+  const childTranscript = userInput(0, '2026-07-27T18:07:00Z', 'do the research')
+
+  // The parent's own DB has zero gen_metadata rows (empty model) — everything real happened in
+  // the one child, under one model.
+  const parsed = parseAll([
+    ['parent-1', parentTranscript, tokens(0, 0, 0, '')],
+    [CHILD_A, childTranscript, tokens(50, 5, 5, 'gemini-3.6-flash-tiered')],
+  ], parentOf)
+  const merged = rollUpAntigravitySessions(parsed, parentOf)[0]!
+
+  // `model` must carry the dominant model, not be dropped as undefined — with only one model
+  // involved, model_usage is not populated (by design), so `model` is the ONLY place this
+  // session's model — and therefore its tokens, via every model-keyed consumer — can be found.
+  expect(merged.model).toBe('gemini-3.6-flash-tiered')
+  expect(merged.model_usage).toBeUndefined()
+  expect(merged.input_tokens).toBe(50)
+  expect(merged.cache_read_input_tokens).toBe(5)
+  expect(merged.output_tokens).toBe(5)
+})
+
 test('D5: uses_task_agent is true exactly when the conversation dispatched a sub-agent', () => {
   const parent = parseAntigravityTranscript(PARENT_WITH_SUBAGENTS, 'parent-1', '')
   expect(parent!.uses_task_agent).toBe(true)

--- a/packages/server/server/adapters/antigravity-parse.ts
+++ b/packages/server/server/adapters/antigravity-parse.ts
@@ -655,6 +655,18 @@ function sumRecords(a: Record<string, number>, b: Record<string, number>): Recor
   return out
 }
 
+/** The model carrying the most tokens (in+out+cache) in a per-model usage map, or '' if empty. */
+function dominantModelOf(usage: Record<string, ModelUsage>): string {
+  let best = ''
+  let bestTokens = -1
+  for (const [model, u] of Object.entries(usage)) {
+    const total = (u.inputTokens ?? 0) + (u.outputTokens ?? 0)
+      + (u.cacheReadInputTokens ?? 0) + (u.cacheCreationInputTokens ?? 0)
+    if (total > bestTokens) { bestTokens = total; best = model }
+  }
+  return best
+}
+
 /**
  * Pure: fold an `invoke_subagent` CHILD conversation into its PARENT.
  *
@@ -667,9 +679,16 @@ function sumRecords(a: Record<string, number>, b: Record<string, number>): Recor
  *  - tokens: SUMMED (input / output / cache read / cache write).
  *  - `model_usage`: unioned per model, so the merged session stays cost-exact even when parent and
  *    child ran different models (Opus parent + Gemini Flash subagents is the normal case).
- *  - `model`: the PARENT's own dominant model, never the child's. One label cannot honestly
- *    describe a multi-model session; the parent's own model is the defensible choice and the
- *    per-model breakdown carries the truth.
+ *  - `model`: the PARENT's own dominant model, never the child's, WHEN the parent generated any
+ *    tokens itself. One label cannot honestly describe a multi-model session; the parent's own
+ *    model is the defensible choice there and the per-model breakdown carries the truth. But a
+ *    pure orchestrator — a parent that only dispatches subagents and never generates a token of
+ *    its own — has no such label, and leaving `model` empty is not neutral: every caller that
+ *    prices or aggregates a session keys off `model` first (`sessionModelUsage`'s own fallback
+ *    included) and treats "no model" as "no session", dropping real, merged-in child spend from
+ *    every total that does not separately consult `model_usage`. So a parentless model falls back
+ *    to the DOMINANT model of the merged usage — real attribution (it is where the tokens actually
+ *    went), not a guess.
  *  - work: tool_counts / tool_errors (+categories) / lines added+removed SUMMED, files UNIONED
  *    (a file both touched is one file), capability flags OR-ed, uses_task_agent forced true.
  *  - message counts, message_hours and user_message_timestamps are NOT merged: a child's
@@ -726,8 +745,10 @@ export function mergeAntigravityChild(
     uses_web_search: !!p.uses_web_search || !!c.uses_web_search,
     uses_web_fetch: !!p.uses_web_fetch || !!c.uses_web_fetch,
     uses_task_agent: true,
-    // Keep the parent's own label; the honest multi-model picture lives in model_usage.
-    model: p.model,
+    // Keep the parent's own label when it has one; a pure orchestrator falls back to the
+    // dominant merged model rather than losing its label (and its tokens) entirely. The honest
+    // multi-model picture, when there is one, lives in model_usage regardless.
+    model: p.model || dominantModelOf(usage) || undefined,
     ...(Object.keys(usage).length > 1 ? { model_usage: usage } : {}),
   }
   return { session, modifiedFiles: [...files] }

--- a/packages/web/src/hooks/useData.ts
+++ b/packages/web/src/hooks/useData.ts
@@ -1322,26 +1322,32 @@ export function computeDerivedStats(data: AppData | null, filters: Filters, tags
     let filteredModelUsage: Record<string, import('@agentistics/core').ModelUsage>
 
     if (cacheBlindScope || nonClaudeHarness || harnessesFiltered) {
-      // Build per-model breakdown from sessions that have a model field.
-      // Sessions without a model field are excluded from the per-model breakdown.
+      // Build per-model breakdown from sessions, via sessionModelUsage — same helper the other
+      // two branches use below, and the same one every per-session cost path in this file goes
+      // through. A session's own `model` field can be empty while it still carries real tokens
+      // (an Antigravity rollup whose root conversation never generated a token itself, only its
+      // subagent children did — see mergeAntigravityChild's model fallback), and a plain
+      // `sess.model` read here used to drop that session's tokens/cost from every total that
+      // isn't the raw per-session sum, while cards summing `input_tokens` directly stayed correct
+      // — the two disagreeing is what made the filtered totals read far below the real spend.
       // Also used when a non-Claude harness is selected (statsCache has no harness granularity).
       filteredModelUsage = {}
       for (const sess of filteredSessions) {
-        const m = sess.model
-        if (!m) continue
-        if (modelSet && !modelSet.has(m)) continue
-        if (!filteredModelUsage[m]) {
-          filteredModelUsage[m] = {
-            inputTokens: 0, outputTokens: 0,
-            cacheReadInputTokens: 0, cacheCreationInputTokens: 0,
-            webSearchRequests: 0, costUSD: 0,
+        for (const [m, u] of sessionModelUsage(sess)) {
+          if (modelSet && !modelSet.has(m)) continue
+          if (!filteredModelUsage[m]) {
+            filteredModelUsage[m] = {
+              inputTokens: 0, outputTokens: 0,
+              cacheReadInputTokens: 0, cacheCreationInputTokens: 0,
+              webSearchRequests: 0, costUSD: 0,
+            }
           }
+          const entry = filteredModelUsage[m]!
+          entry.inputTokens              += u.inputTokens
+          entry.outputTokens             += u.outputTokens
+          entry.cacheReadInputTokens     += u.cacheReadInputTokens
+          entry.cacheCreationInputTokens += u.cacheCreationInputTokens
         }
-        const entry = filteredModelUsage[m]!
-        entry.inputTokens              += sess.input_tokens ?? 0
-        entry.outputTokens             += sess.output_tokens ?? 0
-        entry.cacheReadInputTokens     += sess.cache_read_input_tokens ?? 0
-        entry.cacheCreationInputTokens += sess.cache_creation_input_tokens ?? 0
       }
     } else if (dateFiltered) {
       // Build approximate model usage from dailyModelTokens (date-filtered, Claude-only).


### PR DESCRIPTION
## Summary
- A rolled-up Antigravity session whose root conversation never generates a `gen_metadata` row of its own (a pure orchestrator that only dispatches subagents) kept `model: undefined` after `mergeAntigravityChild`, even though its subagent children's real tokens were correctly folded in.
- `useData.ts`'s harness-filtered per-model aggregation branch dropped any session with no `model` entirely — silently excluding its tokens/cache/cost from every filtered total (header cost/token summary), while cards that sum `input_tokens` directly stayed correct. That's why the gap only showed up in totals/cost, not in the raw token cards.
- Found while investigating a large discrepancy between the vendor's own Antigravity quota panel and Agentistics' harness-filtered totals for two machines.

## Fix
- `antigravity-parse.ts`: `mergeAntigravityChild` now falls back to the dominant model (by token volume) of the merged usage when the parent has no model of its own, instead of leaving `model` undefined.
- `useData.ts`: the harness-filtered aggregation branch now goes through `sessionModelUsage()`, same as the other two aggregation branches, instead of reading `sess.model` directly and dropping model-less sessions.
- Added a regression test reproducing the exact scenario (parentless orchestrator + single-model child).

## Test plan
- [x] `bun test` — full suite, 4223 pass / 0 fail
- [x] `bun tsc --noEmit` — clean
- [x] New regression test: `mergeAntigravityChild: a parentless model falls back to the dominant merged model`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014LiTGTLw1h7fRWZLeSLt9L