### PR TITLE
revert: undo transcript search, TUI navigation and session approvals (3e9f06c)

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -181,8 +181,6 @@ export interface SessionMeta {
    *  the transcript; we surface it as the session's display name. Falls back to `first_prompt`
    *  in the UI when absent (older sessions, non-Claude harnesses). */
   title?: string
-  /** Concatenated user & assistant conversation messages text for full-text search across sessions. */
-  transcript_text?: string
   /**
    * The name the USER gave this session in the session manager, and their own note.
    *
@@ -459,7 +457,6 @@ export interface AppData {
   /** Assistants running right now that have no persisted session yet (e.g. an agy that has not
    *  completed its first turn). Carries no metrics — there is nothing measured yet. */
   liveProcesses?: LiveProcess[]
-  liveApprovals?: Record<string, LiveApprovalInfo>
   /** Why this machine cannot observe running assistants AT ALL. Set only when detection is
    *  structurally impossible here (not Linux, no /proc, a container that cannot see the host's
    *  processes, or one whose uid may not read their cwd). An empty list then means "we cannot
@@ -480,13 +477,6 @@ export type LiveUnavailableReason =
   | 'permission-denied'
   /** This exposure profile has revoked local host power (`CAPS.localProcesses`). */
   | 'capability-off'
-
-export interface LiveApprovalInfo {
-  approvalLines?: string[]
-  dialogOptions?: Array<{ number: number; label: string }>
-  canApprove?: boolean
-  canChoose?: boolean
-}
 
 /**
  * Drops any `dailyActivity`/`dailyModelTokens` entry whose `date` is missing or not a string.

--- a/packages/server/server/cli-start.ts
+++ b/packages/server/server/cli-start.ts
@@ -1653,10 +1653,7 @@ async function restorableSessions(fell: readonly ManagedSession[]): Promise<Rest
   }))
 }
 
-export function createControlHost(
-  initialLang: CliLang = 'pt',
-  altScreen: Suspendable = { suspend: <T>(fn: () => Promise<T>) => fn() },
-): StartHost {
+function createControlHost(initialLang: CliLang, altScreen: Suspendable): StartHost {
   let lang = initialLang
   const S = () => cliStrings(lang)
   // Built here so it always reports in the language the host is currently speaking.

--- a/packages/server/server/data.ts
+++ b/packages/server/server/data.ts
@@ -124,7 +124,6 @@ export async function loadSessionMetas(roots: string[] = [SESSION_META_DIR]): Pr
             output_tokens: (data.output_tokens as number) ?? 0,
             first_prompt: (data.first_prompt as string) ?? '',
             title: (data.title as string) ?? (data.summary as string) ?? undefined,
-            transcript_text: (data.transcript_text as string) ?? undefined,
             user_interruptions: (data.user_interruptions as number) ?? 0,
             user_response_times: (data.user_response_times as number[]) ?? [],
             tool_errors: (data.tool_errors as number) ?? 0,

--- a/packages/server/server/index.ts
+++ b/packages/server/server/index.ts
@@ -43,7 +43,6 @@ async function readLocalLiveSnapshot(sessions: SessionMeta[]): Promise<{
   liveSessionIds: string[]
   liveProcesses: LiveProcess[]
   liveSessionActivities?: Record<string, 'working' | 'waiting' | 'waiting-approval' | 'exited'>
-  liveApprovals?: Record<string, import('@agentistics/core').LiveApprovalInfo>
   liveUnavailable?: LiveUnavailableReason
 }> {
   if (!CAPS.localProcesses) {
@@ -1297,66 +1296,6 @@ async function handleRequestInner(req: Request, server: Server<WSData>): Promise
       } catch {
         return new Response(JSON.stringify({ liveSessionIds: [], liveProcesses: [] }), {
           status: 200,
-          headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
-        })
-      }
-    }
-
-    if (url.pathname === '/api/session-answer' && req.method === 'POST') {
-      try {
-        const body = await req.json() as { id?: string; choice?: number }
-        if (!body.id || typeof body.id !== 'string') {
-          return new Response(JSON.stringify({ ok: false, message: 'Missing session id' }), {
-            status: 400,
-            headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
-          })
-        }
-        const { createControlHost } = await import('./cli-start')
-        const ctrl = createControlHost()
-        if (!ctrl.answerSession) {
-          return new Response(JSON.stringify({ ok: false, message: 'Answer session not supported' }), {
-            status: 400,
-            headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
-          })
-        }
-        const result = await ctrl.answerSession(body.id, body.choice)
-        return new Response(JSON.stringify(result), {
-          status: result.ok ? 200 : 400,
-          headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
-        })
-      } catch (err) {
-        return new Response(JSON.stringify({ ok: false, message: err instanceof Error ? err.message : String(err) }), {
-          status: 500,
-          headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
-        })
-      }
-    }
-
-    if (url.pathname === '/api/session-prompt' && req.method === 'POST') {
-      try {
-        const body = await req.json() as { id?: string; text?: string }
-        if (!body.id || typeof body.id !== 'string' || !body.text) {
-          return new Response(JSON.stringify({ ok: false, message: 'Missing session id or text' }), {
-            status: 400,
-            headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
-          })
-        }
-        const { createControlHost } = await import('./cli-start')
-        const ctrl = createControlHost()
-        if (!ctrl.promptSession) {
-          return new Response(JSON.stringify({ ok: false, message: 'Prompt session not supported' }), {
-            status: 400,
-            headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
-          })
-        }
-        const result = await ctrl.promptSession(body.id, body.text)
-        return new Response(JSON.stringify(result), {
-          status: result.ok ? 200 : 400,
-          headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
-        })
-      } catch (err) {
-        return new Response(JSON.stringify({ ok: false, message: err instanceof Error ? err.message : String(err) }), {
-          status: 500,
           headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
         })
       }

--- a/packages/server/server/jsonl.ts
+++ b/packages/server/server/jsonl.ts
@@ -222,7 +222,6 @@ export async function parseSessionJsonl(
   // Maps tool_use_id → tool name for error attribution
   const toolUseIdToName = new Map<string, string>()
   let lastAssistantTs = ''
-  const transcriptParts: string[] = []
   // Per-turn timeline feeding computeActiveTime() — see docs/harness-contract.md. Every
   // timestamped line advances the clock; only a genuine human message opens a turn; Claude Code's
   // own `system`/`turn_duration` line closes one with the duration IT measured.
@@ -308,16 +307,15 @@ export async function parseSessionJsonl(
         // All messages after the first count as interruptions
         if (userMsgs > 1) userInterruptions++
 
-        if (contentArr) {
+        if (!firstPrompt && contentArr) {
           for (const p of contentArr) {
-            if (p.type === 'text' && typeof p.text === 'string' && p.text.trim()) {
-              transcriptParts.push(p.text.trim())
-              if (!firstPrompt) firstPrompt = p.text.trim().slice(0, 200)
+            if (p.type === 'text' && typeof p.text === 'string') {
+              firstPrompt = (p.text as string).slice(0, 200)
+              break
             }
           }
-        } else if (typeof msgContent === 'string' && msgContent.trim()) {
-          transcriptParts.push(msgContent.trim())
-          if (!firstPrompt) firstPrompt = msgContent.trim().slice(0, 200)
+        } else if (!firstPrompt && typeof msgContent === 'string') {
+          firstPrompt = msgContent.slice(0, 200)
         }
       }
     } else if (e.type === 'assistant') {
@@ -341,9 +339,6 @@ export async function parseSessionJsonl(
       const toolsInMessage: string[] = []
       if (Array.isArray(msg?.content)) {
         for (const p of msg!.content as Record<string, unknown>[]) {
-          if (p.type === 'text' && typeof p.text === 'string' && p.text.trim()) {
-            transcriptParts.push(p.text.trim())
-          }
           if (p.type === 'tool_use' && typeof p.name === 'string') {
             const toolName = p.name as string
             toolCounts[toolName] = (toolCounts[toolName] ?? 0) + 1
@@ -447,7 +442,6 @@ export async function parseSessionJsonl(
     ...(contextTokens > 0 ? { context_tokens: contextTokens } : {}),
     first_prompt: firstPrompt,
     title: sessionTitle || undefined,
-    transcript_text: transcriptParts.join(' ').replace(/\s+/g, ' ').slice(0, 200000) || undefined,
     user_interruptions: userInterruptions,
     user_response_times: userResponseTimes,
     tool_errors: toolErrors,

--- a/packages/server/server/live-sessions.ts
+++ b/packages/server/server/live-sessions.ts
@@ -571,8 +571,6 @@ export interface LiveSnapshot {
   liveProcesses: UnmatchedProcess[]
   /** Map of session_id to current activity status (working, waiting, waiting-approval, exited). */
   liveSessionActivities?: Record<string, 'working' | 'waiting' | 'waiting-approval' | 'exited'>
-  /** Map of session_id to current approval dialog information. */
-  liveApprovals?: Record<string, import('@agentistics/core').LiveApprovalInfo>
   /** Set when this configuration cannot observe host processes AT ALL. An empty list then means
    *  "we cannot know", not "nobody is working", and the UI must say which. */
   liveUnavailable?: LiveUnavailableReason
@@ -636,7 +634,6 @@ export async function getLiveSnapshot(sessions: SessionMeta[]): Promise<LiveSnap
   const snap = resolveLiveSnapshot(procs, sessions)
 
   const liveSessionActivities: Record<string, 'working' | 'waiting' | 'waiting-approval' | 'exited'> = {}
-  const liveApprovals: Record<string, import('@agentistics/core').LiveApprovalInfo> = {}
   try {
     const { createEventStore } = await import('./events/event-store')
     const store = createEventStore()
@@ -662,25 +659,6 @@ export async function getLiveSnapshot(sessions: SessionMeta[]): Promise<LiveSnap
     }
   }
 
-  try {
-    const { createControlHost } = await import('./cli-start')
-    const host = createControlHost()
-    if (host.sessions) {
-      const ctrlSnap = await host.sessions()
-      for (const s of ctrlSnap.sessions) {
-        if (s.canApprove || s.canChoose || (s.dialogOptions && s.dialogOptions.length > 0) || (s.approvalLines && s.approvalLines.length > 0)) {
-          liveApprovals[s.id] = {
-            approvalLines: s.approvalLines,
-            dialogOptions: s.dialogOptions,
-            canApprove: s.canApprove,
-            canChoose: s.canChoose,
-          }
-          liveSessionActivities[s.id] = 'waiting-approval'
-        }
-      }
-    }
-  } catch { /* best effort */ }
-
-  const result: LiveSnapshot = { ...snap, liveSessionActivities, liveApprovals }
+  const result: LiveSnapshot = { ...snap, liveSessionActivities }
   return unavailable ? { ...result, liveUnavailable: unavailable } : result
 }

--- a/packages/tui/src/control/tabs/SessionWizard.tsx
+++ b/packages/tui/src/control/tabs/SessionWizard.tsx
@@ -466,24 +466,6 @@ function ProjectSearch({ host, strings: s, width, height, isActive, onPick }: {
   }, [host, query])
 
   const list = options ?? []
