### PR TITLE
feat(tui): selectable cumulative search scopes + two-way all (j-20260826-fi #3)

### DIFF
--- a/packages/tui/src/control/i18n.ts
+++ b/packages/tui/src/control/i18n.ts
@@ -384,6 +384,14 @@ export interface ControlStrings {
   /** Named in words, never rendered as a zero — see `TranscriptSearch.unavailable`. */
   searchNoGrep: string
   searchNoTranscripts: string
+  /** The transcription depth is switched off — a choice, distinct from "none on this machine". */
+  searchTranscriptOff: string
+  /** The search-depth section in the view menu, and its three cumulative toggles + the "all" row. */
+  viewSearchDepth: string
+  searchDepthName: string
+  searchDepthPrompt: string
+  searchDepthTranscript: string
+  searchDepthAll: string
   searchCovered: (harnesses: string) => string
   searchFailed: (harnesses: string) => string
   /** How long ago, from a whole number of SECONDS — the caller does the clock arithmetic so this
@@ -909,6 +917,12 @@ const EN: ControlStrings = {
   searchRunning: 'reading transcripts…',
   searchNoGrep: 'transcripts not searched — grep is not available here',
   searchNoTranscripts: 'transcripts not searched — none on this machine',
+  searchTranscriptOff: 'transcription off',
+  viewSearchDepth: 'Search in',
+  searchDepthName: 'title',
+  searchDepthPrompt: 'first prompt',
+  searchDepthTranscript: 'transcription (full session)',
+  searchDepthAll: 'all',
   searchCovered: h => `transcripts: ${h}`,
   searchFailed: h => `could not read: ${h}`,
   sessionsAgo: (sec: number) => {
@@ -1360,6 +1374,12 @@ const PT: ControlStrings = {
   searchRunning: 'lendo transcripts…',
   searchNoGrep: 'transcripts não buscados — não há grep aqui',
   searchNoTranscripts: 'transcripts não buscados — nenhum nesta máquina',
+  searchTranscriptOff: 'transcrição desligada',
+  viewSearchDepth: 'Buscar em',
+  searchDepthName: 'título',
+  searchDepthPrompt: 'primeiro prompt',
+  searchDepthTranscript: 'transcrição (sessão completa)',
+  searchDepthAll: 'todos',
   searchCovered: h => `transcripts: ${h}`,
   searchFailed: h => `não deu pra ler: ${h}`,
   sessionsAgo: (sec: number) => {

--- a/packages/tui/src/control/search-scope.test.ts
+++ b/packages/tui/src/control/search-scope.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, test } from 'bun:test'
 import {
   activeScopes, allState, DEFAULT_SCOPE_SELECTION, emptyScopeCounts, matchScopes, normalizeSelection,
-  scopeCounts, searchDepthText, toggleAllScopes, toggleScope, transcriptScopeOn,
-  type SearchFields, type SearchScopeSelection,
+  scopeCounts, searchDepthText, selectionFromScopes, selectionToScopes, toggleAllScopes, toggleScope,
+  transcriptScopeOn, SEARCH_SCOPES, SEARCH_TOGGLES,
+  type SearchFields, type SearchScope, type SearchScopeSelection,
 } from './search-scope'
 
 const fields = (o: Partial<SearchFields> = {}): SearchFields => ({
@@ -211,5 +212,66 @@ describe('matchScopes honours the active selection', () => {
     const counts = scopeCounts(rows, 'docker', activeScopes(sel({ title: false, transcript: false })))
     expect(counts.name).toBe(0)
     expect(counts.transcript).toBe(0)
+  })
+})
+
+// The CANONICAL persisted shape is the scope ARRAY (server contract, #240). The tui keeps its
+// on/off object internally and converts at the edge, so these pin that the two never disagree —
+// what makes SessionViewPrefs.searchScopes: SearchScope[] and the merge with dev typecheck.
+describe('selection <-> canonical scope array (the #240 array contract)', () => {
+  test('the default selection is exactly the default persisted set — all own fields, no transcript', () => {
+    // Same value the server derives (preferences.ts DEFAULT_SESSION_SEARCH_SCOPES = all but transcript).
+    expect(selectionToScopes(DEFAULT_SCOPE_SELECTION)).toEqual(
+      SEARCH_SCOPES.filter(s => s !== 'transcript') as SearchScope[],
+    )
+  })
+
+  test('the array is in canonical SEARCH_SCOPES order, whatever order the toggles imply', () => {
+    const scopes = selectionToScopes(sel({ title: true, prompt: true, transcript: true }))
+    expect(scopes).toEqual([...SEARCH_SCOPES])
+    // strictly increasing indices — never a shuffled set
+    const idx = scopes.map(s => SEARCH_SCOPES.indexOf(s))
+    expect(idx).toEqual([...idx].sort((a, b) => a - b))
+  })
+
+  test('every one of the 8 toggle combinations round-trips through the array unchanged', () => {
+    for (const title of [false, true]) {
+      for (const prompt of [false, true]) {
+        for (const transcript of [false, true]) {
+          const s = { title, prompt, transcript }
+          expect(selectionFromScopes(selectionToScopes(s))).toEqual(s)
+        }
+      }
+    }
+  })
+
+  test('the toggleable depths map to their own scopes; the always-on ones ride along', () => {
+    expect(selectionToScopes(sel({ title: true, prompt: false, transcript: false })))
+      .toEqual(['name', 'folder', 'harness', 'note', 'task'])
+    expect(selectionToScopes(sel({ title: false, prompt: false, transcript: false })))
+      .toEqual(['folder', 'harness', 'note', 'task'])
+    // reading back ignores the always-on scopes, so the toggles are recovered exactly
+    expect(selectionFromScopes(['folder', 'harness', 'note', 'task']))
+      .toEqual({ title: false, prompt: false, transcript: false })
+  })
+
+  test('absent, empty, or a pre-array (object) value all degrade to the default selection', () => {
+    expect(selectionFromScopes(undefined)).toEqual(DEFAULT_SCOPE_SELECTION)
+    // a value written by the pre-array build was an object, not an array — must not throw
+    expect(selectionFromScopes({ title: true, prompt: true, transcript: false } as never))
+      .toEqual(DEFAULT_SCOPE_SELECTION)
+  })
+
+  test('a returned default is a fresh object, never the shared constant', () => {
+    const got = selectionFromScopes(undefined)
+    got.title = false
+    expect(DEFAULT_SCOPE_SELECTION.title).toBe(true)
+  })
+
+  test('the array a selection persists is exactly what activeScopes searches', () => {
+    for (const t of [...SEARCH_TOGGLES]) {
+      const s = sel({ [t]: true })
+      expect(new Set(selectionToScopes(s))).toEqual(activeScopes(s))
+    }
   })
 })

--- a/packages/tui/src/control/search-scope.test.ts
+++ b/packages/tui/src/control/search-scope.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from 'bun:test'
 import {
-  emptyScopeCounts, matchScopes, scopeCounts, searchDepthText, type SearchFields,
+  activeScopes, allState, DEFAULT_SCOPE_SELECTION, emptyScopeCounts, matchScopes, normalizeSelection,
+  scopeCounts, searchDepthText, toggleAllScopes, toggleScope, transcriptScopeOn,
+  type SearchFields, type SearchScopeSelection,
 } from './search-scope'
 
 const fields = (o: Partial<SearchFields> = {}): SearchFields => ({
@@ -72,6 +74,7 @@ const words = {
   },
   noGrep: 'no grep here',
   noTranscripts: 'none on this machine',
+  transcriptOff: 'transcript off',
 }
 
 describe('searchDepthText', () => {
@@ -89,6 +92,14 @@ describe('searchDepthText', () => {
     expect(searchDepthText(emptyScopeCounts(), words, {})).toBe('transcript 0')
   })
 
+  test('a transcription depth switched OFF says so, distinct from "none on this machine"', () => {
+    const counts = { ...emptyScopeCounts(), name: 2 }
+    expect(searchDepthText(counts, words, { off: true })).toBe('name 2 · transcript off')
+    // …and it outranks a stale running/unavailable flag: nothing ran, so nothing is pending.
+    expect(searchDepthText(counts, words, { off: true, running: true, runningWord: 'reading…' }))
+      .toBe('name 2 · transcript off')
+  })
+
   test('an unsearchable transcript says WHY instead of showing a zero', () => {
     const counts = { ...emptyScopeCounts(), name: 2 }
     expect(searchDepthText(counts, words, { unavailable: 'no-grep' }))
@@ -101,5 +112,104 @@ describe('searchDepthText', () => {
     const counts = { ...emptyScopeCounts(), name: 2 }
     expect(searchDepthText(counts, words, { running: true, runningWord: 'reading…' }))
       .toBe('name 2 · reading…')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Selectable, cumulative search depth + the two-way "all" — finding (3).
+
+const sel = (o: Partial<SearchScopeSelection> = {}): SearchScopeSelection =>
+  ({ ...DEFAULT_SCOPE_SELECTION, ...o })
+
+describe('scope selection defaults', () => {
+  test('title and first prompt on, transcription OFF — the disk read is opt-in', () => {
+    expect(DEFAULT_SCOPE_SELECTION).toEqual({ title: true, prompt: true, transcript: false })
+  })
+
+  test('a stored selection missing a key reads as that key’s default, never as false', () => {
+    expect(normalizeSelection(undefined)).toEqual(DEFAULT_SCOPE_SELECTION)
+    expect(normalizeSelection({ transcript: true })).toEqual({ title: true, prompt: true, transcript: true })
+    expect(normalizeSelection({ title: false })).toEqual({ title: false, prompt: true, transcript: false })
+  })
+})
+
+describe('activeScopes', () => {
+  test('the structured scopes are always searched, whatever the toggles say', () => {
+    const off = activeScopes({ title: false, prompt: false, transcript: false })
+    for (const s of ['folder', 'harness', 'note', 'task'] as const) expect(off.has(s)).toBe(true)
+    // …and the three human depths are all off.
+    expect(off.has('name')).toBe(false)
+    expect(off.has('prompt')).toBe(false)
+    expect(off.has('transcript')).toBe(false)
+  })
+
+  test('each toggle turns on exactly its own scope — cumulative, several at once', () => {
+    expect(activeScopes(sel({ transcript: true })).has('transcript')).toBe(true)
+    const titleOnly = activeScopes({ title: true, prompt: false, transcript: false })
+    expect(titleOnly.has('name')).toBe(true)
+    expect(titleOnly.has('prompt')).toBe(false)
+  })
+
+  test('transcriptScopeOn is the single gate for the expensive disk search', () => {
+    expect(transcriptScopeOn(sel({ transcript: false }))).toBe(false)
+    expect(transcriptScopeOn(sel({ transcript: true }))).toBe(true)
+  })
+})
+
+describe('the "all" control is two-way and never contradicts the individuals', () => {
+  test('all shows ON exactly when every individual is checked', () => {
+    expect(allState({ title: true, prompt: true, transcript: true })).toBe('on')
+  })
+  test('all shows OFF when none is, and MIXED when some are', () => {
+    expect(allState({ title: false, prompt: false, transcript: false })).toBe('off')
+    expect(allState({ title: true, prompt: false, transcript: false })).toBe('mixed')
+    expect(allState(DEFAULT_SCOPE_SELECTION)).toBe('mixed')
+  })
+  test('checking all from mixed turns every individual on; from all-on it clears them', () => {
+    expect(toggleAllScopes({ title: true, prompt: false, transcript: false }))
+      .toEqual({ title: true, prompt: true, transcript: true })
+    expect(toggleAllScopes({ title: true, prompt: true, transcript: true }))
+      .toEqual({ title: false, prompt: false, transcript: false })
+    expect(toggleAllScopes({ title: false, prompt: false, transcript: false }))
+      .toEqual({ title: true, prompt: true, transcript: true })
+  })
+  test('turning the last individual on makes all read ON — the reverse direction, by derivation', () => {
+    const oneOff = { title: true, prompt: true, transcript: false }
+    expect(allState(oneOff)).toBe('mixed')
+    expect(allState(toggleScope(oneOff, 'transcript'))).toBe('on')
+  })
+})
+
+describe('matchScopes honours the active selection', () => {
+  const active = (s: SearchScopeSelection) => activeScopes(s)
+
+  test('a title-only match is invisible while the title toggle is off', () => {
+    const row = fields({ name: 'docker' })
+    expect(matchScopes(row, 'docker', {}, active(sel({ title: true })))).toEqual(['name'])
+    expect(matchScopes(row, 'docker', {}, active(sel({ title: false })))).toEqual([])
+  })
+
+  test('a transcript hit is dropped unless the transcription toggle is on — the perf guard', () => {
+    const row = fields()
+    expect(matchScopes(row, 'docker', { transcript: true }, active(sel({ transcript: false })))).toEqual([])
+    expect(matchScopes(row, 'docker', { transcript: true }, active(sel({ transcript: true })))).toEqual(['transcript'])
+  })
+
+  test('the always-on structured scopes still match with every toggle off', () => {
+    const row = fields({ note: 'docker note', task: 'docker task' })
+    const allOff = active({ title: false, prompt: false, transcript: false })
+    expect(matchScopes(row, 'docker', {}, allOff)).toEqual(['note', 'task'])
+  })
+
+  test('with no active set given, behaviour is unchanged — every scope is searched', () => {
+    const row = fields({ name: 'docker', prompt: 'docker build' })
+    expect(matchScopes(row, 'docker')).toEqual(['name', 'prompt'])
+  })
+
+  test('scopeCounts respects the active set too, so the depth line cannot exceed what was searched', () => {
+    const rows = [{ fields: fields({ name: 'docker' }), transcript: true }]
+    const counts = scopeCounts(rows, 'docker', activeScopes(sel({ title: false, transcript: false })))
+    expect(counts.name).toBe(0)
+    expect(counts.transcript).toBe(0)
   })
 })

--- a/packages/tui/src/control/search-scope.test.ts
+++ b/packages/tui/src/control/search-scope.test.ts
@@ -275,3 +275,29 @@ describe('selection <-> canonical scope array (the #240 array contract)', () => 
     }
   })
 })
+
+// F2 — the transcript disk read (Sessions.tsx) keys on transcriptScopeOn(scopes), NOT the whole
+// object, so a title/first-prompt toggle never re-fires the ~255 ms grep. These pin the semantic
+// that fix rests on: the cheap depths leave the gate untouched; only transcription flips it.
+describe('F2: the disk-read gate moves only with the transcription depth', () => {
+  test('toggling title or first prompt leaves transcriptScopeOn unchanged', () => {
+    for (const on of [true, false]) {
+      const base = { title: true, prompt: false, transcript: on }
+      expect(transcriptScopeOn(toggleScope(base, 'title'))).toBe(on)
+      expect(transcriptScopeOn(toggleScope(base, 'prompt'))).toBe(on)
+    }
+  })
+
+  test('toggling transcription — and only that — flips the gate, so the read re-runs', () => {
+    expect(transcriptScopeOn(toggleScope({ title: true, prompt: true, transcript: false }, 'transcript')))
+      .toBe(true)
+    expect(transcriptScopeOn(toggleScope({ title: true, prompt: true, transcript: true }, 'transcript')))
+      .toBe(false)
+  })
+
+  test('the two-way "all" flips the gate too, since it carries transcription', () => {
+    // all-off -> all-on turns transcription on; all-on -> off turns it off.
+    expect(transcriptScopeOn(toggleAllScopes({ title: false, prompt: false, transcript: false }))).toBe(true)
+    expect(transcriptScopeOn(toggleAllScopes({ title: true, prompt: true, transcript: true }))).toBe(false)
+  })
+})

--- a/packages/tui/src/control/search-scope.ts
+++ b/packages/tui/src/control/search-scope.ts
@@ -47,6 +47,89 @@ export function emptySearchFields(): SearchFields {
 }
 
 /**
+ * The user-facing, CUMULATIVE search-depth toggles — persisted, several active at once.
+ *
+ * The PE named three: the title, the opening prompt, and the full transcription. They gate the
+ * scopes in `TOGGLE_SCOPES`. The remaining structured scopes (`folder`/`harness`/`note`/`task`) are
+ * ALWAYS searched — they are cheap in-memory reads already in the row, and dropping them would
+ * silently narrow a search that works today. What the toggles exist for is the one scope worth NOT
+ * paying for by default: `transcript` reads the disk, so it is off until the user asks for it.
+ */
+export const SEARCH_TOGGLES = ['title', 'prompt', 'transcript'] as const
+export type SearchToggle = typeof SEARCH_TOGGLES[number]
+export type SearchScopeSelection = Record<SearchToggle, boolean>
+
+/** Which `SearchScope`s each toggle turns on. Disjoint, so the three read as three independent depths. */
+const TOGGLE_SCOPES: Record<SearchToggle, readonly SearchScope[]> = {
+  title: ['name'],
+  prompt: ['prompt'],
+  transcript: ['transcript'],
+}
+
+/** Searched no matter what the toggles say — cheap structured fields, never a disk read. */
+const ALWAYS_SCOPES: readonly SearchScope[] = ['folder', 'harness', 'note', 'task']
+
+/**
+ * Title and first prompt on, transcription OFF.
+ *
+ * Transcription is the only scope that reads the disk. Defaulting it off keeps typing responsive on
+ * a machine with hundreds of megabytes of transcripts, and turns its cost into an opt-in the user
+ * can see — the spec's own rule: a search that hangs the TUI is worse than one that only reads titles.
+ */
+export const DEFAULT_SCOPE_SELECTION: SearchScopeSelection = { title: true, prompt: true, transcript: false }
+
+/** A stored selection, defaulted field by field — a file missing a key reads as that key's default. */
+export function normalizeSelection(x: Partial<SearchScopeSelection> | undefined): SearchScopeSelection {
+  return {
+    title: x?.title ?? DEFAULT_SCOPE_SELECTION.title,
+    prompt: x?.prompt ?? DEFAULT_SCOPE_SELECTION.prompt,
+    transcript: x?.transcript ?? DEFAULT_SCOPE_SELECTION.transcript,
+  }
+}
+
+/** The scopes a selection actually searches — the toggled-on ones, plus the always-on structured set. */
+export function activeScopes(sel: SearchScopeSelection): Set<SearchScope> {
+  const out = new Set<SearchScope>(ALWAYS_SCOPES)
+  for (const t of SEARCH_TOGGLES) if (sel[t]) for (const s of TOGGLE_SCOPES[t]) out.add(s)
+  return out
+}
+
+/** Whether the deep transcript search should run at all — the one scope worth not paying for. */
+export function transcriptScopeOn(sel: SearchScopeSelection): boolean {
+  return sel.transcript
+}
+
+export type AllState = 'on' | 'mixed' | 'off'
+
+/**
+ * The "all" control, DERIVED — on when every toggle is on, off when none is, mixed otherwise.
+ *
+ * Derived and never stored, so it can never contradict the individual toggles on screen: there is
+ * only one source, read two ways. This is the "when every individual is checked, all shows checked"
+ * half of the PE's two-way requirement.
+ */
+export function allState(sel: SearchScopeSelection): AllState {
+  const on = SEARCH_TOGGLES.filter(t => sel[t]).length
+  return on === SEARCH_TOGGLES.length ? 'on' : on === 0 ? 'off' : 'mixed'
+}
+
+/** Toggle one depth on or off. */
+export function toggleScope(sel: SearchScopeSelection, t: SearchToggle): SearchScopeSelection {
+  return { ...sel, [t]: !sel[t] }
+}
+
+/**
+ * The other half of the two-way "all": checking it turns every toggle on; from all-on it clears them.
+ *
+ * Paired with `allState` above, the two are one value read two ways, so "all" and the individuals
+ * can never disagree — the PE's requirement, met by construction rather than by keeping them in sync.
+ */
+export function toggleAllScopes(sel: SearchScopeSelection): SearchScopeSelection {
+  const next = allState(sel) !== 'on'
+  return { title: next, prompt: next, transcript: next }
+}
+
+/**
  * The scopes of one row that carry `query`, in `SEARCH_SCOPES` order.
  *
  * An empty query matches NOTHING rather than everything: the caller decides that an unfiltered
@@ -56,15 +139,22 @@ export function matchScopes(
   fields: SearchFields,
   query: string,
   found: { transcript?: boolean } = {},
+  /**
+   * The scopes the search is CURRENTLY looking in. Absent means every scope — the behaviour before
+   * depth was selectable, and what the tests without a selection still assert. A scope not in the
+   * set is not tested, so a title-only match is invisible while the title toggle is off.
+   */
+  active?: ReadonlySet<SearchScope>,
 ): SearchScope[] {
   const q = query.trim().toLowerCase()
   if (q === '') return []
+  const on = (scope: SearchScope) => active === undefined || active.has(scope)
 
   const hit: SearchScope[] = []
   for (const scope of OWN_SCOPES) {
-    if (fields[scope].toLowerCase().includes(q)) hit.push(scope)
+    if (on(scope) && fields[scope].toLowerCase().includes(q)) hit.push(scope)
   }
-  if (found.transcript) hit.push('transcript')
+  if (found.transcript && on('transcript')) hit.push('transcript')
   return hit
 }
 
@@ -73,8 +163,9 @@ export function matchesQuery(
   fields: SearchFields,
   query: string,
   found: { transcript?: boolean } = {},
+  active?: ReadonlySet<SearchScope>,
 ): boolean {
-  return query.trim() === '' || matchScopes(fields, query, found).length > 0
+  return query.trim() === '' || matchScopes(fields, query, found, active).length > 0
 }
 
 /** The words the depth line needs, supplied by the caller — this module holds no strings. */
@@ -82,6 +173,8 @@ export interface SearchScopeWords {
   scope: Record<SearchScope, string>
   noGrep: string
   noTranscripts: string
+  /** How the line names a transcription depth the user has switched OFF. */
+  transcriptOff: string
 }
 
 /** What the transcript half of the search is currently doing. */
@@ -89,6 +182,14 @@ export interface TranscriptState {
   running?: boolean
   runningWord?: string
   unavailable?: 'no-grep' | 'no-transcripts'
+  /**
+   * The transcription DEPTH is switched off, so no disk read was even attempted.
+   *
+   * Distinct from `no-transcripts` ("this machine has none") on purpose: one is a choice the user
+   * can reverse with a keypress, the other is a fact about the machine, and a line that confused
+   * them would send someone to look for a switch that is not the problem.
+   */
+  off?: boolean
 }
 
 /**
@@ -111,7 +212,11 @@ export function searchDepthText(
     if (counts[scope] > 0) parts.push(`${words.scope[scope]} ${counts[scope]}`)
   }
 
-  if (state.unavailable) {
+  if (state.off) {
+    // The depth the user turned off — said, not silently omitted, so the transcript is always
+    // accounted for one way or another (the same reason its count is always stated below).
+    parts.push(words.transcriptOff)
+  } else if (state.unavailable) {
     parts.push(state.unavailable === 'no-grep' ? words.noGrep : words.noTranscripts)
   } else if (state.running) {
     // Not `transcript 0`: the count is simply not in yet, and a zero that turns into 47 a moment
@@ -139,11 +244,12 @@ export function emptyScopeCounts(): ScopeCounts {
 export function scopeCounts(
   rows: readonly { fields: SearchFields; transcript?: boolean }[],
   query: string,
+  active?: ReadonlySet<SearchScope>,
 ): ScopeCounts {
   const counts = emptyScopeCounts()
   if (query.trim() === '') return counts
   for (const row of rows) {
-    for (const scope of matchScopes(row.fields, query, { transcript: row.transcript })) {
+    for (const scope of matchScopes(row.fields, query, { transcript: row.transcript }, active)) {
       counts[scope]++
     }
   }

--- a/packages/tui/src/control/search-scope.ts
+++ b/packages/tui/src/control/search-scope.ts
@@ -94,6 +94,39 @@ export function activeScopes(sel: SearchScopeSelection): Set<SearchScope> {
   return out
 }
 
+/**
+ * The CANONICAL persisted shape — the cumulative scope ARRAY, in `SEARCH_SCOPES` order.
+ *
+ * `Preferences.sessionView.searchScopes` (server, `preferences.ts`) and
+ * `SessionViewPrefs.searchScopes` (this package) are BOTH `SearchScope[]`: the server owns the
+ * stored format and the tui produces and consumes it, so the two never disagree on the wire. The
+ * `SearchScopeSelection` object is only this screen's own on/off convenience — it is converted to
+ * the array on the way out (`selectionToScopes`) and back on the way in (`selectionFromScopes`), so
+ * nothing downstream ever sees the object. The array is exactly what `activeScopes` searches, which
+ * is what keeps the persisted set and the actual search in step.
+ */
+export function selectionToScopes(sel: SearchScopeSelection): SearchScope[] {
+  const set = activeScopes(sel)
+  return SEARCH_SCOPES.filter(s => set.has(s))
+}
+
+/**
+ * Recover the depth toggles from a persisted scope array — the inverse of `selectionToScopes` over
+ * the three USER-controlled depths (title→`name`, prompt, transcript).
+ *
+ * The always-searched structured scopes (folder/harness/note/task) carry no toggle, so they are
+ * ignored here exactly as they are in the UI — which is why the toggles round-trip through
+ * `selectionToScopes` even though the array also names them. Anything that is NOT an array — absent,
+ * or a value written by the pre-array build — reads as the default (title + first prompt on,
+ * transcription off), the same robustness the server's `resolveSessionSearchScopes` applies to a
+ * hand-edited or newer-binary file.
+ */
+export function selectionFromScopes(scopes: readonly SearchScope[] | undefined): SearchScopeSelection {
+  if (!Array.isArray(scopes)) return { ...DEFAULT_SCOPE_SELECTION }
+  const set = new Set<SearchScope>(scopes)
+  return { title: set.has('name'), prompt: set.has('prompt'), transcript: set.has('transcript') }
+}
+
 /** Whether the deep transcript search should run at all — the one scope worth not paying for. */
 export function transcriptScopeOn(sel: SearchScopeSelection): boolean {
   return sel.transcript

--- a/packages/tui/src/control/sessions.ts
+++ b/packages/tui/src/control/sessions.ts
@@ -59,11 +59,13 @@ export function filterSessions(
   list: readonly ControlSession[],
   query: string,
   transcriptHits?: ReadonlySet<string>,
+  /** The scopes the search is looking in — see `search-scope.ts`. Absent means every scope. */
+  active?: ReadonlySet<SearchScope>,
 ): ControlSession[] {
   if (query.trim() === '') return [...list]
   return list.filter(v => matchesQuery(v.searchFields, query, {
     transcript: transcriptOf(v, transcriptHits),
-  }))
+  }, active))
 }
 
 /**
@@ -82,8 +84,9 @@ export function rowScopes(
   v: ControlSession,
   query: string,
   transcriptHits?: ReadonlySet<string>,
+  active?: ReadonlySet<SearchScope>,
 ): SearchScope[] {
-  return matchScopes(v.searchFields, query, { transcript: transcriptOf(v, transcriptHits) })
+  return matchScopes(v.searchFields, query, { transcript: transcriptOf(v, transcriptHits) }, active)
 }
 
 /** How deep the search went: how many rows carry the query in each scope. */
