### PR TITLE
fix(agentop): skip npm postinstall download inside this monorepo's own checkout

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -46,14 +46,14 @@
     },
     "packages/agentop": {
       "name": "@agentistics/agentop",
-      "version": "1.22.1",
+      "version": "1.22.3",
       "bin": {
         "agentop": "bin/agentop.js",
       },
     },
     "packages/core": {
       "name": "@agentistics/core",
-      "version": "1.22.1",
+      "version": "1.22.3",
       "dependencies": {
         "@opentelemetry/api": "^1.9.1",
         "date-fns": "^4.1.0",
@@ -71,7 +71,7 @@
     },
     "packages/mcp": {
       "name": "@agentistics/mcp",
-      "version": "1.22.1",
+      "version": "1.22.3",
       "bin": {
         "agentistics-mcp": "dist/agentistics-mcp.js",
       },
@@ -81,7 +81,7 @@
     },
     "packages/server": {
       "name": "@agentistics/server",
-      "version": "1.22.1",
+      "version": "1.22.3",
       "dependencies": {
         "@agentistics/core": "workspace:*",
         "@agentistics/tui": "workspace:*",
@@ -91,7 +91,7 @@
     },
     "packages/tui": {
       "name": "@agentistics/tui",
-      "version": "1.22.1",
+      "version": "1.22.3",
       "dependencies": {
         "@agentistics/core": "workspace:*",
         "es-toolkit": "^1.50.0",
@@ -105,7 +105,7 @@
     },
     "packages/web": {
       "name": "@agentistics/web",
-      "version": "1.22.1",
+      "version": "1.22.3",
       "dependencies": {
         "@agentistics/core": "workspace:*",
         "@opentelemetry/api": "^1.9.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentistics",
-  "version": "1.22.2",
+  "version": "1.22.3",
   "description": "Local analytics dashboard for AI coding assistants — tracks tokens, cost, sessions, and activity from ~/.claude/",
   "keywords": [
     "claude",

--- a/packages/agentop/package.json
+++ b/packages/agentop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentistics/agentop",
-  "version": "1.22.2",
+  "version": "1.22.3",
   "description": "agentop CLI — npm install for the same native binary distributed via install.sh (Linux x86_64 only)",
   "type": "commonjs",
   "bin": {

--- a/packages/agentop/scripts/platform.js
+++ b/packages/agentop/scripts/platform.js
@@ -59,4 +59,24 @@ function resolveAsset(platform, arch, version) {
   };
 }
 
-module.exports = { resolveAsset, REPO, BINARY };
+// True when the ancestor package.json (the root of whatever checkout this
+// package sits in) IS the agentistics monorepo itself, rather than some
+// unrelated project that installed @agentistics/agentop as a dependency.
+// `bun install` at this repo's own root runs every workspace member's
+// postinstall (workspace-local scripts are trusted by default, unlike a
+// dependency's) — so without this check, every contributor's `bun install`,
+// and any CI job that runs it for an unrelated reason (e.g. the Windows
+// desktop build, which has nothing to do with the agentop CLI), downloaded
+// an 87MB binary it never uses, and failed outright on a platform this npm
+// package doesn't support. The repo already builds its own binary via
+// `bun run build:binary` — the npm postinstall exists for EXTERNAL installs.
+/**
+ * @param {{name?: string} | null} ancestorPkg - the parsed package.json 3
+ *   levels up from this file (repo root), or null if none was found/readable
+ * @returns {boolean}
+ */
+function isMonorepoCheckout(ancestorPkg) {
+  return ancestorPkg != null && ancestorPkg.name === 'agentistics';
+}
+
+module.exports = { resolveAsset, isMonorepoCheckout, REPO, BINARY };

--- a/packages/agentop/scripts/platform.test.js
+++ b/packages/agentop/scripts/platform.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { resolveAsset } from './platform.js';
+import { resolveAsset, isMonorepoCheckout } from './platform.js';
 
 describe('resolveAsset', () => {
   test('linux x64 resolves the version-tagged GitHub release asset URL', () => {
@@ -36,5 +36,19 @@ describe('resolveAsset', () => {
     const result = resolveAsset('freebsd', 'mips', '1.22.1');
     expect(result.ok).toBe(false);
     expect(result.message).toContain('detected: freebsd');
+  });
+});
+
+describe('isMonorepoCheckout', () => {
+  test('true when the ancestor package.json is the agentistics monorepo root', () => {
+    expect(isMonorepoCheckout({ name: 'agentistics' })).toBe(true);
+  });
+
+  test('false for an unrelated consumer project (npm install as a dependency)', () => {
+    expect(isMonorepoCheckout({ name: 'some-other-app' })).toBe(false);
+  });
+
+  test('false when there is no ancestor package.json at all', () => {
+    expect(isMonorepoCheckout(null)).toBe(false);
   });
 });

--- a/packages/agentop/scripts/postinstall.js
+++ b/packages/agentop/scripts/postinstall.js
@@ -11,13 +11,23 @@
 const fs = require('fs');
 const path = require('path');
 const https = require('https');
-const { resolveAsset } = require('./platform.js');
+const { resolveAsset, isMonorepoCheckout } = require('./platform.js');
 
 const pkg = require('../package.json');
 
 const BIN_DIR = path.join(__dirname, '..', 'bin');
 const BIN_PATH = path.join(BIN_DIR, 'agentop-bin');
 const MAX_REDIRECTS = 5;
+// packages/agentop/scripts -> packages/agentop -> packages -> repo root
+const MONOREPO_ROOT_PKG = path.join(__dirname, '..', '..', '..', 'package.json');
+
+function readAncestorPkg() {
+  try {
+    return JSON.parse(fs.readFileSync(MONOREPO_ROOT_PKG, 'utf8'));
+  } catch {
+    return null;
+  }
+}
 
 function download(url, destPath, redirectsLeft) {
   return new Promise((resolve, reject) => {
@@ -51,6 +61,13 @@ function download(url, destPath, redirectsLeft) {
 }
 
 async function main() {
+  if (isMonorepoCheckout(readAncestorPkg())) {
+    console.log(
+      'Skipping agentop binary download — running inside the agentistics monorepo itself (build it with `bun run build:binary`).'
+    );
+    return;
+  }
+
   const asset = resolveAsset(process.platform, process.arch, pkg.version);
 
   if (!asset.ok) {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentistics/core",
-  "version": "1.22.2",
+  "version": "1.22.3",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentistics/mcp",
-  "version": "1.22.2",
+  "version": "1.22.3",
   "description": "Agentistics MCP server — Claude Code analytics for Claude Desktop and Claude Code",
   "type": "module",
   "main": "./dist/agentistics-mcp.js",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentistics/server",
-  "version": "1.22.2",
+  "version": "1.22.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentistics/tui",
-  "version": "1.22.2",
+  "version": "1.22.3",
   "private": true,
   "type": "module",
   "main": "src/control/index.ts",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentistics/web",
-  "version": "1.22.2",
+  "version": "1.22.3",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

Regression from #231/#232, found while confirming the previous two releases were clean: the last two `Build & Release` runs (v1.22.2, v1.22.3) both broke **Build Tauri Desktop (Windows)** — a job unrelated to `agentop` entirely. The prior ten release runs were green.

## Root cause

`bun install --frozen-lockfile` at the monorepo root (used everywhere, including the Windows desktop-build job) runs a **workspace member's** postinstall by default — unlike an external dependency's, workspace-local lifecycle scripts are trusted. So installing this repo's own dependencies also ran `@agentistics/agentop`'s postinstall:

- On the Windows runner, it correctly detected an unsupported platform and exited 1 (as designed for a real `npm i -g @agentistics/agentop` on Windows) — except this killed `bun install` for the *entire monorepo*, breaking a job that never touches the agentop CLI.
- On Linux (verified locally), it downloaded a real 87MB binary on every single `bun install` — every contributor, every CI job — even though this repo already builds its own binary via `bun run build:binary`.

## Fix

`postinstall.js` now skips (exit 0, no download, one log line) when it detects it's running as a workspace member of this repo itself — checked via a new pure, tested `isMonorepoCheckout()` in `platform.js`: the package.json 3 levels up (`packages/agentop/scripts/../../../package.json`) is this repo's own root iff its `name` is `"agentistics"`.

Verified both paths directly (not just via the unit test):
- Inside this checkout: `node scripts/postinstall.js` → logs the skip, exits 0, no download.
- Copied the package out to a directory with no ancestor `package.json` (simulating a real external `npm i`): still downloads normally.
- `bun install` at the repo root no longer creates `packages/agentop/bin/agentop-bin`.

## Test plan

- [x] 3 new unit tests for `isMonorepoCheckout()` (monorepo root / unrelated consumer / no ancestor found).
- [x] Full suite (4435 tests) + `bun tsc --noEmit` pass.
- [x] Manual verification of both the skip path and the still-works-standalone path, described above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Snow6QDpU5ficdNPAcHTLH