### PR TITLE
release: chat-turn colors in the session detail pane, configurable refresh interval

### DIFF
--- a/packages/server/server/cli-start.ts
+++ b/packages/server/server/cli-start.ts
@@ -69,7 +69,10 @@ import type {
 } from '@agentistics/tui/control'
 import { DEFAULT_SESSION_VIEW } from '@agentistics/tui/control'
 import { PORT, WEB_PORT } from './config'
-import { readPreferences, writePreferences, resolveArchiveMode, type ArchiveMode } from './preferences'
+import {
+  readPreferences, writePreferences, resolveArchiveMode, type ArchiveMode,
+  clampSessionPollMs, sessionPollMsOrDefault, SESSION_POLL_DEFAULT_MS,
+} from './preferences'
 import { centralRuntimeChoices, centralStartPlan, runCentral, type CentralStartPlan } from './cli-central'
 import { flagFor, type CentralRuntimeId, type CentralRuntimeOption } from './central-runtime'
 import { onOutputLine, publishLines, streamCommand } from './cli-stream'
@@ -193,7 +196,9 @@ type Mode = 'solo' | 'central' | 'member'
  * that question with one endpoint out of three is the same misreport `agentop status` was fixed
  * for.
  */
-async function loadState(): Promise<{ mode: Mode; endpoint?: string; connections: TeamConnection[]; mouse: boolean }> {
+async function loadState(): Promise<{
+  mode: Mode; endpoint?: string; connections: TeamConnection[]; mouse: boolean; sessionPollMs: number
+}> {
   try {
     const prefs = await readPreferences()
     // Mouse ON unless the preference says otherwise — the default the control center assumes, and
@@ -204,9 +209,10 @@ async function loadState(): Promise<{ mode: Mode; endpoint?: string; connections
       endpoint: prefs.team?.endpoint,
       connections: prefs.team?.connections ?? [],
       mouse: prefs.mouse !== false,
+      sessionPollMs: sessionPollMsOrDefault(prefs),
     }
   } catch {
-    return { mode: 'solo', connections: [], mouse: true }
+    return { mode: 'solo', connections: [], mouse: true, sessionPollMs: SESSION_POLL_DEFAULT_MS }
   }
 }
 
@@ -2084,7 +2090,8 @@ export function createControlHost(initialLang: CliLang, altScreen: Suspendable):
 
     async refresh(): Promise<ControlStatus> {
       const s = S()
-      const [{ mode, endpoint, connections, mouse }, services] = await Promise.all([loadState(), serviceRows()])
+      const [{ mode, endpoint, connections, mouse, sessionPollMs }, services] =
+        await Promise.all([loadState(), serviceRows()])
       return remember({
         mode,
         modeLabel: modeSentence(s, mode, connections.length),
@@ -2120,6 +2127,7 @@ export function createControlHost(initialLang: CliLang, altScreen: Suspendable):
           : {},
         ...(await sessionViewPref()),
         mouse,
+        sessionPollMs,
       })
     },
 
@@ -2453,6 +2461,15 @@ export function createControlHost(initialLang: CliLang, altScreen: Suspendable):
       // tell the next remount the mouse is still what it was before the key was pressed.
       if (lastStatus) remember({ ...lastStatus, mouse: on })
       try { await writePreferences({ mouse: on }) } catch { /* best-effort */ }
+    },
+
+    async setSessionPollMs(ms: number): Promise<void> {
+      // Same shape as `setMouse`: this changes the running `setInterval` in the shell, which reads
+      // it back straight off the row it just pressed enter on rather than waiting a poll cycle for
+      // a `refresh()` this action does not otherwise trigger.
+      const clamped = clampSessionPollMs(ms)
+      if (lastStatus) remember({ ...lastStatus, sessionPollMs: clamped })
+      try { await writePreferences({ sessionPollMs: clamped }) } catch { /* best-effort */ }
     },
 
     /**

--- a/packages/server/server/preferences.test.ts
+++ b/packages/server/server/preferences.test.ts
@@ -671,3 +671,23 @@ test('C1 end to end: the guarded payload written through writePreferencesTo pres
   const wiped = await readPreferencesFrom(primary, legacy)
   expect(wiped.team!.connections).toEqual([])
 })
+
+import {
+  clampSessionPollMs, sessionPollMsOrDefault,
+  SESSION_POLL_DEFAULT_MS, SESSION_POLL_MIN_MS, SESSION_POLL_MAX_MS,
+} from './preferences'
+
+test('sessionPollMsOrDefault falls back to the built-in default when unset', () => {
+  expect(sessionPollMsOrDefault({})).toBe(SESSION_POLL_DEFAULT_MS)
+})
+
+test('sessionPollMsOrDefault clamps a stored value to the floor and ceiling', () => {
+  expect(sessionPollMsOrDefault({ sessionPollMs: 1 })).toBe(SESSION_POLL_MIN_MS)
+  expect(sessionPollMsOrDefault({ sessionPollMs: 1_000_000 })).toBe(SESSION_POLL_MAX_MS)
+  expect(sessionPollMsOrDefault({ sessionPollMs: 2_000 })).toBe(2_000)
+})
+
+test('clampSessionPollMs falls back to the default for a non-finite value', () => {
+  expect(clampSessionPollMs(NaN)).toBe(SESSION_POLL_DEFAULT_MS)
+  expect(clampSessionPollMs(Infinity)).toBe(SESSION_POLL_DEFAULT_MS)
+})

--- a/packages/server/server/preferences.ts
+++ b/packages/server/server/preferences.ts
@@ -61,6 +61,17 @@ export interface Preferences {
    *    - 'off'         = do nothing, use Claude's default folder */
   archiveMode?: 'off' | 'consolidate' | 'full'
   /**
+   * How often the cockpit refreshes the fleet list and the session detail pane, in milliseconds.
+   *
+   * `undefined` reads as the built-in default (`SESSION_POLL_DEFAULT_MS`). Clamped to
+   * `[SESSION_POLL_MIN_MS, SESSION_POLL_MAX_MS]` on write, never on read — a value saved by an
+   * older binary before the floor existed still parses, and `sessionPollMsOrDefault` is where the
+   * clamp actually applies. Below the floor the cost is real: each tick captures a `tmux` pane per
+   * live session, and a poll faster than the terminal can usefully redraw buys no responsiveness,
+   * only load.
+   */
+  sessionPollMs?: number
+  /**
    * How the cockpit's fleet list was last arranged.
    *
    * Stored here rather than held in the TUI because the control center owns no persistence — the
@@ -134,6 +145,25 @@ export function resolveArchiveMode(p: Preferences): ArchiveMode | undefined {
 
 export async function getArchiveMode(): Promise<ArchiveMode | undefined> {
   return resolveArchiveMode(await readPreferences())
+}
+
+/** The cockpit's built-in refresh cadence — unchanged from what the feature shipped with. */
+export const SESSION_POLL_DEFAULT_MS = 5_000
+/** Below this, a tick captures a `tmux` pane per live session more often than a terminal can
+ *  usefully redraw — all cost, no perceptible gain. */
+export const SESSION_POLL_MIN_MS = 1_000
+export const SESSION_POLL_MAX_MS = 30_000
+/** The presets offered in the config pane, fastest first. */
+export const SESSION_POLL_PRESETS_MS = [1_000, 2_000, SESSION_POLL_DEFAULT_MS, 10_000] as const
+
+export function clampSessionPollMs(ms: number): number {
+  if (!Number.isFinite(ms)) return SESSION_POLL_DEFAULT_MS
+  return Math.min(SESSION_POLL_MAX_MS, Math.max(SESSION_POLL_MIN_MS, Math.round(ms)))
+}
+
+/** The effective poll interval — `undefined` reads as the default, exactly like `archiveMode`. */
+export function sessionPollMsOrDefault(p: Preferences): number {
+  return p.sessionPollMs !== undefined ? clampSessionPollMs(p.sessionPollMs) : SESSION_POLL_DEFAULT_MS
 }
 
 /** Read + parse a preferences JSON file.

--- a/packages/server/server/sessions/chat-tail.test.ts
+++ b/packages/server/server/sessions/chat-tail.test.ts
@@ -1,0 +1,164 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { mkdtemp, mkdir, rm, writeFile, utimes } from 'node:fs/promises'
+import {
+  forgetChatTailContent, forgetChatTailPaths, readRecentChatTurns, resolveChatTranscriptPath,
+} from './chat-tail'
+
+const SESSION_ID = 'a1b2c3d4-e5f6-4789-a0b1-c2d3e4f56789'
+
+function line(obj: unknown): string {
+  return JSON.stringify(obj)
+}
+
+const userTurn = (text: string) => line({ type: 'user', message: { content: text } })
+const assistantTurn = (text: string) => line({
+  type: 'assistant', message: { content: [{ type: 'text', text }] },
+})
+const toolResultTurn = () => line({
+  type: 'user', message: { content: [{ type: 'tool_result', content: 'ok' }] },
+})
+
+describe('resolveChatTranscriptPath', () => {
+  let root: string
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), 'chat-tail-'))
+    forgetChatTailPaths()
+  })
+  afterEach(async () => { await rm(root, { recursive: true, force: true }) })
+
+  test('finds the transcript at the directly encoded project path', async () => {
+    const projectDir = join(root, '-home-user-my-project')
+    await mkdir(projectDir, { recursive: true })
+    const file = join(projectDir, `${SESSION_ID}.jsonl`)
+    await writeFile(file, userTurn('hi') + '\n')
+
+    const resolved = await resolveChatTranscriptPath('/home/user/my-project', SESSION_ID, root)
+    expect(resolved).toBe(file)
+  })
+
+  test('falls back to a scan when the directly encoded path does not exist', async () => {
+    // The naive encoding of this cwd would land on a directory that is not where Claude actually
+    // put the file (an ambiguous-dash collision) — the scan is what finds it anyway, by filename.
+    const realDir = join(root, 'some-other-directory-name')
+    await mkdir(realDir, { recursive: true })
+    const file = join(realDir, `${SESSION_ID}.jsonl`)
+    await writeFile(file, userTurn('hi') + '\n')
+
+    const resolved = await resolveChatTranscriptPath('/home/user/my-project', SESSION_ID, root)
+    expect(resolved).toBe(file)
+  })
+
+  test('returns null and never throws when nothing matches', async () => {
+    const resolved = await resolveChatTranscriptPath('/nowhere', SESSION_ID, root)
+    expect(resolved).toBeNull()
+  })
+
+  test('rejects a non-UUID session id without touching the filesystem', async () => {
+    const resolved = await resolveChatTranscriptPath('/nowhere', 'not-a-uuid', root)
+    expect(resolved).toBeNull()
+  })
+
+  test('caches a miss so a second lookup does not re-scan', async () => {
+    const first = await resolveChatTranscriptPath('/nowhere', SESSION_ID, root)
+    expect(first).toBeNull()
+
+    // Adding the file after the miss was cached must not change the cached answer.
+    const lateDir = join(root, '-late')
+    await mkdir(lateDir, { recursive: true })
+    await writeFile(join(lateDir, `${SESSION_ID}.jsonl`), userTurn('hi') + '\n')
+
+    const second = await resolveChatTranscriptPath('/nowhere', SESSION_ID, root)
+    expect(second).toBeNull()
+  })
+})
+
+describe('readRecentChatTurns', () => {
+  let root: string
+  let file: string
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), 'chat-tail-content-'))
+    file = join(root, 'transcript.jsonl')
+    forgetChatTailContent()
+  })
+  afterEach(async () => { await rm(root, { recursive: true, force: true }) })
+
+  test('returns turns oldest-first with real roles', async () => {
+    await writeFile(file, [
+      userTurn('what does this do'),
+      assistantTurn('it does the thing'),
+    ].join('\n') + '\n')
+
+    const turns = await readRecentChatTurns(file)
+    expect(turns).toEqual([
+      { role: 'user', text: 'what does this do' },
+      { role: 'assistant', text: 'it does the thing' },
+    ])
+  })
+
+  test('filters out tool-result-only user entries', async () => {
+    await writeFile(file, [
+      userTurn('do the thing'),
+      assistantTurn('doing it'),
+      toolResultTurn(),
+      assistantTurn('done'),
+    ].join('\n') + '\n')
+
+    const turns = await readRecentChatTurns(file)
+    expect(turns.map(t => t.role)).toEqual(['user', 'assistant', 'assistant'])
+  })
+
+  test('stops parsing once `max` turns are collected, from the end', async () => {
+    const lines: string[] = []
+    for (let i = 0; i < 20; i++) {
+      lines.push(userTurn(`q${i}`))
+      lines.push(assistantTurn(`a${i}`))
+    }
+    await writeFile(file, lines.join('\n') + '\n')
+
+    const turns = await readRecentChatTurns(file, 2)
+    expect(turns).toEqual([
+      { role: 'user', text: 'q19' },
+      { role: 'assistant', text: 'a19' },
+    ])
+  })
+
+  test('skips malformed lines without throwing', async () => {
+    await writeFile(file, [
+      'not json at all',
+      userTurn('hello'),
+    ].join('\n') + '\n')
+
+    const turns = await readRecentChatTurns(file)
+    expect(turns).toEqual([{ role: 'user', text: 'hello' }])
+  })
+
+  test('returns empty for a missing file rather than throwing', async () => {
+    const turns = await readRecentChatTurns(join(root, 'nope.jsonl'))
+    expect(turns).toEqual([])
+  })
+
+  test('re-parses when the file changes and reuses the cache when it has not', async () => {
+    await writeFile(file, userTurn('first') + '\n')
+    const first = await readRecentChatTurns(file)
+    expect(first).toEqual([{ role: 'user', text: 'first' }])
+
+    // Unchanged mtime: appending nothing and re-reading must return the cached array instance.
+    const cached = await readRecentChatTurns(file)
+    expect(cached).toBe(first)
+
+    // Bump mtime forward so the cache is invalidated even on filesystems with coarse resolution.
+    const future = new Date(Date.now() + 5_000)
+    await writeFile(file, userTurn('first') + '\n' + assistantTurn('second') + '\n')
+    await utimes(file, future, future)
+
+    const updated = await readRecentChatTurns(file)
+    expect(updated).toEqual([
+      { role: 'user', text: 'first' },
+      { role: 'assistant', text: 'second' },
+    ])
+  })
+})

--- a/packages/server/server/sessions/chat-tail.test.ts
+++ b/packages/server/server/sessions/chat-tail.test.ts
@@ -19,6 +19,10 @@ const assistantTurn = (text: string) => line({
 const toolResultTurn = () => line({
   type: 'user', message: { content: [{ type: 'tool_result', content: 'ok' }] },
 })
+const toolUseTurn = (...names: string[]) => line({
+  type: 'assistant',
+  message: { content: names.map(name => ({ type: 'tool_use', name, input: {} })) },
+})
 
 describe('resolveChatTranscriptPath', () => {
   let root: string
@@ -109,6 +113,40 @@ describe('readRecentChatTurns', () => {
 
     const turns = await readRecentChatTurns(file)
     expect(turns.map(t => t.role)).toEqual(['user', 'assistant', 'assistant'])
+  })
+
+  test('surfaces a pending tool-activity turn when the newest event is a tool call with no text yet', async () => {
+    await writeFile(file, [
+      userTurn('fix the bug'),
+      assistantTurn('looking into it'),
+      toolUseTurn('Bash'),
+    ].join('\n') + '\n')
+
+    const turns = await readRecentChatTurns(file)
+    expect(turns).toEqual([
+      { role: 'user', text: 'fix the bug' },
+      { role: 'assistant', text: 'looking into it' },
+      { role: 'assistant', text: 'Running Bash', pending: true },
+    ])
+  })
+
+  test('names every tool called in the newest entry', async () => {
+    await writeFile(file, [userTurn('go'), toolUseTurn('Read', 'Bash')].join('\n') + '\n')
+    const turns = await readRecentChatTurns(file)
+    expect(turns.at(-1)).toEqual({ role: 'assistant', text: 'Running Read, Bash', pending: true })
+  })
+
+  test('does NOT synthesize a pending turn for an older tool call that already has a result', async () => {
+    // Only the newest event in the file may be read as "busy right now" — an earlier tool_use with
+    // nothing after it in this fixture would otherwise misreport a finished exchange as still running.
+    await writeFile(file, [
+      toolUseTurn('Bash'),
+      toolResultTurn(),
+      assistantTurn('done'),
+    ].join('\n') + '\n')
+
+    const turns = await readRecentChatTurns(file)
+    expect(turns).toEqual([{ role: 'assistant', text: 'done' }])
   })
 
   test('stops parsing once `max` turns are collected, from the end', async () => {

--- a/packages/server/server/sessions/chat-tail.ts
+++ b/packages/server/server/sessions/chat-tail.ts
@@ -26,6 +26,14 @@ import { isHumanUserEntry } from '../jsonl'
 export interface ChatTurn {
   role: 'user' | 'assistant'
   text: string
+  /**
+   * This is not something the assistant SAID — it is a synthesized note that a tool call has been
+   * written to the transcript and no text has followed it yet, which is exactly the window where a
+   * session is visibly busy and the pane would otherwise show nothing (or a stale turn from before
+   * the tool call). Rendered dim, like every other status line in this pane, never in the role
+   * colours — it is not a message either side wrote.
+   */
+  pending?: boolean
 }
 
 /** Resolved paths and one-time-scan misses, keyed by conversation id. Never re-scanned once known. */
