### PR TITLE
fix(antigravity): read the token fields agy actually bills, not the ones beside them

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -625,9 +625,10 @@ cumulative input 44.3M against a context of 455k, so a gauge built from the tota
 **codex** — `last_token_usage.input_tokens`, which already includes the cached portion, NOT the
 cumulative `total_token_usage`; **kimi** — the input side of one per-turn `usage.record`, from the
 **main** agent only and chosen by timestamp (a subagent runs its own, emptier window, and file read
-order must not decide the answer); **antigravity** — protobuf field `1.4.5`, already documented as
-"a gauge, never a sum", off the last row. **gemini** and **copilot** are `false`: gemini's chat
-files carry no token data at all, and copilot reports tokens only cumulatively at shutdown.
+order must not decide the answer); **antigravity** — protobuf field `1.9.10.1`, off the last row,
+with the window agy declares beside it in `1.9.10.4`. **gemini** and **copilot** are `false`:
+gemini's chat files carry no token data at all, and copilot reports tokens only cumulatively at
+shutdown.
 
 **The window** is `resolveContextWindow` (`packages/core/src/contextWindows.ts`) — the
 `MODEL_PRICING` provenance rule applied to a different number. `ContextWindow` requires
@@ -635,11 +636,16 @@ files carry no token data at all, and copilot reports tokens only cumulatively a
 the table draws no bar**. That is deliberate: an absent gauge is visible, a wrong percentage is not,
 and the same 212.959 tokens is 106% of a 200k window and 21% of a 1M one. Two consequences:
 - **A harness that states its own window outranks the table.** Codex writes `model_context_window`
-  into every `token_count` event → `SessionMeta.context_window`. It knows the deployment and any
-  per-session cap; a model id cannot express either.
+  into every `token_count` event → `SessionMeta.context_window`, and **Antigravity states it too**,
+  in protobuf field `1.9.10.4` beside its gauge. It knows the deployment and any per-session cap; a
+  model id cannot express either — measured on one machine, agy ran `gemini-3.6-flash` under a
+  128.000 window on some conversations and 256.000 on others, which no table keyed by model id
+  could ever have told apart.
 - **OpenAI and Google models are absent** (checked 2026-08-14: neither publishes a citable input
-  token limit). So Antigravity's Gemini conversations and Kimi's routed models measure a context and
-  still draw no bar. Add them the day the figures can be cited, never before.
+  token limit). So Kimi's routed models measure a context and still draw no bar. Add them the day
+  the figures can be cited, never before. Antigravity is the case that shows the table is not the
+  only way out: it draws a bar with no row here at all, because the harness declares the window
+  itself.
 
 **Known limitation, stated rather than papered over:** Claude Code can run `claude-opus-5` under a
 200k session cap (its `opus[1m]` picker) and the transcript records only `claude-opus-5` — no
@@ -675,10 +681,22 @@ a conversation with no genuine user turn is dropped (same principle as the Gemin
 **Tokens / model / cost are REAL for agy.** They come from `conversations/<conversation-id>.db`
 (SQLite), table `gen_metadata`, column `data` — a protobuf blob per LLM call, decoded by the pure,
 dependency-free `adapters/antigravity-protobuf.ts`. Verified wire layout:
-`1.4.1` input, `1.4.2` cache read, `1.4.3` output, `1.4.5` context-size gauge, `1.4.9` thinking,
-`1.4.10` completion, `1.19` technical model id, `1.21` display name. Rules:
+`1.4.1` the CONSTANT system-instruction size, `1.4.2` input, `1.4.3` output, `1.4.5` cache read,
+`1.4.9` thinking, `1.4.10` completion, `1.9.10.1` context-size gauge, `1.9.10.4` the declared
+context window, `1.19` technical model id, `1.21` display name. Rules:
 - **`1.4.3` already includes `1.4.9`** — never add thinking on top of output.
-- **`1.4.5` is a gauge, never a sum** — it is the context size at that call.
+- **`1.9.10.1` is a gauge, never a sum** — it is the context size at that call.
+- **`1.4.1` is a CONSTANT and belongs in no sum.** This mapping was wrong for a release and the
+  bug was invisible from inside: the first reader took `1.4.1` as input, `1.4.2` as cache and
+  `1.4.5` as the gauge, and every number it produced looked plausible. It was off by **4,8x in
+  tokens and 6,3x in cost** (52,6 mi / R$111 against a billed ~250 mi / R$703). What exposed it was
+  a comparison with the provider's own console — and what would have caught it earlier is in the
+  data itself: **`1.4.1` was the same 1072 on all 2.966 rows** (`min === max`), and a per-call
+  counter cannot be constant. When adopting a field from an undocumented binary format, check that
+  the values VARY the way the thing they claim to count varies, and reconcile the total against a
+  bill before trusting it. The mapping above is pinned by tests and by the arithmetic recorded in
+  `antigravity-protobuf.ts`'s header (input/cache/output and the 80,6 % cache share all land within
+  a few percent of the console's figures for the same project; no other assignment is close).
 - agy records **no cache-write** counter, so `cache_creation_input_tokens` stays 0.
 - `model` is the dominant `1.19` across the conversation's rows (e.g. `gemini-3.6-flash`; agy can
   also drive Claude models, e.g. `claude-opus-4-6-thinking`). **Cost is `calcCost()` only** —

