### PR TITLE
feat(web): real session verbs on the Sessions page, and Home stops listing sessions

### DIFF
--- a/packages/server/server/capability-guard.test.ts
+++ b/packages/server/server/capability-guard.test.ts
@@ -25,6 +25,14 @@ describe('routeCapability', () => {
     expect(routeCapability('/api/exec')).toBe('localShell')
   })
 
+  it('maps the session fleet routes to localShell', () => {
+    // Reading the fleet CAPTURES each live session's screen and acting on it types keystrokes into
+    // a terminal on this host. That is shell access under another name, so it must be unreachable
+    // on an exposed profile whoever is authenticated.
+    expect(routeCapability('/api/fleet')).toBe('localShell')
+    expect(routeCapability('/api/fleet/act')).toBe('localShell')
+  })
+
   it('maps the local chat routes', () => {
     expect(routeCapability('/api/chat-tty')).toBe('localChat')
     expect(routeCapability('/api/chat-harnesses')).toBe('localChat')

--- a/packages/server/server/capability-guard.ts
+++ b/packages/server/server/capability-guard.ts
@@ -32,6 +32,13 @@ const EXACT: ReadonlyMap<string, keyof Capabilities> = new Map<string, keyof Cap
   // deployment that should read a transcript but not this.
   ['/api/billing/detect', 'localTranscripts'],
   ['/api/hardware-resources', 'localProcesses'],
+  // The session fleet, and acting on it. `/api/fleet` alone captures each live session's SCREEN —
+  // a coding assistant's terminal, transcript and all — and `/api/fleet/act` types into it, sends
+  // it a keystroke that answers a permission prompt, or kills it. That is shell access with extra
+  // steps, so it rides `localShell` rather than the softer `localChat`: there is no deployment
+  // that should expose someone's keyboard to the internet and a shell is the honest name for it.
+  ['/api/fleet', 'localShell'],
+  ['/api/fleet/act', 'localShell'],
 ])
 
 /** Prefix (no trailing slash) → capability. Matches `<prefix>` and `<prefix>/…` only. */

--- a/packages/server/server/cli-start.ts
+++ b/packages/server/server/cli-start.ts
@@ -1264,7 +1264,7 @@ function makeSuspend(altScreen: Suspendable, strings: () => CliStrings): Suspend
 // ---------------------------------------------------------------------------
 
 /** The host, plus the language it currently speaks (runStart needs it after the app exits). */
-interface StartHost extends ControlHost {
+export interface StartHost extends ControlHost {
   readonly lang: CliLang
 }
 
@@ -1653,7 +1653,17 @@ async function restorableSessions(fell: readonly ManagedSession[]): Promise<Rest
   }))
 }
 