@@ -114,6 +122,21 @@ function extractAssistantText(e: Record<string, unknown>): string | null {
   return text?.trim() || null
 }
 
+/** The tool names an assistant entry is calling, when it carries no text at all — see `ChatTurn.pending`. */
+function extractToolActivity(e: Record<string, unknown>): string[] | null {
+  if (e.type !== 'assistant') return null
+  const msgContent = (e.message as Record<string, unknown> | undefined)?.content
+  if (!Array.isArray(msgContent)) return null
+  const names = (msgContent as Record<string, unknown>[])
+    .filter(p => p.type === 'tool_use' && typeof p.name === 'string')
+    .map(p => p.name as string)
+  return names.length > 0 ? names : null
+}
+
+function toolActivityLabel(tools: string[]): string {
+  return `Running ${tools.join(', ')}`
+}
+
 /**
  * The most recent chat turns in a Claude transcript, oldest first.
  *
@@ -134,16 +157,27 @@ export async function readRecentChatTurns(path: string, max = 6): Promise<ChatTu
 
   const lines = content.split('\n')
   const turns: ChatTurn[] = []
+  // Set once, on the first substantive (non-blank, parseable) line the loop inspects — which is the
+  // NEWEST event in the transcript. Only there does "no text yet" mean "busy right now"; the same
+  // shape earlier in the file is just an ordinary tool call whose result and follow-up text already
+  // exist further down and will be read on a later iteration.
+  let newest = true
   for (let i = lines.length - 1; i >= 0 && turns.length < max; i--) {
     const line = (lines[i] ?? '').trim()
     if (!line) continue
     let e: Record<string, unknown>
     try { e = JSON.parse(line) } catch { continue }
+    const isNewest = newest
+    newest = false
 
     const userText = extractUserText(e)
     if (userText) { turns.push({ role: 'user', text: userText }); continue }
     const assistantText = extractAssistantText(e)
-    if (assistantText) turns.push({ role: 'assistant', text: assistantText })
+    if (assistantText) { turns.push({ role: 'assistant', text: assistantText }); continue }
+    if (isNewest) {
+      const tools = extractToolActivity(e)
+      if (tools) turns.push({ role: 'assistant', text: toolActivityLabel(tools), pending: true })
+    }
   }
   turns.reverse()
 

--- a/packages/server/server/sessions/chat-tail.ts
+++ b/packages/server/server/sessions/chat-tail.ts
@@ -1,0 +1,152 @@
+/**
+ * chat-tail.ts — the LIVE session detail pane's chat content, read from the harness's own JSONL
+ * transcript instead of the terminal screen.
+ *
+ * Only Claude Code has an exact live-session -> conversation-id link
+ * (`harness-sessions.ts`'s `byManagedId`), so this is Claude-only; every other harness keeps the
+ * existing raw-tail behavior in `sessions-host.ts`. Absence here is never an error, only "not
+ * available for this row" — the same rule every other enrichment in this file follows.
+ *
+ * Claude encodes a project's absolute path into its directory name by replacing `/` and `.` with
+ * `-` (`nay-sessions.ts` uses the same encoding), but that encoding is documented as ambiguous for
+ * directory names that already contain dashes (`data.ts`). Rather than trust it, the resolver
+ * treats the conversation id (a UUID) as the reliable key: it tries the direct encoded path first
+ * — cheap, and right the overwhelming majority of the time — and falls back to a one-time scan of
+ * `PROJECTS_DIR` for a file literally named `<id>.jsonl`, exactly as `transcript-search.ts` does.
+ * Both the hit and the miss are cached per conversation id, so a resolved (or unresolvable) session
+ * is never re-scanned on a later poll.
+ */
+
+import { readFile, readdir, stat } from 'node:fs/promises'
+import { join } from 'node:path'
+import { PROJECTS_DIR } from '../config'
+import { UUID_RE } from '../git'
+import { isHumanUserEntry } from '../jsonl'
+
+export interface ChatTurn {
+  role: 'user' | 'assistant'
+  text: string
+}
+
+/** Resolved paths and one-time-scan misses, keyed by conversation id. Never re-scanned once known. */
+const pathCache = new Map<string, string | null>()
+
+/** Reset the memo. Tests only. */
+export function forgetChatTailPaths(): void {
+  pathCache.clear()
+}
+
+function encodeProjectDir(cwd: string): string {
+  return cwd.replace(/[/.]/g, '-')
+}
+
+async function exists(path: string): Promise<boolean> {
+  try { await stat(path); return true } catch { return false }
+}
+
+/** Find `<sessionId>.jsonl` under `projectsDir`, scanning every project directory once. */
+async function scanForTranscript(sessionId: string, projectsDir: string): Promise<string | null> {
+  let dirs: string[]
+  try { dirs = await readdir(projectsDir) } catch { return null }
+  for (const dir of dirs) {
+    const candidate = join(projectsDir, dir, `${sessionId}.jsonl`)
+    if (await exists(candidate)) return candidate
+  }
+  return null
+}
+
+/**
+ * The absolute path to a live Claude conversation's transcript, or `null` when it cannot be found.
+ *
+ * `null` is cached too — a session whose directory encoding is ambiguous costs one scan, not one
+ * scan per poll for the rest of its life.
+ *
+ * `projectsDir` defaults to the real `PROJECTS_DIR` and is overridable only so tests can point it
+ * at a fixture tree without needing a subprocess — `config.ts`'s constants are fixed at import
+ * time and shared across a whole `bun test` run.
+ */
+export async function resolveChatTranscriptPath(
+  cwd: string,
+  sessionId: string,
+  projectsDir: string = PROJECTS_DIR,
+): Promise<string | null> {
+  if (!UUID_RE.test(sessionId)) return null
+  const cached = pathCache.get(sessionId)
+  if (cached !== undefined) return cached
+
+  const direct = join(projectsDir, encodeProjectDir(cwd), `${sessionId}.jsonl`)
+  const resolved = (await exists(direct)) ? direct : await scanForTranscript(sessionId, projectsDir)
+  pathCache.set(sessionId, resolved)
+  return resolved
+}
+
+interface Cached {
+  mtimeMs: number
+  turns: ChatTurn[]
+}
+
+/** Parsed turns, keyed by transcript path — re-parsed only when the file's mtime has moved. */
+const contentCache = new Map<string, Cached>()
+
+/** Reset the memo. Tests only. */
+export function forgetChatTailContent(): void {
+  contentCache.clear()
+}
+
+function extractUserText(e: Record<string, unknown>): string | null {
+  if (!isHumanUserEntry(e)) return null
+  const msgContent = (e.message as Record<string, unknown> | undefined)?.content
+  if (typeof msgContent === 'string') return msgContent.trim() || null
+  if (Array.isArray(msgContent)) {
+    const text = (msgContent as Record<string, unknown>[])
+      .find(p => p.type === 'text' && typeof p.text === 'string')?.text as string | undefined
+    return text?.trim() || null
+  }
+  return null
+}
+
+function extractAssistantText(e: Record<string, unknown>): string | null {
+  if (e.type !== 'assistant') return null
+  const msgContent = (e.message as Record<string, unknown> | undefined)?.content
+  if (!Array.isArray(msgContent)) return null
+  const text = (msgContent as Record<string, unknown>[])
+    .find(p => p.type === 'text' && typeof p.text === 'string')?.text as string | undefined
+  return text?.trim() || null
+}
+
+/**
+ * The most recent chat turns in a Claude transcript, oldest first.
+ *
+ * Reads the whole file (the same "tail -n" shape `cli-start.ts`'s `tailFile` already uses in this
+ * codebase — there is no incremental byte-offset reader here) but parses from the END and stops as
+ * soon as `max` turns are collected, so a long-running session's transcript is not fully
+ * `JSON.parse`d every poll just to show the last few lines.
+ */
+export async function readRecentChatTurns(path: string, max = 6): Promise<ChatTurn[]> {
+  let mtimeMs: number
+  try { mtimeMs = (await stat(path)).mtimeMs } catch { return [] }
+
+  const hit = contentCache.get(path)
+  if (hit && hit.mtimeMs === mtimeMs) return hit.turns
+
+  let content: string
+  try { content = await readFile(path, 'utf-8') } catch { return [] }
+
+  const lines = content.split('\n')
+  const turns: ChatTurn[] = []
+  for (let i = lines.length - 1; i >= 0 && turns.length < max; i--) {
+    const line = (lines[i] ?? '').trim()
+    if (!line) continue
+    let e: Record<string, unknown>
+    try { e = JSON.parse(line) } catch { continue }
+
+    const userText = extractUserText(e)
+    if (userText) { turns.push({ role: 'user', text: userText }); continue }
+    const assistantText = extractAssistantText(e)
+    if (assistantText) turns.push({ role: 'assistant', text: assistantText })
+  }
+  turns.reverse()
+
+  contentCache.set(path, { mtimeMs, turns })
+  return turns
+}