--- a/docs/harness-contract.md
+++ b/docs/harness-contract.md
@@ -123,9 +123,13 @@ the window. Rules:
 - **A subagent's window is not the session's.** Where a harness folds child agents into one
   session (Kimi), the gauge comes from the main agent only, chosen by timestamp so it does not
   depend on the order the files were read.
-- **A harness that states its own window wins.** Codex writes `model_context_window` per session;
-  store it in `SessionMeta.context_window` and it outranks any table lookup, because it knows the
-  deployment and any per-session cap that a model id cannot express.
+- **A harness that states its own window wins.** Codex writes `model_context_window` per session
+  and Antigravity states it too (protobuf field `1.9.10.4`); store it in
+  `SessionMeta.context_window` and it outranks any table lookup, because it knows the deployment
+  and any per-session cap that a model id cannot express. Measured on one machine, agy ran
+  `gemini-3.6-flash` under a 128.000 window on some conversations and 256.000 on others — one model
+  id, two windows, which no table could have told apart. It is also the escape hatch for a vendor
+  that publishes no citable limit: agy draws a bar with no `CONTEXT_WINDOWS` row at all.
 - **Otherwise the window comes from `resolveContextWindow`** (`packages/core/src/contextWindows.ts`),
   which holds only models with a dated source — the `MODEL_PRICING` provenance rule applied to a
   different number. A model that is not in it draws no bar at all: an absent gauge is visible, a
@@ -181,3 +185,24 @@ Then compare against the harness's own numbers where it publishes any. For activ
 that matters is: *does the reconstruction agree with the harness's own measurement where both
 exist?* If a future harness publishes durations, run that comparison before trusting the
 reconstruction for the turns where it doesn't.
+
+### Reading an undocumented binary format
+
+Antigravity's token counts live in a protobuf blob with no schema published anywhere, and the first
+reader of it got **every counter but output pointing at the wrong field**. It reported 52,6 mi
+tokens where the provider billed ~250 mi, and R$111 against R$703 — 4,8x and 6,3x low. Nothing
+inside the product looked wrong: the numbers were the right order of magnitude, they moved with
+usage, and the per-model split was self-consistent. Two checks would have caught it, and both are
+now required before a decoded field is trusted:
+
+- **Check that the value VARIES the way the thing it claims to count varies.** The field being read
+  as `input_tokens` was the constant 1072 on all 2.966 rows (`min === max`). A per-call counter
+  cannot be constant — that alone disqualified it, with no external source needed.
+- **Reconcile the total against a bill.** Where the vendor exposes a usage console, sum the whole
+  local store and compare — per model and per day, not just the headline. The correct mapping came
+  out within a few percent on input, cache, output *and* the 78,5 % cache share simultaneously;
+  every wrong candidate broke at least one of those. A single aggregate can be matched by luck, a
+  four-way agreement cannot.
+
+Record the reconciliation in the reader's own header, with the figures and the date. The next
+person to touch those field numbers needs to see what pinned them, not just what they are.

