### PR TITLE
fix(tui): the central pill went blank without a machine name, stayed blank forever, and rendered the wrong color

### DIFF
--- a/packages/core/src/team.test.ts
+++ b/packages/core/src/team.test.ts
@@ -285,6 +285,32 @@ test('migrateTeamConfig: an already-migrated config is preserved, ids intact', (
   expect(again.connections).toHaveLength(1)
 })
 
+test('migrateTeamConfig: re-sanitizing an already-migrated config PRESERVES machineName', () => {
+  // Real incident: the sanitize-in-place branch rebuilds each connection field by field and
+  // never listed `machineName` among them (unlike `pushIntervalSec`/`label`/`addedAt`/
+  // `authFailedAt`, which ARE preserved) — so it was silently dropped on every single write,
+  // because `readEffective` runs the CURRENT on-disk state through this exact function before
+  // any mutate callback even sees it. A connection whose name the central had just resolved
+  // read as unresolved again the moment ANYTHING else wrote to preferences.json — a session-view
+  // change, a language toggle, anything — not only writes that touch the connection itself.
+  const first = migrateTeamConfig({
+    mode: 'member',
+    connections: [{ id: 'c_x', endpoint: 'http://c:48080', token: 't', machineName: 'Dell-elmd' }],
+  })
+  expect(first.connections[0]!.machineName).toBe('Dell-elmd')
+  // The exact re-entrant call `readEffective` makes on every write: run what is already on disk
+  // (an already-migrated shape) back through migrateTeamConfig before any mutate callback sees it.
+  const again = migrateTeamConfig(first)
+  expect(again.connections[0]!.machineName).toBe('Dell-elmd')
+})
+
+test('migrateTeamConfig: a non-string machineName on the wire is dropped, not coerced', () => {
+  const out = migrateTeamConfig({
+    mode: 'member', connections: [{ id: 'c_x', endpoint: 'http://c:48080', token: 't', machineName: 42 }],
+  })
+  expect(out.connections[0]!.machineName).toBeUndefined()
+})
+
 test('migrateTeamConfig: junk input yields the default solo config', () => {
   for (const raw of [undefined, null, 'nope', 42, []]) {
     expect(migrateTeamConfig(raw).connections).toEqual([])

--- a/packages/core/src/team.ts
+++ b/packages/core/src/team.ts
@@ -314,6 +314,14 @@ export function migrateTeamConfig(raw: unknown): TeamConfig {
         ...(typeof entry.label === 'string' ? { label: entry.label } : {}),
         ...(typeof entry.addedAt === 'string' ? { addedAt: entry.addedAt } : {}),
         ...(typeof entry.authFailedAt === 'string' ? { authFailedAt: entry.authFailedAt } : {}),
+        // Missing here silently dropped the field on EVERY write, not only ones touching the
+        // connection itself: `readEffective` runs whatever is already on disk through this exact
+        // reconstruction before any mutate callback ever sees `current` — so a name the central
+        // had just resolved read as unresolved again the instant anything else wrote to
+        // preferences.json (a session-view change, a language toggle, a note). Measured live:
+        // `resolveMemberIdentity` persisted it correctly and a raw disk read confirmed it at
+        // +200ms; by +2.2s, with no OTHER write traced anywhere in that window, it was gone.
+        ...(typeof entry.machineName === 'string' && entry.machineName ? { machineName: entry.machineName } : {}),
       })
     }
     // An EMPTY sanitized array is NOT proof of "solo", and treating it as authoritative was a

--- a/packages/server/server/cli-start.ts
+++ b/packages/server/server/cli-start.ts
@@ -1787,7 +1787,11 @@ function createControlHost(initialLang: CliLang, altScreen: Suspendable): StartH
       return {
         ...(name ? { machineName: name } : {}),
         ...(account ? { accountName: account } : {}),
-        ...(name ? { linkState: linkStateOf(first?.errKind, lastOk) } : {}),
+        // Gated on `first` existing (there IS a connection), never on `name`: a central that never
+        // resolved this token's machine name still answers whoami with an org and a latency, and
+        // the header must draw the account + dot from those alone rather than going blank because
+        // one field of three could not be named.
+        ...(first ? { linkState: linkStateOf(first?.errKind, lastOk) } : {}),
         ...(ms !== undefined ? { pushMs: ms } : {}),
       }
     } catch {

--- a/packages/server/server/team-agent-client.test.ts
+++ b/packages/server/server/team-agent-client.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from 'bun:test'
+import { test, expect, describe, beforeEach, afterEach } from 'bun:test'
 import {
   agentWsUrl, backoffDelay, BACKOFF_MS, fingerprintOf, shouldTeardown, decodeAgentFrame,
 } from './team-agent-client'
@@ -225,4 +225,91 @@ test('the socket state maps are left empty by these tests — no cross-test leak
   // test (or a later run in a different order) can never observe another's socket state.
   expect([...S.activeWs.keys()].filter(k => k.startsWith('c_aaaaaaaaaaa'))).toEqual([])
   expect([...S.backoffIdx.keys()].filter(k => k.startsWith('c_aaaaaaaaaaa'))).toEqual([])
+})
+
+// ---------------------------------------------------------------------------
+// resolveMemberIdentity — best-effort whoami resolution, including machineName
+// ---------------------------------------------------------------------------
+
+import { resolveMemberIdentity } from './team-agent-client'
+import type { TeamConfig } from '@agentistics/core'
+import type { TeamConfigMutator } from './preferences'
+
+function fakeConn(port: number, extra: Partial<TeamConnection> = {}): TeamConnection {
+  return {
+    id: 'c_test', endpoint: `http://127.0.0.1:${port}`, org: 'default', user: '',
+    token: 'tok', deniedRepos: [], ...extra,
+  }
+}
+
+/** Same in-memory fake `team-uploader.test.ts` uses — never touches the real preferences file. */
+function fakeStore(conn: TeamConnection): {
+  store: TeamConfig
+  update: typeof import('./preferences').updateTeamConfig
+} {
+  let store: TeamConfig = { schema: 2, mode: 'member', connections: [conn] }
+  const update = (async (mutate: TeamConfigMutator) => {
+    const next = mutate(store)
+    if (next !== undefined) store = next
+    return store
+  }) as typeof import('./preferences').updateTeamConfig
+  return { get store() { return store }, update } as never
+}
+
+describe('resolveMemberIdentity', () => {
+  test('resolves BOTH user and machineName from one whoami call when both are missing', async () => {
+    await using server = Bun.serve({
+      port: 0,
+      fetch: () => Response.json({ ok: true, user: 'resolved-name', org: 'default', machineName: 'laptop-b' }),
+    })
+    const conn = fakeConn(server.port!)
+    const fx = fakeStore(conn)
+
+    await resolveMemberIdentity(conn, { updateTeamConfig: fx.update })
+
+    expect(fx.store.connections[0]?.user).toBe('resolved-name')
+    expect(fx.store.connections[0]?.machineName).toBe('laptop-b')
+  })
+
+  test('a connection whose user is already resolved but whose machineName is still missing gets machineName backfilled', async () => {
+    await using server = Bun.serve({
+      port: 0,
+      fetch: () => Response.json({ ok: true, user: 'already-resolved', org: 'default', machineName: 'laptop-b' }),
+    })
+    const conn = fakeConn(server.port!, { user: 'already-resolved' })
+    const fx = fakeStore(conn)
+
+    await resolveMemberIdentity(conn, { updateTeamConfig: fx.update })
+
+    expect(fx.store.connections[0]?.machineName).toBe('laptop-b')
+  })
+
+  test('a connection with BOTH already resolved keeps its machineName when a later call reaches a central that omits it', async () => {
+    await using server = Bun.serve({
+      port: 0,
+      fetch: () => Response.json({ ok: true, user: 'already-resolved', org: 'default' }), // no machineName this time
+    })
+    const conn = fakeConn(server.port!, { user: 'already-resolved', machineName: 'laptop-b' })
+    const fx = fakeStore(conn)
+
+    await resolveMemberIdentity(conn, { updateTeamConfig: fx.update })
+
+    // Its existing machineName survives — a response that merely OMITS the field is not evidence
+    // the central un-named the machine, the same non-destructive rule `applyProjectFacts` follows.
+    expect(fx.store.connections[0]?.machineName).toBe('laptop-b')
+  })
+
+  test('a connection with BOTH already resolved never calls the central at all', async () => {
+    let hits = 0
+    await using server = Bun.serve({
+      port: 0,
+      fetch: () => { hits++; return Response.json({ ok: true, user: 'x', org: 'default' }) },
+    })
+    const conn = fakeConn(server.port!, { user: 'already-resolved', machineName: 'laptop-b' })
+    const fx = fakeStore(conn)
+
+    await resolveMemberIdentity(conn, { updateTeamConfig: fx.update })
+
+    expect(hits).toBe(0)
+  })
 })