--- a/packages/server/server/sessions/control-session.ts
+++ b/packages/server/server/sessions/control-session.ts
@@ -146,6 +146,7 @@ export function toControlSession(
       : {}),
     ...(v.resume ? { resume: v.resume } : {}),
     ...(v.lastLines?.length ? { lastLines: v.lastLines } : {}),
+    ...(v.chatTurns?.length ? { chatTurns: v.chatTurns } : {}),
     ...(v.approvalLines?.length ? { approvalLines: v.approvalLines } : {}),
     ...(v.dialogOptions?.length ? { dialogOptions: v.dialogOptions } : {}),
     // Picking one of them needs a VERIFIED way to select by number on this harness. Only claude has

--- a/packages/server/server/sessions/session-view.test.ts
+++ b/packages/server/server/sessions/session-view.test.ts
@@ -43,6 +43,16 @@ describe('buildSessionViews', () => {
     })
   })
 
+  it('carries chat turns onto the view, keyed by session id — and leaves them off a session with none', () => {
+    const reconciled = [row('a'), row('b')]
+    const chatTails = new Map([
+      ['a', [{ role: 'user' as const, text: 'hi' }, { role: 'assistant' as const, text: 'hello' }]],
+    ])
+    const [a, b] = buildSessionViews({ reconciled, activity: new Map(), processes: [], chatTails })
+    expect(a!.chatTurns).toEqual([{ role: 'user', text: 'hi' }, { role: 'assistant', text: 'hello' }])
+    expect(b!.chatTurns).toBeUndefined()
+  })
+
   it('reports approval detection exactly where rules exist, for every harness', () => {
     // Written as an INVARIANT rather than against one harness that happens to be unprobed today:
     // this test used to name gemini, and it broke the day gemini was probed — asserting a fact

--- a/packages/server/server/sessions/session-view.ts
+++ b/packages/server/server/sessions/session-view.ts
@@ -64,6 +64,16 @@ export interface SessionView {
    */
   lastLines?: string[]
   /**
+   * The last few CHAT TURNS of this session, role-tagged, read from its own JSONL transcript
+   * rather than the screen — see `chat-tail.ts`.
+   *
+   * Claude only: it is the one harness with an exact live-session -> conversation-id link, which
+   * is what makes trusting the transcript's own `role` field safe rather than a guess. Absent for
+   * every other harness (and for a Claude row whose transcript could not be resolved yet), in
+   * which case the detail pane falls back to `lastLines` exactly as it always has.
+   */
+  chatTurns?: { role: 'user' | 'assistant'; text: string }[]
+  /**
    * The BOTTOM of the screen verbatim, present only while this session is blocked on a dialog.
    *
    * A different reading of the same frame from `lastLines`, and it has to be: `frameTail` cuts the
@@ -283,6 +293,8 @@ export function buildSessionViews(o: {
   activity: ReadonlyMap<string, SessionActivity>
   /** The tail of each hosted session's screen, keyed by session id. */
   tails?: ReadonlyMap<string, string[]>
+  /** Role-tagged chat turns, keyed by session id — see `SessionView.chatTurns`. */
+  chatTails?: ReadonlyMap<string, { role: 'user' | 'assistant'; text: string }[]>
   /** The DIALOG a blocked session is showing, keyed by session id — see `SessionView.approvalLines`. */
   approvals?: ReadonlyMap<string, string[]>
   /** The options that dialog offers, keyed by session id. Absent where they could not be read. */
@@ -407,6 +419,7 @@ export function buildSessionViews(o: {
       status: finished ? ('exited' as const) : r.status,
       ...(activity ? { activity } : {}),
       ...((o.tails?.get(r.id)?.length ?? 0) > 0 ? { lastLines: o.tails!.get(r.id)! } : {}),
+      ...((o.chatTails?.get(r.id)?.length ?? 0) > 0 ? { chatTurns: o.chatTails!.get(r.id)! } : {}),
       // Only while it is genuinely asking. A dialog frame carried on a row that has moved on would
       // be shown under "what you are about to confirm" for a question that is no longer open.
       ...(activity === 'waiting-approval' && (o.approvals?.get(r.id)?.length ?? 0) > 0

--- a/packages/server/server/sessions/session-view.ts
+++ b/packages/server/server/sessions/session-view.ts
@@ -21,6 +21,7 @@ import type { ReconciledSession } from './session-ref'
 import type { Conversation } from './conversations'
 import { conversationForProcess } from './conversations'
 import type { ManagedSession, SessionActivity } from './types'
+import type { ChatTurn } from './chat-tail'
 
 /**
  * The registry's own record of when a session began, as epoch ms — PURE.
@@ -72,7 +73,7 @@ export interface SessionView {
    * every other harness (and for a Claude row whose transcript could not be resolved yet), in
    * which case the detail pane falls back to `lastLines` exactly as it always has.
    */
-  chatTurns?: { role: 'user' | 'assistant'; text: string }[]
+  chatTurns?: ChatTurn[]
   /**
    * The BOTTOM of the screen verbatim, present only while this session is blocked on a dialog.
    *
@@ -294,7 +295,7 @@ export function buildSessionViews(o: {
   /** The tail of each hosted session's screen, keyed by session id. */
   tails?: ReadonlyMap<string, string[]>
   /** Role-tagged chat turns, keyed by session id — see `SessionView.chatTurns`. */
-  chatTails?: ReadonlyMap<string, { role: 'user' | 'assistant'; text: string }[]>
+  chatTails?: ReadonlyMap<string, ChatTurn[]>
   /** The DIALOG a blocked session is showing, keyed by session id — see `SessionView.approvalLines`. */
   approvals?: ReadonlyMap<string, string[]>
   /** The options that dialog offers, keyed by session id. Absent where they could not be read. */

--- a/packages/server/server/sessions/sessions-host.ts
+++ b/packages/server/server/sessions/sessions-host.ts
@@ -15,6 +15,7 @@ import { createLimiter } from '../utils'
 import type { HarnessProcess } from '../live-sessions'
 import { rulesFor } from './attention-rules'
 import { approvalTail, attentionOf, digestFrame, frameTail } from './attention'
+import { readRecentChatTurns, resolveChatTranscriptPath, type ChatTurn } from './chat-tail'
 import { parseDialogOptions, type DialogOption } from './dialog-choice'
 // Taking a running session back when its registry record is gone. See `session-adopt.ts`.
 import { planAdoptions } from './session-adopt'
@@ -45,6 +46,9 @@ const CAPTURE_CONCURRENCY = 4
 /** How much of what a session is saying to carry. Enough that a tall pane has something to fill it
  *  with; the pane cuts from the bottom to whatever it can actually draw. */
 const TAIL_LINES = 8
+
+/** How many role-tagged chat turns to carry for a Claude session — see `chat-tail.ts`. */
+const TAIL_CHAT_TURNS = 6
 
 /**
  * How much of a blocked session's screen to carry as the dialog.
@@ -205,6 +209,7 @@ export function createSessionsPoller(o: {
       const tails = new Map<string, string[]>()
       const approvals = new Map<string, string[]>()
       const dialogOptions = new Map<string, DialogOption[]>()
+      const chatTails = new Map<string, ChatTurn[]>()
 
       await Promise.all(reconciled.map(r => limit(async () => {
         const b = r.backend
@@ -217,6 +222,20 @@ export function createSessionsPoller(o: {
         tails.set(r.id, frameTail(frame, TAIL_LINES))
 
         const harness = harnessOf.get(r.id)
+
+        // Claude only: the one harness with an EXACT live-session -> conversation-id link
+        // (`harness-sessions.ts`), which is what makes reading its own transcript safe rather than
+        // a guess. Every other harness keeps the raw screen tail above as its only detail content.
+        const cwd = r.managed?.cwd
+        const conversationId = harnessSessions.byManagedId.get(r.id)?.sessionId
+        if (harness === 'claude' && cwd && conversationId) {
+          const path = await resolveChatTranscriptPath(cwd, conversationId).catch(() => null)
+          if (path) {
+            const turns = await readRecentChatTurns(path, TAIL_CHAT_TURNS).catch(() => [] as ChatTurn[])
+            if (turns.length > 0) chatTails.set(r.id, turns)
+          }
+        }
+
         const rules = harness ? rulesFor(harness) : undefined
         const before = prevDigest.get(r.id)
         const state = attentionOf({
@@ -301,6 +320,7 @@ export function createSessionsPoller(o: {
         reconciled,
         activity,
         tails,
+        chatTails,
         approvals,
         dialogOptions,
         processes,

--- a/packages/tui/scripts/preview.tsx
+++ b/packages/tui/scripts/preview.tsx
@@ -431,6 +431,7 @@ function fakeHost(opts: Options, apiUrl?: string): ControlHost {
     // The preview has no terminal to report a mouse, so `ControlCenter` is rendered without a
     // channel and never asks for tracking — this only satisfies the contract.
     setMouse: async () => {},
+    setSessionPollMs: async () => {},
     // Present so the preview shows the cockpit's full action row. `openUrl` is optional on the
     // host, and a host without it makes the action, the `o` key and its footer hint all disappear.
     openUrl: done,

--- a/packages/tui/src/control/ControlCenter.test.tsx
+++ b/packages/tui/src/control/ControlCenter.test.tsx
@@ -63,6 +63,7 @@ function probingHost(known: ControlStatus | null): ControlHost {
     setLang: async () => {},
     setSessionView: async () => {},
     setMouse: async () => {},
+    setSessionPollMs: async () => {},
     onOutput: () => () => {},
     readLog: async () => [],
     sessions: async () => FLEET,

--- a/packages/tui/src/control/ControlCenter.tsx
+++ b/packages/tui/src/control/ControlCenter.tsx
@@ -100,8 +100,11 @@ export interface TaskView {
 export type RunAction = (fn: () => Promise<ActionResult>, label?: string) => Promise<ActionResult>
 
 /**
- * How often the fleet is re-read. Five seconds — the interval the monitor was specified at, and slow
- * enough that a machine running a dozen sessions is not forking a `capture-pane` per second.
+ * The built-in fallback for how often the fleet is re-read, used only until the host answers
+ * `status.sessionPollMs` (or if it never does). Five seconds — the interval the monitor was
+ * originally specified at. The user-facing default and floor/ceiling live in `preferences.ts`
+ * (`SESSION_POLL_DEFAULT_MS` and friends); this constant is deliberately not imported from there —
+ * the TUI reads no preferences of its own, exactly like the mouse and the language.
  */
 const SESSION_POLL_MS = 5_000
 
@@ -198,6 +201,20 @@ export function ControlCenter({ host, lang: initialLang, initial, onExit, mouse 
   )
 
   /**
+   * How often the fleet is re-read — `null`-until-chosen, same shape as `mouseChoice` below: the
+   * default until the host answers is the built-in one, and once the config pane row has been
+   * pressed the local answer wins so a stale `refresh()` cannot flicker it back to what it was.
+   */
+  const [pollChoice, setPollChoice] = useState<number | null>(null)
+  const sessionPollMs = pollChoice ?? status?.sessionPollMs ?? SESSION_POLL_MS
+
+  const setSessionPollMs = useCallback((next: number) => {
+    setPollChoice(next)
+    // The TUI owns no persistence — the host stores it beside every other preference.
+    void host.setSessionPollMs(next)
+  }, [host])
+
+  /**
    * One read of the fleet, callable on demand as well as on the interval.
    *
    * The sessions screen calls it straight after an action, because a kill or a rename the user just
@@ -225,9 +242,11 @@ export function ControlCenter({ host, lang: initialLang, initial, onExit, mouse 
   useEffect(() => {
     if (!host.sessions) return
     void pollFleet()
-    const timer = setInterval(() => { void pollFleet() }, SESSION_POLL_MS)
+    // Re-armed whenever `sessionPollMs` changes, so pressing the config row's action takes effect
+    // on the very next tick rather than waiting out whatever interval was already running.
+    const timer = setInterval(() => { void pollFleet() }, sessionPollMs)
     return () => clearInterval(timer)
-  }, [host, pollFleet])
+  }, [host, pollFleet, sessionPollMs])
 
   /**
    * The task the last action started, or `null` when nothing has been performed yet.
@@ -579,6 +598,8 @@ export function ControlCenter({ host, lang: initialLang, initial, onExit, mouse 
             // `m` key together rather than leaving a control for a device that cannot report.
             mouseOn={mouseOn}
             onMouse={mouse ? toggleMouse : undefined}
+            sessionPollMs={sessionPollMs}
+            onSessionPollMs={setSessionPollMs}
             // A machine that has never been configured opens with the wizard already asking. It is
             // a question of this screen now rather than a tab of its own — see `TAB_ORDER`.
             initialSetup={initial?.setup}

--- a/packages/tui/src/control/i18n.ts
+++ b/packages/tui/src/control/i18n.ts
@@ -104,6 +104,9 @@ export interface ControlStrings {
   mouseLabel: string
   mouseOn: string
   mouseOff: string
+  /** The config pane's refresh-interval row. */
+  sessionPollLabel: string
+  actSessionPoll: string
 
   /** Detail pane. */
   pidLabel: string
@@ -639,6 +642,8 @@ const EN: ControlStrings = {
   mouseLabel: 'mouse',
   mouseOn: 'on',
   mouseOff: 'off',
+  sessionPollLabel: 'refresh',
+  actSessionPoll: 'Change',
 
   pidLabel: 'pid',
   uptimeLabel: 'up',
@@ -1104,6 +1109,8 @@ const PT: ControlStrings = {
   mouseLabel: 'mouse',
   mouseOn: 'ligado',
   mouseOff: 'desligado',
+  sessionPollLabel: 'atualização',
+  actSessionPoll: 'Trocar',
 
   pidLabel: 'pid',
   uptimeLabel: 'no ar há',

--- a/packages/tui/src/control/session-poll.test.ts
+++ b/packages/tui/src/control/session-poll.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from 'bun:test'
+import { nextSessionPollMs, SESSION_POLL_PRESETS_MS } from './session-poll'
+
+describe('nextSessionPollMs', () => {
+  test('steps forward through the presets', () => {
+    expect(nextSessionPollMs(1_000)).toBe(2_000)
+    expect(nextSessionPollMs(2_000)).toBe(5_000)
+    expect(nextSessionPollMs(5_000)).toBe(10_000)
+  })
+
+  test('wraps from the last preset back to the first', () => {
+    expect(nextSessionPollMs(10_000)).toBe(SESSION_POLL_PRESETS_MS[0])
+  })
+
+  test('a value between two presets moves to the next preset above it', () => {
+    expect(nextSessionPollMs(3_000)).toBe(5_000)
+  })
+
+  test('a value above every preset wraps to the first', () => {
+    expect(nextSessionPollMs(30_000)).toBe(SESSION_POLL_PRESETS_MS[0])
+  })
+})

--- a/packages/tui/src/control/session-poll.ts
+++ b/packages/tui/src/control/session-poll.ts
@@ -1,0 +1,27 @@
+/**
+ * session-poll.ts — PURE. The presets the config pane's refresh row cycles through, and the cycle
+ * itself.
+ *
+ * The floor/ceiling and the persisted default live in the server's `preferences.ts`
+ * (`SESSION_POLL_MIN_MS`/`SESSION_POLL_MAX_MS`/`SESSION_POLL_DEFAULT_MS`) — this file duplicates
+ * only the four values a person actually picks between, the same way `ControlCenter.tsx` keeps its
+ * own `5_000` fallback rather than importing across the `server -> tui` boundary. The TUI reads no
+ * preferences of its own; it only needs to know what the row should say and do next.
+ */
+
+/** Fastest first, so a user pressing the row repeatedly reaches the floor before the default. */
+export const SESSION_POLL_PRESETS_MS = [1_000, 2_000, 5_000, 10_000] as const
+
+const FIRST_PRESET_MS: number = SESSION_POLL_PRESETS_MS[0]
+
+/**
+ * The preset the row moves to next. Wraps from the last preset back to the first.
+ *
+ * A value that is not itself one of the presets (an older or hand-edited preference) is treated as
+ * sitting just before the smallest preset greater than it, so pressing the row always lands on a
+ * preset rather than repeating a number the row cannot itself produce.
+ */
+export function nextSessionPollMs(current: number): number {
+  const next: number | undefined = SESSION_POLL_PRESETS_MS.find(ms => ms > current)
+  return next ?? FIRST_PRESET_MS
+}

--- a/packages/tui/src/control/sessions.test.ts
+++ b/packages/tui/src/control/sessions.test.ts
@@ -560,6 +560,16 @@ describe('detailLines — the two non-actionable rows say different things', () 
     expect(l.map(x => x.value)).not.toContain('this must not appear')
   })
 
+  it('draws a pending tool-activity turn dim, in neither role colour', () => {
+    const l = detailLines(session('m', {
+      chatTurns: [
+        { role: 'user', text: 'fix the bug' },
+        { role: 'assistant', text: 'Running Bash', pending: true },
+      ],
+    }), labels, ago)
+    expect(l[1]).toMatchObject({ value: 'Running Bash', note: true, say: false, role: undefined })
+  })
+
   it('collapses a multi-line chat turn onto one detail line', () => {
     const l = detailLines(session('m', {
       chatTurns: [{ role: 'assistant', text: 'line one\n  line two\nline three' }],

--- a/packages/tui/src/control/sessions.test.ts
+++ b/packages/tui/src/control/sessions.test.ts
@@ -547,6 +547,32 @@ describe('detailLines — the two non-actionable rows say different things', () 
     expect(l[0]).toMatchObject({ label: 'saying', value: '● done', say: true })
   })
 
+  it('prefers role-tagged chat turns over the raw screen tail, and tags them', () => {
+    const l = detailLines(session('m', {
+      lastLines: ['this must not appear'],
+      chatTurns: [
+        { role: 'user', text: 'fix the bug' },
+        { role: 'assistant', text: 'done' },
+      ],
+    }), labels, ago)
+    expect(l[0]).toMatchObject({ label: 'saying', value: 'fix the bug', role: 'user', say: false })
+    expect(l[1]).toMatchObject({ label: '', value: 'done', role: 'assistant', say: true })
+    expect(l.map(x => x.value)).not.toContain('this must not appear')
+  })
+
+  it('collapses a multi-line chat turn onto one detail line', () => {
+    const l = detailLines(session('m', {
+      chatTurns: [{ role: 'assistant', text: 'line one\n  line two\nline three' }],
+    }), labels, ago)
+    expect(l[0]?.value).toBe('line one line two line three')
+  })
+
+  it('falls back to the raw screen tail when there are no chat turns', () => {
+    const l = detailLines(session('m', { lastLines: ['● done'], chatTurns: [] }), labels, ago)
+    expect(l[0]?.value).toBe('● done')
+    expect(l[0]?.role).toBeUndefined()
+  })
+
   it('shows usage only where the conversation recorded any', () => {
     expect(detailLines(session('m'), labels, ago).map(x => x.key)).not.toContain('metrics')
     const l = detailLines(session('m', { tokens: '41.4K', cost: 'USD 0.26' }), labels, ago)

--- a/packages/tui/src/control/sessions.ts
+++ b/packages/tui/src/control/sessions.ts
@@ -631,8 +631,12 @@ export function detailLines(s: ControlSession, labels: {
         // it truncates the same way every other detail line does rather than breaking the pane's
         // one-fact-per-row shape.
         value: turn.text.replace(/\s*\n\s*/g, ' '),
-        say: turn.role === 'assistant',
-        role: turn.role,
+        // A `pending` turn is not something either side SAID — it is "a tool call is running and
+        // nothing has followed it yet", drawn dim like every other status line on this pane rather
+        // than in either role's colour, which would claim an author for a note neither of them wrote.
+        say: turn.role === 'assistant' && !turn.pending,
+        role: turn.pending ? undefined : turn.role,
+        note: turn.pending === true,
       })
     })
   } else if (s.lastLines?.length) {

--- a/packages/tui/src/control/sessions.ts
+++ b/packages/tui/src/control/sessions.ts
@@ -546,6 +546,12 @@ export interface DetailLine {
   note?: boolean
   /** A line the assistant itself wrote, rendered in the text colour rather than as a label. */
   say?: boolean
+  /**
+   * Who wrote this line, when it is known EXACTLY — from a chat turn read off the session's own
+   * transcript (`ChatTurn`), never guessed from the screen. Absent for a raw `lastLines` fallback
+   * line, which carries `say` but no verified author.
+   */
+  role?: 'user' | 'assistant'
 }
 
 /**
@@ -613,8 +619,23 @@ export function detailLines(s: ControlSession, labels: {
   const out: DetailLine[] = []
 
   // WHAT IT IS SAYING comes first, because it is the reason someone selected the row. Everything
-  // below is context for it.
-  if (s.lastLines?.length) {
+  // below is context for it. `chatTurns` — role-tagged, read from the session's own transcript —
+  // is preferred whenever it is available; `lastLines` (the raw screen tail) is the fallback for
+  // every harness that has no exact way to read its own transcript live. See `chat-tail.ts`.
+  if (s.chatTurns?.length) {
+    s.chatTurns.forEach((turn, i) => {
+      out.push({
+        key: `chat${i}`,
+        label: i === 0 ? labels.doing : '',
+        // A turn is the transcript's own text, which can span several lines — collapsed to one so
+        // it truncates the same way every other detail line does rather than breaking the pane's
+        // one-fact-per-row shape.
+        value: turn.text.replace(/\s*\n\s*/g, ' '),
+        say: turn.role === 'assistant',
+        role: turn.role,
+      })
+    })
+  } else if (s.lastLines?.length) {
     s.lastLines.forEach((line, i) => {
       out.push({ key: `say${i}`, label: i === 0 ? labels.doing : '', value: line, say: true })
     })

--- a/packages/tui/src/control/tabs/Services.tsx
+++ b/packages/tui/src/control/tabs/Services.tsx
@@ -82,6 +82,7 @@ import { Menu } from '../Menu'
 import { OutputView } from '../Output'
 import { ArchiveChoice } from '../ArchiveChoice'
 import { archiveGateOnOpen } from '../archive-gate'
+import { nextSessionPollMs } from '../session-poll'
 import { ConfirmPrompt, TextPrompt } from '../Prompt'
 import type { ControlStrings } from '../i18n'
 import type { CliLang } from '../lang'
@@ -278,6 +279,10 @@ export interface ServicesProps {
   mouseOn?: boolean
   /** Absent when there is no mouse at all, and then the config pane has no row for one. */
   onMouse?: () => void
+  /** How often the cockpit re-reads the fleet, in milliseconds — the config row states it. */
+  sessionPollMs: number
+  /** Cycles to the next preset in `SESSION_POLL_PRESETS_MS` — see the config row's action. */
+  onSessionPollMs: (ms: number) => void
   /**
    * Open with the wizard already asking — a machine that has never been configured.
    *
@@ -290,7 +295,7 @@ export interface ServicesProps {
 
 export function Services({
   host, status, strings: s, lang, width, height, isActive, run, task, onDismissTask,
-  onChrome, onExit, onLang, mouseOn, onMouse, initialSetup,
+  onChrome, onExit, onLang, mouseOn, onMouse, sessionPollMs, onSessionPollMs, initialSetup,
 }: ServicesProps) {
   const l = launcherStrings(lang)
 
@@ -676,8 +681,15 @@ export function Services({
         action: { label: s.actMouse, run: onMouse },
       })
     }
+    rows.push({
+      key: 'sessionPoll',
+      label: s.sessionPollLabel,
+      value: `${sessionPollMs / 1000}s`,
+      short: `${sessionPollMs / 1000}s`,
+      action: { label: s.actSessionPoll, run: () => onSessionPollMs(nextSessionPollMs(sessionPollMs)) },
+    })
     return rows
-  }, [s, status, connectAction, onLang, lang, mouseOn, onMouse])
+  }, [s, status, connectAction, onLang, lang, mouseOn, onMouse, sessionPollMs, onSessionPollMs])
 
   const configSelection = Math.min(configIndex, Math.max(0, configRows.length - 1))
 

--- a/packages/tui/src/control/tabs/Sessions.tsx
+++ b/packages/tui/src/control/tabs/Sessions.tsx
@@ -2527,9 +2527,15 @@ function Detail({ lines, width, rows }: {
       {lines.slice(0, Math.max(0, rows)).map(l => (
         <Text key={l.key} wrap="truncate" dimColor={l.note}>
           {l.label ? <Text dimColor>{l.label.padEnd(labelWidth)}  </Text> : <Text>{' '.repeat(labelWidth + 2)}</Text>}
-          {/* What the assistant said is drawn in the text colour: it is the content, and everything
-              else on this pane is a label for it. */}
-          <Text color={l.say ? COLORS.text : undefined}>
+          {/*
+            A chat turn is coloured by who wrote it, read off the transcript's own `role` — never
+            guessed from the screen (see `chat-tail.ts`). The user's own text takes `COLORS.info`,
+            the same token this app already uses elsewhere for "what the user themselves did"; the
+            assistant keeps the plain text colour it always had. A `say` line with no `role` is the
+            raw-screen-tail fallback for a harness with no verified author, and stays in the
+            content colour rather than being coloured as either side.
+          */}
+          <Text color={l.role === 'user' ? COLORS.info : l.say ? COLORS.text : undefined}>
             {truncate(l.value, Math.max(1, width - labelWidth - 2))}
           </Text>
         </Text>

--- a/packages/tui/src/control/types.ts
+++ b/packages/tui/src/control/types.ts
@@ -561,7 +561,13 @@ export interface ControlSession {
    * only. When present, the detail pane renders THIS instead of `lastLines`, so the user's and the
    * assistant's own text can be told apart by role rather than by a guess at the screen's layout.
    */
-  chatTurns?: { role: 'user' | 'assistant'; text: string }[]
+  chatTurns?: {
+    role: 'user' | 'assistant'
+    text: string
+    /** A synthesized "running a tool" note, not something either side actually said — see the
+     *  server's `ChatTurn.pending`. Rendered dim, never in the role colours. */
+    pending?: boolean
+  }[]
   /**
    * The DIALOG this session is blocked on, verbatim — present only while it is asking.
    *

--- a/packages/tui/src/control/types.ts
+++ b/packages/tui/src/control/types.ts
@@ -557,6 +557,12 @@ export interface ControlSession {
    */
   lastLines?: string[]
   /**
+   * The last few chat turns of this session, role-tagged, read from its own transcript — Claude
+   * only. When present, the detail pane renders THIS instead of `lastLines`, so the user's and the
+   * assistant's own text can be told apart by role rather than by a guess at the screen's layout.
+   */
+  chatTurns?: { role: 'user' | 'assistant'; text: string }[]
+  /**
    * The DIALOG this session is blocked on, verbatim — present only while it is asking.
    *
    * A different reading of the frame from `lastLines`, which cuts the input box and the status strip
@@ -1049,6 +1055,13 @@ export interface ControlStatus {
    * stores it beside the language and the archive mode, and hands the answer over like any other.
    */
   mouse?: boolean
+  /**
+   * How often the cockpit re-reads the fleet, in milliseconds — the same STATUS-not-TUI shape as
+   * `mouse` and the language, for the same reason: the TUI reads no preferences of its own.
+   * Absent means the host has not answered yet; the shell falls back to its own built-in default
+   * exactly as it does for `mouse` and for `lang`.
+   */
+  sessionPollMs?: number
 }
 
 export interface ActionResult {
@@ -1166,6 +1179,14 @@ export interface ControlHost {
    * this session.
    */
   setMouse(on: boolean): Promise<void>
+
+  /**
+   * Persist how often the cockpit re-reads the fleet. Same shape as `setMouse` — best-effort, and
+   * the shell applies the new interval to its own running poll immediately rather than waiting for
+   * a `refresh()` this action does not itself trigger. The host clamps to its own floor/ceiling, so
+   * a value from an older or hand-edited preferences file can never be handed back as-is.
+   */
+  setSessionPollMs(ms: number): Promise<void>
 
   /**
    * Hand a URL to the desktop's browser.


### PR DESCRIPTION
## Summary

Promotes `dev` to `main`. Ships #229:

- Session detail pane colors user/assistant text by real role (read from the Claude Code transcript), with a dim "Running <tool>" note while a tool call is in flight.
- The cockpit's fleet refresh interval is now a configurable, persisted preference (1s–30s) instead of a fixed 5s.

## Test plan

- [x] `bun tsc --noEmit` / `bun test` clean on `dev`
- [x] CI green on #229