--- a/packages/server/server/adapters/antigravity-parse.ts
+++ b/packages/server/server/adapters/antigravity-parse.ts
@@ -60,14 +60,23 @@ export interface AntigravityTokenTotals {
   /** Number of `gen_metadata` rows that decoded — used by the reconciliation test. */
   rowCount?: number
   /**
-   * Field `1.4.5` of the LAST decoded row — how full the window was at that generation.
+   * Field `1.9.10.1` of the LAST decoded row — how full the window was at that generation.
    *
    * agy is the one harness that measures this directly rather than leaving it to be reconstructed:
-   * the field is documented as "a gauge, never a sum" precisely because it is a level, not a
-   * quantity. Everything else on this interface is summed across rows; this one is read off the
-   * last.
+   * the field is a gauge, never a sum, precisely because it is a level, not a quantity. Everything
+   * else on this interface is summed across rows; this one is read off the last.
    */
   contextTokens?: number
+  /**
+   * Field `1.9.10.4` of the LAST decoded row — the window agy DECLARES for the call (128.000, and
+   * 256.000 on some rows).
+   *
+   * This is Codex's `model_context_window` rule applied to agy: a harness stating the window for
+   * the session it is running outranks any table, and it is the ONLY way an agy session gets a
+   * context bar — Google publishes no citable input limit, so `CONTEXT_WINDOWS` has no row for
+   * these models and never will until it can be cited.
+   */
+  contextWindow?: number
 }
 
 /** Optional inputs for {@link parseAntigravityTranscript}. */