@@ -91,10 +94,12 @@ export function searchDepth(
   list: readonly ControlSession[],
   query: string,
   transcriptHits?: ReadonlySet<string>,
+  active?: ReadonlySet<SearchScope>,
 ): ScopeCounts {
   return scopeCounts(
     list.map(v => ({ fields: v.searchFields, transcript: transcriptOf(v, transcriptHits) })),
     query,
+    active,
   )
 }
 

--- a/packages/tui/src/control/tabs/Sessions.tsx
+++ b/packages/tui/src/control/tabs/Sessions.tsx
@@ -3014,6 +3014,25 @@ function Question({
 }
 
 /**
+ * The scroll window for the view menu — PURE, so the "does it actually scroll" guarantee is
+ * testable without a tty (an input-driven render test flakes under concurrent load; this does not).
+ *
+ * The menu draws a title and a hint above its rows, so the rows get `height - 2`. Over that budget
+ * it uses the SAME following window (`windowOffset`) every other list in this package uses, centred
+ * on the cursor — which is what keeps the row the cursor lands on drawn. Slicing from zero
+ * (`rows.slice(0, height - 2)`) left the Search-in depths below the fold and unreachable on a short
+ * terminal — the `Math.max(1, height - chrome)` trap CLAUDE.md names.
+ */
+export function viewMenuWindow(
+  rowCount: number,
+  cursorRow: number,
+  height: number,
+): { offset: number; body: number } {
+  const body = Math.max(1, height - 2)
+  return { offset: windowOffset(cursorRow, rowCount, body), body }
+}
+
+/**
  * Everything about WHAT the list shows, as ONE vertical panel.
  *
  * It replaced a cramped horizontal strip that cycled the grouping on a hidden key and had nowhere
@@ -3089,7 +3108,10 @@ function ViewOptions({
     if (row.kind === 'scopeAll') return onToggleAllScopes()
   }, { isActive })
 
-  const body = Math.max(1, height - 2)
+  // The list — every grouping, the two Show switches, and the Search-in depths — outgrows a short
+  // terminal, so it SCROLLS: `viewMenuWindow` is the same following window every other list here
+  // uses, and it keeps the cursor's row drawn. Slicing from zero left the depth rows below the fold.
+  const { offset, body } = viewMenuWindow(rows.length, cursorRow, height)
   // The "all" glyph is TRI-STATE: a half-dot when only some depths are on, so it can never claim to
   // be on while a depth is off. `allState` is derived from the very toggles above, so the two read
   // as one — the PE's two-way requirement, met by there being only one source.
@@ -3100,7 +3122,10 @@ function ViewOptions({
     <Box flexDirection="column" width={width} flexShrink={0}>
       <Text bold>{truncate(s.viewTitle, width)}</Text>
       <Text dimColor>{truncate(s.viewHint, width)}</Text>
-      {rows.slice(0, body).map((row, i) => {
+      {rows.slice(offset, offset + body).map((row, localIndex) => {
+        // `i` is the row's index in the WHOLE list, not the visible slice, so the cursor comparison
+        // and the React keys stay correct once the window has scrolled off zero.
+        const i = offset + localIndex
         if (row.kind === 'heading') {
           return <Text key={`h${i}`} dimColor bold>{truncate(row.label, width)}</Text>
         }

--- a/packages/tui/src/control/tabs/Sessions.tsx
+++ b/packages/tui/src/control/tabs/Sessions.tsx
@@ -21,7 +21,11 @@ import type {
   TranscriptSearch,
 } from '../types'
 import type { ControlStrings } from '../i18n'
-import { searchDepthText } from '../search-scope'
+import {
+  activeScopes, allState, normalizeSelection, toggleAllScopes, toggleScope, transcriptScopeOn,
+  SEARCH_TOGGLES, searchDepthText,
+  type SearchScopeSelection, type SearchToggle,
+} from '../search-scope'
 import { searchDepth } from '../sessions'
 import { sessionWordBook } from '../i18n'
 import type { TabChrome } from '../ControlCenter'
@@ -250,6 +254,15 @@ export function Sessions({
    */
   const [transcript, setTranscript] = useState<TranscriptSearch | null>(null)
   const [searchingText, setSearchingText] = useState(false)
+  /**
+   * Which search DEPTHS are active — title, first prompt, transcription — cumulative and persisted.
+   *
+   * Restored from `view.searchScopes` below (absent reads as the default: title + first prompt on,
+   * transcription off). The active SCOPE set derived from it gates both what the rows filter on and
+   * whether the expensive disk read runs at all.
+   */
+  const [scopes, setScopes] = useState<SearchScopeSelection>(() => normalizeSelection(view?.searchScopes))
+  const active = useMemo(() => activeScopes(scopes), [scopes])
 
   /**
    * Ask the disk, once the typing settles.
@@ -262,20 +275,27 @@ export function Sessions({
    */
   useEffect(() => {
     const q = query.trim()
-    if (q === '' || !host.searchTranscripts) { setTranscript(null); setSearchingText(false); return }
+    // The disk read is GATED on the transcription toggle — this is the performance answer. Reading
+    // hundreds of megabytes of transcripts on every query is what would hang the TUI, so it runs
+    // only when the user has switched that depth on; with it off, the in-memory scopes alone answer
+    // instantly and `transcript` stays null (the depth line then omits the transcript count rather
+    // than reporting a stale one).
+    if (q === '' || !host.searchTranscripts || !transcriptScopeOn(scopes)) {
+      setTranscript(null); setSearchingText(false); return
+    }
 
     let cancelled = false
     setSearchingText(true)
     const timer = setTimeout(() => {
       host.searchTranscripts!(q)
         .then(r => { if (!cancelled) { setTranscript(r); setSearchingText(false) } })
-        // A failed deep search must not take the list with it: the six in-memory scopes are still
+        // A failed deep search must not take the list with it: the in-memory scopes are still
         // a perfectly good search, so the row count stays right and only the transcript half is lost.
         .catch(() => { if (!cancelled) { setTranscript(null); setSearchingText(false) } })
     }, TRANSCRIPT_DEBOUNCE_MS)
 
     return () => { cancelled = true; clearTimeout(timer); }
-  }, [query, host])
+  }, [query, host, scopes])
   const [showDone, setShowDone] = useState(view?.showDone ?? DEFAULT_SESSION_VIEW.showDone ?? false)
   /**
    * What the list is narrowed to, per dimension — the ONE source, and the whole answer.
@@ -399,6 +419,7 @@ export function Sessions({
         && (showDone || taskFilter !== null || !(v.task && done.has(v.task)))),
       query,
       transcript?.ids,
+      active,
     ),
     grouping,
     words,
@@ -413,7 +434,7 @@ export function Sessions({
      // Absent when nothing is marked, so the band is not merely empty — it does not exist.
      marked.size > 0 ? { ids: marked, label: s.sessionsMarkedBand } : undefined), [
     fleet?.sessions, fleet?.finishedTasks, fleet?.fell, done, grouping, cascade, query, transcript, filters,
-    showNamed, showDone, taskFilter, dimensionCtx, order, words, marked,
+    showNamed, showDone, taskFilter, dimensionCtx, order, words, marked, active,
   ])
 
   /**
@@ -422,16 +443,26 @@ export function Sessions({
    */
   const depth = useMemo(() => {
     if (query.trim() === '') return ''
+    const transcriptOn = transcriptScopeOn(scopes)
     return searchDepthText(
-      searchDepth(fleet?.sessions ?? [], query, transcript?.ids),
-      { scope: s.searchScope, noGrep: s.searchNoGrep, noTranscripts: s.searchNoTranscripts },
+      searchDepth(fleet?.sessions ?? [], query, transcript?.ids, active),
       {
-        running: searchingText,
-        runningWord: s.searchRunning,
-        ...(transcript?.unavailable ? { unavailable: transcript.unavailable } : {}),
+        scope: s.searchScope, noGrep: s.searchNoGrep,
+        noTranscripts: s.searchNoTranscripts, transcriptOff: s.searchTranscriptOff,
+      },
+      {
+        // With transcription switched off the disk read never ran; the line says so rather than
+        // claiming a count of zero or a search still in flight.
+        ...(transcriptOn
+          ? {
+              running: searchingText,
+              runningWord: s.searchRunning,
+              ...(transcript?.unavailable ? { unavailable: transcript.unavailable } : {}),
+            }
+          : { off: true }),
       },
     )
-  }, [fleet?.sessions, query, transcript, searchingText, s])
+  }, [fleet?.sessions, query, transcript, searchingText, s, active, scopes])
 
   const selectable = useMemo(() => selectableIndexes(rows), [rows])
 
