### PR TITLE
fix(sessions): stable session identity — no duplicate rows, title preserved on finalise

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,7 +177,14 @@ packages/server/server/          — server-side modules (never bundled by Vite)
   │                          harness — `nameSince` exists only from claude 2.1.232, and the
   │                          complaint this answers is a rename made inside the session that agentop
   │                          went on ignoring. NEITHER name is discarded when they differ: the row
-  │                          says which place the one it is showing came from. `session-view.ts` merges the managed fleet
+  │                          says which place the one it is showing came from. **A `/rename` name
+  │                          OUTLIVES the process**: the harness deletes its `<pid>.json` on exit, so a
+  │                          finished session lost that name and its title FLIPPED to another source,
+  │                          breaking search — the poller now PERSISTS the live non-derived name into
+  │                          `ManagedSession.harnessName`/`harnessNameSince` (mirror of
+  │                          `recordConversation`, one write per rename, `chosenName` only), and
+  │                          `buildSessionViews` reads it as the fallback when the live file is gone, so
+  │                          `pickTitle` returns the same title alive or finished. `session-view.ts` merges the managed fleet
   │                          with the EXTERNAL assistants `/proc` reports (listed, marked, and
   │                          carrying no activity — nothing about them is capturable), and
   │                          `sessions-host.ts` is the 5s poller, whose failed poll keeps the
@@ -187,8 +194,20 @@ packages/server/server/          — server-side modules (never bundled by Vite)
   │                          **A reboot takes tmux and leaves the registry**, so every managed
   │                          session reconciles to `lost` while keeping its name, note and task —
   │                          `session-view.ts` therefore offers REOPEN for any managed row that is