-
-  const sourceWord = useCallback((o: ProjectOption): string =>
-    o.source === 'cwd' ? s.wizSourceCwd
-      : o.source === 'typed' ? s.wizSourceTyped
-      : o.source === 'history' ? s.wizSourceHistory
-      : o.source === 'repo' ? s.wizSourceRepo
-      : '', [s])
-
-  const table: ProjectRow[] = useMemo(() => list.map(o => ({
-    name: o.label, repo: o.repo ?? '', path: o.detail, why: sourceWord(o),
-  })), [list, sourceWord])
-
-  const picks = useMemo(() => projectPickRows(table, s.wizNoRepo), [table, s.wizNoRepo])
-  const flat = picks.rows
-  const visualIndices = useMemo(() => flat
-    .filter((r): r is { kind: 'project'; row: ProjectRow; index: number } => r.kind === 'project')
-    .map(r => r.index), [flat])
-
   const at = list.length === 0 ? 0 : Math.min(index, list.length - 1)
 
   useInput((input, key) => {
@@ -496,11 +478,8 @@ function ProjectSearch({ host, strings: s, width, height, isActive, onPick }: {
     if (key.backspace || key.delete) { setQuery(v => v.slice(0, -1)); return }
     if (key.upArrow || key.downArrow) {
       const nav: NavKey = { input, upArrow: key.upArrow, downArrow: key.downArrow }
-      const currentVis = visualIndices.indexOf(at)
-      const baseIdx = currentVis >= 0 ? currentVis : 0
-      const nextVis = resolveListKey(nav, baseIdx, Math.max(1, visualIndices.length))
-      const nextAt = visualIndices[nextVis] ?? 0
-      if (nextAt !== at) setIndex(nextAt)
+      const next = resolveListKey(nav, at, Math.max(1, list.length))
+      if (next !== at) setIndex(next)
       return
     }
     if (key.ctrl && input === 'u') { setQuery(''); return }
@@ -512,6 +491,24 @@ function ProjectSearch({ host, strings: s, width, height, isActive, onPick }: {
   // Label, hint, the field itself — and the table's header row.
   const page = Math.max(1, height - 4)
 
+  // A folder that was merely FOUND on disk must not read like one you have worked in — the words
+  // are the only thing distinguishing them, since both are just a directory name on a row.
+  const sourceWord = (o: ProjectOption): string =>
+    o.source === 'cwd' ? s.wizSourceCwd
+      : o.source === 'typed' ? s.wizSourceTyped
+      : o.source === 'history' ? s.wizSourceHistory
+      : o.source === 'repo' ? s.wizSourceRepo
+      : ''
+
+  const table: ProjectRow[] = list.map(o => ({
+    name: o.label, repo: o.repo ?? '', path: o.detail, why: sourceWord(o),
+  }))
+  // Grouped by REPOSITORY, which is the shape of the question: three worktrees of one repo are
+  // three answers to "which checkout", and a flat list mixed them in among unrelated folders that
+  // merely sorted nearby. The repo COLUMN then goes — the heading over the row already says it,
+  // the same rule the sessions list follows for its task cell — and the path gets the width back.
+  const picks = projectPickRows(table, s.wizNoRepo)
+  const flat = picks.rows
   // Windowed over the DRAWN rows, not the projects: headings take rows too, and paging by project
   // count scrolls the selection off a list whose real length is larger than the number it counted.
   const cursorAt = Math.max(0, flat.findIndex(r => r.kind === 'project' && r.index === at))

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -1754,12 +1754,22 @@ export default function AppLayout() {
         lang: lang === 'pt' ? 'pt' : 'en',
       })
     : null
-  const headerCostTitle = headerPlanBasis
-    ? [
-        lang === 'pt' ? 'Custo do seu plano no período medido' : 'Your plan cost over the measured period',
-        headerCostScope,
-      ].filter(Boolean).join(' · ')
-    : (lang === 'pt' ? 'Estimativa a preços de API' : 'API-price estimate')
+  // The strip's totals (sessions/cost/tokens) all narrow to online members BY DEFAULT on a
+  // central whose operator turned off `includeOfflineData` — nobody chose that on this screen, so
+  // it needs the same disclosure `planScopeNote` gives a plan-basis figure. An explicit "Offline"
+  // presence pill already reads as a filter the user picked and needs no extra sentence.
+  const presenceScopeNote = derived?.presenceScope.isPolicyDefault
+    ? (lang === 'pt' ? 'somente membros online (política do central)' : 'online members only (central policy)')
+    : null
+  const headerCostTitle = [
+    headerPlanBasis
+      ? [
+          lang === 'pt' ? 'Custo do seu plano no período medido' : 'Your plan cost over the measured period',
+          headerCostScope,
+        ].filter(Boolean).join(' · ')
+      : (lang === 'pt' ? 'Estimativa a preços de API' : 'API-price estimate'),
+    presenceScopeNote,
+  ].filter(Boolean).join(' · ')
 
   /**
    * The header's token figure and the sentence explaining it.
@@ -1771,7 +1781,8 @@ export default function AppLayout() {
    */
   const headerTokens = derived ? totalTokens(derived.tokenTotals) : 0
   const headerTokensTitle = derived
-    ? totalTokensExplained(derived.tokenTotals, lang === 'pt' ? 'pt' : 'en')
+    ? [totalTokensExplained(derived.tokenTotals, lang === 'pt' ? 'pt' : 'en'), presenceScopeNote]
+        .filter(Boolean).join(' · ')
     : ''
 
   const models = useMemo(() => {

--- a/packages/web/src/components/RecentSessions.tsx
+++ b/packages/web/src/components/RecentSessions.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useMemo, useEffect, useRef } from 'react'
 import type { SessionMeta } from '@agentistics/core'
 import { sessionTime } from '../lib/sessionTime'
+import { useIsMobile } from '../hooks/useIsMobile'
 import { formatProjectName, repoShortName, sessionLabel, sessionTokenTotal } from '@agentistics/core'
 import type { SessionActivity } from '../lib/sessionNotifications'
 import { resumeCommand } from '../lib/resumeCommand'
@@ -277,11 +278,13 @@ function PillButton({
   onClick: () => void
   children: React.ReactNode
 }) {
+  const isMobile = useIsMobile()
   return (
     <button
       onClick={onClick}
       style={{
-        padding: '4px 10px',
+        padding: isMobile ? '4px 12px' : '4px 10px',
+        minHeight: isMobile ? 44 : undefined,
         borderRadius: 999,
         border: active
           ? '1px solid var(--anthropic-orange, #e8690b)'
@@ -313,6 +316,7 @@ function IconButton({
   title?: string
   children: React.ReactNode
 }) {
+  const isMobile = useIsMobile()
   return (
     <button
       onClick={onClick}
@@ -322,8 +326,8 @@ function IconButton({
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',
-        width: 28,
-        height: 28,
+        width: isMobile ? 44 : 28,
+        height: isMobile ? 44 : 28,
         borderRadius: 6,
         border: '1px solid var(--border-subtle)',
         background: 'transparent',
@@ -419,6 +423,7 @@ const PAGE_SIZE_OPTIONS = [5, 10, 20, 50]
 
 export function RecentSessions({ sessions, lang, onSelect, pinnedIds, activities, viewMode: externalViewMode, onViewModeChange, title, subtitle, topActions }: Props) {
   const t = T[lang]
+  const isMobile = useIsMobile()
 
   // Grouping state (default 'project' to match agentop session ls)
   const [groupBy, setGroupBy] = useState<SessionGrouping>('project')
@@ -725,8 +730,8 @@ export function RecentSessions({ sessions, lang, onSelect, pinnedIds, activities
           </div>
 
           {/* Search Input & View Mode */}
-          <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexShrink: 0 }}>
-            <div style={{ position: 'relative', width: 180 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexShrink: 0, width: isMobile ? '100%' : undefined }}>
+            <div style={{ position: 'relative', width: isMobile ? '100%' : 180, flex: isMobile ? 1 : undefined }}>
               <Search
                 size={12}
                 style={{
@@ -1061,6 +1066,7 @@ export function RecentSessions({ sessions, lang, onSelect, pinnedIds, activities
               onClick={() => setPromptModal(true)}
               style={{
                 padding: '6px 12px',
+                minHeight: isMobile ? 44 : undefined,
                 borderRadius: 6,
                 background: 'var(--anthropic-orange)',
                 color: '#fff',
@@ -1083,6 +1089,7 @@ export function RecentSessions({ sessions, lang, onSelect, pinnedIds, activities
               }}
               style={{
                 padding: '6px 12px',
+                minHeight: isMobile ? 44 : undefined,
                 borderRadius: 6,
                 background: 'rgba(239, 68, 68, 0.15)',
                 color: '#ef4444',
@@ -1111,6 +1118,7 @@ export function RecentSessions({ sessions, lang, onSelect, pinnedIds, activities
               }}
               style={{
                 padding: '6px 12px',
+                minHeight: isMobile ? 44 : undefined,
                 borderRadius: 6,
                 background: 'rgba(34, 197, 94, 0.15)',
                 color: '#22c55e',
@@ -1128,6 +1136,7 @@ export function RecentSessions({ sessions, lang, onSelect, pinnedIds, activities
               onClick={() => setSelectedIds(new Set())}
               style={{
                 padding: '6px 12px',
+                minHeight: isMobile ? 44 : undefined,
                 borderRadius: 6,
                 background: 'transparent',
                 color: 'var(--text-tertiary)',
@@ -1146,11 +1155,16 @@ export function RecentSessions({ sessions, lang, onSelect, pinnedIds, activities
       {openWarningModal && (
         <div style={{
           position: 'fixed', inset: 0, zIndex: 1000, background: 'rgba(0,0,0,0.6)',
-          display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 20
+          display: 'flex', alignItems: isMobile ? 'stretch' : 'center', justifyContent: 'center',
+          padding: isMobile ? 0 : 20,
         }}>
           <div style={{
-            background: 'var(--bg-card)', border: '1px solid var(--border)', borderRadius: 12,
-            padding: 24, maxWidth: 480, width: '100%', display: 'flex', flexDirection: 'column', gap: 16
+            background: 'var(--bg-card)', border: isMobile ? 'none' : '1px solid var(--border)',
+            borderRadius: isMobile ? 0 : 12,
+            padding: 24, maxWidth: isMobile ? '100%' : 480, width: '100%',
+            height: isMobile ? '100%' : undefined,
+            display: 'flex', flexDirection: 'column', gap: 16,
+            boxSizing: 'border-box',
           }}>
             <div style={{ fontSize: 16, fontWeight: 700, color: '#ef4444' }}>
               {lang === 'pt' ? 'Aviso: Não é possível reabrir' : 'Warning: Cannot reopen'}
@@ -1185,11 +1199,16 @@ export function RecentSessions({ sessions, lang, onSelect, pinnedIds, activities
       {promptModal && (
         <div style={{
           position: 'fixed', inset: 0, zIndex: 1000, background: 'rgba(0,0,0,0.6)',
-          display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 20
+          display: 'flex', alignItems: isMobile ? 'stretch' : 'center', justifyContent: 'center',
+          padding: isMobile ? 0 : 20,
         }}>
           <div style={{
-            background: 'var(--bg-card)', border: '1px solid var(--border)', borderRadius: 12,
-            padding: 24, maxWidth: 500, width: '100%', display: 'flex', flexDirection: 'column', gap: 16
+            background: 'var(--bg-card)', border: isMobile ? 'none' : '1px solid var(--border)',
+            borderRadius: isMobile ? 0 : 12,
+            padding: 24, maxWidth: isMobile ? '100%' : 500, width: '100%',
+            height: isMobile ? '100%' : undefined,
+            display: 'flex', flexDirection: 'column', gap: 16,
+            boxSizing: 'border-box',
           }}>
             <div style={{ fontSize: 15, fontWeight: 700, color: 'var(--text-primary)' }}>
               {lang === 'pt' ? `Enviar prompt para ${selectedIds.size} sessões` : `Send prompt to ${selectedIds.size} sessions`}

--- a/packages/web/src/components/RecentSessions.tsx
+++ b/packages/web/src/components/RecentSessions.tsx
@@ -1,13 +1,19 @@
-import React, { useState, useMemo } from 'react'
+import React, { useState, useMemo, useEffect, useRef } from 'react'
 import type { SessionMeta } from '@agentistics/core'
 import { sessionTime } from '../lib/sessionTime'
-import { fmt, formatProjectName, sessionLabel, sessionTokenTotal } from '@agentistics/core'
+import { formatProjectName, repoShortName, sessionLabel, sessionTokenTotal } from '@agentistics/core'
+import type { SessionActivity } from '../lib/sessionNotifications'
+import { resumeCommand } from '../lib/resumeCommand'
 import { HARNESS_LABELS, HARNESS_COLORS } from '../lib/harness'
 import { format, parseISO } from 'date-fns'
 import {
   ChevronLeft,
   ChevronRight,
   ChevronsLeft,
+  Terminal,
+  Send,
+  Check,
+  Copy,
   ChevronsRight,
   Search,
   Clock,
@@ -15,6 +21,20 @@ import {
   FileCode,
   GitCommit,
   ExternalLink,
+  LayoutGrid,
+  List,
+  Layers,
+  ChevronDown,
+  ChevronUp,
+  Folder,
+  Radio,
+  Tag,
+  Bookmark,
+  Bot,
+  ArrowUpDown,
+  Filter,
+  Maximize2,
+  X,
 } from 'lucide-react'
 
 // Types
@@ -25,58 +45,118 @@ interface Props {
   onSelect?: (session: SessionMeta) => void
   /** session_ids to pin to the top of the list (e.g. live/open sessions), regardless of sort. */
   pinnedIds?: Set<string>
+  /** What each LIVE session is doing right now, from `/api/live-sessions`. A session absent here
+   *  has no observable state — the row says so rather than claiming one. */
+  activities?: Record<string, SessionActivity>
+  viewMode?: 'list' | 'grid'
+  onViewModeChange?: (mode: 'list' | 'grid') => void
+  title?: React.ReactNode
+  subtitle?: React.ReactNode
+  topActions?: React.ReactNode
 }
 
-type SortKey = 'date' | 'tokens' | 'messages' | 'tools' | 'files'
+/** `task` is deliberately absent: a task is a fact of the agentop session registry, not of a
+ *  stored `SessionMeta`, so a "group by task" here could only ever produce one "no task" band. */
+export type SessionGrouping = 'none' | 'status' | 'repo' | 'project' | 'harness' | 'model' | 'marked'
 
+const STATUS_BUCKETS: Record<SessionActivity, { label: string; color: string }> = {
+  'waiting-approval': { label: 'Aguardando aprovação', color: '#ef4444' },
+  waiting: { label: 'Aguardando resposta', color: '#f59e0b' },
+  working: { label: 'Trabalhando', color: '#22c55e' },
+  exited: { label: 'Encerradas / Histórico', color: 'var(--text-tertiary)' },
+}
+export type StatusShortcut = 'all' | 'active' | 'waiting' | 'closed'
+export type SortKey = 'date' | 'status' | 'tokens' | 'messages' | 'tools' | 'files' | 'name'
+export type SortDir = 'asc' | 'desc'
 
 // Translations
 
 const T = {
   pt: {
+    group_by: 'Agrupar por:',
+    group_none: 'Nenhum',
+    group_status: 'Status',
+    group_repo: 'Repositório',
+    group_project: 'Projeto',
+    group_task: 'Tarefa',
+    group_harness: 'Harness',
+    group_model: 'Modelo',
+    group_marked: 'Marcadas',
+
+    shortcut_all: 'Todas',
+    shortcut_active: 'Ativas',
+    shortcut_waiting: 'Aguardando',
+    shortcut_closed: 'Encerradas',
+
     sort_date: 'Data',
+    sort_status: 'Status',
     sort_tokens: 'Tokens',
     sort_messages: 'Mensagens',
     sort_tools: 'Tools',
     sort_files: 'Arquivos',
+    sort_name: 'Nome',
+
     filters: 'Filtros',
     search_placeholder: 'Buscar sessão...',
-    min_tokens: 'Tokens mín.',
-    min_messages: 'Msgs mín.',
     showing: 'Exibindo',
     of: 'de',
     per_page: 'por página',
     no_results: 'Nenhuma sessão encontrada',
     page: 'Página',
+    sessions_unit: 'sessões',
+    details_btn: 'Detalhes da sessão',
   },
   en: {
+    group_by: 'Group by:',
+    group_none: 'None',
+    group_status: 'Status',
+    group_repo: 'Repo',
+    group_project: 'Project',
+    group_task: 'Task',
+    group_harness: 'Harness',
+    group_model: 'Model',
+    group_marked: 'Marked',
+
+    shortcut_all: 'All',
+    shortcut_active: 'Active',
+    shortcut_waiting: 'Waiting',
+    shortcut_closed: 'Closed',
+
     sort_date: 'Date',
+    sort_status: 'Status',
     sort_tokens: 'Tokens',
     sort_messages: 'Messages',
     sort_tools: 'Tools',
     sort_files: 'Files',
+    sort_name: 'Name',
+
     filters: 'Filters',
     search_placeholder: 'Search session...',
-    min_tokens: 'Min tokens',
-    min_messages: 'Min messages',
     showing: 'Showing',
     of: 'of',
     per_page: 'per page',
     no_results: 'No sessions found',
     page: 'Page',
+    sessions_unit: 'sessions',
+    details_btn: 'Session details',
   },
 }
 
 // Helpers
 
+function fmt(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
+  if (n >= 1_000) return `${(n / 1_000).toFixed(0)}K`
+  return String(n)
+}
 
-/** Every billed counter — the column header says "tokens", so it must be all of them. */
 function totalTokens(s: SessionMeta): number {
+  // All four billed counters — `input + output` alone is a fraction of a percent of the volume.
   return sessionTokenTotal(s)
 }
 
 function totalMessages(s: SessionMeta): number {
-  return s.user_message_count + s.assistant_message_count
+  return (s.user_message_count || 0) + (s.assistant_message_count || 0)
 }
 
 function totalTools(s: SessionMeta): number {
@@ -86,6 +166,21 @@ function totalTools(s: SessionMeta): number {
 function truncate(str: string, max: number): string {
   if (!str) return ''
   return str.length <= max ? str : str.slice(0, max) + '…'
+}
+
+/** The state is the live poll's, never the session record's — a stored session has none, and a
+ *  pinned row is only known to be OPEN, which is why it falls back to "working". */
+function getStatusInfo(state?: SessionActivity, isPinned?: boolean): { color: string; labelPt: string; labelEn: string } {
+  if (state === 'waiting-approval') {
+    return { color: '#ef4444', labelPt: 'precisa de aprovação', labelEn: 'needs approval' }
+  }
+  if (state === 'waiting') {
+    return { color: '#f59e0b', labelPt: 'aguardando resposta', labelEn: 'waiting input' }
+  }
+  if (state === 'working' || isPinned) {
+    return { color: '#22c55e', labelPt: 'trabalhando', labelEn: 'working' }
+  }
+  return { color: 'rgba(156, 163, 175, 0.5)', labelPt: 'encerrada', labelEn: 'closed' }
 }
 
 // Sub-components
@@ -121,25 +216,25 @@ function Chip({
 }
 
 function HarnessBadge({ harness }: { harness?: string }) {
-  // Only show badge for non-Claude harnesses — Claude is the default and needs no label
-  if (!harness || harness === 'claude') return null
-  const color = (HARNESS_COLORS as Record<string, string>)[harness] ?? '#888'
-  const label = (HARNESS_LABELS as Record<string, string>)[harness] ?? harness
+  if (!harness) return null
+  const h = harness.toLowerCase()
+  const color = (HARNESS_COLORS as Record<string, string>)[h] ?? '#888'
+  const label = (HARNESS_LABELS as Record<string, string>)[h] ?? harness
   return (
     <span
       title={label}
       style={{
         display: 'inline-flex',
         alignItems: 'center',
-        padding: '1px 5px',
-        borderRadius: 999,
-        fontSize: 9,
+        padding: '2px 6px',
+        borderRadius: 4,
+        fontSize: 10,
         fontWeight: 600,
         letterSpacing: 0.3,
-        lineHeight: 1.6,
-        background: `${color}22`,
+        lineHeight: 1.4,
+        background: `${color}18`,
         color,
-        border: `1px solid ${color}55`,
+        border: `1px solid ${color}44`,
         flexShrink: 0,
         textTransform: 'uppercase',
       }}
@@ -198,6 +293,8 @@ function PillButton({
         cursor: 'pointer',
         transition: 'all 0.15s',
         lineHeight: 1.4,
+        fontFamily: 'inherit',
+        whiteSpace: 'nowrap',
       }}
     >
       {children}
@@ -242,16 +339,11 @@ function IconButton({
   )
 }
 
-// Open in Claude / Nay helpers
-
 function isNayChatSession(projectPath: string): boolean {
   return projectPath.includes('.agentistics/nay-chat')
 }
 
 function encodeProjectDir(projectPath: string): string {
-  // Claude encodes the project folder by replacing every non-alphanumeric char
-  // (slash, dot, underscore, etc.) with a dash — e.g. ".../bridge-cse_01H" →
-  // "...-bridge-cse-01H". Matching this exactly is required to locate the JSONL.
   return projectPath.replace(/[^a-zA-Z0-9-]/g, '-')
 }
 
@@ -274,103 +366,244 @@ function openSession(s: SessionMeta, e: React.MouseEvent) {
   }
 }
 
-// Main Component
+// Grouping Helper: extracts bucket key for a session
+function getSessionBucketKey(
+  s: SessionMeta,
+  groupBy: SessionGrouping,
+  pinnedIds?: Set<string>,
+  activities?: Record<string, SessionActivity>,
+): { key: string; label: string; icon: React.ReactNode } {
+  const isPinned = pinnedIds?.has(s.session_id)
+  switch (groupBy) {
+    case 'status': {
+      // The state comes from the live poll, never from the session record — a stored session
+      // carries no state, and grouping every one of them under "working" would be an invention.
+      const st = activities?.[s.session_id]
+      if (st) {
+        const info = STATUS_BUCKETS[st]
+        return { key: st, label: info.label, icon: <Radio size={13} style={{ color: info.color }} /> }
+      }
+      if (isPinned) return { key: 'working', label: 'Em Execução / Ativa', icon: <Radio size={13} style={{ color: '#22c55e' }} /> }
+      return { key: 'closed', label: 'Encerradas / Histórico', icon: <Radio size={13} style={{ color: 'var(--text-tertiary)' }} /> }
+    }
+    case 'repo': {
+      // A repo is keyed by its normalized git remote — never by a path segment, which splits the
+      // same repository across machines and worktrees.
+      const remote = s.git_remote ? repoShortName(s.git_remote) : ''
+      const repo = remote || 'Sem repositório'
+      return { key: repo, label: repo, icon: <GitCommit size={13} style={{ color: 'var(--accent-purple, #a855f7)' }} /> }
+    }
+    case 'project': {
+      const proj = s.project_path ? formatProjectName(s.project_path) : 'Sem projeto'
+      return { key: proj, label: proj, icon: <Folder size={13} style={{ color: 'var(--anthropic-orange)' }} /> }
+    }
+    case 'harness': {
+      const h = s.harness || 'claude'
+      const label = (HARNESS_LABELS as Record<string, string>)[h] ?? h
+      return { key: h, label, icon: <Bot size={13} style={{ color: (HARNESS_COLORS as Record<string, string>)[h] || 'var(--text-primary)' }} /> }
+    }
+    case 'model': {
+      const model = s.model || 'Sem modelo definido'
+      return { key: model, label: model, icon: <Tag size={13} style={{ color: 'var(--accent-blue, #3b82f6)' }} /> }
+    }
+    case 'marked': {
+      if (isPinned) return { key: 'marked', label: 'Marcadas / Live Sessions', icon: <Bookmark size={13} style={{ color: 'var(--anthropic-orange)' }} /> }
+      return { key: 'unmarked', label: 'Outras Sessões', icon: <Bookmark size={13} style={{ color: 'var(--text-tertiary)' }} /> }
+    }
+    default:
+      return { key: 'all', label: 'Todas as Sessões', icon: <Layers size={13} /> }
+  }
+}
 
-const PAGE_SIZE_OPTIONS = [10, 20, 50]
+const PAGE_SIZE_OPTIONS = [5, 10, 20, 50]
 
-export function RecentSessions({ sessions, lang, onSelect, pinnedIds }: Props) {
+export function RecentSessions({ sessions, lang, onSelect, pinnedIds, activities, viewMode: externalViewMode, onViewModeChange, title, subtitle, topActions }: Props) {
   const t = T[lang]
+
+  // Grouping state (default 'project' to match agentop session ls)
+  const [groupBy, setGroupBy] = useState<SessionGrouping>('project')
+
+  // Status shortcut filter
+  const [statusShortcut, setStatusShortcut] = useState<StatusShortcut>('all')
 
   // Sort state
   const [sortKey, setSortKey] = useState<SortKey>('date')
+  const [sortDir, setSortDir] = useState<SortDir>('desc')
 
-  // Filter state
+  // Search state
   const [search, setSearch] = useState('')
 
-  // Pagination state
+  // View mode (list vs grid)
+  const [internalViewMode, setInternalViewMode] = useState<'list' | 'grid'>('list')
+  const viewMode = externalViewMode ?? internalViewMode
+
+  function handleViewModeChange(mode: 'list' | 'grid') {
+    if (onViewModeChange) onViewModeChange(mode)
+    setInternalViewMode(mode)
+  }
+
+  // Pagination state (default 5 per page)
   const [page, setPage] = useState(0)
-  const [pageSize, setPageSize] = useState(10)
+  const [pageSize, setPageSize] = useState(5)
+
+  // Per-group pagination state
+  const [groupPages, setGroupPages] = useState<Record<string, number>>({})
 
   // Batch selection state
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
+  function toggleSelect(id: string) {
+    setSelectedIds(prev => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }
   const [openWarningModal, setOpenWarningModal] = useState<string[] | null>(null)
   const [promptModal, setPromptModal] = useState<boolean>(false)
   const [batchPromptText, setBatchPromptText] = useState('')
 
-  // Derived: sorted + filtered
-  const processed = useMemo<SessionMeta[]>(() => {
+  // Collapsed groups accordion map
+  const [collapsedGroups, setCollapsedGroups] = useState<Record<string, boolean>>({})
+
+  // Filter & Sort list
+  const filteredAndSorted = useMemo(() => {
     let list = [...sessions]
 
-    // Filter: text search
+    // Text search filter
     if (search.trim()) {
       const q = search.trim().toLowerCase()
       list = list.filter(
         s =>
           (s.title ?? '').toLowerCase().includes(q) ||
           (s.first_prompt ?? '').toLowerCase().includes(q) ||
-          (s.user_label ?? '').toLowerCase().includes(q) ||
-          (s.user_note ?? '').toLowerCase().includes(q) ||
           (s.project_path ?? '').toLowerCase().includes(q) ||
-          (s.harness ?? '').toLowerCase().includes(q) ||
-          (s.transcript_text ?? '').toLowerCase().includes(q)
+          (s.git_remote ?? '').toLowerCase().includes(q)
       )
     }
 
-    // Sort — pinned (e.g. live/open) sessions always float to the top, regardless of sortKey.
+    // Status shortcut filter
+    if (statusShortcut !== 'all') {
+      list = list.filter(s => {
+        const isLive = pinnedIds?.has(s.session_id)
+        if (statusShortcut === 'active') return isLive
+        if (statusShortcut === 'waiting') {
+          const st = activities?.[s.session_id]
+          return isLive && (st === 'waiting' || st === 'waiting-approval')
+        }
+        if (statusShortcut === 'closed') return !isLive
+        return true
+      })
+    }
+
+    // Sorting
     list.sort((a, b) => {
-      if (pinnedIds) {
+      // Float pinned sessions if sortKey is date
+      if (pinnedIds && sortKey === 'date') {
         const pa = pinnedIds.has(a.session_id) ? 1 : 0
         const pb = pinnedIds.has(b.session_id) ? 1 : 0
         if (pa !== pb) return pb - pa
       }
+
+      let res = 0
       switch (sortKey) {
         case 'date':
-          return new Date(b.start_time).getTime() - new Date(a.start_time).getTime()
+          res = new Date(b.start_time).getTime() - new Date(a.start_time).getTime()
+          break
         case 'tokens':
-          return totalTokens(b) - totalTokens(a)
+          res = totalTokens(b) - totalTokens(a)
+          break
         case 'messages':
-          return totalMessages(b) - totalMessages(a)
+          res = totalMessages(b) - totalMessages(a)
+          break
         case 'tools':
-          return totalTools(b) - totalTools(a)
+          res = totalTools(b) - totalTools(a)
+          break
         case 'files':
-          return (b.files_modified ?? 0) - (a.files_modified ?? 0)
+          res = (b.files_modified ?? 0) - (a.files_modified ?? 0)
+          break
+        case 'name':
+          res = (sessionLabel(a) || a.project_path || '').localeCompare(sessionLabel(b) || b.project_path || '')
+          break
+        case 'status': {
+          const pa = pinnedIds?.has(a.session_id) ? 1 : 0
+          const pb = pinnedIds?.has(b.session_id) ? 1 : 0
+          res = pb - pa
+          break
+        }
         default:
-          return 0
+          res = 0
       }
+      return sortDir === 'asc' ? -res : res
     })
 
     return list
-  }, [sessions, search, sortKey, pinnedIds])
+  }, [sessions, search, statusShortcut, sortKey, sortDir, pinnedIds])
 
-  // Reset to page 0 when filters/sort/pageSize change
-  const totalItems = processed.length
+  // Grouped list
+  const groups = useMemo(() => {
+    if (groupBy === 'none') return []
+
+    const map = new Map<string, { key: string; label: string; icon: React.ReactNode; sessions: SessionMeta[] }>()
+    for (const s of filteredAndSorted) {
+      const bucket = getSessionBucketKey(s, groupBy, pinnedIds, activities)
+      const existing = map.get(bucket.key)
+      if (existing) {
+        existing.sessions.push(s)
+      } else {
+        map.set(bucket.key, { key: bucket.key, label: bucket.label, icon: bucket.icon, sessions: [s] })
+      }
+    }
+    return Array.from(map.values())
+  }, [filteredAndSorted, groupBy, pinnedIds, activities])
+
+  // Reset page on filter changes
+  const totalItems = filteredAndSorted.length
   const totalPages = Math.max(1, Math.ceil(totalItems / pageSize))
   const safePage = Math.min(page, totalPages - 1)
   const startIdx = safePage * pageSize
   const endIdx = Math.min(startIdx + pageSize, totalItems)
-  const pageItems = processed.slice(startIdx, endIdx)
+  const pageItems = filteredAndSorted.slice(startIdx, endIdx)
 
   function changeSort(key: SortKey) {
-    setSortKey(key)
+    if (sortKey === key) {
+      setSortDir(d => (d === 'desc' ? 'asc' : 'desc'))
+    } else {
+      setSortKey(key)
+      setSortDir('desc')
+    }
     setPage(0)
   }
 
-  function changePageSize(size: number) {
-    setPageSize(size)
-    setPage(0)
+  function toggleGroupCollapse(key: string) {
+    setCollapsedGroups(prev => ({ ...prev, [key]: !prev[key] }))
   }
 
-  function handleSearchChange(v: string) {
-    setSearch(v)
-    setPage(0)
-  }
+  const groupOptions: { key: SessionGrouping; label: string }[] = [
+    { key: 'none', label: t.group_none },
+    { key: 'status', label: t.group_status },
+    { key: 'repo', label: t.group_repo },
+    { key: 'project', label: t.group_project },
+    { key: 'harness', label: t.group_harness },
+    { key: 'model', label: t.group_model },
+    { key: 'marked', label: t.group_marked },
+  ]
+
+  const shortcutOptions: { key: StatusShortcut; label: string }[] = [
+    { key: 'all', label: t.shortcut_all },
+    { key: 'active', label: t.shortcut_active },
+    { key: 'waiting', label: t.shortcut_waiting },
+    { key: 'closed', label: t.shortcut_closed },
+  ]
 
   const sortOptions: { key: SortKey; label: string }[] = [
     { key: 'date', label: t.sort_date },
+    { key: 'status', label: t.sort_status },
     { key: 'tokens', label: t.sort_tokens },
     { key: 'messages', label: t.sort_messages },
     { key: 'tools', label: t.sort_tools },
     { key: 'files', label: t.sort_files },
+    { key: 'name', label: t.sort_name },
   ]
 
   const inputStyle: React.CSSProperties = {
@@ -382,70 +615,182 @@ export function RecentSessions({ sessions, lang, onSelect, pinnedIds }: Props) {
     fontSize: 11,
     outline: 'none',
     minWidth: 0,
+    fontFamily: 'inherit',
   }
 
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
-      {/* Sort controls */}
-      <div style={{ display: 'flex', alignItems: 'center', gap: 6, flexWrap: 'wrap' }}>
-        {sortOptions.map(opt => (
-          <PillButton key={opt.key} active={sortKey === opt.key} onClick={() => changeSort(opt.key)}>
-            {opt.label}
-          </PillButton>
-        ))}
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 12, width: '100%', minWidth: 0, boxSizing: 'border-box' }}>
+      {/* Control Bar: Agrupar por + Filtros + Ordenação */}
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 12,
+          padding: '14px 18px',
+          borderRadius: 12,
+          background: 'var(--bg-surface)',
+          border: '1px solid var(--border-subtle)',
+        }}
+      >
+        {/* Row 0: Title, Subtitle, and Top Actions (Notifications + View Mode) if provided */}
+        {(title || subtitle || topActions) && (
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12, flexWrap: 'wrap', paddingBottom: 10, borderBottom: '1px solid var(--border-subtle)' }}>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 4, flex: 1, minWidth: 260 }}>
+              {title && (
+                <div style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 18, fontWeight: 700, color: 'var(--text-primary)' }}>
+                  {title}
+                </div>
+              )}
+              {subtitle && (
+                <div style={{ fontSize: 12, color: 'var(--text-tertiary)', lineHeight: 1.5 }}>
+                  {subtitle}
+                </div>
+              )}
+            </div>
+            {topActions && (
+              <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                {topActions}
+              </div>
+            )}
+          </div>
+        )}
 
-        <button
-          onClick={() => {
-            if (selectedIds.size === pageItems.length && pageItems.length > 0) {
-              setSelectedIds(new Set())
-            } else {
-              setSelectedIds(new Set(pageItems.map(s => s.session_id)))
-            }
-          }}
-          style={{
-            padding: '4px 10px',
-            borderRadius: 6,
-            border: '1px solid var(--border-subtle)',
-            background: 'var(--bg-elevated)',
-            color: 'var(--text-secondary)',
-            fontSize: 11,
-            cursor: 'pointer',
-            marginLeft: 4,
-          }}
-        >
-          {selectedIds.size === pageItems.length && pageItems.length > 0
-            ? (lang === 'pt' ? 'Desmarcar todas' : 'Deselect all')
-            : (lang === 'pt' ? 'Selecionar todas' : 'Select all')}
-        </button>
+        {/* Row 1: Agrupar por */}
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 5, fontSize: 11, fontWeight: 600, color: 'var(--text-secondary)', flexShrink: 0 }}>
+            <Layers size={13} style={{ color: 'var(--anthropic-orange)' }} />
+            <span>{t.group_by}</span>
+          </div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 4, flexWrap: 'wrap' }}>
+            {groupOptions.map(opt => (
+              <PillButton key={opt.key} active={groupBy === opt.key} onClick={() => { setGroupBy(opt.key); setPage(0) }}>
+                {opt.label}
+              </PillButton>
+            ))}
+          </div>
+        </div>
 
-        {/* Spacer */}
-        <div style={{ flex: 1 }} />
+        {/* Row 2: Status Shortcuts + Sort + Search + View Mode */}
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 10, flexWrap: 'wrap' }}>
+          {/* Shortcuts & Sort */}
+          <div style={{ display: 'flex', alignItems: 'center', gap: 12, flexWrap: 'wrap' }}>
+            {/* Status shortcuts */}
+            <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+              <Filter size={12} style={{ color: 'var(--text-tertiary)', flexShrink: 0 }} />
+              {shortcutOptions.map(opt => (
+                <PillButton key={opt.key} active={statusShortcut === opt.key} onClick={() => { setStatusShortcut(opt.key); setPage(0) }}>
+                  {opt.label}
+                </PillButton>
+              ))}
+            </div>
 
-        {/* Search — always visible */}
-        <div style={{ position: 'relative', width: 180 }}>
-          <Search
-            size={11}
-            style={{
-              position: 'absolute',
-              left: 8,
-              top: '50%',
-              transform: 'translateY(-50%)',
-              color: 'var(--text-tertiary)',
-              pointerEvents: 'none',
-            }}
-          />
-          <input
-            type="text"
-            value={search}
-            onChange={e => handleSearchChange(e.target.value)}
-            placeholder={t.search_placeholder}
-            style={{ ...inputStyle, paddingLeft: 24, width: '100%', boxSizing: 'border-box' }}
-          />
+            {/* Separator */}
+            <div style={{ width: 1, height: 16, background: 'var(--border-subtle)' }} />
+
+            {/* Sort keys */}
+            <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+              <ArrowUpDown size={12} style={{ color: 'var(--text-tertiary)', flexShrink: 0 }} />
+              {sortOptions.map(opt => (
+                <PillButton key={opt.key} active={sortKey === opt.key} onClick={() => changeSort(opt.key)}>
+                  {opt.label} {sortKey === opt.key ? (sortDir === 'asc' ? '↑' : '↓') : ''}
+                </PillButton>
+              ))}
+            </div>
+
+            {/* Select all — over everything the filters and search left standing, NOT one page.
+                With bands and per-group paging there is no single "page" this could mean. */}
+            <button
+              onClick={() => {
+                if (selectedIds.size === filteredAndSorted.length && filteredAndSorted.length > 0) {
+                  setSelectedIds(new Set())
+                } else {
+                  setSelectedIds(new Set(filteredAndSorted.map(s => s.session_id)))
+                }
+              }}
+              style={{
+                padding: '4px 10px',
+                borderRadius: 6,
+                border: '1px solid var(--border-subtle)',
+                background: 'var(--bg-elevated)',
+                color: 'var(--text-secondary)',
+                fontSize: 11,
+                cursor: 'pointer',
+                marginLeft: 4,
+              }}
+            >
+              {selectedIds.size === filteredAndSorted.length && filteredAndSorted.length > 0
+                ? (lang === 'pt' ? 'Desmarcar todas' : 'Deselect all')
+                : (lang === 'pt' ? 'Selecionar todas' : 'Select all')}
+            </button>
+          </div>
+
+          {/* Search Input & View Mode */}
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexShrink: 0 }}>
+            <div style={{ position: 'relative', width: 180 }}>
+              <Search
+                size={12}
+                style={{
+                  position: 'absolute',
+                  left: 8,
+                  top: '50%',
+                  transform: 'translateY(-50%)',
+                  color: 'var(--text-tertiary)',
+                  pointerEvents: 'none',
+                }}
+              />
+              <input
+                type="text"
+                value={search}
+                onChange={e => { setSearch(e.target.value); setPage(0) }}
+                placeholder={t.search_placeholder}
+                style={{ ...inputStyle, paddingLeft: 24, width: '100%', boxSizing: 'border-box' }}
+              />
+            </div>
+
+            <div style={{ display: 'flex', alignItems: 'center', border: '1px solid var(--border-subtle)', borderRadius: 6, padding: 2, background: 'var(--bg-elevated)' }}>
+              <button
+                onClick={() => handleViewModeChange('list')}
+                title={lang === 'pt' ? 'Exibir em lista' : 'List view'}
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  width: 24,
+                  height: 22,
+                  borderRadius: 4,
+                  border: 'none',
+                  background: viewMode === 'list' ? 'var(--bg-card)' : 'transparent',
+                  color: viewMode === 'list' ? 'var(--anthropic-orange)' : 'var(--text-tertiary)',
+                  cursor: 'pointer',
+                }}
+              >
+                <List size={13} />
+              </button>
+              <button
+                onClick={() => handleViewModeChange('grid')}
+                title={lang === 'pt' ? 'Exibir em grid' : 'Grid view'}
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  width: 24,
+                  height: 22,
+                  borderRadius: 4,
+                  border: 'none',
+                  background: viewMode === 'grid' ? 'var(--bg-card)' : 'transparent',
+                  color: viewMode === 'grid' ? 'var(--anthropic-orange)' : 'var(--text-tertiary)',
+                  cursor: 'pointer',
+                }}
+              >
+                <LayoutGrid size={13} />
+              </button>
+            </div>
+          </div>
         </div>
       </div>
 
-      {/* Session list */}
-      {pageItems.length === 0 ? (
+      {/* Main Content Area: Grouped or Ungrouped */}
+      {filteredAndSorted.length === 0 ? (
         <div
           style={{
             display: 'flex',
@@ -455,279 +800,237 @@ export function RecentSessions({ sessions, lang, onSelect, pinnedIds }: Props) {
             padding: '40px 24px',
             gap: 8,
             color: 'var(--text-tertiary)',
+            background: 'var(--bg-card)',
+            borderRadius: 10,
+            border: '1px solid var(--border-subtle)',
           }}
         >
           <Search size={28} style={{ opacity: 0.35 }} />
           <span style={{ fontSize: 13, fontWeight: 500 }}>{t.no_results}</span>
         </div>
-      ) : (
-        <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
-          {pageItems.map(s => {
-            const tokens = totalTokens(s)
-            const tools = totalTools(s)
-            const msgs = totalMessages(s)
+      ) : groupBy !== 'none' ? (
+        /* Group Bands View */
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+          {groups.map(g => {
+            const isCollapsed = Boolean(collapsedGroups[g.key])
+            const gTotal = g.sessions.length
+            const gTotalPages = Math.max(1, Math.ceil(gTotal / pageSize))
+            const gPage = groupPages[g.key] ?? 0
+            const gSafePage = Math.min(gPage, gTotalPages - 1)
+            const gStart = gSafePage * pageSize
+            const gEnd = Math.min(gStart + pageSize, gTotal)
+            const gItems = g.sessions.slice(gStart, gEnd)
 
-            const clickable = Boolean(onSelect)
             return (
               <div
-                key={s.session_id}
-                onClick={clickable ? () => onSelect!(s) : undefined}
-                onKeyDown={clickable ? (e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onSelect!(s) } }) : undefined}
-                tabIndex={clickable ? 0 : undefined}
-                role={clickable ? 'button' : undefined}
+                key={g.key}
                 style={{
-                  background: 'var(--bg-elevated)',
+                  background: 'var(--bg-surface)',
                   border: '1px solid var(--border-subtle)',
                   borderRadius: 10,
-                  padding: '12px 14px',
-                  cursor: clickable ? 'pointer' : 'default',
-                  transition: 'border-color 0.15s, background 0.15s',
+                  padding: 12,
+                  display: 'flex',
+                  flexDirection: 'column',
+                  gap: 10,
                 }}
-                onMouseEnter={clickable ? (e => {
-                  (e.currentTarget as HTMLDivElement).style.borderColor = 'var(--anthropic-orange)'
-                }) : undefined}
-                onMouseLeave={clickable ? (e => {
-                  (e.currentTarget as HTMLDivElement).style.borderColor = 'var(--border-subtle)'
-                }) : undefined}
               >
-                {/* Header */}
+                {/* Group Band Header */}
                 <div
+                  onClick={() => toggleGroupCollapse(g.key)}
                   style={{
                     display: 'flex',
-                    alignItems: 'flex-start',
+                    alignItems: 'center',
                     justifyContent: 'space-between',
-                    gap: 12,
-                    marginBottom: 7,
+                    cursor: 'pointer',
+                    userSelect: 'none',
+                    padding: '2px 4px',
                   }}
                 >
-                  <div style={{ display: 'flex', alignItems: 'flex-start', gap: 10, flex: 1, minWidth: 0 }}>
-                    <input
-                      type="checkbox"
-                      checked={selectedIds.has(s.session_id)}
-                      onChange={(e) => {
-                        e.stopPropagation()
-                        const next = new Set(selectedIds)
-                        if (next.has(s.session_id)) next.delete(s.session_id)
-                        else next.add(s.session_id)
-                        setSelectedIds(next)
-                      }}
-                      onClick={(e) => e.stopPropagation()}
-                      style={{ cursor: 'pointer', width: 16, height: 16, marginTop: 2, accentColor: 'var(--anthropic-orange)' }}
-                    />
-                    <div style={{ flex: 1, minWidth: 0 }}>
-                    {/* Project name + source dot */}
-                    <div
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 13, fontWeight: 700, color: 'var(--text-primary)' }}>
+                    {g.icon}
+                    <span>{g.label}</span>
+                    <span
                       style={{
-                        display: 'flex',
-                        alignItems: 'center',
-                        gap: 5,
                         fontSize: 11,
-                        color: 'var(--text-tertiary)',
-                        marginBottom: 3,
+                        padding: '1px 8px',
+                        borderRadius: 999,
+                        background: 'rgba(232,105,11,0.12)',
+                        color: 'var(--anthropic-orange)',
+                        fontWeight: 600,
                       }}
                     >
-                      <SourceDot source={s._source} />
-                      <HarnessBadge harness={s.harness} />
-                      <span
+                      {gTotal} {t.sessions_unit}
+                    </span>
+                  </div>
+                  <div style={{ color: 'var(--text-tertiary)' }}>
+                    {isCollapsed ? <ChevronDown size={15} /> : <ChevronUp size={15} />}
+                  </div>
+                </div>
+
+                {/* Group Items */}
+                {!isCollapsed && (
+                  <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+                    <div
+                      style={{
+                        display: 'grid',
+                        gridTemplateColumns: viewMode === 'grid' ? 'repeat(auto-fill, minmax(min(100%, 320px), 1fr))' : '1fr',
+                        gap: 8,
+                        width: '100%',
+                        minWidth: 0,
+                        boxSizing: 'border-box',
+                      }}
+                    >
+                      {gItems.map(s => (
+                        <SessionCard
+                          key={s.session_id}
+                          s={s}
+                          lang={lang}
+                          onSelect={onSelect}
+                          isPinned={pinnedIds?.has(s.session_id)}
+                          state={activities?.[s.session_id]}
+                          selected={selectedIds.has(s.session_id)}
+                          onToggleSelect={toggleSelect}
+                          viewMode={viewMode}
+                        />
+                      ))}
+                    </div>
+
+                    {/* Group pagination — every grouping keeps the same page size */}
+                    {gTotal > pageSize && (
+                      <div
                         style={{
-                          overflow: 'hidden',
-                          textOverflow: 'ellipsis',
-                          whiteSpace: 'nowrap',
+                          display: 'flex',
+                          alignItems: 'center',
+                          justifyContent: 'space-between',
+                          flexWrap: 'wrap',
+                          gap: 8,
+                          paddingTop: 8,
+                          borderTop: '1px solid var(--border-subtle)',
                         }}
                       >
-                        {formatProjectName(s.project_path)}
-                      </span>
-                    </div>
+                        <span style={{ fontSize: 11, color: 'var(--text-tertiary)', flexShrink: 0 }}>
+                          {`${t.showing} ${gStart + 1}–${gEnd} ${t.of} ${gTotal}`}
+                        </span>
 
-                    {/* First prompt */}
-                    <div
-                      style={{
-                        fontSize: 12,
-                        color: 'var(--text-secondary)',
-                        lineHeight: 1.45,
-                        wordBreak: 'break-word',
-                      }}
-                    >
-                      {(() => { const label = sessionLabel(s); return label ? truncate(label, 120) : '(no prompt)' })()}
-                    </div>
+                        <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+                          <IconButton
+                            onClick={() => setGroupPages(p => ({ ...p, [g.key]: 0 }))}
+                            disabled={gSafePage === 0}
+                            title={`${t.page} 1`}
+                          >
+                            <ChevronsLeft size={12} />
+                          </IconButton>
+                          <IconButton
+                            onClick={() => setGroupPages(p => ({ ...p, [g.key]: Math.max(0, gSafePage - 1) }))}
+                            disabled={gSafePage === 0}
+                          >
+                            <ChevronLeft size={12} />
+                          </IconButton>
+
+                          <span style={{ fontSize: 11, color: 'var(--text-secondary)', padding: '0 6px', whiteSpace: 'nowrap' }}>
+                            {gSafePage + 1} / {gTotalPages}
+                          </span>
+
+                          <IconButton
+                            onClick={() => setGroupPages(p => ({ ...p, [g.key]: Math.min(gTotalPages - 1, gSafePage + 1) }))}
+                            disabled={gSafePage >= gTotalPages - 1}
+                          >
+                            <ChevronRight size={12} />
+                          </IconButton>
+                          <IconButton
+                            onClick={() => setGroupPages(p => ({ ...p, [g.key]: gTotalPages - 1 }))}
+                            disabled={gSafePage >= gTotalPages - 1}
+                            title={`${t.page} ${gTotalPages}`}
+                          >
+                            <ChevronsRight size={12} />
+                          </IconButton>
+                        </div>
+                      </div>
+                    )}
                   </div>
-                </div>
-
-                  {/* Timestamp + open button */}
-                  <div
-                    style={{
-                      flexShrink: 0,
-                      display: 'flex',
-                      flexDirection: 'column',
-                      alignItems: 'flex-end',
-                      gap: 4,
-                    }}
-                  >
-                    <span style={{ fontSize: 11, color: 'var(--text-tertiary)' }}>
-                      {s.start_time ? format(parseISO(s.start_time), 'MMM d, HH:mm') : ''}
-                    </span>
-                    <button
-                      onClick={(e) => openSession(s, e)}
-                      title={isNayChatSession(s.project_path) ? 'Open in Nay Chat' : 'View transcript'}
-                      style={{
-                        display: 'flex',
-                        alignItems: 'center',
-                        gap: 3,
-                        padding: '2px 6px',
-                        borderRadius: 4,
-                        border: '1px solid var(--border-subtle)',
-                        background: 'transparent',
-                        color: 'var(--text-tertiary)',
-                        fontSize: 10,
-                        cursor: 'pointer',
-                        transition: 'all 0.15s',
-                        lineHeight: 1.4,
-                        fontFamily: 'inherit',
-                      }}
-                      onMouseEnter={e => {
-                        const btn = e.currentTarget
-                        const hoverColor = isNayChatSession(s.project_path)
-                          ? 'var(--anthropic-orange)'
-                          : HARNESS_COLORS[s.harness ?? 'claude']
-                        btn.style.borderColor = hoverColor
-                        btn.style.color = hoverColor
-                      }}
-                      onMouseLeave={e => {
-                        const btn = e.currentTarget
-                        btn.style.borderColor = 'var(--border-subtle)'
-                        btn.style.color = 'var(--text-tertiary)'
-                      }}
-                    >
-                      <ExternalLink size={9} />
-                      {isNayChatSession(s.project_path) ? 'Nay' : HARNESS_LABELS[s.harness ?? 'claude']}
-                    </button>
-                  </div>
-                </div>
-
-                {/* Stats row */}
-                <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap' }}>
-                  {/* Active time leads, wall clock qualifies it — a session reopened over weeks
-                      used to read as "57492m" of work here. */}
-                  <Chip icon={<Clock size={10} />} label={sessionTime(s, lang).combined}
-                    title={sessionTime(s, lang).tooltip} />
-                  <Chip
-                    icon={null}
-                    label={`${msgs} msgs`}
-                    color="var(--accent-blue, #3b82f6)"
-                  />
-                  {tokens > 0 && (
-                    <Chip
-                      icon={null}
-                      label={`${fmt(tokens)} tkn`}
-                      color="var(--anthropic-orange, #e8690b)"
-                    />
-                  )}
-                  {tools > 0 && (
-                    <Chip
-                      icon={<Wrench size={10} />}
-                      label={`${tools} tools`}
-                      color="var(--accent-green, #22c55e)"
-                    />
-                  )}
-                  {s.git_commits > 0 && (
-                    <Chip
-                      icon={<GitCommit size={10} />}
-                      label={`${s.git_commits} commits`}
-                      color="var(--accent-purple, #a855f7)"
-                    />
-                  )}
-                  {s.files_modified > 0 && (
-                    <Chip
-                      icon={<FileCode size={10} />}
-                      label={`${s.files_modified} files`}
-                    />
-                  )}
-                  {s.uses_mcp && (
-                    <Chip icon={null} label="MCP" color="var(--accent-cyan, #06b6d4)" />
-                  )}
-                </div>
+                )}
               </div>
             )
           })}
         </div>
+      ) : (
+        /* Flat List/Grid View with Pagination */
+        <div
+          style={{
+            display: 'grid',
+            gridTemplateColumns: viewMode === 'grid' ? 'repeat(auto-fill, minmax(min(100%, 320px), 1fr))' : '1fr',
+            gap: 8,
+            width: '100%',
+            minWidth: 0,
+            boxSizing: 'border-box',
+          }}
+        >
+          {pageItems.map(s => (
+            <SessionCard
+              key={s.session_id}
+              s={s}
+              lang={lang}
+              onSelect={onSelect}
+              isPinned={pinnedIds?.has(s.session_id)}
+              state={activities?.[s.session_id]}
+              selected={selectedIds.has(s.session_id)}
+              onToggleSelect={toggleSelect}
+              viewMode={viewMode}
+            />
+          ))}
+        </div>
       )}
 
-      {/* Pagination */}
-      <div
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'space-between',
-          flexWrap: 'wrap',
-          gap: 8,
-          marginTop: 2,
-        }}
-      >
-        {/* Showing X–Y of Z */}
-        <span style={{ fontSize: 11, color: 'var(--text-tertiary)', flexShrink: 0 }}>
-          {totalItems === 0
-            ? `0 ${t.of} 0`
-            : `${t.showing} ${startIdx + 1}–${endIdx} ${t.of} ${totalItems}`}
-        </span>
-
-        {/* Page navigation */}
-        <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
-          <IconButton
-            onClick={() => setPage(0)}
-            disabled={safePage === 0}
-            title={`${t.page} 1`}
-          >
-            <ChevronsLeft size={13} />
-          </IconButton>
-          <IconButton
-            onClick={() => setPage(p => Math.max(0, p - 1))}
-            disabled={safePage === 0}
-          >
-            <ChevronLeft size={13} />
-          </IconButton>
-
-          <span
-            style={{
-              fontSize: 11,
-              color: 'var(--text-secondary)',
-              padding: '0 6px',
-              whiteSpace: 'nowrap',
-            }}
-          >
-            {safePage + 1} / {totalPages}
+      {/* Pagination Footer (when not grouped or flat view) */}
+      {groupBy === 'none' && totalItems > 0 && (
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            flexWrap: 'wrap',
+            gap: 8,
+            marginTop: 2,
+            paddingTop: 10,
+            borderTop: '1px solid var(--border-subtle)',
+          }}
+        >
+          <span style={{ fontSize: 11, color: 'var(--text-tertiary)', flexShrink: 0 }}>
+            {`${t.showing} ${startIdx + 1}–${endIdx} ${t.of} ${totalItems}`}
           </span>
 
-          <IconButton
-            onClick={() => setPage(p => Math.min(totalPages - 1, p + 1))}
-            disabled={safePage >= totalPages - 1}
-          >
-            <ChevronRight size={13} />
-          </IconButton>
-          <IconButton
-            onClick={() => setPage(totalPages - 1)}
-            disabled={safePage >= totalPages - 1}
-            title={`${t.page} ${totalPages}`}
-          >
-            <ChevronsRight size={13} />
-          </IconButton>
-        </div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+            <IconButton onClick={() => setPage(0)} disabled={safePage === 0} title={`${t.page} 1`}>
+              <ChevronsLeft size={13} />
+            </IconButton>
+            <IconButton onClick={() => setPage(p => Math.max(0, p - 1))} disabled={safePage === 0}>
+              <ChevronLeft size={13} />
+            </IconButton>
 
-        {/* Items per page */}
-        <div style={{ display: 'flex', alignItems: 'center', gap: 6, flexShrink: 0 }}>
-          <span style={{ fontSize: 11, color: 'var(--text-tertiary)' }}>{t.per_page}</span>
-          <div style={{ display: 'flex', gap: 4 }}>
-            {PAGE_SIZE_OPTIONS.map(size => (
-              <PillButton
-                key={size}
-                active={pageSize === size}
-                onClick={() => changePageSize(size)}
-              >
-                {size}
-              </PillButton>
-            ))}
+            <span style={{ fontSize: 11, color: 'var(--text-secondary)', padding: '0 6px', whiteSpace: 'nowrap' }}>
+              {safePage + 1} / {totalPages}
+            </span>
+
+            <IconButton onClick={() => setPage(p => Math.min(totalPages - 1, p + 1))} disabled={safePage >= totalPages - 1}>
+              <ChevronRight size={13} />
+            </IconButton>
+            <IconButton onClick={() => setPage(totalPages - 1)} disabled={safePage >= totalPages - 1} title={`${t.page} ${totalPages}`}>
+              <ChevronsRight size={13} />
+            </IconButton>
+          </div>
+
+          <div style={{ display: 'flex', alignItems: 'center', gap: 6, flexShrink: 0 }}>
+            <span style={{ fontSize: 11, color: 'var(--text-tertiary)' }}>{t.per_page}</span>
+            <div style={{ display: 'flex', gap: 4 }}>
+              {PAGE_SIZE_OPTIONS.map(size => (
+                <PillButton key={size} active={pageSize === size} onClick={() => { setPageSize(size); setPage(0) }}>
+                  {size}
+                </PillButton>
+              ))}
+            </div>
           </div>
         </div>
-      </div>
+      )}
 
       {/* Sticky Floating Mass Action Bar */}
       {selectedIds.size > 0 && (
@@ -927,5 +1230,877 @@ export function RecentSessions({ sessions, lang, onSelect, pinnedIds }: Props) {
         </div>
       )}
     </div>
+  )
+}
+
+// Modal for copying session resume command via Agentop or Native Harness CLI
+function ResumeCommandModal({
+  s,
+  lang,
+  onClose,
+}: {
+  s: SessionMeta
+  lang: 'pt' | 'en'
+  onClose: () => void
+}) {
+  const [copiedAgentop, setCopiedAgentop] = useState(false)
+  const [copiedNative, setCopiedNative] = useState(false)
+
+  useEffect(() => {
+    const originalStyle = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    return () => {
+      document.body.style.overflow = originalStyle
+    }
+  }, [])
+
+  const nativeCmd = resumeCommand(s) || (s.project_path ? `cd '${s.project_path}' && ${s.harness || 'claude'} --resume ${s.session_id}` : `${s.harness || 'claude'} --resume ${s.session_id}`)
+  const agentopCmd = s.project_path
+    ? `cd '${s.project_path}' && agentop session attach ${s.session_id}`
+    : `agentop session attach ${s.session_id}`
+
+  const titleName = s.title || (s.project_path ? formatProjectName(s.project_path) : '') || s.session_id.slice(0, 8)
+
+  return (
+    <div
+      onClick={onClose}
+      style={{
+        position: 'fixed',
+        inset: 0,
+        zIndex: 9999,
+        background: 'rgba(0, 0, 0, 0.7)',
+        backdropFilter: 'blur(4px)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: 20,
+      }}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        style={{
+          width: '100%',
+          maxWidth: 540,
+          background: 'var(--bg-surface)',
+          border: '1px solid var(--border-subtle)',
+          borderRadius: 12,
+          padding: 24,
+          boxShadow: '0 20px 50px rgba(0,0,0,0.6)',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 18,
+          color: 'var(--text-primary)',
+        }}
+      >
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+            <div
+              style={{
+                width: 36,
+                height: 36,
+                borderRadius: 8,
+                background: 'rgba(232, 105, 11, 0.12)',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                color: 'var(--anthropic-orange)',
+              }}
+            >
+              <Terminal size={18} />
+            </div>
+            <div>
+              <h3 style={{ margin: 0, fontSize: 16, fontWeight: 700 }}>
+                {lang === 'pt' ? 'Retomar Sessão' : 'Resume AI Session'}
+              </h3>
+              <div style={{ fontSize: 12, color: 'var(--text-tertiary)', marginTop: 2 }}>
+                {titleName}
+              </div>
+            </div>
+          </div>
+          <button
+            onClick={onClose}
+            style={{
+              background: 'transparent',
+              border: 'none',
+              color: 'var(--text-tertiary)',
+              cursor: 'pointer',
+              padding: 4,
+              borderRadius: 6,
+            }}
+          >
+            <X size={18} />
+          </button>
+        </div>
+
+        {/* Option 1: Agentop CLI */}
+        <div
+          style={{
+            background: 'var(--bg-elevated)',
+            border: '1px solid var(--border-subtle)',
+            borderRadius: 8,
+            padding: 14,
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 8,
+          }}
+        >
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+            <span style={{ fontSize: 12, fontWeight: 700, color: 'var(--anthropic-orange)' }}>
+              {lang === 'pt' ? 'Opção 1: Via Agentop CLI (agentop session attach)' : 'Option 1: Via Agentop CLI (agentop session attach)'}
+            </span>
+            <button
+              onClick={() => {
+                navigator.clipboard.writeText(agentopCmd)
+                setCopiedAgentop(true)
+                setTimeout(() => setCopiedAgentop(false), 2000)
+              }}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 4,
+                padding: '4px 10px',
+                borderRadius: 6,
+                border: copiedAgentop ? '1px solid rgba(34, 197, 94, 0.4)' : '1px solid var(--border-subtle)',
+                background: copiedAgentop ? 'rgba(34, 197, 94, 0.12)' : 'var(--bg-surface)',
+                color: copiedAgentop ? '#22c55e' : 'var(--text-primary)',
+                fontSize: 11,
+                fontWeight: 600,
+                cursor: 'pointer',
+              }}
+            >
+              {copiedAgentop ? <Check size={12} color="#22c55e" /> : <Copy size={12} />}
+              <span>{copiedAgentop ? (lang === 'pt' ? 'Copiado!' : 'Copied!') : (lang === 'pt' ? 'Copiar comando Agentop' : 'Copy Agentop command')}</span>
+            </button>
+          </div>
+          <code
+            style={{
+              fontSize: 12,
+              fontFamily: 'var(--font-mono, monospace)',
+              background: 'var(--bg-base)',
+              padding: '8px 12px',
+              borderRadius: 6,
+              color: 'var(--text-primary)',
+              wordBreak: 'break-all',
+            }}
+          >
+            {agentopCmd}
+          </code>
+        </div>
+
+        {/* Option 2: Native Harness CLI */}
+        <div
+          style={{
+            background: 'var(--bg-elevated)',
+            border: '1px solid var(--border-subtle)',
+            borderRadius: 8,
+            padding: 14,
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 8,
+          }}
+        >
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+            <span style={{ fontSize: 12, fontWeight: 700, color: 'var(--accent-blue, #3b82f6)' }}>
+              {lang === 'pt' ? `Opção 2: Via ${HARNESS_LABELS[s.harness ?? 'claude']} Nativo` : `Option 2: Via Native ${HARNESS_LABELS[s.harness ?? 'claude']}`}
+            </span>
+            <button
+              onClick={() => {
+                navigator.clipboard.writeText(nativeCmd)
+                setCopiedNative(true)
+                setTimeout(() => setCopiedNative(false), 2000)
+              }}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 4,
+                padding: '4px 10px',
+                borderRadius: 6,
+                border: copiedNative ? '1px solid rgba(34, 197, 94, 0.4)' : '1px solid var(--border-subtle)',
+                background: copiedNative ? 'rgba(34, 197, 94, 0.12)' : 'var(--bg-surface)',
+                color: copiedNative ? '#22c55e' : 'var(--text-primary)',
+                fontSize: 11,
+                fontWeight: 600,
+                cursor: 'pointer',
+              }}
+            >
+              {copiedNative ? <Check size={12} color="#22c55e" /> : <Copy size={12} />}
+              <span>{copiedNative ? (lang === 'pt' ? 'Copiado!' : 'Copied!') : (lang === 'pt' ? 'Copiar comando Nativo' : 'Copy Native command')}</span>
+            </button>
+          </div>
+          <code
+            style={{
+              fontSize: 12,
+              fontFamily: 'var(--font-mono, monospace)',
+              background: 'var(--bg-base)',
+              padding: '8px 12px',
+              borderRadius: 6,
+              color: 'var(--text-primary)',
+              wordBreak: 'break-all',
+            }}
+          >
+            {nativeCmd}
+          </code>
+        </div>
+      </div>
+
+    </div>
+  )
+}
+
+function SessionCard({
+  s,
+  lang,
+  onSelect,
+  isPinned,
+  state,
+  selected,
+  onToggleSelect,
+  viewMode = 'list',
+}: {
+  s: SessionMeta
+  lang: 'pt' | 'en'
+  onSelect?: (s: SessionMeta) => void
+  isPinned?: boolean
+  /** What this session is doing right now; absent when it is not live. */
+  state?: SessionActivity
+  /** Whether this row is in the batch selection. */
+  selected?: boolean
+  onToggleSelect?: (id: string) => void
+  viewMode?: 'list' | 'grid'
+}) {
+  const t = T[lang]
+  const tokens = totalTokens(s)
+  const tools = totalTools(s)
+  const msgs = totalMessages(s)
+  const clickable = Boolean(onSelect)
+  const status = getStatusInfo(state, isPinned)
+
+  const cmd = resumeCommand(s)
+  const [showResumeModal, setShowResumeModal] = useState(false)
+  const [promptText, setPromptText] = useState('')
+  const [sendingPrompt, setSendingPrompt] = useState(false)
+  const [promptFeedback, setPromptFeedback] = useState<{ ok: boolean; msg: string } | null>(null)
+
+  async function handleSendPrompt(e?: React.FormEvent) {
+    if (e) {
+      e.preventDefault()
+      e.stopPropagation()
+    }
+    const text = promptText.trim()
+    if (!text || sendingPrompt) return
+
+    setSendingPrompt(true)
+    setPromptFeedback(null)
+    try {
+      const res = await fetch('/api/sessions/prompt', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ sessionId: s.session_id, prompt: text }),
+      })
+      const json = await res.json() as { ok?: boolean; message?: string; error?: string }
+      if (res.ok && json.ok) {
+        setPromptFeedback({
+          ok: true,
+          msg: lang === 'pt' ? 'Prompt enviado para a sessão!' : 'Prompt sent to terminal!',
+        })
+        setPromptText('')
+      } else {
+        setPromptFeedback({
+          ok: false,
+          msg: json.error || (lang === 'pt' ? 'Erro ao enviar.' : 'Failed to send.'),
+        })
+      }
+    } catch (err: any) {
+      setPromptFeedback({
+        ok: false,
+        msg: err?.message || (lang === 'pt' ? 'Erro de rede.' : 'Network error.'),
+      })
+    } finally {
+      setSendingPrompt(false)
+      setTimeout(() => setPromptFeedback(null), 4000)
+    }
+  }
+
+  const [showDetails, setShowDetails] = useState(false)
+  const [messages, setMessages] = useState<{ role: 'user' | 'assistant'; content: string; timestamp?: number | string; tools?: string[] }[] | null>(null)
+  const [loadingMsgs, setLoadingMsgs] = useState(false)
+  const detailsContainerRef = useRef<HTMLDivElement>(null)
+
+  // Click outside listener for Detalhes popover
+  useEffect(() => {
+    if (!showDetails) return
+    function handleClickOutside(e: MouseEvent) {
+      if (detailsContainerRef.current && !detailsContainerRef.current.contains(e.target as Node)) {
+        setShowDetails(false)
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [showDetails])
+
+  // Body scroll lock when Detalhes popover is open
+  useEffect(() => {
+    if (!showDetails) return
+    const originalOverflow = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    return () => {
+      document.body.style.overflow = originalOverflow
+    }
+  }, [showDetails])
+
+  const isLiveSession = Boolean(isPinned || cmd)
+  const isWaitingForInput = isLiveSession && (state === 'waiting' || state === 'waiting-approval')
+  const titleName = s.title || (s.project_path ? formatProjectName(s.project_path) : '') || s.session_id.slice(0, 8)
+
+  useEffect(() => {
+    if (!showDetails) return
+
+    let interval: ReturnType<typeof setInterval> | null = null
+    const fetchMsgs = () => {
+      fetch(`/api/sessions/${encodeURIComponent(s.session_id)}/messages?harness=${encodeURIComponent(s.harness || 'claude')}&projectPath=${encodeURIComponent(s.project_path || '')}`)
+        .then(r => r.ok ? r.json() : [])
+        .then((msgs: any[]) => {
+          if (Array.isArray(msgs)) setMessages(msgs)
+          else setMessages([])
+        })
+        .catch(() => setMessages([]))
+        .finally(() => setLoadingMsgs(false))
+    }
+
+    if (messages === null && !loadingMsgs) {
+      setLoadingMsgs(true)
+    }
+    fetchMsgs()
+
+    const es = new EventSource('/api/events')
+    es.addEventListener('change', fetchMsgs)
+    if (isLiveSession) {
+      interval = setInterval(fetchMsgs, 2000)
+    }
+
+    return () => {
+      es.close()
+      if (interval) clearInterval(interval)
+    }
+  }, [showDetails, s.session_id, s.harness, s.project_path, isLiveSession])
+  const isList = viewMode === 'list'
+
+  return (
+    <>
+      {showResumeModal && (
+        <ResumeCommandModal s={s} lang={lang} onClose={() => setShowResumeModal(false)} />
+      )}
+
+      <div
+        style={{
+          position: 'relative',
+          background: 'var(--bg-elevated)',
+          border: '1px solid var(--border-subtle)',
+          borderRadius: 10,
+          padding: isList ? '14px 18px' : '16px 18px',
+          boxSizing: 'border-box',
+          minWidth: 0,
+          width: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 12,
+          transition: 'all 0.15s ease',
+        }}
+      >
+        {/* List Mode Layout */}
+        {isList ? (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 10, width: '100%' }}>
+            {/* Single Header Row: Badges, Title, Date/Time & Action Buttons ALL in one row */}
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12, flexWrap: 'wrap' }}>
+              {/* Left Group: Badges & Title */}
+              <div style={{ display: 'flex', alignItems: 'center', gap: 10, flex: 1, minWidth: 200 }}>
+                {onToggleSelect && (
+                  <input
+                    type="checkbox"
+                    checked={Boolean(selected)}
+                    onChange={e => { e.stopPropagation(); onToggleSelect(s.session_id) }}
+                    onClick={e => e.stopPropagation()}
+                    aria-label={lang === 'pt' ? 'Selecionar sessão' : 'Select session'}
+                    style={{ cursor: 'pointer', width: 16, height: 16, flexShrink: 0, accentColor: 'var(--anthropic-orange)' }}
+                  />
+                )}
+                {/* Status Badge */}
+                <span
+                  style={{
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    gap: 5,
+                    padding: '3px 8px',
+                    borderRadius: 999,
+                    fontSize: 11,
+                    fontWeight: 600,
+                    color: status.color,
+                    background: `${status.color}14`,
+                    border: `1px solid ${status.color}33`,
+                    flexShrink: 0,
+                  }}
+                >
+                  <span style={{ width: 6, height: 6, borderRadius: '50%', background: status.color }} />
+                  {lang === 'pt' ? status.labelPt : status.labelEn}
+                </span>
+
+                <HarnessBadge harness={s.harness} />
+
+                {/* Project Title */}
+                <span
+                  style={{
+                    fontSize: 15,
+                    fontWeight: 600,
+                    color: 'var(--text-primary)',
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                  }}
+                  title={titleName}
+                >
+                  {titleName}
+                </span>
+              </div>
+
+              {/* Right Group: Date/Time + Action Buttons */}
+              <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexShrink: 0 }}>
+                <span style={{ fontSize: 12, color: 'var(--text-tertiary)', fontVariantNumeric: 'tabular-nums', marginRight: 4 }}>
+                  {s.start_time ? format(parseISO(s.start_time), 'MMM d, HH:mm') : ''}
+                </span>
+
+                {/* Retomar Sessão Button */}
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    setShowResumeModal(true)
+                  }}
+                  title={lang === 'pt' ? 'Retomar sessão (Agentop / Nativo)' : 'Resume session (Agentop / Native)'}
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 5,
+                    padding: '5px 10px',
+                    borderRadius: 6,
+                    border: '1px solid var(--border-subtle)',
+                    background: 'var(--bg-surface)',
+                    color: 'var(--anthropic-orange)',
+                    fontSize: 12,
+                    fontWeight: 600,
+                    cursor: 'pointer',
+                    transition: 'all 0.15s',
+                    fontFamily: 'inherit',
+                  }}
+                >
+                  <Terminal size={12} />
+                  <span>{lang === 'pt' ? 'Retomar Sessão' : 'Resume'}</span>
+                </button>
+
+                {/* Detalhes Trigger & Popover Wrapper */}
+                <div ref={detailsContainerRef} style={{ position: 'relative' }}>
+                  <button
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      setShowDetails(v => !v)
+                    }}
+                    style={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 4,
+                      padding: '5px 10px',
+                      borderRadius: 6,
+                      border: showDetails ? '1px solid var(--anthropic-orange)' : '1px solid var(--border-subtle)',
+                      background: showDetails ? 'rgba(232, 105, 11, 0.1)' : 'var(--bg-surface)',
+                      color: showDetails ? 'var(--anthropic-orange)' : 'var(--text-secondary)',
+                      fontSize: 12,
+                      fontWeight: 600,
+                      cursor: 'pointer',
+                      transition: 'all 0.15s',
+                      fontFamily: 'inherit',
+                    }}
+                  >
+                    <span>{lang === 'pt' ? 'Detalhes' : 'Details'}</span>
+                    {showDetails ? <ChevronUp size={11} /> : <ChevronDown size={11} />}
+                  </button>
+
+                  {/* Floating Detalhes Popover */}
+                  {showDetails && (
+                    <div
+                      onClick={(e) => e.stopPropagation()}
+                      style={{
+                        position: 'absolute',
+                        top: 'calc(100% + 6px)',
+                        right: 0,
+                        width: 380,
+                        maxWidth: '90vw',
+                        zIndex: 100,
+                        background: 'var(--bg-surface)',
+                        border: '1px solid var(--anthropic-orange)',
+                        borderRadius: 10,
+                        padding: '14px 16px',
+                        boxShadow: '0 10px 25px -5px rgba(0, 0, 0, 0.5)',
+                        display: 'flex',
+                        flexDirection: 'column',
+                        gap: 12,
+                      }}
+                    >
+                      {s.first_prompt && (
+                        <div>
+                          <div style={{ fontSize: 11, fontWeight: 700, color: 'var(--text-tertiary)', textTransform: 'uppercase', marginBottom: 4 }}>
+                            {lang === 'pt' ? 'Prompt Inicial' : 'First Prompt'}
+                          </div>
+                          <div style={{ fontSize: 12, color: 'var(--text-secondary)', fontStyle: 'italic', lineHeight: 1.5, whiteSpace: 'pre-wrap', wordBreak: 'break-word', maxHeight: 120, overflowY: 'auto' }}>
+                            "{s.first_prompt}"
+                          </div>
+                        </div>
+                      )}
+
+                      <div>
+                        <div style={{ fontSize: 11, fontWeight: 700, color: 'var(--text-tertiary)', textTransform: 'uppercase', marginBottom: 4 }}>
+                          {lang === 'pt' ? 'Últimas mensagens' : 'Latest messages'}
+                        </div>
+                        {loadingMsgs ? (
+                          <div style={{ fontSize: 11, color: 'var(--text-tertiary)' }}>{lang === 'pt' ? 'Carregando...' : 'Loading...'}</div>
+                        ) : !messages || messages.length === 0 ? (
+                          <div style={{ fontSize: 11, color: 'var(--text-tertiary)', fontStyle: 'italic' }}>{lang === 'pt' ? 'Nenhuma mensagem recente' : 'No recent messages'}</div>
+                        ) : (
+                          <div style={{ display: 'flex', flexDirection: 'column', gap: 6, maxHeight: 180, overflowY: 'auto' }}>
+                            {messages.slice(-3).map((m, mi) => (
+                              <div key={mi} style={{ fontSize: 11, padding: '6px 8px', borderRadius: 6, background: 'var(--bg-card)', border: '1px solid var(--border-subtle)', display: 'flex', flexDirection: 'column', gap: 2 }}>
+                                <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+                                  <span style={{ fontWeight: 700, color: m.role === 'user' ? 'var(--accent-blue)' : 'var(--anthropic-orange)' }}>
+                                    {m.role === 'user' ? 'User: ' : 'Assistant: '}
+                                  </span>
+                                  {m.timestamp && (
+                                    <span style={{ fontSize: 10, color: 'var(--text-tertiary)' }}>
+                                      {format(parseISO(typeof m.timestamp === 'string' ? m.timestamp : new Date(m.timestamp).toISOString()), 'HH:mm:ss')}
+                                    </span>
+                                  )}
+                                </div>
+                                <span style={{ color: 'var(--text-secondary)', whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>{m.content.slice(0, 200)}</span>
+                              </div>
+                            ))}
+                          </div>
+                        )}
+                      </div>
+                    </div>
+                  )}
+                </div>
+
+                {/* Métricas Modal Button */}
+                {clickable && (
+                  <button
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      onSelect!(s)
+                    }}
+                    style={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 5,
+                      padding: '5px 10px',
+                      borderRadius: 6,
+                      border: '1px solid var(--border-subtle)',
+                      background: 'var(--bg-surface)',
+                      color: 'var(--text-primary)',
+                      fontSize: 12,
+                      fontWeight: 600,
+                      cursor: 'pointer',
+                      transition: 'all 0.15s',
+                      fontFamily: 'inherit',
+                    }}
+                  >
+                    <Maximize2 size={11} />
+                    <span>{lang === 'pt' ? 'Métricas da sessão' : 'Session metrics'}</span>
+                  </button>
+                )}
+              </div>
+            </div>
+
+            {/* Bottom Row: Stats Chips */}
+            <div style={{ display: 'flex', alignItems: 'center', gap: 6, flexWrap: 'wrap' }}>
+              <Chip icon={<Clock size={11} />} label={sessionTime(s, lang).combined} title={sessionTime(s, lang).tooltip} />
+              <Chip icon={null} label={`${msgs} msgs`} color="var(--accent-blue, #3b82f6)" />
+              {tokens > 0 && <Chip icon={null} label={`${fmt(tokens)} tkn`} color="var(--anthropic-orange, #e8690b)" />}
+              {tools > 0 && <Chip icon={<Wrench size={11} />} label={`${tools} tools`} color="var(--accent-green, #22c55e)" />}
+              {s.git_commits > 0 && <Chip icon={<GitCommit size={11} />} label={`${s.git_commits} commits`} color="var(--accent-purple, #a855f7)" />}
+              {s.files_modified > 0 && <Chip icon={<FileCode size={11} />} label={`${s.files_modified} files`} />}
+            </div>
+          </div>
+        ) : (
+          /* Grid Mode Layout */
+          <>
+            {/* Header Row: Badges & Time */}
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8 }}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                <span
+                  style={{
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    gap: 4,
+                    padding: '3px 8px',
+                    borderRadius: 999,
+                    fontSize: 11,
+                    fontWeight: 600,
+                    color: status.color,
+                    background: `${status.color}14`,
+                    border: `1px solid ${status.color}33`,
+                  }}
+                >
+                  <span style={{ width: 6, height: 6, borderRadius: '50%', background: status.color }} />
+                  {lang === 'pt' ? status.labelPt : status.labelEn}
+                </span>
+                <HarnessBadge harness={s.harness} />
+              </div>
+
+              <span style={{ fontSize: 11, color: 'var(--text-tertiary)', fontVariantNumeric: 'tabular-nums' }}>
+                {s.start_time ? format(parseISO(s.start_time), 'MMM d, HH:mm') : ''}
+              </span>
+            </div>
+
+            {/* Title */}
+            <div
+              style={{
+                fontSize: 15,
+                fontWeight: 600,
+                color: 'var(--text-primary)',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+              }}
+              title={titleName}
+            >
+              {titleName}
+            </div>
+
+            {/* Minimal Essential Chips */}
+            <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap', alignItems: 'center' }}>
+              <Chip icon={<Clock size={11} />} label={sessionTime(s, lang).combined} title={sessionTime(s, lang).tooltip} />
+              <Chip icon={null} label={`${msgs} msgs`} color="var(--accent-blue, #3b82f6)" />
+              {tokens > 0 && <Chip icon={null} label={`${fmt(tokens)} tkn`} color="var(--anthropic-orange, #e8690b)" />}
+            </div>
+
+            {/* Actions Row */}
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8, paddingTop: 4, flexWrap: 'wrap' }}>
+              <button
+                onClick={(e) => {
+                  e.stopPropagation()
+                  setShowResumeModal(true)
+                }}
+                title={lang === 'pt' ? 'Retomar sessão' : 'Resume session'}
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 4,
+                  padding: '4px 8px',
+                  borderRadius: 6,
+                  border: '1px solid var(--border-subtle)',
+                  background: 'var(--bg-surface)',
+                  color: 'var(--anthropic-orange)',
+                  fontSize: 11,
+                  fontWeight: 600,
+                  cursor: 'pointer',
+                  fontFamily: 'inherit',
+                }}
+              >
+                <Terminal size={11} />
+                <span>{lang === 'pt' ? 'Retomar Sessão' : 'Resume'}</span>
+              </button>
+
+              <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                <div ref={detailsContainerRef} style={{ position: 'relative' }}>
+                  <button
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      setShowDetails(v => !v)
+                    }}
+                    style={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 3,
+                      padding: '4px 8px',
+                      borderRadius: 6,
+                      border: showDetails ? '1px solid var(--anthropic-orange)' : '1px solid var(--border-subtle)',
+                      background: showDetails ? 'rgba(232, 105, 11, 0.1)' : 'var(--bg-surface)',
+                      color: showDetails ? 'var(--anthropic-orange)' : 'var(--text-secondary)',
+                      fontSize: 11,
+                      fontWeight: 600,
+                      cursor: 'pointer',
+                      fontFamily: 'inherit',
+                    }}
+                  >
+                    <span>{lang === 'pt' ? 'Detalhes' : 'Details'}</span>
+                    {showDetails ? <ChevronUp size={10} /> : <ChevronDown size={10} />}
+                  </button>
+
+                  {/* Floating Detalhes Popover Grid Mode */}
+                  {showDetails && (
+                    <div
+                      onClick={(e) => e.stopPropagation()}
+                      style={{
+                        position: 'absolute',
+                        top: 'calc(100% + 6px)',
+                        right: 0,
+                        width: 300,
+                        maxWidth: '85vw',
+                        zIndex: 100,
+                        background: 'var(--bg-surface)',
+                        border: '1px solid var(--anthropic-orange)',
+                        borderRadius: 10,
+                        padding: '12px 14px',
+                        boxShadow: '0 10px 25px -5px rgba(0, 0, 0, 0.5)',
+                        display: 'flex',
+                        flexDirection: 'column',
+                        gap: 10,
+                      }}
+                    >
+                      {s.first_prompt && (
+                        <div>
+                          <div style={{ fontSize: 10, fontWeight: 700, color: 'var(--text-tertiary)', textTransform: 'uppercase', marginBottom: 4 }}>
+                            {lang === 'pt' ? 'Prompt Inicial' : 'First Prompt'}
+                          </div>
+                          <div style={{ fontSize: 11, color: 'var(--text-secondary)', fontStyle: 'italic', lineHeight: 1.4, whiteSpace: 'pre-wrap', wordBreak: 'break-word', maxHeight: 100, overflowY: 'auto' }}>
+                            "{s.first_prompt}"
+                          </div>
+                        </div>
+                      )}
+
+                      <div>
+                        <div style={{ fontSize: 10, fontWeight: 700, color: 'var(--text-tertiary)', textTransform: 'uppercase', marginBottom: 4 }}>
+                          {lang === 'pt' ? 'Últimas mensagens' : 'Latest messages'}
+                        </div>
+                        {loadingMsgs ? (
+                          <div style={{ fontSize: 11, color: 'var(--text-tertiary)' }}>{lang === 'pt' ? 'Carregando...' : 'Loading...'}</div>
+                        ) : !messages || messages.length === 0 ? (
+                          <div style={{ fontSize: 11, color: 'var(--text-tertiary)', fontStyle: 'italic' }}>{lang === 'pt' ? 'Nenhuma mensagem recente' : 'No recent messages'}</div>
+                        ) : (
+                          <div style={{ display: 'flex', flexDirection: 'column', gap: 6, maxHeight: 160, overflowY: 'auto' }}>
+                            {messages.slice(-3).map((m, mi) => (
+                              <div key={mi} style={{ fontSize: 11, padding: '5px 7px', borderRadius: 6, background: 'var(--bg-card)', border: '1px solid var(--border-subtle)', display: 'flex', flexDirection: 'column', gap: 2 }}>
+                                <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+                                  <span style={{ fontWeight: 700, color: m.role === 'user' ? 'var(--accent-blue)' : 'var(--anthropic-orange)' }}>
+                                    {m.role === 'user' ? 'User: ' : 'Assistant: '}
+                                  </span>
+                                  {m.timestamp && (
+                                    <span style={{ fontSize: 10, color: 'var(--text-tertiary)' }}>
+                                      {format(parseISO(typeof m.timestamp === 'string' ? m.timestamp : new Date(m.timestamp).toISOString()), 'HH:mm:ss')}
+                                    </span>
+                                  )}
+                                </div>
+                                <span style={{ color: 'var(--text-secondary)', whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>{m.content.slice(0, 180)}</span>
+                              </div>
+                            ))}
+                          </div>
+                        )}
+                      </div>
+                    </div>
+                  )}
+                </div>
+
+                {clickable && (
+                  <button
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      onSelect!(s)
+                    }}
+                    style={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 3,
+                      padding: '4px 8px',
+                      borderRadius: 6,
+                      border: '1px solid var(--border-subtle)',
+                      background: 'var(--bg-surface)',
+                      color: 'var(--text-primary)',
+                      fontSize: 11,
+                      fontWeight: 600,
+                      cursor: 'pointer',
+                      fontFamily: 'inherit',
+                    }}
+                  >
+                    <Maximize2 size={10} />
+                    <span>{lang === 'pt' ? 'Métricas' : 'Metrics'}</span>
+                  </button>
+                )}
+              </div>
+            </div>
+          </>
+        )}
+
+        {/* Live Session Interactive Short Prompt Resizable Textarea Form (only when waiting for user response) */}
+        {isWaitingForInput && (
+          <div style={{ paddingTop: 2 }}>
+            <form
+              onSubmit={handleSendPrompt}
+              onClick={(e) => e.stopPropagation()}
+              style={{
+                display: 'flex',
+                alignItems: 'flex-end',
+                gap: 8,
+                background: 'var(--bg-card)',
+                border: '1px solid var(--border-subtle)',
+                borderRadius: 6,
+                padding: '6px 8px',
+              }}
+            >
+              <textarea
+                rows={1}
+                value={promptText}
+                onChange={e => setPromptText(e.target.value)}
+                onKeyDown={e => {
+                  if (e.key === 'Enter' && !e.shiftKey) {
+                    e.preventDefault()
+                    handleSendPrompt()
+                  }
+                }}
+                placeholder={lang === 'pt' ? 'Enviar short prompt...' : 'Send short prompt...'}
+                style={{
+                  flex: 1,
+                  background: 'transparent',
+                  border: 'none',
+                  outline: 'none',
+                  fontSize: 12,
+                  color: 'var(--text-primary)',
+                  fontFamily: 'inherit',
+                  resize: 'vertical',
+                  minHeight: 36,
+                  maxHeight: 140,
+                  padding: '2px 4px',
+                  boxSizing: 'border-box',
+                }}
+              />
+              <button
+                type="submit"
+                disabled={sendingPrompt || !promptText.trim()}
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 4,
+                  padding: '6px 12px',
+                  borderRadius: 5,
+                  border: 'none',
+                  background: 'var(--anthropic-orange)',
+                  color: '#fff',
+                  fontSize: 11,
+                  fontWeight: 600,
+                  cursor: sendingPrompt || !promptText.trim() ? 'not-allowed' : 'pointer',
+                  opacity: sendingPrompt || !promptText.trim() ? 0.5 : 1,
+                  fontFamily: 'inherit',
+                  flexShrink: 0,
+                  alignSelf: 'flex-end',
+                }}
+              >
+                <Send size={11} />
+                <span>{lang === 'pt' ? 'Enviar' : 'Send'}</span>
+              </button>
+            </form>
+            {promptFeedback && (
+              <div style={{ fontSize: 11, color: promptFeedback.ok ? '#22c55e' : '#ef4444', fontStyle: 'italic', marginTop: 4 }}>
+                {promptFeedback.msg}
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </>
   )
 }

