### PR TITLE
fix(sessions): confirm the waiting state and guarantee the initial prompt lands

### DIFF
--- a/docs/session-manager.md
+++ b/docs/session-manager.md
@@ -312,10 +312,20 @@ CLI, so it exists only for the harnesses that were probed (claude, codex, kimi).
 harness a blocking question shows as `waiting` — still counted, still surfaced, but the reason
 cannot be named. `ls` and `list` both say so rather than leaving you to assume otherwise.
 
-The states are also honest about their own timing. When a turn ends, the poll that *observes* it
-ending sees a frame that changed since the last one, which is movement — so the session reads
-`working` for that one interval before settling on `waiting`. The signal is therefore at most one
-interval late and never early, which is the right way round for something a person acts on.
+The states are also honest about their own timing, and deliberately biased. A single frame is a
+noisy sample: a session that has just finished a turn, or one whose pane a plugin repainted for a
+moment, reads `working` on one poll and `waiting` on the next with nothing about it having changed.
+Believing that lone `waiting` is how the counter came to say "waiting on you" about a session that
+had already gone back to work — a false summons that wastes the most expensive resource here and,
+once it has cried wolf, stops being read. So the two directions are confirmed differently
+(`attention-confirm.ts`): **`waiting` and `NEEDS APPROVAL` are believed only once the same reading
+has held for two consecutive polls**, while a return to `working` (a screen that moved — unambiguous
+proof) and `exited` are believed at once. The counter therefore never spikes on a single quiet
+frame, and it DROPS on the very next poll after work resumes. The cost is that a genuine wait takes
+one extra interval to appear — the cheap direction, since a slightly late "needs you" only delays a
+person while a false one wastes them. The event channel (`agentop events`) confirms every transition
+the same way for the same reason, so the two surfaces agree on when a session starts waiting; the
+fleet display just clears it a poll sooner.
 
 ## Harness support
 
@@ -330,6 +340,20 @@ interval late and never early, which is the right way round for something a pers
 
 `kimi` and `copilot` have no flag for an initial prompt in an interactive session — their `-p` runs
 one prompt non-interactively and exits — so agentop types the prompt in once the session is up.
+
+**Delivering the initial prompt is READINESS-GATED** (`initial-prompt.ts`), not a fixed sleep. A
+detached session created with a prompt has to receive it with no human in the loop, and two things
+used to break that silently: a slow-starting harness lost a prompt typed after a fixed 1200 ms into
+a pane that had not drawn yet, and a positional prompt was left entirely to the CLI to auto-submit —
+which some versions do not do (the prompt "stays in the field" and the agent sits waiting for
+something that already arrived). So agentop now polls the pane and delivers only once the harness is
+genuinely ready — its input surface drawn, and NOT sitting on a startup/approval dialog — and then
+once: a typed harness has its text typed and submitted; a positional harness whose "working" marker
+lets us tell an auto-submitted turn from an idle prompt (claude) gets a single Enter to submit the
+pre-filled text, but only after it has sat idle for a few polls without ever running, so a CLI that
+DOES auto-submit is never double-submitted. It is never delivered into a dialog — launched in a
+folder it does not yet trust, claude opens with a trust prompt whose default is "No, exit", and a
+blind early Enter would select it and kill the session.
 
 Codex's reasoning effort is a `-c key=value` configuration override rather than a flag; it is not
 wired up because the key could not be verified from the CLI itself, and agentop does not guess flags.

