### PR TITLE
release: fix npm postinstall breaking the monorepo's own install

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -46,14 +46,14 @@
     },
     "packages/agentop": {
       "name": "@agentistics/agentop",
-      "version": "1.22.1",
+      "version": "1.22.3",
       "bin": {
         "agentop": "bin/agentop.js",
       },
     },
     "packages/core": {
       "name": "@agentistics/core",
-      "version": "1.22.1",
+      "version": "1.22.3",
       "dependencies": {
         "@opentelemetry/api": "^1.9.1",
         "date-fns": "^4.1.0",
@@ -71,7 +71,7 @@
     },
     "packages/mcp": {
       "name": "@agentistics/mcp",
-      "version": "1.22.1",
+      "version": "1.22.3",
       "bin": {
         "agentistics-mcp": "dist/agentistics-mcp.js",
       },
@@ -81,7 +81,7 @@
     },
     "packages/server": {
       "name": "@agentistics/server",
-      "version": "1.22.1",
+      "version": "1.22.3",
       "dependencies": {
         "@agentistics/core": "workspace:*",
         "@agentistics/tui": "workspace:*",
@@ -91,7 +91,7 @@
     },
     "packages/tui": {
       "name": "@agentistics/tui",
-      "version": "1.22.1",
+      "version": "1.22.3",
       "dependencies": {
         "@agentistics/core": "workspace:*",
         "es-toolkit": "^1.50.0",
@@ -105,7 +105,7 @@
     },
     "packages/web": {
       "name": "@agentistics/web",
-      "version": "1.22.1",
+      "version": "1.22.3",
       "dependencies": {
         "@agentistics/core": "workspace:*",
         "@opentelemetry/api": "^1.9.1",

--- a/packages/agentop/scripts/platform.js
+++ b/packages/agentop/scripts/platform.js
@@ -59,4 +59,24 @@ function resolveAsset(platform, arch, version) {
   };
 }
 
-module.exports = { resolveAsset, REPO, BINARY };
+// True when the ancestor package.json (the root of whatever checkout this
+// package sits in) IS the agentistics monorepo itself, rather than some
+// unrelated project that installed @agentistics/agentop as a dependency.
+// `bun install` at this repo's own root runs every workspace member's
+// postinstall (workspace-local scripts are trusted by default, unlike a
+// dependency's) — so without this check, every contributor's `bun install`,
+// and any CI job that runs it for an unrelated reason (e.g. the Windows
+// desktop build, which has nothing to do with the agentop CLI), downloaded
+// an 87MB binary it never uses, and failed outright on a platform this npm
+// package doesn't support. The repo already builds its own binary via
+// `bun run build:binary` — the npm postinstall exists for EXTERNAL installs.
+/**
+ * @param {{name?: string} | null} ancestorPkg - the parsed package.json 3
+ *   levels up from this file (repo root), or null if none was found/readable
+ * @returns {boolean}
+ */
+function isMonorepoCheckout(ancestorPkg) {
+  return ancestorPkg != null && ancestorPkg.name === 'agentistics';
+}
+
+module.exports = { resolveAsset, isMonorepoCheckout, REPO, BINARY };

--- a/packages/agentop/scripts/platform.test.js
+++ b/packages/agentop/scripts/platform.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { resolveAsset } from './platform.js';
+import { resolveAsset, isMonorepoCheckout } from './platform.js';
 
 describe('resolveAsset', () => {
   test('linux x64 resolves the version-tagged GitHub release asset URL', () => {
@@ -36,5 +36,19 @@ describe('resolveAsset', () => {
     const result = resolveAsset('freebsd', 'mips', '1.22.1');
     expect(result.ok).toBe(false);
     expect(result.message).toContain('detected: freebsd');
+  });
+});
+
+describe('isMonorepoCheckout', () => {
+  test('true when the ancestor package.json is the agentistics monorepo root', () => {
+    expect(isMonorepoCheckout({ name: 'agentistics' })).toBe(true);
+  });
+
+  test('false for an unrelated consumer project (npm install as a dependency)', () => {
+    expect(isMonorepoCheckout({ name: 'some-other-app' })).toBe(false);
+  });
+
+  test('false when there is no ancestor package.json at all', () => {
+    expect(isMonorepoCheckout(null)).toBe(false);
   });
 });

--- a/packages/agentop/scripts/postinstall.js
+++ b/packages/agentop/scripts/postinstall.js
@@ -11,13 +11,23 @@
 const fs = require('fs');
 const path = require('path');
 const https = require('https');
-const { resolveAsset } = require('./platform.js');
+const { resolveAsset, isMonorepoCheckout } = require('./platform.js');
 
 const pkg = require('../package.json');
 
 const BIN_DIR = path.join(__dirname, '..', 'bin');
 const BIN_PATH = path.join(BIN_DIR, 'agentop-bin');
 const MAX_REDIRECTS = 5;
+// packages/agentop/scripts -> packages/agentop -> packages -> repo root
+const MONOREPO_ROOT_PKG = path.join(__dirname, '..', '..', '..', 'package.json');
+
+function readAncestorPkg() {
+  try {
+    return JSON.parse(fs.readFileSync(MONOREPO_ROOT_PKG, 'utf8'));
+  } catch {
+    return null;
+  }
+}
 
 function download(url, destPath, redirectsLeft) {
   return new Promise((resolve, reject) => {
@@ -51,6 +61,13 @@ function download(url, destPath, redirectsLeft) {
 }
 
 async function main() {
+  if (isMonorepoCheckout(readAncestorPkg())) {
+    console.log(
+      'Skipping agentop binary download — running inside the agentistics monorepo itself (build it with `bun run build:binary`).'
+    );
+    return;
+  }
+
   const asset = resolveAsset(process.platform, process.arch, pkg.version);
 
   if (!asset.ok) {


### PR DESCRIPTION
## Summary

Promotes dev to main: fixes the regression from #231/#232 where `bun install` at this repo's own root ran `@agentistics/agentop`'s postinstall (workspace-local scripts are trusted by bun), breaking `Build Tauri Desktop (Windows)` on the last two releases and downloading an unused 87MB binary on every contributor's install. See #235 for full detail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Snow6QDpU5ficdNPAcHTLH