--- a/packages/web/src/components/team/CentralAdminPanel.tsx
+++ b/packages/web/src/components/team/CentralAdminPanel.tsx
@@ -3,6 +3,7 @@ import { Loader2, Server } from 'lucide-react'
 import { TeamMembers } from '../TeamMembers'
 import { PUSH_INTERVAL, type MemberPresence } from '@agentistics/core'
 import { SectionHeader, Divider, PrefRow } from '../../pages/settings/primitives'
+import { useIsMobile } from '../../hooks/useIsMobile'
 
 /**
  * CentralAdminPanel — the team-central branch of the old `TeamSettings.tsx`, lifted verbatim
@@ -77,6 +78,7 @@ function IntervalSelect({ value, onChange, options, disabled = false }: {
 
 export function CentralAdminPanel({ lang, presence }: CentralAdminPanelProps) {
   const pt = lang === 'pt'
+  const isMobile = useIsMobile()
   const [centralInterval, setCentralInterval] = useState<number>(PUSH_INTERVAL.DEFAULT_SEC)
   const [express, setExpress] = useState(false)
   const [intervalSaving, setIntervalSaving] = useState(false)
@@ -137,7 +139,7 @@ export function CentralAdminPanel({ lang, presence }: CentralAdminPanelProps) {
 
       <SectionHeader label={pt ? 'Configurações de envio' : 'Push settings'} />
       <PrefRow label={c('pushInterval', lang)} sub={c('pushIntervalSubCentral', lang)}>
-        <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10, flexWrap: isMobile ? 'wrap' : 'nowrap' }}>
           <IntervalSelect
             value={centralInterval}
             onChange={handleCentralIntervalChange}

--- a/packages/web/src/hooks/useData.test.ts
+++ b/packages/web/src/hooks/useData.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect } from 'bun:test'
-import { calcStreak, calcLongestStreak, getDateRangeFilter, filterByHarness, computeHarnessSummaries, computeFilteredHarnessSummaries, sortRepos, pickLongestSession, repositoryGitTotals, apportionModelUsage, summarizeApiCostByDay, computeDerivedStats } from './useData'
-import { EMPTY_TOKENS, mergeStatsCaches } from '@agentistics/core'
+import { calcStreak, calcLongestStreak, getDateRangeFilter, filterByHarness, computeHarnessSummaries, computeFilteredHarnessSummaries, sortRepos, pickLongestSession, repositoryGitTotals, apportionModelUsage, summarizeApiCostByDay, computeDerivedStats, resolvePresenceScope } from './useData'
+import { EMPTY_TOKENS, mergeStatsCaches, totalTokens } from '@agentistics/core'
 import type { RepoSortKey, RepoStat } from './useData'
 import type { SessionMeta } from '@agentistics/core'
 import { format, subDays } from 'date-fns'
@@ -1381,5 +1381,124 @@ describe('the Claude harness chip reads the cache, not only the surviving sessio
     // cannot serve a selection that also contains a harness the cache knows nothing about.
     const mixed = computeDerivedStats(data, filters({ harnesses: ['claude', 'codex'] }))!
     expect(mixed.totalSessions).toBe(1)
+  })
+})
+
+describe('resolvePresenceScope', () => {
+  const presence: Record<string, import('@agentistics/core').MemberPresence> = {
+    'Online Person': { online: true, lastSeenAt: null, latencyMs: 0 },
+    'Offline Person': { online: false, lastSeenAt: null, latencyMs: null },
+  }
+
+  const filters = (over: Partial<import('@agentistics/core').Filters> = {}): import('@agentistics/core').Filters =>
+    ({ dateRange: 'all', customStart: '', customEnd: '', projects: [], models: [], ...over })
+
+  test('no presence data at all → no scoping', () => {
+    const scope = resolvePresenceScope({ presence: undefined, includeOfflineData: false }, filters())
+    expect(scope.effective).toBeNull()
+    expect(scope.isPolicyDefault).toBe(false)
+    expect(scope.allowedUsers).toBeNull()
+  })
+
+  test('includeOfflineData !== false → no default narrowing even with presence data', () => {
+    const scope = resolvePresenceScope({ presence, includeOfflineData: true }, filters())
+    expect(scope.effective).toBeNull()
+    expect(scope.allowedUsers).toBeNull()
+  })
+
+  test('includeOfflineData === false and no explicit filter → defaults to online-only, and SAYS it is a default', () => {
+    const scope = resolvePresenceScope({ presence, includeOfflineData: false }, filters())
+    expect(scope.effective).toBe('online')
+    expect(scope.isPolicyDefault).toBe(true)
+    expect(scope.allowedUsers).toEqual(new Set(['Online Person']))
+  })
+
+  test('an explicit filters.presence wins and is NOT a policy default', () => {
+    const scope = resolvePresenceScope({ presence, includeOfflineData: false }, filters({ presence: 'offline' }))
+    expect(scope.effective).toBe('offline')
+    expect(scope.isPolicyDefault).toBe(false)
+    expect(scope.allowedUsers).toEqual(new Set(['Offline Person']))
+  })
+
+  test('an explicit filter can also just restate the default — still not a policy default', () => {
+    const scope = resolvePresenceScope({ presence, includeOfflineData: false }, filters({ presence: 'online' }))
+    expect(scope.isPolicyDefault).toBe(false)
+  })
+})
+
+describe('the header total never exceeds — and is never disconnected from — a presence-scoped member drill-down', () => {
+  // Regression: the header (`derived.totalCostUSD` / `tokenTotals` / `totalSessions`) is built
+  // from `effectiveStatsCache`, which silently drops an offline member's statsCache whenever the
+  // central's `includeOfflineData` policy defaults to online-only — while `MembersPage` read
+  // `data.machineStatsCaches` / `userStatsCaches` directly, un-scoped by presence, so a member the
+  // header excluded still showed its full, all-time history on its own row: a small "total" next
+  // to one of its own (excluded) parts, dwarfing it, with nothing on screen explaining why.
+  //
+  // This test pins the HEADER half of the fix: with the policy default in effect, the header's
+  // totals must equal exactly the online member's cache (never silently include the offline one,
+  // and never silently drop the online one either).
+  const onlineCache: import('@agentistics/core').StatsCache = {
+    version: 1, lastComputedDate: '2026-07-01',
+    dailyActivity: [{ date: '2026-07-01', sessionCount: 3, messageCount: 30, toolCallCount: 0 }],
+    dailyModelTokens: [],
+    modelUsage: {
+      'claude-sonnet-4-5': {
+        inputTokens: 1_000, outputTokens: 500,
+        cacheReadInputTokens: 2_000, cacheCreationInputTokens: 100,
+        webSearchRequests: 0, costUSD: 0,
+      },
+    },
+    totalSessions: 3, totalMessages: 30, hourCounts: {},
+  } as unknown as import('@agentistics/core').StatsCache
+
+  // The offline member's deep history dwarfs the online one's — exactly the shape of the reported
+  // bug (93.9M tok header vs. 23.4B tok on one excluded member's own row).
+  const offlineCache: import('@agentistics/core').StatsCache = {
+    version: 1, lastComputedDate: '2026-07-01',
+    dailyActivity: [{ date: '2026-07-01', sessionCount: 400, messageCount: 4000, toolCallCount: 0 }],
+    dailyModelTokens: [],
+    modelUsage: {
+      'claude-sonnet-4-5': {
+        inputTokens: 5_000_000_000, outputTokens: 2_000_000_000,
+        cacheReadInputTokens: 15_000_000_000, cacheCreationInputTokens: 1_000_000_000,
+        webSearchRequests: 0, costUSD: 0,
+      },
+    },
+    totalSessions: 400, totalMessages: 4000, hourCounts: {},
+  } as unknown as import('@agentistics/core').StatsCache
+
+  const presence: Record<string, import('@agentistics/core').MemberPresence> = {
+    'Online Person': { online: true, lastSeenAt: null, latencyMs: 0 },
+    'Offline Person': { online: false, lastSeenAt: null, latencyMs: null },
+  }
+
+  const data = {
+    statsCache: onlineCache, // the viewing central's own local cache, not used once user caches resolve
+    presence,
+    includeOfflineData: false,
+    userStatsCaches: { 'Online Person': onlineCache, 'Offline Person': offlineCache },
+    sessions: [],
+    allSessions: [],
+    projects: [],
+    harnesses: ['claude'],
+  } as unknown as import('@agentistics/core').AppData
+
+  const filters = (over: Partial<import('@agentistics/core').Filters> = {}): import('@agentistics/core').Filters =>
+    ({ dateRange: 'all', customStart: '', customEnd: '', projects: [], models: [], ...over })
+
+  test('by default (policy narrows, nothing explicit) the header totals are exactly the online member\'s cache', () => {
+    const d = computeDerivedStats(data, filters())!
+    expect(d.presenceScope.isPolicyDefault).toBe(true)
+    const onlineTokens = 1_000 + 500 + 2_000 + 100
+    expect(totalTokens(d.tokenTotals)).toBe(onlineTokens)
+    expect(d.totalSessions).toBe(3)
+  })
+
+  test('explicitly asking for offline flips the header to the (huge) offline member\'s cache — consistently, not partially', () => {
+    const d = computeDerivedStats(data, filters({ presence: 'offline' }))!
+    expect(d.presenceScope.isPolicyDefault).toBe(false)
+    const offlineTokens = 5_000_000_000 + 2_000_000_000 + 15_000_000_000 + 1_000_000_000
+    expect(totalTokens(d.tokenTotals)).toBe(offlineTokens)
+    expect(d.totalSessions).toBe(400)
   })
 })

--- a/packages/web/src/hooks/useData.ts
+++ b/packages/web/src/hooks/useData.ts
@@ -959,6 +959,50 @@ export function repositoryGitTotals(
 
 
 /**
+ * The presence scope every scoped aggregate (header totals, per-member/-machine cache totals)
+ * must agree on. An explicit `filters.presence` always wins; otherwise a central whose operator
+ * turned OFF `includeOfflineData` narrows to online members by DEFAULT — a policy decision, not
+ * something the viewer asked for on this screen.
+ *
+ * `isPolicyDefault` is what lets a consumer decide whether the narrowing needs a label: a viewer
+ * who explicitly picked the "Offline" pill already knows their total is scoped, but nobody chose
+ * the silent default, and CLAUDE.md's own rule is that an unexplained smaller total reads as a
+ * bug. Any surface that reads a presence-scoped aggregate (a statsCache merge, a per-row cache
+ * substitution) must resolve scope through THIS function — a second inline copy is exactly how
+ * the header and the Members drill-down disagreed: the header excluded an offline machine's
+ * history from its total while the machine's own row kept substituting that history whole,
+ * unfiltered, with nothing on screen explaining why one dwarfed the other.
+ */
+export interface PresenceScope {
+  /** The presence actually being enforced, or null when nothing narrows the scope. */
+  effective: 'online' | 'offline' | null
+  /** True when `effective` came from the central's policy default rather than an explicit
+   *  `filters.presence` choice. */
+  isPolicyDefault: boolean
+  /** Display names ("user") allowed under `effective`, or null when there is no scoping. */
+  allowedUsers: Set<string> | null
+}
+
+export function resolvePresenceScope(
+  data: Pick<AppData, 'presence' | 'includeOfflineData'> | null | undefined,
+  filters: Filters,
+): PresenceScope {
+  const presence = data?.presence
+  const effective: 'online' | 'offline' | null =
+    filters.presence ?? (presence && data?.includeOfflineData === false ? 'online' : null)
+  const isPolicyDefault = effective !== null && filters.presence == null
+  const allowedUsers: Set<string> | null =
+    effective && presence
+      ? new Set(
+          Object.entries(presence)
+            .filter(([, p]) => (effective === 'online' ? p.online : !p.online))
+            .map(([name]) => name),
+        )
+      : null
+  return { effective, isPolicyDefault, allowedUsers }
+}
+
+/**
  * The whole derivation, as a PURE function of (data, filters, tags).
  *
  * Extracted from the hook so it can be called N TIMES for N scopes — the compare page derives one
@@ -994,20 +1038,12 @@ export function computeDerivedStats(data: AppData | null, filters: Filters, tags
     const machinesFiltered = (filters.machines ?? []).length > 0
     const modelSet = filters.models && filters.models.length > 0 ? new Set(filters.models) : null
 
-    // Presence scope — team/central: restrict to online/offline members
-    // Effective presence: an explicit filter wins; otherwise the central policy
-    // (includeOfflineData === false → online-only by default). null = all members.
-    const presence = data.presence
-    const effectivePresence: 'online' | 'offline' | null =
-      filters.presence ?? (presence && data.includeOfflineData === false ? 'online' : null)
-    const presenceAllowedUsers: Set<string> | null =
-      effectivePresence && presence
-        ? new Set(
-            Object.entries(presence)
-              .filter(([, p]) => (effectivePresence === 'online' ? p.online : !p.online))
-              .map(([name]) => name),
-          )
-        : null
+    // Presence scope — team/central: restrict to online/offline members. Resolved through the
+    // single shared `resolvePresenceScope` so every scoped aggregate (this function's totals, the
+    // Members page's per-row cache substitution) agrees on the same scope — see its docstring.
+    const presenceScope = resolvePresenceScope(data, filters)
+    const effectivePresence = presenceScope.effective
+    const presenceAllowedUsers = presenceScope.allowedUsers
 
     // Harness filter — applied first so all downstream filters compose on top
     // Compose (all AND predicates): presence scope → legacy single-harness field (now always
@@ -1808,6 +1844,7 @@ export function computeDerivedStats(data: AppData | null, filters: Filters, tags
       : filteredSessions.length > 0 ? 1 : 0
 
     return {
+      presenceScope,
       totalMessages,
       totalSessions,
       allTimeTotalSessions,

--- a/packages/web/src/lib/member-metrics.test.ts
+++ b/packages/web/src/lib/member-metrics.test.ts
@@ -1,5 +1,5 @@
-import { test, expect } from 'bun:test'
-import { aggregateMemberMetrics, withStatsCacheTotals } from './member-metrics'
+import { test, expect, describe } from 'bun:test'
+import { aggregateMemberMetrics, withStatsCacheTotals, presenceFilterCaches } from './member-metrics'
 import type { SessionMeta, StatsCache } from '@agentistics/core'
 
 const cache = (over: Partial<StatsCache>): StatsCache => ({
@@ -111,4 +111,57 @@ test('a row whose totals come from the statsCache SAYS SO, because the parts sto
 test('a session-only row does not claim cache totals', () => {
   // No caches passed → nothing was substituted → nothing to disclose.
   expect(aggregateMemberMetrics([sess({})], 'machine')[0]!.totalsFromCache).toBeFalsy()
+})
+
+// presenceFilterCaches — the header-vs-drilldown consistency fix.
+//
+// Regression: a machine excluded from the header's total by the central's default "online only"
+// scope (`resolvePresenceScope`'s `presenceAllowedUsers`) still had its own row substituted from
+// its FULL, all-time cache in MembersPage, because `withStatsCacheTotals` was handed the raw,
+// presence-unfiltered `data.machineStatsCaches` — a huge unscoped number sitting beside a small
+// scoped "total" with nothing on screen explaining either one.
+
+describe('presenceFilterCaches', () => {
+  test('drops a machine whose owner is not in the allowed set', () => {
+    const caches = { alienware: deep, dell: deep }
+    const machineOwners = {
+      alienware: { user: 'Bryan Soares', teamIds: [] },
+      dell: { user: 'Offline Person', teamIds: [] },
+    }
+    const out = presenceFilterCaches(caches, 'machine', new Set(['Bryan Soares']), machineOwners)
+    expect(Object.keys(out!)).toEqual(['alienware'])
+  })
+
+  test('grouping by user keys the allow-check on the row key directly (no machineOwners needed)', () => {
+    const caches = { 'Bryan Soares': deep, 'Offline Person': deep }
+    const out = presenceFilterCaches(caches, 'user', new Set(['Bryan Soares']), undefined)
+    expect(Object.keys(out!)).toEqual(['Bryan Soares'])
+  })
+
+  test('null allowedUsers (no presence scoping) is a no-op', () => {
+    const caches = { alienware: deep }
+    expect(presenceFilterCaches(caches, 'machine', null, {})).toBe(caches)
+  })
+
+  test('undefined caches stays undefined', () => {
+    expect(presenceFilterCaches(undefined, 'machine', new Set(['x']), {})).toBeUndefined()
+  })
+
+  test('end-to-end: an excluded machine falls back to its (empty) session total instead of the deep cache', () => {
+    const sessions = [sess({ memberId: 'dell', user: 'Offline Person' })]
+    const base = aggregateMemberMetrics(sessions, 'machine')
+    const rawCaches = { dell: deep }
+    const machineOwners = { dell: { user: 'Offline Person', teamIds: [] } }
+
+    // No scoping: the row is inflated to the deep, all-time cache.
+    const unscoped = withStatsCacheTotals(base, sessions, 'machine', rawCaches)
+    expect(unscoped[0]!.sessions).toBe(472)
+
+    // Scoped to online members only, and "Offline Person" is not among them: the row keeps its
+    // real (one-session) total instead of borrowing the excluded machine's full history.
+    const scopedCaches = presenceFilterCaches(rawCaches, 'machine', new Set(['Bryan Soares']), machineOwners)
+    const scoped = withStatsCacheTotals(base, sessions, 'machine', scopedCaches)
+    expect(scoped[0]!.sessions).toBe(1)
+    expect(scoped[0]!.totalTokens).toBeLessThan(unscoped[0]!.totalTokens)
+  })
 })

--- a/packages/web/src/lib/member-metrics.ts
+++ b/packages/web/src/lib/member-metrics.ts
@@ -372,3 +372,33 @@ export function withStatsCacheTotals(
     }
   }).sort((a, b) => (b.sessions - a.sessions) || (b.costUSD - a.costUSD) || a.key.localeCompare(b.key))
 }
+
+/**
+ * Narrows a cache map to the SAME presence scope the header total is built from
+ * (`resolvePresenceScope` in `hooks/useData.ts`), before it reaches `withStatsCacheTotals`.
+ *
+ * Without this, a machine/member excluded from the header's total by the central's
+ * "online only" default kept its own row substituted from its FULL, all-time cache — a huge,
+ * unscoped number sitting beside a small "total" with nothing on screen explaining either one.
+ * `withStatsCacheTotals` already leaves a row alone when its key is absent from `caches`, so
+ * dropping the excluded keys here is enough: that row falls back to its session-based total,
+ * which — since `presenceAllowedUsers` is resolved at the PERSON level, exactly like the
+ * session-list filter upstream — is only ever non-zero when the owner is actually in scope.
+ *
+ * `allowedUsers: null` means "no scoping" (no presence data, or an explicit filter already
+ * narrowed the session list some other way) and is a no-op.
+ */
+export function presenceFilterCaches(
+  caches: Record<string, StatsCache> | undefined,
+  groupBy: MemberGroupBy,
+  allowedUsers: Set<string> | null,
+  machineOwners: Record<string, { user: string; teamIds: string[] }> | undefined,
+): Record<string, StatsCache> | undefined {
+  if (!caches || !allowedUsers) return caches
+  const out: Record<string, StatsCache> = {}
+  for (const [key, cache] of Object.entries(caches)) {
+    const owner = groupBy === 'machine' ? (machineOwners?.[key]?.user ?? '') : key
+    if (allowedUsers.has(owner)) out[key] = cache
+  }
+  return out
+}