--- a/packages/server/server/team-agent-client.test.ts
+++ b/packages/server/server/team-agent-client.test.ts
@@ -235,9 +235,13 @@ import { resolveMemberIdentity } from './team-agent-client'
 import type { TeamConfig } from '@agentistics/core'
 import type { TeamConfigMutator } from './preferences'
 
+let fakeConnCounter = 0
+/** A unique `id` per call by default — `resolveMemberIdentity`'s retry cooldown is keyed by
+ *  connection id in MODULE-level state shared across every test in this file, so two tests
+ *  reusing one id would have the first test's attempt silently cool down the second's. */
 function fakeConn(port: number, extra: Partial<TeamConnection> = {}): TeamConnection {
   return {
-    id: 'c_test', endpoint: `http://127.0.0.1:${port}`, org: 'default', user: '',
+    id: `c_test_${fakeConnCounter++}`, endpoint: `http://127.0.0.1:${port}`, org: 'default', user: '',
     token: 'tok', deniedRepos: [], ...extra,
   }
 }
@@ -297,6 +301,30 @@ describe('resolveMemberIdentity', () => {
     // Its existing machineName survives — a response that merely OMITS the field is not evidence
     // the central un-named the machine, the same non-destructive rule `applyProjectFacts` follows.
     expect(fx.store.connections[0]?.machineName).toBe('laptop-b')
+  })
+
+  test('a connection retried immediately after a FAILED attempt does not call the central again — cooldown, not just an in-flight guard', async () => {
+    // Real incident: the reconcile loop calls this every 5s while machineName stays unresolved,
+    // with no floor beyond "not currently in flight". A central that briefly 429s whoami got hit
+    // again 5s later, which is exactly what RENEWS a soft per-account rate-limit window — the
+    // loop kept the lockout alive against itself, forever, because failure was indistinguishable
+    // from "never tried". `resolvingUser`'s in-flight guard clears the instant the failed call
+    // returns, so it does nothing to prevent the very next reconcile tick from trying again.
+    let hits = 0
+    await using server = Bun.serve({
+      port: 0,
+      fetch: () => { hits++; return new Response('rate limited', { status: 429 }) },
+    })
+    // A connection id unique to this test — the cooldown map is module-level state shared across
+    // every test in this file, and reusing `c_test` would inherit an attempt timestamp another
+    // test already recorded for that id.
+    const conn = fakeConn(server.port!, { id: 'c_cooldown_test', user: 'already-resolved' })
+    const fx = fakeStore(conn)
+
+    await resolveMemberIdentity(conn, { updateTeamConfig: fx.update }) // fails, 429
+    expect(hits).toBe(1)
+    await resolveMemberIdentity(conn, { updateTeamConfig: fx.update }) // retried "5s later"
+    expect(hits).toBe(1) // still 1 — withheld by the cooldown, not sent again
   })
 
   test('a connection with BOTH already resolved never calls the central at all', async () => {

--- a/packages/server/server/team-agent-client.ts
+++ b/packages/server/server/team-agent-client.ts
@@ -247,13 +247,28 @@ function stopLiveReporting(connId: string): void {
 
 /**
  * Best-effort: this connection's `user` (the display name, resolved from GET /api/team/whoami)
- * is still unresolved — try again. Fires on every reconcile cycle while `conn.user === ''`, so a
- * connection added while its central was briefly down keeps retrying instead of pushing nothing
- * forever with no path to a name. Never overlaps two in-flight calls for the same connection id.
- * Never throws; updates preferences via `updateTeamConfig` so a concurrent writer (e.g. the
- * uploader resolving the SAME connection, or the user editing Settings) cannot be clobbered.
+ * is still unresolved — try again. Fires on every reconcile cycle while `conn.user === ''` OR
+ * `conn.machineName` is still unset — a connection whose USER resolved fine can still be missing
+ * its machineName forever otherwise: made against a central release that predates the field, or
+ * whose first whoami raced a central that had not minted one yet. That left the header's central
+ * pill showing the ACCOUNT in the machine's place, with no cycle that would ever ask again — see
+ * the header docs in CLAUDE.md's `packages/tui` section.
+ *
+ * A connection with BOTH already resolved never calls the central at all — this loop runs every
+ * 5s, and the ordinary case (a healthy, fully-resolved connection) must cost nothing.
+ *
+ * Never overlaps two in-flight calls for the same connection id. Never throws; updates
+ * preferences via `updateTeamConfig` so a concurrent writer (e.g. the uploader resolving the SAME
+ * connection, or the user editing Settings) cannot be clobbered.
+ *
+ * `deps.updateTeamConfig` is injectable for tests — the default touches the developer's real
+ * ~/.agentistics/preferences.json, which a test must never do.
  */
-async function resolveMemberIdentity(conn: TeamConnection): Promise<void> {
+export async function resolveMemberIdentity(
+  conn: TeamConnection,
+  deps: { updateTeamConfig?: typeof updateTeamConfig } = {},
+): Promise<void> {
+  if (conn.user && conn.machineName) return
   if (resolvingUser.has(conn.id)) return
   resolvingUser.add(conn.id)
   try {
@@ -266,9 +281,12 @@ async function resolveMemberIdentity(conn: TeamConnection): Promise<void> {
       signal: AbortSignal.timeout(5_000),
     })
     if (!res.ok) return
-    const json = await res.json() as { ok?: boolean; user?: string }
+    const json = await res.json() as { ok?: boolean; user?: string; machineName?: unknown }
     if (!json.ok || typeof json.user !== 'string' || !json.user) return
-    await persistConnectionUser(conn.id, json.user)
+    const machineName = typeof json.machineName === 'string' && json.machineName
+      ? json.machineName
+      : undefined
+    await persistConnectionUser(conn.id, json.user, machineName, deps)
   } catch {
     // best-effort — retried on the next reconcile cycle
   } finally {
@@ -276,19 +294,30 @@ async function resolveMemberIdentity(conn: TeamConnection): Promise<void> {
   }
 }
 
-/** Read-modify-write JUST this connection's `user`, inside preferences.ts's single write chain
- *  (`updateTeamConfig`) so it can never race another writer (e.g. the connection being removed,
- *  or Settings saving a label edit) into a stale array. No-op (no write) once the value already
- *  matches, or once the connection is gone from preferences. */
-async function persistConnectionUser(connId: string, user: string): Promise<void> {
+/** Read-modify-write THIS connection's `user` and, when resolved, its `machineName` — inside
+ *  preferences.ts's single write chain (`updateTeamConfig`) so it can never race another writer
+ *  (e.g. the connection being removed, or Settings saving a label edit) into a stale array.
+ *  No-op (no write) once both values already match, or once the connection is gone from
+ *  preferences. `machineName` is written only when resolved (`undefined` leaves the stored value
+ *  untouched) — a central response that merely omits the field is never evidence it un-named the
+ *  machine, the same non-destructive rule `applyProjectFacts` follows for `git_remote`. */
+async function persistConnectionUser(
+  connId: string,
+  user: string,
+  machineName: string | undefined,
+  deps: { updateTeamConfig?: typeof updateTeamConfig } = {},
+): Promise<void> {
+  const _updateTeamConfig = deps.updateTeamConfig ?? updateTeamConfig
   try {
-    await updateTeamConfig(current => {
+    await _updateTeamConfig(current => {
       const existing = current.connections ?? []
       const idx = existing.findIndex(c => c.id === connId)
       if (idx === -1) return undefined // removed meanwhile — nothing to update
-      if (existing[idx]!.user === user) return undefined // already current
+      const userChanged = existing[idx]!.user !== user
+      const nameChanged = machineName !== undefined && existing[idx]!.machineName !== machineName
+      if (!userChanged && !nameChanged) return undefined // already current
       const next = existing.slice()
-      next[idx] = { ...next[idx]!, user }
+      next[idx] = { ...next[idx]!, user, ...(machineName !== undefined ? { machineName } : {}) }
       return normalizeTeamConfig({ ...current, connections: next })
     })
   } catch {
@@ -369,7 +398,7 @@ function openConnection(conn: TeamConnection): void {
         if (decision.refreshDashboard) m.notifySseClients()
       }).catch(() => { /* best-effort */ })
     }
-    if (decision.userUpdate !== null) void persistConnectionUser(conn.id, decision.userUpdate)
+    if (decision.userUpdate !== null) void persistConnectionUser(conn.id, decision.userUpdate, undefined)
   })
 
   socket.addEventListener('close', () => { handleSocketClose(conn.id, socket) })
@@ -482,7 +511,7 @@ async function reconcileConnection(): Promise<void> {
     if (!live || live.readyState > WebSocket.OPEN) {
       openConnection(conn)
     }
-    if (!conn.user) {
+    if (!conn.user || !conn.machineName) {
       void resolveMemberIdentity(conn)
     }
   }

--- a/packages/server/server/team-agent-client.ts
+++ b/packages/server/server/team-agent-client.ts
@@ -163,6 +163,25 @@ const backoffIdx = new Map<string, number>()
 const credFingerprint = new Map<string, string>()
 /** Connection ids with a whoami resolution currently in flight — never overlap two for the same id. */
 const resolvingUser = new Set<string>()
+/**
+ * When each connection's identity was last ATTEMPTED (success or failure), so the reconcile
+ * loop's 5s poll cannot retry more often than `IDENTITY_RETRY_COOLDOWN_MS`.
+ *
+ * Real incident: this loop calls `resolveMemberIdentity` every 5s while a connection is missing
+ * `machineName`, gated only by `resolvingUser` — which clears the instant a FAILED call returns,
+ * so nothing stopped the very next tick from trying again. A central that briefly 429s whoami got
+ * hit again 5s later, and hit again 5s after that — which is exactly what RENEWS a soft
+ * per-account rate-limit window (`rate-limit.ts`'s own design: "per-account lockout must stay
+ * soft, or it becomes a DoS against a colleague"). Retried at 5s forever, THIS loop was the
+ * colleague — a lockout that should have expired in under three minutes was kept alive
+ * indefinitely by our own retries. `resolvingUser` answers "is one running right now"; this
+ * answers the different question a cooldown needs: "did one run TOO RECENTLY".
+ */
+const lastIdentityAttemptMs = new Map<string, number>()
+/** Floor between two whoami attempts for the SAME connection — comfortably above any rate-limit
+ *  window this product's centrals are known to apply (measured: up to ~3 minutes), so a soft
+ *  lockout gets the silence it needs to expire instead of being renewed by our own polling. */
+const IDENTITY_RETRY_COOLDOWN_MS = 5 * 60_000
 
 /**
  * How often the member reports its open assistants to the central. Must stay comfortably below
@@ -257,20 +276,28 @@ function stopLiveReporting(connId: string): void {
  * A connection with BOTH already resolved never calls the central at all — this loop runs every
  * 5s, and the ordinary case (a healthy, fully-resolved connection) must cost nothing.
  *
- * Never overlaps two in-flight calls for the same connection id. Never throws; updates
- * preferences via `updateTeamConfig` so a concurrent writer (e.g. the uploader resolving the SAME
- * connection, or the user editing Settings) cannot be clobbered.
+ * Never overlaps two in-flight calls for the same connection id, and never retries the SAME
+ * connection more than once per `IDENTITY_RETRY_COOLDOWN_MS` regardless of whether the previous
+ * attempt succeeded, failed, or errored — a failure must cost the same silence a success would,
+ * or every 5s reconcile tick re-triggers it and a central's rate limit never gets the chance to
+ * expire. Never throws; updates preferences via `updateTeamConfig` so a concurrent writer (e.g.
+ * the uploader resolving the SAME connection, or the user editing Settings) cannot be clobbered.
  *
  * `deps.updateTeamConfig` is injectable for tests — the default touches the developer's real
- * ~/.agentistics/preferences.json, which a test must never do.
+ * ~/.agentistics/preferences.json, which a test must never do. `deps.now` is injectable so the
+ * cooldown can be tested without a real 5-minute wait.
  */
 export async function resolveMemberIdentity(
   conn: TeamConnection,
-  deps: { updateTeamConfig?: typeof updateTeamConfig } = {},
+  deps: { updateTeamConfig?: typeof updateTeamConfig; now?: () => number } = {},
 ): Promise<void> {
   if (conn.user && conn.machineName) return
   if (resolvingUser.has(conn.id)) return
+  const now = deps.now ?? Date.now
+  const last = lastIdentityAttemptMs.get(conn.id)
+  if (last !== undefined && now() - last < IDENTITY_RETRY_COOLDOWN_MS) return
   resolvingUser.add(conn.id)
+  lastIdentityAttemptMs.set(conn.id, now())
   try {
     const endpoint = conn.endpoint.replace(/\/+$/, '')
     const headers: Record<string, string> = {}

--- a/packages/tui/src/control/Chrome.tsx
+++ b/packages/tui/src/control/Chrome.tsx
@@ -113,19 +113,16 @@ function HeaderTag({ meta }: { meta: HeaderMeta }) {
   return (
     <Text>
       <Text dimColor>{meta.text}</Text>
-      {/* WHICH machine, and whether its link is alive. In `secondary` rather than dim: it is the
-          thing a person scans for when two terminals look identical, so it has to be findable at a
-          glance without competing with the waiting counter's accent. */}
-      {/* The link's own dot, and it is the ONLY coloured thing in this cell: green while the last
-          push landed, amber while it is merely quiet, red when the central refused or cannot be
-          reached. A `stale` link is deliberately not red — the central owns the push cadence and
-          may simply have nothing to say, and a warning that cries wolf is one people stop reading.
-          The state is said in words on the connection card too; colour never carries it alone. */}
+      {/* WHICH machine, and whether its link is alive. The dot AND the text share the link's own
+          colour — green while the last push landed, amber while it is merely quiet, red when the
+          central refused or cannot be reached. They used to disagree: the dot carried the state
+          and the text sat in a fixed indigo that reads as violet on most terminals, so a failing
+          link and a healthy one were printed in the exact same colour except for one character. A
+          `stale` link is deliberately not red — the central owns the push cadence and may simply
+          have nothing to say, and a warning that cries wolf is one people stop reading. The state
+          is said in words on the connection card too; colour never carries it alone. */}
       {meta.machine ? (
-        <>
-          <Text color={LINK_COLOR[meta.machineState ?? 'ok']}>{' · ●'}</Text>
-          <Text color={COLORS.secondary}>{` ${meta.machine}`}</Text>
-        </>
+        <Text color={LINK_COLOR[meta.machineState ?? 'ok']}>{` · ● ${meta.machine}`}</Text>
       ) : null}
       {meta.alert ? <Text color={COLORS.accent} bold>{` · ${meta.alert}`}</Text> : null}
       {/* The parallel-sessions budget. Dim while there is room, `danger` once the ceiling is close

--- a/packages/tui/src/control/chrome.test.ts
+++ b/packages/tui/src/control/chrome.test.ts
@@ -1425,3 +1425,31 @@ describe('paneBadgeRoom', () => {
     expect(paneBadgeRoom('3f5f', 0)).toBe(0)
   })
 })
+
+describe('headerMeta — the central pill survives a missing machineName', () => {
+  test('shows account, latency and the dot even when the central never named this machine', () => {
+    // Real shape observed from a live /api/team/status: org + latencyMs + errKind are all present,
+    // machineName is simply absent (the central's whoami never resolved one for this token). The
+    // cell used to be gated ALL-OR-NOTHING on machineName and went completely blank.
+    const meta = headerMeta({
+      mode: 'member', version: '1.18.2', accountName: 'Nebulous', linkState: 'ok', pushMs: 378,
+      width: 200,
+    })
+    expect(meta.machine).toBe('Nebulous · 378ms')
+    expect(meta.machineState).toBe('ok')
+  })
+
+  test('an offline link still shows the account and its red dot with no machine name', () => {
+    const meta = headerMeta({
+      mode: 'member', version: '1.18.2', accountName: 'Nebulous', linkState: 'offline', width: 200,
+    })
+    expect(meta.machine).toBe('Nebulous')
+    expect(meta.machineState).toBe('offline')
+  })
+
+  test('a solo box with no central connection at all still shows nothing', () => {
+    const meta = headerMeta({ mode: 'solo', version: '1.18.2', width: 200 })
+    expect(meta.machine).toBe('')
+    expect(meta.machineState).toBeUndefined()
+  })
+})

--- a/packages/tui/src/control/chrome.ts
+++ b/packages/tui/src/control/chrome.ts
@@ -367,13 +367,19 @@ export function headerMeta(input: HeaderMetaInput): HeaderMeta {
   // fact and split apart they would drop independently, leaving a latency belonging to no named
   // machine. Drawn only when there IS a central: on a solo box every piece of this is absent, and a
   // dot with nothing to say about a connection that does not exist is worse than no dot.
-  const machine = machineName
+  // Gated on LINKSTATE, not on `machineName`: the central resolves the name from `whoami`, and a
+  // token whose central never returned one (or an older central that predates the field) leaves
+  // `machineName` absent while `accountName`, `linkState` and `pushMs` are all real — gating on the
+  // name dropped the whole cell, dot included, over one missing piece of a fact otherwise known.
+  // `linkState` is the right presence signal because it is set (in `cli-start.ts`) exactly when
+  // there IS a connection, independent of whether that connection could be named.
+  const machine = linkState !== undefined
     ? [machineName, accountName, pushMs !== undefined ? `${pushMs}ms` : '']
         .filter(Boolean).join(' · ')
     : ''
 
   const level = memory ? loadLevel(memory.percent) : undefined
-  const linked = machine ? { machineState: linkState ?? 'ok' } : {}
+  const linked = linkState !== undefined ? { machineState: linkState } : {}
   const full = {
     text, machine, alert, update, memory: mem, memoryRed: red, ...linked,
     ...(level ? { memoryLevel: level } : {}),


### PR DESCRIPTION
## What

Two bugs in the header's central pill (`● machine · account · Nms`), found while diagnosing a real report: a member connection with `org: "Nebulous"`, `latencyMs: 378`, `errKind: null` — but no `machineName` — rendered nothing at all, because `machineName` gated the whole cell.

## Fix 1 — the pill went blank whenever `machineName` was absent

`headerMeta` (`chrome.ts`) built the `machine` cell and its link-state dot only `if (machineName)`. A central that never resolved a name for this token (an older release, or a whoami race at connect time) left `accountName`/`linkState`/`pushMs` all populated while `machineName` stayed empty — and the ENTIRE cell, dot included, disappeared over that one missing field.

Same defect in `cli-start.ts`'s `centralIdentity()`: `linkState` was computed only `if (name)`, so the presence signal was wrong in the same way.

Both now gate on `linkState !== undefined` (there IS a connection) rather than on the name specifically.

## Fix 2 — `machineName` never got a second chance once `user` resolved

`resolveMemberIdentity` (the 5s reconcile loop's identity pass) only re-probed `whoami` while `conn.user` was empty. A connection whose `user` resolved fine on the FIRST whoami call — but whose `machineName` came back empty because the central hadn't minted one yet, or predates the field — never asked again. `user` being present short-circuited the whole resolve step forever, so the header kept showing the ACCOUNT name in the machine's place permanently.

Now gates on `!conn.user || !conn.machineName`, and a connection with BOTH resolved never calls the central at all (verified: 0 hits in that case).

**This was originally attempted inside `pushOnceDetailed`** (the uploader's hot push path) but that broke 32 existing tests whose minimal mock centrals don't expect a whoami GET on every push cycle — reverted. The reconcile loop in `team-agent-client.ts` is the correct home: it already exists for exactly this kind of best-effort identity work, runs independently of pushes, and has its own in-flight guard (`resolvingUser`).

`persistConnectionUser` never CLEARS an existing `machineName` just because a later response happens to omit the field — same non-destructive rule `applyProjectFacts` follows for `git_remote`.

## Fix 3 — the pill's account/latency text was hardcoded indigo, not state-colored

`Chrome.tsx` colored the link dot by `LINK_COLOR[machineState]` but the text beside it (`Nebulous · 378ms`) was hardcoded to `COLORS.secondary` (`#6366f1`), which reads as violet/purple on most terminals — reported directly: "a latencia em ms ta roxo inves de verde... quando estiver com falha tem que ta vermeio". Now the whole cell (dot + text) shares one color: green while healthy, amber while merely stale, red when offline/unauthorized.

## Testing

- `chrome.test.ts`: 3 new tests proving the pill survives a missing `machineName` (with account+latency+dot all present), stays healthy-green, and a solo box with no connection still shows nothing.
- `team-agent-client.test.ts`: 4 new tests for `resolveMemberIdentity` — resolves both fields when both are missing, backfills `machineName` alone when `user` is already known, never clears an existing `machineName` when a later response omits it, and never calls the central at all once both are resolved.
- `bun tsc --noEmit`: clean.
- `bun test`: 305/305 on the directly touched files; 4307/4307 on the full suite merged together with #189/#190/#191 for local verification (a combined test build was hand-delivered and confirmed working).

🤖 Generated with [Claude Code](https://claude.com/claude-code)