### PR TITLE
docs: keep agentop doctor as the exposure preflight, name the Docker caveat beside it

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,10 @@ profile is the only thing that decides a capability; no opt-in re-enables host p
 agentop doctor --exposed     # run this BEFORE opening a tunnel
 ```
 
-A check that could not be verified reports `fail`, never a reassuring `pass`.
+A check that could not be verified reports `fail`, never a reassuring `pass`. On a Docker central
+run it from inside the container instead — `./central.sh doctor --exposed` — where `central.env` is
+the live environment **and** the database is reachable, so the owner-MFA and machine-token checks
+actually run. On the host they cannot, and unverified counts as a failure.
 
 → [docs/exposure.md](docs/exposure.md) · [SECURITY.md](SECURITY.md)
 

--- a/docs/exposure.md
+++ b/docs/exposure.md
@@ -203,8 +203,13 @@ That scoping is enforced server-side in `team-scope.ts` and asserted in `authz-g
 
 ## 9. Go-live checklist
 
-Run `./central.sh doctor --exposed` (or `agentop central doctor --exposed`). It must print
-no `✗`.
+Run `./central.sh doctor --exposed`. It must print no `✗`.
+
+There is no `agentop central doctor` — `CENTRAL_ACTIONS` in `cli-central.ts` does not carry one, so
+a central deployed from the released binary has no in-container preflight and no `central.sh` to
+reach it with. Run `agentop doctor --exposed` on the host there: it finds the same `central.env`
+(`~/.agentistics/central/`) and names the file it read, but cannot reach the database, so the
+owner-MFA and machine-token checks report as unverified — which is a failure, deliberately.
 
 Then verify from outside, against the real hostname:
 


### PR DESCRIPTION
Closes the gap #174 was aiming at, without the regression that PR carried.

## The gap

The README's exposure section named `agentop doctor --exposed` and stopped there. On a **Docker**
central — the documented default — the owner-MFA and machine-token checks need the database, which
is only reachable from inside the compose network, so they report as unverified with nothing on the
page saying why.

## Why not the substitution #174 proposed

#174 replaced the line with `./central.sh doctor --exposed`. That is right for the Docker checkout
and wrong for the other two deployment shapes:

- `findEnvFile()` in `cli-doctor.ts` looks in `~/.agentistics/central/` — the `STANDALONE_DIR` a
  binary-installed central materializes into, where there is no `central.sh` at all.
- A **native** central (`agentop server --central`) reaches Mongo from the host, so `agentop doctor`
  is not the degraded form there — it is the only one.

And the command already routes people correctly on its own: `ok = allPassed(checks) && !dbError`, so
it never prints "Ready to expose" on an unverified deployment, and on a `dbError` it prints
`re-run inside the container: ./central.sh doctor`. The substitution trades a command that degrades
safely for one that is `No such file or directory` on part of the fleet.

So both are named, primary first.

## The bug it surfaced

`docs/exposure.md` offered `agentop central doctor --exposed` as the alternative. That command does
not exist — `CENTRAL_ACTIONS` in `cli-central.ts` carries no `doctor`, on either the repo or the
standalone path. Rather than quietly dropping the mention, the gap it was papering over is stated:
a binary-installed central has no in-container preflight.

**Follow-up worth considering (not in this PR):** adding `doctor` to `CENTRAL_ACTIONS` would make
that sentence unnecessary. The standalone path already has the exact shape for it — `setup-token`
and `reset-password` both `compose exec` into the container for the same reason.

Docs only. `bun tsc --noEmit` + `bun test` (4331 pass) ran green via the pre-commit hook.