--- a/packages/web/src/pages/MembersPage.tsx
+++ b/packages/web/src/pages/MembersPage.tsx
@@ -6,7 +6,7 @@ import { useOutletContext } from 'react-router-dom'
 import { Users, Search, Monitor, User as UserIcon, GitBranch, FolderOpen, Cpu, Terminal } from 'lucide-react'
 import type { AppContext } from '../lib/app-context'
 import { fmt, fmtCost, formatModel, repoShortName, type HarnessId } from '@agentistics/core'
-import { aggregateMemberMetrics, withStatsCacheTotals, LOCAL_KEY, type MemberGroupBy, type MemberMetrics } from '../lib/member-metrics'
+import { aggregateMemberMetrics, withStatsCacheTotals, presenceFilterCaches, LOCAL_KEY, type MemberGroupBy, type MemberMetrics } from '../lib/member-metrics'
 import { cacheTotalsUsable } from '../lib/topUsage'
 import { MetricNote } from '../components/MetricNote'
 import { HARNESS_LABELS, HARNESS_COLORS } from '../lib/harness'
@@ -43,14 +43,19 @@ export default function MembersPage() {
   // are all gone still has real history in the cache, and filtering first would delete them.
   const rows = useMemo(() => {
     const base = aggregateMemberMetrics(derived.filteredSessions, groupBy)
-    const caches = groupBy === 'machine' ? data?.machineStatsCaches : data?.userStatsCaches
+    const rawCaches = groupBy === 'machine' ? data?.machineStatsCaches : data?.userStatsCaches
+    // Scope the caches to the SAME presence the header total is built from — otherwise a
+    // machine/member the header excludes by the central's "online only" default kept showing
+    // its full, all-time history here, dwarfing the header's own number with nothing on screen
+    // explaining either one. See `presenceFilterCaches`.
+    const caches = presenceFilterCaches(rawCaches, groupBy, derived.presenceScope.allowedUsers, data?.machineOwners)
     return withStatsCacheTotals(
       base,
       derived.filteredSessions,
       groupBy,
       cacheTotalsUsable(filters) ? caches : undefined,
     ).filter(r => r.sessions > 0 || r.totalTokens > 0 || r.costUSD > 0)
-  }, [derived.filteredSessions, groupBy, data?.machineStatsCaches, data?.userStatsCaches, filters])
+  }, [derived.filteredSessions, derived.presenceScope, groupBy, data?.machineStatsCaches, data?.userStatsCaches, data?.machineOwners, filters])
 
   /** The signed-in principal, matched the way the rest of the app keys a member: by display name
    *  (the token doc `user`, which follows the owner account's name). Undefined off a central. */

