### PR TITLE
feat(sessions): live terminal read channel (SSE) — Phase 1 (read-only)

### DIFF
--- a/docs/terminal-channel.md
+++ b/docs/terminal-channel.md
@@ -1,0 +1,144 @@
+# Live terminal channel
+
+`GET /api/fleet/stream` streams a managed session's terminal — the actual screen a coding assistant
+is drawing, colours and all — to the browser over SSE, so the sessions tab can show what an agent is
+doing without anyone opening a terminal and running `tmux attach`.
+
+This is the **server contract** the web dashboard consumes. The web side (the terminal panel and its
+emulator) must build on exactly this — it does not invent its own endpoint.
+
+**Phase 1 is read-only.** There is no write path yet: no keystrokes reach the session through this
+channel. A write channel (`Phase 2`) is a separate, later delivery with its own security contract;
+until it exists the web must show **no input box**, because a text field that does nothing is the
+same kind of lie as a frozen terminal that looks live.
+
+## Transport, and why
+
+**SSE (Server-Sent Events), snapshot-based, viewer-gated, one shared loop per session.**
+
+- **SSE over WebSocket.** The read channel is one-directional (server → browser). SSE is plain
+  HTTP, reconnects on its own, and is already the dashboard's push transport (`/api/events`). A
+  WebSocket would buy bidirectionality Phase 1 does not use and a dependency the repo does not have.
+- **Snapshot (`tmux capture-pane`) over a raw byte stream (`pipe-pane`).** `capture-pane` returns
+  the *rendered grid* — a spinner, a redrawn line, a moved cursor are already resolved to their
+  final glyphs by tmux before we see them. So every frame is a **complete, self-contained picture**:
+  a reader that joins late or reconnects needs no replay, and what we show is what the pane actually
+  rendered (the `attention-rules.ts` discipline: never a reconstruction from memory of what a CLI
+  prints). Colours survive because we capture with `-e`.
+- **Viewer-gated + shared.** A session is captured **only while at least one browser is watching**
+  it. Many readers of the same session share **one** capture loop and **one** tmux read per tick; an
+  unchanged frame is sent to nobody. So the server's work scales with the number of open *terminals*
+  (usually one), never with the size of the fleet — the criterion the spec set.
+
+Tuning constants live in `packages/server/server/sessions/terminal-stream.ts`
+(`TERMINAL_VIEW_LINES`, `TERMINAL_POLL_MS`) and `terminal-web.ts` (`MAX_TERMINAL_STREAMS`,
+`KEEPALIVE_MS`). The poll cadence is overridable with `AGENTISTICS_TERMINAL_POLL_MS`.
+
+## Request
+
+```
+GET /api/fleet/stream?id=<sessionId>
+Accept: text/event-stream
+```
+
+- `id` — the session's id, the **same `id`** carried on every row of `GET /api/fleet` and accepted
+  by `POST /api/fleet/act`. No other identifier.
+- Same-origin only; no body.
+
+### Status codes (before the stream opens)
+
+| Code | Meaning |
+|------|---------|
+| `200` | Stream opens (`text/event-stream`). |
+| `400` | `{"error":"bad_request"}` — `id` missing. |
+| `404` | `{"error":"not_found"}` — `id` is not a session this machine manages (**scope**). |
+| `404` | `{"error":"fleet_central"}` — called on a team central (the fleet lives on members). |
+| `403` | `{"error":"capability_disabled","capability":"localShell"}` — exposed profile (see Security). |
+| `503` | `{"error":"too_many_streams"}` — process at `MAX_TERMINAL_STREAMS`. |
+
+## Events
+
+The stream emits named SSE events. `: keepalive` comment lines arrive ~every 15s and are ignored.
+
+### `open` — once, first
+
+```json
+{ "id": "3f5f", "viewLines": 200, "historyLimit": 50000 }
+```
+
+### `frame` — the screen, on every change (deduped)
+
+```json
+{
+  "seq": 7,
+  "content": "[1m[35mclaude[0m … ",
+  "cols": 120,
+  "rows": 40,
+  "cursor": { "x": 6, "y": 12 },
+  "alive": true,
+  "lines": 53,
+  "historyLimit": 50000,
+  "truncated": false
+}
+```
+
+| Field | Meaning |
+|-------|---------|
+| `seq` | Monotonic within one stream; advances **only when the screen changed**. A late reader's first frame is the current one, whatever its `seq`. |
+| `content` | The rendered pane, `\n`-joined, **with SGR escape sequences intact**. Feed it to a terminal emulator. |
+| `cols` / `rows` | Pane geometry (`0` cols is a rare "don't know" fallback; the emulator sizes itself). |
+| `cursor` | Block-cursor position, or **`null` once the pane is dead** — never draw a cursor on a dead frame. |
+| `alive` | `false` once the hosted command has exited. The last frame stays readable and must be shown as **finished**, not live. |
+| `lines` | How many lines `content` carries — the honest "you are seeing N lines" number. |
+| `historyLimit` | The scrollback ceiling tmux keeps (`50000`), for a "showing last N of up to M" line. |
+| `truncated` | `true` when there is more scrollback above than this frame carries. |
+
+**Rendering.** Each `frame` is a full snapshot, not a delta: on receipt, reset the emulator and write
+`content` (`term.reset(); term.write(frame.content)`), or the equivalent. Do not append frames.
+
+### `end` — once, last (then the stream closes)
+
+```json
+{ "reason": "gone" }
+```
+
+- `gone` — the session left tmux (killed, or the machine's tmux went away). Mark the terminal
+  ended; the last `frame` is the last thing it drew.
+- `not-found` — the id stopped being a managed session mid-stream (scope).
+- `error` — the backend could not be read.
+
+A session that merely **exits** does **not** end the stream — it keeps arriving as `frame`s with
+`alive:false`, so the finished screen stays readable. `end` is only for a session that is gone.
+
+## Security
+
+The read channel inherits the fleet's existing model exactly — it invents no new auth:
+
+- **`localShell` capability** (`capability-guard.ts`). Streaming a session's screen is a coding
+  assistant's terminal, transcript and all — shell access with extra steps. So it is **403'd on any
+  exposed profile** (`lan`/`public`) regardless of who is authenticated, the same as `/api/fleet`.
+  On a `local` profile (127.0.0.1, the machine's own dashboard) it is available, as the fleet is.
+- **Scope.** A stream opens only for a session **this machine manages** (its own registry). The read
+  power never reaches past the fleet the dashboard already lists — the boundary the Phase 2 *write*
+  path will inherit, established here where it is cheap.
+- **404 on a central.** Like `/api/fleet`; the fleet is a member/solo concept.
+
+## Status indicators beside the terminal
+
+Any activity indicator the web shows next to the terminal (working / needs-you) must come from the
+**fleet's own state** (`GET /api/fleet`, the `activity`/attention the cockpit already computes) —
+which, per PR #243, requires **two concordant samples** before it asserts `waiting` and accepts a
+return to work immediately. Do **not** recompute a separate "looks idle" signal from the terminal
+frames: a still screen is not the same as a session waiting on a person, and inventing a second
+source is how the two disagree.
+
+## Files
+
+| File | Role |
+|------|------|
+| `sessions/tmux-cli.ts` | pure — `capturePaneAnsiArgs` (`-e`), `paneInfoArgs` / `parsePaneInfo`. |
+| `sessions/terminal-stream.ts` | pure — frame shape, dedup digest, `buildFrame`, SSE encoder. |
+| `sessions/terminal-hub.ts` | the shared, ref-counted, deduped capture loop (injectable). |
+| `sessions/backend-tmux.ts` | `captureTerminal` — one ANSI-preserving read + geometry. |
+| `sessions/terminal-web.ts` | singleton wiring + SSE plumbing + scope/cap gates. |
+| `server/index.ts` | the `GET /api/fleet/stream` route. |

--- a/packages/server/server/capability-guard.test.ts
+++ b/packages/server/server/capability-guard.test.ts
@@ -31,6 +31,9 @@ describe('routeCapability', () => {
     // on an exposed profile whoever is authenticated.
     expect(routeCapability('/api/fleet')).toBe('localShell')
     expect(routeCapability('/api/fleet/act')).toBe('localShell')
+    // The live terminal channel streams a session's SCREEN. It is a read, but a read of a coding
+    // assistant's terminal, so it must be as unreachable on an exposed profile as the fleet itself.
+    expect(routeCapability('/api/fleet/stream')).toBe('localShell')
   })
 
   it('maps the local chat routes', () => {

--- a/packages/server/server/capability-guard.ts
+++ b/packages/server/server/capability-guard.ts
@@ -39,6 +39,10 @@ const EXACT: ReadonlyMap<string, keyof Capabilities> = new Map<string, keyof Cap
   // that should expose someone's keyboard to the internet and a shell is the honest name for it.
   ['/api/fleet', 'localShell'],
   ['/api/fleet/act', 'localShell'],
+  // The live terminal channel — an SSE stream of a session's SCREEN, colours and all. It is a read,
+  // but it is a read of a coding assistant's terminal, so it rides the same `localShell` as
+  // `/api/fleet`: there is no deployment that should stream someone's terminal to the internet.
+  ['/api/fleet/stream', 'localShell'],
 ])
 
 /** Prefix (no trailing slash) → capability. Matches `<prefix>` and `<prefix>/…` only. */

--- a/packages/server/server/index.ts
+++ b/packages/server/server/index.ts
@@ -1014,7 +1014,7 @@ async function handleRequestInner(req: Request, server: Server<WSData>): Promise
     // take. A central never answers it: it aggregates many machines and hosts none of their
     // sessions, so a fleet read there would be this box's own processes under someone else's page.
     // `capability-guard.ts` has already refused both paths on an exposed profile.
-    if (url.pathname === '/api/fleet' || url.pathname === '/api/fleet/act') {
+    if (url.pathname === '/api/fleet' || url.pathname === '/api/fleet/act' || url.pathname === '/api/fleet/stream') {
       if (TEAM_CENTRAL) {
         return new Response(JSON.stringify({ error: 'fleet_central' }), {
           status: 404,
@@ -1051,6 +1051,43 @@ async function handleRequestInner(req: Request, server: Server<WSData>): Promise
           headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
         })
       }
+    }
+
+    // The live terminal channel: an SSE stream of one session's screen. Read-only (Phase 1). Already
+    // gated by `localShell` (capability-guard) and 404'd on a central above, so this handler only has
+    // to enforce SCOPE — the session must be one this machine manages — and the stream ceiling.
+    if (url.pathname === '/api/fleet/stream' && req.method === 'GET') {
+      const id = url.searchParams.get('id')
+      if (!id) {
+        return new Response(JSON.stringify({ error: 'bad_request' }), {
+          status: 400,
+          headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
+        })
+      }
+      const { terminalSessionExists, terminalAtCapacity, openTerminalStream } = await import('./sessions/terminal-web')
+      if (!(await terminalSessionExists(id))) {
+        return new Response(JSON.stringify({ error: 'not_found' }), {
+          status: 404,
+          headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
+        })
+      }
+      if (await terminalAtCapacity()) {
+        return new Response(JSON.stringify({ error: 'too_many_streams' }), {
+          status: 503,
+          headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
+        })
+      }
+      const stream = await openTerminalStream(id, req.signal)
+      return new Response(stream, {
+        status: 200,
+        headers: {
+          ...CORS_HEADERS,
+          'Content-Type': 'text/event-stream',
+          'Cache-Control': 'no-cache',
+          'Connection': 'keep-alive',
+          'X-Accel-Buffering': 'no',
+        },
+      })
     }
 
     // Chat is opt-in. `capability-guard.ts` has already refused these paths where the exposure

--- a/packages/server/server/sessions/backend-tmux.ts
+++ b/packages/server/server/sessions/backend-tmux.ts
@@ -4,12 +4,15 @@
  */
 
 import {
-  attachArgs, capturePaneArgs, idFromTmuxName, isSessionGoneError, killSessionArgs, listSessionsArgs,
-  newSessionArgs, parsePrefix, parseTmuxList, serverOptionsArgs, sendKeysNamedArgs,
-  sendKeysLiteralArgs, showPrefixArgs, trimCapture,
+  attachArgs, capturePaneArgs, capturePaneAnsiArgs, idFromTmuxName, isSessionGoneError,
+  killSessionArgs, listSessionsArgs, newSessionArgs, paneInfoArgs, parsePaneInfo, parsePrefix,
+  parseTmuxList, serverOptionsArgs, sendKeysNamedArgs, sendKeysLiteralArgs, showPrefixArgs,
+  trimCapture,
 } from './tmux-cli'
 import { planPromptDelivery } from './initial-prompt'
-import type { BackendInitialPrompt, BackendSession, BackendSpawn, SessionBackend } from './types'
+import type {
+  BackendInitialPrompt, BackendSession, BackendSpawn, SessionBackend, TerminalCapture,
+} from './types'
 
 /** How often to re-read the pane while waiting for the harness to be ready to receive the prompt. */
 const DELIVER_POLL_MS = 400
@@ -136,6 +139,28 @@ export const tmuxBackend: SessionBackend = {
     const { code, out } = await tmux(capturePaneArgs(id, lines))
     if (code !== 0) return []
     return trimCapture(out.split('\n'))
+  },
+
+  async captureTerminal(id: string, lines: number): Promise<TerminalCapture | null> {
+    // Content FIRST: a non-zero capture is how we learn the session is gone, and there is no point
+    // asking for its geometry once it is. `-e` keeps the colours; the frame is NOT trailing-trimmed
+    // because a full-screen TUI's blank rows are part of its layout, not padding to discard.
+    const cap = await tmux(capturePaneAnsiArgs(id, lines))
+    if (cap.code !== 0) return null // tmux no longer has this session — the caller ends the stream
+    // A trailing '' from the final newline is not a real row; drop only that one.
+    const raw = cap.out.split('\n')
+    if (raw.length && raw[raw.length - 1] === '') raw.pop()
+
+    const meta = await tmux(paneInfoArgs(id))
+    const info = meta.code === 0 ? parsePaneInfo(meta.out) : null
+    if (!info) {
+      // The pane exists (capture succeeded) but display-message could not be read or parsed. Rather
+      // than ship a confident-wrong cursor, fall back to a minimal honest geometry: the browser
+      // emulator sizes itself, so `cols: 0` is a "don't know" the client can ignore, and `alive` is
+      // true because the capture just worked. Never a throw.
+      return { lines: raw, info: { cols: 0, rows: raw.length, cursorX: 0, cursorY: 0, alive: true, historySize: 0 } }
+    }
+    return { lines: raw, info }
   },
 
   async kill(id: string) {

--- a/packages/server/server/sessions/sessions-host.test.ts
+++ b/packages/server/server/sessions/sessions-host.test.ts
@@ -31,6 +31,10 @@ function fakeBackend(o: {
     async spawn() {},
     async list() { return o.sessions },
     async capture(id) { o.onCapture?.(id); return o.frames?.[id] ?? [] },
+    async captureTerminal(id) {
+      const lines = o.frames?.[id] ?? []
+      return { lines, info: { cols: 80, rows: lines.length, cursorX: 0, cursorY: 0, alive: true, historySize: 0 } }
+    },
     async kill() { return true },
     attachCommand(id) { return ['tmux', 'attach', id] },
     async detachHint() { return 'Ctrl-b then d' },

--- a/packages/server/server/sessions/terminal-hub.test.ts
+++ b/packages/server/server/sessions/terminal-hub.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from 'bun:test'
+import { createTerminalHub, type TerminalSink } from './terminal-hub'
+import type { TerminalFrame } from './terminal-stream'
+import type { PaneInfo, TerminalCapture } from './types'
+
+const info = (over: Partial<PaneInfo> = {}): PaneInfo => ({
+  cols: 80, rows: 40, cursorX: 0, cursorY: 0, alive: true, historySize: 0, ...over,
+})
+const cap = (lines: string[], over: Partial<PaneInfo> = {}): TerminalCapture => ({ lines, info: info(over) })
+
+const flush = () => new Promise<void>(r => setTimeout(r, 0))
+
+/** A recording sink. */
+function sink() {
+  const frames: TerminalFrame[] = []
+  const ends: string[] = []
+  const s: TerminalSink = { onFrame: f => frames.push(f), onEnd: r => ends.push(r) }
+  return { s, frames, ends }
+}
+
+/**
+ * A harness whose "tmux" is a variable and whose interval is a captured callback, so ticks happen
+ * exactly when the test calls `tick()`. This is dependency injection, not filesystem mocking — the
+ * same shape `createSessionsPoller` is built with in this directory.
+ */
+function harness(opts: { managed?: boolean } = {}) {
+  let next: TerminalCapture | null = cap(['boot'])
+  let intervalFn: (() => void) | null = null
+  let cleared = false
+  let captureCalls = 0
+
+  const hub = createTerminalHub({
+    capture: async () => { captureCalls++; return next },
+    isManaged: async () => opts.managed ?? true,
+    historyLimit: 50_000,
+    viewLines: 200,
+    pollMs: 500,
+    setInterval: fn => { intervalFn = fn; return 1 as unknown as ReturnType<typeof setInterval> },
+    clearInterval: () => { cleared = true },
+  })
+
+  return {
+    hub,
+    set: (c: TerminalCapture | null) => { next = c },
+    tick: async () => { intervalFn?.(); await flush() },
+    intervalStarted: () => intervalFn !== null,
+    cleared: () => cleared,
+    captureCalls: () => captureCalls,
+  }
+}
+
+describe('createTerminalHub', () => {
+  it('one loop, one tmux read per tick, however many readers share a session', async () => {
+    const h = harness()
+    const a = sink()
+    const b = sink()
+    await h.hub.subscribe('s1', a.s)
+    await h.hub.subscribe('s1', b.s)
+    await flush()
+
+    expect(h.hub.activeLoops()).toBe(1) // ONE loop for two readers — no duplicated work
+    expect(h.hub.subscribers()).toBe(2)
+
+    const before = h.captureCalls()
+    h.set(cap(['moved']))
+    await h.tick()
+    // Exactly one more capture served BOTH readers.
+    expect(h.captureCalls()).toBe(before + 1)
+    expect(a.frames.at(-1)!.content).toBe('moved')
+    expect(b.frames.at(-1)!.content).toBe('moved')
+  })
+
+  it('sends an unchanged frame to nobody, and a changed one to everybody', async () => {
+    const h = harness()
+    const a = sink()
+    await h.hub.subscribe('s1', a.s)
+    await flush()
+    const seen = a.frames.length // the immediate first frame
+
+    h.set(cap(['boot'])) // identical to the first
+    await h.tick()
+    expect(a.frames.length).toBe(seen) // deduped — nothing sent
+
+    h.set(cap(['different']))
+    await h.tick()
+    expect(a.frames.length).toBe(seen + 1)
+    expect(a.frames.at(-1)!.seq).toBeGreaterThan(a.frames[0]!.seq) // seq advances only on change
+  })
+
+  it('hands a late reader the current screen immediately, without waiting for a change', async () => {
+    const h = harness()
+    const a = sink()
+    await h.hub.subscribe('s1', a.s)
+    await flush()
+
+    const b = sink()
+    await h.hub.subscribe('s1', b.s)
+    // b gets the last frame at subscribe time — no tick in between.
+    expect(b.frames).toHaveLength(1)
+    expect(b.frames[0]!.content).toBe('boot')
+  })
+
+  it('ends every reader cleanly when the session is gone, and stops the loop', async () => {
+    const h = harness()
+    const a = sink()
+    const b = sink()
+    await h.hub.subscribe('s1', a.s)
+    await h.hub.subscribe('s1', b.s)
+    await flush()
+
+    h.set(null) // tmux no longer has the session
+    await h.tick()
+
+    expect(a.ends).toEqual(['gone'])
+    expect(b.ends).toEqual(['gone'])
+    expect(h.hub.activeLoops()).toBe(0) // a dying session takes nothing else down and leaks nothing
+    expect(h.cleared()).toBe(true)
+  })
+
+  it('serves an EXITED but still-capturable pane as a dead-but-readable frame, not an end', async () => {
+    const h = harness()
+    const a = sink()
+    await h.hub.subscribe('s1', a.s)
+    await flush()
+
+    h.set(cap(['last words'], { alive: false }))
+    await h.tick()
+
+    expect(a.ends).toEqual([]) // NOT ended: the session is still there, just finished
+    expect(a.frames.at(-1)!.alive).toBe(false)
+    expect(a.frames.at(-1)!.cursor).toBeNull()
+    expect(a.frames.at(-1)!.content).toBe('last words')
+  })
+
+  it('refuses a session this machine does not manage — scope, before any loop starts', async () => {
+    const h = harness({ managed: false })
+    const a = sink()
+    await h.hub.subscribe('elsewhere', a.s)
+    await flush()
+
+    expect(a.ends).toEqual(['not-found'])
+    expect(a.frames).toEqual([])
+    expect(h.hub.activeLoops()).toBe(0)
+    expect(h.intervalStarted()).toBe(false)
+  })
+
+  it('stops capturing once the last reader leaves', async () => {
+    const h = harness()
+    const a = sink()
+    const b = sink()
+    const offA = await h.hub.subscribe('s1', a.s)
+    const offB = await h.hub.subscribe('s1', b.s)
+    await flush()
+
+    offA()
+    expect(h.hub.activeLoops()).toBe(1) // b is still watching
+    expect(h.cleared()).toBe(false)
+
+    offB()
+    expect(h.hub.activeLoops()).toBe(0) // nobody left — the loop is stopped
+    expect(h.cleared()).toBe(true)
+  })
+
+  it('is idempotent on a double unsubscribe', async () => {
+    const h = harness()
+    const a = sink()
+    const off = await h.hub.subscribe('s1', a.s)
+    await flush()
+    off()
+    off() // must not throw or double-count
+    expect(h.hub.activeLoops()).toBe(0)
+  })
+})

--- a/packages/server/server/sessions/terminal-hub.ts
+++ b/packages/server/server/sessions/terminal-hub.ts
@@ -1,0 +1,150 @@
+/**
+ * terminal-hub.ts — one capture loop per WATCHED session, shared by every reader of it.
+ *
+ * The criterion the spec sets is "follow the agent without hammering the server with a fleet of open
+ * sessions". Two properties deliver it, and both live here:
+ *
+ *  - **Viewer-gated.** A session is captured only while at least one browser is watching it. The
+ *    loop starts on the first subscriber and stops on the last. So the server's work scales with the
+ *    number of open TERMINALS (usually one), never with the size of the fleet.
+ *  - **Shared, deduped.** Many readers of the same session share ONE loop and ONE tmux read per
+ *    tick; an unchanged frame is sent to nobody. A reader that joins mid-stream is handed the last
+ *    frame immediately, so it sees the current screen without waiting for the next change.
+ *
+ * Injectable on purpose — the backend, the scope check and the clock are passed in — because that is
+ * how `createSessionsPoller` is built and tested in this same directory, and it lets the "one loop
+ * for N readers / dedup / death ends the stream" behaviour be proven without a tmux server. The
+ * decisions that could be silently wrong (what counts as a change, how a capture becomes a frame)
+ * live in the pure `terminal-stream.ts`; this module is the orchestration around them.
+ */
+
+import { buildFrame, captureDigest, type TerminalEndReason, type TerminalFrame } from './terminal-stream'
+import type { TerminalCapture } from './types'
+
+export interface TerminalSink {
+  onFrame(frame: TerminalFrame): void
+  onEnd(reason: TerminalEndReason): void
+}
+
+type TimerHandle = ReturnType<typeof setInterval>
+
+export interface TerminalHubDeps {
+  /** Read the pane, ANSI-preserved. `null` means the session is GONE (ends the stream). */
+  capture(id: string): Promise<TerminalCapture | null>
+  /** Scope gate: is this a session this machine manages and this user may already see? A stream for
+   *  anything else is refused before a loop ever starts — writing power never, reading power never,
+   *  widens past the fleet the dashboard already lists. */
+  isManaged(id: string): Promise<boolean>
+  /** The scrollback ceiling, carried into each frame for the "showing last N of M" honesty. */
+  historyLimit: number
+  /** How many lines of history each capture requests — decides a frame's `truncated` flag. */
+  viewLines: number
+  pollMs: number
+  /** Injectable so a test drives the loop by hand instead of by wall-clock. */
+  setInterval?: (fn: () => void, ms: number) => TimerHandle
+  clearInterval?: (h: TimerHandle) => void
+}
+
+interface Entry {
+  sinks: Set<TerminalSink>
+  handle: TimerHandle | null
+  /** Guards against a slow tmux read overlapping the next tick. */
+  busy: boolean
+  lastDigest: string | null
+  lastFrame: TerminalFrame | null
+  seq: number
+}
+
+export interface TerminalHub {
+  /** Start (or join) watching a session. The returned function unsubscribes; call it once. */
+  subscribe(id: string, sink: TerminalSink): Promise<() => void>
+  /** How many capture loops are running — for the route's cap and for tests. */
+  activeLoops(): number
+  /** Total readers across all sessions — for the route's cap. */
+  subscribers(): number
+}
+
+export function createTerminalHub(deps: TerminalHubDeps): TerminalHub {
+  const setIv: (fn: () => void, ms: number) => TimerHandle =
+    deps.setInterval ?? ((fn, ms) => setInterval(fn, ms) as TimerHandle)
+  const clearIv: (h: TimerHandle) => void = deps.clearInterval ?? clearInterval
+  const entries = new Map<string, Entry>()
+
+  function stop(id: string, entry: Entry): void {
+    if (entry.handle !== null) { clearIv(entry.handle); entry.handle = null }
+    entries.delete(id)
+  }
+
+  async function tick(id: string): Promise<void> {
+    const entry = entries.get(id)
+    if (!entry || entry.busy) return
+    entry.busy = true
+    try {
+      let cap: TerminalCapture | null
+      try {
+        cap = await deps.capture(id)
+      } catch {
+        // A read that THREW is not proof the session is gone (a transient tmux hiccup), so it does
+        // not end the stream — the next tick tries again. Only an explicit `null` means gone.
+        return
+      }
+      const still = entries.get(id)
+      if (!still) return // unsubscribed while the read was in flight
+      if (cap === null) {
+        for (const s of [...still.sinks]) { try { s.onEnd('gone') } catch { /* sink is done */ } }
+        stop(id, still)
+        return
+      }
+      const digest = captureDigest(cap.lines, cap.info)
+      if (digest === still.lastDigest) return // nothing changed — send nobody a frame
+      still.seq += 1
+      const frame = buildFrame(still.seq, cap.lines, cap.info, deps.historyLimit, deps.viewLines)
+      still.lastDigest = digest
+      still.lastFrame = frame
+      for (const s of [...still.sinks]) { try { s.onFrame(frame) } catch { /* sink is done */ } }
+    } finally {
+      const e = entries.get(id)
+      if (e) e.busy = false
+    }
+  }
+
+  return {
+    async subscribe(id, sink) {
+      if (!(await deps.isManaged(id))) {
+        try { sink.onEnd('not-found') } catch { /* sink is done */ }
+        return () => {}
+      }
+      let entry = entries.get(id)
+      if (!entry) {
+        entry = { sinks: new Set(), handle: null, busy: false, lastDigest: null, lastFrame: null, seq: 0 }
+        entries.set(id, entry)
+        // First tick immediately so the first reader is not waiting a whole interval for a screen
+        // that already exists, then on the cadence.
+        entry.handle = setIv(() => { void tick(id) }, deps.pollMs)
+        void tick(id)
+      } else if (entry.lastFrame) {
+        // A newcomer to a running loop gets the current screen now, not at the next change.
+        try { sink.onFrame(entry.lastFrame) } catch { /* sink is done */ }
+      }
+      entry.sinks.add(sink)
+
+      let done = false
+      return () => {
+        if (done) return
+        done = true
+        const e = entries.get(id)
+        if (!e) return
+        e.sinks.delete(sink)
+        if (e.sinks.size === 0) stop(id, e) // last reader left — stop hammering tmux
+      }
+    },
+    activeLoops() {
+      return entries.size
+    },
+    subscribers() {
+      let n = 0
+      for (const e of entries.values()) n += e.sinks.size
+      return n
+    },
+  }
+}

--- a/packages/server/server/sessions/terminal-stream.test.ts
+++ b/packages/server/server/sessions/terminal-stream.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'bun:test'
+import { buildFrame, captureDigest, encodeSse } from './terminal-stream'
+import type { PaneInfo } from './types'
+
+const info = (over: Partial<PaneInfo> = {}): PaneInfo => ({
+  cols: 80, rows: 40, cursorX: 5, cursorY: 2, alive: true, historySize: 0, ...over,
+})
+
+describe('captureDigest', () => {
+  it('is stable for an identical capture, so an unchanged frame is sent to nobody', () => {
+    expect(captureDigest(['a', 'b'], info())).toBe(captureDigest(['a', 'b'], info()))
+  })
+
+  it('changes when the CONTENT changes', () => {
+    expect(captureDigest(['a'], info())).not.toBe(captureDigest(['a', 'b'], info()))
+  })
+
+  it('changes when only the CURSOR moves — a still screen with a moved cursor still moved', () => {
+    expect(captureDigest(['a'], info({ cursorX: 5 }))).not.toBe(captureDigest(['a'], info({ cursorX: 6 })))
+  })
+
+  it('changes when a line scrolled off into history though the visible text looks the same', () => {
+    // historySize is part of the digest precisely so a tail-follower learns the pane moved.
+    expect(captureDigest(['x'], info({ historySize: 10 }))).not.toBe(captureDigest(['x'], info({ historySize: 11 })))
+  })
+
+  it('changes when the pane dies', () => {
+    expect(captureDigest(['x'], info({ alive: true }))).not.toBe(captureDigest(['x'], info({ alive: false })))
+  })
+})
+
+describe('buildFrame', () => {
+  const VIEW = 200
+
+  it('joins the lines with newlines and carries the geometry', () => {
+    const f = buildFrame(3, ['one', 'two'], info({ cols: 100, rows: 30 }), 50_000, VIEW)
+    expect(f.seq).toBe(3)
+    expect(f.content).toBe('one\ntwo')
+    expect(f.cols).toBe(100)
+    expect(f.rows).toBe(30)
+    expect(f.lines).toBe(2)
+    expect(f.historyLimit).toBe(50_000)
+  })
+
+  it('carries the cursor while alive', () => {
+    expect(buildFrame(1, ['x'], info({ cursorX: 7, cursorY: 4 }), 100, VIEW).cursor).toEqual({ x: 7, y: 4 })
+  })
+
+  it('drops the cursor once the pane is dead — a cursor on a frozen frame is the frozen-looks-alive lie', () => {
+    expect(buildFrame(1, ['x'], info({ alive: false }), 100, VIEW).cursor).toBeNull()
+    expect(buildFrame(1, ['x'], info({ alive: false }), 100, VIEW).alive).toBe(false)
+  })
+
+  it('flags truncation when the pane holds more history than the shipped window', () => {
+    // 300 lines of scrollback, only 200 shipped → there is more above the fold.
+    expect(buildFrame(1, ['a'], info({ historySize: 300 }), 50_000, VIEW).truncated).toBe(true)
+  })
+
+  it('does not flag truncation when the whole backlog fits the window', () => {
+    // 40 lines of scrollback, window of 200 → nothing is above the fold.
+    expect(buildFrame(1, ['a'], info({ historySize: 40 }), 50_000, VIEW).truncated).toBe(false)
+    expect(buildFrame(1, ['a'], info({ historySize: 0 }), 50_000, VIEW).truncated).toBe(false)
+  })
+})
+
+describe('encodeSse', () => {
+  it('frames one event with the trailing blank line the protocol needs', () => {
+    expect(encodeSse('frame', { seq: 1 })).toBe('event: frame\ndata: {"seq":1}\n\n')
+  })
+
+  it('preserves ANSI escapes through JSON, so colours survive the wire', () => {
+    const chunk = encodeSse('frame', { content: '\x1b[31mred\x1b[0m' })
+    expect(chunk).toContain('\\u001b[31mred')
+    expect(JSON.parse(chunk.split('data: ')[1]!.trim()).content).toBe('\x1b[31mred\x1b[0m')
+  })
+})

--- a/packages/server/server/sessions/terminal-stream.ts
+++ b/packages/server/server/sessions/terminal-stream.ts
@@ -1,0 +1,103 @@
+/**
+ * terminal-stream.ts — PURE. The shape of what the terminal channel puts on the wire, and the two
+ * decisions that can be silently wrong if written by feel: whether a new capture is worth sending
+ * (dedup) and how the pane's own facts become an honest frame.
+ *
+ * The transport is SSE (see `docs/terminal-channel.md` for the why), and the whole feature is a
+ * SNAPSHOT model: each frame is a complete, self-contained picture of the pane as it renders RIGHT
+ * NOW — colours and all — so a reader that joins late or reconnects needs no replay, and a
+ * line-rewrite or a spinner is already resolved to its final glyph by tmux before we ever see it.
+ * That is the same discipline `attention-rules.ts:5` states: what we show is what the pane really
+ * rendered, never a reconstruction from memory of what a CLI prints.
+ */
+
+import type { PaneInfo } from './types'
+
+/**
+ * How many lines of scrollback+screen each frame carries.
+ *
+ * A screenful plus a margin: enough that a fast burst between two polls is not lost and the browser
+ * has some history to scroll, bounded so a changed frame is tens of KB and not the whole 50k
+ * backlog. The frame SAYS when there is more above it (`truncated`), so this is a shipping budget,
+ * not a claim that this is all there is.
+ */
+export const TERMINAL_VIEW_LINES = 200
+
+/** Default cadence of the shared capture loop. Snappy enough to feel live, slow enough that one
+ *  watched session is two tmux reads a second and no more. Overridable for the real hub / tests. */
+export const TERMINAL_POLL_MS = 500
+
+/** One complete, self-contained picture of a pane. */
+export interface TerminalFrame {
+  /** Monotonic within one stream. A client can spot a gap, and a newcomer's first frame is its own
+   *  seq so "did anything change" is answerable without diffing content. */
+  seq: number
+  /** The rendered pane, `\n`-joined, WITH SGR escape sequences intact. */
+  content: string
+  cols: number
+  rows: number
+  /** Where the block cursor sits — `null` once the pane is dead, because a cursor on a frozen frame
+   *  is the frozen-but-looks-alive lie this channel exists to avoid. */
+  cursor: { x: number; y: number } | null
+  /** False once the hosted command has exited. The last frame stays readable; it is just marked. */
+  alive: boolean
+  /** How many lines `content` carries — the honest "you are seeing N lines" number. */
+  lines: number
+  /** The scrollback ceiling tmux keeps, so the UI can say "showing last N of up to M". */
+  historyLimit: number
+  /** True when there is more scrollback above than this frame carries. */
+  truncated: boolean
+}
+
+/** Why a stream ended. `gone` = the session is no longer in tmux; `not-found` = it was never a
+ *  session this machine manages (scope refusal); `error` = the backend could not be read. */
+export type TerminalEndReason = 'gone' | 'not-found' | 'error'
+
+/**
+ * A cheap, total fingerprint of a capture — content plus every fact a frame carries EXCEPT `seq`
+ * (which is derived from change) and `historyLimit`/`truncated` (which are derived from the rest).
+ * Two captures with the same digest render identically, so the second is not worth a frame.
+ *
+ * `historySize` is deliberately included: the screen can look unchanged while a line has scrolled
+ * off the top into history, and a reader watching the tail wants to know the pane moved.
+ */
+export function captureDigest(lines: string[], info: PaneInfo): string {
+  return [
+    info.cols, info.rows, info.cursorX, info.cursorY,
+    info.alive ? 1 : 0, info.historySize, lines.length,
+  ].join(',') + '\n' + lines.join('\n')
+}
+
+/**
+ * Shape a raw capture into a frame.
+ *
+ * `truncated` is honest about the one thing this snapshot cannot show: scrollback beyond the window
+ * we ship. We capture at most `viewLines` lines of history (`capture-pane -S -viewLines`), so there
+ * is more above the fold precisely when the pane holds MORE history than that. `historyLimit` is the
+ * ceiling tmux would ever keep, for the "showing last N of up to M" line.
+ */
+export function buildFrame(
+  seq: number,
+  lines: string[],
+  info: PaneInfo,
+  historyLimit: number,
+  viewLines: number,
+): TerminalFrame {
+  return {
+    seq,
+    content: lines.join('\n'),
+    cols: info.cols,
+    rows: info.rows,
+    cursor: info.alive ? { x: info.cursorX, y: info.cursorY } : null,
+    alive: info.alive,
+    lines: lines.length,
+    historyLimit,
+    truncated: info.historySize > viewLines,
+  }
+}
+
+/** Encode one SSE event. Kept here, pure and tested, because a stray newline in the framing breaks
+ *  the whole protocol and is exactly the kind of thing that is invisible until a client parses it. */
+export function encodeSse(event: string, data: unknown): string {
+  return `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`
+}

--- a/packages/server/server/sessions/terminal-web.ts
+++ b/packages/server/server/sessions/terminal-web.ts
@@ -1,0 +1,121 @@
+/**
+ * terminal-web.ts — the WEB dashboard's live terminal channel onto one session's pane.
+ *
+ * The sibling of `fleet-web.ts`, and deliberately LEANER than it. `fleet-web` routes through the
+ * Ink control host because the fleet's ACTIONS carry rules that must not be re-implemented in a
+ * browser (a numbered dialog is never answered by a bare confirm). Reading a screen carries no such
+ * rule — a capture is a capture — so this channel talks straight to the session backend and skips
+ * the React/Ink import graph entirely. It keeps exactly ONE rule of its own, the one that matters:
+ * SCOPE. A stream is opened only for a session THIS MACHINE MANAGES (its own registry), so the read
+ * power never reaches past the fleet the dashboard already lists — the same boundary the write path
+ * will inherit in Phase 2, established here where it is cheap.
+ *
+ * The heavy lifting (shared loop, dedup, death) is `terminal-hub.ts`; the framing is the pure
+ * `terminal-stream.ts`. This file is just the singleton wiring and the SSE plumbing. The whole
+ * surface is additionally gated by `localShell` in `capability-guard.ts` and 404'd on a central, so
+ * it is unreachable on an internet-exposed instance regardless of who is authenticated — a captured
+ * terminal is shell access with extra steps.
+ */
+
+import { resolveBackend } from './index'
+import { readRegistry } from './registry'
+import { createTerminalHub, type TerminalHub } from './terminal-hub'
+import { encodeSse, TERMINAL_POLL_MS, TERMINAL_VIEW_LINES } from './terminal-stream'
+import { HISTORY_LIMIT } from './tmux-cli'
+
+/**
+ * A ceiling on concurrent terminal streams for the whole process. Each holds a socket, a controller
+ * and (with the hub's sharing) at worst one capture loop, so an unbounded count is a free way to
+ * exhaust the server (OWASP API4) — the same reason `/api/events` caps its client set.
+ */
+export const MAX_TERMINAL_STREAMS = 100
+
+/**
+ * A comment line every so often to keep the connection warm. A terminal that is deduped to silence
+ * — a session sitting on a permission prompt sends no frames for minutes — is exactly the case a
+ * proxy or load balancer reaps as idle. An SSE comment (`: …`) is ignored by the client, so it
+ * costs nothing but the bytes.
+ */
+const KEEPALIVE_MS = 15_000
+
+const POLL_MS = Number(process.env.AGENTISTICS_TERMINAL_POLL_MS) > 0
+  ? Number(process.env.AGENTISTICS_TERMINAL_POLL_MS)
+  : TERMINAL_POLL_MS
+
+let hub: TerminalHub | null = null
+
+async function getHub(): Promise<TerminalHub> {
+  if (hub) return hub
+  // Resolved once: `resolveBackend` returns a constant object, and the hub then holds it.
+  const backend = await resolveBackend()
+  hub = createTerminalHub({
+    capture: id => backend.captureTerminal(id, TERMINAL_VIEW_LINES),
+    isManaged: async id => (await readRegistry()).some(m => m.id === id),
+    historyLimit: HISTORY_LIMIT,
+    viewLines: TERMINAL_VIEW_LINES,
+    pollMs: POLL_MS,
+  })
+  return hub
+}
+
+/** Scope check for the route, so a session outside this machine's fleet is a clean 404 rather than
+ *  a 200 stream that immediately says `not-found`. The hub re-checks on subscribe regardless. */
+export async function terminalSessionExists(id: string): Promise<boolean> {
+  return (await readRegistry()).some(m => m.id === id)
+}
+
+/** True when the process is already at its stream ceiling — the route answers 503. */
+export async function terminalAtCapacity(): Promise<boolean> {
+  return (await getHub()).subscribers() >= MAX_TERMINAL_STREAMS
+}
+
+/**
+ * Build the SSE body for one session's terminal. The caller wraps it in a Response with the CORS +
+ * event-stream headers (matching `/api/events`). Cleanup is tied to `signal`: when the browser
+ * disconnects, the subscription is dropped, and when the last reader of a session leaves the hub
+ * stops capturing it.
+ */
+export async function openTerminalStream(id: string, signal: AbortSignal): Promise<ReadableStream<Uint8Array>> {
+  const h = await getHub()
+  const enc = new TextEncoder()
+  let unsubscribe: (() => void) | null = null
+  let keepalive: ReturnType<typeof setInterval> | null = null
+
+  const teardown = () => {
+    unsubscribe?.()
+    unsubscribe = null
+    if (keepalive !== null) { clearInterval(keepalive); keepalive = null }
+  }
+
+  return new ReadableStream<Uint8Array>({
+    async start(controller) {
+      let closed = false
+      const send = (chunk: string) => {
+        if (closed) return
+        try { controller.enqueue(enc.encode(chunk)) } catch { closed = true }
+      }
+      const close = () => {
+        if (closed) return
+        closed = true
+        teardown()
+        try { controller.close() } catch { /* already closed */ }
+      }
+
+      // If the browser is already gone by the time we start, do nothing.
+      if (signal.aborted) { close(); return }
+
+      send(encodeSse('open', { id, viewLines: TERMINAL_VIEW_LINES, historyLimit: HISTORY_LIMIT }))
+      keepalive = setInterval(() => send(': keepalive\n\n'), KEEPALIVE_MS)
+
+      unsubscribe = await h.subscribe(id, {
+        onFrame: frame => send(encodeSse('frame', frame)),
+        onEnd: reason => { send(encodeSse('end', { reason })); close() },
+      })
+
+      signal.addEventListener('abort', close)
+    },
+    cancel() {
+      teardown()
+    },
+  })
+}

--- a/packages/server/server/sessions/tmux-cli.test.ts
+++ b/packages/server/server/sessions/tmux-cli.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from 'bun:test'
 import {
-  LIST_FORMAT, attachArgs, capturePaneArgs, idFromTmuxName, isSessionGoneError, killSessionArgs,
-  newSessionArgs, parsePrefix, parseTmuxList, sendKeysEnterArgs, sendKeysLiteralArgs,
+  LIST_FORMAT, PANE_INFO_FORMAT, attachArgs, capturePaneArgs, capturePaneAnsiArgs, idFromTmuxName,
+  isSessionGoneError, killSessionArgs, newSessionArgs, paneInfoArgs, parsePaneInfo, parsePrefix,
+  parseTmuxList, sendKeysEnterArgs, sendKeysLiteralArgs,
   sendKeysNamedArgs, trimCapture,
   tmuxName,
   serverOptionsArgs, HISTORY_LIMIT,
@@ -32,6 +33,10 @@ describe('the other argv builders', () => {
   it('builds them all against our socket and our session name', () => {
     expect(killSessionArgs('a1')).toEqual(['-L', 'agentop', 'kill-session', '-t', 'agentop-a1'])
     expect(capturePaneArgs('a1', 40)).toEqual(['-L', 'agentop', 'capture-pane', '-p', '-t', 'agentop-a1', '-S', '-40'])
+    // The ANSI variant is the plain one with `-e` added — colours survive to the browser. Getting
+    // this wrong is silent: without `-e` the terminal renders monochrome and looks fine.
+    expect(capturePaneAnsiArgs('a1', 40)).toEqual(['-L', 'agentop', 'capture-pane', '-p', '-e', '-t', 'agentop-a1', '-S', '-40'])
+    expect(paneInfoArgs('a1')).toEqual(['-L', 'agentop', 'display-message', '-p', '-t', 'agentop-a1', '-F', PANE_INFO_FORMAT])
     expect(sendKeysLiteralArgs('a1', 'hello there')).toEqual(['-L', 'agentop', 'send-keys', '-t', 'agentop-a1', '-l', 'hello there'])
     expect(sendKeysEnterArgs('a1')).toEqual(['-L', 'agentop', 'send-keys', '-t', 'agentop-a1', 'Enter'])
     expect(attachArgs('a1')).toEqual(['tmux', '-L', 'agentop', 'attach-session', '-t', 'agentop-a1'])
@@ -95,6 +100,30 @@ describe('trimCapture', () => {
 
   it('survives an all-blank frame', () => {
     expect(trimCapture(['', '', ''])).toEqual([])
+  })
+})
+
+describe('parsePaneInfo', () => {
+  it('reads the six numbers our PANE_INFO_FORMAT asks for', () => {
+    expect(parsePaneInfo('12\t3\t80\t40\t0\t500')).toEqual({
+      cols: 80, rows: 40, cursorX: 12, cursorY: 3, alive: true, historySize: 500,
+    })
+  })
+
+  it('reads pane_dead=1 as not alive', () => {
+    expect(parsePaneInfo('0\t0\t80\t40\t1\t0')!.alive).toBe(false)
+  })
+
+  it('returns null on a short or non-numeric line rather than a half-built PaneInfo', () => {
+    // A confident-wrong cursor or "alive" is worse than none: the channel refuses the frame's
+    // metadata instead of shipping a guess.
+    expect(parsePaneInfo('12\t3\t80')).toBeNull()
+    expect(parsePaneInfo('a\tb\tc\td\te\tf')).toBeNull()
+    expect(parsePaneInfo('')).toBeNull()
+  })
+
+  it('asks for exactly the fields it parses', () => {
+    expect(PANE_INFO_FORMAT).toBe('#{cursor_x}\t#{cursor_y}\t#{pane_width}\t#{pane_height}\t#{pane_dead}\t#{history_size}')
   })
 })
 

--- a/packages/server/server/sessions/tmux-cli.ts
+++ b/packages/server/server/sessions/tmux-cli.ts
@@ -13,7 +13,7 @@
  * Every field and flag below was probed against tmux 3.2a on 2026-08-12.
  */
 
-import type { BackendSession } from './types'
+import type { BackendSession, PaneInfo } from './types'
 
 export const TMUX_SOCKET = 'agentop'
 export const SESSION_PREFIX = 'agentop-'
@@ -43,6 +43,57 @@ export function killSessionArgs(id: string): string[] {
 
 export function capturePaneArgs(id: string, lines: number): string[] {
   return sock(['capture-pane', '-p', '-t', tmuxName(id), '-S', `-${lines}`])
+}
+
+/**
+ * The same read as `capturePaneArgs`, but `-e` keeps the SGR escape sequences in the output —
+ * colours, bold, reverse — so the browser terminal renders what a person would have seen on attach.
+ *
+ * A SEPARATE builder rather than a flag on the one above, and deliberately so: the plain capture
+ * feeds the readiness and approval REGEXES (`backend-tmux.ts`, `attention.ts`), and a frame carrying
+ * `\x1b[38;5;39m` in front of every word would break every one of those patterns silently. The two
+ * reads have opposite requirements, so they are two functions — the same reasoning that keeps
+ * `sendKeysLiteralArgs` and `sendKeysNamedArgs` apart.
+ */
+export function capturePaneAnsiArgs(id: string, lines: number): string[] {
+  return sock(['capture-pane', '-p', '-e', '-t', tmuxName(id), '-S', `-${lines}`])
+}
+
+/**
+ * One `display-message` read of the pane's geometry, cursor and liveness — the facts `capture-pane`
+ * cannot report. Tab-separated so `parsePaneInfo` can split it without guessing at spaces (a cwd or
+ * a title would carry them; these six numeric fields never do, but tab is free insurance).
+ *
+ * Must stay in lockstep with `parsePaneInfo` — the test asserts the exact format string for that
+ * reason, the same contract `LIST_FORMAT` keeps with `parseTmuxList`.
+ */
+export const PANE_INFO_FORMAT =
+  '#{cursor_x}\t#{cursor_y}\t#{pane_width}\t#{pane_height}\t#{pane_dead}\t#{history_size}'
+
+export function paneInfoArgs(id: string): string[] {
+  return sock(['display-message', '-p', '-t', tmuxName(id), '-F', PANE_INFO_FORMAT])
+}
+
+/**
+ * Parse the `PANE_INFO_FORMAT` line. `null` on anything that does not read as the six numbers it
+ * must be — a partial `PaneInfo` is worse than none, because the terminal channel would ship a
+ * confident wrong cursor or a wrong "alive". `pane_dead` is `1` once the hosted command has exited.
+ */
+export function parsePaneInfo(stdout: string): PaneInfo | null {
+  const line = stdout.split('\n')[0]?.trim() ?? ''
+  if (!line) return null
+  const parts = line.split('\t')
+  if (parts.length < 6) return null
+  const [cx, cy, w, h, dead, hist] = parts.map(Number)
+  if (![cx, cy, w, h, dead, hist].every(Number.isFinite)) return null
+  return {
+    cols: w!,
+    rows: h!,
+    cursorX: cx!,
+    cursorY: cy!,
+    alive: dead !== 1,
+    historySize: hist!,
+  }
 }
 
 /** `-l` sends the text literally, so a prompt containing `;` or `C-c` is typed, not interpreted. */

--- a/packages/server/server/sessions/types.ts
+++ b/packages/server/server/sessions/types.ts
@@ -152,6 +152,33 @@ export interface BackendInitialPrompt extends InitialPrompt {
   rules?: AttentionRules
 }
 
+/**
+ * The pane's live geometry and cursor, read alongside a capture.
+ *
+ * `capture-pane` renders the grid but says nothing about where the cursor is or whether the hosted
+ * command has exited, and both are things the terminal channel must tell the browser honestly: a
+ * frozen last frame that still shows a blinking cursor is exactly the `waiting` lie this house has
+ * a rule against. So the backend reads it in the same breath as the content (one `display-message`).
+ */
+export interface PaneInfo {
+  cols: number
+  rows: number
+  cursorX: number
+  cursorY: number
+  /** False once the hosted command has exited — the pane is dead but still capturable (remain-on-exit). */
+  alive: boolean
+  /** How many lines of scrollback tmux is holding above the visible screen, right now. */
+  historySize: number
+}
+
+/** One ANSI-preserving read of a pane: its rendered lines plus the geometry beside them. */
+export interface TerminalCapture {
+  /** Newest-last lines of the rendered frame, WITH the SGR escape sequences (`capture-pane -e`).
+   *  NOT trailing-trimmed: a full-screen TUI uses the whole grid and its blank rows are layout. */
+  lines: string[]
+  info: PaneInfo
+}
+
 /** One session as the BACKEND sees it — existence and liveness, no product metadata. */
 export interface BackendSession {
   id: string
@@ -309,6 +336,20 @@ export interface SessionBackend {
   list(): Promise<BackendSession[]>
   /** Newest-last lines of the last rendered frame, trailing blanks removed. */
   capture(id: string, lines: number): Promise<string[]>
+  /**
+   * An ANSI-PRESERVING read of the pane — its rendered lines with colour/attribute escapes intact,
+   * plus the geometry and cursor beside them — for the browser terminal channel.
+   *
+   * Distinct from `capture` on purpose: `capture` strips escapes because its callers pattern-match
+   * the text (readiness, approval detection), and a frame full of SGR codes would break those
+   * regexes. This one KEEPS them, because a terminal that loses its colours is a worse copy of the
+   * one a person would have got from `tmux attach`.
+   *
+   * `null` — never a throw — when the session is GONE (tmux no longer has it): the caller ends the
+   * stream cleanly rather than crashing. A pane that has merely EXITED still returns a capture with
+   * `info.alive === false`, so the last frame stays readable and is honestly marked dead.
+   */
+  captureTerminal(id: string, lines: number): Promise<TerminalCapture | null>
   /**
    * Type `text` into the session and submit it — what a person does at the keyboard.
    *


### PR DESCRIPTION
## What

Phase 1 of the **terminal channel**: stream a managed session's screen to the browser, live, so the web sessions tab can show what an agent is doing without anyone running `tmux attach`. **Read-only** — no keystrokes reach a session yet. Phase 2 (the write channel) is a separate, later delivery with its own security contract.

This is an amplification of an existing path: `backend-tmux.ts` already captured the pane; what was missing was a channel to the browser.

## Transport (decided + justified)

**SSE, snapshot-based, viewer-gated, one shared loop per session.**

- **SSE** over WebSocket — one-directional read, plain HTTP, auto-reconnect, reuses the dashboard's push transport; no new dependency.
- **`capture-pane -e`** (snapshot) over a raw byte stream — each frame is a complete rendered picture (colours intact), so a late reader or reconnect needs no replay, and a spinner/line-rewrite is already resolved by tmux. A **separate** capture builder from the plain one, so the readiness/approval regexes are never fed escape codes.
- **Viewer-gated + shared + deduped** — a session is captured only while watched; readers of the same session share one loop and one tmux read per tick; unchanged frames are sent to nobody. Server work scales with open *terminals* (usually one), not fleet size — the spec's criterion.
- **Death is honest** — a dead pane keeps streaming as `alive:false` (last frame readable, cursor dropped); only a session gone from tmux ends the stream. A dying session takes nothing else down and leaks nothing.

## Security (reuses the fleet model, invents nothing)

`GET /api/fleet/stream` rides the **`localShell`** capability (streaming a terminal is shell access with extra steps) → **403 on any exposed profile**, **404 on a central**, and is **scoped to sessions this machine manages**. The same boundary the Phase 2 write path will inherit.

## Contract

Documented for the web side (Wave 2) in `docs/terminal-channel.md` — events (`open`/`frame`/`end`), frame semantics, status codes, rendering, and the PR #243 rule that any status indicator beside the terminal must come from the fleet's own two-sample-concordant state, not a recomputed one.

## Verification

- `bun tsc --noEmit`, `bun test` (4530 pass / 0 fail incl. tokens lint), `build:binary` — all green; `bun.lock` unchanged.
- New pure tests: ANSI-arg builders + `parsePaneInfo`; frame dedup / cursor-null-when-dead / truncation; hub one-loop-for-N-readers, dedup, death→end, scope refusal, cleanup.
- **Driven against the compiled binary** (`release/agentop server`): ANSI preserved end-to-end, monotonic deduped `frame` events, **404** for an unmanaged id, **400** for a missing id, **403** (`capability_disabled: localShell`) on a public profile. Real-tmux backend check: ANSI + `PaneInfo` parsed, `captureTerminal` returns `null` (no throw) after the session is killed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)