### PR TITLE
fix(team): derive the ingest timeout from the batch, and let the batch adapt

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -435,6 +435,25 @@ packages/server/server/          — server-side modules (never bundled by Vite)
   ├── team-ingest.ts       → POST /api/team/ingest → upsert + triggerSseNotification (real-time central)
   ├── team-source.ts / team-admin.ts → central-side team read for buildApiResponse + members-panel admin routes
   ├── team-uploader.ts     → member→central push: sent-state, sync-signature auto-reconcile, push-on-change (notifyDataChanged), auto-reset on revoke, /api/team/status pill
+  ├── ingest-batch.ts      → **pure**: how many sessions one ingest carries and how long it gets.
+  │                          **A BATCH IS THE UNIT OF DURABLE PROGRESS** — the sent-state advances
+  │                          only on an ACCEPTED batch, so a batch that cannot complete records
+  │                          NOTHING and the next cycle re-sends the same sessions forever. That
+  │                          happened: `BATCH_SIZE` 200 was chosen in one place and a flat 15s
+  │                          timeout in another, nothing checked that one fit the other, and a real
+  │                          central costs ~195 ms/session — so 200 needed ~39s and every first push
+  │                          aborted. Measured on a live member: 1.260 consecutive failures, a
+  │                          sent-state still `{}`, `lastSuccessAt: null`, against a central
+  │                          answering everything else in under a second. So the TIMEOUT IS DERIVED
+  │                          from the batch (`ingestTimeoutMs`, the only place either number is
+  │                          decided) and still BOUNDED (`MAX_TIMEOUT_MS`), because the timeout's
+  │                          original job is releasing a `MAX_CONCURRENT_PUSHES` slot held by a
+  │                          wedged proxy. And the batch ADAPTS (`nextBatchSize`): a derived timeout
+  │                          still rests on an estimate of someone else's hardware, so a failure
+  │                          HALVES and a success grows back GRADUALLY — jumping straight to the
+  │                          ceiling would fail, floor, and fail again, which is the same
+  │                          non-convergence in a slower loop. The ceiling is far below 200 on
+  │                          purpose: smaller batches cost round trips and buy durable progress
   ├── account-repos.ts     → **pure**: buildAccountRepoList (central grouping) + findStillShared (the MACHINE-side intersection). A machine asks the central what repositories it holds FOR ITS ACCOUNT (`GET /api/team/account-repos`, team-account-repos.ts) — a question naming no repository and carrying no rule — and compares locally, so it learns a sibling still shares a repo it hid without disclosing anything
   ├── team-elsewhere.ts    → member side of that: TTL-throttled fetch + cache → ConnectionStatusEntry.elsewhere (same-origin) → the orange banner on the connection card
   ├── (core) siblingRules.ts → **pure** `@agentistics/core`: the REVERSE warning's arithmetic — `bucketSharedBy` (is this repo/project bucket shared by these announced rules?) + `siblingsRestricting` + `mergeSiblingFacts`. It may **never** be derived from the central: a sibling that hides a repo simply leaves the central without it, and absence is ambiguous between "restricted" and "never cloned", so the ONLY sound source is the sealed envelope inbox. `bucketSharedBy` is a second implementation of a privacy rule, so `share-rules.test.ts` cross-checks it against `sessionShared` over every mode x dimension x bucket combination — `share-rules.ts` stays the single source of the semantics. **Projects correlate across machines by FOLDER NAME** (`projectNameKey`: `\`→`/`, trailing separators stripped, final segment, case folded — case because WSL/Windows machines share these accounts), because the same project sits at a different path on every machine and full-`project_path` comparison correlates almost nothing. **That is the CROSS-MACHINE key only**: `bucketSharedBy` and the stored rules stay EXACT, or a local rule denying `/home/a/x/proj` would silently widen to every project named `proj` — `shareBucketKeys` (exact) and `crossMachineKeys` (correlation) must stay separate, and a test fails if the exact predicate is widened. It is a heuristic (`api`, `web`, `docs` collide), so `siblingsWithholding` reports the sibling's OWN path when the announcement carries one, and the UI says "a project with this name"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -182,6 +182,33 @@ A member does **not** name itself — the display name is set by the central whe
 
 The **central owns the cadence** (`server/central-config.ts`, `pushIntervalSec`; normal floor 15s, default 30s, express down to 5s via `EXPRESS_MIN_SEC`). Members fetch it from `GET /api/team/policy` each cycle and can only follow it — there is no member-side override that goes faster. On top of the periodic timer, `server/team-uploader.ts` also does **push-on-change**: the file watcher calls `notifyDataChanged()`, which schedules a debounced push (coalesces bursts, never sooner than the central's interval since the last success). Members push their **supplemented** statsCache (the one the local dashboard shows, gap-filled past the stale `lastComputedDate`), not the raw `~/.claude/stats-cache.json`, so central totals match the member's own dashboard exactly.
 
+### Batch size and its timeout — one decision, not two
+
+A push splits its sessions into batches, and **a batch is the unit of durable progress**: the
+sent-state advances only after the central ACCEPTS one. A batch that can never complete therefore
+records nothing, and the next cycle sends exactly the same sessions again — forever.
+
+That is not hypothetical. A batch size of 200 was chosen in one place and a flat 15s ingest timeout
+in another, with nothing checking that one fit the other. A real remote central costs ~195 ms per
+session (Mongo upserts + stats + SSE fan-out, over the public internet), so 200 sessions need ~39s.
+Measured on a live member: **1.260 consecutive failures, a sent-state still `{}`, and
+`lastSuccessAt: null`** — a machine that had never once pushed while its central answered every
+other request in under a second.
+
+So `server/ingest-batch.ts` (**pure**) owns both numbers:
+
+- **The timeout is DERIVED from the batch** (`ingestTimeoutMs(n)`), never stated beside it, so they
+  cannot drift apart again. It stays bounded (`MAX_TIMEOUT_MS`) because the timeout's original job
+  is to guarantee a `MAX_CONCURRENT_PUSHES` slot is released when a wedged proxy accepts a
+  connection and never answers.
+- **The batch adapts** (`nextBatchSize`): a derived timeout still rests on an estimate of someone
+  else's hardware, so a failed push halves the batch and a successful one grows it back toward the
+  ceiling. A central slower than the estimate converges on a size it can serve instead of retrying
+  an impossible request. Growth is gradual on purpose — jumping straight back to the ceiling would
+  fail, drop to the floor and fail again, which is the same non-convergence in a slower loop.
+- **The ceiling is far below the old 200.** Smaller batches cost round trips and buy durable
+  progress: a member whose network drops mid-push keeps every batch already accepted.
+
 ### Real-time central
 
 A member push lands in `server/team-ingest.ts`, which upserts the sessions/stats and then calls `triggerSseNotification()` — the central's dashboards refresh live over SSE without polling. This is why the "Live" toggle is **hidden on a central**. `server/team-watch.ts` also watches the team collection as a fallback SSE source.

--- a/packages/server/server/ingest-batch.test.ts
+++ b/packages/server/server/ingest-batch.test.ts
@@ -1,0 +1,101 @@
+import { test, expect } from 'bun:test'
+import {
+  MAX_BATCH_SIZE, MIN_BATCH_SIZE, PER_SESSION_MS, BASE_TIMEOUT_MS, MAX_TIMEOUT_MS,
+  ingestTimeoutMs, clampBatchSize, nextBatchSize,
+} from './ingest-batch'
+
+// --- the regression this module exists for --------------------------------------------------
+
+test('a full batch fits its own timeout at the measured cost of a real central', () => {
+  // The bug: BATCH_SIZE 200 under a flat 15s timeout, against a central costing ~195 ms/session.
+  // 200 × 195 ms = 39s > 15s, so the first batch aborted every single time — and because the
+  // sent-state only advances on an ACCEPTED batch, nothing was ever recorded and the same 200
+  // were re-sent forever (measured: 1.260 consecutive failures, sent-state still empty).
+  const MEASURED_MS_PER_SESSION = 195
+  const cost = MAX_BATCH_SIZE * MEASURED_MS_PER_SESSION
+  expect(cost).toBeLessThan(ingestTimeoutMs(MAX_BATCH_SIZE))
+
+  // And the old pairing must still read as impossible, so nobody restores it by halves.
+  expect(200 * MEASURED_MS_PER_SESSION).toBeGreaterThan(15_000)
+})
+
+test('the timeout is derived from the batch, so the two cannot drift apart', () => {
+  expect(ingestTimeoutMs(10)).toBe(BASE_TIMEOUT_MS + 10 * PER_SESSION_MS)
+  expect(ingestTimeoutMs(MAX_BATCH_SIZE)).toBeGreaterThan(ingestTimeoutMs(MIN_BATCH_SIZE))
+})
+
+test('an empty batch still gets the base timeout — it is a real request', () => {
+  // The empty-delta push carries statsCache + workflows and costs the central real work.
+  expect(ingestTimeoutMs(0)).toBe(BASE_TIMEOUT_MS)
+  expect(ingestTimeoutMs(-5)).toBe(BASE_TIMEOUT_MS)
+  expect(ingestTimeoutMs(Number.NaN)).toBe(BASE_TIMEOUT_MS)
+})
+
+test('the derived timeout stays bounded, so a slot is always released', () => {
+  // The timeout exists so a wedged proxy cannot hold a MAX_CONCURRENT_PUSHES slot forever.
+  // Deriving it must not quietly reintroduce an unbounded wait.
+  expect(ingestTimeoutMs(1_000_000)).toBe(MAX_TIMEOUT_MS)
+  expect(ingestTimeoutMs(MAX_BATCH_SIZE)).toBeLessThanOrEqual(MAX_TIMEOUT_MS)
+})
+
+// --- adaptation ------------------------------------------------------------------------------
+
+test('a failed push halves the batch, down to the floor', () => {
+  expect(nextBatchSize(50, 'failed')).toBe(25)
+  expect(nextBatchSize(25, 'failed')).toBe(12)
+  expect(nextBatchSize(MIN_BATCH_SIZE, 'failed')).toBe(MIN_BATCH_SIZE)
+})
+
+test('a successful push grows the batch, up to the ceiling', () => {
+  expect(nextBatchSize(MIN_BATCH_SIZE, 'ok')).toBeGreaterThan(MIN_BATCH_SIZE)
+  expect(nextBatchSize(MAX_BATCH_SIZE, 'ok')).toBe(MAX_BATCH_SIZE)
+})
+
+test('growth never stalls — every size below the ceiling strictly increases', () => {
+  // `Math.floor(size * 1.25)` alone stalls at small sizes (5 → 6 → 7 is fine, but a quarter that
+  // floors to zero would pin the batch at the floor forever on a central that then recovers).
+  for (let n = MIN_BATCH_SIZE; n < MAX_BATCH_SIZE; n++) {
+    expect(nextBatchSize(n, 'ok')).toBeGreaterThan(n)
+  }
+})
+
+test('a permanently slow central converges instead of retrying an impossible request', () => {
+  // A central that can only absorb 8 sessions inside its budget. Shrink on failure, grow on
+  // success: the size must settle at something it can actually complete, and must not oscillate
+  // back to the ceiling forever (which is the same non-convergence in a slower loop).
+  const CAPACITY = 8
+  let size = MAX_BATCH_SIZE
+  const seen: number[] = []
+  for (let cycle = 0; cycle < 60; cycle++) {
+    const ok = size <= CAPACITY
+    size = nextBatchSize(size, ok ? 'ok' : 'failed')
+    if (cycle >= 20) seen.push(size)
+  }
+  // Past the settling period every size it reaches is one the central can serve, or one step above
+  // it — never anywhere near the ceiling.
+  expect(Math.max(...seen)).toBeLessThanOrEqual(CAPACITY + 3)
+  expect(seen.some(s => s <= CAPACITY)).toBe(true)
+})
+
+test('a central that recovers gets its throughput back', () => {
+  let size: number = MIN_BATCH_SIZE
+  for (let i = 0; i < 40; i++) size = nextBatchSize(size, 'ok')
+  expect(size).toBe(MAX_BATCH_SIZE)
+})
+
+// --- clamping --------------------------------------------------------------------------------
+
+test('any stored or injected size is clamped into the usable range', () => {
+  expect(clampBatchSize(0)).toBe(MIN_BATCH_SIZE)
+  expect(clampBatchSize(-100)).toBe(MIN_BATCH_SIZE)
+  expect(clampBatchSize(10_000)).toBe(MAX_BATCH_SIZE)
+  expect(clampBatchSize(Number.NaN)).toBe(MAX_BATCH_SIZE)
+  expect(clampBatchSize(12.9)).toBe(12)
+})
+
+test('the ceiling is far below the old 200 — a batch is the unit of durable progress', () => {
+  // Smaller batches cost round trips and buy durable progress: the sent-state advances per
+  // ACCEPTED batch, so a member whose network drops mid-push keeps what it already landed.
+  expect(MAX_BATCH_SIZE).toBeLessThan(200)
+  expect(MIN_BATCH_SIZE).toBeGreaterThan(1) // a per-session round trip is not the answer either
+})

--- a/packages/server/server/ingest-batch.ts
+++ b/packages/server/server/ingest-batch.ts
@@ -1,0 +1,93 @@
+/**
+ * ingest-batch.ts — PURE. How many sessions one ingest request carries, and how long it is given.
+ *
+ * These two numbers were chosen independently and nothing checked that they fit each other, which
+ * is the whole bug. A batch of 200 was posted under a flat 15s timeout whose own comment asserted
+ * "15s is generous enough for a legitimately slow link pushing a full 200-session batch" — an
+ * assumption nobody had measured. Against a real remote central the cost is ~195 ms per session,
+ * so 200 sessions need ~39 s. Every first push aborted at 15 s.
+ *
+ * That alone would be a slow-recovery bug. What made it permanent is that **a batch is the unit of
+ * durable progress**: `pushOnceDetailed` advances the sent-state only after the central ACCEPTS a
+ * batch, so a batch that can never complete records nothing, and the next cycle re-sends the same
+ * 200 sessions. Measured on the machine that surfaced this: 1.260 consecutive failures, a
+ * sent-state still `{}`, and `lastSuccessAt: null` — a member that had never once pushed while its
+ * central answered every other request in under a second.
+ *
+ * Two rules follow, and the first is the one that matters:
+ *
+ *  1. **The timeout is DERIVED from the batch**, never stated beside it. `ingestTimeoutMs(n)` is
+ *     the only place either number is decided, so they cannot drift apart again.
+ *  2. **The batch adapts to what the central can actually do.** A derived timeout still rests on an
+ *     estimate of ms-per-session, and an estimate is a guess about someone else's hardware. A
+ *     central slower than the guess must converge rather than retry the same impossible request, so
+ *     a failed push HALVES the batch and a successful one grows it back toward the ceiling.
+ *
+ * The ceiling is deliberately far below the old 200. Smaller batches cost round trips and buy
+ * durable progress: with 50, a member that can only finish four batches before the network drops
+ * keeps those four. With 200 it kept nothing.
+ */
+
+/** Largest batch to attempt. A member starts here and adapts down if the central cannot keep up. */
+export const MAX_BATCH_SIZE = 50
+
+/**
+ * Smallest batch to fall back to. Not 1: a per-session round trip turns a full history into
+ * hundreds of requests, and a central that cannot absorb 5 sessions inside
+ * `ingestTimeoutMs(5)` is broken in a way a smaller batch will not fix.
+ */
+export const MIN_BATCH_SIZE = 5
+
+/**
+ * Per-session budget. Measured at ~195 ms/session against a real remote central (Mongo upserts +
+ * stats + SSE fan-out, over the public internet); 300 ms leaves headroom without inviting a
+ * request that occupies a concurrency slot for minutes.
+ */
+export const PER_SESSION_MS = 300
+
+/** Fixed cost of any request: DNS, TLS, proxy hops, and the central's own routing. */
+export const BASE_TIMEOUT_MS = 15_000
+
+/**
+ * Hard ceiling on a single ingest.
+ *
+ * The timeout exists in the first place so a wedged reverse proxy or a suspended container — which
+ * accepts the TCP connection and then never answers — cannot hold a `MAX_CONCURRENT_PUSHES` slot
+ * forever and starve every other connection. A derived timeout must therefore still be bounded, or
+ * a large batch would quietly reintroduce exactly that.
+ */
+export const MAX_TIMEOUT_MS = 60_000
+
+/**
+ * How long a batch of `n` sessions is given. The ONLY place this is decided.
+ *
+ * `n <= 0` still gets the base timeout: the empty-delta push (statsCache + workflows only) is a
+ * real request with a real cost.
+ */
+export function ingestTimeoutMs(batchSize: number): number {
+  const n = Number.isFinite(batchSize) && batchSize > 0 ? Math.floor(batchSize) : 0
+  return Math.min(MAX_TIMEOUT_MS, BASE_TIMEOUT_MS + n * PER_SESSION_MS)
+}
+
+/** Clamp any stored/injected batch size into the usable range. */
+export function clampBatchSize(size: number): number {
+  if (!Number.isFinite(size)) return MAX_BATCH_SIZE
+  return Math.max(MIN_BATCH_SIZE, Math.min(MAX_BATCH_SIZE, Math.floor(size)))
+}
+
+/**
+ * The batch size to use after a push attempt.
+ *
+ * Halve on failure, grow by a quarter on success — the batch settles just under whatever the
+ * central can actually absorb instead of oscillating between the ceiling and the floor.
+ *
+ * Growth is deliberately not a jump back to `MAX_BATCH_SIZE`: on a central that is permanently
+ * slower than `PER_SESSION_MS` assumes, that would fail at the ceiling, drop to the floor, and fail
+ * again forever — the same non-convergence in a slower loop.
+ */
+export function nextBatchSize(current: number, outcome: 'ok' | 'failed'): number {
+  const size = clampBatchSize(current)
+  if (outcome === 'failed') return clampBatchSize(Math.floor(size / 2))
+  // `+1` so growth cannot stall on a size whose quarter floors to zero.
+  return clampBatchSize(Math.floor(size * 1.25) + 1)
+}

--- a/packages/server/server/team-uploader.ts
+++ b/packages/server/server/team-uploader.ts
@@ -35,6 +35,7 @@ import {
 import { parseCapabilities, centralCanForget } from './team-capabilities'
 import { planRulesReconcile, computeLedger, loadRulesState, saveRulesState } from './team-rules'
 import { runForgetSequence, loadForgetJournal, type ForgetJournal, type ForgetProgress } from './team-forget-client'
+import { MAX_BATCH_SIZE, clampBatchSize, ingestTimeoutMs, nextBatchSize } from './ingest-batch'
 
 /** This machine's local workflow runs (computed metrics only — no chat/prompt text). Fallback
  *  source when `buildApiResponse` could not be run (see `buildPushContext`). Mirrors the
@@ -594,7 +595,21 @@ async function recordSentRunIds(connId: string, runs: readonly WorkflowRun[]): P
   }
 }
 
-const BATCH_SIZE = 200
+/**
+ * Per-connection batch size, adapted by `nextBatchSize` from what the central actually manages.
+ *
+ * In memory only: a restart re-probes from `MAX_BATCH_SIZE`, which is the right default for a
+ * central that has since been fixed or moved, and costs one shrink cycle on one that has not.
+ */
+const _batchSize = new Map<string, number>()
+
+function batchSizeFor(connId: string): number {
+  return clampBatchSize(_batchSize.get(connId) ?? MAX_BATCH_SIZE)
+}
+
+function recordBatchOutcome(connId: string, outcome: 'ok' | 'failed'): void {
+  _batchSize.set(connId, nextBatchSize(batchSizeFor(connId), outcome))
+}
 
 // ---------------------------------------------------------------------------
 // Shared push-cycle context — built ONCE per cycle window and reused by every connection's
@@ -631,7 +646,8 @@ export interface PushCycleContext {
   builtAt: number
   /** Ingest fetch timeout override, in ms — injectable for tests so a "central that never
    *  responds" regression test doesn't have to wait out the real production timeout. Production
-   *  code never sets this; `pushOnceDetailed` falls back to `DEFAULT_INGEST_TIMEOUT_MS`. */
+   *  code never sets this; `pushOnceDetailed` derives the budget from the batch via
+   *  `ingestTimeoutMs` (ingest-batch.ts). */
   ingestTimeoutMs?: number
 }
 
@@ -640,9 +656,13 @@ export interface PushCycleContext {
  *  respond — common, not exotic — and `runConnectionPushCycle` holds a concurrency-cap slot
  *  across that fetch, so two such centrals permanently occupy both slots and every OTHER
  *  connection blocks in `acquireSlot()` forever, with no error and a `lastSuccessAt` that is
- *  only ever set, never aged out. 15s is generous enough for a legitimately slow link pushing a
- *  full 200-session batch, while still guaranteeing the slot is released. */
-const DEFAULT_INGEST_TIMEOUT_MS = 15_000
+ *  only ever set, never aged out.
+ *
+ *  It is NOT a flat number any more. A flat 15s was stated here beside a `BATCH_SIZE` of 200
+ *  chosen elsewhere, with nothing checking that one fits the other — and it did not: a real
+ *  central costs ~195 ms/session, so those 200 needed ~39s and every first push aborted, forever,
+ *  because the sent-state only advances on an ACCEPTED batch. `ingestTimeoutMs` (ingest-batch.ts)
+ *  now derives the budget from the batch, and is the only place either number is decided. */
 
 let _cachedContext: PushCycleContext | null = null
 let _contextPromise: Promise<PushCycleContext> | null = null
@@ -884,7 +904,9 @@ export async function pushOnceDetailed(
     if (!user) return { count: 0 } // still unresolved this cycle — retried next time
   }
   const endpoint = conn.endpoint.replace(/\/+$/, '')
-  const ingestTimeoutMs = ctx.ingestTimeoutMs ?? DEFAULT_INGEST_TIMEOUT_MS
+  // The budget for a request carrying `n` sessions. A test may pin it flat; production always
+  // derives it, so the batch and its timeout cannot be chosen independently again.
+  const timeoutFor = (n: number) => ctx.ingestTimeoutMs ?? ingestTimeoutMs(n)
 
   try {
     const rules = shareRulesOf(conn.shareMode, conn.sources)
@@ -987,7 +1009,7 @@ export async function pushOnceDetailed(
             method: 'POST',
             headers,
             body: JSON.stringify({ org: conn.org, user, sessions: [], statsCache, workflows }),
-            signal: AbortSignal.timeout(ingestTimeoutMs),
+            signal: AbortSignal.timeout(timeoutFor(0)),
           })
           // A reachable central (even a non-2xx that isn't auth) counts as contact for the pill.
           if (res.ok) {
@@ -1013,8 +1035,12 @@ export async function pushOnceDetailed(
 
     let pushed = 0
 
-    for (let i = 0; i < toSend.length; i += BATCH_SIZE) {
-      const batch = toSend.slice(i, i + BATCH_SIZE)
+    // Read ONCE for the whole loop: every batch of this push is the size the previous push earned,
+    // and adapting mid-loop would make the same cycle send batches of different sizes for no
+    // reason a reader could follow.
+    const batchSize = batchSizeFor(conn.id)
+    for (let i = 0; i < toSend.length; i += batchSize) {
+      const batch = toSend.slice(i, i + batchSize)
       let res: Response
       try {
         res = await fetch(`${endpoint}/api/team/ingest`, {
@@ -1022,10 +1048,15 @@ export async function pushOnceDetailed(
           headers,
           // Attach the statsCache/workflows to the first batch only (idempotent upsert on the central).
           body: JSON.stringify({ org: conn.org, user, sessions: batch, ...(i === 0 ? { statsCache, workflows } : {}) }),
-          signal: AbortSignal.timeout(ingestTimeoutMs),
+          signal: AbortSignal.timeout(timeoutFor(batch.length)),
         })
       } catch (fetchErr) {
         const msg = fetchErr instanceof Error ? fetchErr.message : String(fetchErr)
+        // The central did not answer in the budget this batch was given, so the batch is too big
+        // for it — shrink, and let the next cycle prove the smaller one. Without this a central
+        // slower than PER_SESSION_MS assumes would retry an impossible request forever, which is
+        // the shape of the bug this module exists to have fixed once.
+        recordBatchOutcome(conn.id, 'failed')
         warnPushError(conn.id, msg)
         void notifyPushError(conn, 'net')
         return { count: pushed, error: msg }
@@ -1050,6 +1081,8 @@ export async function pushOnceDetailed(
       const current = await loadSentState(conn.id)
       await saveSentState(conn.id, { ...current, ...batchSent })
       pushed += batch.length
+      // The central absorbed a batch this size inside its budget — earn a slightly larger one.
+      recordBatchOutcome(conn.id, 'ok')
       markPushSuccess(conn.id)
       clearPushError(conn.id)
       void notifyPushRecovered(conn)


### PR DESCRIPTION
## Summary

- A member could never complete its first push: `BATCH_SIZE` 200 under a flat 15s ingest timeout,
  against a central that costs ~195 ms/session. The batch needs ~39s, aborts at 15s, records
  nothing, and the next cycle re-sends the identical 200 — forever.
- New pure `server/ingest-batch.ts`: the timeout is **derived** from the batch, so the two can
  never be chosen independently again, and the batch **adapts** to what the central can actually
  absorb.
- Ceiling drops 200 → 50, because **a batch is the unit of durable progress**.

## Motivation

Closes #202.

Measured on a live member: **1.260 consecutive failures, sent-state still `{}`,
`lastSuccessAt: null`** — against a central answering `policy`, `whoami` and an empty ingest in
under a second each, and accepting a 2 MiB body in 1,7s. The user-visible symptom is that the
central shows that machine's data as simply missing, while the connection pill says `net` — which
reads as "your network is bad", and the network is fine.

The timeout's own comment asserted *"15s is generous enough for a legitimately slow link pushing a
full 200-session batch"*. Nobody had measured it. The full-history first push is exactly the case
that hits the wall, so a member that has never pushed can never **start**.

## Changes

| file | change |
|---|---|
| `server/ingest-batch.ts` | **new, pure**: `ingestTimeoutMs(n)` (derived, capped), `nextBatchSize(size, outcome)` (halve on failure / grow gradually on success), `clampBatchSize`, and the constants |
| `server/ingest-batch.test.ts` | **new**: 11 tests, including the regression stated as arithmetic and a convergence test against a simulated slow central |
| `server/team-uploader.ts` | per-connection batch size + `timeoutFor(n)`; outcome recorded on both the failure and success paths; `DEFAULT_INGEST_TIMEOUT_MS` removed, its rationale kept and corrected |
| `docs/architecture.md` | new "Batch size and its timeout — one decision, not two" under the push model |
| `CLAUDE.md` | `ingest-batch.ts` in the module map with the invariant |

The test-only `ctx.ingestTimeoutMs` override still pins the timeout flat, so the "central that
never responds" regression test does not have to wait out a real budget.

### Why the batch adapts, and not just a bigger timeout

Deriving the timeout fixes *this* central. It still rests on an estimate of someone else's
hardware — `PER_SESSION_MS = 300` against a measured 195. A central slower than the estimate would
land in the same deadlock, so a failure has to teach it something. Halve on failure, grow by a
quarter on success: the batch settles just under what the central can serve. Growth is deliberately
gradual — jumping straight back to the ceiling would fail, drop to the floor, and fail again, which
is the same non-convergence in a slower loop.

### Why 50 and not 200 with a longer timeout

The sent-state advances per **accepted** batch. With 200, a member whose network drops mid-push
kept nothing. With 50 it keeps every batch already landed. Smaller batches cost round trips and buy
durable progress — and a bounded timeout still has to release the `MAX_CONCURRENT_PUSHES` slot that
a wedged proxy would otherwise hold.

## Test plan

- [x] `bun test` — 4379 pass, 0 fail
- [x] `bun tsc --noEmit` — clean
- [x] Measured against the live central that surfaced this, from the affected machine:

  | request | result |
  |---|---|
  | `GET /api/team/policy` | 200 in 529 ms |
  | `GET /api/team/whoami` | 200 in 721 ms |
  | `POST /ingest` (0 sessions) | 200 in 584 ms |
  | `POST /ingest` (2 MiB body) | 400 in 1.707 ms — size is not a factor |
  | `POST /ingest` (**20 real sessions**) | **200 in 3.903 ms → 195 ms/session** |

  195 ms/session × 200 = 39s > 15s (the old pairing, impossible) and × 50 = 9,8s <
  `ingestTimeoutMs(50)` = 30s (the new one, with headroom). Both are asserted as arithmetic in
  `ingest-batch.test.ts` so the old pairing cannot be restored by halves.

- [x] Convergence: a simulated central that can only absorb 8 sessions settles there within ~20
      cycles instead of oscillating to the ceiling.

**For reviewers:** the load-bearing claim is that a batch is the unit of durable progress — worth
confirming against `pushOnceDetailed`'s per-batch `saveSentState`. Everything else follows from it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Lhkrv9RmicUWo24WXCMiC