--- a/packages/web/src/pages/SessionsPage.tsx
+++ b/packages/web/src/pages/SessionsPage.tsx
@@ -12,6 +12,7 @@ import { Section } from '../components/Section'
 import { RecentSessions } from '../components/RecentSessions'
 import { lastActivityMs, liveEmptyNotice } from '../lib/sessionLive'
 import { resumeCommand } from '../lib/resumeCommand'
+import { useIsMobile } from '../hooks/useIsMobile'
 import {
   getNotificationSettings,
   saveNotificationSettings,
@@ -30,6 +31,7 @@ export default function SessionsPage() {
   const { data, derived, lang, setSelectedSession, isCentral } = ctx
   const pt = lang === 'pt'
   const navigate = useNavigate()
+  const isMobile = useIsMobile()
 
   // Real-time open-session detection.
   const [liveIdList, setLiveIdList] = useState<string[]>(data.liveSessionIds ?? [])
@@ -148,13 +150,14 @@ export default function SessionsPage() {
             padding: '16px 20px',
             marginBottom: 16,
             display: 'flex',
-            alignItems: 'center',
+            flexDirection: isMobile ? 'column' : 'row',
+            alignItems: isMobile ? 'stretch' : 'center',
             justifyContent: 'space-between',
             gap: 16,
             flexWrap: 'wrap',
           }}
         >
-          <div style={{ display: 'flex', alignItems: 'center', gap: 12, flex: 1, minWidth: 280 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 12, flex: 1, minWidth: isMobile ? 0 : 280 }}>
             <div
               style={{
                 width: 38,
@@ -184,14 +187,23 @@ export default function SessionsPage() {
             </div>
           </div>
 
-          <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexShrink: 0 }}>
+          <div style={{
+            display: 'flex',
+            flexDirection: isMobile ? 'column' : 'row',
+            alignItems: isMobile ? 'stretch' : 'center',
+            gap: 8,
+            flexShrink: 0,
+            width: isMobile ? '100%' : undefined,
+          }}>
             <button
               onClick={handleEnableNotifications}
               style={{
                 display: 'flex',
                 alignItems: 'center',
+                justifyContent: isMobile ? 'center' : 'flex-start',
                 gap: 6,
                 padding: '8px 16px',
+                minHeight: isMobile ? 44 : undefined,
                 borderRadius: 8,
                 background: 'var(--anthropic-orange)',
                 color: '#fff',
@@ -210,8 +222,10 @@ export default function SessionsPage() {
               style={{
                 display: 'flex',
                 alignItems: 'center',
+                justifyContent: isMobile ? 'center' : 'flex-start',
                 gap: 4,
                 padding: '8px 12px',
+                minHeight: isMobile ? 44 : undefined,
                 borderRadius: 8,
                 border: '1px solid var(--border-subtle)',
                 background: 'transparent',
@@ -229,6 +243,7 @@ export default function SessionsPage() {
               onClick={handleDismissPrompt}
               style={{
                 padding: '8px 12px',
+                minHeight: isMobile ? 44 : undefined,
                 borderRadius: 8,
                 border: '1px solid var(--border-subtle)',
                 background: 'transparent',

--- a/packages/web/src/pages/SessionsPage.tsx
+++ b/packages/web/src/pages/SessionsPage.tsx
@@ -1,8 +1,11 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react'
 import { useOutletContext, useNavigate } from 'react-router-dom'
-import { Clock, Radio, Copy, Check, Bell, BellOff, Settings, Sparkles, Folder, User, Terminal } from 'lucide-react'
-import type { HarnessId, LiveApprovalInfo, LiveProcess, LiveUnavailableReason, SessionMeta } from '@agentistics/core'
-import { sessionLabel } from '@agentistics/core'
+import ReactMarkdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+import remarkBreaks from 'remark-breaks'
+import { Clock, Radio, Copy, Check, Bell, BellOff, Settings, Sparkles, Folder, User, Terminal, FileText, ChevronDown, ChevronUp, Send, Info, ExternalLink, LayoutGrid, List, ChevronLeft, ChevronRight, MessageSquare, Loader } from 'lucide-react'
+import type { HarnessId, LiveProcess, LiveUnavailableReason, SessionMeta } from '@agentistics/core'
+import { sessionLabel, sessionTokenTotal } from '@agentistics/core'
 import { HARNESS_COLORS, HARNESS_LABELS } from '../lib/harness'
 import type { AppContext } from '../lib/app-context'
 import { Section } from '../components/Section'
@@ -34,7 +37,6 @@ export default function SessionsPage() {
   const [liveUnavailable, setLiveUnavailable] =
     useState<LiveUnavailableReason | undefined>(data.liveUnavailable)
   const [liveActivities, setLiveActivities] = useState<Record<string, SessionActivity>>({})
-  const [liveApprovals, setLiveApprovals] = useState<Record<string, LiveApprovalInfo>>(data.liveApprovals ?? {})
 
   // Notification settings state & prompt banner
   const [notifSettings, setNotifSettings] = useState<NotificationSettings>(getNotificationSettings)
@@ -49,8 +51,6 @@ export default function SessionsPage() {
     return map
   }, [data.sessions])
 
-  const pollRef = useRef<() => void>(() => {})
-
   // Poll live sessions
   useEffect(() => {
     let alive = true
@@ -63,13 +63,11 @@ export default function SessionsPage() {
           liveProcesses?: LiveProcess[]
           liveUnavailable?: LiveUnavailableReason
           liveSessionActivities?: Record<string, SessionActivity>
-          liveApprovals?: Record<string, LiveApprovalInfo>
         }
         if (!alive) return
         if (Array.isArray(json.liveSessionIds)) setLiveIdList(json.liveSessionIds)
         setLiveProcs(Array.isArray(json.liveProcesses) ? json.liveProcesses : [])
         setLiveUnavailable(json.liveUnavailable)
-        setLiveApprovals(json.liveApprovals || {})
 
         const activities = json.liveSessionActivities || {}
         setLiveActivities(activities)
@@ -79,7 +77,6 @@ export default function SessionsPage() {
         prevActivitiesRef.current = activities
       } catch { /* transient — keep last known */ }
     }
-    pollRef.current = poll
     poll()
     const id = setInterval(poll, LIVE_POLL_MS)
     return () => { alive = false; clearInterval(id) }
@@ -93,6 +90,17 @@ export default function SessionsPage() {
   )
   const liveCount = live.length + liveProcs.length
   const notice = liveEmptyNotice({ count: liveCount, central: isCentral, unavailable: liveUnavailable, lang: pt ? 'pt' : 'en' })
+
+  // Pagination (5 by 5) and view mode state for live sessions
+  const [livePage, setLivePage] = useState(1)
+  const [liveViewMode, setLiveViewMode] = useState<'list' | 'grid'>('list')
+  const LIVE_PAGE_SIZE = 5
+  const totalLivePages = Math.max(1, Math.ceil(live.length / LIVE_PAGE_SIZE))
+  const currentLivePage = Math.min(livePage, totalLivePages)
+  const pagedLive = useMemo(() => {
+    const start = (currentLivePage - 1) * LIVE_PAGE_SIZE
+    return live.slice(start, start + LIVE_PAGE_SIZE)
+  }, [live, currentLivePage])
 
   // Handle enabling notifications from prompt banner
   async function handleEnableNotifications() {
@@ -121,7 +129,14 @@ export default function SessionsPage() {
 
   return (
     <>
-      <PageHead pt={pt} central={isCentral} />
+      <PageHead
+        pt={pt}
+        central={isCentral}
+        liveViewMode={liveViewMode}
+        setLiveViewMode={setLiveViewMode}
+        notifSettings={notifSettings}
+        onOpenNotifs={() => navigate('/settings/notifications')}
+      />
 
       {/* Notification Permission Prompt Banner */}
       {showPromptBanner && (
@@ -229,86 +244,139 @@ export default function SessionsPage() {
         </div>
       )}
 
-      {/* "Open now" real-time process detection */}
-      <Section
-        flashId="live-sessions"
-        title={
-          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', width: '100%' }}>
-            <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
-              <Radio size={14} />
-              <span>{pt ? 'Abertas agora' : 'Open now'}</span>
-              {liveCount > 0 && (
-                <span style={{ fontSize: 11, color: 'var(--text-tertiary)' }}>({liveCount})</span>
-              )}
-            </div>
-
-            <button
-              onClick={() => navigate('/settings/notifications')}
-              title={pt ? 'Configurar Notificações' : 'Configure Notifications'}
-              style={{
-                display: 'flex',
-                alignItems: 'center',
-                gap: 4,
-                fontSize: 11,
-                padding: '3px 8px',
-                borderRadius: 6,
-                border: '1px solid var(--border-subtle)',
-                background: 'transparent',
-                color: 'var(--text-tertiary)',
-                cursor: 'pointer',
-                fontFamily: 'inherit',
-              }}
-            >
-              {notifSettings.enabled ? <Bell size={12} style={{ color: 'var(--anthropic-orange)' }} /> : <BellOff size={12} />}
-              <span>{pt ? 'Notificações' : 'Notifications'}</span>
-            </button>
-          </div>
-        }
-      >
-        {notice
-          ? <div style={{ fontSize: 13, color: 'var(--text-tertiary)', padding: '8px 2px', display: 'flex', flexDirection: 'column', gap: 5 }}>
-              <span>{notice.title}</span>
-              {notice.detail && <span style={{ fontSize: 12, lineHeight: 1.5, maxWidth: '68ch' }}>{notice.detail}</span>}
-            </div>
-          : <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
-              {live.map(s => (
-                <LiveCard
-                  key={s.session_id}
-                  s={s}
-                  pt={pt}
-                  central={isCentral}
-                  activity={liveActivities[s.session_id]}
-                  approval={liveApprovals[s.session_id]}
-                  onOpen={() => setSelectedSession(s)}
-                  onRefreshLive={() => pollRef.current()}
-                />
-              ))}
-              {liveProcs.map((p, i) => <StartingCard key={`${p.harness}-${p.cwd}-${i}`} p={p} pt={pt} />)}
-            </div>}
-      </Section>
-
-      <Section flashId="recent-sessions" title={<><Clock size={14} /> {pt ? 'Últimas sessões' : 'Latest sessions'}</>}>
-        <RecentSessions sessions={derived.filteredSessions} lang={lang} onSelect={setSelectedSession} pinnedIds={liveIds} />
-      </Section>
+      {/* Primary Unified Sessions View */}
+      <RecentSessions
+        sessions={derived.filteredSessions}
+        lang={lang}
+        onSelect={setSelectedSession}
+        pinnedIds={liveIds}
+        activities={liveActivities}
+        viewMode={liveViewMode}
+        onViewModeChange={setLiveViewMode}
+      />
     </>
   )
 }
 
-function PageHead({ pt, central }: { pt: boolean; central?: boolean }) {
+function PageHead({
+  pt,
+  central,
+  liveViewMode,
+  setLiveViewMode,
+  notifSettings,
+  onOpenNotifs,
+}: {
+  pt: boolean
+  central?: boolean
+  liveViewMode: 'list' | 'grid'
+  setLiveViewMode: (mode: 'list' | 'grid') => void
+  notifSettings: NotificationSettings
+  onOpenNotifs: () => void
+}) {
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: 4, marginBottom: 4 }}>
-      <div style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 18, fontWeight: 700, color: 'var(--text-primary)' }}>
-        <span style={{ color: 'var(--anthropic-orange)' }}><Clock size={16} /></span>
-        {pt ? 'Sessões' : 'Sessions'}
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        flexWrap: 'wrap',
+        gap: 12,
+        marginBottom: 12,
+        padding: '14px 18px',
+        borderRadius: 12,
+        background: 'var(--bg-surface)',
+        border: '1px solid var(--border-subtle)',
+      }}
+    >
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 4, flex: 1, minWidth: 260 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 18, fontWeight: 700, color: 'var(--text-primary)' }}>
+          <span style={{ color: 'var(--anthropic-orange)' }}><Clock size={18} /></span>
+          {pt ? 'Sessões' : 'Sessions'}
+        </div>
+        <div style={{ fontSize: 12, color: 'var(--text-tertiary)', lineHeight: 1.5 }}>
+          {central
+            ? (pt
+                ? 'Últimas sessões do time (metadados, sem chat) — reativo aos filtros, inclusive por membro.'
+                : "The team's latest sessions (metadata, no chat) — reactive to the filters, including by member.")
+            : (pt
+                ? 'Sessões abertas agora (em tempo real) e as últimas sessões, com comando para retomar.'
+                : 'Sessions open right now (real time) and your latest sessions, with a resume command.')}
+        </div>
       </div>
-      <div style={{ fontSize: 12, color: 'var(--text-tertiary)', lineHeight: 1.5 }}>
-        {central
-          ? (pt
-              ? 'Últimas sessões do time (metadados, sem chat) — reativo aos filtros, inclusive por membro.'
-              : "The team's latest sessions (metadata, no chat) — reactive to the filters, including by member.")
-          : (pt
-              ? 'Sessões abertas agora (em tempo real) e as últimas sessões, com comando para retomar.'
-              : 'Sessions open right now (real time) and your latest sessions, with a resume command.')}
+
+      {/* Right Side Controls: View Mode TabMenu & Notifications Button */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: 10, flexShrink: 0 }}>
+        {/* TabMenu: List vs Grid Toggle */}
+        <div style={{ display: 'flex', alignItems: 'center', border: '1px solid var(--border-subtle)', borderRadius: 8, padding: 3, background: 'var(--bg-elevated)' }}>
+          <button
+            onClick={() => setLiveViewMode('list')}
+            title={pt ? 'Exibir em lista' : 'List view'}
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 5,
+              padding: '4px 10px',
+              borderRadius: 6,
+              border: 'none',
+              background: liveViewMode === 'list' ? 'var(--bg-card)' : 'transparent',
+              color: liveViewMode === 'list' ? 'var(--anthropic-orange)' : 'var(--text-tertiary)',
+              fontSize: 11,
+              fontWeight: liveViewMode === 'list' ? 600 : 400,
+              cursor: 'pointer',
+              fontFamily: 'inherit',
+              transition: 'all 0.15s',
+            }}
+          >
+            <List size={13} />
+            <span>{pt ? 'Lista' : 'List'}</span>
+          </button>
+          <button
+            onClick={() => setLiveViewMode('grid')}
+            title={pt ? 'Exibir em grade' : 'Grid view'}
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 5,
+              padding: '4px 10px',
+              borderRadius: 6,
+              border: 'none',
+              background: liveViewMode === 'grid' ? 'var(--bg-card)' : 'transparent',
+              color: liveViewMode === 'grid' ? 'var(--anthropic-orange)' : 'var(--text-tertiary)',
+              fontSize: 11,
+              fontWeight: liveViewMode === 'grid' ? 600 : 400,
+              cursor: 'pointer',
+              fontFamily: 'inherit',
+              transition: 'all 0.15s',
+            }}
+          >
+            <LayoutGrid size={13} />
+            <span>{pt ? 'Grade' : 'Grid'}</span>
+          </button>
+        </div>
+
+        {/* Notifications Settings Button */}
+        <button
+          onClick={onOpenNotifs}
+          title={pt ? 'Configurar Notificações' : 'Configure Notifications'}
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 6,
+            fontSize: 11,
+            fontWeight: 500,
+            padding: '6px 12px',
+            borderRadius: 8,
+            border: '1px solid var(--border-subtle)',
+            background: 'var(--bg-elevated)',
+            color: 'var(--text-secondary)',
+            cursor: 'pointer',
+            fontFamily: 'inherit',
+            transition: 'all 0.15s',
+          }}
+        >
+          {notifSettings.enabled ? <Bell size={13} style={{ color: 'var(--anthropic-orange)' }} /> : <BellOff size={13} />}
+          <span>{pt ? 'Notificações' : 'Notifications'}</span>
+        </button>
       </div>
     </div>
   )