--- a/packages/server/server/cli-start.ts
+++ b/packages/server/server/cli-start.ts
@@ -1509,7 +1509,11 @@ async function spawnManaged(req: {
       id,
       cwd: req.cwd,
       argv: planned.plan.argv,
-      ...(planned.plan.sendKeys ? { sendKeys: planned.plan.sendKeys } : {}),
+      // Deliver the initial prompt once the harness is ready (see `initial-prompt.ts`). The harness's
+      // screen rules ride along so the backend can tell an idle prompt from a startup dialog.
+      ...(planned.plan.initialPrompt
+        ? { initialPrompt: { ...planned.plan.initialPrompt, ...(rulesFor(req.harness) ? { rules: rulesFor(req.harness)! } : {}) } }
+        : {}),
     })
   } catch (e) {
     return { ok: false, message: s.sessSpawnFailed(e instanceof Error ? e.message : String(e)) }

--- a/packages/server/server/sessions/attention-confirm.test.ts
+++ b/packages/server/server/sessions/attention-confirm.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'bun:test'
+import type { SessionActivity } from './types'
+import { EMPTY_CONFIRM_MEMORY, confirmActivities, type ConfirmMemory } from './attention-confirm'
+
+/** Drive one poll: feed a raw reading per session, get the CONFIRMED reading back. */
+function step(
+  memory: ConfirmMemory,
+  raw: Record<string, SessionActivity>,
+): { out: Record<string, SessionActivity>; memory: ConfirmMemory } {
+  const r = confirmActivities(memory, new Map(Object.entries(raw)))
+  return { out: Object.fromEntries(r.activities), memory: r.memory }
+}
+
+describe('confirmActivities', () => {
+  it('believes a first sighting as read — nothing prior to contradict it', () => {
+    const { out } = step(EMPTY_CONFIRM_MEMORY, { a: 'waiting', b: 'working' })
+    expect(out).toEqual({ a: 'waiting', b: 'working' })
+  })
+
+  it('does NOT flip to waiting on a single quiet poll — the reported false positive', () => {
+    // A session confirmed working, then ONE poll reads quiet. That single reading is not yet a fact:
+    // the fleet must not assert a person is needed on the strength of one frame.
+    let m = EMPTY_CONFIRM_MEMORY
+    ;({ memory: m } = step(m, { a: 'working' }))
+    ;({ memory: m } = step(m, { a: 'working' }))
+    const { out } = step(m, { a: 'waiting' })
+    expect(out.a).toBe('working') // held, not the raw 'waiting'
+  })
+
+  it('believes waiting only once it is seen on two consecutive polls', () => {
+    let m = EMPTY_CONFIRM_MEMORY
+    ;({ memory: m } = step(m, { a: 'working' }))
+    let r = step(m, { a: 'waiting' })
+    expect(r.out.a).toBe('working') // first waiting reading — held
+    r = step(r.memory, { a: 'waiting' })
+    expect(r.out.a).toBe('waiting') // confirmed on the second
+  })
+
+  it('clears waiting the moment work resumes — the asymmetry, believed at once', () => {
+    // Confirm a waiting state, then the session moves. A screen that moved is unambiguous proof of
+    // work, and clearing attention fast is the cheap direction — so it is adopted on the NEXT sample.
+    let m = EMPTY_CONFIRM_MEMORY
+    ;({ memory: m } = step(m, { a: 'waiting' }))
+    ;({ memory: m } = step(m, { a: 'waiting' })) // confirmed waiting
+    const { out } = step(m, { a: 'working' })
+    expect(out.a).toBe('working')
+  })
+
+  it('the count drops on the sample after work resumes', () => {
+    const count = (o: Record<string, SessionActivity>) =>
+      Object.values(o).filter(a => a === 'waiting' || a === 'waiting-approval').length
+    let m = EMPTY_CONFIRM_MEMORY
+    let r = step(m, { a: 'waiting', b: 'waiting' })
+    r = step(r.memory, { a: 'waiting', b: 'waiting' }) // both confirmed waiting
+    expect(count(r.out)).toBe(2)
+    r = step(r.memory, { a: 'working', b: 'waiting' }) // a resumes
+    expect(count(r.out)).toBe(1) // fell on the very next sample
+  })
+
+  it('does not flicker on waiting -> (repaint) -> waiting', () => {
+    // The event-plan flicker, on the fleet: a cosmetic repaint moves the frame for one poll.
+    let m = EMPTY_CONFIRM_MEMORY
+    ;({ memory: m } = step(m, { a: 'waiting' }))
+    let r = step(m, { a: 'waiting' }) // confirmed waiting
+    expect(r.out.a).toBe('waiting')
+    r = step(r.memory, { a: 'working' }) // the repaint — one frame
+    expect(r.out.a).toBe('working') // movement is believed at once (cheap direction)
+    r = step(r.memory, { a: 'waiting' }) // back to quiet
+    // Held at working for this poll (single new waiting reading), then confirmed next — never a
+    // duplicate needs-you spike from a one-frame twitch.
+    expect(r.out.a).toBe('working')
+    r = step(r.memory, { a: 'waiting' })
+    expect(r.out.a).toBe('waiting')
+  })
+
+  it('adopts exited immediately — a dead session is not held as working', () => {
+    let m = EMPTY_CONFIRM_MEMORY
+    ;({ memory: m } = step(m, { a: 'working' }))
+    ;({ memory: m } = step(m, { a: 'working' }))
+    const { out } = step(m, { a: 'exited' })
+    expect(out.a).toBe('exited')
+  })
+
+  it('escalates waiting -> waiting-approval only once confirmed', () => {
+    let m = EMPTY_CONFIRM_MEMORY
+    ;({ memory: m } = step(m, { a: 'waiting' }))
+    ;({ memory: m } = step(m, { a: 'waiting' })) // confirmed waiting
+    let r = step(m, { a: 'waiting-approval' })
+    expect(r.out.a).toBe('waiting') // one reading — held at the last confirmed needs-you state
+    r = step(r.memory, { a: 'waiting-approval' })
+    expect(r.out.a).toBe('waiting-approval')
+  })
+
+  it('forgets sessions that leave the fleet — memory cannot grow unbounded', () => {
+    let m = EMPTY_CONFIRM_MEMORY
+    ;({ memory: m } = step(m, { a: 'working', b: 'working' }))
+    const r = step(m, { a: 'working' }) // b is gone
+    expect(r.memory.confirmed.has('b')).toBe(false)
+    expect(r.memory.lastRaw.has('b')).toBe(false)
+  })
+})

--- a/packages/server/server/sessions/attention-confirm.ts
+++ b/packages/server/server/sessions/attention-confirm.ts
@@ -1,0 +1,118 @@
+/**
+ * attention-confirm.ts — PURE. Turns the fleet's INSTANTANEOUS per-poll reading into a CONFIRMED
+ * one, so the "needs you" counter stops lying.
+ *
+ * ## The defect this exists for
+ *
+ * `attention.ts` answers "what is this session doing" from a SINGLE frame, and it is right to: for
+ * the several harnesses whose only working signal is movement, "the screen moved, so it is working"
+ * is the only rule there is. But a single frame is a noisy sample. A session that has just finished
+ * a turn, or one whose pane a plugin repainted for a moment, reads `working` on one poll and
+ * `waiting` on the next with nothing about the session having changed — and a coordinator operating
+ * a fleet reported being sent to a session as "waiting on you" that had already gone back to work.
+ * The written rule in that workspace became "do not trust the activity field; read the pane with
+ * `tmux capture-pane`" — which is exactly the manual work the monitor exists to remove.
+ *
+ * ## The asymmetry that shapes the rule
+ *
+ * Getting these two states wrong does NOT cost the same. Saying "working" about a session that has
+ * stopped merely delays a person by one poll. Saying "needs you" about a session that is moving
+ * WASTES the person — the most expensive resource here — and, worse, corrodes trust in the
+ * indicator; once it has cried wolf, it stops being read, and that cost is permanent. So the two
+ * directions are confirmed differently:
+ *
+ *  - **Returning to work (`working`) and exiting (`exited`) are believed at once.** A screen that
+ *    moved is unambiguous proof, and clearing attention eagerly is the cheap error — a person is
+ *    never sent to a session that has already resumed. This also makes the counter DROP on the very
+ *    next sample after work resumes, which is the behaviour a person watching the fleet expects.
+ *  - **`waiting` and `waiting-approval` — the states that summon a person — are believed only once
+ *    the same reading has been seen on TWO CONSECUTIVE polls.** A one-frame quiet or a cosmetic
+ *    repaint never reaches the counter; genuine attention holds the screen for longer than one
+ *    interval and is confirmed on the following poll (one interval of latency, the cheap direction).
+ *
+ * ## Relationship to `event-plan.ts`
+ *
+ * The event channel confirms EVERY transition on two polls (`planEvents`), because a duplicate
+ * notification is the failure IT is judged on. This module confirms only the needs-you direction and
+ * clears eagerly, because a stale "needs you" on a live dashboard is the failure THIS surface is
+ * judged on. The two therefore AGREE on the reported harm — neither raises `waiting` from a single
+ * frame — and diverge only on how fast they clear it, by design: the fleet display drops attention a
+ * poll sooner than the notification stream, which is the right way round for each.
+ *
+ * Pure, and total: it reads a memory + one poll's raw readings and returns the confirmed readings
+ * plus the memory for the next poll. The poller (`sessions-host.ts`) carries the memory and feeds
+ * the confirmed map to `buildSessionViews`, so the count, the sort, the bell and the TUI all read
+ * the confirmed state without knowing this step happened.
+ */
+
+import type { SessionActivity } from './types'
+
+/**
+ * What the confirmer carries between polls.
+ *
+ * `lastRaw` is the previous poll's RAW reading and exists only to decide whether the current reading
+ * has now been seen twice. `confirmed` is the state the fleet currently BELIEVES a session is in,
+ * and is what a new needs-you reading is held against.
+ */
+export interface ConfirmMemory {
+  lastRaw: ReadonlyMap<string, SessionActivity>
+  confirmed: ReadonlyMap<string, SessionActivity>
+}
+
+export const EMPTY_CONFIRM_MEMORY: ConfirmMemory = { lastRaw: new Map(), confirmed: new Map() }
+
+/** The states that summon a PERSON — the expensive-to-get-wrong ones, confirmed before believed. */
+function needsPerson(a: SessionActivity): boolean {
+  return a === 'waiting' || a === 'waiting-approval'
+}
+
+export interface ConfirmResult {
+  /** The confirmed reading per session — what every downstream surface should show. */
+  activities: Map<string, SessionActivity>
+  /** What to carry into the next poll. */
+  memory: ConfirmMemory
+}
+
+/**
+ * Confirm one poll's raw readings against the memory — PURE.
+ *
+ * Only sessions present in `raw` are carried forward, so the memory cannot grow with every session
+ * the machine has ever hosted: a session that leaves the fleet is simply forgotten and, if it comes
+ * back, is a first sighting again.
+ */
+export function confirmActivities(
+  memory: ConfirmMemory,
+  raw: ReadonlyMap<string, SessionActivity>,
+): ConfirmResult {
+  const lastRaw = new Map<string, SessionActivity>()
+  const confirmed = new Map<string, SessionActivity>()
+  const activities = new Map<string, SessionActivity>()
+
+  for (const [id, r] of raw) {
+    lastRaw.set(id, r)
+    const prevConfirmed = memory.confirmed.get(id)
+    const prevRaw = memory.lastRaw.get(id)
+
+    let next: SessionActivity
+    if (!needsPerson(r)) {
+      // Work resumed, or the session exited. Believed at once — see the header's asymmetry.
+      next = r
+    } else if (prevConfirmed === r || prevRaw === r) {
+      // Already the believed state, or seen on two consecutive polls: confirmed.
+      next = r
+    } else if (prevConfirmed !== undefined) {
+      // A single new needs-you reading is not yet a fact. Hold the last believed state (typically
+      // `working`) rather than assert attention the fleet may not actually need.
+      next = prevConfirmed
+    } else {
+      // First sighting: nothing prior to contradict. A session first seen at its prompt genuinely IS
+      // waiting, and there is no `working` being overturned — so the reading stands.
+      next = r
+    }
+
+    confirmed.set(id, next)
+    activities.set(id, next)
+  }
+
+  return { activities, memory: { lastRaw, confirmed } }
+}

--- a/packages/server/server/sessions/attention-events-agree.test.ts
+++ b/packages/server/server/sessions/attention-events-agree.test.ts
@@ -1,0 +1,65 @@
+/**
+ * The fleet's confirmed activity (`attention-confirm.ts`) and the event channel (`event-plan.ts`)
+ * must AGREE on the reported harm: neither may raise `waiting` from a single-frame blip. They use
+ * different confirmation rules on purpose — the fleet clears attention a poll sooner than the
+ * notification stream — so this pins the ONE thing they must never disagree about, and documents the
+ * one thing they legitimately do.
+ */
+import { describe, expect, it } from 'bun:test'
+import type { SessionActivity } from './types'
+import { EMPTY_CONFIRM_MEMORY, confirmActivities, type ConfirmMemory } from './attention-confirm'
+import { EMPTY_MEMORY, planEvents, type EventMemory } from '../events/event-plan'
+
+/** Raw readings across a sequence of polls, for one session `a`. */
+const BLIP: SessionActivity[] = ['waiting', 'waiting', 'working', 'waiting', 'waiting']
+
+describe('fleet confirmation and the event channel agree on the reported harm', () => {
+  it('neither believes `waiting` from a one-frame quiet after work', () => {
+    // A session confirmed working, then exactly one poll reads quiet, then it moves again.
+    const raw: SessionActivity[] = ['working', 'working', 'waiting', 'working']
+
+    // Fleet: the single quiet frame never becomes the shown state.
+    let fm: ConfirmMemory = EMPTY_CONFIRM_MEMORY
+    const fleetStates = raw.map(a => {
+      const r = confirmActivities(fm, new Map([['a', a]]))
+      fm = r.memory
+      return r.activities.get('a')
+    })
+    expect(fleetStates).not.toContain('waiting')
+
+    // Events: no `waiting` event is ever emitted for that blip.
+    let em: EventMemory = EMPTY_MEMORY
+    const emitted: SessionActivity[] = []
+    for (const a of raw) {
+      const r = planEvents({ memory: em, sessions: [{ id: 'a', cwd: '/x', activity: a }], nowIso: '2026-08-28T00:00:00.000Z' })
+      em = r.memory
+      for (const e of r.events) emitted.push(e.kind as SessionActivity)
+    }
+    expect(emitted).not.toContain('waiting')
+  })
+
+  it('both raise `waiting` only after it holds for two consecutive polls', () => {
+    // The genuine wait: a repaint blips `working` for one poll in the middle of a wait. Neither the
+    // fleet nor the events channel should treat that blip as the wait ending and restarting.
+    let fm: ConfirmMemory = EMPTY_CONFIRM_MEMORY
+    let em: EventMemory = EMPTY_MEMORY
+    let fleetWaitingCount = 0
+    let waitingEvents = 0
+    for (const a of BLIP) {
+      const rf = confirmActivities(fm, new Map([['a', a]]))
+      fm = rf.memory
+      if (rf.activities.get('a') === 'waiting') fleetWaitingCount++
+
+      const re = planEvents({ memory: em, sessions: [{ id: 'a', cwd: '/x', activity: a }], nowIso: '2026-08-28T00:00:00.000Z' })
+      em = re.memory
+      waitingEvents += re.events.filter(e => e.kind === 'waiting').length
+    }
+    // The fleet SHOWS waiting on the polls where it is confirmed (it seeds `waiting` as a first
+    // sighting, holds through the blip, and re-confirms) — but it never spikes on the lone `working`.
+    expect(fleetWaitingCount).toBeGreaterThan(0)
+    // The event channel emits at most the single genuine `waiting` transition after the blip, never a
+    // duplicate per twitch. (Seeded first sighting emits nothing; the blip is one frame; the return
+    // to waiting is one confirmed transition.)
+    expect(waitingEvents).toBeLessThanOrEqual(1)
+  })
+})

--- a/packages/server/server/sessions/backend-tmux.ts
+++ b/packages/server/server/sessions/backend-tmux.ts
@@ -8,10 +8,23 @@ import {
   newSessionArgs, parsePrefix, parseTmuxList, serverOptionsArgs, sendKeysNamedArgs,
   sendKeysLiteralArgs, showPrefixArgs, trimCapture,
 } from './tmux-cli'
-import type { BackendSession, BackendSpawn, SessionBackend } from './types'
+import { planPromptDelivery } from './initial-prompt'
+import type { BackendInitialPrompt, BackendSession, BackendSpawn, SessionBackend } from './types'
 
-/** How long to wait for a harness to draw its prompt before typing into it. */
-const SEND_KEYS_DELAY_MS = 1200
+/** How often to re-read the pane while waiting for the harness to be ready to receive the prompt. */
+const DELIVER_POLL_MS = 400
+/**
+ * How long to keep trying to deliver the initial prompt before giving up.
+ *
+ * Robust to a SLOW start (a big CLAUDE.md, MCP servers loading) — the old fixed 1200ms lost the
+ * keys to a pane that had not drawn its prompt yet. Bounded so a session stuck on an unrecognised
+ * dialog cannot block a batch forever. Overridable for tests.
+ */
+const DELIVER_DEADLINE_MS = Number(process.env.AGENTISTICS_DELIVER_DEADLINE_MS) > 0
+  ? Number(process.env.AGENTISTICS_DELIVER_DEADLINE_MS)
+  : 15_000
+/** How much of the pane to read to judge readiness — enough for the input box and its footer. */
+const DELIVER_CAPTURE_LINES = 40
 
 async function tmux(args: string[]): Promise<{ code: number; out: string; err: string }> {
   try {
@@ -47,6 +60,38 @@ async function sendTextTo(id: string, text: string): Promise<boolean> {
   return (await tmux(sendKeysNamedArgs(id, 'Enter'))).code === 0
 }
 
+async function captureFrame(id: string): Promise<string[]> {
+  const { code, out } = await tmux(capturePaneArgs(id, DELIVER_CAPTURE_LINES))
+  if (code !== 0) return []
+  return trimCapture(out.split('\n'))
+}
+
+/**
+ * Deliver the initial prompt once the harness is genuinely ready to receive it — see
+ * `initial-prompt.ts` for the WHY. This is the impure half: it polls the pane, hands each frame to
+ * the pure `planPromptDelivery`, and does exactly what it says. It NEVER submits into a startup or
+ * approval dialog (the pure planner never returns an action for one), so the "press Enter too early
+ * and select No, exit" accident cannot happen.
+ */
+async function deliverInitialPrompt(id: string, d: BackendInitialPrompt): Promise<void> {
+  const deadline = Date.now() + DELIVER_DEADLINE_MS
+  let readyStreak = 0
+  while (Date.now() < deadline) {
+    const frame = await captureFrame(id)
+    const step = planPromptDelivery({ frame, mode: d.mode, readyStreak, ...(d.rules ? { rules: d.rules } : {}) })
+    readyStreak = step.readyStreak
+    if (step.action === 'done') return // a positional prompt that already auto-submitted
+    if (step.action === 'type') { await sendTextTo(id, d.text ?? ''); return }
+    if (step.action === 'submit') { await tmux(sendKeysNamedArgs(id, 'Enter')); return }
+    await sleep(DELIVER_POLL_MS)
+  }
+  // Timed out. For a `type` harness, fall back to the old best-effort so a slow-but-eventually-up
+  // harness still gets its prompt (never worse than before). For `submit`, do nothing: the text is
+  // in the field, the CLI may still auto-submit, and a blind Enter now could land on a dialog we
+  // never confirmed had cleared.
+  if (d.mode === 'type') await sendTextTo(id, d.text ?? '')
+}
+
 let tmuxPresent: boolean | null = null
 
 export const tmuxBackend: SessionBackend = {
@@ -67,12 +112,10 @@ export const tmuxBackend: SessionBackend = {
     for (const args of serverOptionsArgs()) await tmux(args)
     const { code, out } = await tmux(newSessionArgs({ id: req.id, cwd: req.cwd, argv: req.argv }))
     if (code !== 0) throw new Error(out.trim() || `tmux new-session failed (code ${code})`)
-    if (req.sendKeys) {
-      // The harness has to have drawn its prompt before anything typed into it lands anywhere. Only
-      // the OPENING line needs this wait; `sendText` below is called on a session that is already up
-      // and must not pay for it.
-      await sleep(SEND_KEYS_DELAY_MS)
-      await sendTextTo(req.id, req.sendKeys)
+    if (req.initialPrompt) {
+      // Deliver the prompt only once the harness is READY — polled, not a fixed sleep — so a slow
+      // start does not lose it and a startup dialog is never submitted into. See `deliverInitialPrompt`.
+      await deliverInitialPrompt(req.id, req.initialPrompt)
     }
   },
 

--- a/packages/server/server/sessions/cli-session.ts
+++ b/packages/server/server/sessions/cli-session.ts
@@ -24,6 +24,7 @@ import { toControlSession } from './control-session'
 import { recordedRepo, repoFacts } from './repo-facts'
 import { emptyReason, renderSessionTable, resolveWidth } from './session-table'
 import { SPAWN_SPECS, planSpawn } from './spawn-spec'
+import { rulesFor } from './attention-rules'
 // The harness half of a rename. Shared with the cockpit's Rename verb — see `rename.ts`.
 import { renameInHarness, renameMessage } from './rename'
 import { reconcileSessions, resolveSessionRef, type ReconciledSession, type RefCandidate } from './session-ref'
@@ -39,7 +40,19 @@ import { liveConversationHolders } from './live-claims'
 import { POLL_MS, SETTLE_MS, spawnOutcome } from './spawn-outcome'
 import { parseHarnessAgents } from './harness-agents'
 import { planTakeover, type TakeoverRefusal } from './takeover'
-import type { ManagedSession, SessionBackend, SpawnPlanError } from './types'
+import type { BackendInitialPrompt, ManagedSession, SessionBackend, SpawnPlan, SpawnPlanError } from './types'
+
+/**
+ * The initial-prompt argument for `backend.spawn`, with the harness's screen RULES attached so the
+ * backend can gate delivery on readiness without importing the harness table. Absent when the plan
+ * carries no prompt to deliver. One helper for both spawn sites — the rules must never be forgotten
+ * on one of them.
+ */
+function spawnPromptArg(plan: SpawnPlan, harness: HarnessId): { initialPrompt?: BackendInitialPrompt } {
+  if (!plan.initialPrompt) return {}
+  const rules = rulesFor(harness)
+  return { initialPrompt: { ...plan.initialPrompt, ...(rules ? { rules } : {}) } }
+}
 
 /** Derived from the specs, never a second hand-written list — the two could not then disagree. */
 const STARTABLE: HarnessId[] = HARNESS_ORDER.filter(h => SPAWN_SPECS[h] !== null)
@@ -192,7 +205,7 @@ async function start(
 
   const id = newSessionId()
   try {
-    await backend.spawn({ id, cwd, argv: planned.plan.argv, ...(planned.plan.sendKeys ? { sendKeys: planned.plan.sendKeys } : {}) })
+    await backend.spawn({ id, cwd, argv: planned.plan.argv, ...spawnPromptArg(planned.plan, cmd.harness) })
   } catch (e) {
     console.error(`Could not start the session: ${e instanceof Error ? e.message : String(e)}`)
     return 1
@@ -300,7 +313,7 @@ async function batch(
     try {
       await backend.spawn({
         id, cwd, argv: planned.plan.argv,
-        ...(planned.plan.sendKeys ? { sendKeys: planned.plan.sendKeys } : {}),
+        ...spawnPromptArg(planned.plan, spec.harness),
       })
     } catch (e) {
       failed.push({ harness: spec.harness, reason: e instanceof Error ? e.message : String(e) })
@@ -492,10 +505,26 @@ function fleetJson(snap: SessionSnapshot): unknown {
  * able from a fleet that was alive — and `crash-group.ts` would be reading a write nobody made a
  * claim with.
  */
+/**
+ * How long between the two confirming polls a one-shot command makes. Long enough for a working
+ * session's screen to have moved (or a quiet one to have stayed still) — tmux's activity clock has
+ * one-second resolution — short enough not to be felt on the command line.
+ */
+const CONFIRM_POLL_GAP_MS = 700
+
 async function pollFleet(backend: SessionBackend): Promise<SessionSnapshot> {
   const poller = createSessionsPoller({
     backend, readRegistry, scanProcesses, loadConversations, loadHarnessSessions,
   })
+  // Poll TWICE, and return the second. The cockpit debounces the noisy per-frame reading by
+  // confirming a `waiting` state across two polls (`attention-confirm.ts`), but a one-shot command
+  // has no memory of a previous poll — so a single reading cannot be confirmed and a lone quiet
+  // frame (a finished sub-turn, a repaint) would be reported as "waiting on you" for a session that
+  // is still working. The first poll seeds the poller's confirmation memory; the second returns the
+  // confirmed reading, so `session ls`/`list` agrees with the cockpit and the event channel instead
+  // of reviving the exact false positive on the command line.
+  await poller.poll()
+  await new Promise(r => setTimeout(r, CONFIRM_POLL_GAP_MS))
   return await poller.poll()
 }
 

--- a/packages/server/server/sessions/initial-prompt.test.ts
+++ b/packages/server/server/sessions/initial-prompt.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'bun:test'
+import { rulesFor } from './attention-rules'
+import { promptSurfaceReady, turnRunning, planPromptDelivery } from './initial-prompt'
+
+const claude = rulesFor('claude')
+
+// Real frames captured from claude 2.1.251 under tmux on 2026-08-28 (see the PR's reproduction).
+const BOOT_SPLASH = ['', ' ▐▛███▛█   Claude Code v2.1.251', '']
+const TRUST_DIALOG = [
+  ' Quick safety check: Is this a project you created or one you trust?',
+  '',
+  ' ❯ No, exit',
+  '   Yes, I trust this folder',
+  '',
+  ' Enter to confirm · Esc to cancel',
+]
+const PREFILLED_IDLE = [
+  '❯ @/home/u/.aipe/journeys/x/prompts/brief.md',
+  '────────────────────────────────',
+  '❯ @/home/u/.aipe/journeys/x/prompts/brief.md',
+  '────────────────────────────────',
+  '  ⏵⏵ auto mode on (shift+tab to cycle) · ? for shortcuts',
+]
+const RUNNING = [
+  '❯ @/home/u/.aipe/journeys/x/prompts/brief.md',
+  '  ⎿  Read brief.md (2 lines)',
+  '',
+  '✻ Working… (3s · esc to interrupt)',
+]
+
+describe('promptSurfaceReady', () => {
+  it('is false on the boot splash (nothing drawn yet)', () => {
+    expect(promptSurfaceReady(BOOT_SPLASH, claude)).toBe(false)
+  })
+  it('is false while a startup/trust dialog is up — never deliver into a dialog', () => {
+    expect(promptSurfaceReady(TRUST_DIALOG, claude)).toBe(false)
+  })
+  it('is true once the harness is at its input prompt', () => {
+    expect(promptSurfaceReady(PREFILLED_IDLE, claude)).toBe(true)
+  })
+  it('is true while a turn runs (a running surface is a drawn one)', () => {
+    expect(promptSurfaceReady(RUNNING, claude)).toBe(true)
+  })
+})
+
+describe('turnRunning', () => {
+  it('is true when the working marker is in the footer — the prompt was submitted', () => {
+    expect(turnRunning(RUNNING, claude)).toBe(true)
+  })
+  it('is false at an idle prompt', () => {
+    expect(turnRunning(PREFILLED_IDLE, claude)).toBe(false)
+  })
+  it('is false for a harness with no probed working marker', () => {
+    expect(turnRunning(RUNNING, rulesFor('codex'))).toBe(false)
+  })
+})
+
+describe('planPromptDelivery — the backend loop reads this each poll', () => {
+  const step = (frame: string[], readyStreak: number, mode: 'type' | 'submit', rules = claude) =>
+    planPromptDelivery({ frame, rules, mode, readyStreak })
+
+  it('waits while the boot splash is up', () => {
+    expect(step(BOOT_SPLASH, 0, 'submit')).toEqual({ action: 'wait', readyStreak: 0 })
+  })
+
+  it('waits while a dialog is up, and does NOT submit into it (a blind Enter would pick "No, exit")', () => {
+    expect(step(TRUST_DIALOG, 2, 'submit')).toEqual({ action: 'wait', readyStreak: 0 })
+  })
+
+  it('is DONE the moment a turn is running — the positional prompt auto-submitted', () => {
+    expect(step(RUNNING, 0, 'submit')).toEqual({ action: 'done', readyStreak: 0 })
+  })
+
+  it('counts consecutive ready polls before acting, giving auto-submit its beat', () => {
+    // A positional harness sitting idle with the prompt pre-filled: ready, but not yet for long
+    // enough to be sure it will not auto-submit.
+    expect(step(PREFILLED_IDLE, 0, 'submit')).toEqual({ action: 'wait', readyStreak: 1 })
+    expect(step(PREFILLED_IDLE, 1, 'submit')).toEqual({ action: 'wait', readyStreak: 2 })
+    // Stably idle across READY_CONFIRM polls and never ran — it will not auto-submit. Submit it.
+    expect(step(PREFILLED_IDLE, 2, 'submit')).toEqual({ action: 'submit', readyStreak: 3 })
+  })
+
+  it('types once ready for a send-keys harness', () => {
+    const idleKimi = ['│ Type a message │', '↑↓ navigate']
+    // kimi has no working marker; readiness alone gates typing.
+    const r1 = planPromptDelivery({ frame: idleKimi, rules: rulesFor('kimi'), mode: 'type', readyStreak: 2 })
+    expect(r1).toEqual({ action: 'type', readyStreak: 3 })
+  })
+
+  it('a submit-mode harness with no working marker never forces an Enter (cannot verify safely)', () => {
+    // codex is positional but has no working marker — we cannot tell "auto-submitted" from "idle",
+    // so we never risk a double-submit. It reaches ready and stays `wait` (the CLI's positional
+    // contract is left to run).
+    const idleCodex = ['› Find and fix a bug', '  send q to quit']
+    const r = planPromptDelivery({ frame: idleCodex, rules: rulesFor('codex'), mode: 'submit', readyStreak: 5 })
+    expect(r.action).toBe('wait')
+  })
+})

--- a/packages/server/server/sessions/initial-prompt.ts
+++ b/packages/server/server/sessions/initial-prompt.ts
@@ -1,0 +1,135 @@
+/**
+ * initial-prompt.ts — PURE. When and how a detached session's INITIAL PROMPT reaches the harness.
+ *
+ * ## The defect this exists for
+ *
+ * A session created detached with a prompt has to receive that prompt with no human in the loop. The
+ * old path did not guarantee it: for a `send-keys` harness it typed after a FIXED 1200ms sleep (a
+ * race a slow-starting harness loses — the keys land in a pane that has not drawn its prompt yet),
+ * and for a `positional`/`flag` harness it passed the text in argv and relied entirely on the CLI
+ * auto-submitting it. That reliance is fragile in two proven ways:
+ *
+ *  1. **Some harnesses/versions PRE-FILL without auto-submitting.** The field symptom was exact — the
+ *     prompt "stays in the field" and nothing is sent, so the agent sits waiting for something that
+ *     already arrived. A coordinator worked around it by `tmux send-keys`-ing every dispatch by hand;
+ *     the workaround became a habit and the habit hid the defect for days.
+ *  2. **A startup dialog can block the initial prompt.** Launched in a folder the harness does not
+ *     yet trust, claude opens with a trust prompt whose DEFAULT option is "No, exit". The positional
+ *     prompt is queued behind it — and a naive "just press Enter" would select "No, exit" and KILL
+ *     the session. Submitting too early fails as silently and as badly as not submitting at all.
+ *
+ * ## The rule
+ *
+ * Deliver only once the harness is genuinely READY — its input surface drawn, and NOT sitting on a
+ * startup/approval dialog — and then deliver ONCE:
+ *
+ *  - A `send-keys` harness (its only prompt flag exits) has the text TYPED IN after readiness.
+ *  - A `positional` harness whose working marker lets us tell "already submitted" from "idle" (claude)
+ *    gets a single Enter to SUBMIT the pre-filled text — but only after it has sat idle for a few
+ *    consecutive polls without ever running, which gives a CLI that DOES auto-submit its beat to do
+ *    so (we see the working marker and stand down). A running turn means it already went in.
+ *  - A `positional` harness with no working marker (codex) is left to its CLI's own contract: we
+ *    cannot tell an auto-submitted turn from an idle prompt, so forcing an Enter risks a double
+ *    submit. Refusing to guess is the same discipline `attention-rules.ts` uses for an unprobed
+ *    dialog.
+ *  - A `flag` harness (`--prompt-interactive`) runs the prompt by design; nothing is delivered.
+ *
+ * Never into a dialog: a frame whose footer is a startup/approval prompt is never `ready`, so the
+ * destructive early Enter cannot happen.
+ *
+ * The IMPURE loop lives in `backend-tmux.ts`; this module only reads a frame and a small streak and
+ * says what to do, so every rule above is testable without a tmux server.
+ */
+
+import type { AttentionRules } from './types'
+import { FOOTER_LINES } from './attention'
+
+/**
+ * How many consecutive READY-and-not-running polls before we act.
+ *
+ * For a `submit` harness it is the "auto-submit's beat": if the CLI were going to submit the
+ * positional prompt itself, the working marker would have appeared within this window and we would
+ * have stood down. For a `type` harness it just means the surface has been stably drawn — a hedge
+ * against typing into a half-rendered frame. At the poll interval below (~400ms) this is a bit over a
+ * second, matching the old fixed delay while being adaptive instead of a fixed guess.
+ */
+const READY_CONFIRM = 3
+
+/** A line that is only box-drawing / rule characters — a frame's furniture, not its content. */
+const RULE = /^[─━═╌┄┈╭╰╮╯┌└┐┘│|+\-=_~]+$/
+/** A prompt or box glyph at the start of a line — every one of these CLIs draws its input box with
+ *  one. Its presence is the cross-harness "the input surface is on screen" signal. */
+const INPUT_GLYPH = /^\s*[❯›»▌│|>]/
+
+function footerOf(frame: readonly string[]): string {
+  return frame.slice(Math.max(0, frame.length - FOOTER_LINES)).join('\n')
+}
+
+/** A startup/approval dialog is on screen — matched in the FOOTER only, and never a running turn. */
+function dialogPresent(frame: readonly string[], rules: AttentionRules): boolean {
+  const footer = footerOf(frame)
+  const working = rules.working?.some(re => re.test(footer)) ?? false
+  return !working && rules.approval.some(re => re.test(footer))
+}
+
+/** The harness has drawn an input surface (a box edge or a prompt glyph), past the boot splash. */
+function hasInputSurface(frame: readonly string[]): boolean {
+  return frame.some(l => {
+    const t = l.trim()
+    if (!t) return false
+    return RULE.test(t) || INPUT_GLYPH.test(l)
+  })
+}
+
+/**
+ * The harness is ready to receive the initial prompt: its input surface is drawn and it is not
+ * sitting on a startup/approval dialog. PURE.
+ */
+export function promptSurfaceReady(frame: readonly string[], rules?: AttentionRules): boolean {
+  if (rules && dialogPresent(frame, rules)) return false
+  return hasInputSurface(frame)
+}
+
+/** A turn is running — for a positional harness that means the prompt was already submitted. PURE. */
+export function turnRunning(frame: readonly string[], rules?: AttentionRules): boolean {
+  if (!rules?.working) return false
+  const footer = footerOf(frame)
+  return rules.working.some(re => re.test(footer))
+}
+
+export interface DeliveryDecision {
+  action: 'wait' | 'type' | 'submit' | 'done'
+  /** The consecutive-ready streak to carry to the next poll. */
+  readyStreak: number
+}
+
+/**
+ * What the backend should do with the initial prompt on THIS poll — PURE.
+ *
+ * `mode` is the delivery kind the plan chose (`type` for a send-keys harness, `submit` for a
+ * positional one). `readyStreak` is how many consecutive ready-and-not-running polls preceded this
+ * one. The returned `readyStreak` is what to pass back next time.
+ */
+export function planPromptDelivery(o: {
+  frame: readonly string[]
+  rules?: AttentionRules
+  mode: 'type' | 'submit'
+  readyStreak: number
+}): DeliveryDecision {
+  // A running turn (positional auto-submit already fired) — nothing left to do.
+  if (o.mode === 'submit' && turnRunning(o.frame, o.rules)) return { action: 'done', readyStreak: 0 }
+
+  // Not ready (boot splash, or a dialog we must never submit into): wait, and reset the streak so a
+  // momentary ready frame followed by a repaint does not count toward acting.
+  if (!promptSurfaceReady(o.frame, o.rules)) return { action: 'wait', readyStreak: 0 }
+
+  const readyStreak = o.readyStreak + 1
+  if (readyStreak < READY_CONFIRM) return { action: 'wait', readyStreak }
+
+  if (o.mode === 'type') return { action: 'type', readyStreak }
+
+  // submit mode: only where a working marker lets us verify the CLI did NOT auto-submit. Without one
+  // (codex) we cannot tell submitted from idle, so we never force an Enter — see the header.
+  if (!o.rules?.working) return { action: 'wait', readyStreak }
+  return { action: 'submit', readyStreak }
+}

--- a/packages/server/server/sessions/sessions-host.test.ts
+++ b/packages/server/server/sessions/sessions-host.test.ts
@@ -66,6 +66,42 @@ describe('createSessionsPoller', () => {
     expect(snap.attention).toBe(1)
   })
 
+  it('does NOT count a working session that goes quiet for a single poll — the reported false positive', async () => {
+    // The field report: the fleet said "waiting on you" about a session that had already gone back to
+    // work. It reproduces at the poller: a session working (its probed footer moving), then ONE poll
+    // where the frame is momentarily quiet — a repaint settling, a sub-turn finishing — reads `waiting`
+    // raw. Before this fix the counter jumped to 1 on that single frame and a person was summoned.
+    const frames: Record<string, string[]> = { a: ['working hard · esc to interrupt'] }
+    const p = poller({
+      backend: fakeBackend({ sessions: [backendSession('a')], frames }),
+      registry: [managed('a')],
+    })
+    // Establish the confirmed working state.
+    expect((await p.poll()).attention).toBe(0)
+    // The marker goes away and the frame stops moving for exactly one poll.
+    frames.a = ['❯ ']
+    const blip = await p.poll()
+    expect(blip.sessions[0]!.activity).toBe('working') // held — not summoned on one frame
+    expect(blip.attention).toBe(0)
+    expect(blip.rang).toEqual([])
+  })
+
+  it('the waiting count DROPS on the sample after work resumes', async () => {
+    // The transition the acceptance names: waiting -> back to working -> the count falls on the next
+    // sample. Clearing attention is the cheap direction, so it is believed at once.
+    const frames: Record<string, string[]> = { a: ['❯ '] }
+    const p = poller({
+      backend: fakeBackend({ sessions: [backendSession('a')], frames }),
+      registry: [managed('a')],
+    })
+    // Two quiet polls confirm waiting.
+    await p.poll()
+    expect((await p.poll()).attention).toBe(1)
+    // The session resumes — a moving footer.
+    frames.a = ['back at it · esc to interrupt']
+    expect((await p.poll()).attention).toBe(0) // fell on the very next sample
+  })
+
   it('reports a session working from its probed footer', async () => {
     const p = poller({
       backend: fakeBackend({
@@ -78,7 +114,7 @@ describe('createSessionsPoller', () => {
     expect((await p.poll()).attention).toBe(0)
   })
 
-  it('sees a frame that changed between two polls as working', async () => {
+  it('sees a frame that changed between two polls as working, and confirms waiting before it flips', async () => {
     const frames: Record<string, string[]> = { a: ['one'] }
     const p = poller({
       backend: fakeBackend({ sessions: [backendSession('a')], frames }),
@@ -86,8 +122,14 @@ describe('createSessionsPoller', () => {
     })
     expect((await p.poll()).sessions[0]!.activity).toBe('waiting')
     frames.a = ['two']
+    // A changed frame is movement, and movement is believed at once.
     expect((await p.poll()).sessions[0]!.activity).toBe('working')
-    // Third poll: unchanged again, so it settles back to waiting with no extra interval of lag.
+    // Now the frame goes quiet. The RAW reading is `waiting`, but a single quiet poll after work is
+    // not yet a fact — the fleet holds `working` rather than assert a person is needed on one frame.
+    // This one-interval confirmation is the whole point: it is what stopped the counter reporting a
+    // session that had just gone quiet (a repaint, a finished sub-turn) as "waiting on you".
+    expect((await p.poll()).sessions[0]!.activity).toBe('working')
+    // Seen quiet on two consecutive polls now — confirmed waiting.
     expect((await p.poll()).sessions[0]!.activity).toBe('waiting')
   })
 
@@ -120,7 +162,15 @@ describe('createSessionsPoller', () => {
     frames.a = ['done']
     expect((await p.poll()).sessions[0]!.activity).toBe('working')
 
-    // Next poll: the frame is unchanged and the session has settled.
+    // Next poll: the frame is unchanged, so the RAW reading is `waiting` — but it has been seen only
+    // once, so the fleet still shows `working` and the bell does NOT ring. The bell fires on the
+    // CONFIRMED transition, never on a single frame: that is what stops a one-frame quiet ringing a
+    // person for a session that is still working.
+    const held = await p.poll()
+    expect(held.sessions[0]!.activity).toBe('working')
+    expect(held.rang).toEqual([])
+
+    // The poll after that confirms the quiet — waiting is now believed, and the bell rings once.
     const settled = await p.poll()
     expect(settled.sessions[0]!.activity).toBe('waiting')
     expect(settled.rang).toEqual(['a'])

--- a/packages/server/server/sessions/sessions-host.ts
+++ b/packages/server/server/sessions/sessions-host.ts
@@ -15,6 +15,7 @@ import { createLimiter } from '../utils'
 import type { HarnessProcess } from '../live-sessions'
 import { rulesFor } from './attention-rules'
 import { approvalTail, attentionOf, digestFrame, frameTail } from './attention'
+import { EMPTY_CONFIRM_MEMORY, confirmActivities, type ConfirmMemory } from './attention-confirm'
 import { readRecentChatTurns, resolveChatTranscriptPath, type ChatTurn } from './chat-tail'
 import { parseDialogOptions, type DialogOption } from './dialog-choice'
 // Taking a running session back when its registry record is gone. See `session-adopt.ts`.
@@ -155,6 +156,11 @@ export function createSessionsPoller(o: {
   // first is how movement is detected; the second is what makes the bell a transition.
   let prevDigest = new Map<string, string>()
   let prevActivity = new Map<string, SessionActivity>()
+  // The raw per-poll reading is noisy: a session that just finished, or a pane a plugin repainted,
+  // reads `working` then `waiting` across two polls with nothing changed. `confirmActivities` turns
+  // that into a CONFIRMED reading — a needs-you state must be seen twice before the counter believes
+  // it, while a return to work is believed at once — so the "waiting on you" count stops lying.
+  let confirmMemory: ConfirmMemory = EMPTY_CONFIRM_MEMORY
   const prevProcStats = new Map<number, ProcStatSample>()
   let last: SessionSnapshot | null = null
   /**
@@ -340,9 +346,19 @@ export function createSessionsPoller(o: {
         }
       }
 
+      // Confirm the raw readings before anything downstream sees them: the count, the sort, the bell
+      // and the TUI all read `activity`, so confirming here is the one place that makes every surface
+      // honest at once. A needs-you state must hold for two polls to be believed; a return to work is
+      // believed immediately (see `attention-confirm.ts`). The dialog/approval frames captured above
+      // are keyed to the RAW `waiting-approval` reading and only reach a row once its CONFIRMED state
+      // is `waiting-approval` too — `buildSessionViews` gates them on `activity`.
+      const confirm = confirmActivities(confirmMemory, activity)
+      confirmMemory = confirm.memory
+      const confirmedActivity = confirm.activities
+
       const sessions = buildSessionViews({
         reconciled,
-        activity,
+        activity: confirmedActivity,
         tails,
         chatTails,
         approvals,

--- a/packages/server/server/sessions/spawn-spec.test.ts
+++ b/packages/server/server/sessions/spawn-spec.test.ts
@@ -30,19 +30,27 @@ describe('SPAWN_SPECS', () => {
 })
 
 describe('planSpawn', () => {
-  it('puts a claude prompt in the positional slot, after the flags', () => {
+  it('puts a claude prompt in the positional slot, after the flags, and marks it for submit', () => {
+    // Positional, so the text is in argv — but the backend must still SUBMIT it (an Enter) on a
+    // version that pre-fills without auto-submitting, without double-submitting one that does.
     const r = planSpawn({ harness: 'claude', cwd: '/tmp', prompt: 'fix the tests', model: 'opus', effort: 'high' })
-    expect(r).toEqual({ ok: true, plan: { argv: ['claude', '--model', 'opus', '--effort', 'high', 'fix the tests'] } })
+    expect(r).toEqual({
+      ok: true,
+      plan: { argv: ['claude', '--model', 'opus', '--effort', 'high', 'fix the tests'], initialPrompt: { mode: 'submit' } },
+    })
   })
 
-  it('puts a codex prompt in the positional slot', () => {
+  it('puts a codex prompt in the positional slot and marks it for submit', () => {
     const r = planSpawn({ harness: 'codex', cwd: '/tmp', prompt: 'implement X', model: 'o3' })
-    expect(r).toEqual({ ok: true, plan: { argv: ['codex', '--model', 'o3', 'implement X'] } })
+    expect(r).toEqual({
+      ok: true,
+      plan: { argv: ['codex', '--model', 'o3', 'implement X'], initialPrompt: { mode: 'submit' } },
+    })
   })
 
   it('types a kimi prompt in, because kimi has no interactive prompt flag', () => {
     const r = planSpawn({ harness: 'kimi', cwd: '/tmp', prompt: 'implement X' })
-    expect(r).toEqual({ ok: true, plan: { argv: ['kimi'], sendKeys: 'implement X' } })
+    expect(r).toEqual({ ok: true, plan: { argv: ['kimi'], initialPrompt: { mode: 'type', text: 'implement X' } } })
   })
 
   it('omits the prompt entirely when there is none', () => {
@@ -72,7 +80,7 @@ describe('planSpawn', () => {
 
   it('types a copilot prompt in, because its -p exits after answering', () => {
     const r = planSpawn({ harness: 'copilot', cwd: '/tmp', prompt: 'review this' })
-    expect(r).toEqual({ ok: true, plan: { argv: ['copilot'], sendKeys: 'review this' } })
+    expect(r).toEqual({ ok: true, plan: { argv: ['copilot'], initialPrompt: { mode: 'type', text: 'review this' } } })
   })
 
   it('accepts agy effort, which its own --help prints as a closed set', () => {

--- a/packages/server/server/sessions/spawn-spec.ts
+++ b/packages/server/server/sessions/spawn-spec.ts
@@ -18,7 +18,7 @@
 
 import type { HarnessId } from '@agentistics/core'
 import { HARNESS_SESSION_SOURCES } from './harness-session-file'
-import type { SpawnRequest, SpawnPlanResult, SpawnSpec } from './types'
+import type { InitialPrompt, SpawnRequest, SpawnPlanResult, SpawnSpec } from './types'
 
 export const SPAWN_SPECS: Record<HarnessId, SpawnSpec | null> = {
   // `Usage: claude [options] [command] [prompt]` / `Arguments: prompt  Your prompt`
@@ -173,11 +173,19 @@ export function planSpawn(req: SpawnRequest): SpawnPlanResult {
   if (req.model && spec.modelFlag) argv.push(spec.modelFlag, req.model)
   if (req.effort && spec.effortFlag) argv.push(spec.effortFlag, req.effort)
 
-  let sendKeys: string | undefined
+  // How the initial prompt will be DELIVERED once the session is up — see `initial-prompt.ts`. A
+  // `positional` prompt is in argv but may not have been auto-submitted (`submit`); a `send-keys`
+  // harness needs it typed (`type`); a `flag` harness runs it itself and needs no delivery.
+  let initialPrompt: InitialPrompt | undefined
   if (req.prompt) {
-    if (spec.prompt.kind === 'positional') argv.push(req.prompt)
-    else if (spec.prompt.kind === 'flag') argv.push(spec.prompt.flag, req.prompt)
-    else sendKeys = req.prompt
+    if (spec.prompt.kind === 'positional') {
+      argv.push(req.prompt)
+      initialPrompt = { mode: 'submit' }
+    } else if (spec.prompt.kind === 'flag') {
+      argv.push(spec.prompt.flag, req.prompt)
+    } else {
+      initialPrompt = { mode: 'type', text: req.prompt }
+    }
   }
 
   // The conversation this spawn is KNOWN to drive: the one we asked to reopen, or the one we just
@@ -189,7 +197,7 @@ export function planSpawn(req: SpawnRequest): SpawnPlanResult {
     ok: true,
     plan: {
       argv,
-      ...(sendKeys === undefined ? {} : { sendKeys }),
+      ...(initialPrompt ? { initialPrompt } : {}),
       ...(conversationId ? { conversationId } : {}),
     },
   }

--- a/packages/server/server/sessions/types.ts
+++ b/packages/server/server/sessions/types.ts
@@ -86,10 +86,27 @@ export interface SpawnRequest {
   task?: string
 }
 
+/**
+ * How the initial prompt reaches the harness once it is READY to receive it — see `initial-prompt.ts`.
+ *
+ * `type`   — a `send-keys` harness (its only prompt flag exits): the text is typed in and submitted.
+ * `submit` — a `positional` harness: the text is already in argv; it may only need an Enter to submit
+ *            it, on a harness/version that pre-fills without auto-submitting. Verified by a working
+ *            marker so a CLI that DID auto-submit is never double-submitted.
+ *
+ * A `flag` harness (`--prompt-interactive`) runs the prompt by design and carries no delivery.
+ */
+export interface InitialPrompt {
+  mode: 'type' | 'submit'
+  /** The text to type. Present only for mode `type`. */
+  text?: string
+}
+
 export interface SpawnPlan {
   argv: string[]
-  /** Typed into the session once it is up, for a `send-keys` harness. */
-  sendKeys?: string
+  /** How to deliver the initial prompt once the harness is up — absent when there is no prompt, or a
+   *  `flag` harness that runs it itself. */
+  initialPrompt?: InitialPrompt
   /**
    * The conversation this spawn is KNOWN to drive — the id reopened, or the id assigned.
    *
@@ -119,7 +136,20 @@ export interface BackendSpawn {
   id: string
   cwd: string
   argv: string[]
-  sendKeys?: string
+  /**
+   * How to deliver the initial prompt once the harness is ready to receive it.
+   *
+   * The harness's screen RULES ride along so the backend can tell a live turn and a startup dialog
+   * from an idle prompt WITHOUT importing the harness table — it stays harness-agnostic, the caller
+   * resolves the rules. Absent when there is nothing to deliver.
+   */
+  initialPrompt?: BackendInitialPrompt
+}
+
+export interface BackendInitialPrompt extends InitialPrompt {
+  /** The harness's probed markers, for readiness / already-submitted detection. Absent = only the
+   *  input-surface heuristic gates readiness, and a `submit` is never forced (cannot verify safely). */
+  rules?: AttentionRules
 }
 
 /** One session as the BACKEND sees it — existence and liveness, no product metadata. */


### PR DESCRIPTION
## Summary

Two field-reported defects in the session manager, one code path (`packages/server/server/sessions/`).

**A — the `waiting on you` counter lied.** The fleet read each session's state from a **single frame**, so a session that had just gone quiet (a finished sub-turn, a plugin repaint) flipped to `waiting` for one poll and a person was summoned to a session that was still working. New pure `attention-confirm.ts` confirms a needs-you state across **two consecutive polls** before believing it, while a return to `working`/`exited` is believed at once (a screen that moved is unambiguous proof). The counter never spikes on a lone frame and **drops on the next poll after work resumes**. The one-shot `session ls`/`list` now double-polls so the command line agrees with the cockpit and the event channel.

**B — a detached session's initial prompt was not guaranteed to be submitted.** The old path typed after a fixed 1200 ms (a race a slow start loses) and left a positional prompt entirely to the CLI to auto-submit — which some versions/launch states do not, leaving the prompt sitting in the field with nothing sent (the daily manual-`tmux send-keys` workaround the coordinators lived with). New pure `initial-prompt.ts` delivers only once the harness is **ready** (input surface drawn, **not** on a startup/approval dialog) and then **once**: typed harnesses are typed+submitted; a positional claude gets a single Enter to submit only after it has sat idle without ever running (so an auto-submitting CLI is **never double-submitted**); a startup trust dialog (default `No, exit`) is **never** submitted into — a blind early Enter there would kill the session.

## Motivation

The `waiting` false positive made a coordinator adopt the written rule "don't trust the `activity` field, read the pane with `tmux capture-pane`" — the exact manual work agentop exists to remove — and a false "needs you" wastes the most expensive resource (human attention) and corrodes trust in the indicator permanently. The unsubmitted-prompt defect broke dispatches silently (reported as "the specialist is born without its brief") and was worked around so often the workaround hid it for days. Both are the same session code path, hence one PR.

Design bias throughout: **prefer honest uncertainty / the cheap error to a wrong assertion.** Clearing "needs you" eagerly and raising it conservatively; never submitting into a dialog; never double-submitting.

## Test plan

- **Unit (pure, RED→GREEN):** `attention-confirm.test.ts` (9) — single-frame quiet never spikes the count, waiting confirmed on two polls, count drops the sample after work resumes; `initial-prompt.test.ts` (13) — readiness vs dialog vs boot, positional-submit only after the auto-submit beat, never a forced Enter without a working marker; `attention-events-agree.test.ts` (2) — fleet confirmation and the event channel agree that no single-frame blip raises `waiting`; updated `sessions-host.test.ts` + `spawn-spec.test.ts`.
- **Whole suite:** `bun test` → 4506 pass / 0 fail; `bun tsc --noEmit` clean; `bun run build:binary` green; `bun.lock` unchanged.
- **Driven for real (defect B), against live processes under tmux:** a pre-filled-no-submit harness reproduces "prompt stays in the field" and the fix submits it (`trace=[wait,wait,submit]` → the agent starts working alone, no manual send-keys); a slow-starting (6 s) send-keys harness proves the old fixed-1200 ms loses the input while the readiness gate delivers it; a startup dialog is left untouched (`No, exit` not selected); **real claude 2.1.251** auto-submits and the fix stands down (`0` Enters sent — no regression, no double-submit).
- **Driven on the compiled binary (defect A):** `./release/agentop session list --json` reported this actively-working session as `waiting` before the fix and `working` after — the exact false positive, gone.

Journey: j-20260828-ht · task `waiting-e-autosubmit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
