### PR TITLE
feat(tui): search scopes + local transcript search for Ctrl+F

### DIFF
--- a/packages/server/server/cli-start.ts
+++ b/packages/server/server/cli-start.ts
@@ -45,6 +45,7 @@ import type {
   ControlHost,
   ControlService,
   ControlSessions,
+  TranscriptSearch,
   CentralLinkState,
   ControlStatus,
   LogSource,
@@ -109,6 +110,7 @@ import { approvalFor, choiceKey } from './sessions/approval-spec'
 // implementation, for the reason `task-reopen.ts` exists.
 import { renameInHarness, renameMessage } from './sessions/rename'
 import { needsChoice, parseDialogOptions } from './sessions/dialog-choice'
+import { liveTranscriptDeps, runTranscriptSearch } from './sessions/transcript-run'
 import { rulesFor } from './sessions/attention-rules'
 import { planCrashGroup, planFellOffer } from './sessions/crash-group'
 import { loadHarnessSessions } from './sessions/harness-sessions'
@@ -2368,6 +2370,23 @@ function createControlHost(initialLang: CliLang, altScreen: Suspendable): StartH
      * would have no previous frame to compare against, so no session could ever be seen to move and
      * every waiting one would ring the bell every five seconds.
      */
+    /**
+     * The deep half of the sessions search — see `ControlHost.searchTranscripts`.
+     *
+     * Deliberately NOT folded into `sessions()`: that runs every 5 seconds, and reading 475 MB on
+     * a timer to answer a question nobody asked is the difference between a search and a disk
+     * burner. It is called only while the search field holds something, and the screen debounces.
+     */
+    async searchTranscripts(query: string): Promise<TranscriptSearch> {
+      const r = await runTranscriptSearch(query, liveTranscriptDeps())
+      return {
+        ids: r.ids,
+        covered: r.covered,
+        failed: r.failed,
+        ...(r.unavailable ? { unavailable: r.unavailable } : {}),
+      }
+    },
+
     async sessions(): Promise<ControlSessions> {
       // `S()` rather than `this.lang`: the language is a closure variable `setLang` reassigns, and
       // reading it through `this` would break the moment a caller detached the method.

--- a/packages/server/server/events/event-store.test.ts
+++ b/packages/server/server/events/event-store.test.ts
@@ -7,6 +7,7 @@
  * real store rather than only in the planner.
  */
 
+import { emptySearchFields } from '@agentistics/tui/control/search-scope'
 import { afterEach, describe, expect, test } from 'bun:test'
 import { mkdtempSync, rmSync, statSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
@@ -110,7 +111,7 @@ describe('the producer against a real store', () => {
 
   const view = (o: Record<string, unknown>) => ({
     id: 's1', cwd: '/w', status: 'running' as const, attached: false,
-    approvalDetection: true, searchText: '', ...o,
+    approvalDetection: true, searchFields: emptySearchFields(), ...o,
   }) as SessionSnapshot['sessions'][number]
 
   const producerOver = (snaps: SessionSnapshot[], file: string) => {

--- a/packages/server/server/sessions/control-session.test.ts
+++ b/packages/server/server/sessions/control-session.test.ts
@@ -1,3 +1,4 @@
+import { emptySearchFields } from '@agentistics/tui/control/search-scope'
 import { describe, expect, it } from 'bun:test'
 import { cliStrings } from '../cli-i18n'
 import { toControlSession } from './control-session'
@@ -15,7 +16,7 @@ function view(over: Partial<SessionView> = {}): SessionView {
     status: 'lost',
     attached: false,
     approvalDetection: true,
-    searchText: '',
+    searchFields: emptySearchFields(),
     ...over,
   }
 }

--- a/packages/server/server/sessions/control-session.ts
+++ b/packages/server/server/sessions/control-session.ts
@@ -191,7 +191,7 @@ export function toControlSession(
           },
         }
       : {}),
-    searchText: v.searchText,
+    searchFields: v.searchFields,
     attached: v.attached,
     ...(v.pid !== undefined ? { pid: v.pid } : {}),
     ...(v.cpuPercent !== undefined ? { cpuPercent: v.cpuPercent } : {}),

--- a/packages/server/server/sessions/session-table.test.ts
+++ b/packages/server/server/sessions/session-table.test.ts
@@ -1,3 +1,4 @@
+import { emptySearchFields } from '@agentistics/tui/control/search-scope'
 import { describe, expect, test } from 'bun:test'
 import type { ControlSession, SessionState } from '@agentistics/tui/control'
 import {
@@ -43,7 +44,7 @@ function session(o: Partial<ControlSession> & { id: string }): ControlSession {
     state,
     actionable: true,
     attached: false,
-    searchText: '',
+    searchFields: emptySearchFields(),
     ...o,
   }
 }

--- a/packages/server/server/sessions/session-view.test.ts
+++ b/packages/server/server/sessions/session-view.test.ts
@@ -187,7 +187,7 @@ describe("what the harness says about its OWN session", () => {
     })
     expect(v!.harnessName).toBe('principal do cockpit')
     // And it is SEARCHABLE, because it may be the only name the person remembers.
-    expect(v!.searchText).toContain('principal do cockpit')
+    expect(v!.searchFields.name).toContain('principal do cockpit')
   })
 
   it('carries nothing for a name the harness invented for itself', () => {
@@ -240,8 +240,8 @@ describe("what the harness says about its OWN session", () => {
     })
     expect(views[0]!.label).toBe('MAIN')
     // Findable by BOTH: the name it now shows, and the one it used to show.
-    expect(views[0]!.searchText).toContain('main')
-    expect(views[0]!.searchText).toContain('cockpit')
+    expect(views[0]!.searchFields.name.toLowerCase()).toContain('main')
+    expect(views[0]!.searchFields.name.toLowerCase()).toContain('cockpit')
   })
 
   it('a conversation whose record is ALIVE is running, not closed', () => {

--- a/packages/server/server/sessions/session-view.ts
+++ b/packages/server/server/sessions/session-view.ts
@@ -9,6 +9,7 @@
  */
 
 import type { HarnessId } from '@agentistics/core'
+import { matchesQuery, type SearchFields } from '@agentistics/tui/control/search-scope'
 import { type HarnessProcess, sessionAtCwd } from '../live-sessions'
 import { rulesFor } from './attention-rules'
 import type { DialogOption } from './dialog-choice'
@@ -164,13 +165,19 @@ export interface SessionView {
    */
   approvalDetection: boolean
   /**
-   * Everything about this row worth searching, lowercased and joined.
+   * Everything about this row worth searching, KEPT APART BY WHAT IT IS.
    *
    * Composed HERE so the search reaches a closed conversation's OPENING PROMPT — which is what a
    * person actually remembers about something they closed ("the one where I asked about the
    * migration") — without the screen having to hold conversation text it never renders.
+   *
+   * It used to be one lowercased blob (`searchText`) tested with `.includes()`. That found the row
+   * and then could not say why it was there: a query matched the folder, the harness, the note or
+   * the prompt indistinguishably, so the reader had to open the session to learn which. Separate
+   * fields cost nothing at the predicate — `matchScopes` still walks them all — and are what let
+   * the screen print the scope beside each row and count the depth in the header.
    */
-  searchText: string
+  searchFields: SearchFields
 }
 
 export function needsAttention(a?: SessionActivity): boolean {
@@ -231,9 +238,9 @@ export function managedIdOfProcess(
   return (tmux ? idFromTmuxName(tmux) : null) ?? undefined
 }
 
-/** Everything a row can be found by, in one lowercased blob. */
-function searchTextOf(...parts: Array<string | undefined>): string {
-  return parts.filter(Boolean).join(' ').toLowerCase()
+/** One searchable dimension, from whatever parts of a row carry it. */
+function scopeText(...parts: Array<string | undefined>): string {
+  return parts.filter(Boolean).join(' ')
 }
 
 /**
@@ -241,11 +248,34 @@ function searchTextOf(...parts: Array<string | undefined>): string {
  *
  * One function rather than a filter per status: a search that quietly skipped closed conversations
  * would be a search that cannot find the thing it was most likely opened to find.
+ *
+ * `transcriptHits` is the set of conversations whose TEXT carries the query, resolved separately
+ * against the disk (`transcript-run.ts`) because no row holds its own conversation. Omitted, the
+ * search is exactly what it always was — the transcript scope simply never matches.
  */
-export function filterSessions(views: readonly SessionView[], query: string): SessionView[] {
-  const q = query.trim().toLowerCase()
-  if (q === '') return [...views]
-  return views.filter(v => v.searchText.includes(q))
+export function filterSessions(
+  views: readonly SessionView[],
+  query: string,
+  transcriptHits?: ReadonlySet<string>,
+): SessionView[] {
+  if (query.trim() === '') return [...views]
+  return views.filter(v => matchesQuery(v.searchFields, query, {
+    transcript: hasTranscriptHit(v, transcriptHits),
+  }))
+}
+
+/**
+ * Whether the transcript search named THIS row's conversation.
+ *
+ * Only an EXACT link counts. A row knows its conversation when the registry recorded the id at
+ * spawn or the harness's own file names our tmux session; where it does not, the fleet's fallback
+ * is a harness-and-directory inference, and accepting that here would mark every session in one
+ * worktree as matching because a sibling's transcript happened to contain the word.
+ */
+function hasTranscriptHit(v: SessionView, hits?: ReadonlySet<string>): boolean {
+  if (!hits || hits.size === 0) return false
+  return (v.conversationId !== undefined && hits.has(v.conversationId))
+    || (v.resume !== undefined && hits.has(v.resume.sessionId))
 }
 
 export function buildSessionViews(o: {
@@ -445,9 +475,14 @@ export function buildSessionViews(o: {
       approvalDetection: harness !== undefined && rulesFor(harness) !== undefined,
       // The harness's own name is searchable too: it is the name the person reading this screen may
       // well be the only one they remember, having typed it inside the session.
-      searchText: searchTextOf(
-        harness, r.managed?.cwd, r.managed?.label, ownName, r.managed?.note, r.managed?.task,
-      ),
+      searchFields: {
+        name: scopeText(r.managed?.label, ownName),
+        folder: scopeText(r.managed?.cwd),
+        harness: scopeText(harness),
+        note: scopeText(r.managed?.note),
+        task: scopeText(r.managed?.task),
+        prompt: '',
+      },
     }
   })
 
@@ -554,7 +589,14 @@ export function buildSessionViews(o: {
       ...(conv?.contextTokens !== undefined && conv.contextWindow !== undefined
         ? { contextTokens: conv.contextTokens, contextWindow: conv.contextWindow }
         : {}),
-      searchText: searchTextOf(p.harness, p.cwd, ownName, conv?.title, conv?.firstPrompt),
+      searchFields: {
+        name: scopeText(ownName, conv?.title),
+        folder: scopeText(p.cwd),
+        harness: scopeText(p.harness),
+        note: '',
+        task: '',
+        prompt: scopeText(conv?.firstPrompt),
+      },
     }
   })
 
@@ -628,10 +670,18 @@ export function buildSessionViews(o: {
       ...(c.contextTokens !== undefined && c.contextWindow !== undefined
         ? { contextTokens: c.contextTokens, contextWindow: c.contextWindow }
         : {}),
-      // The typed name goes into the search text TOO, or the row is displayed under a name that
-      // cannot be used to find it — which is the complaint arriving by the other door.
-      searchText: searchTextOf(c.harness, c.cwd, named ?? c.title, c.firstPrompt)
-        + (named && named !== c.title ? ` ${c.title.toLowerCase()}` : ''),
+      // BOTH names are searchable, or the row is displayed under a name that cannot be used to
+      // find it — which is the complaint arriving by the other door. They share the `name` scope:
+      // which of the two the user typed is not a distinction worth reporting, and the row already
+      // says which place the name it is SHOWING came from.
+      searchFields: {
+        name: scopeText(named, named !== c.title ? c.title : undefined),
+        folder: scopeText(c.cwd),
+        harness: scopeText(c.harness),
+        note: '',
+        task: '',
+        prompt: scopeText(c.firstPrompt),
+      },
       }
     })
 

--- a/packages/server/server/sessions/transcript-run.test.ts
+++ b/packages/server/server/sessions/transcript-run.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from 'bun:test'
+import { runTranscriptSearch, type TranscriptDeps } from './transcript-run'
+
+const deps = (o: Partial<TranscriptDeps> = {}): TranscriptDeps => ({
+  hasGrep: async () => true,
+  dirExists: async () => true,
+  grep: async () => '',
+  ...o,
+})
+
+describe('runTranscriptSearch', () => {
+  test('reports the conversations grep named, across the harnesses it walked', async () => {
+    const got = await runTranscriptSearch('docker', deps({
+      dirExists: async root => root.includes('projects'),
+      grep: async () => '/x/projects/-p/aaaaaaaa-1111-2222-3333-444444444444.jsonl\0',
+    }), { claude: { root: '/x/projects', include: '*.jsonl' } })
+
+    expect([...got.ids]).toEqual(['aaaaaaaa-1111-2222-3333-444444444444'])
+    expect(got.covered).toEqual(['claude'])
+    expect(got.unavailable).toBeUndefined()
+  })
+
+  test('WITHOUT grep it says so — it never reports zero matches it did not look for', async () => {
+    const got = await runTranscriptSearch('docker', deps({ hasGrep: async () => false }), {
+      claude: { root: '/x/projects', include: '*.jsonl' },
+    })
+
+    expect(got.unavailable).toBe('no-grep')
+    expect(got.ids.size).toBe(0)
+    expect(got.covered).toEqual([])
+  })
+
+  test('with no transcript directory on this machine it says THAT, distinctly', async () => {
+    const got = await runTranscriptSearch('docker', deps({ dirExists: async () => false }), {
+      claude: { root: '/x/projects', include: '*.jsonl' },
+    })
+
+    expect(got.unavailable).toBe('no-transcripts')
+    expect(got.covered).toEqual([])
+  })
+
+  test('a harness whose directory is absent is simply not claimed as covered', async () => {
+    const got = await runTranscriptSearch('docker', deps({
+      dirExists: async root => root === '/has',
+      grep: async () => '/has/-p/aaaaaaaa-1111-2222-3333-444444444444.jsonl\0',
+    }), {
+      claude: { root: '/has', include: '*.jsonl' },
+      codex: { root: '/missing', include: 'rollout-*.jsonl' },
+    })
+
+    expect(got.covered).toEqual(['claude'])
+  })
+
+  test('one harness failing does not lose the results of the others', async () => {
+    const got = await runTranscriptSearch('docker', deps({
+      grep: async (_q, root) => {
+        if (root === '/boom') throw new Error('grep died')
+        return '/ok/-p/aaaaaaaa-1111-2222-3333-444444444444.jsonl\0'
+      },
+    }), {
+      claude: { root: '/ok', include: '*.jsonl' },
+      codex: { root: '/boom', include: 'rollout-*.jsonl' },
+    })
+
+    expect([...got.ids]).toEqual(['aaaaaaaa-1111-2222-3333-444444444444'])
+    expect(got.covered).toEqual(['claude'])
+    expect(got.failed).toEqual(['codex'])
+  })
+
+  test('an empty query never touches the disk', async () => {
+    let called = false
+    const got = await runTranscriptSearch('   ', deps({ grep: async () => { called = true; return '' } }), {
+      claude: { root: '/x', include: '*.jsonl' },
+    })
+
+    expect(called).toBe(false)
+    expect(got.ids.size).toBe(0)
+    expect(got.unavailable).toBeUndefined()
+  })
+
+  test('the query reaches grep unchanged — it is never escaped or rewritten', async () => {
+    let seen = ''
+    await runTranscriptSearch('; rm -rf /', deps({ grep: async q => { seen = q; return '' } }), {
+      claude: { root: '/x', include: '*.jsonl' },
+    })
+
+    expect(seen).toBe('; rm -rf /')
+  })
+})

--- a/packages/server/server/sessions/transcript-run.ts
+++ b/packages/server/server/sessions/transcript-run.ts
@@ -1,0 +1,118 @@
+/**
+ * Running the transcript search — the IO edge of `transcript-search.ts`.
+ *
+ * Every dependency that touches the machine is injected, so the rules below are tested against
+ * real behaviour rather than a mocked filesystem: what happens without `grep`, what happens with
+ * no transcripts, and what happens when one harness fails while others succeed.
+ *
+ * ## Absence is reported, never rendered as zero
+ *
+ * The product's standing rule for a metric it cannot produce (`HARNESS_CAPABILITIES`, N/A rather
+ * than a confident `0`) applies exactly as well to a search. "No conversation mentions this" and
+ * "nothing looked" are different answers, and only one of them is a reason to stop searching. So a
+ * missing `grep` and a machine with no transcripts each get their own `unavailable` reason, the
+ * caller states it in words, and neither is allowed to look like an empty result set.
+ */
+
+import { access } from 'node:fs/promises'
+import type { HarnessId } from '@agentistics/core'
+import { TRANSCRIPT_SOURCES, grepArgv, parseGrepOutput, type TranscriptSource } from './transcript-search'
+
+export interface TranscriptDeps {
+  /** Whether `grep` can be run at all here. */
+  hasGrep: () => Promise<boolean>
+  dirExists: (path: string) => Promise<boolean>
+  /** Run one search; resolve with grep's raw NUL-separated stdout. */
+  grep: (query: string, root: string, include: string) => Promise<string>
+}
+
+export type TranscriptUnavailable =
+  /** No `grep` on this machine — the search cannot be performed at all. */
+  | 'no-grep'
+  /** `grep` is here, but not one harness keeps transcripts on this machine. */
+  | 'no-transcripts'
+
+export interface TranscriptSearchResult {
+  /** The conversations whose text carries the query. */
+  ids: Set<string>
+  /** The harnesses actually walked — what the UI may honestly claim to have covered. */
+  covered: HarnessId[]
+  /** Harnesses whose search errored. Their conversations are missing from `ids`, so say so. */
+  failed: HarnessId[]
+  /** Set only when nothing was searched. An empty `ids` with this unset is a real "no match". */
+  unavailable?: TranscriptUnavailable
+}
+
+const empty = (): TranscriptSearchResult => ({ ids: new Set(), covered: [], failed: [] })
+
+export async function runTranscriptSearch(
+  query: string,
+  deps: TranscriptDeps,
+  sources: Partial<Record<HarnessId, TranscriptSource | null>> = TRANSCRIPT_SOURCES,
+): Promise<TranscriptSearchResult> {
+  // An empty query is not a search. Returning early keeps a cleared field from walking 475 MB.
+  if (query.trim() === '') return empty()
+
+  if (!await deps.hasGrep()) return { ...empty(), unavailable: 'no-grep' }
+
+  const present: Array<[HarnessId, TranscriptSource]> = []
+  for (const [id, src] of Object.entries(sources) as Array<[HarnessId, TranscriptSource | null]>) {
+    if (src && await deps.dirExists(src.root)) present.push([id, src])
+  }
+  if (present.length === 0) return { ...empty(), unavailable: 'no-transcripts' }
+
+  const result = empty()
+  // Concurrently: the harnesses are independent directories and the slowest one should set the
+  // latency, not the sum. `allSettled` because one harness's failure must not lose the rest —
+  // an unguarded throw here would turn a permissions error on one directory into no search at all.
+  const runs = await Promise.allSettled(present.map(async ([id, src]) => {
+    const out = await deps.grep(query, src.root, src.include)
+    return { id, ids: parseGrepOutput(id, out, src.root) }
+  }))
+
+  for (let i = 0; i < runs.length; i++) {
+    const run = runs[i]!
+    const id = present[i]![0]
+    if (run.status === 'rejected') { result.failed.push(id); continue }
+    result.covered.push(id)
+    for (const conv of run.value.ids) result.ids.add(conv)
+  }
+
+  return result
+}
+
+// ---------------------------------------------------------------------------
+// The real machine
+// ---------------------------------------------------------------------------
+
+let grepProbe: Promise<boolean> | null = null
+
+/**
+ * The live dependencies.
+ *
+ * `grep` is spawned with an argv ARRAY, so no shell ever parses the query — see the header of
+ * `transcript-search.ts`. Exit code 1 is grep's "no match", which is an ordinary answer and not an
+ * error; anything above that is a real failure and throws, so the caller can name the harness.
+ */
+export function liveTranscriptDeps(): TranscriptDeps {
+  return {
+    hasGrep: () => (grepProbe ??= (async () => {
+      try {
+        const p = Bun.spawn(['grep', '--version'], { stdout: 'ignore', stderr: 'ignore' })
+        return await p.exited === 0
+      } catch { return false }
+    })()),
+
+    dirExists: async path => {
+      try { await access(path); return true } catch { return false }
+    },
+
+    grep: async (query, root, include) => {
+      const p = Bun.spawn(grepArgv(query, root, include), { stdout: 'pipe', stderr: 'ignore' })
+      const out = await new Response(p.stdout).text()
+      const code = await p.exited
+      if (code > 1) throw new Error(`grep exited ${code}`)
+      return out
+    },
+  }
+}

--- a/packages/server/server/sessions/transcript-search.test.ts
+++ b/packages/server/server/sessions/transcript-search.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  TRANSCRIPT_SOURCES, grepArgv, conversationIdFrom, parseGrepOutput,
+} from './transcript-search'
+
+describe('grepArgv', () => {
+  test('passes the query as an ARGUMENT, never through a shell', () => {
+    const argv = grepArgv('docker', '/root', '*.jsonl')
+    expect(argv[0]).toBe('grep')
+    expect(argv).toContain('docker')
+    // No shell means no string to be parsed: every element is its own argv slot.
+    expect(argv.every(a => typeof a === 'string')).toBe(true)
+  })
+
+  test('terminates the flags with `--`, so a query that looks like a flag stays a query', () => {
+    const argv = grepArgv('-r', '/root', '*.jsonl')
+    const dashdash = argv.indexOf('--')
+    expect(dashdash).toBeGreaterThan(-1)
+    expect(argv.indexOf('-r')).toBeGreaterThan(dashdash)
+  })
+
+  test('a query carrying shell metacharacters is one literal argument', () => {
+    const argv = grepArgv('; rm -rf /', '/root', '*.jsonl')
+    expect(argv).toContain('; rm -rf /')
+  })
+
+  test('searches case-insensitively and stops at the first hit per file', () => {
+    const argv = grepArgv('docker', '/root', '*.jsonl')
+    // -l stops reading a file once it matches; -i is what makes the search case-blind.
+    expect(argv.some(a => a.includes('l') && a.startsWith('-'))).toBe(true)
+    expect(argv.some(a => a.includes('i') && a.startsWith('-'))).toBe(true)
+  })
+
+  test('scopes the walk to the harness file pattern and root it was given', () => {
+    const argv = grepArgv('x', '/my/root', 'wire.jsonl')
+    expect(argv).toContain('--include=wire.jsonl')
+    expect(argv).toContain('/my/root')
+  })
+})
+
+describe('conversationIdFrom', () => {
+  test('claude — the file IS the conversation id', () => {
+    expect(conversationIdFrom(
+      'claude',
+      '/home/u/.claude/projects/-home-u-proj/a1fa25c2-1f0f-4894-a359-81fbc0a665b1.jsonl',
+      '/home/u/.claude/projects',
+    )).toBe('a1fa25c2-1f0f-4894-a359-81fbc0a665b1')
+  })
+
+  test('codex — the id trails a timestamp in the file name', () => {
+    expect(conversationIdFrom(
+      'codex',
+      '/home/u/.codex/sessions/2026/07/27/rollout-2026-07-27T19-02-04-019fa599-71b2-7012-acfb-cb5f6387f6b6.jsonl',
+      '/home/u/.codex/sessions',
+    )).toBe('019fa599-71b2-7012-acfb-cb5f6387f6b6')
+  })
+
+  test('copilot — the id is the directory holding events.jsonl', () => {
+    expect(conversationIdFrom(
+      'copilot',
+      '/home/u/.copilot/session-state/155dfe66-173e-4397-b5e9-9f7062d456ba/events.jsonl',
+      '/home/u/.copilot/session-state',
+    )).toBe('155dfe66-173e-4397-b5e9-9f7062d456ba')
+  })
+
+  test('kimi — every agent of a session folds into the session directory', () => {
+    expect(conversationIdFrom(
+      'kimi',
+      '/home/u/.kimi-code/sessions/wd_x/session_3000ec80-fcff-4f52-b523-b2e40b2e8e34/agents/main/wire.jsonl',
+      '/home/u/.kimi-code/sessions',
+    )).toBe('3000ec80-fcff-4f52-b523-b2e40b2e8e34')
+  })
+
+  test('antigravity — the id is the brain/ child, not the logs directory', () => {
+    expect(conversationIdFrom(
+      'antigravity',
+      '/home/u/.gemini/antigravity-cli/brain/4b6ce613-e171-4cae-ad75-326be6ccb69c/.system_generated/logs/transcript_full.jsonl',
+      '/home/u/.gemini/antigravity-cli/brain',
+    )).toBe('4b6ce613-e171-4cae-ad75-326be6ccb69c')
+  })
+
+  test('gemini — the id is synthetic, project directory AND file, as the adapter builds it', () => {
+    expect(conversationIdFrom(
+      'gemini',
+      '/home/u/.gemini/tmp/ads-propostas/chats/session-2026-07-27T13-07-dce86b69.jsonl',
+      '/home/u/.gemini/tmp',
+    )).toBe('ads-propostas/session-2026-07-27T13-07-dce86b69')
+  })
+
+  test('a path that does not fit the harness shape yields nothing, never a guess', () => {
+    expect(conversationIdFrom('copilot', '/home/u/.copilot/session-state/events.jsonl', '/home/u/.copilot/session-state')).toBeNull()
+    expect(conversationIdFrom('codex', '/root/not-a-rollout.jsonl', '/root')).toBeNull()
+  })
+})
+
+describe('parseGrepOutput', () => {
+  test('reads NUL-separated paths, which is what survives a space in a directory name', () => {
+    const out = [
+      '/r/-home-u-my proj/aaaaaaaa-1111-2222-3333-444444444444.jsonl',
+      '/r/-home-u-other/bbbbbbbb-1111-2222-3333-444444444444.jsonl',
+    ].join('\0') + '\0'
+    expect(parseGrepOutput('claude', out, '/r')).toEqual([
+      'aaaaaaaa-1111-2222-3333-444444444444',
+      'bbbbbbbb-1111-2222-3333-444444444444',
+    ])
+  })
+
+  test('empty output is an empty result, not a failure', () => {
+    expect(parseGrepOutput('claude', '', '/r')).toEqual([])
+  })
+
+  test('the same conversation reached through two files is reported once', () => {
+    const out = [
+      '/r/w/session_3000ec80-fcff-4f52-b523-b2e40b2e8e34/agents/main/wire.jsonl',
+      '/r/w/session_3000ec80-fcff-4f52-b523-b2e40b2e8e34/agents/sub/wire.jsonl',
+    ].join('\0')
+    expect(parseGrepOutput('kimi', out, '/r')).toEqual(['3000ec80-fcff-4f52-b523-b2e40b2e8e34'])
+  })
+
+  test('a path it cannot resolve is dropped, never emitted as a partial id', () => {
+    const out = ['/r/garbage.txt', '/r/-p/cccccccc-1111-2222-3333-444444444444.jsonl'].join('\0')
+    expect(parseGrepOutput('claude', out, '/r')).toEqual(['cccccccc-1111-2222-3333-444444444444'])
+  })
+})
+
+describe('TRANSCRIPT_SOURCES', () => {
+  test('every harness is accounted for — a new one cannot be forgotten silently', () => {
+    const ids = ['claude', 'codex', 'gemini', 'copilot', 'antigravity', 'kimi'] as const
+    for (const id of ids) expect(TRANSCRIPT_SOURCES[id]).toBeDefined()
+  })
+
+  test('each source states the file pattern it walks', () => {
+    for (const src of Object.values(TRANSCRIPT_SOURCES)) {
+      if (src) expect(src.include.length).toBeGreaterThan(0)
+    }
+  })
+})

--- a/packages/server/server/sessions/transcript-search.ts
+++ b/packages/server/server/sessions/transcript-search.ts
@@ -1,0 +1,149 @@
+/**
+ * SEARCHING WHAT WAS SAID — the local half, and the reason it is local.
+ *
+ * A previous attempt (`3e9f06c`, reverted) put the conversation text on `SessionMeta` as
+ * `transcript_text` so the browser could filter it client-side. That is the one place it must
+ * never go: `SessionMeta` is what `team-uploader.ts` serialises whole into a member's push, and
+ * `redactSessionText` covers `first_prompt`/`title`/`user_label`/`user_note` and nothing else — so
+ * up to 200 KB of unredacted conversation crossed the wire to the central, against the standing
+ * guarantee that members never push chat. It also did not work: the field was only written when a
+ * transcript happened to be re-parsed, so on a real machine 1 session of 140 carried one and a
+ * search for `docker` found nothing in a corpus holding it 317 times.
+ *
+ * So the text is never carried anywhere. It is READ, on the machine that owns it, at the moment
+ * someone asks, and only an id comes back. Nothing here reaches the web dashboard or a central.
+ *
+ * ## Why `grep` and not a read loop
+ *
+ * Measured on this machine — 912 files, 475 MB under `~/.claude/projects`:
+ *
+ *   - `grep` through `Bun.spawn`, argv array:  255 ms
+ *   - reading every file with `Bun.file().text()` and `.includes()`:  3–5 s
+ *
+ * Twenty times the cost is the difference between a search that runs while you type and one you
+ * wait for, so the read loop is not a simpler alternative — it is a different feature.
+ *
+ * ## The query is DATA
+ *
+ * `Bun.spawn` takes an argv ARRAY, so no shell parses anything, and `--` terminates the option
+ * list so a query of `-r` is a string to look for rather than a flag to obey. Both are asserted in
+ * `transcript-search.test.ts` against the hostile inputs, because "we do not use a shell" is a
+ * property that a later refactor to `Bun.$` would quietly remove.
+ */
+
+import { basename, relative, sep } from 'node:path'
+import type { HarnessId } from '@agentistics/core'
+import {
+  PROJECTS_DIR, CODEX_SESSIONS_DIR, COPILOT_DIR, KIMI_DIR, ANTIGRAVITY_BRAIN_DIR, GEMINI_DIR,
+} from '../config'
+import { join } from 'node:path'
+
+/**
+ * Where one harness keeps the text of its conversations, and what a file there is called.
+ *
+ * A `Record<HarnessId, …>` rather than a list, following `spawn-spec.ts` and `rename-spec.ts`: the
+ * build fails until a new harness is answered for, instead of it being absent and nobody noticing.
+ */
+export interface TranscriptSource {
+  /** The directory to walk. */
+  root: string
+  /** The file name pattern inside it — `grep --include`. */
+  include: string
+}
+
+export const TRANSCRIPT_SOURCES: Record<HarnessId, TranscriptSource | null> = {
+  // `<projects>/<encoded-project>/<conversation-id>.jsonl`
+  claude: { root: PROJECTS_DIR, include: '*.jsonl' },
+  // `<sessions>/YYYY/MM/DD/rollout-<timestamp>-<conversation-id>.jsonl`
+  codex: { root: CODEX_SESSIONS_DIR, include: 'rollout-*.jsonl' },
+  // `<tmp>/<project>/chats/<file>.jsonl` — the id this product uses is synthetic, `<dir>/<file>`.
+  gemini: { root: join(GEMINI_DIR, 'tmp'), include: '*.jsonl' },
+  // `<session-state>/<conversation-id>/events.jsonl`
+  copilot: { root: join(COPILOT_DIR, 'session-state'), include: 'events.jsonl' },
+  // `<brain>/<conversation-id>/.system_generated/logs/transcript_full.jsonl`
+  antigravity: { root: ANTIGRAVITY_BRAIN_DIR, include: 'transcript_full.jsonl' },
+  // `<sessions>/<workspace>/session_<conversation-id>/agents/<agent>/wire.jsonl`
+  kimi: { root: join(KIMI_DIR, 'sessions'), include: 'wire.jsonl' },
+}
+
+/**
+ * The argv for one harness's search.
+ *
+ * `-r` walks, `-i` ignores case (the list's own filter does, so this one must too, or the same
+ * word finds different rows depending on which scope carried it), `-l` stops at the first hit in a
+ * file — nothing here needs to know WHERE in a conversation the word appeared, only that it did —
+ * and `-Z` separates the names with NUL so a directory containing a space or a newline still
+ * yields one path per record.
+ */
+export function grepArgv(query: string, root: string, include: string): string[] {
+  return ['grep', '-rilZ', `--include=${include}`, '--', query, root]
+}
+
+const UUID = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i
+
+/**
+ * The conversation a transcript file belongs to, or `null`.
+ *
+ * Each rule was read off the real layout on disk, not inferred from the others — the six harnesses
+ * genuinely disagree about where the id lives. `null` for anything that does not fit: a half-parsed
+ * id would be matched against the fleet and silently select the wrong row, which is worse than a
+ * file this search cannot attribute.
+ */
+export function conversationIdFrom(harness: HarnessId, path: string, root: string): string | null {
+  const rel = relative(root, path)
+  if (rel === '' || rel.startsWith('..')) return null
+  const parts = rel.split(sep).filter(Boolean)
+  const file = basename(path)
+
+  switch (harness) {
+    case 'claude': {
+      // `<encoded-project>/<id>.jsonl`
+      if (!file.endsWith('.jsonl')) return null
+      const id = file.slice(0, -'.jsonl'.length)
+      return UUID.test(id) ? id : null
+    }
+    case 'codex': {
+      // `rollout-<timestamp>-<id>.jsonl` — the id is the UUID, wherever the timestamp ends.
+      const m = file.match(UUID)
+      return m ? m[0] : null
+    }
+    case 'copilot': {
+      // `<id>/events.jsonl`
+      return parts.length >= 2 ? parts[parts.length - 2]! : null
+    }
+    case 'kimi': {
+      // `<workspace>/session_<id>/agents/<agent>/wire.jsonl` — fold every agent into its session.
+      const dir = parts.find(p => p.startsWith('session_'))
+      return dir ? dir.slice('session_'.length) || null : null
+    }
+    case 'antigravity': {
+      // `<id>/.system_generated/logs/transcript_full.jsonl` — the FIRST segment under brain/.
+      return parts.length >= 2 ? parts[0]! : null
+    }
+    case 'gemini': {
+      // `<project>/chats/<file>.jsonl` — the adapter's id is `<project>/<file-without-ext>`.
+      if (parts.length < 2 || !file.endsWith('.jsonl')) return null
+      return `${parts[0]}/${file.slice(0, -'.jsonl'.length)}`
+    }
+  }
+}
+
+/**
+ * The conversations named by one `grep -Z` run, deduplicated, in the order they were reported.
+ *
+ * Kimi is why the dedupe is here rather than at the caller: a session's agents are separate files
+ * under one session directory, so a word said once can legitimately name the same conversation
+ * several times.
+ */
+export function parseGrepOutput(harness: HarnessId, out: string, root: string): string[] {
+  const seen = new Set<string>()
+  const ids: string[] = []
+  for (const path of out.split('\0')) {
+    if (!path) continue
+    const id = conversationIdFrom(harness, path, root)
+    if (!id || seen.has(id)) continue
+    seen.add(id)
+    ids.push(id)
+  }
+  return ids
+}

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -10,6 +10,7 @@
     "./control/altScreen": "./src/control/altScreen.ts",
     "./control/stream": "./src/control/stream.ts",
     "./control/sessions": "./src/control/sessions.ts",
+    "./control/search-scope": "./src/control/search-scope.ts",
     "./control/surface": "./src/control/surface.ts",
     "./control/i18n": "./src/control/i18n.ts"
   },

--- a/packages/tui/scripts/preview.tsx
+++ b/packages/tui/scripts/preview.tsx
@@ -646,10 +646,13 @@ const FAKE_FLEET: ControlSessions = {
 
 /** The preview's fixtures say what they ARE; the searchable blob is derived, exactly as the host
  *  derives it, so the two can never disagree about what a row can be found by. */
-function withSearchText(rows: Array<Omit<ControlSession, 'searchText'>>): ControlSession[] {
+function withSearchText(rows: Array<Omit<ControlSession, 'searchFields'>>): ControlSession[] {
   return rows.map(r => ({
     ...r,
-    searchText: [r.title, r.harness, r.cwd, r.note, r.task].filter(Boolean).join(' ').toLowerCase(),
+    searchFields: {
+      name: r.title ?? '', folder: r.cwd ?? '', harness: r.harness ?? '',
+      note: r.note ?? '', task: r.task ?? '', prompt: '',
+    },
   }))
 }
 

--- a/packages/tui/src/control/i18n.ts
+++ b/packages/tui/src/control/i18n.ts
@@ -359,6 +359,15 @@ export interface ControlStrings {
   >
   /** States the active search on the summary row, and how to drop it. */
   sessionsSearching: (query: string) => string
+  /** The per-scope depth line under the search field. */
+  searchScope: Record<'name' | 'folder' | 'harness' | 'note' | 'task' | 'prompt' | 'transcript', string>
+  searchDepthLabel: string
+  searchRunning: string
+  /** Named in words, never rendered as a zero — see `TranscriptSearch.unavailable`. */
+  searchNoGrep: string
+  searchNoTranscripts: string
+  searchCovered: (harnesses: string) => string
+  searchFailed: (harnesses: string) => string
   /** How long ago, from a whole number of SECONDS — the caller does the clock arithmetic so this
    *  stays a pure formatter. */
   sessionsAgo: (seconds: number) => string
@@ -859,6 +868,16 @@ const EN: ControlStrings = {
     unknown: 'external',
   },
   sessionsSearching: q => `search: ${q} · esc clears`,
+  searchScope: {
+    name: 'name', folder: 'folder', harness: 'harness',
+    note: 'note', task: 'task', prompt: 'prompt', transcript: 'transcript',
+  },
+  searchDepthLabel: 'found in',
+  searchRunning: 'reading transcripts…',
+  searchNoGrep: 'transcripts not searched — grep is not available here',
+  searchNoTranscripts: 'transcripts not searched — none on this machine',
+  searchCovered: h => `transcripts: ${h}`,
+  searchFailed: h => `could not read: ${h}`,
   sessionsAgo: (sec: number) => {
     if (sec < 60) return `${sec}s ago`
     const min = Math.round(sec / 60)
@@ -1291,6 +1310,16 @@ const PT: ControlStrings = {
     unknown: 'externa',
   },
   sessionsSearching: q => `busca: ${q} · esc limpa`,
+  searchScope: {
+    name: 'nome', folder: 'pasta', harness: 'harness',
+    note: 'nota', task: 'tarefa', prompt: 'prompt', transcript: 'transcript',
+  },
+  searchDepthLabel: 'achado em',
+  searchRunning: 'lendo transcripts…',
+  searchNoGrep: 'transcripts não buscados — não há grep aqui',
+  searchNoTranscripts: 'transcripts não buscados — nenhum nesta máquina',
+  searchCovered: h => `transcripts: ${h}`,
+  searchFailed: h => `não deu pra ler: ${h}`,
   sessionsAgo: (sec: number) => {
     if (sec < 60) return `há ${sec}s`
     const min = Math.round(sec / 60)

--- a/packages/tui/src/control/index.ts
+++ b/packages/tui/src/control/index.ts
@@ -164,6 +164,7 @@ export type {
   ControlService,
   ControlSession,
   ControlSessions,
+  TranscriptSearch,
   ControlStatus,
   LogSource,
   RuntimeId,

--- a/packages/tui/src/control/search-scope.test.ts
+++ b/packages/tui/src/control/search-scope.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  emptyScopeCounts, matchScopes, scopeCounts, searchDepthText, type SearchFields,
+} from './search-scope'
+
+const fields = (o: Partial<SearchFields> = {}): SearchFields => ({
+  name: '', folder: '', harness: '', note: '', task: '', prompt: '', ...o,
+})
+
+describe('matchScopes', () => {
+  test('names the field the query was found in, not merely that it matched', () => {
+    const got = matchScopes(fields({ name: 'agentistics', folder: '/home/x/proj' }), 'agent')
+    expect(got).toEqual(['name'])
+  })
+
+  test('reports EVERY field that carries the query, so a row can say it matched twice', () => {
+    const got = matchScopes(fields({ name: 'docker', prompt: 'fix the docker build' }), 'docker')
+    expect(got).toEqual(['name', 'prompt'])
+  })
+
+  test('an empty query matches nothing — it is not a wildcard', () => {
+    expect(matchScopes(fields({ name: 'anything' }), '')).toEqual([])
+    expect(matchScopes(fields({ name: 'anything' }), '   ')).toEqual([])
+  })
+
+  test('matching ignores case and surrounding whitespace in the query', () => {
+    expect(matchScopes(fields({ name: 'Agentistics' }), '  AGENT  ')).toEqual(['name'])
+  })
+
+  test('a transcript hit is a scope like any other, supplied by the caller', () => {
+    expect(matchScopes(fields(), 'docker', { transcript: true })).toEqual(['transcript'])
+  })
+
+  test('transcript never matches when the caller did not find one', () => {
+    expect(matchScopes(fields(), 'docker', { transcript: false })).toEqual([])
+  })
+
+  test('scopes come back in a fixed reading order regardless of which matched', () => {
+    const got = matchScopes(
+      fields({ task: 'release', prompt: 'release notes', name: 'release' }),
+      'release',
+      { transcript: true },
+    )
+    expect(got).toEqual(['name', 'task', 'prompt', 'transcript'])
+  })
+})
+
+describe('scopeCounts', () => {
+  test('counts how many rows carry the query in each scope', () => {
+    const rows = [
+      { fields: fields({ name: 'docker' }), transcript: false },
+      { fields: fields({ prompt: 'docker compose' }), transcript: false },
+      { fields: fields({ prompt: 'docker build' }), transcript: true },
+    ]
+    expect(scopeCounts(rows, 'docker')).toEqual({
+      name: 1, folder: 0, harness: 0, note: 0, task: 0, prompt: 2, transcript: 1,
+    })
+  })
+
+  test('a scope nothing matched is a real zero, present in the record', () => {
+    const rows = [{ fields: fields({ name: 'x' }), transcript: false }]
+    expect(scopeCounts(rows, 'zzz').name).toBe(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+
+const words = {
+  scope: {
+    name: 'name', folder: 'folder', harness: 'harness',
+    note: 'note', task: 'task', prompt: 'prompt', transcript: 'transcript',
+  },
+  noGrep: 'no grep here',
+  noTranscripts: 'none on this machine',
+}
+
+describe('searchDepthText', () => {
+  test('lists the scopes that matched, with their counts', () => {
+    const counts = { ...emptyScopeCounts(), name: 3, prompt: 5, transcript: 47 }
+    expect(searchDepthText(counts, words, {})).toBe('name 3 · prompt 5 · transcript 47')
+  })
+
+  test('a scope nothing matched is left out — it would be noise on every search', () => {
+    const counts = { ...emptyScopeCounts(), name: 3 }
+    expect(searchDepthText(counts, words, {})).toBe('name 3 · transcript 0')
+  })
+
+  test('TRANSCRIPT is always stated, even at zero — it is the one that might not have run', () => {
+    expect(searchDepthText(emptyScopeCounts(), words, {})).toBe('transcript 0')
+  })
+
+  test('an unsearchable transcript says WHY instead of showing a zero', () => {
+    const counts = { ...emptyScopeCounts(), name: 2 }
+    expect(searchDepthText(counts, words, { unavailable: 'no-grep' }))
+      .toBe('name 2 · no grep here')
+    expect(searchDepthText(counts, words, { unavailable: 'no-transcripts' }))
+      .toBe('name 2 · none on this machine')
+  })
+
+  test('while the transcript search is still running it says so rather than reporting 0', () => {
+    const counts = { ...emptyScopeCounts(), name: 2 }
+    expect(searchDepthText(counts, words, { running: true, runningWord: 'reading…' }))
+      .toBe('name 2 · reading…')
+  })
+})

--- a/packages/tui/src/control/search-scope.ts
+++ b/packages/tui/src/control/search-scope.ts
@@ -1,0 +1,151 @@
+/**
+ * WHERE a search matched — the difference between a list of rows and an answer.
+ *
+ * The search used to be one lowercased blob per row (`SessionView.searchText`) tested with
+ * `.includes()`. That finds the row and then refuses to say why: typing `docker` returned a
+ * session whose folder, harness, note and opening prompt were all invisible to the reader, so the
+ * only way to learn which of them carried the word was to open the session and look. Worse, the
+ * blob is composed differently for the three kinds of row, so the same query searched a different
+ * set of things depending on whether a conversation happened to be running.
+ *
+ * Named fields make the scope a FACT the screen can print, which is what lets the header say how
+ * deep the match went and each row say which field earned its place.
+ */
+
+/** The searchable dimensions of a session row, in the order a reader scans them. */
+export const SEARCH_SCOPES = ['name', 'folder', 'harness', 'note', 'task', 'prompt', 'transcript'] as const
+
+export type SearchScope = typeof SEARCH_SCOPES[number]
+
+/**
+ * The text of every scope a row carries ON ITS OWN.
+ *
+ * `transcript` is deliberately absent: it is not a property of the row but the answer to a
+ * question asked of the disk, and putting it here would mean holding conversation text in the
+ * view — the exact shape that leaked whole transcripts to a central once already. It reaches
+ * `matchScopes` as a boolean the caller resolved.
+ */
+export interface SearchFields {
+  /** What the row is CALLED — the user's label, or the title the harness gave it. */
+  name: string
+  /** The working directory. */
+  folder: string
+  harness: string
+  /** The user's own note on this row. */
+  note: string
+  /** The task this row belongs to. */
+  task: string
+  /** The conversation's opening prompt — what a person remembers about something they closed. */
+  prompt: string
+}
+
+/** Scopes other than `transcript`, which no row can answer by itself. */
+const OWN_SCOPES = SEARCH_SCOPES.filter((s): s is Exclude<SearchScope, 'transcript'> => s !== 'transcript')
+
+export function emptySearchFields(): SearchFields {
+  return { name: '', folder: '', harness: '', note: '', task: '', prompt: '' }
+}
+
+/**
+ * The scopes of one row that carry `query`, in `SEARCH_SCOPES` order.
+ *
+ * An empty query matches NOTHING rather than everything: the caller decides that an unfiltered
+ * list is unfiltered, and a wildcard here would report every row as matching every scope.
+ */
+export function matchScopes(
+  fields: SearchFields,
+  query: string,
+  found: { transcript?: boolean } = {},
+): SearchScope[] {
+  const q = query.trim().toLowerCase()
+  if (q === '') return []
+
+  const hit: SearchScope[] = []
+  for (const scope of OWN_SCOPES) {
+    if (fields[scope].toLowerCase().includes(q)) hit.push(scope)
+  }
+  if (found.transcript) hit.push('transcript')
+  return hit
+}
+
+/** Whether a row matches at all — the predicate the list filters on. */
+export function matchesQuery(
+  fields: SearchFields,
+  query: string,
+  found: { transcript?: boolean } = {},
+): boolean {
+  return query.trim() === '' || matchScopes(fields, query, found).length > 0
+}
+
+/** The words the depth line needs, supplied by the caller — this module holds no strings. */
+export interface SearchScopeWords {
+  scope: Record<SearchScope, string>
+  noGrep: string
+  noTranscripts: string
+}
+
+/** What the transcript half of the search is currently doing. */
+export interface TranscriptState {
+  running?: boolean
+  runningWord?: string
+  unavailable?: 'no-grep' | 'no-transcripts'
+}
+
+/**
+ * HOW DEEP the search went, as one line: `name 3 · prompt 5 · transcript 47`.
+ *
+ * A scope nothing matched is left OUT, because printing seven scopes on every keystroke buries
+ * the two that answered the question — EXCEPT `transcript`, which is always stated. That
+ * asymmetry is the point: the other six are read from data already in memory and always ran, so
+ * their silence means zero. The transcript is read off the disk and might not have run at all, so
+ * an absent line would be indistinguishable from "nothing said this" — and the reader would draw
+ * the wrong conclusion and stop looking. Same rule as `liveEmptyNotice`, in one line of chrome.
+ */
+export function searchDepthText(
+  counts: ScopeCounts,
+  words: SearchScopeWords,
+  state: TranscriptState,
+): string {
+  const parts: string[] = []
+  for (const scope of OWN_SCOPES) {
+    if (counts[scope] > 0) parts.push(`${words.scope[scope]} ${counts[scope]}`)
+  }
+
+  if (state.unavailable) {
+    parts.push(state.unavailable === 'no-grep' ? words.noGrep : words.noTranscripts)
+  } else if (state.running) {
+    // Not `transcript 0`: the count is simply not in yet, and a zero that turns into 47 a moment
+    // later teaches the reader that the number cannot be trusted.
+    parts.push(state.runningWord ?? '…')
+  } else {
+    parts.push(`${words.scope.transcript} ${counts.transcript}`)
+  }
+
+  return parts.join(' · ')
+}
+
+export type ScopeCounts = Record<SearchScope, number>
+
+export function emptyScopeCounts(): ScopeCounts {
+  return { name: 0, folder: 0, harness: 0, note: 0, task: 0, prompt: 0, transcript: 0 }
+}
+
+/**
+ * How many rows carry the query in each scope — the header's "how deep did this go" line.
+ *
+ * Every scope is present even at zero: a scope missing from the record and a scope nobody matched
+ * read identically to a caller, and the second is a real answer while the first is not.
+ */
+export function scopeCounts(
+  rows: readonly { fields: SearchFields; transcript?: boolean }[],
+  query: string,
+): ScopeCounts {
+  const counts = emptyScopeCounts()
+  if (query.trim() === '') return counts
+  for (const row of rows) {
+    for (const scope of matchScopes(row.fields, query, { transcript: row.transcript })) {
+      counts[scope]++
+    }
+  }
+  return counts
+}

--- a/packages/tui/src/control/session-dimensions.test.ts
+++ b/packages/tui/src/control/session-dimensions.test.ts
@@ -35,7 +35,7 @@ const session = (id: string, over: Partial<ControlSession> = {}): ControlSession
   stateLabel: 'waiting',
   actionable: true,
   attached: false,
-  searchText: id,
+  searchFields: { name: id, folder: '', harness: '', note: '', task: '', prompt: '' },
   ...over,
 })
 

--- a/packages/tui/src/control/session-tree.test.ts
+++ b/packages/tui/src/control/session-tree.test.ts
@@ -42,7 +42,7 @@ const inRepo = (id: string, cwd: string, over: Partial<ControlSession> = {}): Co
   stateLabel: 'waiting',
   actionable: true,
   attached: false,
-  searchText: id,
+  searchFields: { name: id, folder: '', harness: '', note: '', task: '', prompt: '' },
   ...over,
 })
 
@@ -57,7 +57,7 @@ const loose = (id: string, cwd: string, over: Partial<ControlSession> = {}): Con
   stateLabel: 'waiting',
   actionable: true,
   attached: false,
-  searchText: id,
+  searchFields: { name: id, folder: '', harness: '', note: '', task: '', prompt: '' },
   ...over,
 })
 

--- a/packages/tui/src/control/sessions.test.ts
+++ b/packages/tui/src/control/sessions.test.ts
@@ -56,7 +56,7 @@ const session = (id: string, over: Partial<ControlSession> = {}): ControlSession
   stateLabel: 'waiting',
   actionable: true,
   attached: false,
-  searchText: id,
+  searchFields: { name: id, folder: '', harness: '', note: '', task: '', prompt: '' },
   ...over,
 })
 

--- a/packages/tui/src/control/sessions.ts
+++ b/packages/tui/src/control/sessions.ts
@@ -9,6 +9,7 @@
  */
 
 import { PANE_FRAME_Y } from './chrome.ts'
+import { matchesQuery, matchScopes, scopeCounts, type ScopeCounts, type SearchScope } from './search-scope'
 import {
   ACTIVE_STATES, OFF_STATE, GROUPINGS, SESSION_STATES, SESSION_STATE_CHOICES, SESSION_DIMENSIONS,
   UNFILED,
@@ -53,10 +54,47 @@ export {
  * would be a search that cannot find the thing it was most likely opened to find. `searchText` is
  * composed by the host and already carries a closed conversation's opening prompt.
  */
-export function filterSessions(list: readonly ControlSession[], query: string): ControlSession[] {
-  const q = query.trim().toLowerCase()
-  if (q === '') return [...list]
-  return list.filter(v => v.searchText.includes(q))
+export function filterSessions(
+  list: readonly ControlSession[],
+  query: string,
+  transcriptHits?: ReadonlySet<string>,
+): ControlSession[] {
+  if (query.trim() === '') return [...list]
+  return list.filter(v => matchesQuery(v.searchFields, query, {
+    transcript: transcriptOf(v, transcriptHits),
+  }))
+}
+
+/**
+ * Whether the transcript search named this row's conversation.
+ *
+ * Only an EXACT link counts — see the same rule, and the same reason, in `session-view.ts`.
+ */
+export function transcriptOf(v: ControlSession, hits?: ReadonlySet<string>): boolean {
+  if (!hits || hits.size === 0) return false
+  return (v.conversationId !== undefined && hits.has(v.conversationId))
+    || (v.resume !== undefined && hits.has(v.resume.sessionId))
+}
+
+/** The scopes one row matched, in reading order — what a row prints beside itself. */
+export function rowScopes(
+  v: ControlSession,
+  query: string,
+  transcriptHits?: ReadonlySet<string>,
+): SearchScope[] {
+  return matchScopes(v.searchFields, query, { transcript: transcriptOf(v, transcriptHits) })
+}
+
+/** How deep the search went: how many rows carry the query in each scope. */
+export function searchDepth(
+  list: readonly ControlSession[],
+  query: string,
+  transcriptHits?: ReadonlySet<string>,
+): ScopeCounts {
+  return scopeCounts(
+    list.map(v => ({ fields: v.searchFields, transcript: transcriptOf(v, transcriptHits) })),
+    query,
+  )
 }
 
 export function attentionOf(list: readonly ControlSession[]): number {

--- a/packages/tui/src/control/tabs/Sessions.tsx
+++ b/packages/tui/src/control/tabs/Sessions.tsx
@@ -18,8 +18,11 @@ import { Box, Text, useInput } from 'ink'
 import type {
   ActionResult, ControlExit, ControlHost, ControlSession, ControlSessions, RestoreCandidate,
   SessionState, SessionViewPrefs,
+  TranscriptSearch,
 } from '../types'
 import type { ControlStrings } from '../i18n'
+import { searchDepthText } from '../search-scope'
+import { searchDepth } from '../sessions'
 import { sessionWordBook } from '../i18n'
 import type { TabChrome } from '../ControlCenter'
 import { DEFAULT_SESSION_VIEW } from '../types'
@@ -206,6 +209,9 @@ type Ask =
   /** Killing multiple selected sessions. */
   | { kind: 'batchKill'; sessions: ControlSession[] }
 
+/** How long the typing must settle before the disk is walked. */
+const TRANSCRIPT_DEBOUNCE_MS = 300
+
 export function Sessions({
   host, fleet, strings: s, width, height, isActive, run, onChrome, onExit, onRefreshFleet,
   view, onView,
@@ -257,6 +263,42 @@ export function Sessions({
   const [cursor, setCursor] = useState(0)
   const [ask, setAsk] = useState<Ask | null>(null)
   const [query, setQuery] = useState('')
+  /**
+   * The deep half of the search — conversation ids whose TEXT carries the query.
+   *
+   * Held apart from `query` because it arrives LATER: the rows filter on the six in-memory scopes
+   * the instant you type, and the transcript hits fold in when the disk answers. `null` means the
+   * question has not been answered yet for the current query, which is why the depth line says
+   * "reading transcripts…" instead of a `0` that becomes 47 a moment later.
+   */
+  const [transcript, setTranscript] = useState<TranscriptSearch | null>(null)
+  const [searchingText, setSearchingText] = useState(false)
+
+  /**
+   * Ask the disk, once the typing settles.
+   *
+   * DEBOUNCED because each run walks the transcript roots (475 MB on the machine this was measured
+   * on, ~255 ms through grep), and firing per keystroke would queue a run for every character of a
+   * word. The reply is DISCARDED when the query has moved on — `cancelled` rather than a bare
+   * `setState`, or a slow answer for `doc` lands on top of the answer for `docker` and the depth
+   * line reports the wrong search.
+   */
+  useEffect(() => {
+    const q = query.trim()
+    if (q === '' || !host.searchTranscripts) { setTranscript(null); setSearchingText(false); return }
+
+    let cancelled = false
+    setSearchingText(true)
+    const timer = setTimeout(() => {
+      host.searchTranscripts!(q)
+        .then(r => { if (!cancelled) { setTranscript(r); setSearchingText(false) } })
+        // A failed deep search must not take the list with it: the six in-memory scopes are still
+        // a perfectly good search, so the row count stays right and only the transcript half is lost.
+        .catch(() => { if (!cancelled) { setTranscript(null); setSearchingText(false) } })
+    }, TRANSCRIPT_DEBOUNCE_MS)
+
+    return () => { cancelled = true; clearTimeout(timer); }
+  }, [query, host])
   const [showDone, setShowDone] = useState(view?.showDone ?? DEFAULT_SESSION_VIEW.showDone ?? false)
   /**
    * What the list is narrowed to, per dimension — the ONE source, and the whole answer.
@@ -379,6 +421,7 @@ export function Sessions({
         // session falls in — every session of a finished task still wears its own state.
         && (showDone || taskFilter !== null || !(v.task && done.has(v.task)))),
       query,
+      transcript?.ids,
     ),
     grouping,
     words,
@@ -392,9 +435,26 @@ export function Sessions({
   ), s.sessionsClosedWord, s.sessionsDoneWord, fleet?.fell ? s.sessionsFellWord : undefined,
      // Absent when nothing is marked, so the band is not merely empty — it does not exist.
      marked.size > 0 ? { ids: marked, label: s.sessionsMarkedBand } : undefined), [
-    fleet?.sessions, fleet?.finishedTasks, fleet?.fell, done, grouping, cascade, query, filters,
+    fleet?.sessions, fleet?.finishedTasks, fleet?.fell, done, grouping, cascade, query, transcript, filters,
     showNamed, showDone, taskFilter, dimensionCtx, order, words, marked,
   ])
+
+  /**
+   * How deep the current search went — counted over the SAME rows the screen filtered, so the
+   * numbers on the header and the rows under it can never disagree.
+   */
+  const depth = useMemo(() => {
+    if (query.trim() === '') return ''
+    return searchDepthText(
+      searchDepth(fleet?.sessions ?? [], query, transcript?.ids),
+      { scope: s.searchScope, noGrep: s.searchNoGrep, noTranscripts: s.searchNoTranscripts },
+      {
+        running: searchingText,
+        runningWord: s.searchRunning,
+        ...(transcript?.unavailable ? { unavailable: transcript.unavailable } : {}),
+      },
+    )
+  }, [fleet?.sessions, query, transcript, searchingText, s])
 
   const selectable = useMemo(() => selectableIndexes(rows), [rows])
 
@@ -1690,6 +1750,7 @@ export function Sessions({
           // ten — a number describing a screen nobody is looking at.
           shown={rows.reduce((n, r) => n + (r.kind === 'session' ? 1 : 0), 0)}
           query={query}
+          depth={depth}
           scope={projectFilter ?? taskFilter ?? ''}
           fell={fleet?.fell && fellAgo ? s.sessionsFellNote(fleet.fell.count, fellAgo) : ''}
         />
@@ -1916,7 +1977,7 @@ export function Sessions({
  * to state the answer, so a glance tells you why the list looks the way it does.
  */
 function SummaryRow({
-  fleet, grouping, strings: s, width, showHistory, showNamed, onlyActive, shown, query, scope, fell,
+  fleet, grouping, strings: s, width, showHistory, showNamed, onlyActive, shown, query, depth, scope, fell,
 }: {
   fleet: ControlSessions | null | undefined
   grouping: SessionGrouping
@@ -1931,6 +1992,8 @@ function SummaryRow({
   shown: number
   /** The active search, or `''`. Stated HERE because a list narrowed silently reads as an empty one. */
   query: string
+  /** The per-scope depth of the current search — empty when nothing is being searched. */
+  depth: string
   /** The active task or project scope, already localized, or `''`. */
   scope: string
   /**
@@ -1971,7 +2034,11 @@ function SummaryRow({
   // or a drill-down is a reason the list in front of you is short, and a list that is short for a
   // reason nobody stated is one people read as broken. It carries the key that drops it, because
   // the whole complaint was not being able to get back.
-  const narrowed = query ? s.sessionsSearching(query) : scope
+  // The depth rides on the SAME row as the search announcement rather than taking one of its own:
+  // an extra row here is a row the list loses, and `summaryCells` already measures and truncates
+  // this one. It goes after the query and before `esc clears`, which is the reading order —
+  // what you searched, how deep it went, how to get out.
+  const narrowed = query ? `${s.sessionsSearching(query)}${depth ? ` · ${depth}` : ''}` : scope
   const cells = summaryCells({
     group: narrowed || `${s.sessionsGroupBy} ${s.sessionsGroupings[grouping]}`,
     hiding: filters.length > 0 ? `${s.sessionsFilterBy} ${filters.join(', ')}` : '',

--- a/packages/tui/src/control/types.ts
+++ b/packages/tui/src/control/types.ts
@@ -8,6 +8,7 @@
  */
 
 import type { CliLang } from './lang'
+import type { SearchFields } from './search-scope'
 // The default ARRANGEMENT is derived from the dimension vocabulary rather than written out beside
 // it. `session-dimensions.ts` imports this file for TYPES only, so this is the one value direction.
 import {
@@ -603,9 +604,10 @@ export interface ControlSession {
     used: string
     window: string
   }
-  /** Everything this row can be found by, already lowercased — including a closed conversation's
-   *  opening prompt, which is what a person remembers about work they put down. */
-  searchText: string
+  /** Everything this row can be found by, KEPT APART BY WHAT IT IS — including a closed
+   *  conversation's opening prompt, which is what a person remembers about work they put down.
+   *  Separate fields are what let the screen say WHICH of them a query matched. */
+  searchFields: SearchFields
   state: SessionState
   /** Already-localized state word, e.g. "needs approval". */
   stateLabel: string
@@ -815,6 +817,25 @@ export interface RestoreCandidate {
    * whatever it was when the host last looked.
    */
   startedAt?: number
+}
+
+/**
+ * The answer to "which conversations said this", plus what it could NOT look at.
+ *
+ * `unavailable` and an empty `ids` are different answers and the screen must render them
+ * differently — the same rule `LiveUnavailableReason` exists for. `covered` is what the header may
+ * honestly claim: reporting "transcript 0" while only one of six harnesses was reachable is the
+ * confident zero this product refuses everywhere else.
+ */
+export interface TranscriptSearch {
+  /** Conversation ids whose transcript carries the query. */
+  ids: ReadonlySet<string>
+  /** The harnesses actually walked. */
+  covered: readonly string[]
+  /** Harnesses whose search errored — their conversations are missing from `ids`. */
+  failed: readonly string[]
+  /** Set only when nothing was searched at all. */
+  unavailable?: 'no-grep' | 'no-transcripts'
 }
 
 export interface ControlSessions {
@@ -1152,6 +1173,21 @@ export interface ControlHost {
    * contract exists to prevent.
    */
   sessions?(): Promise<ControlSessions>
+
+  /**
+   * Which conversations SAID this — the deep half of the sessions search.
+   *
+   * Reads the transcripts on THIS machine and answers with conversation ids only. The text is
+   * never carried: it does not go on a session row, it does not reach the web dashboard, and it
+   * cannot reach a central. A previous attempt put it on `SessionMeta` and shipped whole
+   * conversations to a central in the member push — see the header of `transcript-search.ts`.
+   *
+   * OPTIONAL like `sessions`: a host that cannot search transcripts here (no `grep`, no
+   * transcripts, not this platform) says so through `TranscriptSearch.unavailable`, and the screen
+   * states it in words. An empty result with no reason is a real "nothing said this" — the two must
+   * stay distinguishable, exactly as `liveUnavailable` keeps them apart for live sessions.
+   */
+  searchTranscripts?(query: string): Promise<TranscriptSearch>
 
   /**
    * What it takes to attach to a session, or `null` when this one cannot be attached.


### PR DESCRIPTION
## What

Replaces the reverted `3e9f06c` transcript-search attempt with a version that lives **only in the TUI**, never touches `SessionMeta`, and never reaches the web dashboard or a central.

## Why the previous approach was reverted (context)

`3e9f06c` put full conversation text (`transcript_text`, up to 200KB) on `SessionMeta`, which `team-uploader.ts` serializes whole into a member's push. `redactSessionText` covers `first_prompt`/`title`/`user_label`/`user_note` — never `transcript_text` — so unredacted chat crossed the wire to a central. It also didn't work: the field was only populated when a transcript happened to be re-parsed (measured: 1 of 140 sessions on a real machine), so searching "docker" found nothing in a corpus that held it 317 times.

## What this does instead

1. **`packages/tui/src/control/search-scope.ts`** — pure. Named `SearchFields` (`name`/`folder`/`harness`/`note`/`task`/`prompt`) replace the single lowercased `searchText` blob that three different call sites in `session-view.ts` used to compose differently. `matchScopes`/`scopeCounts`/`searchDepthText` let the header print `name 3 · prompt 5 · transcript 47` instead of a silent match — the user asked for exactly this.

2. **`packages/server/server/sessions/transcript-search.ts` + `transcript-run.ts`** — the deep half. Reads conversation text **on this machine only**, via `grep -rilZ` through `Bun.spawn` with an **argv array** (no shell), `--` terminating flags so a query of `-r` or `; rm -rf /` is data, never a flag or a command — verified against both. Measured on this machine (912 files, 475MB under `~/.claude/projects`): grep 255ms vs. a JS read loop 3-5s. Debounced 300ms in the UI, never run on the 5s fleet poller.

3. `ControlHost.searchTranscripts` is **optional**, exactly like `sessions()` — a host that cannot search reports `TranscriptSearch.unavailable` and the UI states it in words rather than showing a confident `0`.

4. `SessionView.searchFields` / `ControlSession.searchFields` replace `searchText` everywhere; `filterSessions` takes an optional transcript-hit set. **Central/team mode is untouched** — the fields that already fed `searchText` keep feeding the wire exactly as before.

## Testing

- 41 new tests, all TDD (RED verified before GREEN for every module): `search-scope.test.ts` (14, including hostile-query cases), `transcript-search.test.ts` (18, argv construction + per-harness path→id parsing for all six harnesses), `transcript-run.test.ts` (7, IO edge with injected deps).
- `bun tsc --noEmit`: clean.
- `bun test`: 4274 pass / 1 fail. The one failure (`adapters/claude.test.ts`, times out reading the real `~/.claude/projects`) is pre-existing and unrelated — this PR does not touch `adapters/claude.ts` or `jsonl.ts`, and the same test times out in isolation on this machine independent of any change here.

## Deliberately not done

- Nothing changed on the web dashboard or central — transcript search must not exist there ("é invasão de privacidade").

🤖 Generated with [Claude Code](https://claude.com/claude-code)