@@ -390,83 +458,129 @@ function LiveCard({
   onOpen,
   central,
   activity,
-  approval,
-  onRefreshLive,
+  viewMode = 'list',
 }: {
   s: SessionMeta
   pt: boolean
   onOpen: () => void
   central?: boolean
   activity?: SessionActivity
-  approval?: LiveApprovalInfo
-  onRefreshLive?: () => void
+  viewMode?: 'list' | 'grid'
 }) {
   const cmd = central ? null : resumeCommand(s)
   const [copied, setCopied] = useState(false)
-  const [submitting, setSubmitting] = useState(false)
-  const [answerFeedback, setAnswerFeedback] = useState<string | null>(null)
+  const [showDetails, setShowDetails] = useState(false)
+  const [promptText, setPromptText] = useState('')
+  const [sendingPrompt, setSendingPrompt] = useState(false)
+  const [promptFeedback, setPromptFeedback] = useState<{ ok: boolean; msg: string } | null>(null)
+
+  const [messages, setMessages] = useState<{ role: 'user' | 'assistant'; content: string; timestamp?: number; tools?: string[] }[] | null>(null)
+  const [loadingMsgs, setLoadingMsgs] = useState(false)
+
+  const detailsRef = useRef<HTMLDivElement>(null)
+
+  // Click outside to dismiss floating details popover
+  useEffect(() => {
+    if (!showDetails) return
+    function handleClickOutside(e: MouseEvent) {
+      if (detailsRef.current && !detailsRef.current.contains(e.target as Node)) {
+        setShowDetails(false)
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [showDetails])
+
+  useEffect(() => {
+    if (showDetails && messages === null && !loadingMsgs) {
+      setLoadingMsgs(true)
+      fetch(`/api/sessions/${encodeURIComponent(s.session_id)}/messages?harness=${encodeURIComponent(s.harness || 'claude')}&projectPath=${encodeURIComponent(s.project_path || '')}`)
+        .then(r => r.ok ? r.json() : [])
+        .then((msgs: any[]) => {
+          if (Array.isArray(msgs)) setMessages(msgs)
+          else setMessages([])
+        })
+        .catch(() => setMessages([]))
+        .finally(() => setLoadingMsgs(false))
+    }
+  }, [showDetails, s.session_id, s.harness, s.project_path, messages, loadingMsgs])
+
   const mins = Math.max(0, Math.round((Date.now() - lastActivityMs(s)) / 60_000))
   const title = sessionLabel(s) || (s.project_path ? (s.project_path.split('/').filter(Boolean).pop() || '') : '') || s.session_id.slice(0, 8)
 
-  async function handleAnswer(choice?: number) {
-    setSubmitting(true)
-    setAnswerFeedback(null)
+  async function handleSendPrompt(e?: React.FormEvent) {
+    if (e) e.preventDefault()
+    const text = promptText.trim()
+    if (!text || sendingPrompt) return
+
+    setSendingPrompt(true)
+    setPromptFeedback(null)
     try {
-      const res = await fetch('/api/session-answer', {
+      const res = await fetch('/api/sessions/prompt', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ id: s.session_id, choice }),
+        body: JSON.stringify({ sessionId: s.session_id, prompt: text }),
       })
-      const json = await res.json() as { ok: boolean; message?: string }
+      const json = await res.json() as { ok?: boolean; message?: string; error?: string }
       if (res.ok && json.ok) {
-        setAnswerFeedback(pt ? 'Aprovado / Respondido com sucesso!' : 'Approved / Answered successfully!')
-        setTimeout(() => setAnswerFeedback(null), 3000)
-        onRefreshLive?.()
+        setPromptFeedback({
+          ok: true,
+          msg: pt ? 'Prompt enviado com sucesso para a sessão no terminal!' : 'Prompt sent successfully to session in terminal!',
+        })
+        setPromptText('')
       } else {
-        setAnswerFeedback(json.message || (pt ? 'Falha ao responder' : 'Failed to answer'))
+        setPromptFeedback({
+          ok: false,
+          msg: json.error || (pt ? 'Erro ao enviar prompt para a sessão.' : 'Failed to send prompt.'),
+        })
       }
-    } catch {
-      setAnswerFeedback(pt ? 'Erro de conexão' : 'Network error')
+    } catch (err: any) {
+      setPromptFeedback({
+        ok: false,
+        msg: err?.message || (pt ? 'Erro de rede ao enviar prompt.' : 'Network error.'),
+      })
     } finally {
-      setSubmitting(false)
+      setSendingPrompt(false)
+      setTimeout(() => setPromptFeedback(null), 4000)
     }
   }
 
-  const hasApproval = !!(
-    approval &&
-    (approval.canApprove || approval.canChoose || (approval.dialogOptions && approval.dialogOptions.length > 0) || (approval.approvalLines && approval.approvalLines.length > 0))
-  )
+  // All four billed counters — the conversational pair alone is a fraction of a percent.
+  const totalTokens = sessionTokenTotal(s)
 
   return (
     <div
       style={{
-        border: hasApproval ? '1.5px solid var(--anthropic-orange)' : '1px solid var(--border)',
+        position: 'relative',
+        border: '1px solid var(--border)',
         borderRadius: 12,
         padding: '16px 18px',
         background: 'var(--bg-card)',
         display: 'flex',
         flexDirection: 'column',
         gap: 12,
-        boxShadow: hasApproval ? '0 0 12px rgba(232, 105, 11, 0.15)' : '0 1px 3px rgba(0,0,0,0.03)',
+        boxShadow: '0 1px 3px rgba(0,0,0,0.03)',
+        boxSizing: 'border-box',
+        width: '100%',
+        minWidth: 0,
+        maxWidth: '100%',
       }}
     >
-      {/* Header Row */}
+      {/* Header Row: Title on Left, Stacked Badges + Elapsed Time on Right */}
       <div
         style={{
           display: 'flex',
-          alignItems: 'center',
+          alignItems: 'flex-start',
           justifyContent: 'space-between',
           gap: 12,
-          flexWrap: 'wrap',
         }}
       >
-        {/* Title & Harness */}
-        <div
-          onClick={onOpen}
-          style={{ cursor: 'pointer', display: 'flex', alignItems: 'center', gap: 10, minWidth: 0, flex: 1 }}
-        >
-          <span
+        {/* Title & Project Path */}
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 4, minWidth: 0, flex: 1 }}>
+          <div
+            onClick={onOpen}
             style={{
+              cursor: 'pointer',
               fontSize: 15,
               fontWeight: 600,
               color: 'var(--text-primary)',
@@ -474,143 +588,46 @@ function LiveCard({
               textOverflow: 'ellipsis',
               whiteSpace: 'nowrap',
             }}
+            title={title}
           >
             {title}
-          </span>
-          <HarnessBadge harness={s.harness} />
-        </div>
-
-        {/* Status Badge & Elapsed Time */}
-        <div style={{ display: 'flex', alignItems: 'center', gap: 10, flexShrink: 0 }}>
-          <StatusBadge activity={activity} pt={pt} />
-          <span style={{ fontSize: 11, color: 'var(--text-tertiary)', display: 'flex', alignItems: 'center', gap: 4 }}>
-            <Clock size={12} />
-            <span>{pt ? `há ${mins} min` : `${mins} min ago`}</span>
-          </span>
-        </div>
-      </div>
-
-      {/* Context Details (Project Path / Member) */}
-      <div style={{ display: 'flex', alignItems: 'center', gap: 14, fontSize: 12, color: 'var(--text-tertiary)' }}>
-        <div
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: 6,
-            minWidth: 0,
-            overflow: 'hidden',
-            textOverflow: 'ellipsis',
-            whiteSpace: 'nowrap',
-          }}
-          title={s.project_path}
-        >
-          <Folder size={13} style={{ flexShrink: 0, color: 'var(--text-tertiary)' }} />
-          <span style={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>{s.project_path}</span>
-        </div>
-
-        {central && s.user && (
-          <div style={{ display: 'flex', alignItems: 'center', gap: 4, flexShrink: 0, color: 'var(--text-secondary)' }}>
-            <User size={13} />
-            <span>{s.user}</span>
-          </div>
-        )}
-      </div>
-
-      {/* Direct Approval Controls */}
-      {hasApproval && (
-        <div
-          style={{
-            border: '1px solid var(--anthropic-orange-dim, rgba(232, 105, 11, 0.35))',
-            background: 'rgba(232, 105, 11, 0.08)',
-            borderRadius: 10,
-            padding: '12px 14px',
-            display: 'flex',
-            flexDirection: 'column',
-            gap: 10,
-          }}
-        >
-          <div style={{ display: 'flex', alignItems: 'center', gap: 6, fontWeight: 600, fontSize: 13, color: 'var(--anthropic-orange)' }}>
-            <Sparkles size={14} />
-            <span>{pt ? 'Ação ou permissão necessária diretamente nesta listagem:' : 'Action or permission needed directly from listing:'}</span>
           </div>
 
-          {approval!.approvalLines && approval!.approvalLines.length > 0 && (
-            <div
-              style={{
-                fontSize: 12,
-                color: 'var(--text-primary)',
-                fontFamily: 'var(--font-mono, monospace)',
-                whiteSpace: 'pre-wrap',
-                lineHeight: 1.4,
-                background: 'var(--bg-elevated)',
-                padding: '8px 10px',
-                borderRadius: 6,
-                border: '1px solid var(--border-subtle)',
-              }}
-            >
-              {approval!.approvalLines.join('\n')}
-            </div>
-          )}
-
-          <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap', marginTop: 2 }}>
-            {approval!.canApprove && (
-              <button
-                disabled={submitting}
-                onClick={() => handleAnswer()}
-                style={{
-                  padding: '7px 16px',
-                  borderRadius: 8,
-                  border: 'none',
-                  background: 'var(--anthropic-orange)',
-                  color: '#fff',
-                  fontSize: 12,
-                  fontWeight: 600,
-                  cursor: submitting ? 'wait' : 'pointer',
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: 6,
-                  boxShadow: '0 2px 4px rgba(232, 105, 11, 0.2)',
-                  fontFamily: 'inherit',
-                }}
-              >
-                <Check size={14} />
-                <span>{pt ? 'Aprovar / Aceitar' : 'Approve / Accept'}</span>
-              </button>
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 6,
+              fontSize: 12,
+              color: 'var(--text-tertiary)',
+              minWidth: 0,
+            }}
+          >
+            <Folder size={12} style={{ flexShrink: 0, color: 'var(--text-tertiary)' }} />
+            <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }} title={s.project_path}>
+              {s.project_path}
+            </span>
+            {central && s.user && (
+              <span style={{ display: 'flex', alignItems: 'center', gap: 4, flexShrink: 0, marginLeft: 6, color: 'var(--text-secondary)' }}>
+                <User size={12} />
+                <span>{s.user}</span>
+              </span>
             )}
-
-            {approval!.dialogOptions && approval!.dialogOptions.map((opt: { number: number; label: string }) => (
-              <button
-                key={opt.number}
-                disabled={submitting}
-                onClick={() => handleAnswer(opt.number)}
-                style={{
-                  padding: '6px 14px',
-                  borderRadius: 8,
-                  border: '1px solid var(--border)',
-                  background: 'var(--bg-elevated)',
-                  color: 'var(--text-primary)',
-                  fontSize: 12,
-                  fontWeight: 500,
-                  cursor: submitting ? 'wait' : 'pointer',
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: 6,
-                  fontFamily: 'inherit',
-                }}
-              >
-                <span style={{ fontWeight: 700, color: 'var(--anthropic-orange)' }}>{opt.number}.</span>
-                <span>{opt.label}</span>
-              </button>
-            ))}
           </div>
-
-          {answerFeedback && (
-            <div style={{ fontSize: 12, fontWeight: 500, color: answerFeedback.includes('sucesso') || answerFeedback.includes('success') ? '#22c55e' : '#ef4444' }}>
-              {answerFeedback}
-            </div>
-          )}
         </div>
-      )}
+
+        {/* Stacked Badges Cluster on Right */}
+        <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: 4, flexShrink: 0 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+            <HarnessBadge harness={s.harness} />
+            <StatusBadge activity={activity} pt={pt} />
+          </div>
+          <div style={{ fontSize: 11, color: 'var(--text-tertiary)', display: 'flex', alignItems: 'center', gap: 4 }}>
+            <Clock size={11} />
+            <span>{pt ? `há ${mins} min` : `${mins} min ago`}</span>
+          </div>
+        </div>
+      </div>
 
       {/* Command Box */}
       {cmd ? (
@@ -624,9 +641,14 @@ function LiveCard({
             borderRadius: 8,
             background: 'var(--bg-elevated)',
             border: '1px solid var(--border-subtle)',
+            width: '100%',
+            minWidth: 0,
+            maxWidth: '100%',
+            boxSizing: 'border-box',
+            overflow: 'hidden',
           }}
         >
-          <div style={{ display: 'flex', alignItems: 'center', gap: 8, minWidth: 0, flex: 1 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8, minWidth: 0, flex: 1, overflow: 'hidden' }}>
             <Terminal size={13} style={{ color: 'var(--anthropic-orange)', flexShrink: 0 }} />
             <code
               style={{
@@ -636,6 +658,8 @@ function LiveCard({
                 overflowX: 'auto',
                 whiteSpace: 'nowrap',
                 scrollbarWidth: 'none',
+                maxWidth: '100%',
+                display: 'block',
               }}
             >
               {cmd}
@@ -682,6 +706,269 @@ function LiveCard({
       ) : central ? null : (
         <div style={{ fontSize: 11, color: 'var(--text-tertiary)', fontStyle: 'italic' }}>
           {pt ? 'Retomar não disponível para este harness.' : 'Resume not available for this harness.'}
+        </div>
+      )}
+
+      {/* Machine Mode Explicit Controls: Detalhes Button & Short Prompt Form */}
+      {!central && (
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 10,
+            paddingTop: 8,
+            borderTop: '1px solid var(--border-subtle)',
+          }}
+        >
+          {/* Action Toolbar */}
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8, flexWrap: 'wrap' }}>
+            {/* Detalhes Toggle Button */}
+            <button
+              onClick={() => setShowDetails(v => !v)}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 6,
+                padding: '6px 12px',
+                borderRadius: 6,
+                border: showDetails ? '1px solid var(--anthropic-orange-dim, rgba(232,105,11,0.4))' : '1px solid var(--border)',
+                background: showDetails ? 'rgba(232,105,11,0.08)' : 'var(--bg-card)',
+                color: showDetails ? 'var(--anthropic-orange)' : 'var(--text-primary)',
+                fontSize: 12,
+                fontWeight: 600,
+                cursor: 'pointer',
+                fontFamily: 'inherit',
+                transition: 'all 0.15s ease',
+              }}
+            >
+              <FileText size={13} />
+              <span>{pt ? 'Detalhes' : 'Details'}</span>
+              {showDetails ? <ChevronUp size={13} /> : <ChevronDown size={13} />}
+            </button>
+
+            {/* Quick link to open full drilldown modal */}
+            <button
+              onClick={onOpen}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 4,
+                fontSize: 11,
+                color: 'var(--text-tertiary)',
+                background: 'transparent',
+                border: 'none',
+                cursor: 'pointer',
+                fontFamily: 'inherit',
+              }}
+            >
+              <ExternalLink size={12} />
+              <span>{pt ? 'Abrir no Modal' : 'Open in Modal'}</span>
+            </button>
+          </div>
+
+          {/* Short Prompt Input Bar */}
+          <form
+            onSubmit={handleSendPrompt}
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 8,
+              background: 'var(--bg-elevated)',
+              border: '1px solid var(--border-subtle)',
+              borderRadius: 8,
+              padding: '4px 6px 4px 10px',
+            }}
+          >
+            <input
+              type="text"
+              value={promptText}
+              onChange={e => setPromptText(e.target.value)}
+              placeholder={pt ? 'Enviar short prompt para a sessão...' : 'Send short prompt to session...'}
+              style={{
+                flex: 1,
+                background: 'transparent',
+                border: 'none',
+                outline: 'none',
+                fontSize: 12,
+                color: 'var(--text-primary)',
+                fontFamily: 'inherit',
+              }}
+            />
+            <button
+              type="submit"
+              disabled={sendingPrompt || !promptText.trim()}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 5,
+                padding: '5px 12px',
+                borderRadius: 6,
+                background: 'var(--anthropic-orange)',
+                color: '#fff',
+                border: 'none',
+                fontSize: 11,
+                fontWeight: 600,
+                cursor: sendingPrompt || !promptText.trim() ? 'not-allowed' : 'pointer',
+                opacity: sendingPrompt || !promptText.trim() ? 0.6 : 1,
+                fontFamily: 'inherit',
+                flexShrink: 0,
+              }}
+            >
+              <Send size={11} />
+              <span>{sendingPrompt ? (pt ? 'Enviando...' : 'Sending...') : (pt ? 'Enviar Prompt' : 'Send')}</span>
+            </button>
+          </form>
+
+          {/* Prompt Feedback Toast */}
+          {promptFeedback && (
+            <div
+              style={{
+                fontSize: 11,
+                padding: '4px 8px',
+                borderRadius: 6,
+                background: promptFeedback.ok ? 'rgba(34,197,94,0.1)' : 'rgba(239,68,68,0.1)',
+                color: promptFeedback.ok ? '#22c55e' : '#ef4444',
+                border: promptFeedback.ok ? '1px solid rgba(34,197,94,0.2)' : '1px solid rgba(239,68,68,0.2)',
+                display: 'flex',
+                alignItems: 'center',
+                gap: 6,
+              }}
+            >
+              {promptFeedback.ok ? <Check size={12} /> : <Info size={12} />}
+              <span>{promptFeedback.msg}</span>
+            </div>
+          )}
+
+          {/* Expandable Details Panel — Floating Popover in Grid View / Inline in List View */}
+          {showDetails && (
+            <div
+              ref={detailsRef}
+              style={{
+                display: 'flex',
+                flexDirection: 'column',
+                gap: 10,
+                padding: '12px 14px',
+                borderRadius: 10,
+                background: 'var(--bg-elevated)',
+                border: '1px solid var(--anthropic-orange-dim, rgba(232,105,11,0.4))',
+                width: '100%',
+                minWidth: 0,
+                boxSizing: 'border-box',
+                overflow: 'hidden',
+                ...(viewMode === 'grid'
+                  ? {
+                      position: 'absolute',
+                      top: '100%',
+                      left: 0,
+                      right: 0,
+                      zIndex: 300,
+                      marginTop: 6,
+                      boxShadow: '0 12px 36px rgba(0,0,0,0.5)',
+                      animation: 'ttyChatFadeIn 0.15s ease-out',
+                    }
+                  : {
+                      marginTop: 6,
+                    }),
+              }}
+            >
+              <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', borderBottom: '1px solid var(--border-subtle)', paddingBottom: 6 }}>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 12, fontWeight: 600, color: 'var(--text-primary)' }}>
+                  <MessageSquare size={13} style={{ color: 'var(--anthropic-orange)' }} />
+                  <span>{pt ? 'Últimas mensagens da conversa' : 'Recent conversation messages'}</span>
+                </div>
+                {messages && messages.length > 0 && (
+                  <span style={{ fontSize: 11, color: 'var(--text-tertiary)' }}>
+                    {pt ? `exibindo ${Math.min(4, messages.length)} de ${messages.length}` : `showing ${Math.min(4, messages.length)} of ${messages.length}`}
+                  </span>
+                )}
+              </div>
+
+              {loadingMsgs ? (
+                <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '12px 0', fontSize: 12, color: 'var(--text-tertiary)' }}>
+                  <Loader size={14} style={{ animation: 'spin 1s linear infinite' }} />
+                  <span>{pt ? 'Carregando histórico do transcript...' : 'Loading transcript history...'}</span>
+                </div>
+              ) : messages && messages.length > 0 ? (
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 8, maxHeight: 280, overflowY: 'auto', paddingRight: 4 }}>
+                  {messages.slice(-4).map((m, idx) => {
+                    const isUser = m.role === 'user'
+                    const colour = HARNESS_COLORS[s.harness] ?? 'var(--anthropic-orange)'
+                    const roleLabel = isUser ? (pt ? 'Você' : 'You') : (HARNESS_LABELS[s.harness] ?? s.harness)
+                    return (
+                      <div key={idx} style={{ display: 'flex', flexDirection: 'column', alignItems: isUser ? 'flex-end' : 'flex-start', gap: 2, width: '100%', minWidth: 0 }}>
+                        <div style={{ fontSize: 10, fontWeight: 600, color: isUser ? 'var(--text-tertiary)' : colour }}>
+                          {roleLabel}
+                        </div>
+                        <div
+                          style={{
+                            maxWidth: '96%',
+                            minWidth: 0,
+                            padding: '8px 10px',
+                            borderRadius: isUser ? '10px 10px 2px 10px' : '10px 10px 10px 2px',
+                            background: isUser ? 'rgba(59, 130, 246, 0.12)' : 'var(--bg-card)',
+                            border: isUser ? '1px solid rgba(59, 130, 246, 0.25)' : `1px solid ${colour}44`,
+                            fontSize: 12,
+                            color: 'var(--text-primary)',
+                            lineHeight: 1.5,
+                            wordBreak: 'break-word',
+                            overflowWrap: 'anywhere',
+                            overflow: 'hidden',
+                          }}
+                        >
+                          <ReactMarkdown
+                            remarkPlugins={[remarkGfm, remarkBreaks]}
+                            components={{
+                              p: ({ children }) => <span style={{ display: 'block', margin: '0 0 4px 0' }}>{children}</span>,
+                              ul: ({ children }) => <ul style={{ margin: '2px 0 4px 0', paddingLeft: 18 }}>{children}</ul>,
+                              ol: ({ children }) => <ol style={{ margin: '2px 0 4px 0', paddingLeft: 18 }}>{children}</ol>,
+                              li: ({ children }) => <li style={{ margin: '1px 0' }}>{children}</li>,
+                              code: ({ children, className }) => {
+                                const isBlock = !!className
+                                return isBlock
+                                  ? <pre style={{ background: 'var(--bg-surface)', padding: '6px 8px', borderRadius: 4, overflowX: 'auto', margin: '4px 0', fontSize: 11, maxWidth: '100%' }}><code style={{ whiteSpace: 'pre', display: 'block' }}>{children}</code></pre>
+                                  : <code style={{ background: 'var(--bg-surface)', padding: '1px 4px', borderRadius: 3, fontSize: 11 }}>{children}</code>
+                              },
+                              pre: ({ children }) => <>{children}</>,
+                            }}
+                          >
+                            {m.content.length > 500 ? m.content.slice(0, 500) + '...' : m.content}
+                          </ReactMarkdown>
+                        </div>
+                      </div>
+                    )
+                  })}
+                </div>
+              ) : (
+                <div style={{ fontSize: 12, color: 'var(--text-tertiary)', fontStyle: 'italic', padding: '6px 0' }}>
+                  {pt ? 'Nenhuma mensagem recente encontrada nesta sessão.' : 'No recent messages found in this session.'}
+                </div>
+              )}
+
+              <button
+                onClick={onOpen}
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  gap: 6,
+                  padding: '6px 12px',
+                  borderRadius: 6,
+                  border: '1px solid var(--border-subtle)',
+                  background: 'var(--bg-card)',
+                  color: 'var(--anthropic-orange)',
+                  fontSize: 11,
+                  fontWeight: 600,
+                  cursor: 'pointer',
+                  fontFamily: 'inherit',
+                  marginTop: 4,
+                  width: '100%',
+                }}
+              >
+                <ExternalLink size={12} />
+                <span>{pt ? 'Abrir Transcrição Completa e Métricas no Modal →' : 'Open Full Transcript & Metrics in Modal →'}</span>
+              </button>
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/packages/web/src/pages/settings/primitives.tsx
+++ b/packages/web/src/pages/settings/primitives.tsx
@@ -369,7 +369,11 @@ export function TabSelect<T extends string>({
 
 export function PrefRow({ label, sub, children }: { label: string; sub?: string; children: React.ReactNode }) {
   return (
-    <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 14, gap: 12 }}>
+    // flexWrap: 'wrap' is a no-op whenever a row's label + children already fit on one line (every
+    // existing caller) and only kicks in once they don't — e.g. CentralAdminPanel's push-interval
+    // row (select + Express checkbox + save status), which sits right at the edge of a 390px
+    // viewport. Wrapping there beats a silent horizontal overflow.
+    <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 14, gap: 12, flexWrap: 'wrap' }}>
       <div>
         <div style={{ fontSize: 13, color: 'var(--text-secondary)', fontWeight: 500 }}>{label}</div>
         {sub && <div style={{ fontSize: 11, color: 'var(--text-tertiary)', marginTop: 2 }}>{sub}</div>}