-  │                          not running, not only for one the user finished, and the pure
-  │                          `task-reopen.ts` holds what "open the whole task" means (a running row
+  │                          not running, not only for one the user finished. **But a RETIRED
+  │                          predecessor is not a second session**: every attach/reopen/restart mints a
+  │                          new managedId for the SAME conversation and retires the old record without
+  │                          removing it, so a conversation reopened N times drew N `exited` rows beside
+  │                          its live continuation — the row key was the per-spawn id, not the identity.
+  │                          The pure `collapseSupersededSessions` (session-view.ts, applied at the
+  │                          return) drops a predecessor ONLY when it is provably dead (`endedMs` set)
+  │                          AND superseded by a same-`conversationId` sibling (a live row, or a newer
+  │                          ended one). It NEVER hides a live row, a `lost` row with no recorded end,
+  │                          or the newest ended row (the reopenable one); rows with NO conversationId
+  │                          are never grouped, because a shared directory or label is not an identity —
+  │                          the coordinator reads this list to decide whether to re-dispatch over work
+  │                          in flight, so a row it cannot prove dead is never removed. The
+  │                          pure `task-reopen.ts` holds what "open the whole task" means (a running row
   │                          is left alone and reported as `already`, never as a skip; a FINISHED
   │                          row is not resurrected; an unresolvable one is skipped AND counted;
   │                          everything reopened RETIRES the row it replaced, or a laptop closed

--- a/docs/session-manager.md
+++ b/docs/session-manager.md
@@ -233,6 +233,28 @@ you are in. A row that does know its conversation never falls back to that guess
 before the transcript exists: "not written yet" and "some other conversation in this directory" are
 different answers.
 
+### One row per session, and a name that outlives the process
+
+A session's durable identity is its **conversation**, but the registry keys a record by the
+per-spawn managed id — a new one every time a session is attached, reopened or restarted. Each of
+those retires the record it replaced (`endedAt`) without removing it, so a conversation reopened five
+times used to stand on screen as five `exited` rows beside its one live continuation, all wearing the
+same name. The list collapses those: a retired predecessor is hidden **only** when it is provably
+dead (`endedAt` is set) **and** superseded by a row of the same conversation — a live one, or a newer
+ended one, which *is* that session continued. A live row is never hidden, a `lost` row with no
+recorded end (a reboot) is never hidden, and the newest ended row of a conversation with nothing live
+is kept, because it is the one you reopen. Two rows that merely share a directory or a label are left
+alone: only a shared **conversation id** proves two rows are one session, so the list never merges
+sessions that are genuinely distinct.
+
+A **title is an identity**: whatever a session is called while it runs, it stays called after it
+ends. The name you give a session from *inside* Claude Code (`/rename`) lives only in the harness's
+own record, which Claude deletes when the process exits — so a finished session used to lose that
+name, its displayed title fell back to a different source, and `CTRL+F` could no longer find the row
+by the name it wore a second earlier. agentop now captures that name into the registry while the
+session is alive, so the title is the same before and after it finishes. Only a name a person typed
+is kept; a name the harness invented for itself never displaces your own label.
+
 ### Tasks
 
 A task is whatever you say it is: a free string, chosen while starting a session or added later, and
@@ -341,8 +363,14 @@ None of this touches your own tmux: different socket, different server, differen
 tasks, and an `endedAt` on the ones that are over. tmux is authoritative about what is RUNNING; this
 file is authoritative about what it MEANS, which is why a reboot takes the first and leaves the
 second. A session is marked finished rather than deleted: it is still a thing that happened, and
-reopening it is the ordinary next thing to want.
+reopening it is the ordinary next thing to want. It also holds `harnessName` — the `/rename` name
+captured from the harness while the session was alive, so the title survives after the harness
+deletes its own record.
 
-`~/.agentistics/preferences.json` — `sessionView` (how the list is arranged) and `finishedTasks`
-(the tasks you marked done). Both are properties of this machine rather than of any session, which
-is why they do not live in the registry.
+`~/.agentistics/preferences.json` — `sessionView` (how the list is arranged, including
+`searchScopes`: which fields the search looks in) and `finishedTasks` (the tasks you marked done).
+Both are properties of this machine rather than of any session, which is why they do not live in the
+registry. `searchScopes` is a set — name, folder, harness, note, task, prompt, transcript — so the
+"all" control is simply every scope present; when it has never been chosen the search covers every
+field a row carries on its own, and `transcript` (a text scan of the conversation on disk) is an
+explicit opt-in rather than a cost paid on every keystroke.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentistics",
-  "version": "1.22.3",
+  "version": "1.22.4",
   "description": "Local analytics dashboard for AI coding assistants — tracks tokens, cost, sessions, and activity from ~/.claude/",
   "keywords": [
     "claude",

--- a/packages/agentop/package.json
+++ b/packages/agentop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentistics/agentop",
-  "version": "1.22.3",
+  "version": "1.22.4",
   "description": "agentop CLI — npm install for the same native binary distributed via install.sh (Linux x86_64 only)",
   "type": "commonjs",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentistics/core",
-  "version": "1.22.3",
+  "version": "1.22.4",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentistics/mcp",
-  "version": "1.22.3",
+  "version": "1.22.4",
   "description": "Agentistics MCP server — Claude Code analytics for Claude Desktop and Claude Code",
   "type": "module",
   "main": "./dist/agentistics-mcp.js",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentistics/server",
-  "version": "1.22.3",
+  "version": "1.22.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/server/server/cli-start.ts
+++ b/packages/server/server/cli-start.ts
@@ -1425,6 +1425,10 @@ async function ensureSessionsPoller(): Promise<SessionsPoller> {
     // Written once per session, not once per poll — the poller only calls this when the harness's
     // own record disagrees with the registry.
     recordConversation: (id, conversationId) => patchSession(id, { conversationId }),
+    // The `/rename` name, persisted so the title survives the process — same once-per-change
+    // discipline. See `ManagedSession.harnessName` and `pickTitle`.
+    recordHarnessName: (id, name, since) =>
+      patchSession(id, { harnessName: name, ...(since !== undefined ? { harnessNameSince: since } : {}) }),
     // Take back a running session whose registry record was lost. Called only with a non-empty
     // list, so a healthy fleet never writes. See `session-adopt.ts` for what may be adopted.
     adoptSessions: async records => { for (const r of records) await addSession(r) },

--- a/packages/server/server/preferences.test.ts
+++ b/packages/server/server/preferences.test.ts
@@ -691,3 +691,29 @@ test('clampSessionPollMs falls back to the default for a non-finite value', () =
   expect(clampSessionPollMs(NaN)).toBe(SESSION_POLL_DEFAULT_MS)
   expect(clampSessionPollMs(Infinity)).toBe(SESSION_POLL_DEFAULT_MS)
 })
+
+// THREE — the persisted search-scope preference the cockpit (j-20260826-fi) builds on.
+// The scope SET rides `sessionView` and its whole-object write; this file owns where it lives,
+// its default, and its validation. The renderer is the TUI's.
+import { resolveSessionSearchScopes, DEFAULT_SESSION_SEARCH_SCOPES } from './preferences'
+
+test('search scopes: never chosen reads as the default (all own fields, no transcript)', () => {
+  expect(resolveSessionSearchScopes({})).toEqual([...DEFAULT_SESSION_SEARCH_SCOPES])
+  expect(DEFAULT_SESSION_SEARCH_SCOPES).not.toContain('transcript')
+  expect(DEFAULT_SESSION_SEARCH_SCOPES).toContain('name')
+})
+
+test('search scopes: a stored set is honoured, in canonical order and deduped', () => {
+  const p = { sessionView: { grouping: 'none', showClosed: false, showExited: false, showUnfiled: false, searchScopes: ['prompt', 'name', 'prompt', 'transcript'] } } as never
+  expect(resolveSessionSearchScopes(p)).toEqual(['name', 'prompt', 'transcript'])
+})
+
+test('search scopes: an empty stored array is a real (empty) choice, distinct from never-chosen', () => {
+  const p = { sessionView: { grouping: 'none', showClosed: false, showExited: false, showUnfiled: false, searchScopes: [] } } as never
+  expect(resolveSessionSearchScopes(p)).toEqual([])
+})
+
+test('search scopes: unknown values are dropped rather than crashing', () => {
+  const p = { sessionView: { grouping: 'none', showClosed: false, showExited: false, showUnfiled: false, searchScopes: ['name', 'bogus', 'folder'] } } as never
+  expect(resolveSessionSearchScopes(p)).toEqual(['name', 'folder'])
+})

--- a/packages/server/server/preferences.ts
+++ b/packages/server/server/preferences.ts
@@ -6,6 +6,10 @@ import { migrateTeamConfig } from '@agentistics/core'
 // TYPE-only, and the allowed direction: `server -> tui`. The arrangements are declared once, in
 // `session-dimensions.ts`, and this file stores whichever one was chosen.
 import type { SessionGroupingId } from '@agentistics/tui/control'
+// The searchable dimensions, declared once in the TUI's `search-scope.ts` and stored here — the
+// same `server -> tui` direction, and the same single-source rule as `SessionGroupingId`: a scope
+// added there fails this build until it is handled, rather than being silently un-persistable.
+import { SEARCH_SCOPES, type SearchScope } from '@agentistics/tui/control/search-scope'
 
 // Preferences live in the writable ~/.agentistics dir. The legacy location under CLAUDE_DIR
 // is read-only in Docker (host ~/.claude mounted :ro), which silently broke persistence and
@@ -113,6 +117,21 @@ export interface Preferences {
     /** The session at the top of the open card page: a page number would name other sessions by
      *  the next poll, so the page is remembered by identity. */
     cardAnchor?: string
+    /**
+     * WHICH scopes the session search looks in — the cumulative set the user has enabled (name,
+     * folder, harness, note, task, prompt, transcript). It is a SET, so the "all" control is simply
+     * every scope present, and an empty array is a real choice (search nothing but what is typed
+     * against no field — the caller decides what an empty set means for its filter).
+     *
+     * Stored inside `sessionView` because it is part of "how the fleet list was last arranged", and
+     * so it rides the SAME whole-object `setSessionView` / PUT `/api/preferences` write every other
+     * field here does — no new route, no new setter. Absent = never chosen; read it through
+     * `resolveSessionSearchScopes`, which supplies the default and drops any value this build does
+     * not know, so an older or hand-edited config degrades to a sane search rather than a crash.
+     *
+     * The renderer/UI is the TUI's (`j-20260826-fi`); this is only where the choice persists.
+     */
+    searchScopes?: SearchScope[]
   }
   /**
    * The session TASKS the user has marked finished.
@@ -164,6 +183,35 @@ export function clampSessionPollMs(ms: number): number {
 /** The effective poll interval — `undefined` reads as the default, exactly like `archiveMode`. */
 export function sessionPollMsOrDefault(p: Preferences): number {
   return p.sessionPollMs !== undefined ? clampSessionPollMs(p.sessionPollMs) : SESSION_POLL_DEFAULT_MS
+}
+
+/**
+ * The scopes the session search looks in when the user has NEVER chosen — every scope a row carries
+ * ON ITS OWN.
+ *
+ * `transcript` is deliberately OUT of the default: it is the only scope that is not a property of a
+ * row but a question asked of the disk (a text scan of every conversation), so making it always-on
+ * would put a file walk behind every keystroke. It stays an explicit opt-in the user enables — which
+ * is exactly the cumulative control the cockpit is adding. This default reproduces the search's
+ * existing reach (all own fields), so nothing narrows on upgrade.
+ */
+export const DEFAULT_SESSION_SEARCH_SCOPES: SearchScope[] =
+  SEARCH_SCOPES.filter((s): s is SearchScope => s !== 'transcript')
+
+/**
+ * The effective session-search scopes — `undefined` reads as the default, exactly like every other
+ * `sessionView` field.
+ *
+ * Validated on read: only scopes THIS build knows survive, returned in canonical `SEARCH_SCOPES`
+ * order and deduped, so a config hand-edited or written by a newer binary degrades to a sane search
+ * rather than a crash. A stored EMPTY array is honoured as a real (empty) choice — distinct from
+ * "never chosen", which is the `undefined` branch above.
+ */
+export function resolveSessionSearchScopes(p: Preferences): SearchScope[] {
+  const stored = p.sessionView?.searchScopes
+  if (!Array.isArray(stored)) return [...DEFAULT_SESSION_SEARCH_SCOPES]
+  const set = new Set(stored)
+  return SEARCH_SCOPES.filter(s => set.has(s))
 }
 
 /** Read + parse a preferences JSON file.

--- a/packages/server/server/sessions/registry.ts
+++ b/packages/server/server/sessions/registry.ts
@@ -53,6 +53,11 @@ export interface SessionPatch {
   task?: string
   endedAt?: string
   conversationId?: string
+  /** The harness's own `/rename` name, persisted so the title survives the process — see
+   *  `ManagedSession.harnessName`. Written by the poller only when it CHANGES, one write per rename. */
+  harnessName?: string
+  /** Written alongside `harnessName`, never on its own — see `ManagedSession.harnessNameSince`. */
+  harnessNameSince?: number
 }
 
 export interface SessionRegistry {

--- a/packages/server/server/sessions/session-view.test.ts
+++ b/packages/server/server/sessions/session-view.test.ts
@@ -5,7 +5,8 @@ import type { HarnessProcess } from '../live-sessions'
 import type { ManagedSession, SessionActivity } from './types'
 import type { ReconciledSession } from './session-ref'
 import {
-  attentionCount, bellTransitions, buildSessionViews, needsAttention,
+  attentionCount, bellTransitions, buildSessionViews, collapseSupersededSessions,
+  needsAttention, type SessionView,
 } from './session-view'
 
 const managed = (id: string, over: Partial<ManagedSession> = {}): ManagedSession => ({
@@ -493,5 +494,138 @@ describe('a session that CHANGED DIRECTORY is still the row hosting it', () => {
       harnessSessions: index({ byPid: { 777: { pid: 777, tmux: 'agentop-gonefromregistry:@0.%0' } } }),
     })
     expect(views.filter(v => v.status === 'external')).toHaveLength(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// ONE — duplicate rows. A conversation reopened N times left N `exited` rows
+// beside its one live continuation, because the row key is the per-spawn
+// managedId, not the conversation. `collapseSupersededSessions` drops a
+// predecessor ONLY when it is provably dead (endedMs) AND superseded.
+// ---------------------------------------------------------------------------
+describe('collapseSupersededSessions', () => {
+  const sv = (id: string, o: Partial<SessionView> = {}): SessionView => ({
+    id, cwd: '/repo/a', status: 'exited', attached: false, approvalDetection: true,
+    searchFields: { name: '', folder: '', harness: '', note: '', task: '', prompt: '' },
+    ...o,
+  })
+
+  it('drops a retired predecessor when a LIVE row drives the same conversation', () => {
+    const rows = [
+      sv('live', { status: 'running', conversationId: 'c1', createdMs: 2000 }),
+      sv('dead', { status: 'exited', conversationId: 'c1', createdMs: 1000, endedMs: 1500 }),
+    ]
+    const out = collapseSupersededSessions(rows)
+    expect(out.map(v => v.id)).toEqual(['live'])
+  })
+
+  it('keeps the NEWEST ended row when nothing is live, and drops the older ended ones', () => {
+    const rows = [
+      sv('old1', { conversationId: 'c1', createdMs: 1000, endedMs: 1100 }),
+      sv('old2', { conversationId: 'c1', createdMs: 2000, endedMs: 2100 }),
+      sv('newest', { conversationId: 'c1', createdMs: 3000, endedMs: 3100 }),
+    ]
+    const out = collapseSupersededSessions(rows)
+    // The newest ended row survives — it is the reopenable representative of the conversation.
+    expect(out.map(v => v.id)).toEqual(['newest'])
+  })
+
+  // NEGATIVE — the guarantee the coordinator reads this list for.
+  it('NEVER drops a live row, even when it shares a conversation with another live row', () => {
+    const rows = [
+      sv('liveA', { status: 'running', conversationId: 'c1', createdMs: 1000 }),
+      sv('liveB', { status: 'running', conversationId: 'c1', createdMs: 2000 }),
+    ]
+    const out = collapseSupersededSessions(rows)
+    expect(out.map(v => v.id).sort()).toEqual(['liveA', 'liveB'])
+  })
+
+  it('NEVER drops a row it cannot prove is dead — a lost row with no end time is kept', () => {
+    const rows = [
+      sv('live', { status: 'running', conversationId: 'c1', createdMs: 2000 }),
+      // `lost` with no endedMs: the backend cannot see it, which is not proof the process is gone.
+      sv('unproven', { status: 'lost', conversationId: 'c1', createdMs: 1000 }),
+    ]
+    const out = collapseSupersededSessions(rows)
+    expect(out.map(v => v.id).sort()).toEqual(['live', 'unproven'])
+  })
+
+  it('never collapses genuinely distinct sessions — different conversations both stay', () => {
+    const rows = [
+      sv('a', { status: 'exited', conversationId: 'c1', createdMs: 1000, endedMs: 1100 }),
+      sv('b', { status: 'exited', conversationId: 'c2', createdMs: 1000, endedMs: 1100 }),
+    ]
+    const out = collapseSupersededSessions(rows)
+    expect(out.map(v => v.id).sort()).toEqual(['a', 'b'])
+  })
+
+  it('never groups rows with NO conversationId — a shared directory is not an identity', () => {
+    const rows = [
+      sv('a', { status: 'exited', createdMs: 1000, endedMs: 1100 }),
+      sv('b', { status: 'exited', createdMs: 2000, endedMs: 2100 }),
+    ]
+    const out = collapseSupersededSessions(rows)
+    expect(out.map(v => v.id).sort()).toEqual(['a', 'b'])
+  })
+
+  it('the whole pipeline: a reopen chain collapses to one row through buildSessionViews', () => {
+    const m = (id: string, o: Partial<ManagedSession> = {}): ManagedSession => ({
+      id, harness: 'claude', cwd: '/repo/a', createdAt: '2026-08-14T10:00:00.000Z',
+      conversationId: 'conv', ...o,
+    })
+    const reconciled: ReconciledSession[] = [
+      { id: 'r1', managed: m('r1', { createdAt: '2026-08-14T10:00:00.000Z', endedAt: '2026-08-14T11:00:00.000Z' }), status: 'lost' },
+      { id: 'r2', managed: m('r2', { createdAt: '2026-08-14T12:00:00.000Z', endedAt: '2026-08-14T13:00:00.000Z' }), status: 'lost' },
+      {
+        id: 'r3', managed: m('r3', { createdAt: '2026-08-14T14:00:00.000Z' }),
+        backend: { id: 'r3', createdMs: 5000, attached: false, alive: true, lastActivityMs: 5000 },
+        status: 'running',
+      },
+    ]
+    const views = buildSessionViews({ reconciled, activity: new Map([['r3', 'working']]), processes: [] })
+    const forConv = views.filter(v => v.conversationId === 'conv')
+    expect(forConv.map(v => v.id)).toEqual(['r3'])
+    expect(forConv[0]!.status).toBe('running')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// TWO — a title is an identity. The `/rename` name lived only in the harness's
+// own file, which it deletes on exit; the title then flipped and CTRL+F broke.
+// The poller persists the name into the registry, so buildSessionViews reads it
+// even when the live file is gone.
+// ---------------------------------------------------------------------------
+describe('title survives the process (persisted harness name)', () => {
+  const m = (id: string, o: Partial<ManagedSession> = {}): ManagedSession => ({
+    id, harness: 'claude', cwd: '/repo/a', createdAt: '2026-08-14T10:00:00.000Z', ...o,
+  })
+
+  it('a finished row (no live file) still carries its persisted /rename name', () => {
+    const [v] = buildSessionViews({
+      reconciled: [{
+        id: 'm1',
+        managed: m('m1', { label: 'Integrar CLI', harnessName: 'AIPE + agentop CLI', harnessNameSince: 42, endedAt: '2026-08-14T11:00:00.000Z' }),
+        status: 'lost',
+      }],
+      activity: new Map(),
+      processes: [],
+      // No harnessSessions entry — the process is gone, the file deleted.
+    })
+    expect(v!.harnessName).toBe('AIPE + agentop CLI')
+    expect(v!.harnessNameSince).toBe(42)
+  })
+
+  it('the LIVE file still wins while the session runs — persistence is only a fallback', () => {
+    const [v] = buildSessionViews({
+      reconciled: [{ id: 'm1', managed: m('m1', { harnessName: 'stale name', harnessNameSince: 1 }), status: 'lost' }],
+      activity: new Map(),
+      processes: [],
+      harnessSessions: {
+        byManagedId: new Map([['m1', { name: 'fresh name', nameSince: 99 }]]),
+        byPid: new Map(), byConversation: new Map(),
+      } as never,
+    })
+    expect(v!.harnessName).toBe('fresh name')
+    expect(v!.harnessNameSince).toBe(99)
   })
 })

--- a/packages/server/server/sessions/session-view.ts
+++ b/packages/server/server/sessions/session-view.ts
@@ -213,6 +213,77 @@ function rankOf(v: SessionView): number {
 }
 
 /**
+ * Collapse a session's RETIRED predecessors against its own continuation — PURE, and keyed on the
+ * one thing that is an identity rather than a guess: the harness's `conversationId`.
+ *
+ * ## Why this exists
+ *
+ * A session's durable identity is its CONVERSATION, but the registry keys a record by the per-spawn
+ * `managedId`. Every attach / reopen / restart mints a NEW managedId for the SAME conversation and
+ * retires the old record (`endedAt`) without removing it — so `reconcileSessions` returns one record
+ * per spawn and `buildSessionViews` draws one row per record. A conversation reopened five times
+ * therefore stood on screen as five `exited` rows beside its one live continuation, all wearing the
+ * same name. Measured here: 18 conversations held more than one record, 36 rows of pure history that
+ * a person reads as "this session is open many times over".
+ *
+ * ## What it may and may NOT drop — the guarantee
+ *
+ * The coordinator reads this list to decide whether to re-dispatch over work in flight, so a row it
+ * cannot prove is dead is NEVER hidden. A row is dropped only when BOTH hold:
+ *
+ *  1. it is PROVABLY dead — `endedMs` is set, which means the system retired or the user finished it;
+ *     a `lost` row with no end time (a reboot, say) is never touched, because "the backend cannot see
+ *     it right now" is not proof the process is gone; and
+ *  2. it is SUPERSEDED — the same conversation has either a LIVE row (running / unregistered) or a
+ *     strictly newer ended row. That sibling IS this session, continued, so the predecessor is its
+ *     own history, not a second session.
+ *
+ * Consequences, each deliberate:
+ *  - a LIVE row is never dropped (it has no `endedMs`);
+ *  - the newest ended row of a conversation with nothing live is KEPT — it is the reopenable
+ *    representative, and a finished session the user wants back must still be there;
+ *  - rows with NO `conversationId` are never grouped and never collapsed: two sessions that merely
+ *    share a directory or a label are genuinely distinct, and the list telling the truth about them
+ *    is the whole point — the fix is identity, never appearance.
+ *
+ * Two rows with the SAME `conversationId` cannot be distinct sessions: it is the harness's own id for
+ * one conversation. So this never merges two real sessions — only a session with its own past lives.
+ */
+export function collapseSupersededSessions(managed: readonly SessionView[]): SessionView[] {
+  const groups = new Map<string, SessionView[]>()
+  for (const v of managed) {
+    if (!v.conversationId) continue
+    const arr = groups.get(v.conversationId) ?? []
+    arr.push(v)
+    groups.set(v.conversationId, arr)
+  }
+
+  const drop = new Set<string>()
+  for (const group of groups.values()) {
+    if (group.length < 2) continue
+    const hasLive = group.some(v => v.status === 'running' || v.status === 'unregistered')
+    // The reopenable representative when nothing is live: the newest by start time, id as a
+    // deterministic tiebreak so the same fleet always keeps the same row.
+    const newest = group.reduce((a, b) => {
+      const am = a.createdMs ?? -Infinity
+      const bm = b.createdMs ?? -Infinity
+      if (bm !== am) return bm > am ? b : a
+      return b.id > a.id ? b : a
+    })
+    for (const v of group) {
+      // Rule 1: only a row proven ended may go. A live row (no `endedMs`) and a `lost` row with no
+      // recorded end are both kept, whatever else the group holds.
+      if (v.endedMs === undefined) continue
+      // Rule 2: dropped only when a continuation supersedes it — anything live retires every dead
+      // predecessor; otherwise all but the newest ended row.
+      if (hasLive || v !== newest) drop.add(v.id)
+    }
+  }
+
+  return managed.filter(v => !drop.has(v.id))
+}
+
+/**
  * An id for an external process that is STABLE across polls and unique per process.
  *
  * The start time is what does both jobs: it distinguishes two assistants of the same harness open
@@ -403,7 +474,16 @@ export function buildSessionViews(o: {
     // What the harness says about ITSELF, matched by the tmux session it recorded — the one exact
     // link between its record and this row.
     const own: HarnessSessionFile | undefined = o.harnessSessions?.byManagedId.get(r.id)
-    const ownName = chosenName(own)
+    // The live harness file when there is one, ELSE the name the poller persisted while there was.
+    // Claude deletes `~/.claude/sessions/<pid>.json` the instant the process ends, so a finished
+    // session's `/rename` name lives only in the registry copy — without this fallback the title
+    // flipped to a different source on finish and `CTRL+F` stopped finding the row by the name it
+    // wore a second earlier. A title is an identity; it must not change because the process died.
+    const ownName = chosenName(own) ?? r.managed?.harnessName
+    // The recency stamp travels with whichever name won: the live file's `nameSince` while alive,
+    // the persisted mirror once it is gone. `pickTitle` then settles the label-vs-harness contest
+    // identically in both states.
+    const ownNameSince = own?.nameSince ?? r.managed?.harnessNameSince
     // A session the user FINISHED reports `exited` whatever the backend still holds: the row exists
     // to be reopened, and calling it `running` because a dead tmux pane lingers would put it back
     // among the things you can talk to.
@@ -433,7 +513,7 @@ export function buildSessionViews(o: {
       ...(r.managed?.label ? { label: r.managed.label } : {}),
       ...(r.managed?.labelSince !== undefined ? { labelSince: r.managed.labelSince } : {}),
       ...(ownName ? { harnessName: ownName } : {}),
-      ...(ownName && own?.nameSince !== undefined ? { harnessNameSince: own.nameSince } : {}),
+      ...(ownName && ownNameSince !== undefined ? { harnessNameSince: ownNameSince } : {}),
       ...(r.managed?.note ? { note: r.managed.note } : {}),
       ...(r.managed?.model ? { model: r.managed.model } : {}),
       ...(r.managed?.effort ? { effort: r.managed.effort } : {}),
@@ -699,7 +779,10 @@ export function buildSessionViews(o: {
       }
     })
 
-  return [...managed, ...external, ...closed].sort((a, b) => {
+  // Retired predecessors are dropped LAST, so everything above — the external-twin dedup and the
+  // closed-history cover set — still reasons over the full managed list. Only the final rows the
+  // reader sees lose the superseded duplicates; the registry itself is untouched.
+  return [...collapseSupersededSessions(managed), ...external, ...closed].sort((a, b) => {
     const byRank = rankOf(a) - rankOf(b)
     if (byRank !== 0) return byRank
     return (b.createdMs ?? 0) - (a.createdMs ?? 0)

--- a/packages/server/server/sessions/sessions-host.test.ts
+++ b/packages/server/server/sessions/sessions-host.test.ts
@@ -294,3 +294,51 @@ describe('the dialog a blocked session is showing', () => {
     expect((await p.poll()).sessions[0]!.approvalLines).toBeUndefined()
   })
 })
+
+describe('persisting the harness /rename name', () => {
+  const index = (byManagedId: Record<string, Record<string, unknown>>) => async () => ({
+    byManagedId: new Map(Object.entries(byManagedId)),
+    byPid: new Map(), byConversation: new Map(),
+  } as never)
+
+  it('persists a name a person typed, exactly once, and only when it CHANGES', async () => {
+    const calls: { id: string; name: string; since?: number }[] = []
+    const p = createSessionsPoller({
+      backend: fakeBackend({ sessions: [backendSession('m1')], frames: { m1: ['x'] } }),
+      readRegistry: async () => [managed('m1')],
+      scanProcesses: async () => ({ procs: [] }),
+      now: () => NOW,
+      loadHarnessSessions: index({ m1: { name: 'MAIN', nameSince: 7, tmux: 'agentop-m1:@0.%0' } }),
+      recordHarnessName: async (id, name, since) => { calls.push({ id, name, ...(since !== undefined ? { since } : {}) }) },
+    })
+    await p.poll()
+    expect(calls).toEqual([{ id: 'm1', name: 'MAIN', since: 7 }])
+
+    // Registry now already holds the name — the next poll must not write again.
+    calls.length = 0
+    const p2 = createSessionsPoller({
+      backend: fakeBackend({ sessions: [backendSession('m1')], frames: { m1: ['x'] } }),
+      readRegistry: async () => [managed('m1', { harnessName: 'MAIN', harnessNameSince: 7 })],
+      scanProcesses: async () => ({ procs: [] }),
+      now: () => NOW,
+      loadHarnessSessions: index({ m1: { name: 'MAIN', nameSince: 7, tmux: 'agentop-m1:@0.%0' } }),
+      recordHarnessName: async (id, name, since) => { calls.push({ id, name, ...(since !== undefined ? { since } : {}) }) },
+    })
+    await p2.poll()
+    expect(calls).toEqual([])
+  })
+
+  it('never persists a name the harness invented for itself', async () => {
+    const calls: unknown[] = []
+    const p = createSessionsPoller({
+      backend: fakeBackend({ sessions: [backendSession('m1')], frames: { m1: ['x'] } }),
+      readRegistry: async () => [managed('m1')],
+      scanProcesses: async () => ({ procs: [] }),
+      now: () => NOW,
+      loadHarnessSessions: index({ m1: { name: 'agentistics-77', nameSource: 'derived', tmux: 'agentop-m1:@0.%0' } }),
+      recordHarnessName: async (...a) => { calls.push(a) },
+    })
+    await p.poll()
+    expect(calls).toEqual([])
+  })
+})

--- a/packages/server/server/sessions/sessions-host.ts
+++ b/packages/server/server/sessions/sessions-host.ts
@@ -22,6 +22,7 @@ import { planAdoptions } from './session-adopt'
 import { loadConversations, type Conversation } from './conversations'
 import { HEARTBEAT_MS, planCrashGroup, type CrashGroup } from './crash-group'
 import { emptyHarnessSessionIndex, type HarnessSessionIndex } from './harness-sessions'
+import { chosenName } from './harness-session-file'
 import { reconcileSessions } from './session-ref'
 import {
   attentionCount, bellTransitions, buildSessionViews, type SessionView,
@@ -121,6 +122,17 @@ export function createSessionsPoller(o: {
    * conversation.
    */
   recordConversation?: (id: string, conversationId: string) => Promise<unknown>
+  /**
+   * Persist the name a managed row was given INSIDE the harness (`/rename`), so the title survives
+   * the process.
+   *
+   * Mirror of `recordConversation`, and for the same reason: the harness deletes its own session
+   * file when the process ends, so a name that lived only there is lost the instant the session
+   * finishes — the displayed title then flips to a different source and `CTRL+F` can no longer find
+   * the row by the name it wore a moment ago. Called ONLY when the live, non-derived name disagrees
+   * with what the registry already holds, so it writes once per rename and not once per poll.
+   */
+  recordHarnessName?: (id: string, name: string, since?: number) => Promise<unknown>
   /**
    * Write registry records for sessions the backend is running and the registry has lost.
    *
@@ -277,6 +289,18 @@ export function createSessionsPoller(o: {
           const exact = harnessSessions.byManagedId.get(m.id)?.sessionId
           if (!exact || m.conversationId === exact) continue
           await o.recordConversation(m.id, exact).catch(() => undefined)
+        }
+      }
+
+      // The `/rename` name, captured WHILE there is still a harness file to read it from, so the
+      // title outlives the process. Only a name a PERSON typed (`chosenName` drops the harness's own
+      // invented `agentistics-77`), and only when it CHANGED — one write per rename, never per poll.
+      if (o.recordHarnessName) {
+        for (const m of registry) {
+          const file = harnessSessions.byManagedId.get(m.id)
+          const name = chosenName(file)
+          if (!name || (m.harnessName === name && m.harnessNameSince === file?.nameSince)) continue
+          await o.recordHarnessName(m.id, name, file?.nameSince).catch(() => undefined)
         }
       }
 

--- a/packages/server/server/sessions/types.ts
+++ b/packages/server/server/sessions/types.ts
@@ -214,6 +214,29 @@ export interface ManagedSession {
    * never as "no repository", so an older row simply behaves as it always did.
    */
   repo?: RepoFacts
+  /**
+   * The name the user gave this session FROM INSIDE the harness (Claude Code's `/rename`), captured
+   * while the session was alive so it OUTLIVES the process.
+   *
+   * A title is an identity: whatever a session is called while it runs, it stays called after it
+   * ends. But that name lives only in the harness's own `~/.claude/sessions/<pid>.json`, which Claude
+   * DELETES when the process exits — so a session that showed a `/rename` name while running lost it
+   * the instant it finished, the displayed title fell back to a different source, and `CTRL+F` could
+   * no longer find the row by the name it had a second earlier. The poller persists the LIVE,
+   * non-derived name here (via `chosenName`) the moment it sees it, so the title is stable across the
+   * running -> finished transition. Only a name a PERSON typed is stored: a harness-invented
+   * `agentistics-77` never reaches this field, so it can never displace an agentop label. See
+   * `pickTitle` and `harness-session-file.ts`.
+   *
+   * Absent for a session that was never `/rename`d, and on a row written by a build predating this —
+   * both read exactly as they did before (the live file, when present, still wins).
+   */
+  harnessName?: string
+  /** When `harnessName` was set inside the harness, epoch ms — the recency side of the title
+   *  contest, mirrored from the harness's own `nameSince` so `pickTitle` settles it the same way
+   *  whether the session is alive (live file) or finished (this persisted copy). Absent on a claude
+   *  older than 2.1.232, which writes the name with no timestamp. */
+  harnessNameSince?: number
 }
 
 /**

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentistics/tui",
-  "version": "1.22.3",
+  "version": "1.22.4",
   "private": true,
   "type": "module",
   "main": "src/control/index.ts",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentistics/web",
-  "version": "1.22.3",
+  "version": "1.22.4",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

- **ONE — duplicate rows.** The same conversation was drawn as many rows (one per spawn record); now a superseded, provably-dead predecessor is collapsed against its live/newest continuation. Live rows are never hidden.
- **TWO — title changed on finalise (broke CTRL+F).** The `/rename` name is now persisted while the session is alive, so the title is the same before and after it finishes.
- **THREE — persisted search-scope preference** for the cockpit's cumulative search scopes (dependency of `j-20260826-fi`). API declared below.

Closes #239

## Diagnosis — one cause or two?

**One root cause, two distinct code sites.** A session's durable identity is its **conversation**, but the code keyed the row and derived the title from **ephemeral, per-spawn** state.

- **ONE** — every attach / reopen / restart mints a new `managedId` for the same conversation and retires the old record (`endedAt`) without removing it. `reconcileSessions` yields one `ReconciledSession` per record; **`buildSessionViews` (`session-view.ts:401`) maps them 1:1** — that map is the specific line that produces the extra row. Retired records accumulate, so a conversation reopened N times draws N `exited` rows beside its live one.
- **TWO** — the title is derived at render time by **`pickTitle` (`harness-session-file.ts:216-217`, `if (!harness) return {title: label}`)** from the harness's `~/.claude/sessions/<pid>.json`, which Claude **deletes** when the process ends (so `own`/`ownName` at `session-view.ts:405` is `undefined` after finish). While running a `/rename` name wins the contest; on finish it is gone and the title falls back to the label or the derived fallback.

The coordinator's hypothesis (finalise creates a new record) is **true for the reopen/attach path** — that is exactly what accumulates ONE's rows. But TWO happens to a **single** record with no new record created: the title flips purely because the ephemeral source vanished. So: same class (identity from ephemeral per-spawn state), **two separate mechanisms, two separate fixes.**

### Reproduced on this machine (before)

Driven through the real pipeline against the live registry (110 records):

```
ONE: 18 conversations held >1 record  ->  36 extra rows
     COORDENADOR conv ed808e9b: df77a1a879 (running) + 58bb52ce2a (exited)   [+ a genuinely distinct closed conv f32ddf59 -> 3 rows total]
     Integrar CLI conv b9665719: 6 rows
TWO: 10 live sessions whose title changes on finalise, e.g.
     a7a69ddd8d  RUNNING "AIPE + agentop CLI"  ->  FINISHED "Integrar CLI do agentop com aipe..."
     external    RUNNING "COORDENADOR"         ->  FINISHED "claude in aipe-blpsoares"
```

### After (real `ls --json`)

```
total rows: 122 -> 86        (36 duplicate rows removed)
conversations in >1 row: 0
COORDENADOR: 3 -> 2 rows     df77a1a879 (running, kept) + closed:f32ddf59 (a DISTINCT earlier conversation, truthful & reopenable)
                             the dead duplicate 58bb52ce2a (same conv as the running one) collapsed
running rows: all 4 preserved (Victor, Jesse, Skyler, COORDENADOR)  -- no live session hidden
TWO: a finished row with the harness file gone but harnessName persisted keeps its title "AIPE + agentop CLI"
```

The third `COORDENADOR` (`closed:f32ddf59`) is a **genuinely distinct conversation** (a different harness conversation id, from before the socket/id change the coordinator observed). Merging it with the running `ed808e9b` would require inferring that two conversation ids are one session, which cannot be proven — so it stays, truthful and reopenable. This is the "list is truthful; fix is presentation, say so plainly" branch, not a bug to hide.

## Fix — identity, not appearance

- **`collapseSupersededSessions` (pure, `session-view.ts`)** — drops a predecessor **only** when BOTH hold: (1) it is provably dead (`endedMs` set), and (2) it is superseded by a same-`conversationId` sibling (a live row, or a strictly newer ended one). It **never** hides a live row, a `lost` row with no recorded end, or the newest ended row (the reopenable representative); rows with **no** `conversationId` are never grouped (a shared directory/label is not an identity). Applied at the `buildSessionViews` return, so the external-twin dedup and closed-history cover set still reason over the full managed list, and the **registry is untouched**.
- **Persisted `/rename` name** — `ManagedSession.harnessName` / `harnessNameSince` (+ `SessionPatch`). The poller persists the live, non-derived name (`chosenName`) when it changes — a mirror of `recordConversation`, one write per rename — and `buildSessionViews` reads it as the fallback when the live harness file is gone. `pickTitle` then returns the same title alive or finished. Injected only by the daemon poller; `ls` (one-shot) reads and never writes.

## THREE — the preference API (Skyler's dependency, declared)

The persisted search-scope preference lives **inside `sessionView`**, so it rides the existing `setSessionView` / `PUT /api/preferences` whole-object write — no new route, no new setter, no new `ControlHost` method.

```ts
// packages/server/server/preferences.ts
Preferences.sessionView.searchScopes?: SearchScope[]   // SearchScope from @agentistics/tui/control/search-scope

DEFAULT_SESSION_SEARCH_SCOPES: SearchScope[]           // all own fields, transcript OUT (opt-in)
resolveSessionSearchScopes(p: Preferences): SearchScope[]  // undefined -> default; validates + dedups + canonical order; [] is a real empty choice
```

**For `j-20260826-fi`:** add `searchScopes?: SearchScope[]` to the TUI's `SessionViewPrefs` and include it in the object you pass to `setSessionView`; read it back from the persisted `sessionView`. The "all" control is simply every scope present in the array. Changing this shape later is an escalation, not a silent edit.

## Changes

- `packages/server/server/sessions/session-view.ts` — `collapseSupersededSessions` + applied at return; persisted-name fallback in `buildSessionViews`.
- `packages/server/server/sessions/sessions-host.ts` — `recordHarnessName` hook + persist-on-change in the poll loop.
- `packages/server/server/sessions/types.ts`, `registry.ts` — `harnessName`/`harnessNameSince` on `ManagedSession` and `SessionPatch`.
- `packages/server/server/cli-start.ts` — inject `recordHarnessName` in the daemon poller.
- `packages/server/server/preferences.ts` — `sessionView.searchScopes` + `DEFAULT_SESSION_SEARCH_SCOPES` + `resolveSessionSearchScopes`.
- Tests: `session-view.test.ts`, `sessions-host.test.ts`, `preferences.test.ts`.
- Docs: `docs/session-manager.md`, `CLAUDE.md`.

## Test plan

- [x] `bun tsc --noEmit` clean; `bun test` — 4450 pass, 0 fail (pre-commit hook).
- [x] **RED→GREEN, ONE**: collapse drops the retired predecessor beside a live/newer row; end-to-end reopen chain collapses to one row through `buildSessionViews`.
- [x] **Negative (the guarantee)**: a live row is never dropped (even two live rows of one conversation); a `lost` row with no `endedMs` is never dropped; distinct conversations and rows with no `conversationId` are never merged.
- [x] **RED→GREEN, TWO**: a finished row with no live file keeps its persisted `/rename` name; the live file still wins while running.
- [x] Poller persists a person-typed name once and only on change; never persists a harness-invented (`derived`) name.
- [x] **THREE**: `resolveSessionSearchScopes` — default when unset, validated/deduped/ordered when set, empty-array honoured, unknown values dropped.
- [x] Driven against this machine's real session list — before/after both shown above; `--group task`, `--group project`, `--json` verified still correct.