@@ -1181,6 +1212,7 @@ export function Sessions({
     // empty set — see `SessionFilterState.marked`.
     setMarked(new Set(restoredFilters.marked))
     setOrder((view.sort as SessionOrder | undefined) ?? DEFAULT_ORDER)
+    setScopes(normalizeSelection(view.searchScopes))
     setHideDetail(view.hideDetail ?? false)
     // The DEFAULT, never a literal — same rule, same reason as `onlyActive` above.
     setLayout(view.layout ?? DEFAULT_SESSION_VIEW.layout ?? 'list')
@@ -1226,9 +1258,10 @@ export function Sessions({
       cascade,
       ...(cardAnchor ? { cardAnchor } : {}),
       sort: order,
+      searchScopes: scopes,
     } as SessionViewPrefs)
   }, [grouping, cascade, filters, showNamed, showDone, hideDetail,
-      layout, cardAnchor, order, marked, onView, view])
+      layout, cardAnchor, order, marked, scopes, onView, view])
 
   useEffect(() => {
     if (!isActive) return
@@ -1545,12 +1578,15 @@ export function Sessions({
           grouping={grouping}
           showHistory={showHistory}
           showNamed={showNamed}
+          scopes={scopes}
           width={width}
           height={height}
           isActive={isActive}
           onGrouping={g => { setGrouping(g); setCursor(0) }}
           onShowClosed={() => pressShortcut('history')}
           onShowNamed={() => { setShowNamed(v => !v); setCursor(0) }}
+          onToggleScope={t => setScopes(sc => toggleScope(sc, t))}
+          onToggleAllScopes={() => setScopes(toggleAllScopes)}
           onClose={() => setAsk(null)}
         />
       </Box>
@@ -2989,19 +3025,22 @@ function Question({
  * squeezing it under the list is what made it unreadable the first time.
  */
 function ViewOptions({
-  strings: s, grouping, showHistory, showNamed, width, height, isActive,
-  onGrouping, onShowClosed, onShowNamed, onClose,
+  strings: s, grouping, showHistory, showNamed, scopes, width, height, isActive,
+  onGrouping, onShowClosed, onShowNamed, onToggleScope, onToggleAllScopes, onClose,
 }: {
   strings: ControlStrings
   grouping: SessionGrouping
   showHistory: boolean
   showNamed: boolean
+  scopes: SearchScopeSelection
   width: number
   height: number
   isActive: boolean
   onGrouping: (g: SessionGrouping) => void
   onShowClosed: () => void
   onShowNamed: () => void
+  onToggleScope: (t: SearchToggle) => void
+  onToggleAllScopes: () => void
   onClose: () => void
 }) {
   // One flat list of rows so the cursor moves over exactly what is drawn — the same reason the
@@ -3011,7 +3050,13 @@ function ViewOptions({
     | { kind: 'group'; value: SessionGrouping }
     | { kind: 'closed' }
     | { kind: 'named' }
+    // The cumulative search depths, plus the two-way "all" — see `search-scope.ts`.
+    | { kind: 'scope'; toggle: SearchToggle }
+    | { kind: 'scopeAll' }
 
+  const scopeLabel: Record<SearchToggle, string> = {
+    title: s.searchDepthName, prompt: s.searchDepthPrompt, transcript: s.searchDepthTranscript,
+  }
   const rows: Row[] = [
     { kind: 'heading', label: s.viewGroupBy },
     ...GROUPINGS.map(g => ({ kind: 'group' as const, value: g })),
@@ -3020,6 +3065,9 @@ function ViewOptions({
     // Was the unfiled switch, which only meant anything while grouping by task. That bucket is now
     // a row in the task section, on every grouping; this is the widening that had no control at all.
     { kind: 'named' },
+    { kind: 'heading', label: s.viewSearchDepth },
+    ...SEARCH_TOGGLES.map(t => ({ kind: 'scope' as const, toggle: t })),
+    { kind: 'scopeAll' },
   ]
   const selectable = rows.map((r, i) => (r.kind === 'heading' ? -1 : i)).filter(i => i >= 0)
 
@@ -3037,9 +3085,16 @@ function ViewOptions({
     if (row.kind === 'group') return onGrouping(row.value)
     if (row.kind === 'closed') return onShowClosed()
     if (row.kind === 'named') return onShowNamed()
+    if (row.kind === 'scope') return onToggleScope(row.toggle)
+    if (row.kind === 'scopeAll') return onToggleAllScopes()
   }, { isActive })
 
   const body = Math.max(1, height - 2)
+  // The "all" glyph is TRI-STATE: a half-dot when only some depths are on, so it can never claim to
+  // be on while a depth is off. `allState` is derived from the very toggles above, so the two read
+  // as one — the PE's two-way requirement, met by there being only one source.
+  const all = allState(scopes)
+  const allGlyph = all === 'on' ? '● ' : all === 'off' ? '○ ' : '◐ '
 
   return (
     <Box flexDirection="column" width={width} flexShrink={0}>
@@ -3055,16 +3110,23 @@ function ViewOptions({
         // The dot means ON, always — for every row on this panel.
         const on = row.kind === 'group'
           ? row.value === grouping
-          : row.kind === 'closed' ? showHistory : showNamed
+          : row.kind === 'closed' ? showHistory
+          : row.kind === 'named' ? showNamed
+          : row.kind === 'scope' ? scopes[row.toggle]
+          : all === 'on'
         const label = row.kind === 'group'
           ? s.sessionsGroupings[row.value]
           : row.kind === 'closed' ? s.viewClosedOn
-          : s.toggleNamed
+          : row.kind === 'named' ? s.toggleNamed
+          : row.kind === 'scope' ? scopeLabel[row.toggle]
+          : s.searchDepthAll
+        // The "all" row wears the tri-state glyph; every other row is a plain on/off dot.
+        const glyph = row.kind === 'scopeAll' ? allGlyph : on ? '● ' : '○ '
         return (
           <Text key={`r${i}`} wrap="truncate">
             <Text color={active ? COLORS.accent : undefined}>{active ? '  ❯ ' : '    '}</Text>
             {/* Glyph plus word: which options are on must survive a terminal that drops colour. */}
-            <Text color={on ? COLORS.success : COLORS.muted}>{on ? '● ' : '○ '}</Text>
+            <Text color={on ? COLORS.success : COLORS.muted}>{glyph}</Text>
             <Text color={active ? COLORS.accent : undefined} bold={active}>
               {truncate(label, Math.max(1, width - 8))}
             </Text>

--- a/packages/tui/src/control/tabs/Sessions.tsx
+++ b/packages/tui/src/control/tabs/Sessions.tsx
@@ -22,8 +22,8 @@ import type {
 } from '../types'
 import type { ControlStrings } from '../i18n'
 import {
-  activeScopes, allState, normalizeSelection, toggleAllScopes, toggleScope, transcriptScopeOn,
-  SEARCH_TOGGLES, searchDepthText,
+  activeScopes, allState, selectionFromScopes, selectionToScopes, toggleAllScopes, toggleScope,
+  transcriptScopeOn, SEARCH_TOGGLES, searchDepthText,
   type SearchScopeSelection, type SearchToggle,
 } from '../search-scope'
 import { searchDepth } from '../sessions'
@@ -261,7 +261,7 @@ export function Sessions({
    * transcription off). The active SCOPE set derived from it gates both what the rows filter on and
    * whether the expensive disk read runs at all.
    */
-  const [scopes, setScopes] = useState<SearchScopeSelection>(() => normalizeSelection(view?.searchScopes))
+  const [scopes, setScopes] = useState<SearchScopeSelection>(() => selectionFromScopes(view?.searchScopes))
   const active = useMemo(() => activeScopes(scopes), [scopes])
 
   /**
@@ -1212,7 +1212,7 @@ export function Sessions({
     // empty set — see `SessionFilterState.marked`.
     setMarked(new Set(restoredFilters.marked))
     setOrder((view.sort as SessionOrder | undefined) ?? DEFAULT_ORDER)
-    setScopes(normalizeSelection(view.searchScopes))
+    setScopes(selectionFromScopes(view.searchScopes))
     setHideDetail(view.hideDetail ?? false)
     // The DEFAULT, never a literal — same rule, same reason as `onlyActive` above.
     setLayout(view.layout ?? DEFAULT_SESSION_VIEW.layout ?? 'list')
@@ -1258,7 +1258,9 @@ export function Sessions({
       cascade,
       ...(cardAnchor ? { cardAnchor } : {}),
       sort: order,
-      searchScopes: scopes,
+      // The persisted shape is the canonical scope ARRAY (server contract, #240), derived from this
+      // screen's toggles at the edge so the object never crosses the boundary.
+      searchScopes: selectionToScopes(scopes),
     } as SessionViewPrefs)
   }, [grouping, cascade, filters, showNamed, showDone, hideDetail,
       layout, cardAnchor, order, marked, scopes, onView, view])

--- a/packages/tui/src/control/tabs/Sessions.tsx
+++ b/packages/tui/src/control/tabs/Sessions.tsx
@@ -263,6 +263,12 @@ export function Sessions({
    */
   const [scopes, setScopes] = useState<SearchScopeSelection>(() => selectionFromScopes(view?.searchScopes))
   const active = useMemo(() => activeScopes(scopes), [scopes])
+  // The disk read below keys on THIS boolean, not the whole `scopes` object. Toggling title or
+  // first prompt makes a new `scopes` (they are in-memory scopes, searched instantly), and depending
+  // on the object re-fired the ~255 ms transcript grep on those cheap toggles for no new result. The
+  // deep read only has to re-run when the transcription depth itself flips — which is exactly what
+  // this value tracks.
+  const transcriptSearchOn = transcriptScopeOn(scopes)
 
   /**
    * Ask the disk, once the typing settles.
@@ -280,7 +286,7 @@ export function Sessions({
     // only when the user has switched that depth on; with it off, the in-memory scopes alone answer
     // instantly and `transcript` stays null (the depth line then omits the transcript count rather
     // than reporting a stale one).
-    if (q === '' || !host.searchTranscripts || !transcriptScopeOn(scopes)) {
+    if (q === '' || !host.searchTranscripts || !transcriptSearchOn) {
       setTranscript(null); setSearchingText(false); return
     }
 
@@ -295,7 +301,9 @@ export function Sessions({
     }, TRANSCRIPT_DEBOUNCE_MS)
 
     return () => { cancelled = true; clearTimeout(timer); }
-  }, [query, host, scopes])
+    // Keyed on `transcriptSearchOn`, NOT `scopes`: a title/first-prompt toggle must not re-run the
+    // disk read, only a change to the transcription depth (or the query/host) may. See F2.
+  }, [query, host, transcriptSearchOn])
   const [showDone, setShowDone] = useState(view?.showDone ?? DEFAULT_SESSION_VIEW.showDone ?? false)
   /**
    * What the list is narrowed to, per dimension — the ONE source, and the whole answer.

--- a/packages/tui/src/control/tabs/view-options.test.tsx
+++ b/packages/tui/src/control/tabs/view-options.test.tsx
@@ -1,0 +1,67 @@
+/**
+ * The "Search in" panel scrolls, so every option is reachable.
+ *
+ * `ViewOptions` is one flat list — Group by (every grouping), Show, and the Search-in depths with
+ * their two-way "all". Long enough to overflow a short terminal. It used to slice from zero
+ * (`rows.slice(0, height - 2)`), which left the depth rows BELOW THE FOLD: the cursor moved onto
+ * them and the screen never drew them, so the section this delivery added was unreachable exactly
+ * when the terminal was small — the `Math.max(1, height - chrome)` trap.
+ *
+ * The window arithmetic is pure (`viewMenuWindow`), so the guarantee is pinned here without a tty:
+ * whatever row the cursor lands on, that row is inside the visible window, and the window really is
+ * a window (smaller than the list) rather than the whole list drawn from the top. An input-driven
+ * render test proved the same thing but flaked under concurrent load, because ink reads stdin on a
+ * timer the full suite does not give it — the pure test cannot flake.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { viewMenuWindow } from './Sessions'
+
+// One heading + 8 groupings + one heading + closed + named + one heading + 3 depths + all = 17 rows.
+// The last selectable row (the two-way "all") is index 16; the "Search in" section is indices 12-16.
+const ROWS = 17
+const SEARCH_IN_SECTION = [12, 13, 14, 15, 16]
+
+// A cursor row is visible when it lies inside the [offset, offset + body) window the menu draws.
+const visible = (cursorRow: number, height: number) => {
+  const { offset, body } = viewMenuWindow(ROWS, cursorRow, height)
+  return cursorRow >= offset && cursorRow < offset + body
+}
+
+describe('viewMenuWindow — the "Search in" list scrolls', () => {
+  test('a short terminal cannot show the whole list — it is a window, not the top', () => {
+    const { offset, body } = viewMenuWindow(ROWS, 16, 10)
+    // 10 rows of terminal, minus the title and hint, is 8 — fewer than the 17 rows.
+    expect(body).toBe(8)
+    expect(body).toBeLessThan(ROWS)
+    // With the cursor at the bottom the window has scrolled off zero to keep it in view.
+    expect(offset).toBeGreaterThan(0)
+  })
+
+  test('every row the cursor can reach stays on screen, at every height that clips the list', () => {
+    for (const height of [6, 8, 10, 12, 16, 18]) {
+      for (let cursor = 0; cursor < ROWS; cursor++) {
+        expect(visible(cursor, height), `row ${cursor} hidden at height ${height}`).toBe(true)
+      }
+    }
+  })
+
+  test('the whole Search-in section is reachable — the regression that failed review', () => {
+    // At the height where the bug showed (10), each depth row is inside the window when selected.
+    for (const row of SEARCH_IN_SECTION) {
+      expect(visible(row, 10), `Search-in row ${row} unreachable`).toBe(true)
+    }
+  })
+
+  test('a tall terminal shows everything from the top — no needless scroll', () => {
+    const { offset, body } = viewMenuWindow(ROWS, 16, 40)
+    expect(offset).toBe(0)
+    expect(body).toBeGreaterThanOrEqual(ROWS)
+  })
+
+  test('a one-line terminal still yields a usable window, never a negative height', () => {
+    const { body } = viewMenuWindow(ROWS, 5, 1)
+    expect(body).toBe(1)
+    expect(visible(5, 1)).toBe(true)
+  })
+})

--- a/packages/tui/src/control/types.ts
+++ b/packages/tui/src/control/types.ts
@@ -8,7 +8,7 @@
  */
 
 import type { CliLang } from './lang'
-import type { SearchFields } from './search-scope'
+import type { SearchFields, SearchScopeSelection } from './search-scope'
 // The default ARRANGEMENT is derived from the dimension vocabulary rather than written out beside
 // it. `session-dimensions.ts` imports this file for TYPES only, so this is the one value direction.
 import {
@@ -812,6 +812,15 @@ export interface SessionViewPrefs {
    * useful — you marked the row because you were about to go into it.
    */
   marked?: string[]
+  /**
+   * Which search DEPTHS are active — title, first prompt, transcription — cumulative.
+   *
+   * Persisted like the rest of the arrangement so the depth someone chose survives a restart, and
+   * absent reads as `DEFAULT_SCOPE_SELECTION` (title + first prompt on, transcription off) via
+   * `normalizeSelection` — never a literal here, for the same reason `layout` is not: a hand-written
+   * fallback drifts from the one in `search-scope.ts`. See finding (3) in the journey.
+   */
+  searchScopes?: SearchScopeSelection
 }
 
 /**

--- a/packages/tui/src/control/types.ts
+++ b/packages/tui/src/control/types.ts
@@ -8,7 +8,7 @@
  */
 
 import type { CliLang } from './lang'
-import type { SearchFields, SearchScopeSelection } from './search-scope'
+import type { SearchFields, SearchScope } from './search-scope'
 // The default ARRANGEMENT is derived from the dimension vocabulary rather than written out beside
 // it. `session-dimensions.ts` imports this file for TYPES only, so this is the one value direction.
 import {
@@ -813,14 +813,18 @@ export interface SessionViewPrefs {
    */
   marked?: string[]
   /**
-   * Which search DEPTHS are active — title, first prompt, transcription — cumulative.
+   * WHICH scopes the session search looks in — the cumulative set (name, folder, harness, note,
+   * task, prompt, transcript), persisted like the rest of the arrangement so the depth someone chose
+   * survives a restart.
    *
-   * Persisted like the rest of the arrangement so the depth someone chose survives a restart, and
-   * absent reads as `DEFAULT_SCOPE_SELECTION` (title + first prompt on, transcription off) via
-   * `normalizeSelection` — never a literal here, for the same reason `layout` is not: a hand-written
-   * fallback drifts from the one in `search-scope.ts`. See finding (3) in the journey.
+   * A `SearchScope[]`, not this package's `SearchScopeSelection` object: the STORED format is the
+   * server's (`Preferences.sessionView.searchScopes` in `preferences.ts`, shipped in #240), and this
+   * type is the same contract read back through `cli-start.ts`. The tui converts to and from its own
+   * on/off toggles at the edge (`selectionToScopes` / `selectionFromScopes`), so the object never
+   * crosses this boundary. Absent reads as the default (title + first prompt on, transcription off)
+   * — never a literal here, for the same reason `layout` is not. See finding (3) in the journey.
    */
-  searchScopes?: SearchScopeSelection
+  searchScopes?: SearchScope[]
 }
 
 /**


### PR DESCRIPTION
## What & why

Journey **j-20260826-fi**. The sessions search matched every scope on every
keystroke, always paying the transcript disk read. This adds **selectable,
cumulative search depths** the PE asked for — **title**, **first prompt**,
**transcription (full session)** — plus a two-way **all**, persisted, with the
expensive disk read made opt-in.

This PR delivers **finding (3) only**. Findings (1) and (2) are **escalated to
`agentistics/server`** — diagnosis below.

## Finding (3) — search depth

- **`search-scope.ts` (pure)** — `SearchScopeSelection` + `activeScopes` /
  `allState` / `toggleScope` / `toggleAllScopes` / `normalizeSelection` /
  `transcriptScopeOn`. `matchScopes` / `matchesQuery` / `scopeCounts` take an
  optional active-scope set (absent ⇒ every scope, so nothing else changes).
- **Two-way "all", by construction.** `allState` is *derived* from the three
  toggles, so "all" can never contradict them on screen — checking all turns each
  on; when each is on, all reads on. (The PE's "quando eu marcar todos…".)
- **Performance.** The transcript disk read is **gated on the transcription
  toggle, off by default**. Typing stays instant on the in-memory scopes; the disk
  search runs only when opted in, debounced + async, so it never blocks a
  keystroke. Measured on this machine's real transcripts (475 MB):

  | query | cold | warm | hits |
  |---|---|---|---|
  | `docker` | 1281 ms | 170 ms | 120 |
  | `COORDENADOR` | 432 ms | 303 ms | 37 |
  | `session` | 32 ms | 23 ms | 249 |
  | (no match) | 296 ms | 312 ms | 0 |

  No hard cap is added: results are conversation-id matches folded into the
  already-bounded fleet list, the read is off by default and debounced, and it is
  async — so a ~1.3s cold read cannot hang the TUI. A search that hangs the TUI is
  worse than one that only reads titles.
- **Persistence.** `SessionViewPrefs.searchScopes`, round-tripped through the
  existing opaque `setSessionView` write (the same path `cascade` already uses) —
  **no server edit**.
- **UI.** A "Search in" section in the view menu (`v`); the "all" row wears a
  tri-state glyph (`●`/`◐`/`○`). The depth line names a switched-off transcription
  (`transcription off`), distinct from "none on this machine".
- **Scope decision (stated, not silent):** the structured scopes
  `folder`/`harness`/`note`/`task` stay **always searched** — cheap in-memory
  reads already on the row; dropping them would narrow a search that works today.
  The three toggles gate the human depths the PE named and, above all, the one
  expensive one.

### Tests / gates
- `search-scope.test.ts`: defaults, cumulative scopes, the **all two-way**
  relationship (both directions), the transcript perf gate, and the negatives (a
  title-only match invisible with title off; a transcript hit dropped with
  transcription off). RED→GREEN.
- `bun tsc --noEmit` clean · `bun test` **4450 pass / 0 fail** · `bun run
  build:binary` succeeds (TUI compiles into the native binary).
- Verified in the compiled UI via `scripts/preview.tsx`: the "Search in" section,
  the `◐` tri-state, both toggle directions, and the depth line showing
  `transcription off`.

## Findings (1) & (2) — ESCALATE → `agentistics/server`

Both root causes live outside `packages/tui`; a tui-only fix cannot make them
correct (finding 1 would desync `--json` from the table; finding 2's title is
derived server-side). Driven against this machine's real session list.

**(1) Duplicate rows** — a reopen/restart creates a *new* managed record and
retires the previous by stamping `endedAt` but keeping it; the fleet renders one
row per record. Confirmed: `managed-sessions.json` holds up to **6 records for
one `conversationId`** (`b9665719`), and `ls --json` shows 4 COORDENADOR / 4
Integrar rows sharing one conversation each.
- Row-multiplier: **`session-view.ts:401`** `o.reconciled.map(...)`; retirement
  only flips `status`→`exited`, no collapse by `conversationId`.
- `claimResume` (**session-view.ts:362-366**) exact-id path doesn't gate on
  `claimed`, so every twin gets the same resume target.
- Per the spec's own tree this is "same session re-identified → fix upstream of
  the display." **Fix:** collapse the fleet by `conversationId` at assembly (live
  wins; keep one row for a dead conversation; never drop a conversation with no
  live representative), applied before both `fleetJson` and the table.

**(2) Title flips on finalise** — while running `pickTitle` can let the harness's
own newer name win; on finalise Claude deletes `~/.claude/sessions/<pid>.json`,
so `pickTitle` loses its input and falls back to the agentop label. Reproduced
deterministically: `RUNNING "Split aipe session in two" → FINALISED
"Jesse-divida-sessao-aipe"`. Site: **`pickTitle` (harness-session-file.ts:220-235)**
+ `control-session.ts`.
- Note: on current `dev`, `searchFields.name` already carries **both** names for
  managed rows, so CTRL-F **by the label already survives finalise** (probed:
  `58bb5` exited → `"COORDENADOR COORDENADOR"`). The residual defects are the
  *displayed* identity flipping and search *by the harness title*.
- **Fix:** persist the winning title onto the record at finalise so the displayed
  identity does not change under the user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