### PR DESCRIPTION
## O que este PR faz

Reverte `3e9f06c` — *"feat: add transcript search, fix TUI navigation and session approvals"* — que entrou no `main` via #187 e foi publicado como **v1.19.0**.

Este é o **único delta** entre `dev` e `main`. Todo o resto do `dev` já está no `main` desde o #187.

## Por que

O feature foi testado localmente em um worktree de `origin/main` (`bun install` + stub de tipos). `bun tsc --noEmit` passa e `bun test` passa (4236/4236) — os problemas abaixo **não são pegos por tipo nem por teste**, só por execução.

### 1. A busca por transcript não busca nada

`transcript_text` só é produzido quando `parseSessionJsonl` reprocessa o arquivo; não há backfill para o que já está no consolidate store. Medido em `/api/data` real, 140 sessões:

```
sessões: 140   com transcript_text: 1   (0,7%)

busca "docker":  0 de 140
busca "central": 0 de 140
busca "mongo":   0 de 140
busca "token":   0 de 140
```

A única sessão com transcript era a que estava sendo escrita naquele instante. A busca full-text cobre efetivamente uma sessão: a atual.

### 2. `transcript_text` atravessa o wire sem redação

O campo carrega **até 200 KB de conversa completa** (`user` + `assistant`) e é adicionado ao `SessionMeta` — que é justamente o objeto que o `team-uploader` serializa inteiro no push (`sessions: batch`).

