### PR TITLE
release: docs — mention npm install in the CLI doc

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -5,8 +5,9 @@ the terminal TUI, the OpenTelemetry daemon, host or join a **Team Mode** central
 and manage autostart + updates.
 
 Get the binary from the [install instructions](../README.md#install) (`install.sh`,
-the Windows installer, or `bun run build:binary` from source). From a checkout you
-can also run it directly with `bun run packages/server/bin/cli.ts <command>`.
+`npm i -g @agentistics/agentop`, the Windows installer, or `bun run build:binary` from
+source). From a checkout you can also run it directly with
+`bun run packages/server/bin/cli.ts <command>`.
 
 ```bash
 agentop --help       # full usage


### PR DESCRIPTION
## Summary

Promotes dev to main: documentation follow-up (#233) to the npm distribution channel added in #231/#232 — `docs/cli.md` now mentions `npm i -g @agentistics/agentop` alongside `install.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Snow6QDpU5ficdNPAcHTLH