@@ -579,13 +588,16 @@ export function parseAntigravityTranscriptDetailed(
     git_commits: gitCommits,
     git_pushes: gitPushes,
     input_tokens: tokens?.inputTokens ?? 0,
-    // gen_metadata field 3 is the TOTAL output (thinking + completion) — never add thinking.
+    // gen_metadata field 1.4.3 is the TOTAL output (thinking + completion) — never add thinking.
     output_tokens: tokens?.outputTokens ?? 0,
     cache_read_input_tokens: tokens?.cachedTokens ?? 0,
     // agy does not record cache WRITES separately.
     cache_creation_input_tokens: 0,
-    // The `1.4.5` gauge off the last generation — absent when no row carried one.
+    // The `1.9.10.1` gauge off the last generation — absent when no row carried one.
     ...(tokens?.contextTokens ? { context_tokens: tokens.contextTokens } : {}),
+    // The window agy DECLARES (`1.9.10.4`), which outranks CONTEXT_WINDOWS exactly as Codex's
+    // `model_context_window` does — and is the only reason an agy session can draw a bar.
+    ...(tokens?.contextWindow ? { context_window: tokens.contextWindow } : {}),
     first_prompt: firstPrompt,
     title,
     user_interruptions: 0,

--- a/packages/server/server/adapters/antigravity-protobuf.test.ts
+++ b/packages/server/server/adapters/antigravity-protobuf.test.ts
@@ -28,22 +28,30 @@ function str(s: string): number[] {
   return [...new TextEncoder().encode(s)]
 }
 
-/** Build a blob shaped exactly like a real gen_metadata.data row. */
+/**
+ * Build a blob shaped exactly like a real gen_metadata.data row.
+ *
+ * The parameter names are the SEMANTICS, not the field numbers, and the mapping below is the one
+ * verified against the provider's billing console: input is `1.4.2`, cache is `1.4.5`, and `1.4.1`
+ * is the constant system-instruction size that belongs in no sum.
+ */
 function buildBlob(o: {
-  input?: number, cached?: number, output?: number, context?: number,
+  input?: number, cached?: number, output?: number,
+  systemInstruction?: number, context?: number, window?: number,
   thinking?: number, completion?: number, modelId?: string, modelDisplay?: string,
 }): Uint8Array {
   const usage = [
-    ...vfield(1, o.input ?? 0),
-    ...vfield(2, o.cached ?? 0),
+    ...vfield(1, o.systemInstruction ?? 0),
+    ...vfield(2, o.input ?? 0),
     ...vfield(3, o.output ?? 0),
-    ...vfield(5, o.context ?? 0),
+    ...vfield(5, o.cached ?? 0),
     ...vfield(6, 24), // unknown constant present in the real data — must be ignored
     ...vfield(9, o.thinking ?? 0),
     ...vfield(10, o.completion ?? 0),
   ]
   const gen = [
     ...lfield(4, usage),
+    ...lfield(9, lfield(10, [...vfield(1, o.context ?? 0), ...vfield(4, o.window ?? 0)])),
     ...lfield(19, str(o.modelId ?? '')),
     ...lfield(21, str(o.modelDisplay ?? '')),
   ]
@@ -52,21 +60,54 @@ function buildBlob(o: {
 
 // ---------------------------------------------------------------------------
 
-test('decodes the verified real row 0 (input 1072 / cached 22504 / output 472)', () => {
+test('decodes a verified real row (input 18804 / cached 17105 / output 472)', () => {
   const blob = buildBlob({
-    input: 1072, cached: 22504, output: 472, thinking: 401, completion: 71,
+    systemInstruction: 1072, input: 18804, cached: 17105, output: 472, thinking: 401, completion: 71,
+    context: 30125, window: 128_000,
     modelId: 'gemini-3.6-flash', modelDisplay: 'Gemini 3.6 Flash (Medium)',
   })
   expect(parseGenMetadataBlob(blob)).toEqual({
-    inputTokens: 1072,
-    cachedTokens: 22504,
+    inputTokens: 18804,
+    cachedTokens: 17105,
     outputTokens: 472,
     thinkingTokens: 401,
     completionTokens: 71,
-    totalContextTokens: 0,
+    systemInstructionTokens: 1072,
+    contextTokens: 30125,
+    contextWindow: 128_000,
     modelId: 'gemini-3.6-flash',
     modelDisplay: 'Gemini 3.6 Flash (Medium)',
   })
+})
+
+test('field 1.4.1 is the constant system-instruction size, NOT the input count', () => {
+  // The regression this whole mapping exists to prevent. On the machine the fields were verified
+  // against, 1.4.1 was 1072 on every one of 2.966 rows while the real input varied per call; the
+  // adapter summed the constant and reported 52,6 mi tokens where the provider billed ~250 mi.
+  // A constant can never be a per-call counter, so it must never reach `inputTokens`.
+  const a = parseGenMetadataBlob(buildBlob({ systemInstruction: 1072, input: 2810 }))!
+  const b = parseGenMetadataBlob(buildBlob({ systemInstruction: 1072, input: 76273 }))!
+  expect(a.systemInstructionTokens).toBe(1072)
+  expect(b.systemInstructionTokens).toBe(1072)
+  expect(a.inputTokens).toBe(2810)
+  expect(b.inputTokens).toBe(76273)
+})
+
+test('the context gauge and the declared window come from 1.9.10, not from the usage message', () => {
+  const m = parseGenMetadataBlob(buildBlob({ input: 8011, cached: 70131, context: 91958, window: 256_000 }))!
+  expect(m.contextTokens).toBe(91958)
+  expect(m.contextWindow).toBe(256_000)
+  // The gauge is a LEVEL and sits apart from the two additive counters beside it.
+  expect(m.inputTokens).toBe(8011)
+  expect(m.cachedTokens).toBe(70131)
+})
+
+test('a row with no 1.9.10 reports no window rather than a guessed one', () => {
+  const gen = [...lfield(4, [...vfield(2, 500), ...vfield(3, 20)]), ...lfield(19, str('gemini-3.6-flash'))]
+  const m = parseGenMetadataBlob(new Uint8Array(lfield(1, gen)))!
+  expect(m.contextTokens).toBe(0)
+  expect(m.contextWindow).toBe(0)
+  expect(m.inputTokens).toBe(500)
 })
 
 test('output already contains thinking — the reader never adds them', () => {
@@ -75,11 +116,14 @@ test('output already contains thinking — the reader never adds them', () => {
   expect(m.thinkingTokens + m.completionTokens).toBe(m.outputTokens)
 })
 
-test('field 5 (context size) is reported separately and never folded into a sum', () => {
-  const m = parseGenMetadataBlob(buildBlob({ input: 10, output: 20, context: 20366 }))!
-  expect(m.totalContextTokens).toBe(20366)
-  expect(m.inputTokens).toBe(10)
-  expect(m.outputTokens).toBe(20)
+test('field 1.4.5 is the cache READ — the biggest counter agy produces', () => {
+  // ~80 % of agy's prompt volume lands here (80,6 % measured over 2.966 rows, against the 78,5 %
+  // the provider's console reports for the same project). Reading it as a context gauge, as the
+  // first version of this module did, dropped four fifths of the billed tokens on the floor.
+  const m = parseGenMetadataBlob(buildBlob({ input: 8011, cached: 70131, output: 183 }))!
+  expect(m.cachedTokens).toBe(70131)
+  expect(m.inputTokens).toBe(8011)
+  expect(m.outputTokens).toBe(183)
 })
 
 test('multi-byte varints above 2^21 decode correctly', () => {
@@ -89,11 +133,11 @@ test('multi-byte varints above 2^21 decode correctly', () => {
 })
 
 test('unknown fields of every wire type are skipped, not fatal', () => {
-  const usage = [...vfield(1, 5), ...vfield(3, 7)]
+  const usage = [...vfield(2, 5), ...vfield(3, 7)]
   const gen = [
     ...varint(7 * 8 + 5), 1, 2, 3, 4,             // fixed32 unknown
     ...varint(8 * 8 + 1), 1, 2, 3, 4, 5, 6, 7, 8, // fixed64 unknown
-    ...vfield(9, 999),                             // varint unknown
+    ...vfield(11, 999),                            // varint unknown
     ...lfield(12, str('ignored')),                 // LEN unknown
     ...lfield(4, usage),
     ...lfield(19, str('gemini-3.6-flash')),
@@ -112,8 +156,8 @@ test('empty / absent input returns null', () => {
 
 test('a truncated blob never throws and yields at most partial data', () => {
   const full = buildBlob({
-    input: 1072, cached: 22504, output: 472, thinking: 401, completion: 71,
-    modelId: 'gemini-3.6-flash',
+    systemInstruction: 1072, input: 1072, cached: 22504, output: 472, thinking: 401, completion: 71,
+    context: 30125, window: 128_000, modelId: 'gemini-3.6-flash',
   })
   for (let cut = 1; cut < full.length; cut++) {
     const m = parseGenMetadataBlob(full.subarray(0, cut))
@@ -139,7 +183,7 @@ test('garbage bytes never throw', () => {
 })
 
 test('an implausibly huge token count is treated as corruption, not data', () => {
-  const usage = [...vfield(1, Number.MAX_SAFE_INTEGER)]
+  const usage = [...vfield(2, Number.MAX_SAFE_INTEGER)]
   const m = parseGenMetadataBlob(new Uint8Array(lfield(1, lfield(4, usage))))!
   expect(m.inputTokens).toBe(0)
 })

--- a/packages/server/server/adapters/antigravity-protobuf.ts
+++ b/packages/server/server/adapters/antigravity-protobuf.ts
@@ -3,30 +3,69 @@
 // PURE, dependency-free, minimal protobuf wire-format reader for the Antigravity CLI's
 // `gen_metadata.data` BLOBs (~/.gemini/antigravity-cli/conversations/<conversation-id>.db).
 //
-// Verified wire layout (decoded from the real bytes on a live machine):
+// Verified wire layout (decoded from the real bytes on a live machine, and CHECKED AGAINST THE
+// PROVIDER'S OWN BILLING CONSOLE — see "How the mapping was established" below):
 //
 //   data
 //    └─ field 1  (LEN, submessage: generation info)
 //        ├─ field 4  (LEN, submessage: token usage)
-//        │    ├─ field 1  varint  input_tokens          (non-cached input)
-//        │    ├─ field 2  varint  cached_tokens         (context-cache read)
+//        │    ├─ field 1  varint  system_instruction_tokens  CONSTANT per install — NEVER a sum
+//        │    ├─ field 2  varint  input_tokens          (fresh / uncached prompt)
 //        │    ├─ field 3  varint  output_tokens         (TOTAL output; == f9 + f10)
-//        │    ├─ field 5  varint  total_context_tokens  (context SIZE gauge, never additive)
+//        │    ├─ field 5  varint  cached_tokens         (context-cache READ)
 //        │    ├─ field 9  varint  thinking_tokens
 //        │    └─ field 10 varint  completion_tokens     (visible answer)
+//        ├─ field 9  (LEN, submessage: request info)
+//        │    └─ field 10 (LEN, submessage: context)
+//        │         ├─ field 1  varint  context_tokens   (context SIZE gauge, never additive)
+//        │         └─ field 4  varint  context_window   (the window agy itself declares)
 //        ├─ field 19 (LEN, string) technical model id   e.g. "gemini-3.6-flash"
 //        └─ field 21 (LEN, string) display model name   e.g. "Gemini 3.6 Flash (Medium)"
 //
-// CRITICAL: field 3 ALREADY includes field 9 — never add thinking to output.
+// CRITICAL: field 1.4.3 ALREADY includes field 1.4.9 — never add thinking to output.
+//
+// ## How the mapping was established (and why the earlier one was wrong)
+//
+// The first version of this reader mapped 1.4.1 → input, 1.4.2 → cache and 1.4.5 → a context
+// gauge. Every one of those was wrong, and the errors compounded: agy reported 52,6 mi tokens
+// where the provider billed ~250 mi, and R$111 against R$703.
+//
+// The tell is in the data itself: across 2.966 rows on a real machine, **1.4.1 is the constant
+// 1072** (min === max). A per-call input count cannot be constant, so that field is the fixed
+// system-instruction size and belongs in no sum at all.
+//
+// The rest was settled by measurement, not by reading field numbers off a guess — the provider's
+// console reports the same project this machine feeds, split by model:
+//
+//                       this machine (1.4.2 / 1.4.5 / 1.4.3)   provider console (gemini-3.6-flash)
+//   input                            48.281.400                 54.448.878  (live)
+//   cache                           200.401.323                199.363.144  (live)
+//   output                            1.100.635                  1.219.673  (live)
+//   % cache                               80,6 %                      78,5 %
+//
+// and per DAY against the console's own chart: 2026-08-14 → R$44,94 here vs ~R$45 there;
+// 2026-08-15 → R$479,91 vs ~R$465. The residual (~18 %) is a second machine feeding the same
+// project plus two days this machine has no DB for. No other assignment of these fields lands
+// anywhere near: reading 1.9.10.1 as the billed prompt gives 283,97 mi (+24 % over the console's
+// total) and puts % cache at 70,6; keeping 1.4.2 as the cache gives 17 %.
+//
+// So 1.9.10.1 is what it looks like — the context SIZE at that call, which grows to 127.968
+// against the 128.000 in 1.9.10.4 beside it. It is the gauge, and summing it would be exactly the
+// mistake this comment warns about for 1.4.5's old reading.
+//
+// 1.9.10.4 is the window agy DECLARES for the call (128.000, and 256.000 on some rows). It is
+// treated like Codex's `model_context_window`: a harness stating the window for the session it is
+// running outranks any table, which is what lets an agy session draw a context bar at all —
+// Google publishes no citable input limit, so `CONTEXT_WINDOWS` has no row to fall back to.
 //
 // Contract: this module NEVER throws. Malformed / truncated / garbage input yields `null`
 // (or partially-filled zeros) so the caller can degrade to "no tokens" instead of failing.
 
 /** Decoded token usage + model identity of a single `gen_metadata` row. */
 export interface GenMetadata {
-  /** field 1.4.1 — non-cached input tokens. */
+  /** field 1.4.2 — fresh (uncached) input tokens. Additive. */
   inputTokens: number
-  /** field 1.4.2 — context-cache read tokens. */
+  /** field 1.4.5 — context-cache read tokens. Additive, and ~80 % of agy's prompt volume. */
   cachedTokens: number
   /** field 1.4.3 — TOTAL output tokens (thinking + completion). Additive. */
   outputTokens: number
@@ -34,8 +73,16 @@ export interface GenMetadata {
   thinkingTokens: number
   /** field 1.4.10 — visible completion tokens. Already inside `outputTokens`. */
   completionTokens: number
-  /** field 1.4.5 — context-window size at this generation. A GAUGE, never summed. */
-  totalContextTokens: number
+  /**
+   * field 1.4.1 — the system-instruction size. CONSTANT for an install (1072 on the machine this
+   * was verified against, on every one of 2.966 rows). Decoded so the constancy stays visible and
+   * checkable; it is deliberately NOT part of any token sum.
+   */
+  systemInstructionTokens: number
+  /** field 1.9.10.1 — context size at this generation. A GAUGE, never summed. */
+  contextTokens: number
+  /** field 1.9.10.4 — the context window agy declares for this call. 0 when absent. */
+  contextWindow: number
   /** field 1.19 — technical model id, e.g. `gemini-3.6-flash`. */
   modelId: string
   /** field 1.21 — human display name, e.g. `Gemini 3.6 Flash (Medium)`. */
@@ -139,14 +186,51 @@ function readTokenUsage(buf: Uint8Array, start: number, end: number, out: GenMet
       const v = readVarint(c)
       if (v === null) return
       switch (fieldNo) {
-        case 1: out.inputTokens = sane(v); break
-        case 2: out.cachedTokens = sane(v); break
+        case 1: out.systemInstructionTokens = sane(v); break
+        case 2: out.inputTokens = sane(v); break
         case 3: out.outputTokens = sane(v); break
-        case 5: out.totalContextTokens = sane(v); break
+        case 5: out.cachedTokens = sane(v); break
         case 9: out.thinkingTokens = sane(v); break
         case 10: out.completionTokens = sane(v); break
         default: break // field 6 and any future field: ignored on purpose
       }
+      continue
+    }
+    if (!skipField(c, wireType)) return
+  }
+}
+
+/** Parse the context submessage (field 1.9.10) into `out`. */
+function readContextInfo(buf: Uint8Array, start: number, end: number, out: GenMetadata): void {
+  const c: Cursor = { buf, pos: start, end }
+  while (c.pos < c.end) {
+    const key = readVarint(c)
+    if (key === null) return
+    const fieldNo = Math.floor(key / 8)
+    const wireType = key % 8
+    if (wireType === WIRE_VARINT) {
+      const v = readVarint(c)
+      if (v === null) return
+      if (fieldNo === 1) out.contextTokens = sane(v)
+      else if (fieldNo === 4) out.contextWindow = sane(v)
+      continue
+    }
+    if (!skipField(c, wireType)) return
+  }
+}
+
+/** Parse the request-info submessage (field 1.9) into `out`. Only field 10 is of interest. */
+function readRequestInfo(buf: Uint8Array, start: number, end: number, out: GenMetadata): void {
+  const c: Cursor = { buf, pos: start, end }
+  while (c.pos < c.end) {
+    const key = readVarint(c)
+    if (key === null) return
+    const fieldNo = Math.floor(key / 8)
+    const wireType = key % 8
+    if (wireType === WIRE_LEN) {
+      const range = readLenRange(c)
+      if (range === null) return
+      if (fieldNo === 10) readContextInfo(buf, range.start, range.end, out)
       continue
     }
     if (!skipField(c, wireType)) return
@@ -165,6 +249,7 @@ function readGenerationInfo(buf: Uint8Array, start: number, end: number, out: Ge
       const range = readLenRange(c)
       if (range === null) return
       if (fieldNo === 4) readTokenUsage(buf, range.start, range.end, out)
+      else if (fieldNo === 9) readRequestInfo(buf, range.start, range.end, out)
       else if (fieldNo === 19) out.modelId = decodeUtf8(buf, range.start, range.end)
       else if (fieldNo === 21) out.modelDisplay = decodeUtf8(buf, range.start, range.end)
       continue
@@ -180,7 +265,9 @@ function emptyGenMetadata(): GenMetadata {
     outputTokens: 0,
     thinkingTokens: 0,
     completionTokens: 0,
-    totalContextTokens: 0,
+    systemInstructionTokens: 0,
+    contextTokens: 0,
+    contextWindow: 0,
     modelId: '',
     modelDisplay: '',
   }

--- a/packages/server/server/adapters/antigravity.ts
+++ b/packages/server/server/adapters/antigravity.ts
@@ -89,9 +89,11 @@ function closeQuietly(db: any): void {
 /**
  * Sum every `gen_metadata` row of one conversation into token totals.
  *
- * Per the verified wire format: input += f1, cache_read += f2, output += f3. Field 3 ALREADY
- * contains the thinking tokens (f9), so f9 is never added; field 5 is a context-size gauge and
- * is never summed. The model id is the most frequent f19 across the rows (a conversation can
+ * Per the verified wire format: input += f1.4.2, cache_read += f1.4.5, output += f1.4.3. Field
+ * 1.4.3 ALREADY contains the thinking tokens (f1.4.9), so f1.4.9 is never added; f1.4.1 is the
+ * CONSTANT system-instruction size and belongs in no sum at all. The context gauge (f1.9.10.1) and
+ * the window agy declares (f1.9.10.4) are levels, read off the last row that carried them rather
+ * than accumulated. The model id is the most frequent f1.19 across the rows (a conversation can
  * switch models mid-way; the dominant one is the honest single label).
  *
  * A missing / locked / corrupt DB yields null → the session reports zero tokens.
@@ -116,10 +118,12 @@ export async function readAntigravityTokensFromFile(
     let cachedTokens = 0
     let outputTokens = 0
     let rowCount = 0
-    // The gauge, off the LAST row that carried one — never accumulated. `SELECT` with no ORDER BY
-    // walks the table in rowid order, which is insertion order, so the last row is the newest
-    // generation. A row with no `1.4.5` leaves the previous reading standing rather than zeroing it.
+    // The gauge and the window agy declares beside it, off the LAST row that carried each — never
+    // accumulated. `SELECT` with no ORDER BY walks the table in rowid order, which is insertion
+    // order, so the last row is the newest generation. A row missing either one leaves the previous
+    // reading standing rather than zeroing it.
     let contextTokens = 0
+    let contextWindow = 0
     const modelCounts = new Map<string, number>()
     const byModel: Record<string, { inputTokens: number; cachedTokens: number; outputTokens: number }> = {}
     for (const row of rows) {
@@ -129,7 +133,8 @@ export async function readAntigravityTokensFromFile(
       )
       if (!meta) continue
       rowCount++
-      if (meta.totalContextTokens > 0) contextTokens = meta.totalContextTokens
+      if (meta.contextTokens > 0) contextTokens = meta.contextTokens
+      if (meta.contextWindow > 0) contextWindow = meta.contextWindow
       inputTokens += meta.inputTokens
       cachedTokens += meta.cachedTokens
       outputTokens += meta.outputTokens
@@ -148,6 +153,7 @@ export async function readAntigravityTokensFromFile(
     return {
       inputTokens, cachedTokens, outputTokens, modelId, byModel, rowCount,
       ...(contextTokens > 0 ? { contextTokens } : {}),
+      ...(contextWindow > 0 ? { contextWindow } : {}),
     }
   } catch {
     return null


### PR DESCRIPTION
## Summary

- Every Antigravity token counter except output was reading the wrong protobuf field in
  `gen_metadata`. Fixed: input is `1.4.2`, cache read is `1.4.5`, output stays `1.4.3`, and
  `1.4.1` — the **constant** system-instruction size — is no longer summed into anything.
- That frees `1.9.10.1` to be the context gauge it actually is, and plumbs `1.9.10.4` (the window
  agy **declares**) into `SessionMeta.context_window` under Codex's `model_context_window` rule.
  agy sessions could not draw a context bar at all before this.
- Records in `docs/harness-contract.md` the two checks that would have caught the bug, so the next
  undocumented binary format is not trusted the same way.

## Motivation

Closes #200.

The bug was invisible from inside the product — the numbers were the right order of magnitude,
moved with usage, and the per-model split was self-consistent. It only showed against the vendor's
own billing console, where agentistics was reporting **52,6 mi tokens and R$111 against a billed
~250 mi and R$830**: 4,8x low in tokens, 6,3x low in cost.

The tell was in the data the whole time: the field being read as `input_tokens` is the **constant
1072 on all 2.966 rows** (`min === max`) on the machine this was verified against. A per-call
counter cannot be constant.

## Changes

| file | change |
|---|---|
| `adapters/antigravity-protobuf.ts` | corrected field mapping; new `readRequestInfo` / `readContextInfo` for `1.9.10`; `totalContextTokens` → `contextTokens` + `contextWindow` + `systemInstructionTokens`; header now carries the reconciliation that pins the mapping |
| `adapters/antigravity.ts` | reads the gauge and the declared window off the last row carrying each; docs corrected |
| `adapters/antigravity-parse.ts` | `AntigravityTokenTotals.contextWindow`; emits `SessionMeta.context_window` |
| `adapters/antigravity-protobuf.test.ts` | fixtures rebuilt around the real layout; new tests pin the constancy of `1.4.1`, the `1.9.10` source of the gauge/window, and "no `1.9.10` ⇒ no guessed window" |
| `docs/harness-contract.md` | §3 — a harness declaring its own window is not just Codex; §8 — new "Reading an undocumented binary format" |
| `CLAUDE.md` | wire layout corrected; the failure recorded as an invariant |

Renaming `totalContextTokens` was deliberate: it made the compiler point at every consumer rather
than leaving one reading a field whose meaning had quietly changed.

## Test plan

- [x] `bun test` — 4334 pass, 0 fail
- [x] `bun tsc --noEmit` — clean
- [x] Ran the corrected adapter over the **22 real conversation DBs** and reconciled against the
      provider's billing console for the same project, on four axes at once:

  | | corrected adapter | console (`gemini-3.6-flash`, live) |
  |---|---|---|
  | input | 48.289.075 | 54.448.878 |
  | cache read | 200.488.688 | 199.363.144 |
  | output | 1.100.757 | 1.219.673 |
  | % cache | 80,6 % | 78,5 % |
  | cost | US$ 110,76 | R$ 766,83 (≡ US$ 120,72) |

  and per day against the console's own chart: 2026-08-14 → R$44,94 vs ~R$45; 2026-08-15 →
  R$479,91 vs ~R$465. The ~18 % residual is a second machine feeding the same project plus two
  days this machine holds no DB for.

  No other assignment of these fields comes close: reading `1.9.10.1` as the billed prompt
  overshoots the console total by 24 %, and keeping `1.4.2` as the cache puts the cache share at
  17 % against a measured 78,5.

- [x] Context bars now resolve per conversation — e.g. `91.958 / 128.000` (72 %) and
      `35.045 / 256.000` (14 %). **Same model id, two different windows**, which is exactly why
      the harness's own declaration has to outrank a table.

**For reviewers:** the thing to check is the field mapping itself. `MODEL_PRICING` for
`gemini-3.6-flash` is untouched and is independently confirmed correct by this comparison — the
console's implied USD→BRL rate comes out identical (6,352) on both its live and consolidated
figures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Lhkrv9RmicUWo24WXCMiC
