### PR TITLE
dev → main: exposure preflight docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,10 @@ profile is the only thing that decides a capability; no opt-in re-enables host p
 agentop doctor --exposed     # run this BEFORE opening a tunnel
 ```
 
-A check that could not be verified reports `fail`, never a reassuring `pass`.
+A check that could not be verified reports `fail`, never a reassuring `pass`. On a Docker central
+run it from inside the container instead — `./central.sh doctor --exposed` — where `central.env` is
+the live environment **and** the database is reachable, so the owner-MFA and machine-token checks
+actually run. On the host they cannot, and unverified counts as a failure.
 
 → [docs/exposure.md](docs/exposure.md) · [SECURITY.md](SECURITY.md)
 

--- a/docs/exposure.md
+++ b/docs/exposure.md
@@ -203,8 +203,13 @@ That scoping is enforced server-side in `team-scope.ts` and asserted in `authz-g
 
 ## 9. Go-live checklist
 
-Run `./central.sh doctor --exposed` (or `agentop central doctor --exposed`). It must print
-no `✗`.
+Run `./central.sh doctor --exposed`. It must print no `✗`.
+
+There is no `agentop central doctor` — `CENTRAL_ACTIONS` in `cli-central.ts` does not carry one, so
+a central deployed from the released binary has no in-container preflight and no `central.sh` to
+reach it with. Run `agentop doctor --exposed` on the host there: it finds the same `central.env`
+(`~/.agentistics/central/`) and names the file it read, but cannot reach the database, so the
+owner-MFA and machine-token checks report as unverified — which is a failure, deliberately.
 
 Then verify from outside, against the real hostname:
 


### PR DESCRIPTION
Promotes #196.

The README's exposure section named `agentop doctor --exposed` alone, so on a Docker central — the
documented default — the owner-MFA and machine-token checks read as unverified with nothing on the
page explaining why. Both forms are now named, primary first, and `docs/exposure.md` no longer
offers `agentop central doctor --exposed`, a command that does not exist.

Docs only: `README.md` and `docs/exposure.md`, +11/-3. No code, no dependencies.

Note: this cuts a patch release (v1.19.0 → v1.19.1) with a binary build and a GHCR image push, as
any push to `main` does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wsta4X6R4t6cHdsZt9pumo