`redactSessionText` (`packages/core/src/redact.ts:144`) cobre `first_prompt`, `title`, `user_label`, `user_note`. Não cobre `transcript_text`. O comentário no próprio arquivo antecipa o caso:

> *"Adding a new one to `SessionMeta` without adding it here is how a credential reaches a central through the one field nobody thought of."*

Isso contraria a garantia documentada em CLAUDE.md e `docs/security.md`: **"Members never push chat — only computed metrics + statsCache"**, cuja única exceção é `first_prompt`/`title`.

### 3. Duas rotas com poder de host fora do capability guard

`/api/session-answer` e `/api/session-prompt` digitam texto numa sessão viva e **aprovam diálogos de permissão**. Nenhuma das duas está em `capability-guard.ts`. Verificado em execução com `AGENTISTICS_EXPOSURE=public`:

```
POST /api/exec            → 403 {"error":"capability_disabled","capability":"localShell"}
POST /api/session-prompt  → 400 (executa o host)
POST /api/session-answer  → 400 (executa o host)
```

Ou seja: no perfil desenhado para exposição à internet, `/api/exec` é negada e as duas rotas que aprovam permissões passam. CLAUDE.md: *"A route that is not registered is assumed harmless, so a missed registration is a vulnerability, not an oversight."*

Ambas também usam `await req.json()` em vez de `readJsonLimited`, e devolvem `err.message` cru ao cliente em vez de `safeError`.

### 4. `createControlHost` exportado com defaults incorretos

```ts
export function createControlHost(
  initialLang: CliLang = 'pt',
  altScreen: Suspendable = { suspend: fn => fn() },
)
```

- `'pt'` como default contraria *"CLI is English by default; language follows --lang / preferences.lang"*. Sintoma visível: as rotas acima respondem em português numa máquina cujo default é inglês.
- O `suspend` no-op entrega a uma ação que precisa de tty real um wrapper que não suspende nada — e o chamador é um handler HTTP, onde não há tty.

### 5. `getLiveSnapshot` passa a sondar o tmux a cada `/api/data`

O novo bloco chama `createControlHost().sessions()` — o poller que faz `capture-pane` por sessão — em toda construção de `/api/data`. Medido: **5,1 s** por requisição. Além disso sobrescreve `liveSessionActivities[s.id] = 'waiting-approval'` incondicionalmente, atropelando a leitura do event store.

### 6. A tela de sessões da web perdeu o redesign do #182

`SessionsPage.tsx` 1010 → 723 linhas e `RecentSessions.tsx` 2106 → 931. Somem grid/list, ordenação asc/desc, agrupamento por `project`/`repo` e o estado `marked` — exatamente o que o #182 (*"restore the sessions screen redesign — grouping, paging and cards"*) tinha acabado de restaurar. Pelo padrão, é o clobber de checkout compartilhado que o CLAUDE.md descreve.

## Observação sobre versão

`main` está em `1.19.0` e `dev` em `1.18.2`; o merge preserva o `1.19.0` (só o `main` tocou o `package.json`). Como isto remove um feature de uma versão já publicada, cabe um `1.19.1` — deixei para o CI de release.

## Verificação

| Checagem | Resultado |
|---|---|
| `bun tsc --noEmit` no `main` | passa |
| `bun test` no `main` | 4236 pass / 0 fail |
| Busca de transcript em dados reais | 1 de 140 sessões |
| `redactSessionText` cobre `transcript_text` | não |
| Rotas novas no `capability-guard` | não |
| `/api/session-*` sob perfil `public` | executam (enquanto `/api/exec` dá 403) |
| Latência de `/api/data` | 5,1 s |

Os testes continuam verdes **depois** do revert — nenhum teste cobria os caminhos acima.