-function createControlHost(initialLang: CliLang, altScreen: Suspendable): StartHost {
+/**
+ * The host, exported so the WEB dashboard's session routes act through the same object the cockpit
+ * does (`sessions/fleet-web.ts`).
+ *
+ * The alternative was a second set of session verbs living in `index.ts`, which is the drift
+ * `task-reopen.ts` was extracted to end: `answerSession` alone re-reads the frame, re-parses the
+ * options and refuses a numbered dialog on a harness with no verified way to pick — a browser copy
+ * of that would be a button that approves the highlighted row. Only `suspend`-requiring actions
+ * (`central.sh init`) need a real terminal, and the web host is never asked for one.
+ */
+export function createControlHost(initialLang: CliLang, altScreen: Suspendable): StartHost {
   let lang = initialLang
   const S = () => cliStrings(lang)
   // Built here so it always reports in the language the host is currently speaking.

--- a/packages/server/server/index.ts
+++ b/packages/server/server/index.ts
@@ -68,7 +68,13 @@ import { validateSecret, ensureSessionSecret } from './secret-store'
 import { requiresStepUp, verifyStepUp, STEPUP_HEADER } from './stepup'
 import { writeAudit, ensureAuditIndexes, listAudit } from './audit'
 import { safeError } from './errors'
-import { LIMITS } from './limits'
+import { LIMITS, readJsonLimited } from './limits'
+// Type only, and from the LEAF: `sessions/fleet-web.ts` reaches `cli-start.ts` and through it Ink
+// and React, so this server names only `fleet-row.ts` — the two handlers load the implementation by
+// dynamic import. Naming `fleet-web` here even in a type position measurably pulled that graph in.
+import type { FleetActionRequest } from './sessions/fleet-row'
+// Type only: the module itself reaches `cli-start` → `@agentistics/tui/control` → Ink, and is
+// loaded by dynamic import inside the two /api/fleet handlers.
 import { canSeeMemberNames } from './iam-view'
 import { buildNotificationAuthorityContext } from './notifications-context'
 import {
@@ -981,6 +987,50 @@ async function handleRequestInner(req: Request, server: Server<WSData>): Promise
         }
         return new Response(JSON.stringify({ ok: false, error: 'unknown action' }), {
           status: 400,
+          headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
+        })
+      } catch (err) {
+        return new Response(JSON.stringify({ ok: false, ...safeError(err, { verbose: PROFILE === 'local' }).body }), {
+          status: 500,
+          headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
+        })
+      }
+    }
+
+    // The session FLEET, for the web Sessions page — the same rows the cockpit draws and
+    // `agentop session ls` prints, with the same `sessionActions` decision about what each one may
+    // take. A central never answers it: it aggregates many machines and hosts none of their
+    // sessions, so a fleet read there would be this box's own processes under someone else's page.
+    // `capability-guard.ts` has already refused both paths on an exposed profile.
+    if (url.pathname === '/api/fleet' || url.pathname === '/api/fleet/act') {
+      if (TEAM_CENTRAL) {
+        return new Response(JSON.stringify({ error: 'fleet_central' }), {
+          status: 404,
+          headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
+        })
+      }
+    }
+
+    if (url.pathname === '/api/fleet' && req.method === 'GET') {
+      const { readFleet, fleetLang } = await import('./sessions/fleet-web')
+      const payload = await readFleet(fleetLang(url.searchParams.get('lang')))
+      return new Response(JSON.stringify(payload), {
+        headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
+      })
+    }
+
+    if (url.pathname === '/api/fleet/act' && req.method === 'POST') {
+      try {
+        const { runFleetAction, fleetLang } = await import('./sessions/fleet-web')
+        const body = await readJsonLimited<FleetActionRequest>(req, LIMITS.bodyBytes)
+        if (!body.ok) {
+          return new Response(JSON.stringify({ ok: false, message: 'bad_request' }), {
+            status: 400,
+            headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
+          })
+        }
+        const out = await runFleetAction(fleetLang(url.searchParams.get('lang')), body.value)
+        return new Response(JSON.stringify(out), {
           headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
         })
       } catch (err) {

--- a/packages/server/server/sessions/fleet-row.test.ts
+++ b/packages/server/server/sessions/fleet-row.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'bun:test'
+import type { ControlSession } from '@agentistics/tui/control'
+import { controlStrings } from '@agentistics/tui/control/i18n'
+import { fleetRow, sessionHandleOf, verbReason } from './fleet-row'
+
+const S = controlStrings('en')
+
+function row(over: Partial<ControlSession> = {}): ControlSession {
+  return {
+    id: 'agentop-abcdef123456',
+    title: 'a session',
+    harness: 'claude',
+    cwd: '/home/u/proj',
+    project: 'proj',
+    state: 'working',
+    stateLabel: 'working',
+    actionable: true,
+    searchText: '',
+    attached: false,
+    ...over,
+  } as ControlSession
+}
+
+const verb = (r: ReturnType<typeof fleetRow>, a: string) => r.verbs.find(v => v.action === a)!
+
+describe('fleetRow — the verbs a web row is offered', () => {
+  it('never offers attach: a browser tab has no terminal, so it carries the command instead', () => {
+    const r = fleetRow(row(), S)
+    expect(r.verbs.some(v => v.action === 'attach')).toBe(false)
+    expect(r.attachCommand).toBe('agentop session attach agentop-abcd')
+  })
+
+  it('keeps the shape constant — an external row is DIMMED, never stripped down to nothing', () => {
+    const lost = fleetRow(row({ state: 'lost' }), S)
+    const external = fleetRow(row({ state: 'unknown', actionable: false }), S)
+    // Same verbs in the same order: a bar that shrank from six buttons to one reads as a broken
+    // feature, which is the reason `sessionActions` returns them all and dims the rest.
+    expect(external.verbs.map(v => v.action)).toEqual(lost.verbs.map(v => v.action))
+    expect(verb(external, 'rename').enabled).toBe(false)
+    expect(verb(external, 'kill').enabled).toBe(false)
+    // The ONE shape difference is the leading verb, and it is the cockpit's own rule: something
+    // running is attached to, everything else is reopened, and they are never both live. Attaching
+    // needs a terminal, so the running row spends that slot on the command instead.
+    expect(fleetRow(row({ state: 'working' }), S).verbs.some(v => v.action === 'resume')).toBe(false)
+  })
+
+  it('an external row refuses in a SENTENCE, never silently', () => {
+    const external = fleetRow(row({ state: 'unknown', actionable: false }), S)
+    expect(verb(external, 'kill').reason).toBe(S.sessionsExternalNote)
+    expect(verb(external, 'prompt').reason).toBe(S.sessionsExternalNote)
+  })
+
+  it('a CLOSED row is not called external — it is a conversation here that is not running', () => {
+    const closed = fleetRow(row({ state: 'closed', actionable: false }), S)
+    expect(verb(closed, 'kill').reason).toBeUndefined()
+    // …and reopen is the verb it actually has, once a conversation resolves.
+    expect(verb(closed, 'resume').enabled).toBe(false)
+    const reopenable = fleetRow(
+      row({ state: 'closed', actionable: false, resume: { sessionId: 'conv-1', title: 'a session' } }),
+      S,
+    )
+    expect(verb(reopenable, 'resume').enabled).toBe(true)
+  })
+
+  it('a running row is offered PROMPT and no reopen; a lost one the reverse', () => {
+    const running = fleetRow(row({ state: 'working' }), S)
+    expect(verb(running, 'prompt').enabled).toBe(true)
+    expect(running.verbs.some(v => v.action === 'resume')).toBe(false)
+
+    const lost = fleetRow(row({ state: 'lost', resume: { sessionId: 'c', title: 't' } }), S)
+    expect(verb(lost, 'resume').enabled).toBe(true)
+    expect(verb(lost, 'prompt').enabled).toBe(false)
+    // A reboot loses every backend session and keeps every name, so the naming verbs survive.
+    expect(verb(lost, 'rename').enabled).toBe(true)
+  })
+
+  it('approve is off unless the session is genuinely asking AND the harness can answer', () => {
+    expect(verb(fleetRow(row({ state: 'working' }), S), 'approve').enabled).toBe(false)
+    const bare = fleetRow(row({ state: 'waiting-approval', canApprove: true }), S)
+    expect(verb(bare, 'approve').enabled).toBe(true)
+  })
+
+  it('a numbered dialog this harness cannot pick from is REFUSED by name, not confirmed', () => {
+    const blind = fleetRow(row({
+      state: 'waiting-approval',
+      dialogOptions: [{ number: 1, label: 'yes', selected: true }, { number: 2, label: 'no', selected: false }],
+      chooseBlind: 'codex cannot be answered by number from here',
+    }), S)
+    // `sessionActions` still ENABLES the verb — pressing it opens the refusal that names what does
+    // work — and the sentence travels with it so the page can say it.
+    expect(blind.chooseBlind).toBe('codex cannot be answered by number from here')
+    expect(blind.dialogOptions).toHaveLength(2)
+  })
+
+  it('carries the row\'s own blind sentences rather than inventing any', () => {
+    const r = fleetRow(row({ approvalBlind: 'no probed rules for gemini' }), S)
+    expect(r.approvalBlind).toBe('no probed rules for gemini')
+    expect(verb(r, 'approve').reason).toBe('no probed rules for gemini')
+  })
+
+  it('verbReason says nothing it cannot know', () => {
+    expect(verbReason(row(), 'rename', S)).toBeUndefined()
+    expect(verbReason(row({ state: 'closed' }), 'kill', S)).toBeUndefined()
+  })
+
+  it('the handle is what `agentop session attach` resolves', () => {
+    expect(sessionHandleOf('agentop-abcdef123456')).toBe('agentop-abcd')
+    expect(sessionHandleOf('short')).toBe('short')
+  })
+})

--- a/packages/server/server/sessions/fleet-row.ts
+++ b/packages/server/server/sessions/fleet-row.ts
@@ -1,0 +1,167 @@
+/**
+ * fleet-row.ts — PURE. One `ControlSession`, shaped into the row the WEB Sessions page draws, with
+ * the verbs it may offer already decided.
+ *
+ * The decision is NOT made here. `sessionActions` (`@agentistics/tui/control/sessions`) is the one
+ * answer to "what can this row take", and the cockpit resolves every keypress against it; this
+ * module calls it and carries the result over the wire. A browser-side re-derivation would be a
+ * second set of rules — the bug `task-reopen.ts` exists to have fixed once — and it would go wrong
+ * in the one direction that costs work: offering `approve` on a numbered dialog belonging to a
+ * harness with no verified way to pick, where the keystroke takes whichever row is highlighted.
+ *
+ * What IS decided here is narrower and belongs to the browser: which of those verbs a PAGE can
+ * perform at all. `attach` hands a real terminal to a session and a browser has none, so the row
+ * carries the command that does it instead of a button that cannot.
+ */
+
+import { actionWords, sessionActions, type SessionAction } from '@agentistics/tui/control/sessions'
+import type { ControlSession } from '@agentistics/tui/control'
+import type { ControlStrings } from '@agentistics/tui/control/i18n'
+
+/**
+ * Verbs the WEB cannot perform, whatever the row says.
+ *
+ * `attach` needs the tty the cockpit gives up to reach it; a browser tab has none, so it is offered
+ * as a COMMAND to copy rather than as a button. The three selection-less verbs (`new`, `search`,
+ * `group`) are chrome of the cockpit's own screen and are not per-row actions at all.
+ */
+const NOT_IN_BROWSER: ReadonlySet<SessionAction> = new Set<SessionAction>([
+  'attach', 'new', 'search', 'group', 'reopenFell',
+])
+
+/**
+ * What the page may ask to be done to one row — a strict subset of the cockpit's verbs.
+ *
+ * It lives HERE, in the leaf, rather than beside its implementation in `fleet-web.ts`: `index.ts`
+ * names this type to parse a request body, and `fleet-web.ts` reaches `cli-start.ts` and through it
+ * Ink and React. The HTTP server must not name that module even in a type position — the two
+ * handlers load it by dynamic import precisely so a machine that never opens the Sessions page
+ * never pays for it, and naming it in an `import type` puts it back in the resolver's path.
+ */
+export type FleetActionId =
+  | 'approve' | 'prompt' | 'rename' | 'note' | 'task' | 'kill' | 'resume'
+  | 'openTask' | 'finishTask'
+
+export interface FleetActionRequest {
+  id: string
+  action: FleetActionId
+  /** The text for `prompt`/`rename`/`note`/`task`. */
+  text?: string
+  /** The option NUMBER for `approve` on a numbered dialog. Never defaulted — see `answerSession`. */
+  choice?: number
+}
+
+/** How a verb is offered to the page: performable, present-but-refused, or absent. */
+export interface FleetVerb {
+  action: SessionAction
+  label: string
+  /**
+   * False when this row cannot take it. Drawn DISABLED, never removed — the cockpit made the same
+   * call and recorded why: with a fleet agentop did not start, a row that drops from nine verbs to
+   * four reads as a broken feature, and absence communicates nothing about WHY.
+   */
+  enabled: boolean
+  /**
+   * Why it is off, when the row can say. Already localized, and it is the row's OWN sentence
+   * (`approveBlind`, `chooseBlind`, …) wherever one exists — a verb that refuses silently is
+   * indistinguishable from a control that is broken.
+   */
+  reason?: string
+}
+
+export interface FleetRow {
+  id: string
+  title: string
+  harness: string
+  cwd: string
+  project: string
+  state: ControlSession['state']
+  stateLabel: string
+  /** True for a row agentop hosts. An `external`/`closed` row carries no activity and no verbs. */
+  actionable: boolean
+  task?: string
+  note?: string
+  model?: string
+  conversationId?: string
+  /** The dialog this session is blocked on, verbatim, and the options read off it. */
+  approvalLines?: string[]
+  dialogOptions?: { number: number; label: string; selected: boolean }[]
+  /** The row's own sentences for what cannot be done to it. Already localized. */
+  approvalBlind?: string
+  approveBlind?: string
+  chooseBlind?: string
+  conversationBlind?: string
+  /** `agentop session attach <handle>` — what a browser offers instead of attaching. */
+  attachCommand: string
+  verbs: FleetVerb[]
+}
+
+/**
+ * The handle `agentop session attach` resolves — the first characters of the id, as the cockpit's
+ * own `id` column prints them. Short on purpose: it is meant to be typed.
+ */
+export function sessionHandleOf(id: string): string {
+  return id.slice(0, 12)
+}
+
+/**
+ * Why a verb is off for this row, in the row's own words where it has any.
+ *
+ * Only the cases the ROW can answer are named. "This session is not running" is not returned for
+ * `prompt` — the state word beside the button already says it, and a sentence repeating a cell one
+ * centimetre away is noise. What is returned is what nothing else on the row says: a row agentop
+ * does not host, a harness whose dialog nobody has read, an option list this harness cannot pick
+ * from, a conversation that can never be linked.
+ *
+ * A `closed` row gets NO sentence and is not treated as external: it is a conversation on this
+ * machine that is simply not running, which its own state word already says. Handing it
+ * "started outside agentop" would be a false sentence in the confident direction.
+ */
+export function verbReason(
+  row: ControlSession,
+  action: SessionAction,
+  s: ControlStrings,
+): string | undefined {
+  if (row.state === 'unknown' && action !== 'resume') return s.sessionsExternalNote
+  if (action === 'approve') return row.chooseBlind ?? row.approveBlind ?? row.approvalBlind
+  if (action === 'resume' && !row.resume) return row.conversationBlind
+  return undefined
+}
+
+/** One control-center row, shaped for the browser — verbs, wording and refusals included. */
+export function fleetRow(row: ControlSession, s: ControlStrings): FleetRow {
+  const words = actionWords(s)
+  const verbs = sessionActions(row)
+    .filter(a => !NOT_IN_BROWSER.has(a.action))
+    .map(a => {
+      const reason = a.enabled ? undefined : verbReason(row, a.action, s)
+      return {
+        action: a.action,
+        label: words[a.action],
+        enabled: a.enabled,
+        ...(reason ? { reason } : {}),
+      }
+    })
+  return {
+    id: row.id,
+    title: row.title,
+    harness: row.harness,
+    cwd: row.cwd,
+    project: row.project,
+    state: row.state,
+    stateLabel: row.stateLabel,
+    actionable: row.actionable,
+    ...(row.task ? { task: row.task } : {}),
+    ...(row.note ? { note: row.note } : {}),
+    ...(row.model ? { model: row.model } : {}),
+    ...(row.conversationId ? { conversationId: row.conversationId } : {}),
+    ...(row.approvalLines?.length ? { approvalLines: row.approvalLines } : {}),
+    ...(row.dialogOptions?.length ? { dialogOptions: [...row.dialogOptions] } : {}),
+    ...(row.approvalBlind ? { approvalBlind: row.approvalBlind } : {}),
+    ...(row.approveBlind ? { approveBlind: row.approveBlind } : {}),
+    ...(row.chooseBlind ? { chooseBlind: row.chooseBlind } : {}),
+    ...(row.conversationBlind ? { conversationBlind: row.conversationBlind } : {}),
+    attachCommand: `agentop session attach ${sessionHandleOf(row.id)}`,
+    verbs,
+  }
+}

--- a/packages/server/server/sessions/fleet-web.ts
+++ b/packages/server/server/sessions/fleet-web.ts
@@ -1,0 +1,182 @@
+/**
+ * fleet-web.ts — the WEB dashboard's window onto the session fleet.
+ *
+ * It owns no rules. The fleet is read through the very `ControlHost` the cockpit drives
+ * (`createControlHost`), the rows are mapped by the very `toControlSession` the cockpit and
+ * `agentop session ls` map with, and which verbs a row may take is the very `sessionActions` the
+ * cockpit resolves every keypress against. What is added is the transport and nothing else.
+ *
+ * That indirection is the point rather than an accident. `answerSession` re-reads the frame
+ * immediately before sending, re-parses the options, and REFUSES a numbered dialog on a harness
+ * with no verified way to select by number — because the confirm key takes whichever row is
+ * highlighted, which on "only my fix / promote everything / stop here" is choosing for somebody. A
+ * browser-side copy of that would be a button that quietly picks. So the browser asks the host.
+ *
+ * The host is built ONCE per language and kept: constructing one fires a version check, and a fresh
+ * host per request would fire one per poll.
+ */
+
+import type { StartHost } from '../cli-start'
+import type { CliLang } from '../cli-lang'
+import { controlStrings } from '@agentistics/tui/control/i18n'
+import { fleetRow, type FleetActionRequest, type FleetRow } from './fleet-row'
+
+// The REQUEST shape lives in the leaf `fleet-row.ts` so `index.ts` can name it without naming
+// this module — see the note there.
+export type { FleetRow, FleetVerb, FleetActionId, FleetActionRequest } from './fleet-row'
+
+export interface FleetPayload {
+  sessions: FleetRow[]
+  /** How many are waiting on a person — the same count the cockpit's header carries. */
+  attention: number
+  /** Already-localized reason this list may not be the whole truth. Never an empty list alone. */
+  unavailable?: string
+  /** The tasks that already exist here, so filing a session is a pick rather than a spelling test. */
+  tasks: string[]
+}
+
+
+export interface FleetActionResponse {
+  ok: boolean
+  /** Already localized, and always present: a refusal that says nothing is a broken control. */
+  message: string
+}
+
+/**
+ * `suspend` exists for the one action that needs a real terminal (`central.sh init`). Nothing the
+ * web routes call goes near it, and it throws rather than silently running a prompt against a
+ * stdin no browser owns.
+ */
+const NO_TERMINAL = {
+  async suspend<T>(_fn: () => Promise<T>): Promise<T> {
+    throw new Error('fleet-web: this action needs a terminal and cannot run from the dashboard')
+  },
+}
+
+const HOSTS = new Map<CliLang, StartHost>()
+
+async function hostFor(lang: CliLang): Promise<StartHost> {
+  const cached = HOSTS.get(lang)
+  if (cached) return cached
+  // Dynamic: `cli-start` reaches `@agentistics/tui/control`, which pulls in Ink and React. The HTTP
+  // server must not carry that in its own import graph for the machines that never open this page.
+  const { createControlHost } = await import('../cli-start')
+  const host = createControlHost(lang, NO_TERMINAL)
+  HOSTS.set(lang, host)
+  return host
+}
+
+/** Only the two languages exist; anything else reads as English, as everywhere else. */
+export function fleetLang(raw: string | null): CliLang {
+  return raw === 'pt' ? 'pt' : 'en'
+}
+
+/**
+ * The fleet, already shaped for the page.
+ *
+ * Never throws: a poll that failed comes back as the previous list plus a sentence, and a machine
+ * with no session backend at all comes back as an empty list plus the reason. An empty list with no
+ * reason would be a confident "nothing is running" from a machine that cannot tell — the same
+ * defect `liveEmptyNotice` exists to prevent on the dashboard.
+ */
+export async function readFleet(lang: CliLang): Promise<FleetPayload> {
+  const s = controlStrings(lang)
+  try {
+    const host = await hostFor(lang)
+    if (!host.sessions) return { sessions: [], attention: 0, tasks: [] }
+    const fleet = await host.sessions()
+    const tasks = host.sessionTasks ? await host.sessionTasks().catch(() => []) : []
+    return {
+      sessions: fleet.sessions.map(row => fleetRow(row, s)),
+      attention: fleet.attention,
+      ...(fleet.unavailable ? { unavailable: fleet.unavailable } : {}),
+      tasks,
+    }
+  } catch (e) {
+    return {
+      sessions: [],
+      attention: 0,
+      unavailable: e instanceof Error ? e.message : String(e),
+      tasks: [],
+    }
+  }
+}
+
+/**
+ * Perform one verb on one row — through the host, so every refusal the cockpit makes is made here.
+ *
+ * `resume` is the exception in shape rather than in principle: the host's reopen takes the
+ * CONVERSATION and the directory, not the row id, so the row is looked up in the very fleet the
+ * page was shown. A row whose reopen target cannot be resolved is refused by name rather than
+ * spawning a session against a guess.
+ */
+export async function runFleetAction(
+  lang: CliLang,
+  req: FleetActionRequest,
+): Promise<FleetActionResponse> {
+  const s = controlStrings(lang)
+  const host = await hostFor(lang)
+  const text = (req.text ?? '').trim()
+
+  switch (req.action) {
+    case 'approve':
+      if (!host.answerSession) return { ok: false, message: s.sessionsNoHost }
+      return await host.answerSession(req.id, req.choice)
+    case 'prompt':
+      if (!host.promptSession) return { ok: false, message: s.sessionsNoHost }
+      return await host.promptSession(req.id, text)
+    case 'rename':
+      if (!host.renameSession) return { ok: false, message: s.sessionsNoHost }
+      return await host.renameSession(req.id, text)
+    case 'note':
+      if (!host.noteSession) return { ok: false, message: s.sessionsNoHost }
+      return await host.noteSession(req.id, text)
+    case 'task':
+      if (!host.taskSession) return { ok: false, message: s.sessionsNoHost }
+      return await host.taskSession(req.id, text)
+    case 'kill':
+      if (!host.killSession) return { ok: false, message: s.sessionsNoHost }
+      return await host.killSession(req.id)
+    // The two TASK verbs act on the piece of WORK the row is filed under, never on a task named in
+    // the request: a caller that could pass its own string could reopen every session of any task
+    // on this machine. The row is looked up in the fleet and its own `task` is what is used.
+    case 'openTask':
+    case 'finishTask': {
+      if (!host.openTask || !host.finishTask || !host.sessions) {
+        return { ok: false, message: s.sessionsNoHost }
+      }
+      const fleet = await host.sessions()
+      const task = fleet.sessions.find(r => r.id === req.id)?.task
+      if (!task) return { ok: false, message: s.taskNone }
+      if (req.action === 'openTask') return await host.openTask(task)
+      // A TOGGLE, read from the snapshot rather than from the request: "finish" and "unfinish" are
+      // the same switch, and letting the browser state which way it goes is how a page one poll
+      // behind marks a task finished that somebody had just reopened.
+      return await host.finishTask(task, !(fleet.finishedTasks ?? []).includes(task))
+    }
+    case 'resume': {
+      if (!host.resumeSession || !host.sessions) return { ok: false, message: s.sessionsNoHost }
+      // Read from the fleet rather than trusted from the browser: the reopen target is a
+      // conversation id and a directory, and taking either from a request body would let a caller
+      // start an assistant anywhere on this machine.
+      const fleet = await host.sessions()
+      const row = fleet.sessions.find(r => r.id === req.id)
+      if (!row?.resume) return { ok: false, message: s.sessionsReopenNone }
+      const out = await host.resumeSession({
+        sessionId: row.resume.sessionId,
+        harness: row.harness,
+        cwd: row.cwd,
+        // The user's own name wins over the conversation's derived one — the same precedence the
+        // cockpit's reopen applies, or a reopen renames the row back to whatever the transcript
+        // called it and undoes the rename every time.
+        label: row.named ? row.title : row.resume.title,
+        // Only a MANAGED row is replaced: an external process's id is synthetic and a closed
+        // conversation's is the harness's own, so retiring either would name a registry row that
+        // does not exist.
+        ...(row.actionable ? { replaces: row.id } : {}),
+        attach: false,
+      })
+      return { ok: out.ok, message: out.message }
+    }
+  }
+}

--- a/packages/tui/src/control/i18n.ts
+++ b/packages/tui/src/control/i18n.ts
@@ -365,6 +365,14 @@ export interface ControlStrings {
   /** The external row's own sentence, in the detail pane. */
   sessionsExternalNote: string
   sessionsClosedNote: string
+  /**
+   * This build cannot run session verbs at all — no backend on this platform, or a host that does
+   * not implement them. Said in words rather than answered with a dead button: a control that is
+   * silently inert is indistinguishable from a broken one.
+   */
+  sessionsNoHost: string
+  /** Reopen was asked for on a row whose conversation cannot be resolved. */
+  sessionsReopenNone: string
   keySessionsGroup: string
   keySessionsAttach: string
   /** How to put the arrangement back to how the app opens on a fresh machine. */
@@ -867,6 +875,8 @@ const EN: ControlStrings = {
   },
   sessionsExternalNote: 'started outside agentop — listed, but it cannot be attached or stopped here.',
   sessionsClosedNote: 'not running — reopen it to pick this conversation back up.',
+  sessionsNoHost: 'session control is not available on this machine.',
+  sessionsReopenNone: 'no conversation to reopen — nothing on this machine resolves this row.',
   keySessionsGroup: 'v group',
   keySessionsAttach: 'o attach',
   keySessionsReset: '^r reset view',
@@ -1299,6 +1309,8 @@ const PT: ControlStrings = {
   },
   sessionsExternalNote: 'iniciada fora do agentop — listada, mas não dá para anexar nem parar por aqui.',
   sessionsClosedNote: 'não está rodando — reabra para retomar esta conversa.',
+  sessionsNoHost: 'o controle de sessões não está disponível nesta máquina.',
+  sessionsReopenNone: 'nenhuma conversa para reabrir — nada nesta máquina resolve esta linha.',
   keySessionsGroup: 'v agrupar',
   keySessionsAttach: 'o anexar',
   keySessionsReset: '^r restaurar view',

--- a/packages/tui/src/control/sessions.ts
+++ b/packages/tui/src/control/sessions.ts
@@ -9,6 +9,7 @@
  */
 
 import { PANE_FRAME_Y } from './chrome.ts'
+import type { ControlStrings } from './i18n'
 import {
   ACTIVE_STATES, OFF_STATE, GROUPINGS, SESSION_STATES, SESSION_STATE_CHOICES, SESSION_DIMENSIONS,
   UNFILED,
@@ -804,6 +805,32 @@ export function sessionActions(
     { action: 'group', enabled: true },
   ]
 }
+
+/**
+ * The already-localized word for every verb, in ONE place.
+ *
+ * It lived inside `tabs/Sessions.tsx` while the cockpit was the only thing offering these verbs.
+ * The web Sessions page offers the same set, resolved by the same `sessionActions`, and a second
+ * copy of the wording is a second place for "Answer its question" to drift back into "Approve" —
+ * which is exactly the promise the keystroke cannot keep. It lives here, beside the decision it
+ * names, so both surfaces read one map.
+ */
+export const actionWords = (s: ControlStrings): Record<SessionAction, string> => ({
+  attach: s.actSessions.attach,
+  resume: s.actSessions.resume,
+  approve: s.actSessions.approve,
+  prompt: s.actSessions.prompt,
+  rename: s.actSessions.rename,
+  note: s.actSessions.note,
+  task: s.actSessions.task,
+  kill: s.actSessions.kill,
+  openTask: s.actSessions.openTask,
+  reopenFell: s.actSessions.reopenFell,
+  finishTask: s.actSessions.finishTask,
+  new: s.actSessions.newSession,
+  search: s.actSessions.search,
+  group: s.actSessions.group,
+})
 
 /** The already-localized labels for those verbs, in the order they are offered. */
 export function actionLabels(

--- a/packages/tui/src/control/tabs/Sessions.tsx
+++ b/packages/tui/src/control/tabs/Sessions.tsx
@@ -81,6 +81,7 @@ import {
   QUESTION_ROWS, askRows, fitApprovalPreview, actionLabels, asideRows, asideSelectable,
   asideRowKey, resolveAsideCursor,
   enabledActionIndexes, filterSessions,
+  actionWords as ACTION_WORDS,
   sessionActions, sessionsCockpit, summaryCells, sessionColumns, padCell,
   taskCounts, projectCounts, sessionMetric, sessionContext, contextLevel,
   sessionHandle, worktreeName, sessionRunning,
@@ -141,30 +142,6 @@ const STATE_COLOR: Record<SessionState, string | undefined> = {
   closed: COLORS.muted,
 }
 
-/**
- * The already-localized word for every verb, in ONE place.
- *
- * It was written out twice — once for the action row and once for the aside menu — and the two are
- * `Record<SessionAction, string>`s of the same map, so adding a verb meant finding both copies. The
- * compiler catches a missing key, which is exactly why the duplicate was cheap enough to survive
- * three verbs and then cost an afternoon on the fourth.
- */
-const ACTION_WORDS = (s: ControlStrings): Record<SessionAction, string> => ({
-  attach: s.actSessions.attach,
-  resume: s.actSessions.resume,
-  approve: s.actSessions.approve,
-  prompt: s.actSessions.prompt,
-  rename: s.actSessions.rename,
-  note: s.actSessions.note,
-  task: s.actSessions.task,
-  kill: s.actSessions.kill,
-  openTask: s.actSessions.openTask,
-  reopenFell: s.actSessions.reopenFell,
-  finishTask: s.actSessions.finishTask,
-  new: s.actSessions.newSession,
-  search: s.actSessions.search,
-  group: s.actSessions.group,
-})
 
 /**
  * A question this screen is asking. While one is open it reports `capture`, so the global keys stand

--- a/packages/web/src/components/RecentSessions.tsx
+++ b/packages/web/src/components/RecentSessions.tsx
@@ -3,6 +3,9 @@ import type { SessionMeta } from '@agentistics/core'
 import { sessionTime } from '../lib/sessionTime'
 import { formatProjectName, repoShortName, sessionLabel, sessionTokenTotal } from '@agentistics/core'
 import type { SessionActivity } from '../lib/sessionNotifications'
+import type { FleetActionId, FleetRow } from '../lib/fleet'
+import { encodeProjectDir, transcriptSource, transcriptUnavailableNote, type TranscriptMessage } from '../lib/sessionTranscript'
+import { SessionActionBar } from './SessionActionBar'
 import { resumeCommand } from '../lib/resumeCommand'
 import { HARNESS_LABELS, HARNESS_COLORS } from '../lib/harness'
 import { format, parseISO } from 'date-fns'
@@ -11,7 +14,6 @@ import {
   ChevronRight,
   ChevronsLeft,
   Terminal,
-  Send,
   Check,
   Copy,
   ChevronsRight,
@@ -50,6 +52,18 @@ interface Props {
   activities?: Record<string, SessionActivity>
   viewMode?: 'list' | 'grid'
   onViewModeChange?: (mode: 'list' | 'grid') => void
+  /**
+   * The LIVE fleet, keyed by the stored session id it is driving — see `lib/fleet.ts`.
+   *
+   * Optional, and its absence is what makes this component reusable outside the Sessions page: the
+   * repo, project and custom-layout surfaces render the same rows as HISTORY and have no business
+   * offering to kill anything. A row with no fleet entry simply draws no action bar; it is never
+   * given a disabled one, because "agentop does not host this conversation" is a different fact
+   * from "this page did not ask".
+   */
+  fleet?: Map<string, FleetRow>
+  onFleetAction?: (req: { id: string; action: FleetActionId; text?: string; choice?: number })
+    => Promise<{ ok: boolean; message: string }>
   title?: React.ReactNode
   subtitle?: React.ReactNode
   topActions?: React.ReactNode
@@ -343,10 +357,6 @@ function isNayChatSession(projectPath: string): boolean {
   return projectPath.includes('.agentistics/nay-chat')
 }
 
-function encodeProjectDir(projectPath: string): string {
-  return projectPath.replace(/[^a-zA-Z0-9-]/g, '-')
-}
-
 function openSession(s: SessionMeta, e: React.MouseEvent) {
   e.stopPropagation()
   if (isNayChatSession(s.project_path)) {
@@ -417,7 +427,7 @@ function getSessionBucketKey(
 
 const PAGE_SIZE_OPTIONS = [5, 10, 20, 50]
 
-export function RecentSessions({ sessions, lang, onSelect, pinnedIds, activities, viewMode: externalViewMode, onViewModeChange, title, subtitle, topActions }: Props) {
+export function RecentSessions({ sessions, lang, onSelect, pinnedIds, activities, viewMode: externalViewMode, onViewModeChange, fleet, onFleetAction, title, subtitle, topActions }: Props) {
   const t = T[lang]
 
   // Grouping state (default 'project' to match agentop session ls)
@@ -448,20 +458,6 @@ export function RecentSessions({ sessions, lang, onSelect, pinnedIds, activities
 
   // Per-group pagination state
   const [groupPages, setGroupPages] = useState<Record<string, number>>({})
-
-  // Batch selection state
-  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
-  function toggleSelect(id: string) {
-    setSelectedIds(prev => {
-      const next = new Set(prev)
-      if (next.has(id)) next.delete(id)
-      else next.add(id)
-      return next
-    })
-  }
-  const [openWarningModal, setOpenWarningModal] = useState<string[] | null>(null)
-  const [promptModal, setPromptModal] = useState<boolean>(false)
-  const [batchPromptText, setBatchPromptText] = useState('')
 
   // Collapsed groups accordion map
   const [collapsedGroups, setCollapsedGroups] = useState<Record<string, boolean>>({})
@@ -697,31 +693,6 @@ export function RecentSessions({ sessions, lang, onSelect, pinnedIds, activities
               ))}
             </div>
 
-            {/* Select all — over everything the filters and search left standing, NOT one page.
-                With bands and per-group paging there is no single "page" this could mean. */}
-            <button
-              onClick={() => {
-                if (selectedIds.size === filteredAndSorted.length && filteredAndSorted.length > 0) {
-                  setSelectedIds(new Set())
-                } else {
-                  setSelectedIds(new Set(filteredAndSorted.map(s => s.session_id)))
-                }
-              }}
-              style={{
-                padding: '4px 10px',
-                borderRadius: 6,
-                border: '1px solid var(--border-subtle)',
-                background: 'var(--bg-elevated)',
-                color: 'var(--text-secondary)',
-                fontSize: 11,
-                cursor: 'pointer',
-                marginLeft: 4,
-              }}
-            >
-              {selectedIds.size === filteredAndSorted.length && filteredAndSorted.length > 0
-                ? (lang === 'pt' ? 'Desmarcar todas' : 'Deselect all')
-                : (lang === 'pt' ? 'Selecionar todas' : 'Select all')}
-            </button>
           </div>
 
           {/* Search Input & View Mode */}
@@ -888,8 +859,8 @@ export function RecentSessions({ sessions, lang, onSelect, pinnedIds, activities
                           onSelect={onSelect}
                           isPinned={pinnedIds?.has(s.session_id)}
                           state={activities?.[s.session_id]}
-                          selected={selectedIds.has(s.session_id)}
-                          onToggleSelect={toggleSelect}
+                          fleetRow={fleet?.get(s.session_id)}
+                          onFleetAction={onFleetAction}
                           viewMode={viewMode}
                         />
                       ))}
@@ -973,8 +944,8 @@ export function RecentSessions({ sessions, lang, onSelect, pinnedIds, activities
               onSelect={onSelect}
               isPinned={pinnedIds?.has(s.session_id)}
               state={activities?.[s.session_id]}
-              selected={selectedIds.has(s.session_id)}
-              onToggleSelect={toggleSelect}
+              fleetRow={fleet?.get(s.session_id)}
+              onFleetAction={onFleetAction}
               viewMode={viewMode}
             />
           ))}
@@ -1032,203 +1003,6 @@ export function RecentSessions({ sessions, lang, onSelect, pinnedIds, activities
         </div>
       )}
 
-      {/* Sticky Floating Mass Action Bar */}
-      {selectedIds.size > 0 && (
-        <div
-          style={{
-            position: 'sticky',
-            bottom: 16,
-            zIndex: 100,
-            background: 'var(--bg-elevated)',
-            border: '1px solid var(--anthropic-orange, #e8690b)',
-            boxShadow: '0 4px 20px rgba(0,0,0,0.25)',
-            borderRadius: 12,
-            padding: '12px 18px',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'space-between',
-            gap: 12,
-            flexWrap: 'wrap',
-          }}
-        >
-          <div style={{ fontSize: 13, fontWeight: 600, color: 'var(--text-primary)' }}>
-            {lang === 'pt' ? `${selectedIds.size} sessão(ões) selecionada(s)` : `${selectedIds.size} session(s) selected`}
-          </div>
-
-          <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
-            {/* Mandar Prompt */}
-            <button
-              onClick={() => setPromptModal(true)}
-              style={{
-                padding: '6px 12px',
-                borderRadius: 6,
-                background: 'var(--anthropic-orange)',
-                color: '#fff',
-                border: 'none',
-                fontSize: 12,
-                fontWeight: 600,
-                cursor: 'pointer',
-              }}
-            >
-              {lang === 'pt' ? '💬 Enviar Prompt' : '💬 Send Prompt'}
-            </button>
-
-            {/* Desligar */}
-            <button
-              onClick={() => {
-                for (const id of selectedIds) {
-                  fetch(`/api/session/kill`, { method: 'POST', body: JSON.stringify({ id }) }).catch(() => {})
-                }
-                setSelectedIds(new Set())
-              }}
-              style={{
-                padding: '6px 12px',
-                borderRadius: 6,
-                background: 'rgba(239, 68, 68, 0.15)',
-                color: '#ef4444',
-                border: '1px solid rgba(239, 68, 68, 0.3)',
-                fontSize: 12,
-                fontWeight: 600,
-                cursor: 'pointer',
-              }}
-            >
-              {lang === 'pt' ? '🛑 Desligar' : '🛑 Kill'}
-            </button>
-
-            {/* Reabrir */}
-            <button
-              onClick={() => {
-                const selectedSessions = sessions.filter(s => selectedIds.has(s.session_id))
-                const open = selectedSessions.filter(s => pinnedIds?.has(s.session_id))
-                if (open.length > 0) {
-                  setOpenWarningModal(open.map(s => sessionLabel(s) || s.session_id))
-                } else {
-                  for (const s of selectedSessions) {
-                    fetch(`/api/session/start`, { method: 'POST', body: JSON.stringify({ resumeId: s.session_id, harness: s.harness, cwd: s.project_path }) }).catch(() => {})
-                  }
-                  setSelectedIds(new Set())
-                }
-              }}
-              style={{
-                padding: '6px 12px',
-                borderRadius: 6,
-                background: 'rgba(34, 197, 94, 0.15)',
-                color: '#22c55e',
-                border: '1px solid rgba(34, 197, 94, 0.3)',
-                fontSize: 12,
-                fontWeight: 600,
-                cursor: 'pointer',
-              }}
-            >
-              {lang === 'pt' ? '🔄 Reabrir' : '🔄 Reopen'}
-            </button>
-
-            {/* Clear selection */}
-            <button
-              onClick={() => setSelectedIds(new Set())}
-              style={{
-                padding: '6px 12px',
-                borderRadius: 6,
-                background: 'transparent',
-                color: 'var(--text-tertiary)',
-                border: '1px solid var(--border-subtle)',
-                fontSize: 12,
-                cursor: 'pointer',
-              }}
-            >
-              {lang === 'pt' ? 'Limpar seleção' : 'Clear selection'}
-            </button>
-          </div>
-        </div>
-      )}
-
-      {/* Warning Modal */}
-      {openWarningModal && (
-        <div style={{
-          position: 'fixed', inset: 0, zIndex: 1000, background: 'rgba(0,0,0,0.6)',
-          display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 20
-        }}>
-          <div style={{
-            background: 'var(--bg-card)', border: '1px solid var(--border)', borderRadius: 12,
-            padding: 24, maxWidth: 480, width: '100%', display: 'flex', flexDirection: 'column', gap: 16
-          }}>
-            <div style={{ fontSize: 16, fontWeight: 700, color: '#ef4444' }}>
-              {lang === 'pt' ? 'Aviso: Não é possível reabrir' : 'Warning: Cannot reopen'}
-            </div>
-            <div style={{ fontSize: 13, color: 'var(--text-secondary)', lineHeight: 1.5 }}>
-              {lang === 'pt'
-                ? 'As seguintes sessões já estão abertas e não podem ser religadas:'
-                : 'The following sessions are already open and cannot be restarted:'}
-            </div>
-            <div style={{ display: 'flex', flexDirection: 'column', gap: 6, background: 'var(--bg-elevated)', padding: 12, borderRadius: 8 }}>
-              {openWarningModal.map(name => (
-                <div key={name} style={{ fontSize: 13, fontWeight: 600, color: 'var(--anthropic-orange)' }}>
-                  • {name}
-                </div>
-              ))}
-            </div>
-            <button
-              onClick={() => setOpenWarningModal(null)}
-              style={{
-                alignSelf: 'flex-end', padding: '8px 18px', borderRadius: 8,
-                background: 'var(--anthropic-orange)', color: '#fff', border: 'none',
-                fontWeight: 600, fontSize: 13, cursor: 'pointer'
-              }}
-            >
-              {lang === 'pt' ? 'Entendido' : 'OK'}
-            </button>
-          </div>
-        </div>
-      )}
-
-      {/* Prompt Modal */}
-      {promptModal && (
-        <div style={{
-          position: 'fixed', inset: 0, zIndex: 1000, background: 'rgba(0,0,0,0.6)',
-          display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 20
-        }}>
-          <div style={{
-            background: 'var(--bg-card)', border: '1px solid var(--border)', borderRadius: 12,
-            padding: 24, maxWidth: 500, width: '100%', display: 'flex', flexDirection: 'column', gap: 16
-          }}>
-            <div style={{ fontSize: 15, fontWeight: 700, color: 'var(--text-primary)' }}>
-              {lang === 'pt' ? `Enviar prompt para ${selectedIds.size} sessões` : `Send prompt to ${selectedIds.size} sessions`}
-            </div>
-            <textarea
-              value={batchPromptText}
-              onChange={e => setBatchPromptText(e.target.value)}
-              placeholder={lang === 'pt' ? 'Digite a instrução para as sessões selecionadas...' : 'Type prompt for selected sessions...'}
-              rows={4}
-              style={{
-                width: '100%', boxSizing: 'border-box', padding: 10, borderRadius: 8,
-                border: '1px solid var(--border)', background: 'var(--bg-elevated)',
-                color: 'var(--text-primary)', fontFamily: 'inherit', fontSize: 13, outline: 'none'
-              }}
-            />
-            <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 10 }}>
-              <button
-                onClick={() => { setPromptModal(false); setBatchPromptText('') }}
-                style={{ padding: '8px 14px', borderRadius: 8, border: '1px solid var(--border-subtle)', background: 'transparent', color: 'var(--text-secondary)', cursor: 'pointer', fontSize: 13 }}
-              >
-                {lang === 'pt' ? 'Cancelar' : 'Cancel'}
-              </button>
-              <button
-                onClick={() => {
-                  for (const id of selectedIds) {
-                    fetch(`/api/session/prompt`, { method: 'POST', body: JSON.stringify({ id, prompt: batchPromptText }) }).catch(() => {})
-                  }
-                  setPromptModal(false)
-                  setBatchPromptText('')
-                  setSelectedIds(new Set())
-                }}
-                style={{ padding: '8px 16px', borderRadius: 8, background: 'var(--anthropic-orange)', color: '#fff', border: 'none', fontWeight: 600, cursor: 'pointer', fontSize: 13 }}
-              >
-                {lang === 'pt' ? 'Enviar' : 'Send'}
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
     </div>
   )
 }
@@ -1453,8 +1227,8 @@ function SessionCard({
   onSelect,
   isPinned,
   state,
-  selected,
-  onToggleSelect,
+  fleetRow,
+  onFleetAction,
   viewMode = 'list',
 }: {
   s: SessionMeta
@@ -1463,9 +1237,10 @@ function SessionCard({
   isPinned?: boolean
   /** What this session is doing right now; absent when it is not live. */
   state?: SessionActivity
-  /** Whether this row is in the batch selection. */
-  selected?: boolean
-  onToggleSelect?: (id: string) => void
+  /** The live fleet row driving this conversation, when one is. Absent = no action bar. */
+  fleetRow?: FleetRow
+  onFleetAction?: (req: { id: string; action: FleetActionId; text?: string; choice?: number })
+    => Promise<{ ok: boolean; message: string }>
   viewMode?: 'list' | 'grid'
 }) {
   const t = T[lang]
@@ -1477,50 +1252,6 @@ function SessionCard({
 
   const cmd = resumeCommand(s)
   const [showResumeModal, setShowResumeModal] = useState(false)
-  const [promptText, setPromptText] = useState('')
-  const [sendingPrompt, setSendingPrompt] = useState(false)
-  const [promptFeedback, setPromptFeedback] = useState<{ ok: boolean; msg: string } | null>(null)
-
-  async function handleSendPrompt(e?: React.FormEvent) {
-    if (e) {
-      e.preventDefault()
-      e.stopPropagation()
-    }
-    const text = promptText.trim()
-    if (!text || sendingPrompt) return
-
-    setSendingPrompt(true)
-    setPromptFeedback(null)
-    try {
-      const res = await fetch('/api/sessions/prompt', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ sessionId: s.session_id, prompt: text }),
-      })
-      const json = await res.json() as { ok?: boolean; message?: string; error?: string }
-      if (res.ok && json.ok) {
-        setPromptFeedback({
-          ok: true,
-          msg: lang === 'pt' ? 'Prompt enviado para a sessão!' : 'Prompt sent to terminal!',
-        })
-        setPromptText('')
-      } else {
-        setPromptFeedback({
-          ok: false,
-          msg: json.error || (lang === 'pt' ? 'Erro ao enviar.' : 'Failed to send.'),
-        })
-      }
-    } catch (err: any) {
-      setPromptFeedback({
-        ok: false,
-        msg: err?.message || (lang === 'pt' ? 'Erro de rede.' : 'Network error.'),
-      })
-    } finally {
-      setSendingPrompt(false)
-      setTimeout(() => setPromptFeedback(null), 4000)
-    }
-  }
-
   const [showDetails, setShowDetails] = useState(false)
   const [messages, setMessages] = useState<{ role: 'user' | 'assistant'; content: string; timestamp?: number | string; tools?: string[] }[] | null>(null)
   const [loadingMsgs, setLoadingMsgs] = useState(false)
@@ -1549,21 +1280,38 @@ function SessionCard({
   }, [showDetails])
 
   const isLiveSession = Boolean(isPinned || cmd)
-  const isWaitingForInput = isLiveSession && (state === 'waiting' || state === 'waiting-approval')
   const titleName = s.title || (s.project_path ? formatProjectName(s.project_path) : '') || s.session_id.slice(0, 8)
+  // Where this harness's messages are read from, or the sentence saying they are never captured.
+  const source = useMemo(
+    () => transcriptSource({ session_id: s.session_id, project_path: s.project_path, harness: s.harness }),
+    [s.session_id, s.project_path, s.harness],
+  )
+  const transcriptUnavailable = source.kind === 'unavailable'
+    ? transcriptUnavailableNote(source.harness, lang)
+    : null
 
   useEffect(() => {
     if (!showDetails) return
 
+    // The reader is the HARNESS's own (`lib/sessionTranscript.ts`). This used to POST at
+    // `/api/sessions/<id>/messages`, a route that has never existed here: it 404s, the
+    // `r.ok ? r.json() : []` turns that into an empty array, and the panel reported "no recent
+    // messages" on a live session with sixty-five of them. A confident emptiness produced by a
+    // request nobody answered is the same defect as a confident zero for a metric nobody can
+    // produce, so a harness with NO reader now says so instead (`transcriptUnavailable`).
+    if (source.kind === 'unavailable') { setMessages([]); setLoadingMsgs(false); return }
+
     let interval: ReturnType<typeof setInterval> | null = null
     const fetchMsgs = () => {
-      fetch(`/api/sessions/${encodeURIComponent(s.session_id)}/messages?harness=${encodeURIComponent(s.harness || 'claude')}&projectPath=${encodeURIComponent(s.project_path || '')}`)
-        .then(r => r.ok ? r.json() : [])
-        .then((msgs: any[]) => {
-          if (Array.isArray(msgs)) setMessages(msgs)
-          else setMessages([])
+      fetch(source.url)
+        .then(r => r.ok ? r.json() : null)
+        .then((msgs: unknown) => {
+          // `null` = the request was refused or failed. Keeping the LAST known list beats replacing
+          // it with an emptiness the server never asserted.
+          if (Array.isArray(msgs)) setMessages(msgs as TranscriptMessage[])
+          else setMessages(prev => prev ?? [])
         })
-        .catch(() => setMessages([]))
+        .catch(() => setMessages(prev => prev ?? []))
         .finally(() => setLoadingMsgs(false))
     }
 
@@ -1582,7 +1330,7 @@ function SessionCard({
       es.close()
       if (interval) clearInterval(interval)
     }
-  }, [showDetails, s.session_id, s.harness, s.project_path, isLiveSession])
+  }, [showDetails, s.session_id, s.harness, s.project_path, isLiveSession, source])
   const isList = viewMode === 'list'
 
   return (
@@ -1614,16 +1362,6 @@ function SessionCard({
             <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12, flexWrap: 'wrap' }}>
               {/* Left Group: Badges & Title */}
               <div style={{ display: 'flex', alignItems: 'center', gap: 10, flex: 1, minWidth: 200 }}>
-                {onToggleSelect && (
-                  <input
-                    type="checkbox"
-                    checked={Boolean(selected)}
-                    onChange={e => { e.stopPropagation(); onToggleSelect(s.session_id) }}
-                    onClick={e => e.stopPropagation()}
-                    aria-label={lang === 'pt' ? 'Selecionar sessão' : 'Select session'}
-                    style={{ cursor: 'pointer', width: 16, height: 16, flexShrink: 0, accentColor: 'var(--anthropic-orange)' }}
-                  />
-                )}
                 {/* Status Badge */}
                 <span
                   style={{
@@ -1761,7 +1499,9 @@ function SessionCard({
                         {loadingMsgs ? (
                           <div style={{ fontSize: 11, color: 'var(--text-tertiary)' }}>{lang === 'pt' ? 'Carregando...' : 'Loading...'}</div>
                         ) : !messages || messages.length === 0 ? (
-                          <div style={{ fontSize: 11, color: 'var(--text-tertiary)', fontStyle: 'italic' }}>{lang === 'pt' ? 'Nenhuma mensagem recente' : 'No recent messages'}</div>
+                          <div style={{ fontSize: 11, color: 'var(--text-tertiary)', fontStyle: 'italic', lineHeight: 1.5 }}>
+                            {transcriptUnavailable ?? (lang === 'pt' ? 'Nenhuma mensagem recente' : 'No recent messages')}
+                          </div>
                         ) : (
                           <div style={{ display: 'flex', flexDirection: 'column', gap: 6, maxHeight: 180, overflowY: 'auto' }}>
                             {messages.slice(-3).map((m, mi) => (
@@ -1971,7 +1711,9 @@ function SessionCard({
                         {loadingMsgs ? (
                           <div style={{ fontSize: 11, color: 'var(--text-tertiary)' }}>{lang === 'pt' ? 'Carregando...' : 'Loading...'}</div>
                         ) : !messages || messages.length === 0 ? (
-                          <div style={{ fontSize: 11, color: 'var(--text-tertiary)', fontStyle: 'italic' }}>{lang === 'pt' ? 'Nenhuma mensagem recente' : 'No recent messages'}</div>
+                          <div style={{ fontSize: 11, color: 'var(--text-tertiary)', fontStyle: 'italic', lineHeight: 1.5 }}>
+                            {transcriptUnavailable ?? (lang === 'pt' ? 'Nenhuma mensagem recente' : 'No recent messages')}
+                          </div>
                         ) : (
                           <div style={{ display: 'flex', flexDirection: 'column', gap: 6, maxHeight: 160, overflowY: 'auto' }}>
                             {messages.slice(-3).map((m, mi) => (
@@ -2026,80 +1768,15 @@ function SessionCard({
           </>
         )}
 
-        {/* Live Session Interactive Short Prompt Resizable Textarea Form (only when waiting for user response) */}
-        {isWaitingForInput && (
-          <div style={{ paddingTop: 2 }}>
-            <form
-              onSubmit={handleSendPrompt}
-              onClick={(e) => e.stopPropagation()}
-              style={{
-                display: 'flex',
-                alignItems: 'flex-end',
-                gap: 8,
-                background: 'var(--bg-card)',
-                border: '1px solid var(--border-subtle)',
-                borderRadius: 6,
-                padding: '6px 8px',
-              }}
-            >
-              <textarea
-                rows={1}
-                value={promptText}
-                onChange={e => setPromptText(e.target.value)}
-                onKeyDown={e => {
-                  if (e.key === 'Enter' && !e.shiftKey) {
-                    e.preventDefault()
-                    handleSendPrompt()
-                  }
-                }}
-                placeholder={lang === 'pt' ? 'Enviar short prompt...' : 'Send short prompt...'}
-                style={{
-                  flex: 1,
-                  background: 'transparent',
-                  border: 'none',
-                  outline: 'none',
-                  fontSize: 12,
-                  color: 'var(--text-primary)',
-                  fontFamily: 'inherit',
-                  resize: 'vertical',
-                  minHeight: 36,
-                  maxHeight: 140,
-                  padding: '2px 4px',
-                  boxSizing: 'border-box',
-                }}
-              />
-              <button
-                type="submit"
-                disabled={sendingPrompt || !promptText.trim()}
-                style={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: 4,
-                  padding: '6px 12px',
-                  borderRadius: 5,
-                  border: 'none',
-                  background: 'var(--anthropic-orange)',
-                  color: '#fff',
-                  fontSize: 11,
-                  fontWeight: 600,
-                  cursor: sendingPrompt || !promptText.trim() ? 'not-allowed' : 'pointer',
-                  opacity: sendingPrompt || !promptText.trim() ? 0.5 : 1,
-                  fontFamily: 'inherit',
-                  flexShrink: 0,
-                  alignSelf: 'flex-end',
-                }}
-              >
-                <Send size={11} />
-                <span>{lang === 'pt' ? 'Enviar' : 'Send'}</span>
-              </button>
-            </form>
-            {promptFeedback && (
-              <div style={{ fontSize: 11, color: promptFeedback.ok ? '#22c55e' : '#ef4444', fontStyle: 'italic', marginTop: 4 }}>
-                {promptFeedback.msg}
-              </div>
-            )}
+        {/* What can actually be done with this session, from `/api/fleet`.
+            It replaced a checkbox and a prompt box that posted to routes which did not exist —
+            every press was silently inert, which is indistinguishable from a broken control. */}
+        {fleetRow && onFleetAction && (
+          <div onClick={e => e.stopPropagation()}>
+            <SessionActionBar row={fleetRow} lang={lang} act={onFleetAction} />
           </div>
         )}
+
       </div>
     </>
   )

--- a/packages/web/src/components/SessionActionBar.tsx
+++ b/packages/web/src/components/SessionActionBar.tsx
@@ -1,0 +1,370 @@
+/**
+ * SessionActionBar — what you can do with ONE session, in the browser.
+ *
+ * It replaced a column of checkboxes plus a floating "N selected" bar. The checkboxes were a
+ * selection model over rows that mostly cannot take the same verb: half a page of stored
+ * conversations, one live session and one assistant agentop never started are not a set anything
+ * can be done to at once, and the bar offered kill / reopen / prompt to all of them equally
+ * — against endpoints that did not exist, so every one of those buttons was silently inert.
+ *
+ * The shape is the cockpit's, and deliberately so:
+ *
+ *  - **Every verb is always drawn, and the ones this row cannot take are DISABLED.** The rule
+ *    elsewhere in this product is that an impossible action is absent; here that is wrong, for the
+ *    reason `sessionActions` records — a fleet agentop did not start would shrink the bar from
+ *    seven buttons to one, and a menu that lost six items reads as a broken feature. Absence
+ *    communicates nothing about WHY.
+ *  - **A disabled verb refuses in a SENTENCE.** Clicking one states the reason (the row's own
+ *    `approveBlind` / `chooseBlind` / external note where it has one, the state word otherwise).
+ *    A control that is silently inert is indistinguishable from a broken one.
+ *  - **A numbered dialog is never answered with a bare confirm.** The options are read off the
+ *    session's own screen by the server and listed here one button each; "answer its question" is
+ *    enabled only where the server said a bare confirm is the whole of the question.
+ *  - **Attaching is a COMMAND, not a button.** It needs a real terminal, and a browser tab has
+ *    none — so the row hands over `agentop session attach <handle>` to copy.
+ *
+ * Nothing here decides availability. Every `enabled` flag and every label arrives from
+ * `/api/fleet`, which resolves them through the same pure `sessionActions` the terminal cockpit
+ * resolves every keypress against.
+ */
+
+import React, { useState } from 'react'
+import { AlertTriangle, Check, Copy, Terminal, X } from 'lucide-react'
+import { useIsMobile } from '../hooks/useIsMobile'
+import { PERFORMABLE, TEXT_VERBS, type FleetActionId, type FleetRow } from '../lib/fleet'
+
+const T = {
+  pt: {
+    heading: 'O que fazer com esta sessão',
+    attach: 'Entrar nesta sessão pelo terminal:',
+    attachWhy: 'Anexar precisa de um terminal de verdade — o navegador não tem um. Copie o comando.',
+    copy: 'Copiar',
+    copied: 'Copiado!',
+    cancel: 'Cancelar',
+    confirm: 'Confirmar',
+    dialog: 'Esta sessão está esperando uma resposta:',
+    pick: 'Escolha uma opção:',
+    notRunning: (state: string) => `Esta sessão não está rodando (${state}).`,
+    notAsking: 'Esta sessão não está perguntando nada agora.',
+    noReopen: 'Não há conversa para reabrir nesta linha.',
+    external: 'Esta sessão não foi iniciada pelo agentop — nada aqui pode agir sobre ela.',
+    noTask: 'Esta sessão não está em nenhuma tarefa.',
+    working: 'Executando…',
+    placeholder: {
+      prompt: 'Uma linha para digitar nesta sessão…',
+      rename: 'Novo nome para esta sessão…',
+      note: 'Uma anotação sobre esta sessão…',
+      task: 'A que tarefa esta sessão pertence…',
+    } as Record<string, string>,
+  },
+  en: {
+    heading: 'What to do with this session',
+    attach: 'Enter this session from a terminal:',
+    attachWhy: 'Attaching needs a real terminal and a browser tab has none. Copy the command.',
+    copy: 'Copy',
+    copied: 'Copied!',
+    cancel: 'Cancel',
+    confirm: 'Confirm',
+    dialog: 'This session is waiting on an answer:',
+    pick: 'Pick one:',
+    notRunning: (state: string) => `This session is not running (${state}).`,
+    notAsking: 'This session is not asking anything right now.',
+    noReopen: 'There is no conversation to reopen on this row.',
+    external: 'This session was not started by agentop — nothing here can act on it.',
+    noTask: 'This session is not filed under any task.',
+    working: 'Running…',
+    placeholder: {
+      prompt: 'One line to type into this session…',
+      rename: 'A new name for this session…',
+      note: 'A note about this session…',
+      task: 'Which task this session belongs to…',
+    } as Record<string, string>,
+  },
+}
+
+/** Verbs that end work and are asked about before they run. */
+const CONFIRM_VERBS: ReadonlySet<FleetActionId> = new Set<FleetActionId>(['kill'])
+
+export function SessionActionBar({
+  row,
+  lang,
+  act,
+}: {
+  row: FleetRow
+  lang: 'pt' | 'en'
+  act: (req: { id: string; action: FleetActionId; text?: string; choice?: number })
+    => Promise<{ ok: boolean; message: string }>
+}) {
+  const t = T[lang]
+  const isMobile = useIsMobile()
+  // Which verb has the inline form open. One at a time: two open forms are two things the Enter
+  // key could mean.
+  const [open, setOpen] = useState<FleetActionId | null>(null)
+  const [text, setText] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [copied, setCopied] = useState(false)
+  const [msg, setMsg] = useState<{ ok: boolean; text: string } | null>(null)
+
+  // 44px is the MOBILE number. Applying it on desktop turns a row of small verbs into a stack of
+  // bars — the same distinction the settings primitives make.
+  const touch = isMobile ? 44 : 28
+
+  async function run(action: FleetActionId, extra?: { text?: string; choice?: number }) {
+    setBusy(true)
+    setMsg(null)
+    const out = await act({ id: row.id, action, ...extra })
+    setBusy(false)
+    setOpen(null)
+    setText('')
+    setMsg({ ok: out.ok, text: out.message })
+  }
+
+  /**
+   * A disabled verb says WHY.
+   *
+   * The row's own sentence wins wherever it has one — those are the findings, per harness, that
+   * nothing else on the page can state ("nobody has read this harness's dialog", "this one cannot
+   * be answered by number"). The fallbacks below are per VERB rather than one sentence for all of
+   * them: "this session is not running" under a session plainly marked `working` is a wrong
+   * sentence, and a wrong explanation is worse than a bare disabled button.
+   */
+  function refuse(action: FleetActionId, reason?: string) {
+    if (reason) return setMsg({ ok: false, text: reason })
+    if (row.state === 'unknown') return setMsg({ ok: false, text: t.external })
+    if (action === 'openTask' || action === 'finishTask') return setMsg({ ok: false, text: t.noTask })
+    if (action === 'approve') return setMsg({ ok: false, text: t.notAsking })
+    if (action === 'resume') return setMsg({ ok: false, text: t.noReopen })
+    setMsg({ ok: false, text: t.notRunning(row.stateLabel) })
+  }
+
+  const btn = (kind: 'plain' | 'danger' | 'primary'): React.CSSProperties => ({
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 6,
+    minHeight: touch,
+    padding: isMobile ? '0 14px' : '4px 10px',
+    borderRadius: 8,
+    fontSize: isMobile ? 13 : 11,
+    fontWeight: 600,
+    fontFamily: 'inherit',
+    cursor: 'pointer',
+    whiteSpace: 'nowrap',
+    border: kind === 'danger'
+      ? '1px solid rgba(239,68,68,0.35)'
+      : kind === 'primary' ? '1px solid var(--anthropic-orange)' : '1px solid var(--border)',
+    background: kind === 'primary' ? 'var(--anthropic-orange)' : 'var(--bg-card)',
+    color: kind === 'primary' ? '#fff' : kind === 'danger' ? '#ef4444' : 'var(--text-secondary)',
+  })
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 10,
+        paddingTop: 10,
+        borderTop: '1px solid var(--border-subtle)',
+        minWidth: 0,
+      }}
+    >
+      <div style={{ fontSize: 11, fontWeight: 600, color: 'var(--text-tertiary)', letterSpacing: 0.2 }}>
+        {t.heading}
+      </div>
+
+      {/* The dialog this session is blocked on, verbatim, and the options read off its own screen.
+          Shown BEFORE the verbs, because it is what has to be read before any of them is pressed. */}
+      {row.approvalLines && row.approvalLines.length > 0 && (
+        <div
+          style={{
+            border: '1px solid rgba(232,105,11,0.35)',
+            background: 'rgba(232,105,11,0.08)',
+            borderRadius: 8,
+            padding: '10px 12px',
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 8,
+            minWidth: 0,
+          }}
+        >
+          <div style={{ fontSize: 11, fontWeight: 600, color: 'var(--anthropic-orange)' }}>{t.dialog}</div>
+          <pre
+            style={{
+              margin: 0,
+              fontSize: 11,
+              lineHeight: 1.45,
+              fontFamily: 'var(--font-mono, monospace)',
+              color: 'var(--text-primary)',
+              whiteSpace: 'pre',
+              overflowX: 'auto',
+              maxWidth: '100%',
+            }}
+          >
+            {row.approvalLines.join('\n')}
+          </pre>
+
+          {row.dialogOptions && row.dialogOptions.length > 0 && (
+            <>
+              <div style={{ fontSize: 11, color: 'var(--text-tertiary)' }}>{t.pick}</div>
+              <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+                {row.dialogOptions.map(o => {
+                  // Picking by NUMBER exists only where the server said this harness has a verified
+                  // way to do it. Everywhere else the options are still shown — reading them is what
+                  // tells you what attaching is about to ask — and the buttons refuse by name.
+                  const can = row.verbs.find(v => v.action === 'approve')?.enabled && !row.chooseBlind
+                  return (
+                    <button
+                      key={o.number}
+                      disabled={busy}
+                      aria-disabled={!can}
+                      onClick={() => (can ? run('approve', { choice: o.number }) : refuse('approve', row.chooseBlind))}
+                      style={{ ...btn(can ? 'primary' : 'plain'), opacity: can ? 1 : 0.45 }}
+                    >
+                      <span style={{ fontWeight: 800 }}>{o.number}.</span>
+                      <span style={{ fontWeight: 500 }}>{o.label}</span>
+                    </button>
+                  )
+                })}
+              </div>
+            </>
+          )}
+        </div>
+      )}
+
+      {/* The verbs. Always all of them; the ones this row cannot take are dim and say why. */}
+      <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', minWidth: 0 }}>
+        {row.verbs.map(v => {
+          const performable = PERFORMABLE.has(v.action)
+          const live = v.enabled && performable
+          // A verb that needs a line of text opens a form; the rest run (or ask) straight away.
+          const onClick = () => {
+            if (!live) return refuse(v.action, v.reason)
+            if (TEXT_VERBS.has(v.action)) {
+              setMsg(null)
+              setText(v.action === 'rename' ? row.title : v.action === 'note' ? (row.note ?? '') : v.action === 'task' ? (row.task ?? '') : '')
+              return setOpen(open === v.action ? null : v.action)
+            }
+            if (CONFIRM_VERBS.has(v.action)) { setMsg(null); return setOpen(open === v.action ? null : v.action) }
+            void run(v.action)
+          }
+          return (
+            <button
+              key={v.action}
+              disabled={busy}
+              aria-disabled={!live}
+              title={live ? v.label : (v.reason ?? v.label)}
+              onClick={onClick}
+              style={{
+                ...btn(v.action === 'kill' ? 'danger' : open === v.action ? 'primary' : 'plain'),
+                opacity: live ? 1 : 0.4,
+              }}
+            >
+              {v.label}
+            </button>
+          )
+        })}
+      </div>
+
+      {/* The inline form for whichever verb asked for one. */}
+      {open && TEXT_VERBS.has(open) && (
+        <form
+          onSubmit={e => { e.preventDefault(); if (text.trim()) void run(open, { text }) }}
+          style={{ display: 'flex', gap: 8, flexWrap: 'wrap', alignItems: 'center', minWidth: 0 }}
+        >
+          <input
+            autoFocus
+            value={text}
+            onChange={e => setText(e.target.value)}
+            placeholder={t.placeholder[open]}
+            // No inline font-size: `index.css` guarantees >= 16px on mobile, and overriding it here
+            // is what makes iOS Safari zoom the viewport and break the sticky header.
+            style={{
+              flex: '1 1 220px',
+              minWidth: 0,
+              minHeight: touch,
+              padding: '0 10px',
+              borderRadius: 8,
+              border: '1px solid var(--border)',
+              background: 'var(--bg-elevated)',
+              color: 'var(--text-primary)',
+              fontFamily: 'inherit',
+              outline: 'none',
+            }}
+          />
+          <button type="submit" disabled={busy || !text.trim()} style={{ ...btn('primary'), opacity: busy || !text.trim() ? 0.5 : 1 }}>
+            <Check size={13} /> {busy ? t.working : t.confirm}
+          </button>
+          <button type="button" onClick={() => { setOpen(null); setText('') }} style={btn('plain')}>
+            <X size={13} /> {t.cancel}
+          </button>
+        </form>
+      )}
+
+      {open && CONFIRM_VERBS.has(open) && (
+        <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', alignItems: 'center' }}>
+          <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6, fontSize: 12, color: '#ef4444' }}>
+            <AlertTriangle size={13} /> {row.verbs.find(v => v.action === open)?.label} — {row.title}
+          </span>
+          <button disabled={busy} onClick={() => void run(open)} style={btn('danger')}>
+            <Check size={13} /> {busy ? t.working : t.confirm}
+          </button>
+          <button onClick={() => setOpen(null)} style={btn('plain')}>
+            <X size={13} /> {t.cancel}
+          </button>
+        </div>
+      )}
+
+      {/* Attaching, as the command that does it. */}
+      <div style={{ display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap', minWidth: 0 }}>
+        <span style={{ fontSize: 11, color: 'var(--text-tertiary)' }} title={t.attachWhy}>{t.attach}</span>
+        <code
+          style={{
+            fontSize: 11,
+            fontFamily: 'var(--font-mono, monospace)',
+            color: 'var(--text-primary)',
+            background: 'var(--bg-elevated)',
+            border: '1px solid var(--border-subtle)',
+            borderRadius: 6,
+            padding: '4px 8px',
+            overflowX: 'auto',
+            maxWidth: '100%',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {row.attachCommand}
+        </code>
+        <button
+          onClick={() => {
+            void navigator.clipboard.writeText(row.attachCommand)
+            setCopied(true)
+            setTimeout(() => setCopied(false), 1600)
+          }}
+          style={btn('plain')}
+        >
+          {copied ? <Check size={12} /> : <Copy size={12} />} {copied ? t.copied : t.copy}
+        </button>
+        <Terminal size={12} style={{ color: 'var(--text-tertiary)' }} />
+      </div>
+
+      {/* Whatever the last press said — a success, or the refusal that names why it could not run.
+          `role="status"` so it is announced rather than merely drawn. */}
+      {msg && (
+        <div
+          role="status"
+          style={{
+            fontSize: 12,
+            lineHeight: 1.5,
+            padding: '6px 10px',
+            borderRadius: 8,
+            background: msg.ok ? 'rgba(34,197,94,0.1)' : 'rgba(239,68,68,0.1)',
+            border: msg.ok ? '1px solid rgba(34,197,94,0.25)' : '1px solid rgba(239,68,68,0.25)',
+            color: msg.ok ? '#22c55e' : '#ef4444',
+            wordBreak: 'break-word',
+          }}
+        >
+          {msg.text}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/packages/web/src/lib/fleet.ts
+++ b/packages/web/src/lib/fleet.ts
@@ -1,0 +1,177 @@
+/**
+ * fleet.ts — the browser's half of `/api/fleet`.
+ *
+ * It holds NO rule about what a session may take. Every `enabled` flag, every refusal sentence and
+ * every verb label arrives already decided from the server, which resolves them through the same
+ * `sessionActions` the terminal cockpit resolves every keypress against. A second implementation
+ * here would be a second set of rules — the bug `task-reopen.ts` exists to have fixed once — and it
+ * would go wrong in the expensive direction: offering "answer its question" on a numbered dialog
+ * belonging to a harness with no verified way to pick, where the keystroke takes whichever option
+ * happens to be highlighted.
+ *
+ * What this module owns is the transport, the poll, and the mapping from a stored `SessionMeta` row
+ * to the live fleet row that is driving it.
+ */
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+
+/** Mirrors `SessionAction` in `@agentistics/tui/control/sessions`, minus the verbs a page cannot do. */
+export type FleetActionId =
+  | 'resume' | 'approve' | 'prompt' | 'rename' | 'note' | 'task' | 'kill'
+  | 'openTask' | 'finishTask'
+
+/** The verbs this page can PERFORM. The rest are shown, dimmed, with their reason. */
+export const PERFORMABLE: ReadonlySet<FleetActionId> = new Set<FleetActionId>([
+  'resume', 'approve', 'prompt', 'rename', 'note', 'task', 'kill', 'openTask', 'finishTask',
+])
+
+/** The verbs that take a line of text before they can run. */
+export const TEXT_VERBS: ReadonlySet<FleetActionId> = new Set<FleetActionId>([
+  'prompt', 'rename', 'note', 'task',
+])
+
+export interface FleetVerb {
+  action: FleetActionId
+  /** Already localized by the server, from the very map the terminal cockpit prints. */
+  label: string
+  enabled: boolean
+  /** Why it is off, when the row can say. Already localized. */
+  reason?: string
+}
+
+export interface FleetRow {
+  id: string
+  title: string
+  harness: string
+  cwd: string
+  project: string
+  state: 'working' | 'waiting' | 'waiting-approval' | 'exited' | 'lost' | 'unknown' | 'closed'
+  stateLabel: string
+  actionable: boolean
+  task?: string
+  note?: string
+  model?: string
+  conversationId?: string
+  approvalLines?: string[]
+  dialogOptions?: { number: number; label: string; selected?: boolean }[]
+  approvalBlind?: string
+  approveBlind?: string
+  chooseBlind?: string
+  conversationBlind?: string
+  attachCommand: string
+  verbs: FleetVerb[]
+}
+
+export interface FleetPayload {
+  sessions: FleetRow[]
+  attention: number
+  unavailable?: string
+  tasks: string[]
+}
+
+const EMPTY: FleetPayload = { sessions: [], attention: 0, tasks: [] }
+
+/** How often the page re-reads the fleet. The cockpit polls at 5s; matching it keeps the two in step. */
+const FLEET_POLL_MS = 5000
+
+export interface FleetState {
+  fleet: FleetPayload
+  /** True until the first answer arrives — an empty list before then is "not asked yet". */
+  loading: boolean
+  /**
+   * The route is absent or refused (a central, or an exposure profile with no host power).
+   *
+   * Distinct from an empty fleet on purpose: "there are no managed sessions" and "this page cannot
+   * ask" are different facts, and rendering the second as the first is a confident zero from a
+   * machine that was never allowed to look.
+   */
+  unsupported: boolean
+  refresh: () => void
+  act: (req: {
+    id: string
+    action: FleetActionId
+    text?: string
+    choice?: number
+  }) => Promise<{ ok: boolean; message: string }>
+}
+
+export function useFleet(lang: 'pt' | 'en', enabled = true): FleetState {
+  const [fleet, setFleet] = useState<FleetPayload>(EMPTY)
+  const [loading, setLoading] = useState(enabled)
+  const [unsupported, setUnsupported] = useState(false)
+  const [tick, setTick] = useState(0)
+
+  const refresh = useCallback(() => setTick(n => n + 1), [])
+
+  useEffect(() => {
+    if (!enabled) { setLoading(false); return }
+    let alive = true
+    const poll = async () => {
+      try {
+        const res = await fetch(`/api/fleet?lang=${lang}`)
+        if (!alive) return
+        // 403 (capability off) / 404 (a central) are ANSWERS, not failures — the page says so
+        // rather than showing an empty fleet it never got to read.
+        if (res.status === 403 || res.status === 404) { setUnsupported(true); setLoading(false); return }
+        if (!res.ok) return
+        const json = await res.json() as FleetPayload
+        if (!alive) return
+        setUnsupported(false)
+        setFleet(json)
+      } catch {
+        /* transient — keep the last known fleet, exactly as the cockpit's poller does */
+      } finally {
+        if (alive) setLoading(false)
+      }
+    }
+    void poll()
+    const id = setInterval(poll, FLEET_POLL_MS)
+    return () => { alive = false; clearInterval(id) }
+  }, [lang, enabled, tick])
+
+  const act = useCallback<FleetState['act']>(async req => {
+    try {
+      const res = await fetch(`/api/fleet/act?lang=${lang}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(req),
+      })
+      const json = await res.json().catch(() => null) as { ok?: boolean; message?: string } | null
+      const out = {
+        ok: Boolean(json?.ok),
+        message: json?.message
+          ?? (lang === 'pt' ? 'A ação não pôde ser executada.' : 'The action could not be run.'),
+      }
+      refresh()
+      return out
+    } catch {
+      return {
+        ok: false,
+        message: lang === 'pt' ? 'Erro de rede ao falar com esta máquina.' : 'Network error talking to this machine.',
+      }
+    }
+  }, [lang, refresh])
+
+  return { fleet, loading, unsupported, refresh, act }
+}
+
+/**
+ * A stored session id → the live fleet row driving it.
+ *
+ * Keyed on BOTH `conversationId` and `id`: the first is the exact link a managed row records (the
+ * uuid handed to `claude --session-id`), the second is what a `closed` row — one read straight out
+ * of the conversation store — is already named by. A managed row's own id is a tmux session name
+ * and can never collide with a conversation id, so one map answers both without ambiguity.
+ */
+export function fleetIndex(rows: readonly FleetRow[]): Map<string, FleetRow> {
+  const map = new Map<string, FleetRow>()
+  for (const r of rows) {
+    map.set(r.id, r)
+    if (r.conversationId) map.set(r.conversationId, r)
+  }
+  return map
+}
+
+export function useFleetIndex(rows: readonly FleetRow[]): Map<string, FleetRow> {
+  return useMemo(() => fleetIndex(rows), [rows])
+}

--- a/packages/web/src/lib/sessionTranscript.ts
+++ b/packages/web/src/lib/sessionTranscript.ts
@@ -1,0 +1,70 @@
+/**
+ * sessionTranscript.ts — PURE. Where a session's messages are read from, per harness.
+ *
+ * The "Details" popover used to fetch `/api/sessions/<id>/messages`, a route that has never existed
+ * on this server. It 404s, the `.then(r => r.ok ? r.json() : [])` turns that into an empty array,
+ * and the panel says "no recent messages" — on a live session with sixty-five of them. A confident
+ * "there is nothing" produced by a request that was never answered is exactly the failure mode
+ * `liveEmptyNotice` and `HARNESS_CAPABILITIES` exist to prevent, one layer up.
+ *
+ * The real readers were already there, one per harness, and they all return the same
+ * `{ role, content, timestamp }` shape. This module is the mapping to them, as a
+ * `Record<HarnessId, …>` so the build fails when a harness is added and nobody decides.
+ */
+
+import type { HarnessId, SessionMeta } from '@agentistics/core'
+
+export interface TranscriptMessage {
+  role: 'user' | 'assistant'
+  content: string
+  timestamp?: number | string
+  tools?: string[]
+}
+
+/** Either where to read the transcript, or WHY it can never be read for this harness. */
+export type TranscriptSource =
+  | { kind: 'url'; url: string }
+  | { kind: 'unavailable'; harness: HarnessId }
+
+/**
+ * Which harnesses this server can serve raw messages for.
+ *
+ * `false` is a FINDING, not a gap to be filled with an empty list: Antigravity and Kimi have no
+ * message reader on this server, so the panel must say that rather than draw the same blank space a
+ * session with nothing in it would draw.
+ */
+const READABLE: Record<HarnessId, boolean> = {
+  claude: true,
+  codex: true,
+  gemini: true,
+  copilot: true,
+  antigravity: false,
+  kimi: false,
+}
+
+/** The `~/.claude/projects` directory name for a path — the same encoding the server walks with. */
+export function encodeProjectDir(projectPath: string): string {
+  return projectPath.replace(/[^a-zA-Z0-9-]/g, '-')
+}
+
+export function transcriptSource(s: Pick<SessionMeta, 'session_id' | 'project_path' | 'harness'>): TranscriptSource {
+  const harness = (s.harness ?? 'claude') as HarnessId
+  if (!READABLE[harness]) return { kind: 'unavailable', harness }
+  const id = encodeURIComponent(s.session_id)
+  // Claude's reader is keyed by the PROJECT directory as well as the id — its transcripts live one
+  // file per session under the encoded project folder, and the id alone does not locate one.
+  if (harness === 'claude') {
+    return {
+      kind: 'url',
+      url: `/api/claude-sessions/${id}?encodedDir=${encodeURIComponent(encodeProjectDir(s.project_path))}`,
+    }
+  }
+  return { kind: 'url', url: `/api/${harness}-sessions/${id}` }
+}
+
+/** The sentence a panel prints instead of a blank list. Never "no messages" — that would be a claim. */
+export function transcriptUnavailableNote(harness: HarnessId, lang: 'pt' | 'en'): string {
+  return lang === 'pt'
+    ? `Este build não lê o transcript do ${harness} — as mensagens desta sessão não são capturadas aqui.`
+    : `This build has no message reader for ${harness} — this session's messages are not captured here.`
+}

--- a/packages/web/src/pages/HomePage.tsx
+++ b/packages/web/src/pages/HomePage.tsx
@@ -28,7 +28,6 @@ import { ProjectsList } from '../components/ProjectsList'
 import { TagCloud } from '../components/TagCloud'
 import { ToolMetricsPanel } from '../components/ToolMetricsPanel'
 import { AgentMetricsPanel } from '../components/AgentMetricsPanel'
-import { RecentSessions } from '../components/RecentSessions'
 import { TopBoards } from '../components/TopBoards'
 import { capable, HARNESS_LABELS, HARNESS_PROVIDERS } from '../lib/harness'
 import { StreakBreakdownButton } from '../components/StreakBreakdownButton'
@@ -335,10 +334,11 @@ export default function HomePage() {
         <AgentMetricsPanel invocations={derived.agentInvocations} agentTypeBreakdown={derived.agentTypeBreakdown} totalInvocations={derived.totalAgentInvocations} totalTokens={derived.totalAgentTokens} totalCostUSD={derived.totalAgentCostUSD} totalDurationMs={derived.totalAgentDurationMs} currency={currency} brlRate={brlRate} planFactor={claudePlanFactor} lang={lang} harness={filters.harness} />
       </Section>
 
-      {/* Recent sessions */}
-      <Section flashId="sessions-list" title={<><Clock size={14} /> {lang === 'pt' ? 'Sessões recentes' : 'Recent sessions'}</>}>
-        <RecentSessions sessions={derived.filteredSessions} lang={lang} onSelect={setSelectedSession} />
-      </Section>
+      {/* Sessions are NOT here. They have their own page (`/sessions`), which is registered
+          unconditionally in both the desktop SideNav and the mobile bottom nav and is the only
+          surface that can offer what to DO with a session — the live fleet, its state and its
+          verbs. Home listing them too meant the same rows in two places, one of them inert, and
+          the page that owns them one click away. */}
     </>
   )
 }

--- a/packages/web/src/pages/SessionsPage.tsx
+++ b/packages/web/src/pages/SessionsPage.tsx
@@ -1,17 +1,22 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react'
+/**
+ * SessionsPage — the one surface that owns sessions.
+ *
+ * It is ONE control surface, not two stacked cards. The page header used to be its own rounded box
+ * (title, subtitle, a List/Grid segmented control and the Notifications button) with the whole
+ * grouping/filter/sort/search block floating in a second box below it — and the second box carried
+ * its OWN list/grid pair, so the same control appeared twice on one screen. `RecentSessions` has
+ * always accepted `title` / `subtitle` / `topActions` and renders them inside its control card, so
+ * the header moved in there and the duplicate toggle went with it. The surviving toggle is the one
+ * in the controls row, beside the search, the sort and the grouping it belongs with.
+ */
+
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { useOutletContext, useNavigate } from 'react-router-dom'
-import ReactMarkdown from 'react-markdown'
-import remarkGfm from 'remark-gfm'
-import remarkBreaks from 'remark-breaks'
-import { Clock, Radio, Copy, Check, Bell, BellOff, Settings, Sparkles, Folder, User, Terminal, FileText, ChevronDown, ChevronUp, Send, Info, ExternalLink, LayoutGrid, List, ChevronLeft, ChevronRight, MessageSquare, Loader } from 'lucide-react'
-import type { HarnessId, LiveProcess, LiveUnavailableReason, SessionMeta } from '@agentistics/core'
-import { sessionLabel, sessionTokenTotal } from '@agentistics/core'
-import { HARNESS_COLORS, HARNESS_LABELS } from '../lib/harness'
+import { Bell, BellOff, Clock, Settings, Sparkles } from 'lucide-react'
+import type { SessionMeta } from '@agentistics/core'
 import type { AppContext } from '../lib/app-context'
-import { Section } from '../components/Section'
 import { RecentSessions } from '../components/RecentSessions'
-import { lastActivityMs, liveEmptyNotice } from '../lib/sessionLive'
-import { resumeCommand } from '../lib/resumeCommand'
+import { useFleet, useFleetIndex } from '../lib/fleet'
 import {
   getNotificationSettings,
   saveNotificationSettings,
@@ -31,27 +36,39 @@ export default function SessionsPage() {
   const pt = lang === 'pt'
   const navigate = useNavigate()
 
-  // Real-time open-session detection.
+  // Real-time open-session detection: which stored conversations have a live process behind them,
+  // and what each of those is doing.
   const [liveIdList, setLiveIdList] = useState<string[]>(data.liveSessionIds ?? [])
-  const [liveProcs, setLiveProcs] = useState<LiveProcess[]>(data.liveProcesses ?? [])
-  const [liveUnavailable, setLiveUnavailable] =
-    useState<LiveUnavailableReason | undefined>(data.liveUnavailable)
   const [liveActivities, setLiveActivities] = useState<Record<string, SessionActivity>>({})
 
-  // Notification settings state & prompt banner
   const [notifSettings, setNotifSettings] = useState<NotificationSettings>(getNotificationSettings)
   const prevActivitiesRef = useRef<Record<string, SessionActivity>>({})
+  /**
+   * Has this mount taken its SILENT BASELINE yet? — the fix for the false notifications.
+   *
+   * `handleSessionStateTransitions` announces anything it has no previous state for, and that is
+   * right for what it is: a session that appears really is news. What was wrong is what this page
+   * handed it. `prevActivitiesRef` starts EMPTY and the first poll called straight into it, so
+   * every live session looked new at once — and this poller lives inside a page component, so its
+   * memory is wiped by every remount: navigating away and back, a language toggle, a dev reload.
+   * The user's report is that burst, for sessions that had been in the same state for an hour.
+   *
+   * So the first answer is RECORDED and not announced. `sessionNotifications.test.ts` pins the
+   * other half deliberately — if the module ever stops firing for genuinely new sessions, this
+   * guard would hide it, so the two must stay separate.
+   *
+   * The cost, stated: a session already waiting when the page opens is not announced. That is the
+   * right trade — it is on screen, marked and counted, while a notification is for the thing that
+   * happened while you were looking somewhere else.
+   */
+  const baselineTakenRef = useRef(false)
 
-  // Sessions map lookup helper
   const sessionsMap = useMemo(() => {
     const map = new Map<string, SessionMeta>()
-    for (const s of data.sessions) {
-      map.set(s.session_id, s)
-    }
+    for (const s of data.sessions) map.set(s.session_id, s)
     return map
   }, [data.sessions])
 
-  // Poll live sessions
   useEffect(() => {
     let alive = true
     const poll = async () => {
@@ -60,55 +77,40 @@ export default function SessionsPage() {
         if (!res.ok) return
         const json = await res.json() as {
           liveSessionIds?: string[]
-          liveProcesses?: LiveProcess[]
-          liveUnavailable?: LiveUnavailableReason
           liveSessionActivities?: Record<string, SessionActivity>
         }
         if (!alive) return
         if (Array.isArray(json.liveSessionIds)) setLiveIdList(json.liveSessionIds)
-        setLiveProcs(Array.isArray(json.liveProcesses) ? json.liveProcesses : [])
-        setLiveUnavailable(json.liveUnavailable)
 
         const activities = json.liveSessionActivities || {}
         setLiveActivities(activities)
-
-        // Check state transitions for notifications
-        handleSessionStateTransitions(prevActivitiesRef.current, activities, sessionsMap, pt ? 'pt' : 'en')
+        // The first answer of this mount is the BASELINE: recorded, never announced. Everything
+        // after it is a genuine transition. See `baselineTakenRef`.
+        if (baselineTakenRef.current) {
+          handleSessionStateTransitions(prevActivitiesRef.current, activities, sessionsMap, pt ? 'pt' : 'en')
+        }
         prevActivitiesRef.current = activities
+        baselineTakenRef.current = true
       } catch { /* transient — keep last known */ }
     }
-    poll()
+    void poll()
     const id = setInterval(poll, LIVE_POLL_MS)
     return () => { alive = false; clearInterval(id) }
   }, [isCentral, sessionsMap, pt])
 
   const liveIds = useMemo(() => new Set(liveIdList), [liveIdList])
-  const live = useMemo(
-    () => data.sessions.filter(s => liveIds.has(s.session_id))
-      .sort((a, b) => lastActivityMs(b) - lastActivityMs(a)),
-    [data.sessions, liveIds],
-  )
-  const liveCount = live.length + liveProcs.length
-  const notice = liveEmptyNotice({ count: liveCount, central: isCentral, unavailable: liveUnavailable, lang: pt ? 'pt' : 'en' })
 
-  // Pagination (5 by 5) and view mode state for live sessions
-  const [livePage, setLivePage] = useState(1)
-  const [liveViewMode, setLiveViewMode] = useState<'list' | 'grid'>('list')
-  const LIVE_PAGE_SIZE = 5
-  const totalLivePages = Math.max(1, Math.ceil(live.length / LIVE_PAGE_SIZE))
-  const currentLivePage = Math.min(livePage, totalLivePages)
-  const pagedLive = useMemo(() => {
-    const start = (currentLivePage - 1) * LIVE_PAGE_SIZE
-    return live.slice(start, start + LIVE_PAGE_SIZE)
-  }, [live, currentLivePage])
+  // The LIVE fleet — what agentop hosts on THIS machine, and what each row may be asked to do.
+  // Never on a central: it aggregates many machines and hosts none of their sessions, so the only
+  // fleet it could read is its own box's, drawn under someone else's rows.
+  const { fleet, unsupported: fleetUnsupported, act } = useFleet(pt ? 'pt' : 'en', !isCentral)
+  const fleetIdx = useFleetIndex(fleet.sessions)
 
-  // Handle enabling notifications from prompt banner
   async function handleEnableNotifications() {
     const perm = await requestNotificationPermission()
     const next = { ...notifSettings, enabled: true, askedPrompt: true }
     setNotifSettings(next)
     saveNotificationSettings(next)
-
     if (perm === 'granted') {
       triggerSessionNotification({
         title: pt ? 'Notificações Ativadas' : 'Notifications Enabled',
@@ -127,18 +129,25 @@ export default function SessionsPage() {
 
   const showPromptBanner = !notifSettings.askedPrompt && getBrowserNotificationPermission() !== 'granted'
 
+  const btn: React.CSSProperties = {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 6,
+    padding: '8px 12px',
+    borderRadius: 8,
+    border: '1px solid var(--border-subtle)',
+    background: 'transparent',
+    color: 'var(--text-secondary)',
+    fontSize: 12,
+    fontWeight: 500,
+    cursor: 'pointer',
+    fontFamily: 'inherit',
+  }
+
   return (
     <>
-      <PageHead
-        pt={pt}
-        central={isCentral}
-        liveViewMode={liveViewMode}
-        setLiveViewMode={setLiveViewMode}
-        notifSettings={notifSettings}
-        onOpenNotifs={() => navigate('/settings/notifications')}
-      />
-
-      {/* Notification Permission Prompt Banner */}
+      {/* Notification permission prompt. Above the card because it is a one-off question about the
+          browser, not a control of this list. */}
       {showPromptBanner && (
         <div
           style={{
@@ -146,7 +155,7 @@ export default function SessionsPage() {
             border: '1px solid var(--anthropic-orange-dim, rgba(232,105,11,0.3))',
             borderRadius: 12,
             padding: '16px 20px',
-            marginBottom: 16,
+            marginBottom: 12,
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'space-between',
@@ -154,18 +163,12 @@ export default function SessionsPage() {
             flexWrap: 'wrap',
           }}
         >
-          <div style={{ display: 'flex', alignItems: 'center', gap: 12, flex: 1, minWidth: 280 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 12, flex: 1, minWidth: 260 }}>
             <div
               style={{
-                width: 38,
-                height: 38,
-                borderRadius: 10,
-                background: 'rgba(232,105,11,0.12)',
-                color: 'var(--anthropic-orange)',
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                flexShrink: 0,
+                width: 38, height: 38, borderRadius: 10, flexShrink: 0,
+                background: 'rgba(232,105,11,0.12)', color: 'var(--anthropic-orange)',
+                display: 'flex', alignItems: 'center', justifyContent: 'center',
               }}
             >
               <Bell size={20} />
@@ -176,835 +179,86 @@ export default function SessionsPage() {
                   ? 'Deseja receber notificações sobre os andamentos de suas live sessions?'
                   : 'Would you like to receive notifications for your live sessions?'}
               </div>
-              <div style={{ fontSize: 12, color: 'var(--text-tertiary)' }}>
+              <div style={{ fontSize: 12, color: 'var(--text-tertiary)', lineHeight: 1.5 }}>
                 {pt
-                  ? 'Receba alertas visuais e sonoros detalhados quando uma sessão precisar de aprovação, aguardar resposta ou encerrar.'
-                  : 'Receive detailed visual and sound alerts when a session needs approval, waits for response, or exits.'}
+                  ? 'Só quando uma sessão MUDA de estado — passa a precisar de você, termina o turno ou encerra. O que já estava esperando quando você abriu a página não dispara nada.'
+                  : 'Only when a session CHANGES state — starts needing you, finishes its turn, or exits. Anything already waiting when you opened the page announces nothing.'}
               </div>
             </div>
           </div>
 
-          <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexShrink: 0 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexShrink: 0, flexWrap: 'wrap' }}>
             <button
               onClick={handleEnableNotifications}
-              style={{
-                display: 'flex',
-                alignItems: 'center',
-                gap: 6,
-                padding: '8px 16px',
-                borderRadius: 8,
-                background: 'var(--anthropic-orange)',
-                color: '#fff',
-                border: 'none',
-                fontSize: 12,
-                fontWeight: 600,
-                cursor: 'pointer',
-                fontFamily: 'inherit',
-              }}
+              style={{ ...btn, background: 'var(--anthropic-orange)', color: '#fff', border: 'none', fontWeight: 600 }}
             >
               <Sparkles size={14} />
               <span>{pt ? 'Sim, ativar notificações' : 'Yes, enable notifications'}</span>
             </button>
-            <button
-              onClick={() => navigate('/settings/notifications')}
-              style={{
-                display: 'flex',
-                alignItems: 'center',
-                gap: 4,
-                padding: '8px 12px',
-                borderRadius: 8,
-                border: '1px solid var(--border-subtle)',
-                background: 'transparent',
-                color: 'var(--text-secondary)',
-                fontSize: 12,
-                fontWeight: 500,
-                cursor: 'pointer',
-                fontFamily: 'inherit',
-              }}
-            >
+            <button onClick={() => navigate('/settings/notifications')} style={btn}>
               <Settings size={13} />
               <span>{pt ? 'Configurar' : 'Configure'}</span>
             </button>
-            <button
-              onClick={handleDismissPrompt}
-              style={{
-                padding: '8px 12px',
-                borderRadius: 8,
-                border: '1px solid var(--border-subtle)',
-                background: 'transparent',
-                color: 'var(--text-tertiary)',
-                fontSize: 12,
-                cursor: 'pointer',
-                fontFamily: 'inherit',
-              }}
-            >
+            <button onClick={handleDismissPrompt} style={{ ...btn, color: 'var(--text-tertiary)' }}>
               {pt ? 'Agora não' : 'Not now'}
             </button>
           </div>
         </div>
       )}
 
-      {/* Primary Unified Sessions View */}
+      {/* Why the rows below may carry no verbs. Said in words rather than left as a bar that never
+          appears: "nothing is running" and "this machine cannot tell" are different facts. */}
+      {!isCentral && (fleetUnsupported || fleet.unavailable) && (
+        <div
+          role="status"
+          style={{
+            fontSize: 12,
+            lineHeight: 1.5,
+            color: 'var(--text-tertiary)',
+            border: '1px solid var(--border-subtle)',
+            borderRadius: 10,
+            padding: '10px 14px',
+            marginBottom: 12,
+          }}
+        >
+          {fleetUnsupported
+            ? (pt
+                ? 'O controle de sessões não está disponível nesta instalação, então as sessões abaixo aparecem só como histórico.'
+                : 'Session control is not available on this install, so the sessions below are listed as history only.')
+            : fleet.unavailable}
+        </div>
+      )}
+
       <RecentSessions
         sessions={derived.filteredSessions}
         lang={lang}
         onSelect={setSelectedSession}
         pinnedIds={liveIds}
         activities={liveActivities}
-        viewMode={liveViewMode}
-        onViewModeChange={setLiveViewMode}
+        fleet={fleetIdx}
+        onFleetAction={act}
+        title={<>
+          <span style={{ color: 'var(--anthropic-orange)', display: 'inline-flex' }}><Clock size={18} /></span>
+          {pt ? 'Sessões' : 'Sessions'}
+        </>}
+        subtitle={isCentral
+          ? (pt
+              ? 'Últimas sessões do time (metadados, sem chat) — reativo aos filtros, inclusive por membro.'
+              : "The team's latest sessions (metadata, no chat) — reactive to the filters, including by member.")
+          : (pt
+              ? 'Sessões abertas agora (em tempo real) e as últimas sessões, com o que dá para fazer com cada uma.'
+              : 'Sessions open right now (real time) and your latest ones, with what can be done to each.')}
+        topActions={
+          <button
+            onClick={() => navigate('/settings/notifications')}
+            title={pt ? 'Configurar Notificações' : 'Configure Notifications'}
+            style={{ ...btn, background: 'var(--bg-elevated)' }}
+          >
+            {notifSettings.enabled ? <Bell size={13} style={{ color: 'var(--anthropic-orange)' }} /> : <BellOff size={13} />}
+            <span>{pt ? 'Notificações' : 'Notifications'}</span>
+          </button>
+        }
       />
     </>
-  )
-}
-
-function PageHead({
-  pt,
-  central,
-  liveViewMode,
-  setLiveViewMode,
-  notifSettings,
-  onOpenNotifs,
-}: {
-  pt: boolean
-  central?: boolean
-  liveViewMode: 'list' | 'grid'
-  setLiveViewMode: (mode: 'list' | 'grid') => void
-  notifSettings: NotificationSettings
-  onOpenNotifs: () => void
-}) {
-  return (
-    <div
-      style={{
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'space-between',
-        flexWrap: 'wrap',
-        gap: 12,
-        marginBottom: 12,
-        padding: '14px 18px',
-        borderRadius: 12,
-        background: 'var(--bg-surface)',
-        border: '1px solid var(--border-subtle)',
-      }}
-    >
-      <div style={{ display: 'flex', flexDirection: 'column', gap: 4, flex: 1, minWidth: 260 }}>
-        <div style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 18, fontWeight: 700, color: 'var(--text-primary)' }}>
-          <span style={{ color: 'var(--anthropic-orange)' }}><Clock size={18} /></span>
-          {pt ? 'Sessões' : 'Sessions'}
-        </div>
-        <div style={{ fontSize: 12, color: 'var(--text-tertiary)', lineHeight: 1.5 }}>
-          {central
-            ? (pt
-                ? 'Últimas sessões do time (metadados, sem chat) — reativo aos filtros, inclusive por membro.'
-                : "The team's latest sessions (metadata, no chat) — reactive to the filters, including by member.")
-            : (pt
-                ? 'Sessões abertas agora (em tempo real) e as últimas sessões, com comando para retomar.'
-                : 'Sessions open right now (real time) and your latest sessions, with a resume command.')}
-        </div>
-      </div>
-
-      {/* Right Side Controls: View Mode TabMenu & Notifications Button */}
-      <div style={{ display: 'flex', alignItems: 'center', gap: 10, flexShrink: 0 }}>
-        {/* TabMenu: List vs Grid Toggle */}
-        <div style={{ display: 'flex', alignItems: 'center', border: '1px solid var(--border-subtle)', borderRadius: 8, padding: 3, background: 'var(--bg-elevated)' }}>
-          <button
-            onClick={() => setLiveViewMode('list')}
-            title={pt ? 'Exibir em lista' : 'List view'}
-            style={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: 5,
-              padding: '4px 10px',
-              borderRadius: 6,
-              border: 'none',
-              background: liveViewMode === 'list' ? 'var(--bg-card)' : 'transparent',
-              color: liveViewMode === 'list' ? 'var(--anthropic-orange)' : 'var(--text-tertiary)',
-              fontSize: 11,
-              fontWeight: liveViewMode === 'list' ? 600 : 400,
-              cursor: 'pointer',
-              fontFamily: 'inherit',
-              transition: 'all 0.15s',
-            }}
-          >
-            <List size={13} />
-            <span>{pt ? 'Lista' : 'List'}</span>
-          </button>
-          <button
-            onClick={() => setLiveViewMode('grid')}
-            title={pt ? 'Exibir em grade' : 'Grid view'}
-            style={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: 5,
-              padding: '4px 10px',
-              borderRadius: 6,
-              border: 'none',
-              background: liveViewMode === 'grid' ? 'var(--bg-card)' : 'transparent',
-              color: liveViewMode === 'grid' ? 'var(--anthropic-orange)' : 'var(--text-tertiary)',
-              fontSize: 11,
-              fontWeight: liveViewMode === 'grid' ? 600 : 400,
-              cursor: 'pointer',
-              fontFamily: 'inherit',
-              transition: 'all 0.15s',
-            }}
-          >
-            <LayoutGrid size={13} />
-            <span>{pt ? 'Grade' : 'Grid'}</span>
-          </button>
-        </div>
-
-        {/* Notifications Settings Button */}
-        <button
-          onClick={onOpenNotifs}
-          title={pt ? 'Configurar Notificações' : 'Configure Notifications'}
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: 6,
-            fontSize: 11,
-            fontWeight: 500,
-            padding: '6px 12px',
-            borderRadius: 8,
-            border: '1px solid var(--border-subtle)',
-            background: 'var(--bg-elevated)',
-            color: 'var(--text-secondary)',
-            cursor: 'pointer',
-            fontFamily: 'inherit',
-            transition: 'all 0.15s',
-          }}
-        >
-          {notifSettings.enabled ? <Bell size={13} style={{ color: 'var(--anthropic-orange)' }} /> : <BellOff size={13} />}
-          <span>{pt ? 'Notificações' : 'Notifications'}</span>
-        </button>
-      </div>
-    </div>
-  )
-}
-
-function StatusBadge({ activity, pt }: { activity?: SessionActivity; pt: boolean }) {
-  const act = activity || 'working'
-  const config = {
-    'working': {
-      labelPt: 'trabalhando',
-      labelEn: 'working',
-      color: '#22c55e',
-      bg: 'rgba(34, 197, 94, 0.12)',
-      border: 'rgba(34, 197, 94, 0.3)',
-    },
-    'waiting': {
-      labelPt: 'aguardando resposta',
-      labelEn: 'waiting input',
-      color: '#f59e0b',
-      bg: 'rgba(245, 158, 11, 0.12)',
-      border: 'rgba(245, 158, 11, 0.3)',
-    },
-    'waiting-approval': {
-      labelPt: 'precisa de aprovação',
-      labelEn: 'needs approval',
-      color: '#ef4444',
-      bg: 'rgba(239, 68, 68, 0.12)',
-      border: 'rgba(239, 68, 68, 0.3)',
-    },
-    'exited': {
-      labelPt: 'encerrada',
-      labelEn: 'exited',
-      color: '#9ca3af',
-      bg: 'rgba(156, 163, 175, 0.12)',
-      border: 'rgba(156, 163, 175, 0.3)',
-    },
-  }[act] || {
-    labelPt: 'trabalhando',
-    labelEn: 'working',
-    color: '#22c55e',
-    bg: 'rgba(34, 197, 94, 0.12)',
-    border: 'rgba(34, 197, 94, 0.3)',
-  }
-
-  return (
-    <span
-      style={{
-        display: 'inline-flex',
-        alignItems: 'center',
-        gap: 5,
-        padding: '2px 8px',
-        borderRadius: 999,
-        fontSize: 10,
-        fontWeight: 600,
-        color: config.color,
-        background: config.bg,
-        border: `1px solid ${config.border}`,
-        whiteSpace: 'nowrap',
-        flexShrink: 0,
-      }}
-    >
-      <span
-        style={{
-          width: 6,
-          height: 6,
-          borderRadius: '50%',
-          background: config.color,
-          boxShadow: `0 0 6px ${config.color}`,
-        }}
-      />
-      {pt ? config.labelPt : config.labelEn}
-    </span>
-  )
-}
-
-function LiveCard({
-  s,
-  pt,
-  onOpen,
-  central,
-  activity,
-  viewMode = 'list',
-}: {
-  s: SessionMeta
-  pt: boolean
-  onOpen: () => void
-  central?: boolean
-  activity?: SessionActivity
-  viewMode?: 'list' | 'grid'
-}) {
-  const cmd = central ? null : resumeCommand(s)
-  const [copied, setCopied] = useState(false)
-  const [showDetails, setShowDetails] = useState(false)
-  const [promptText, setPromptText] = useState('')
-  const [sendingPrompt, setSendingPrompt] = useState(false)
-  const [promptFeedback, setPromptFeedback] = useState<{ ok: boolean; msg: string } | null>(null)
-
-  const [messages, setMessages] = useState<{ role: 'user' | 'assistant'; content: string; timestamp?: number; tools?: string[] }[] | null>(null)
-  const [loadingMsgs, setLoadingMsgs] = useState(false)
-
-  const detailsRef = useRef<HTMLDivElement>(null)
-
-  // Click outside to dismiss floating details popover
-  useEffect(() => {
-    if (!showDetails) return
-    function handleClickOutside(e: MouseEvent) {
-      if (detailsRef.current && !detailsRef.current.contains(e.target as Node)) {
-        setShowDetails(false)
-      }
-    }
-    document.addEventListener('mousedown', handleClickOutside)
-    return () => document.removeEventListener('mousedown', handleClickOutside)
-  }, [showDetails])
-
-  useEffect(() => {
-    if (showDetails && messages === null && !loadingMsgs) {
-      setLoadingMsgs(true)
-      fetch(`/api/sessions/${encodeURIComponent(s.session_id)}/messages?harness=${encodeURIComponent(s.harness || 'claude')}&projectPath=${encodeURIComponent(s.project_path || '')}`)
-        .then(r => r.ok ? r.json() : [])
-        .then((msgs: any[]) => {
-          if (Array.isArray(msgs)) setMessages(msgs)
-          else setMessages([])
-        })
-        .catch(() => setMessages([]))
-        .finally(() => setLoadingMsgs(false))
-    }
-  }, [showDetails, s.session_id, s.harness, s.project_path, messages, loadingMsgs])
-
-  const mins = Math.max(0, Math.round((Date.now() - lastActivityMs(s)) / 60_000))
-  const title = sessionLabel(s) || (s.project_path ? (s.project_path.split('/').filter(Boolean).pop() || '') : '') || s.session_id.slice(0, 8)
-
-  async function handleSendPrompt(e?: React.FormEvent) {
-    if (e) e.preventDefault()
-    const text = promptText.trim()
-    if (!text || sendingPrompt) return
-
-    setSendingPrompt(true)
-    setPromptFeedback(null)
-    try {
-      const res = await fetch('/api/sessions/prompt', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ sessionId: s.session_id, prompt: text }),
-      })
-      const json = await res.json() as { ok?: boolean; message?: string; error?: string }
-      if (res.ok && json.ok) {
-        setPromptFeedback({
-          ok: true,
-          msg: pt ? 'Prompt enviado com sucesso para a sessão no terminal!' : 'Prompt sent successfully to session in terminal!',
-        })
-        setPromptText('')
-      } else {
-        setPromptFeedback({
-          ok: false,
-          msg: json.error || (pt ? 'Erro ao enviar prompt para a sessão.' : 'Failed to send prompt.'),
-        })
-      }
-    } catch (err: any) {
-      setPromptFeedback({
-        ok: false,
-        msg: err?.message || (pt ? 'Erro de rede ao enviar prompt.' : 'Network error.'),
-      })
-    } finally {
-      setSendingPrompt(false)
-      setTimeout(() => setPromptFeedback(null), 4000)
-    }
-  }
-
-  // All four billed counters — the conversational pair alone is a fraction of a percent.
-  const totalTokens = sessionTokenTotal(s)
-
-  return (
-    <div
-      style={{
-        position: 'relative',
-        border: '1px solid var(--border)',
-        borderRadius: 12,
-        padding: '16px 18px',
-        background: 'var(--bg-card)',
-        display: 'flex',
-        flexDirection: 'column',
-        gap: 12,
-        boxShadow: '0 1px 3px rgba(0,0,0,0.03)',
-        boxSizing: 'border-box',
-        width: '100%',
-        minWidth: 0,
-        maxWidth: '100%',
-      }}
-    >
-      {/* Header Row: Title on Left, Stacked Badges + Elapsed Time on Right */}
-      <div
-        style={{
-          display: 'flex',
-          alignItems: 'flex-start',
-          justifyContent: 'space-between',
-          gap: 12,
-        }}
-      >
-        {/* Title & Project Path */}
-        <div style={{ display: 'flex', flexDirection: 'column', gap: 4, minWidth: 0, flex: 1 }}>
-          <div
-            onClick={onOpen}
-            style={{
-              cursor: 'pointer',
-              fontSize: 15,
-              fontWeight: 600,
-              color: 'var(--text-primary)',
-              overflow: 'hidden',
-              textOverflow: 'ellipsis',
-              whiteSpace: 'nowrap',
-            }}
-            title={title}
-          >
-            {title}
-          </div>
-
-          <div
-            style={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: 6,
-              fontSize: 12,
-              color: 'var(--text-tertiary)',
-              minWidth: 0,
-            }}
-          >
-            <Folder size={12} style={{ flexShrink: 0, color: 'var(--text-tertiary)' }} />
-            <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }} title={s.project_path}>
-              {s.project_path}
-            </span>
-            {central && s.user && (
-              <span style={{ display: 'flex', alignItems: 'center', gap: 4, flexShrink: 0, marginLeft: 6, color: 'var(--text-secondary)' }}>
-                <User size={12} />
-                <span>{s.user}</span>
-              </span>
-            )}
-          </div>
-        </div>
-
-        {/* Stacked Badges Cluster on Right */}
-        <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: 4, flexShrink: 0 }}>
-          <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
-            <HarnessBadge harness={s.harness} />
-            <StatusBadge activity={activity} pt={pt} />
-          </div>
-          <div style={{ fontSize: 11, color: 'var(--text-tertiary)', display: 'flex', alignItems: 'center', gap: 4 }}>
-            <Clock size={11} />
-            <span>{pt ? `há ${mins} min` : `${mins} min ago`}</span>
-          </div>
-        </div>
-      </div>
-
-      {/* Command Box */}
-      {cmd ? (
-        <div
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'space-between',
-            gap: 12,
-            padding: '8px 12px',
-            borderRadius: 8,
-            background: 'var(--bg-elevated)',
-            border: '1px solid var(--border-subtle)',
-            width: '100%',
-            minWidth: 0,
-            maxWidth: '100%',
-            boxSizing: 'border-box',
-            overflow: 'hidden',
-          }}
-        >
-          <div style={{ display: 'flex', alignItems: 'center', gap: 8, minWidth: 0, flex: 1, overflow: 'hidden' }}>
-            <Terminal size={13} style={{ color: 'var(--anthropic-orange)', flexShrink: 0 }} />
-            <code
-              style={{
-                fontSize: 11,
-                fontFamily: 'var(--font-mono, monospace)',
-                color: 'var(--text-primary)',
-                overflowX: 'auto',
-                whiteSpace: 'nowrap',
-                scrollbarWidth: 'none',
-                maxWidth: '100%',
-                display: 'block',
-              }}
-            >
-              {cmd}
-            </code>
-          </div>
-
-          <button
-            onClick={() => {
-              navigator.clipboard.writeText(cmd)
-              setCopied(true)
-              setTimeout(() => setCopied(false), 1800)
-            }}
-            title={pt ? 'Copiar comando para o terminal' : 'Copy command to terminal'}
-            style={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: 6,
-              padding: '5px 10px',
-              borderRadius: 6,
-              border: copied ? '1px solid rgba(34, 197, 94, 0.4)' : '1px solid var(--border)',
-              background: copied ? 'rgba(34, 197, 94, 0.1)' : 'var(--bg-card)',
-              color: copied ? '#22c55e' : 'var(--text-secondary)',
-              fontSize: 11,
-              fontWeight: 500,
-              cursor: 'pointer',
-              flexShrink: 0,
-              transition: 'all 0.15s ease',
-              fontFamily: 'inherit',
-            }}
-          >
-            {copied ? (
-              <>
-                <Check size={12} color="#22c55e" />
-                <span>{pt ? 'Copiado!' : 'Copied!'}</span>
-              </>
-            ) : (
-              <>
-                <Copy size={12} />
-                <span>{pt ? 'Copiar' : 'Copy'}</span>
-              </>
-            )}
-          </button>
-        </div>
-      ) : central ? null : (
-        <div style={{ fontSize: 11, color: 'var(--text-tertiary)', fontStyle: 'italic' }}>
-          {pt ? 'Retomar não disponível para este harness.' : 'Resume not available for this harness.'}
-        </div>
-      )}
-
-      {/* Machine Mode Explicit Controls: Detalhes Button & Short Prompt Form */}
-      {!central && (
-        <div
-          style={{
-            display: 'flex',
-            flexDirection: 'column',
-            gap: 10,
-            paddingTop: 8,
-            borderTop: '1px solid var(--border-subtle)',
-          }}
-        >
-          {/* Action Toolbar */}
-          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8, flexWrap: 'wrap' }}>
-            {/* Detalhes Toggle Button */}
-            <button
-              onClick={() => setShowDetails(v => !v)}
-              style={{
-                display: 'flex',
-                alignItems: 'center',
-                gap: 6,
-                padding: '6px 12px',
-                borderRadius: 6,
-                border: showDetails ? '1px solid var(--anthropic-orange-dim, rgba(232,105,11,0.4))' : '1px solid var(--border)',
-                background: showDetails ? 'rgba(232,105,11,0.08)' : 'var(--bg-card)',
-                color: showDetails ? 'var(--anthropic-orange)' : 'var(--text-primary)',
-                fontSize: 12,
-                fontWeight: 600,
-                cursor: 'pointer',
-                fontFamily: 'inherit',
-                transition: 'all 0.15s ease',
-              }}
-            >
-              <FileText size={13} />
-              <span>{pt ? 'Detalhes' : 'Details'}</span>
-              {showDetails ? <ChevronUp size={13} /> : <ChevronDown size={13} />}
-            </button>
-
-            {/* Quick link to open full drilldown modal */}
-            <button
-              onClick={onOpen}
-              style={{
-                display: 'flex',
-                alignItems: 'center',
-                gap: 4,
-                fontSize: 11,
-                color: 'var(--text-tertiary)',
-                background: 'transparent',
-                border: 'none',
-                cursor: 'pointer',
-                fontFamily: 'inherit',
-              }}
-            >
-              <ExternalLink size={12} />
-              <span>{pt ? 'Abrir no Modal' : 'Open in Modal'}</span>
-            </button>
-          </div>
-
-          {/* Short Prompt Input Bar */}
-          <form
-            onSubmit={handleSendPrompt}
-            style={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: 8,
-              background: 'var(--bg-elevated)',
-              border: '1px solid var(--border-subtle)',
-              borderRadius: 8,
-              padding: '4px 6px 4px 10px',
-            }}
-          >
-            <input
-              type="text"
-              value={promptText}
-              onChange={e => setPromptText(e.target.value)}
-              placeholder={pt ? 'Enviar short prompt para a sessão...' : 'Send short prompt to session...'}
-              style={{
-                flex: 1,
-                background: 'transparent',
-                border: 'none',
-                outline: 'none',
-                fontSize: 12,
-                color: 'var(--text-primary)',
-                fontFamily: 'inherit',
-              }}
-            />
-            <button
-              type="submit"
-              disabled={sendingPrompt || !promptText.trim()}
-              style={{
-                display: 'flex',
-                alignItems: 'center',
-                gap: 5,
-                padding: '5px 12px',
-                borderRadius: 6,
-                background: 'var(--anthropic-orange)',
-                color: '#fff',
-                border: 'none',
-                fontSize: 11,
-                fontWeight: 600,
-                cursor: sendingPrompt || !promptText.trim() ? 'not-allowed' : 'pointer',
-                opacity: sendingPrompt || !promptText.trim() ? 0.6 : 1,
-                fontFamily: 'inherit',
-                flexShrink: 0,
-              }}
-            >
-              <Send size={11} />
-              <span>{sendingPrompt ? (pt ? 'Enviando...' : 'Sending...') : (pt ? 'Enviar Prompt' : 'Send')}</span>
-            </button>
-          </form>
-
-          {/* Prompt Feedback Toast */}
-          {promptFeedback && (
-            <div
-              style={{
-                fontSize: 11,
-                padding: '4px 8px',
-                borderRadius: 6,
-                background: promptFeedback.ok ? 'rgba(34,197,94,0.1)' : 'rgba(239,68,68,0.1)',
-                color: promptFeedback.ok ? '#22c55e' : '#ef4444',
-                border: promptFeedback.ok ? '1px solid rgba(34,197,94,0.2)' : '1px solid rgba(239,68,68,0.2)',
-                display: 'flex',
-                alignItems: 'center',
-                gap: 6,
-              }}
-            >
-              {promptFeedback.ok ? <Check size={12} /> : <Info size={12} />}
-              <span>{promptFeedback.msg}</span>
-            </div>
-          )}
-
-          {/* Expandable Details Panel — Floating Popover in Grid View / Inline in List View */}
-          {showDetails && (
-            <div
-              ref={detailsRef}
-              style={{
-                display: 'flex',
-                flexDirection: 'column',
-                gap: 10,
-                padding: '12px 14px',
-                borderRadius: 10,
-                background: 'var(--bg-elevated)',
-                border: '1px solid var(--anthropic-orange-dim, rgba(232,105,11,0.4))',
-                width: '100%',
-                minWidth: 0,
-                boxSizing: 'border-box',
-                overflow: 'hidden',
-                ...(viewMode === 'grid'
-                  ? {
-                      position: 'absolute',
-                      top: '100%',
-                      left: 0,
-                      right: 0,
-                      zIndex: 300,
-                      marginTop: 6,
-                      boxShadow: '0 12px 36px rgba(0,0,0,0.5)',
-                      animation: 'ttyChatFadeIn 0.15s ease-out',
-                    }
-                  : {
-                      marginTop: 6,
-                    }),
-              }}
-            >
-              <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', borderBottom: '1px solid var(--border-subtle)', paddingBottom: 6 }}>
-                <div style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 12, fontWeight: 600, color: 'var(--text-primary)' }}>
-                  <MessageSquare size={13} style={{ color: 'var(--anthropic-orange)' }} />
-                  <span>{pt ? 'Últimas mensagens da conversa' : 'Recent conversation messages'}</span>
-                </div>
-                {messages && messages.length > 0 && (
-                  <span style={{ fontSize: 11, color: 'var(--text-tertiary)' }}>
-                    {pt ? `exibindo ${Math.min(4, messages.length)} de ${messages.length}` : `showing ${Math.min(4, messages.length)} of ${messages.length}`}
-                  </span>
-                )}
-              </div>
-
-              {loadingMsgs ? (
-                <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '12px 0', fontSize: 12, color: 'var(--text-tertiary)' }}>
-                  <Loader size={14} style={{ animation: 'spin 1s linear infinite' }} />
-                  <span>{pt ? 'Carregando histórico do transcript...' : 'Loading transcript history...'}</span>
-                </div>
-              ) : messages && messages.length > 0 ? (
-                <div style={{ display: 'flex', flexDirection: 'column', gap: 8, maxHeight: 280, overflowY: 'auto', paddingRight: 4 }}>
-                  {messages.slice(-4).map((m, idx) => {
-                    const isUser = m.role === 'user'
-                    const colour = HARNESS_COLORS[s.harness] ?? 'var(--anthropic-orange)'
-                    const roleLabel = isUser ? (pt ? 'Você' : 'You') : (HARNESS_LABELS[s.harness] ?? s.harness)
-                    return (
-                      <div key={idx} style={{ display: 'flex', flexDirection: 'column', alignItems: isUser ? 'flex-end' : 'flex-start', gap: 2, width: '100%', minWidth: 0 }}>
-                        <div style={{ fontSize: 10, fontWeight: 600, color: isUser ? 'var(--text-tertiary)' : colour }}>
-                          {roleLabel}
-                        </div>
-                        <div
-                          style={{
-                            maxWidth: '96%',
-                            minWidth: 0,
-                            padding: '8px 10px',
-                            borderRadius: isUser ? '10px 10px 2px 10px' : '10px 10px 10px 2px',
-                            background: isUser ? 'rgba(59, 130, 246, 0.12)' : 'var(--bg-card)',
-                            border: isUser ? '1px solid rgba(59, 130, 246, 0.25)' : `1px solid ${colour}44`,
-                            fontSize: 12,
-                            color: 'var(--text-primary)',
-                            lineHeight: 1.5,
-                            wordBreak: 'break-word',
-                            overflowWrap: 'anywhere',
-                            overflow: 'hidden',
-                          }}
-                        >
-                          <ReactMarkdown
-                            remarkPlugins={[remarkGfm, remarkBreaks]}
-                            components={{
-                              p: ({ children }) => <span style={{ display: 'block', margin: '0 0 4px 0' }}>{children}</span>,
-                              ul: ({ children }) => <ul style={{ margin: '2px 0 4px 0', paddingLeft: 18 }}>{children}</ul>,
-                              ol: ({ children }) => <ol style={{ margin: '2px 0 4px 0', paddingLeft: 18 }}>{children}</ol>,
-                              li: ({ children }) => <li style={{ margin: '1px 0' }}>{children}</li>,
-                              code: ({ children, className }) => {
-                                const isBlock = !!className
-                                return isBlock
-                                  ? <pre style={{ background: 'var(--bg-surface)', padding: '6px 8px', borderRadius: 4, overflowX: 'auto', margin: '4px 0', fontSize: 11, maxWidth: '100%' }}><code style={{ whiteSpace: 'pre', display: 'block' }}>{children}</code></pre>
-                                  : <code style={{ background: 'var(--bg-surface)', padding: '1px 4px', borderRadius: 3, fontSize: 11 }}>{children}</code>
-                              },
-                              pre: ({ children }) => <>{children}</>,
-                            }}
-                          >
-                            {m.content.length > 500 ? m.content.slice(0, 500) + '...' : m.content}
-                          </ReactMarkdown>
-                        </div>
-                      </div>
-                    )
-                  })}
-                </div>
-              ) : (
-                <div style={{ fontSize: 12, color: 'var(--text-tertiary)', fontStyle: 'italic', padding: '6px 0' }}>
-                  {pt ? 'Nenhuma mensagem recente encontrada nesta sessão.' : 'No recent messages found in this session.'}
-                </div>
-              )}
-
-              <button
-                onClick={onOpen}
-                style={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  gap: 6,
-                  padding: '6px 12px',
-                  borderRadius: 6,
-                  border: '1px solid var(--border-subtle)',
-                  background: 'var(--bg-card)',
-                  color: 'var(--anthropic-orange)',
-                  fontSize: 11,
-                  fontWeight: 600,
-                  cursor: 'pointer',
-                  fontFamily: 'inherit',
-                  marginTop: 4,
-                  width: '100%',
-                }}
-              >
-                <ExternalLink size={12} />
-                <span>{pt ? 'Abrir Transcrição Completa e Métricas no Modal →' : 'Open Full Transcript & Metrics in Modal →'}</span>
-              </button>
-            </div>
-          )}
-        </div>
-      )}
-    </div>
-  )
-}
-
-function HarnessBadge({ harness }: { harness: HarnessId }) {
-  const colour = HARNESS_COLORS[harness] ?? 'var(--text-tertiary)'
-  return (
-    <span style={{
-      flexShrink: 0, fontSize: 10, fontWeight: 600, letterSpacing: 0.3, padding: '2px 6px',
-      borderRadius: 999, color: colour, border: `1px solid ${colour}`, background: 'transparent',
-      textTransform: 'uppercase', whiteSpace: 'nowrap',
-    }}>{HARNESS_LABELS[harness] ?? harness}</span>
-  )
-}
-
-function StartingCard({ p, pt }: { p: LiveProcess; pt: boolean }) {
-  const label = HARNESS_LABELS[p.harness] ?? p.harness
-  const colour = HARNESS_COLORS[p.harness] ?? 'var(--text-tertiary)'
-  return (
-    <div style={{ border: '1px dashed var(--border)', borderRadius: 10, padding: 12, background: 'var(--bg-card)' }}>
-      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-        <span style={{ width: 8, height: 8, borderRadius: '50%', background: colour, flexShrink: 0, opacity: 0.7 }} />
-        <span style={{ fontWeight: 600, color: 'var(--text-primary)' }}>{label}</span>
-        {p.user && <span style={{ fontSize: 11, color: 'var(--text-tertiary)' }}>· {p.user}</span>}
-        <span style={{ fontSize: 11, color: 'var(--text-tertiary)', marginLeft: 'auto' }}>
-          {pt ? 'sem conversa ainda' : 'no conversation yet'}
-        </span>
-      </div>
-      <div style={{ fontSize: 11, color: 'var(--text-tertiary)', marginTop: 4, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{p.cwd}</div>
-      <div style={{ fontSize: 11, color: 'var(--text-tertiary)', marginTop: 6, fontStyle: 'italic' }}>
-        {pt
-          ? 'Rodando agora. Aparece com métricas assim que o primeiro turno for gravado.'
-          : 'Running now. It appears with metrics once its first turn is written.'}
-      </div>
-    </div>
   )
 }


### PR DESCRIPTION
The Sessions page decided what to do with a session through a column of checkboxes and a floating
"N selected" bar. Both are gone. In their place is a per-session action bar whose options are the
options that session can actually take — decided by the server, through the same pure
`sessionActions` the terminal cockpit resolves every keypress against.

Three more defects surfaced while verifying it, and are fixed here too.

---

## 1 — Why the checkboxes had to go, not just get restyled

They are a selection model over rows that mostly cannot take the same verb: half a page of stored
conversations, one live session and one assistant agentop never started are not a set anything can
be done to at once. The bar offered **kill / reopen / prompt to all of them equally**.

It also could not have worked. The bar posted to `/api/session/kill`, `/api/session/start` and
`/api/session/prompt`; the card's prompt box posted to `/api/sessions/prompt`; the Details popover
fetched `/api/sessions/<id>/messages`. **None of those routes exists on this server** — verified by
grep and by `curl` (404). Every one of those controls was silently inert, which CLAUDE.md names as
worse than a control that refuses: it is indistinguishable from a broken one.

## 2 — The machine-mode rule, and why I made it unconditional

**Home drops the sessions block in every mode.**

I did not make it mode-dependent, and the reason is in the code rather than in taste:

- `/sessions` is registered **unconditionally** in both the desktop `SideNav` `items` array and the
  `MobileBottomNav` `navTiles` array (`App.tsx`). There is no mode in which the page is absent.
- `SessionsPage`'s own subtitle already branches on `isCentral`, so the page was built to own
  sessions in all three modes — it is the surface that says what a session IS on a central and what
  to DO with one on a machine.
- Home's block was `<RecentSessions sessions={derived.filteredSessions} …/>` with no fleet, so it
  rendered the same rows as the page one click away, minus everything actionable. A mode-dependent
  rule would mean sessions appear twice on a central and once elsewhere — a second rule to keep in
  step, for a duplicate nobody asked for.

"Machine mode" in this codebase is **not a fourth `team.mode`** — the modes are `solo` / `central` /
`member`, and "machine" is the word for a non-central box (`docker-compose.machine.yml`,
`machineStatsCaches`, the cockpit's `MACHINE` detail rule). It is where the reporter noticed the
duplication because it is where they run; the duplication was in every mode.

`RecentSessions` itself is untouched as a reusable component: `RepoDetailPage`, `ProjectsPage` and
`componentCatalog` pass no `fleet`, so they render exactly as before, with **no** action bar. That
absence is deliberate and not a disabled bar — "agentop does not host this conversation" and "this
page did not ask" are different facts.

## 3 — Where the availability decision lives

Nothing about availability is re-derived in the browser. The chain is:

```
sessions-host poll → SessionView → toControlSession → sessionActions   ← the ONE decision
                                                          ↓
                                   fleet-row.ts (pure) → GET /api/fleet → SessionActionBar
                                                          ↓
                                   POST /api/fleet/act → ControlHost (the cockpit's own object)
```

`createControlHost` is now exported and the web routes drive **that** object. The alternative was a
second set of session verbs in `index.ts`, which is the drift `task-reopen.ts` was extracted to end
— and `answerSession` alone re-reads the frame immediately before sending, re-parses the options,
refuses when they changed, and refuses a numbered dialog on any harness with no verified way to
select by number. A browser copy of that is a button that approves the highlighted row.

I moved `ACTION_WORDS` out of `tabs/Sessions.tsx` into the pure `sessions.ts` (as `actionWords`) so
both surfaces read one wording map — otherwise "Answer its question" drifts back to "Approve",
which is a promise the keystroke cannot keep. That is the only TUI behaviour change: the cockpit
imports the same map it defined, and its tests pass unchanged.

### The availability matrix

Rendered for every row; **withheld verbs are drawn disabled, never removed**, on the rule
`sessionActions` records — a fleet agentop did not start would shrink the bar from seven buttons to
one, and a menu that lost six items reads as a broken feature. Clicking a disabled verb **states the
reason** (`role="status"`), and `title` carries it on hover.

| Verb | managed **running** (`working`) | managed **waiting-approval** | managed **lost** / `exited` | managed **finished**/`closed` | **external** |
|---|---|---|---|---|---|
| **Reopen** (`resume`) | absent — attach is the live verb | absent | **offered** when a conversation resolves | **offered** when one resolves | **offered** when one resolves |
| **Answer its question** (`approve`) | off — *"not asking anything right now"* | **offered**; a numbered dialog lists its options one button each | off | off | off — *external note* |
| **Send a prompt** | **offered** | **offered** (host re-reads and refuses on an open dialog) | off — *"not running (…)"* | off | off — *external note* |
| **Rename / Note / Task** | **offered** | **offered** | **offered** — a reboot keeps every name | **offered** | off — *external note* |
| **Open whole task / Finish task** | task-dependent | task-dependent | task-dependent | task-dependent | off — *external note* |
| **Stop session** (`kill`) | **offered**, confirm step | **offered**, confirm step | **offered** | **offered** | off — *external note* |
| **Attach** | **never a button** — the command to copy | same | same | same | same |

How each refusal is communicated:

- **external** → the row's own `sessionsExternalNote` ("started outside agentop — listed, but it
  cannot be attached or stopped here").
- **approval blind spots** → the row's own sentences, unchanged from the cockpit: `approvalBlind`
  (nobody has read this harness's dialog), `approveBlind` (visibly blocked, not answerable from
  here), `chooseBlind` (numbered dialog, no verified way to pick — options are still **shown**,
  because reading them is what tells you what attaching is about to ask).
- **no conversation link** → `conversationBlind`.
- otherwise a per-verb sentence: *not asking anything right now* / *no conversation to reopen* /
  *not running (state)* / *not filed under any task*. Deliberately **per verb**: one blanket "this
  session is not running" printed under a row plainly marked `working` is a wrong explanation, which
  is worse than a bare disabled button.

A **`closed`** row is explicitly not treated as external and gets **no** sentence — its own state
word already says it, and "started outside agentop" would be false in the reassuring direction.

**Attach is a command, not a button.** It needs a real tty and a browser tab has none, so the row
carries `agentop session attach <handle>` with a copy button and says why. `reopenFell` / `new` /
`search` / `group` are absent: they are cockpit chrome, not per-row verbs.

### Security

`/api/fleet` and `/api/fleet/act` are registered in `capability-guard.ts` under **`localShell`** —
the strictest capability, not the softer `localChat`. Reading the fleet captures each live session's
screen and acting on it types keystrokes into a terminal on this host; that is shell access under
another name. Both are authenticated by default (not added to `AUTH_PUBLIC`), the POST goes through
`readJsonLimited`, errors go through `safeError`, and **a central answers 404** — it hosts none of
its members' sessions, so the only fleet it could read is its own box's, drawn under someone else's
rows. `resume` and the two task verbs read their target **out of the fleet**, never out of the
request body: a caller that could pass its own `cwd` or task name could start assistants anywhere.

## 4 — Three defects found while verifying

**Two cards and two list/grid toggles → one of each.** The page header was its own rounded box
(title, subtitle, a List/Grid segmented control, Notifications) with the whole grouping/filter/sort/
search block in a second box below carrying *its own* list/grid pair. `RecentSessions` has always
accepted `title` / `subtitle` / `topActions` and renders them inside its control card, so the header
moved in there. **The surviving toggle is the one in the controls row**, beside the search, sort and
grouping it belongs with — and it is the copy `RecentSessions` owns when used standalone elsewhere.

**"Latest messages" was empty on a session with 65 of them.** The popover fetched
`/api/sessions/<id>/messages` — a route that has never existed — and `r.ok ? r.json() : []` turned
the 404 into a confident emptiness. The real readers were already there, one per harness, all
returning the same `{role, content, timestamp}` shape. `lib/sessionTranscript.ts` (pure) is the
mapping, as a `Record<HarnessId, boolean>` so the build fails when a harness is added and nobody
decides; **Antigravity and Kimi have no reader and the panel now says so** rather than drawing the
blank a real empty session would draw. A failed request keeps the last known list instead of
replacing it with an emptiness the server never asserted.

**The false notification burst.** `prevActivitiesRef` starts empty and the first poll called
straight into `handleSessionStateTransitions`, which announces anything it has no previous state
for. Every live session therefore announced itself at once — and this poller lives inside a page
component, so its memory is wiped by every remount: navigating away and back, a language toggle, a
dev reload. Hence notifications for sessions that had been in the same state for an hour.

The fix is in the **page**, not the module, and that is deliberate:
`sessionNotifications.test.ts` already pins that the module fires for a session it has no previous
state for, with a comment describing the page taking "a silent baseline on its first poll" — an
intent that was never implemented. I first changed the module and reverted it: that guard would have
hidden a real regression in the other half. The first answer of each mount is now recorded and not
announced. **Stated cost:** a session already waiting when the page opens is not announced — it is
on screen, marked and counted, while a notification is for what happened while you looked elsewhere.

## Verification

All commands run in this worktree, output as reported.

```
$ bun tsc --noEmit
TSC=0

$ bun test
 4247 pass
 0 fail
 68286 expect() calls
Ran 4247 tests across 235 files. [43.10s]
```

The pre-commit hook re-ran both on commit: same result.

New tests: `sessions/fleet-row.test.ts` (10) pins the matrix above — that the shape stays constant
for an external row, that its refusals are sentences, that a `closed` row is not called external,
that running offers prompt-and-no-reopen while lost offers the reverse, that approve needs both
halves, and that no verb reason is invented.

**Live API**, against the real fleet on this machine (dev server on 47591/47592, since 47291/47292
are the running agentop; both stopped afterwards):

```
$ curl -s localhost:47591/api/fleet | …
rows 36  attention 1  unavailable None
Counter({'exited': 21, 'closed': 12, 'waiting': 1, 'working': 1, 'lost': 1})
```

A `working` row came back with `prompt/rename/note/task/kill` enabled and `approve` disabled; an
`exited` row with `resume` enabled and `prompt` disabled — the matrix, on real data.

```
$ curl -sX POST localhost:47591/api/fleet/act -d '{"id":"no-such-session","action":"rename","text":"x"}'
{"ok":false,"message":"that session has no record to update — it was not started by agentop."}
$ curl -sX POST 'localhost:47591/api/fleet/act?lang=pt' -d '{"id":"no-such-session","action":"approve"}'
{"ok":false,"message":"essa sessão não tem registro para atualizar — não foi o agentop que iniciou ela."}
```

**Browser (Playwright), desktop 1440×900** on `/sessions`: 9 action bars rendered, **0 checkboxes**,
exactly **one** `["List view","Grid view"]` pair, title + subtitle + "Group by:" inside one card,
`scrollWidth 1430 ≤ innerWidth 1440`, **0 console errors**. Clicking a disabled verb produced
`role="status"` → *"This session is not asking anything right now."* Opening Details rendered
`LATEST MESSAGES` with real turns (previously "No recent messages"). `/` (Home) shows no sessions
heading, no session search, no "Group by:". `/projects` renders with no action bar and no
checkboxes — the reusable path is intact.

**Mobile 390×844**: `scrollWidth 390 ≤ innerWidth 390`; every action-bar touch target **44px**; all
inputs compute to **16px**; of 61 elements wider than the viewport, **0 escape a scroll/clip
container** — the page body never scrolls horizontally.

## One measurement worth recording

`index.ts` deliberately imports the request type from the **leaf** `sessions/fleet-row.ts`, never
from `sessions/fleet-web.ts`. `fleet-web` reaches `cli-start` and through it Ink and React; naming
it from `index.ts` **even in an `import type`** took `adapters/claude.test.ts` from a 31s pass to
past its 120s timeout, reproducibly (5 samples, both directions). The two handlers load the
implementation by dynamic import so a machine that never opens this page never pays for it, and
naming the module in a type position put it back in the resolver's path. I did not fully explain the
mechanism; the leaf-type split removes it and is the better shape regardless.

## Deliberately NOT done

- **No `SessionMeta` field added.** Nothing here travels to a central.
- **`searchText` composition and `filterSessions` untouched** — the in-flight TUI search work owns
  those. My only `sessions.ts` change is the added `actionWords` map.
- **No attach-from-browser.** It needs a tty; offering it would be the "present and failing" button
  this whole change removes.
- **No `deleteTask` / `restoreSessions` / bulk anything.** A bulk verb is what was wrong here; if a
  batch is wanted later it should be built on rows that provably share a verb.
- **The `'sessions-list'` flash id stays in `App.tsx`.** It now points at nothing on Home and is
  inert; removing it is unrelated churn in a file other sessions are editing.
- **The dead `LiveCard` / `StartingCard` / "Open now" scaffolding in `SessionsPage`** was removed —
  it was already unreachable on `dev` (computed `notice`, `liveProcs`, `pagedLive` that nothing
  rendered). Live sessions are covered by the fleet rows, the pinned ids and the status filters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pk2xSsbFgFbhaQ5ofFMJZb
