### PR TITLE
release: waiting honesto, prompt inicial entregue, terminal ao vivo e busca cumulativa

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,7 +177,14 @@ packages/server/server/          — server-side modules (never bundled by Vite)
   │                          harness — `nameSince` exists only from claude 2.1.232, and the
   │                          complaint this answers is a rename made inside the session that agentop
   │                          went on ignoring. NEITHER name is discarded when they differ: the row
-  │                          says which place the one it is showing came from. `session-view.ts` merges the managed fleet
+  │                          says which place the one it is showing came from. **A `/rename` name
+  │                          OUTLIVES the process**: the harness deletes its `<pid>.json` on exit, so a
+  │                          finished session lost that name and its title FLIPPED to another source,
+  │                          breaking search — the poller now PERSISTS the live non-derived name into
+  │                          `ManagedSession.harnessName`/`harnessNameSince` (mirror of
+  │                          `recordConversation`, one write per rename, `chosenName` only), and
+  │                          `buildSessionViews` reads it as the fallback when the live file is gone, so
+  │                          `pickTitle` returns the same title alive or finished. `session-view.ts` merges the managed fleet
   │                          with the EXTERNAL assistants `/proc` reports (listed, marked, and
   │                          carrying no activity — nothing about them is capturable), and
   │                          `sessions-host.ts` is the 5s poller, whose failed poll keeps the
@@ -187,8 +194,20 @@ packages/server/server/          — server-side modules (never bundled by Vite)
   │                          **A reboot takes tmux and leaves the registry**, so every managed
   │                          session reconciles to `lost` while keeping its name, note and task —
   │                          `session-view.ts` therefore offers REOPEN for any managed row that is
-  │                          not running, not only for one the user finished, and the pure
-  │                          `task-reopen.ts` holds what "open the whole task" means (a running row
+  │                          not running, not only for one the user finished. **But a RETIRED
+  │                          predecessor is not a second session**: every attach/reopen/restart mints a
+  │                          new managedId for the SAME conversation and retires the old record without
+  │                          removing it, so a conversation reopened N times drew N `exited` rows beside
+  │                          its live continuation — the row key was the per-spawn id, not the identity.
+  │                          The pure `collapseSupersededSessions` (session-view.ts, applied at the
+  │                          return) drops a predecessor ONLY when it is provably dead (`endedMs` set)
+  │                          AND superseded by a same-`conversationId` sibling (a live row, or a newer
+  │                          ended one). It NEVER hides a live row, a `lost` row with no recorded end,
+  │                          or the newest ended row (the reopenable one); rows with NO conversationId
+  │                          are never grouped, because a shared directory or label is not an identity —
+  │                          the coordinator reads this list to decide whether to re-dispatch over work
+  │                          in flight, so a row it cannot prove dead is never removed. The
+  │                          pure `task-reopen.ts` holds what "open the whole task" means (a running row
   │                          is left alone and reported as `already`, never as a skip; a FINISHED
   │                          row is not resurrected; an unresolvable one is skipped AND counted;
   │                          everything reopened RETIRES the row it replaced, or a laptop closed

--- a/docs/session-manager.md
+++ b/docs/session-manager.md
@@ -312,10 +312,20 @@ CLI, so it exists only for the harnesses that were probed (claude, codex, kimi).
 harness a blocking question shows as `waiting` — still counted, still surfaced, but the reason
 cannot be named. `ls` and `list` both say so rather than leaving you to assume otherwise.
 
-The states are also honest about their own timing. When a turn ends, the poll that *observes* it
-ending sees a frame that changed since the last one, which is movement — so the session reads
-`working` for that one interval before settling on `waiting`. The signal is therefore at most one
-interval late and never early, which is the right way round for something a person acts on.
+The states are also honest about their own timing, and deliberately biased. A single frame is a
+noisy sample: a session that has just finished a turn, or one whose pane a plugin repainted for a
+moment, reads `working` on one poll and `waiting` on the next with nothing about it having changed.
+Believing that lone `waiting` is how the counter came to say "waiting on you" about a session that
+had already gone back to work — a false summons that wastes the most expensive resource here and,
+once it has cried wolf, stops being read. So the two directions are confirmed differently
+(`attention-confirm.ts`): **`waiting` and `NEEDS APPROVAL` are believed only once the same reading
+has held for two consecutive polls**, while a return to `working` (a screen that moved — unambiguous
+proof) and `exited` are believed at once. The counter therefore never spikes on a single quiet
+frame, and it DROPS on the very next poll after work resumes. The cost is that a genuine wait takes
+one extra interval to appear — the cheap direction, since a slightly late "needs you" only delays a
+person while a false one wastes them. The event channel (`agentop events`) confirms every transition
+the same way for the same reason, so the two surfaces agree on when a session starts waiting; the
+fleet display just clears it a poll sooner.
 
 ## Harness support
 
@@ -330,6 +340,20 @@ interval late and never early, which is the right way round for something a pers
 
 `kimi` and `copilot` have no flag for an initial prompt in an interactive session — their `-p` runs
 one prompt non-interactively and exits — so agentop types the prompt in once the session is up.
+
+**Delivering the initial prompt is READINESS-GATED** (`initial-prompt.ts`), not a fixed sleep. A
+detached session created with a prompt has to receive it with no human in the loop, and two things
+used to break that silently: a slow-starting harness lost a prompt typed after a fixed 1200 ms into
+a pane that had not drawn yet, and a positional prompt was left entirely to the CLI to auto-submit —
+which some versions do not do (the prompt "stays in the field" and the agent sits waiting for
+something that already arrived). So agentop now polls the pane and delivers only once the harness is
+genuinely ready — its input surface drawn, and NOT sitting on a startup/approval dialog — and then
+once: a typed harness has its text typed and submitted; a positional harness whose "working" marker
+lets us tell an auto-submitted turn from an idle prompt (claude) gets a single Enter to submit the
+pre-filled text, but only after it has sat idle for a few polls without ever running, so a CLI that
+DOES auto-submit is never double-submitted. It is never delivered into a dialog — launched in a
+folder it does not yet trust, claude opens with a trust prompt whose default is "No, exit", and a
+blind early Enter would select it and kill the session.
 
 Codex's reasoning effort is a `-c key=value` configuration override rather than a flag; it is not
 wired up because the key could not be verified from the CLI itself, and agentop does not guess flags.

--- a/docs/session-manager.md
+++ b/docs/session-manager.md
@@ -233,6 +233,28 @@ you are in. A row that does know its conversation never falls back to that guess
 before the transcript exists: "not written yet" and "some other conversation in this directory" are
 different answers.
 
+### One row per session, and a name that outlives the process
+
+A session's durable identity is its **conversation**, but the registry keys a record by the
+per-spawn managed id — a new one every time a session is attached, reopened or restarted. Each of
+those retires the record it replaced (`endedAt`) without removing it, so a conversation reopened five
+times used to stand on screen as five `exited` rows beside its one live continuation, all wearing the
+same name. The list collapses those: a retired predecessor is hidden **only** when it is provably
+dead (`endedAt` is set) **and** superseded by a row of the same conversation — a live one, or a newer
+ended one, which *is* that session continued. A live row is never hidden, a `lost` row with no
+recorded end (a reboot) is never hidden, and the newest ended row of a conversation with nothing live
+is kept, because it is the one you reopen. Two rows that merely share a directory or a label are left
+alone: only a shared **conversation id** proves two rows are one session, so the list never merges
+sessions that are genuinely distinct.
+
+A **title is an identity**: whatever a session is called while it runs, it stays called after it
+ends. The name you give a session from *inside* Claude Code (`/rename`) lives only in the harness's
+own record, which Claude deletes when the process exits — so a finished session used to lose that
+name, its displayed title fell back to a different source, and `CTRL+F` could no longer find the row
+by the name it wore a second earlier. agentop now captures that name into the registry while the
+session is alive, so the title is the same before and after it finishes. Only a name a person typed
+is kept; a name the harness invented for itself never displaces your own label.
+
 ### Tasks
 
 A task is whatever you say it is: a free string, chosen while starting a session or added later, and
@@ -341,8 +363,14 @@ None of this touches your own tmux: different socket, different server, differen
 tasks, and an `endedAt` on the ones that are over. tmux is authoritative about what is RUNNING; this
 file is authoritative about what it MEANS, which is why a reboot takes the first and leaves the
 second. A session is marked finished rather than deleted: it is still a thing that happened, and
-reopening it is the ordinary next thing to want.
+reopening it is the ordinary next thing to want. It also holds `harnessName` — the `/rename` name
+captured from the harness while the session was alive, so the title survives after the harness
+deletes its own record.
 
-`~/.agentistics/preferences.json` — `sessionView` (how the list is arranged) and `finishedTasks`
-(the tasks you marked done). Both are properties of this machine rather than of any session, which
-is why they do not live in the registry.
+`~/.agentistics/preferences.json` — `sessionView` (how the list is arranged, including
+`searchScopes`: which fields the search looks in) and `finishedTasks` (the tasks you marked done).
+Both are properties of this machine rather than of any session, which is why they do not live in the
+registry. `searchScopes` is a set — name, folder, harness, note, task, prompt, transcript — so the
+"all" control is simply every scope present; when it has never been chosen the search covers every
+field a row carries on its own, and `transcript` (a text scan of the conversation on disk) is an
+explicit opt-in rather than a cost paid on every keystroke.

--- a/docs/terminal-channel.md
+++ b/docs/terminal-channel.md
@@ -1,0 +1,144 @@
+# Live terminal channel
+
+`GET /api/fleet/stream` streams a managed session's terminal — the actual screen a coding assistant
+is drawing, colours and all — to the browser over SSE, so the sessions tab can show what an agent is
+doing without anyone opening a terminal and running `tmux attach`.
+
+This is the **server contract** the web dashboard consumes. The web side (the terminal panel and its
+emulator) must build on exactly this — it does not invent its own endpoint.
+
+**Phase 1 is read-only.** There is no write path yet: no keystrokes reach the session through this
+channel. A write channel (`Phase 2`) is a separate, later delivery with its own security contract;
+until it exists the web must show **no input box**, because a text field that does nothing is the
+same kind of lie as a frozen terminal that looks live.
+
+## Transport, and why
+
+**SSE (Server-Sent Events), snapshot-based, viewer-gated, one shared loop per session.**
+
+- **SSE over WebSocket.** The read channel is one-directional (server → browser). SSE is plain
+  HTTP, reconnects on its own, and is already the dashboard's push transport (`/api/events`). A
+  WebSocket would buy bidirectionality Phase 1 does not use and a dependency the repo does not have.
+- **Snapshot (`tmux capture-pane`) over a raw byte stream (`pipe-pane`).** `capture-pane` returns
+  the *rendered grid* — a spinner, a redrawn line, a moved cursor are already resolved to their
+  final glyphs by tmux before we see them. So every frame is a **complete, self-contained picture**:
+  a reader that joins late or reconnects needs no replay, and what we show is what the pane actually
+  rendered (the `attention-rules.ts` discipline: never a reconstruction from memory of what a CLI
+  prints). Colours survive because we capture with `-e`.
+- **Viewer-gated + shared.** A session is captured **only while at least one browser is watching**
+  it. Many readers of the same session share **one** capture loop and **one** tmux read per tick; an
+  unchanged frame is sent to nobody. So the server's work scales with the number of open *terminals*
+  (usually one), never with the size of the fleet — the criterion the spec set.
+
+Tuning constants live in `packages/server/server/sessions/terminal-stream.ts`
+(`TERMINAL_VIEW_LINES`, `TERMINAL_POLL_MS`) and `terminal-web.ts` (`MAX_TERMINAL_STREAMS`,
+`KEEPALIVE_MS`). The poll cadence is overridable with `AGENTISTICS_TERMINAL_POLL_MS`.
+
+## Request
+
+```
+GET /api/fleet/stream?id=<sessionId>
+Accept: text/event-stream
+```
+
+- `id` — the session's id, the **same `id`** carried on every row of `GET /api/fleet` and accepted
+  by `POST /api/fleet/act`. No other identifier.
+- Same-origin only; no body.
+
+### Status codes (before the stream opens)
+
+| Code | Meaning |
+|------|---------|
+| `200` | Stream opens (`text/event-stream`). |
+| `400` | `{"error":"bad_request"}` — `id` missing. |
+| `404` | `{"error":"not_found"}` — `id` is not a session this machine manages (**scope**). |
+| `404` | `{"error":"fleet_central"}` — called on a team central (the fleet lives on members). |
+| `403` | `{"error":"capability_disabled","capability":"localShell"}` — exposed profile (see Security). |
+| `503` | `{"error":"too_many_streams"}` — process at `MAX_TERMINAL_STREAMS`. |
+
+## Events
+
+The stream emits named SSE events. `: keepalive` comment lines arrive ~every 15s and are ignored.
+
+### `open` — once, first
+
+```json
+{ "id": "3f5f", "viewLines": 200, "historyLimit": 50000 }
+```
+
+### `frame` — the screen, on every change (deduped)
+
+```json
+{
+  "seq": 7,
+  "content": "[1m[35mclaude[0m … ",
+  "cols": 120,
+  "rows": 40,
+  "cursor": { "x": 6, "y": 12 },
+  "alive": true,
+  "lines": 53,
+  "historyLimit": 50000,
+  "truncated": false
+}
+```
+
+| Field | Meaning |
+|-------|---------|
+| `seq` | Monotonic within one stream; advances **only when the screen changed**. A late reader's first frame is the current one, whatever its `seq`. |
+| `content` | The rendered pane, `\n`-joined, **with SGR escape sequences intact**. Feed it to a terminal emulator. |
+| `cols` / `rows` | Pane geometry (`0` cols is a rare "don't know" fallback; the emulator sizes itself). |
+| `cursor` | Block-cursor position, or **`null` once the pane is dead** — never draw a cursor on a dead frame. |
+| `alive` | `false` once the hosted command has exited. The last frame stays readable and must be shown as **finished**, not live. |
+| `lines` | How many lines `content` carries — the honest "you are seeing N lines" number. |
+| `historyLimit` | The scrollback ceiling tmux keeps (`50000`), for a "showing last N of up to M" line. |
+| `truncated` | `true` when there is more scrollback above than this frame carries. |
+
+**Rendering.** Each `frame` is a full snapshot, not a delta: on receipt, reset the emulator and write
+`content` (`term.reset(); term.write(frame.content)`), or the equivalent. Do not append frames.
+
+### `end` — once, last (then the stream closes)
+
+```json
+{ "reason": "gone" }
+```
+
+- `gone` — the session left tmux (killed, or the machine's tmux went away). Mark the terminal
+  ended; the last `frame` is the last thing it drew.
+- `not-found` — the id stopped being a managed session mid-stream (scope).
+- `error` — the backend could not be read.
+
+A session that merely **exits** does **not** end the stream — it keeps arriving as `frame`s with
+`alive:false`, so the finished screen stays readable. `end` is only for a session that is gone.
+
+## Security
+
+The read channel inherits the fleet's existing model exactly — it invents no new auth:
+
+- **`localShell` capability** (`capability-guard.ts`). Streaming a session's screen is a coding
+  assistant's terminal, transcript and all — shell access with extra steps. So it is **403'd on any
+  exposed profile** (`lan`/`public`) regardless of who is authenticated, the same as `/api/fleet`.
+  On a `local` profile (127.0.0.1, the machine's own dashboard) it is available, as the fleet is.
+- **Scope.** A stream opens only for a session **this machine manages** (its own registry). The read
+  power never reaches past the fleet the dashboard already lists — the boundary the Phase 2 *write*
+  path will inherit, established here where it is cheap.
+- **404 on a central.** Like `/api/fleet`; the fleet is a member/solo concept.
+
+## Status indicators beside the terminal
+
+Any activity indicator the web shows next to the terminal (working / needs-you) must come from the
+**fleet's own state** (`GET /api/fleet`, the `activity`/attention the cockpit already computes) —
+which, per PR #243, requires **two concordant samples** before it asserts `waiting` and accepts a
+return to work immediately. Do **not** recompute a separate "looks idle" signal from the terminal
+frames: a still screen is not the same as a session waiting on a person, and inventing a second
+source is how the two disagree.
+
+## Files
+
+| File | Role |
+|------|------|
+| `sessions/tmux-cli.ts` | pure — `capturePaneAnsiArgs` (`-e`), `paneInfoArgs` / `parsePaneInfo`. |
+| `sessions/terminal-stream.ts` | pure — frame shape, dedup digest, `buildFrame`, SSE encoder. |
+| `sessions/terminal-hub.ts` | the shared, ref-counted, deduped capture loop (injectable). |
+| `sessions/backend-tmux.ts` | `captureTerminal` — one ANSI-preserving read + geometry. |
+| `sessions/terminal-web.ts` | singleton wiring + SSE plumbing + scope/cap gates. |
+| `server/index.ts` | the `GET /api/fleet/stream` route. |

--- a/packages/server/server/capability-guard.test.ts
+++ b/packages/server/server/capability-guard.test.ts
@@ -31,6 +31,9 @@ describe('routeCapability', () => {
     // on an exposed profile whoever is authenticated.
     expect(routeCapability('/api/fleet')).toBe('localShell')
     expect(routeCapability('/api/fleet/act')).toBe('localShell')
+    // The live terminal channel streams a session's SCREEN. It is a read, but a read of a coding
+    // assistant's terminal, so it must be as unreachable on an exposed profile as the fleet itself.
+    expect(routeCapability('/api/fleet/stream')).toBe('localShell')
   })
 
   it('maps the local chat routes', () => {

--- a/packages/server/server/capability-guard.ts
+++ b/packages/server/server/capability-guard.ts
@@ -39,6 +39,10 @@ const EXACT: ReadonlyMap<string, keyof Capabilities> = new Map<string, keyof Cap
   // that should expose someone's keyboard to the internet and a shell is the honest name for it.
   ['/api/fleet', 'localShell'],
   ['/api/fleet/act', 'localShell'],
+  // The live terminal channel — an SSE stream of a session's SCREEN, colours and all. It is a read,
+  // but it is a read of a coding assistant's terminal, so it rides the same `localShell` as
+  // `/api/fleet`: there is no deployment that should stream someone's terminal to the internet.
+  ['/api/fleet/stream', 'localShell'],
 ])
 
 /** Prefix (no trailing slash) → capability. Matches `<prefix>` and `<prefix>/…` only. */

--- a/packages/server/server/cli-start.ts
+++ b/packages/server/server/cli-start.ts
@@ -1425,6 +1425,10 @@ async function ensureSessionsPoller(): Promise<SessionsPoller> {
     // Written once per session, not once per poll — the poller only calls this when the harness's
     // own record disagrees with the registry.
     recordConversation: (id, conversationId) => patchSession(id, { conversationId }),
+    // The `/rename` name, persisted so the title survives the process — same once-per-change
+    // discipline. See `ManagedSession.harnessName` and `pickTitle`.
+    recordHarnessName: (id, name, since) =>
+      patchSession(id, { harnessName: name, ...(since !== undefined ? { harnessNameSince: since } : {}) }),
     // Take back a running session whose registry record was lost. Called only with a non-empty
     // list, so a healthy fleet never writes. See `session-adopt.ts` for what may be adopted.
     adoptSessions: async records => { for (const r of records) await addSession(r) },

--- a/packages/server/server/cli-start.ts
+++ b/packages/server/server/cli-start.ts
@@ -1509,7 +1509,11 @@ async function spawnManaged(req: {
       id,
       cwd: req.cwd,
       argv: planned.plan.argv,
-      ...(planned.plan.sendKeys ? { sendKeys: planned.plan.sendKeys } : {}),
+      // Deliver the initial prompt once the harness is ready (see `initial-prompt.ts`). The harness's
+      // screen rules ride along so the backend can tell an idle prompt from a startup dialog.
+      ...(planned.plan.initialPrompt
+        ? { initialPrompt: { ...planned.plan.initialPrompt, ...(rulesFor(req.harness) ? { rules: rulesFor(req.harness)! } : {}) } }
+        : {}),
     })
   } catch (e) {
     return { ok: false, message: s.sessSpawnFailed(e instanceof Error ? e.message : String(e)) }

--- a/packages/server/server/index.ts
+++ b/packages/server/server/index.ts
@@ -1014,7 +1014,7 @@ async function handleRequestInner(req: Request, server: Server<WSData>): Promise
     // take. A central never answers it: it aggregates many machines and hosts none of their
     // sessions, so a fleet read there would be this box's own processes under someone else's page.
     // `capability-guard.ts` has already refused both paths on an exposed profile.
-    if (url.pathname === '/api/fleet' || url.pathname === '/api/fleet/act') {
+    if (url.pathname === '/api/fleet' || url.pathname === '/api/fleet/act' || url.pathname === '/api/fleet/stream') {
       if (TEAM_CENTRAL) {
         return new Response(JSON.stringify({ error: 'fleet_central' }), {
           status: 404,
@@ -1051,6 +1051,43 @@ async function handleRequestInner(req: Request, server: Server<WSData>): Promise
           headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
         })
       }
+    }
+
+    // The live terminal channel: an SSE stream of one session's screen. Read-only (Phase 1). Already
+    // gated by `localShell` (capability-guard) and 404'd on a central above, so this handler only has
+    // to enforce SCOPE — the session must be one this machine manages — and the stream ceiling.
+    if (url.pathname === '/api/fleet/stream' && req.method === 'GET') {
+      const id = url.searchParams.get('id')
+      if (!id) {
+        return new Response(JSON.stringify({ error: 'bad_request' }), {
+          status: 400,
+          headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
+        })
+      }
+      const { terminalSessionExists, terminalAtCapacity, openTerminalStream } = await import('./sessions/terminal-web')
+      if (!(await terminalSessionExists(id))) {
+        return new Response(JSON.stringify({ error: 'not_found' }), {
+          status: 404,
+          headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
+        })
+      }
+      if (await terminalAtCapacity()) {
+        return new Response(JSON.stringify({ error: 'too_many_streams' }), {
+          status: 503,
+          headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
+        })
+      }
+      const stream = await openTerminalStream(id, req.signal)
+      return new Response(stream, {
+        status: 200,
+        headers: {
+          ...CORS_HEADERS,
+          'Content-Type': 'text/event-stream',
+          'Cache-Control': 'no-cache',
+          'Connection': 'keep-alive',
+          'X-Accel-Buffering': 'no',
+        },
+      })
     }
 
     // Chat is opt-in. `capability-guard.ts` has already refused these paths where the exposure

--- a/packages/server/server/preferences.test.ts
+++ b/packages/server/server/preferences.test.ts
@@ -691,3 +691,29 @@ test('clampSessionPollMs falls back to the default for a non-finite value', () =
   expect(clampSessionPollMs(NaN)).toBe(SESSION_POLL_DEFAULT_MS)
   expect(clampSessionPollMs(Infinity)).toBe(SESSION_POLL_DEFAULT_MS)
 })
+
+// THREE — the persisted search-scope preference the cockpit (j-20260826-fi) builds on.
+// The scope SET rides `sessionView` and its whole-object write; this file owns where it lives,
+// its default, and its validation. The renderer is the TUI's.
+import { resolveSessionSearchScopes, DEFAULT_SESSION_SEARCH_SCOPES } from './preferences'
+
+test('search scopes: never chosen reads as the default (all own fields, no transcript)', () => {
+  expect(resolveSessionSearchScopes({})).toEqual([...DEFAULT_SESSION_SEARCH_SCOPES])
+  expect(DEFAULT_SESSION_SEARCH_SCOPES).not.toContain('transcript')
+  expect(DEFAULT_SESSION_SEARCH_SCOPES).toContain('name')
+})
+
+test('search scopes: a stored set is honoured, in canonical order and deduped', () => {
+  const p = { sessionView: { grouping: 'none', showClosed: false, showExited: false, showUnfiled: false, searchScopes: ['prompt', 'name', 'prompt', 'transcript'] } } as never
+  expect(resolveSessionSearchScopes(p)).toEqual(['name', 'prompt', 'transcript'])
+})
+
+test('search scopes: an empty stored array is a real (empty) choice, distinct from never-chosen', () => {
+  const p = { sessionView: { grouping: 'none', showClosed: false, showExited: false, showUnfiled: false, searchScopes: [] } } as never
+  expect(resolveSessionSearchScopes(p)).toEqual([])
+})
+
+test('search scopes: unknown values are dropped rather than crashing', () => {
+  const p = { sessionView: { grouping: 'none', showClosed: false, showExited: false, showUnfiled: false, searchScopes: ['name', 'bogus', 'folder'] } } as never
+  expect(resolveSessionSearchScopes(p)).toEqual(['name', 'folder'])
+})

--- a/packages/server/server/preferences.ts
+++ b/packages/server/server/preferences.ts
@@ -6,6 +6,10 @@ import { migrateTeamConfig } from '@agentistics/core'
 // TYPE-only, and the allowed direction: `server -> tui`. The arrangements are declared once, in
 // `session-dimensions.ts`, and this file stores whichever one was chosen.
 import type { SessionGroupingId } from '@agentistics/tui/control'
+// The searchable dimensions, declared once in the TUI's `search-scope.ts` and stored here — the
+// same `server -> tui` direction, and the same single-source rule as `SessionGroupingId`: a scope
+// added there fails this build until it is handled, rather than being silently un-persistable.
+import { SEARCH_SCOPES, type SearchScope } from '@agentistics/tui/control/search-scope'
 
 // Preferences live in the writable ~/.agentistics dir. The legacy location under CLAUDE_DIR
 // is read-only in Docker (host ~/.claude mounted :ro), which silently broke persistence and
@@ -113,6 +117,21 @@ export interface Preferences {
     /** The session at the top of the open card page: a page number would name other sessions by
      *  the next poll, so the page is remembered by identity. */
     cardAnchor?: string
+    /**
+     * WHICH scopes the session search looks in — the cumulative set the user has enabled (name,
+     * folder, harness, note, task, prompt, transcript). It is a SET, so the "all" control is simply
+     * every scope present, and an empty array is a real choice (search nothing but what is typed
+     * against no field — the caller decides what an empty set means for its filter).
+     *
+     * Stored inside `sessionView` because it is part of "how the fleet list was last arranged", and
+     * so it rides the SAME whole-object `setSessionView` / PUT `/api/preferences` write every other
+     * field here does — no new route, no new setter. Absent = never chosen; read it through
+     * `resolveSessionSearchScopes`, which supplies the default and drops any value this build does
+     * not know, so an older or hand-edited config degrades to a sane search rather than a crash.
+     *
+     * The renderer/UI is the TUI's (`j-20260826-fi`); this is only where the choice persists.
+     */
+    searchScopes?: SearchScope[]
   }
   /**
    * The session TASKS the user has marked finished.
@@ -164,6 +183,35 @@ export function clampSessionPollMs(ms: number): number {
 /** The effective poll interval — `undefined` reads as the default, exactly like `archiveMode`. */
 export function sessionPollMsOrDefault(p: Preferences): number {
   return p.sessionPollMs !== undefined ? clampSessionPollMs(p.sessionPollMs) : SESSION_POLL_DEFAULT_MS
+}
+
+/**
+ * The scopes the session search looks in when the user has NEVER chosen — every scope a row carries
+ * ON ITS OWN.
+ *
+ * `transcript` is deliberately OUT of the default: it is the only scope that is not a property of a
+ * row but a question asked of the disk (a text scan of every conversation), so making it always-on
+ * would put a file walk behind every keystroke. It stays an explicit opt-in the user enables — which
+ * is exactly the cumulative control the cockpit is adding. This default reproduces the search's
+ * existing reach (all own fields), so nothing narrows on upgrade.
+ */
+export const DEFAULT_SESSION_SEARCH_SCOPES: SearchScope[] =
+  SEARCH_SCOPES.filter((s): s is SearchScope => s !== 'transcript')
+
+/**
+ * The effective session-search scopes — `undefined` reads as the default, exactly like every other
+ * `sessionView` field.
+ *
+ * Validated on read: only scopes THIS build knows survive, returned in canonical `SEARCH_SCOPES`
+ * order and deduped, so a config hand-edited or written by a newer binary degrades to a sane search
+ * rather than a crash. A stored EMPTY array is honoured as a real (empty) choice — distinct from
+ * "never chosen", which is the `undefined` branch above.
+ */
+export function resolveSessionSearchScopes(p: Preferences): SearchScope[] {
+  const stored = p.sessionView?.searchScopes
+  if (!Array.isArray(stored)) return [...DEFAULT_SESSION_SEARCH_SCOPES]
+  const set = new Set(stored)
+  return SEARCH_SCOPES.filter(s => set.has(s))
 }
 
 /** Read + parse a preferences JSON file.

--- a/packages/server/server/sessions/attention-confirm.test.ts
+++ b/packages/server/server/sessions/attention-confirm.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'bun:test'
+import type { SessionActivity } from './types'
+import { EMPTY_CONFIRM_MEMORY, confirmActivities, type ConfirmMemory } from './attention-confirm'
+
+/** Drive one poll: feed a raw reading per session, get the CONFIRMED reading back. */
+function step(
+  memory: ConfirmMemory,
+  raw: Record<string, SessionActivity>,
+): { out: Record<string, SessionActivity>; memory: ConfirmMemory } {
+  const r = confirmActivities(memory, new Map(Object.entries(raw)))
+  return { out: Object.fromEntries(r.activities), memory: r.memory }
+}
+
+describe('confirmActivities', () => {
+  it('believes a first sighting as read — nothing prior to contradict it', () => {
+    const { out } = step(EMPTY_CONFIRM_MEMORY, { a: 'waiting', b: 'working' })
+    expect(out).toEqual({ a: 'waiting', b: 'working' })
+  })
+
+  it('does NOT flip to waiting on a single quiet poll — the reported false positive', () => {
+    // A session confirmed working, then ONE poll reads quiet. That single reading is not yet a fact:
+    // the fleet must not assert a person is needed on the strength of one frame.
+    let m = EMPTY_CONFIRM_MEMORY
+    ;({ memory: m } = step(m, { a: 'working' }))
+    ;({ memory: m } = step(m, { a: 'working' }))
+    const { out } = step(m, { a: 'waiting' })
+    expect(out.a).toBe('working') // held, not the raw 'waiting'
+  })
+
+  it('believes waiting only once it is seen on two consecutive polls', () => {
+    let m = EMPTY_CONFIRM_MEMORY
+    ;({ memory: m } = step(m, { a: 'working' }))
+    let r = step(m, { a: 'waiting' })
+    expect(r.out.a).toBe('working') // first waiting reading — held
+    r = step(r.memory, { a: 'waiting' })
+    expect(r.out.a).toBe('waiting') // confirmed on the second
+  })
+
+  it('clears waiting the moment work resumes — the asymmetry, believed at once', () => {
+    // Confirm a waiting state, then the session moves. A screen that moved is unambiguous proof of
+    // work, and clearing attention fast is the cheap direction — so it is adopted on the NEXT sample.
+    let m = EMPTY_CONFIRM_MEMORY
+    ;({ memory: m } = step(m, { a: 'waiting' }))
+    ;({ memory: m } = step(m, { a: 'waiting' })) // confirmed waiting
+    const { out } = step(m, { a: 'working' })
+    expect(out.a).toBe('working')
+  })
+
+  it('the count drops on the sample after work resumes', () => {
+    const count = (o: Record<string, SessionActivity>) =>
+      Object.values(o).filter(a => a === 'waiting' || a === 'waiting-approval').length
+    let m = EMPTY_CONFIRM_MEMORY
+    let r = step(m, { a: 'waiting', b: 'waiting' })
+    r = step(r.memory, { a: 'waiting', b: 'waiting' }) // both confirmed waiting
+    expect(count(r.out)).toBe(2)
+    r = step(r.memory, { a: 'working', b: 'waiting' }) // a resumes
+    expect(count(r.out)).toBe(1) // fell on the very next sample
+  })
+
+  it('does not flicker on waiting -> (repaint) -> waiting', () => {
+    // The event-plan flicker, on the fleet: a cosmetic repaint moves the frame for one poll.
+    let m = EMPTY_CONFIRM_MEMORY
+    ;({ memory: m } = step(m, { a: 'waiting' }))
+    let r = step(m, { a: 'waiting' }) // confirmed waiting
+    expect(r.out.a).toBe('waiting')
+    r = step(r.memory, { a: 'working' }) // the repaint — one frame
+    expect(r.out.a).toBe('working') // movement is believed at once (cheap direction)
+    r = step(r.memory, { a: 'waiting' }) // back to quiet
+    // Held at working for this poll (single new waiting reading), then confirmed next — never a
+    // duplicate needs-you spike from a one-frame twitch.
+    expect(r.out.a).toBe('working')
+    r = step(r.memory, { a: 'waiting' })
+    expect(r.out.a).toBe('waiting')
+  })
+
+  it('adopts exited immediately — a dead session is not held as working', () => {
+    let m = EMPTY_CONFIRM_MEMORY
+    ;({ memory: m } = step(m, { a: 'working' }))
+    ;({ memory: m } = step(m, { a: 'working' }))
+    const { out } = step(m, { a: 'exited' })
+    expect(out.a).toBe('exited')
+  })
+
+  it('escalates waiting -> waiting-approval only once confirmed', () => {
+    let m = EMPTY_CONFIRM_MEMORY
+    ;({ memory: m } = step(m, { a: 'waiting' }))
+    ;({ memory: m } = step(m, { a: 'waiting' })) // confirmed waiting
+    let r = step(m, { a: 'waiting-approval' })
+    expect(r.out.a).toBe('waiting') // one reading — held at the last confirmed needs-you state
+    r = step(r.memory, { a: 'waiting-approval' })
+    expect(r.out.a).toBe('waiting-approval')
+  })
+
+  it('forgets sessions that leave the fleet — memory cannot grow unbounded', () => {
+    let m = EMPTY_CONFIRM_MEMORY
+    ;({ memory: m } = step(m, { a: 'working', b: 'working' }))
+    const r = step(m, { a: 'working' }) // b is gone
+    expect(r.memory.confirmed.has('b')).toBe(false)
+    expect(r.memory.lastRaw.has('b')).toBe(false)
+  })
+})

--- a/packages/server/server/sessions/attention-confirm.ts
+++ b/packages/server/server/sessions/attention-confirm.ts
@@ -1,0 +1,118 @@
+/**
+ * attention-confirm.ts — PURE. Turns the fleet's INSTANTANEOUS per-poll reading into a CONFIRMED
+ * one, so the "needs you" counter stops lying.
+ *
+ * ## The defect this exists for
+ *
+ * `attention.ts` answers "what is this session doing" from a SINGLE frame, and it is right to: for
+ * the several harnesses whose only working signal is movement, "the screen moved, so it is working"
+ * is the only rule there is. But a single frame is a noisy sample. A session that has just finished
+ * a turn, or one whose pane a plugin repainted for a moment, reads `working` on one poll and
+ * `waiting` on the next with nothing about the session having changed — and a coordinator operating
+ * a fleet reported being sent to a session as "waiting on you" that had already gone back to work.
+ * The written rule in that workspace became "do not trust the activity field; read the pane with
+ * `tmux capture-pane`" — which is exactly the manual work the monitor exists to remove.
+ *
+ * ## The asymmetry that shapes the rule
+ *
+ * Getting these two states wrong does NOT cost the same. Saying "working" about a session that has
+ * stopped merely delays a person by one poll. Saying "needs you" about a session that is moving
+ * WASTES the person — the most expensive resource here — and, worse, corrodes trust in the
+ * indicator; once it has cried wolf, it stops being read, and that cost is permanent. So the two
+ * directions are confirmed differently:
+ *
+ *  - **Returning to work (`working`) and exiting (`exited`) are believed at once.** A screen that
+ *    moved is unambiguous proof, and clearing attention eagerly is the cheap error — a person is
+ *    never sent to a session that has already resumed. This also makes the counter DROP on the very
+ *    next sample after work resumes, which is the behaviour a person watching the fleet expects.
+ *  - **`waiting` and `waiting-approval` — the states that summon a person — are believed only once
+ *    the same reading has been seen on TWO CONSECUTIVE polls.** A one-frame quiet or a cosmetic
+ *    repaint never reaches the counter; genuine attention holds the screen for longer than one
+ *    interval and is confirmed on the following poll (one interval of latency, the cheap direction).
+ *
+ * ## Relationship to `event-plan.ts`
+ *
+ * The event channel confirms EVERY transition on two polls (`planEvents`), because a duplicate
+ * notification is the failure IT is judged on. This module confirms only the needs-you direction and
+ * clears eagerly, because a stale "needs you" on a live dashboard is the failure THIS surface is
+ * judged on. The two therefore AGREE on the reported harm — neither raises `waiting` from a single
+ * frame — and diverge only on how fast they clear it, by design: the fleet display drops attention a
+ * poll sooner than the notification stream, which is the right way round for each.
+ *
+ * Pure, and total: it reads a memory + one poll's raw readings and returns the confirmed readings
+ * plus the memory for the next poll. The poller (`sessions-host.ts`) carries the memory and feeds
+ * the confirmed map to `buildSessionViews`, so the count, the sort, the bell and the TUI all read
+ * the confirmed state without knowing this step happened.
+ */
+
+import type { SessionActivity } from './types'
+
+/**
+ * What the confirmer carries between polls.
+ *
+ * `lastRaw` is the previous poll's RAW reading and exists only to decide whether the current reading
+ * has now been seen twice. `confirmed` is the state the fleet currently BELIEVES a session is in,
+ * and is what a new needs-you reading is held against.
+ */
+export interface ConfirmMemory {
+  lastRaw: ReadonlyMap<string, SessionActivity>
+  confirmed: ReadonlyMap<string, SessionActivity>
+}
+
+export const EMPTY_CONFIRM_MEMORY: ConfirmMemory = { lastRaw: new Map(), confirmed: new Map() }
+
+/** The states that summon a PERSON — the expensive-to-get-wrong ones, confirmed before believed. */
+function needsPerson(a: SessionActivity): boolean {
+  return a === 'waiting' || a === 'waiting-approval'
+}
+
+export interface ConfirmResult {
+  /** The confirmed reading per session — what every downstream surface should show. */
+  activities: Map<string, SessionActivity>
+  /** What to carry into the next poll. */
+  memory: ConfirmMemory
+}
+
+/**
+ * Confirm one poll's raw readings against the memory — PURE.
+ *
+ * Only sessions present in `raw` are carried forward, so the memory cannot grow with every session
+ * the machine has ever hosted: a session that leaves the fleet is simply forgotten and, if it comes
+ * back, is a first sighting again.
+ */
+export function confirmActivities(
+  memory: ConfirmMemory,
+  raw: ReadonlyMap<string, SessionActivity>,
+): ConfirmResult {
+  const lastRaw = new Map<string, SessionActivity>()
+  const confirmed = new Map<string, SessionActivity>()
+  const activities = new Map<string, SessionActivity>()
+
+  for (const [id, r] of raw) {
+    lastRaw.set(id, r)
+    const prevConfirmed = memory.confirmed.get(id)
+    const prevRaw = memory.lastRaw.get(id)
+
+    let next: SessionActivity
+    if (!needsPerson(r)) {
+      // Work resumed, or the session exited. Believed at once — see the header's asymmetry.
+      next = r
+    } else if (prevConfirmed === r || prevRaw === r) {
+      // Already the believed state, or seen on two consecutive polls: confirmed.
+      next = r
+    } else if (prevConfirmed !== undefined) {
+      // A single new needs-you reading is not yet a fact. Hold the last believed state (typically
+      // `working`) rather than assert attention the fleet may not actually need.
+      next = prevConfirmed
+    } else {
+      // First sighting: nothing prior to contradict. A session first seen at its prompt genuinely IS
+      // waiting, and there is no `working` being overturned — so the reading stands.
+      next = r
+    }
+
+    confirmed.set(id, next)
+    activities.set(id, next)
+  }
+
+  return { activities, memory: { lastRaw, confirmed } }
+}

--- a/packages/server/server/sessions/attention-events-agree.test.ts
+++ b/packages/server/server/sessions/attention-events-agree.test.ts
@@ -1,0 +1,65 @@
+/**
+ * The fleet's confirmed activity (`attention-confirm.ts`) and the event channel (`event-plan.ts`)
+ * must AGREE on the reported harm: neither may raise `waiting` from a single-frame blip. They use
+ * different confirmation rules on purpose — the fleet clears attention a poll sooner than the
+ * notification stream — so this pins the ONE thing they must never disagree about, and documents the
+ * one thing they legitimately do.
+ */
+import { describe, expect, it } from 'bun:test'
+import type { SessionActivity } from './types'
+import { EMPTY_CONFIRM_MEMORY, confirmActivities, type ConfirmMemory } from './attention-confirm'
+import { EMPTY_MEMORY, planEvents, type EventMemory } from '../events/event-plan'
+
+/** Raw readings across a sequence of polls, for one session `a`. */
+const BLIP: SessionActivity[] = ['waiting', 'waiting', 'working', 'waiting', 'waiting']
+
+describe('fleet confirmation and the event channel agree on the reported harm', () => {
+  it('neither believes `waiting` from a one-frame quiet after work', () => {
+    // A session confirmed working, then exactly one poll reads quiet, then it moves again.
+    const raw: SessionActivity[] = ['working', 'working', 'waiting', 'working']
+
+    // Fleet: the single quiet frame never becomes the shown state.
+    let fm: ConfirmMemory = EMPTY_CONFIRM_MEMORY
+    const fleetStates = raw.map(a => {
+      const r = confirmActivities(fm, new Map([['a', a]]))
+      fm = r.memory
+      return r.activities.get('a')
+    })
+    expect(fleetStates).not.toContain('waiting')
+
+    // Events: no `waiting` event is ever emitted for that blip.
+    let em: EventMemory = EMPTY_MEMORY
+    const emitted: SessionActivity[] = []
+    for (const a of raw) {
+      const r = planEvents({ memory: em, sessions: [{ id: 'a', cwd: '/x', activity: a }], nowIso: '2026-08-28T00:00:00.000Z' })
+      em = r.memory
+      for (const e of r.events) emitted.push(e.kind as SessionActivity)
+    }
+    expect(emitted).not.toContain('waiting')
+  })
+
+  it('both raise `waiting` only after it holds for two consecutive polls', () => {
+    // The genuine wait: a repaint blips `working` for one poll in the middle of a wait. Neither the
+    // fleet nor the events channel should treat that blip as the wait ending and restarting.
+    let fm: ConfirmMemory = EMPTY_CONFIRM_MEMORY
+    let em: EventMemory = EMPTY_MEMORY
+    let fleetWaitingCount = 0
+    let waitingEvents = 0
+    for (const a of BLIP) {
+      const rf = confirmActivities(fm, new Map([['a', a]]))
+      fm = rf.memory
+      if (rf.activities.get('a') === 'waiting') fleetWaitingCount++
+
+      const re = planEvents({ memory: em, sessions: [{ id: 'a', cwd: '/x', activity: a }], nowIso: '2026-08-28T00:00:00.000Z' })
+      em = re.memory
+      waitingEvents += re.events.filter(e => e.kind === 'waiting').length
+    }
+    // The fleet SHOWS waiting on the polls where it is confirmed (it seeds `waiting` as a first
+    // sighting, holds through the blip, and re-confirms) — but it never spikes on the lone `working`.
+    expect(fleetWaitingCount).toBeGreaterThan(0)
+    // The event channel emits at most the single genuine `waiting` transition after the blip, never a
+    // duplicate per twitch. (Seeded first sighting emits nothing; the blip is one frame; the return
+    // to waiting is one confirmed transition.)
+    expect(waitingEvents).toBeLessThanOrEqual(1)
+  })
+})

--- a/packages/server/server/sessions/backend-tmux.ts
+++ b/packages/server/server/sessions/backend-tmux.ts
@@ -4,12 +4,15 @@
  */
 
 import {
-  attachArgs, capturePaneArgs, idFromTmuxName, isSessionGoneError, killSessionArgs, listSessionsArgs,
-  newSessionArgs, parsePrefix, parseTmuxList, serverOptionsArgs, sendKeysNamedArgs,
-  sendKeysLiteralArgs, showPrefixArgs, trimCapture,
+  attachArgs, capturePaneArgs, capturePaneAnsiArgs, idFromTmuxName, isSessionGoneError,
+  killSessionArgs, listSessionsArgs, newSessionArgs, paneInfoArgs, parsePaneInfo, parsePrefix,
+  parseTmuxList, serverOptionsArgs, sendKeysNamedArgs, sendKeysLiteralArgs, showPrefixArgs,
+  trimCapture,
 } from './tmux-cli'
 import { planPromptDelivery } from './initial-prompt'
-import type { BackendInitialPrompt, BackendSession, BackendSpawn, SessionBackend } from './types'
+import type {
+  BackendInitialPrompt, BackendSession, BackendSpawn, SessionBackend, TerminalCapture,
+} from './types'
 
 /** How often to re-read the pane while waiting for the harness to be ready to receive the prompt. */
 const DELIVER_POLL_MS = 400
@@ -136,6 +139,28 @@ export const tmuxBackend: SessionBackend = {
     const { code, out } = await tmux(capturePaneArgs(id, lines))
     if (code !== 0) return []
     return trimCapture(out.split('\n'))
+  },
+
+  async captureTerminal(id: string, lines: number): Promise<TerminalCapture | null> {
+    // Content FIRST: a non-zero capture is how we learn the session is gone, and there is no point
+    // asking for its geometry once it is. `-e` keeps the colours; the frame is NOT trailing-trimmed
+    // because a full-screen TUI's blank rows are part of its layout, not padding to discard.
+    const cap = await tmux(capturePaneAnsiArgs(id, lines))
+    if (cap.code !== 0) return null // tmux no longer has this session — the caller ends the stream
+    // A trailing '' from the final newline is not a real row; drop only that one.
+    const raw = cap.out.split('\n')
+    if (raw.length && raw[raw.length - 1] === '') raw.pop()
+
+    const meta = await tmux(paneInfoArgs(id))
+    const info = meta.code === 0 ? parsePaneInfo(meta.out) : null
+    if (!info) {
+      // The pane exists (capture succeeded) but display-message could not be read or parsed. Rather
+      // than ship a confident-wrong cursor, fall back to a minimal honest geometry: the browser
+      // emulator sizes itself, so `cols: 0` is a "don't know" the client can ignore, and `alive` is
+      // true because the capture just worked. Never a throw.
+      return { lines: raw, info: { cols: 0, rows: raw.length, cursorX: 0, cursorY: 0, alive: true, historySize: 0 } }
+    }
+    return { lines: raw, info }
   },
 
   async kill(id: string) {

--- a/packages/server/server/sessions/backend-tmux.ts
+++ b/packages/server/server/sessions/backend-tmux.ts
@@ -8,10 +8,23 @@ import {
   newSessionArgs, parsePrefix, parseTmuxList, serverOptionsArgs, sendKeysNamedArgs,
   sendKeysLiteralArgs, showPrefixArgs, trimCapture,
 } from './tmux-cli'
-import type { BackendSession, BackendSpawn, SessionBackend } from './types'
+import { planPromptDelivery } from './initial-prompt'
+import type { BackendInitialPrompt, BackendSession, BackendSpawn, SessionBackend } from './types'
 
-/** How long to wait for a harness to draw its prompt before typing into it. */
-const SEND_KEYS_DELAY_MS = 1200
+/** How often to re-read the pane while waiting for the harness to be ready to receive the prompt. */
+const DELIVER_POLL_MS = 400
+/**
+ * How long to keep trying to deliver the initial prompt before giving up.
+ *
+ * Robust to a SLOW start (a big CLAUDE.md, MCP servers loading) — the old fixed 1200ms lost the
+ * keys to a pane that had not drawn its prompt yet. Bounded so a session stuck on an unrecognised
+ * dialog cannot block a batch forever. Overridable for tests.
+ */
+const DELIVER_DEADLINE_MS = Number(process.env.AGENTISTICS_DELIVER_DEADLINE_MS) > 0
+  ? Number(process.env.AGENTISTICS_DELIVER_DEADLINE_MS)
+  : 15_000
+/** How much of the pane to read to judge readiness — enough for the input box and its footer. */
+const DELIVER_CAPTURE_LINES = 40
 
 async function tmux(args: string[]): Promise<{ code: number; out: string; err: string }> {
   try {
@@ -47,6 +60,38 @@ async function sendTextTo(id: string, text: string): Promise<boolean> {
   return (await tmux(sendKeysNamedArgs(id, 'Enter'))).code === 0
 }
 
+async function captureFrame(id: string): Promise<string[]> {
+  const { code, out } = await tmux(capturePaneArgs(id, DELIVER_CAPTURE_LINES))
+  if (code !== 0) return []
+  return trimCapture(out.split('\n'))
+}
+
+/**
+ * Deliver the initial prompt once the harness is genuinely ready to receive it — see
+ * `initial-prompt.ts` for the WHY. This is the impure half: it polls the pane, hands each frame to
+ * the pure `planPromptDelivery`, and does exactly what it says. It NEVER submits into a startup or
+ * approval dialog (the pure planner never returns an action for one), so the "press Enter too early
+ * and select No, exit" accident cannot happen.
+ */
+async function deliverInitialPrompt(id: string, d: BackendInitialPrompt): Promise<void> {
+  const deadline = Date.now() + DELIVER_DEADLINE_MS
+  let readyStreak = 0
+  while (Date.now() < deadline) {
+    const frame = await captureFrame(id)
+    const step = planPromptDelivery({ frame, mode: d.mode, readyStreak, ...(d.rules ? { rules: d.rules } : {}) })
+    readyStreak = step.readyStreak
+    if (step.action === 'done') return // a positional prompt that already auto-submitted
+    if (step.action === 'type') { await sendTextTo(id, d.text ?? ''); return }
+    if (step.action === 'submit') { await tmux(sendKeysNamedArgs(id, 'Enter')); return }
+    await sleep(DELIVER_POLL_MS)
+  }
+  // Timed out. For a `type` harness, fall back to the old best-effort so a slow-but-eventually-up
+  // harness still gets its prompt (never worse than before). For `submit`, do nothing: the text is
+  // in the field, the CLI may still auto-submit, and a blind Enter now could land on a dialog we
+  // never confirmed had cleared.
+  if (d.mode === 'type') await sendTextTo(id, d.text ?? '')
+}
+
 let tmuxPresent: boolean | null = null
 
 export const tmuxBackend: SessionBackend = {
@@ -67,12 +112,10 @@ export const tmuxBackend: SessionBackend = {
     for (const args of serverOptionsArgs()) await tmux(args)
     const { code, out } = await tmux(newSessionArgs({ id: req.id, cwd: req.cwd, argv: req.argv }))
     if (code !== 0) throw new Error(out.trim() || `tmux new-session failed (code ${code})`)
-    if (req.sendKeys) {
-      // The harness has to have drawn its prompt before anything typed into it lands anywhere. Only
-      // the OPENING line needs this wait; `sendText` below is called on a session that is already up
-      // and must not pay for it.
-      await sleep(SEND_KEYS_DELAY_MS)
-      await sendTextTo(req.id, req.sendKeys)
+    if (req.initialPrompt) {
+      // Deliver the prompt only once the harness is READY — polled, not a fixed sleep — so a slow
+      // start does not lose it and a startup dialog is never submitted into. See `deliverInitialPrompt`.
+      await deliverInitialPrompt(req.id, req.initialPrompt)
     }
   },
 

--- a/packages/server/server/sessions/cli-session.ts
+++ b/packages/server/server/sessions/cli-session.ts
@@ -24,6 +24,7 @@ import { toControlSession } from './control-session'
 import { recordedRepo, repoFacts } from './repo-facts'
 import { emptyReason, renderSessionTable, resolveWidth } from './session-table'
 import { SPAWN_SPECS, planSpawn } from './spawn-spec'
+import { rulesFor } from './attention-rules'
 // The harness half of a rename. Shared with the cockpit's Rename verb — see `rename.ts`.
 import { renameInHarness, renameMessage } from './rename'
 import { reconcileSessions, resolveSessionRef, type ReconciledSession, type RefCandidate } from './session-ref'
@@ -39,7 +40,19 @@ import { liveConversationHolders } from './live-claims'
 import { POLL_MS, SETTLE_MS, spawnOutcome } from './spawn-outcome'
 import { parseHarnessAgents } from './harness-agents'
 import { planTakeover, type TakeoverRefusal } from './takeover'
-import type { ManagedSession, SessionBackend, SpawnPlanError } from './types'
+import type { BackendInitialPrompt, ManagedSession, SessionBackend, SpawnPlan, SpawnPlanError } from './types'
+
+/**
+ * The initial-prompt argument for `backend.spawn`, with the harness's screen RULES attached so the
+ * backend can gate delivery on readiness without importing the harness table. Absent when the plan
+ * carries no prompt to deliver. One helper for both spawn sites — the rules must never be forgotten
+ * on one of them.
+ */
+function spawnPromptArg(plan: SpawnPlan, harness: HarnessId): { initialPrompt?: BackendInitialPrompt } {
+  if (!plan.initialPrompt) return {}
+  const rules = rulesFor(harness)
+  return { initialPrompt: { ...plan.initialPrompt, ...(rules ? { rules } : {}) } }
+}
 
 /** Derived from the specs, never a second hand-written list — the two could not then disagree. */
 const STARTABLE: HarnessId[] = HARNESS_ORDER.filter(h => SPAWN_SPECS[h] !== null)
@@ -192,7 +205,7 @@ async function start(
 
   const id = newSessionId()
   try {
-    await backend.spawn({ id, cwd, argv: planned.plan.argv, ...(planned.plan.sendKeys ? { sendKeys: planned.plan.sendKeys } : {}) })
+    await backend.spawn({ id, cwd, argv: planned.plan.argv, ...spawnPromptArg(planned.plan, cmd.harness) })
   } catch (e) {
     console.error(`Could not start the session: ${e instanceof Error ? e.message : String(e)}`)
     return 1
@@ -300,7 +313,7 @@ async function batch(
     try {
       await backend.spawn({
         id, cwd, argv: planned.plan.argv,
-        ...(planned.plan.sendKeys ? { sendKeys: planned.plan.sendKeys } : {}),
+        ...spawnPromptArg(planned.plan, spec.harness),
       })
     } catch (e) {
       failed.push({ harness: spec.harness, reason: e instanceof Error ? e.message : String(e) })
@@ -492,10 +505,26 @@ function fleetJson(snap: SessionSnapshot): unknown {
  * able from a fleet that was alive — and `crash-group.ts` would be reading a write nobody made a
  * claim with.
  */
+/**
+ * How long between the two confirming polls a one-shot command makes. Long enough for a working
+ * session's screen to have moved (or a quiet one to have stayed still) — tmux's activity clock has
+ * one-second resolution — short enough not to be felt on the command line.
+ */
+const CONFIRM_POLL_GAP_MS = 700
+
 async function pollFleet(backend: SessionBackend): Promise<SessionSnapshot> {
   const poller = createSessionsPoller({
     backend, readRegistry, scanProcesses, loadConversations, loadHarnessSessions,
   })
+  // Poll TWICE, and return the second. The cockpit debounces the noisy per-frame reading by
+  // confirming a `waiting` state across two polls (`attention-confirm.ts`), but a one-shot command
+  // has no memory of a previous poll — so a single reading cannot be confirmed and a lone quiet
+  // frame (a finished sub-turn, a repaint) would be reported as "waiting on you" for a session that
+  // is still working. The first poll seeds the poller's confirmation memory; the second returns the
+  // confirmed reading, so `session ls`/`list` agrees with the cockpit and the event channel instead
+  // of reviving the exact false positive on the command line.
+  await poller.poll()
+  await new Promise(r => setTimeout(r, CONFIRM_POLL_GAP_MS))
   return await poller.poll()
 }
 

--- a/packages/server/server/sessions/initial-prompt.test.ts
+++ b/packages/server/server/sessions/initial-prompt.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'bun:test'
+import { rulesFor } from './attention-rules'
+import { promptSurfaceReady, turnRunning, planPromptDelivery } from './initial-prompt'
+
+const claude = rulesFor('claude')
+
+// Real frames captured from claude 2.1.251 under tmux on 2026-08-28 (see the PR's reproduction).
+const BOOT_SPLASH = ['', ' ▐▛███▛█   Claude Code v2.1.251', '']
+const TRUST_DIALOG = [
+  ' Quick safety check: Is this a project you created or one you trust?',
+  '',
+  ' ❯ No, exit',
+  '   Yes, I trust this folder',
+  '',
+  ' Enter to confirm · Esc to cancel',
+]
+const PREFILLED_IDLE = [
+  '❯ @/home/u/.aipe/journeys/x/prompts/brief.md',
+  '────────────────────────────────',
+  '❯ @/home/u/.aipe/journeys/x/prompts/brief.md',
+  '────────────────────────────────',
+  '  ⏵⏵ auto mode on (shift+tab to cycle) · ? for shortcuts',
+]
+const RUNNING = [
+  '❯ @/home/u/.aipe/journeys/x/prompts/brief.md',
+  '  ⎿  Read brief.md (2 lines)',
+  '',
+  '✻ Working… (3s · esc to interrupt)',
+]
+
+describe('promptSurfaceReady', () => {
+  it('is false on the boot splash (nothing drawn yet)', () => {
+    expect(promptSurfaceReady(BOOT_SPLASH, claude)).toBe(false)
+  })
+  it('is false while a startup/trust dialog is up — never deliver into a dialog', () => {
+    expect(promptSurfaceReady(TRUST_DIALOG, claude)).toBe(false)
+  })
+  it('is true once the harness is at its input prompt', () => {
+    expect(promptSurfaceReady(PREFILLED_IDLE, claude)).toBe(true)
+  })
+  it('is true while a turn runs (a running surface is a drawn one)', () => {
+    expect(promptSurfaceReady(RUNNING, claude)).toBe(true)
+  })
+})
+
+describe('turnRunning', () => {
+  it('is true when the working marker is in the footer — the prompt was submitted', () => {
+    expect(turnRunning(RUNNING, claude)).toBe(true)
+  })
+  it('is false at an idle prompt', () => {
+    expect(turnRunning(PREFILLED_IDLE, claude)).toBe(false)
+  })
+  it('is false for a harness with no probed working marker', () => {
+    expect(turnRunning(RUNNING, rulesFor('codex'))).toBe(false)
+  })
+})
+
+describe('planPromptDelivery — the backend loop reads this each poll', () => {
+  const step = (frame: string[], readyStreak: number, mode: 'type' | 'submit', rules = claude) =>
+    planPromptDelivery({ frame, rules, mode, readyStreak })
+
+  it('waits while the boot splash is up', () => {
+    expect(step(BOOT_SPLASH, 0, 'submit')).toEqual({ action: 'wait', readyStreak: 0 })
+  })
+
+  it('waits while a dialog is up, and does NOT submit into it (a blind Enter would pick "No, exit")', () => {
+    expect(step(TRUST_DIALOG, 2, 'submit')).toEqual({ action: 'wait', readyStreak: 0 })
+  })
+
+  it('is DONE the moment a turn is running — the positional prompt auto-submitted', () => {
+    expect(step(RUNNING, 0, 'submit')).toEqual({ action: 'done', readyStreak: 0 })
+  })
+
+  it('counts consecutive ready polls before acting, giving auto-submit its beat', () => {
+    // A positional harness sitting idle with the prompt pre-filled: ready, but not yet for long
+    // enough to be sure it will not auto-submit.
+    expect(step(PREFILLED_IDLE, 0, 'submit')).toEqual({ action: 'wait', readyStreak: 1 })
+    expect(step(PREFILLED_IDLE, 1, 'submit')).toEqual({ action: 'wait', readyStreak: 2 })
+    // Stably idle across READY_CONFIRM polls and never ran — it will not auto-submit. Submit it.
+    expect(step(PREFILLED_IDLE, 2, 'submit')).toEqual({ action: 'submit', readyStreak: 3 })
+  })
+
+  it('types once ready for a send-keys harness', () => {
+    const idleKimi = ['│ Type a message │', '↑↓ navigate']
+    // kimi has no working marker; readiness alone gates typing.
+    const r1 = planPromptDelivery({ frame: idleKimi, rules: rulesFor('kimi'), mode: 'type', readyStreak: 2 })
+    expect(r1).toEqual({ action: 'type', readyStreak: 3 })
+  })
+
+  it('a submit-mode harness with no working marker never forces an Enter (cannot verify safely)', () => {
+    // codex is positional but has no working marker — we cannot tell "auto-submitted" from "idle",
+    // so we never risk a double-submit. It reaches ready and stays `wait` (the CLI's positional
+    // contract is left to run).
+    const idleCodex = ['› Find and fix a bug', '  send q to quit']
+    const r = planPromptDelivery({ frame: idleCodex, rules: rulesFor('codex'), mode: 'submit', readyStreak: 5 })
+    expect(r.action).toBe('wait')
+  })
+})

--- a/packages/server/server/sessions/initial-prompt.ts
+++ b/packages/server/server/sessions/initial-prompt.ts
@@ -1,0 +1,135 @@
+/**
+ * initial-prompt.ts — PURE. When and how a detached session's INITIAL PROMPT reaches the harness.
+ *
+ * ## The defect this exists for
+ *
+ * A session created detached with a prompt has to receive that prompt with no human in the loop. The
+ * old path did not guarantee it: for a `send-keys` harness it typed after a FIXED 1200ms sleep (a
+ * race a slow-starting harness loses — the keys land in a pane that has not drawn its prompt yet),
+ * and for a `positional`/`flag` harness it passed the text in argv and relied entirely on the CLI
+ * auto-submitting it. That reliance is fragile in two proven ways:
+ *
+ *  1. **Some harnesses/versions PRE-FILL without auto-submitting.** The field symptom was exact — the
+ *     prompt "stays in the field" and nothing is sent, so the agent sits waiting for something that
+ *     already arrived. A coordinator worked around it by `tmux send-keys`-ing every dispatch by hand;
+ *     the workaround became a habit and the habit hid the defect for days.
+ *  2. **A startup dialog can block the initial prompt.** Launched in a folder the harness does not
+ *     yet trust, claude opens with a trust prompt whose DEFAULT option is "No, exit". The positional
+ *     prompt is queued behind it — and a naive "just press Enter" would select "No, exit" and KILL
+ *     the session. Submitting too early fails as silently and as badly as not submitting at all.
+ *
+ * ## The rule
+ *
+ * Deliver only once the harness is genuinely READY — its input surface drawn, and NOT sitting on a
+ * startup/approval dialog — and then deliver ONCE:
+ *
+ *  - A `send-keys` harness (its only prompt flag exits) has the text TYPED IN after readiness.
+ *  - A `positional` harness whose working marker lets us tell "already submitted" from "idle" (claude)
+ *    gets a single Enter to SUBMIT the pre-filled text — but only after it has sat idle for a few
+ *    consecutive polls without ever running, which gives a CLI that DOES auto-submit its beat to do
+ *    so (we see the working marker and stand down). A running turn means it already went in.
+ *  - A `positional` harness with no working marker (codex) is left to its CLI's own contract: we
+ *    cannot tell an auto-submitted turn from an idle prompt, so forcing an Enter risks a double
+ *    submit. Refusing to guess is the same discipline `attention-rules.ts` uses for an unprobed
+ *    dialog.
+ *  - A `flag` harness (`--prompt-interactive`) runs the prompt by design; nothing is delivered.
+ *
+ * Never into a dialog: a frame whose footer is a startup/approval prompt is never `ready`, so the
+ * destructive early Enter cannot happen.
+ *
+ * The IMPURE loop lives in `backend-tmux.ts`; this module only reads a frame and a small streak and
+ * says what to do, so every rule above is testable without a tmux server.
+ */
+
+import type { AttentionRules } from './types'
+import { FOOTER_LINES } from './attention'
+
+/**
+ * How many consecutive READY-and-not-running polls before we act.
+ *
+ * For a `submit` harness it is the "auto-submit's beat": if the CLI were going to submit the
+ * positional prompt itself, the working marker would have appeared within this window and we would
+ * have stood down. For a `type` harness it just means the surface has been stably drawn — a hedge
+ * against typing into a half-rendered frame. At the poll interval below (~400ms) this is a bit over a
+ * second, matching the old fixed delay while being adaptive instead of a fixed guess.
+ */
+const READY_CONFIRM = 3
+
+/** A line that is only box-drawing / rule characters — a frame's furniture, not its content. */
+const RULE = /^[─━═╌┄┈╭╰╮╯┌└┐┘│|+\-=_~]+$/
+/** A prompt or box glyph at the start of a line — every one of these CLIs draws its input box with
+ *  one. Its presence is the cross-harness "the input surface is on screen" signal. */
+const INPUT_GLYPH = /^\s*[❯›»▌│|>]/
+
+function footerOf(frame: readonly string[]): string {
+  return frame.slice(Math.max(0, frame.length - FOOTER_LINES)).join('\n')
+}
+
+/** A startup/approval dialog is on screen — matched in the FOOTER only, and never a running turn. */
+function dialogPresent(frame: readonly string[], rules: AttentionRules): boolean {
+  const footer = footerOf(frame)
+  const working = rules.working?.some(re => re.test(footer)) ?? false
+  return !working && rules.approval.some(re => re.test(footer))
+}
+
+/** The harness has drawn an input surface (a box edge or a prompt glyph), past the boot splash. */
+function hasInputSurface(frame: readonly string[]): boolean {
+  return frame.some(l => {
+    const t = l.trim()
+    if (!t) return false
+    return RULE.test(t) || INPUT_GLYPH.test(l)
+  })
+}
+
+/**
+ * The harness is ready to receive the initial prompt: its input surface is drawn and it is not
+ * sitting on a startup/approval dialog. PURE.
+ */
+export function promptSurfaceReady(frame: readonly string[], rules?: AttentionRules): boolean {
+  if (rules && dialogPresent(frame, rules)) return false
+  return hasInputSurface(frame)
+}
+
+/** A turn is running — for a positional harness that means the prompt was already submitted. PURE. */
+export function turnRunning(frame: readonly string[], rules?: AttentionRules): boolean {
+  if (!rules?.working) return false
+  const footer = footerOf(frame)
+  return rules.working.some(re => re.test(footer))
+}
+
+export interface DeliveryDecision {
+  action: 'wait' | 'type' | 'submit' | 'done'
+  /** The consecutive-ready streak to carry to the next poll. */
+  readyStreak: number
+}
+
+/**
+ * What the backend should do with the initial prompt on THIS poll — PURE.
+ *
+ * `mode` is the delivery kind the plan chose (`type` for a send-keys harness, `submit` for a
+ * positional one). `readyStreak` is how many consecutive ready-and-not-running polls preceded this
+ * one. The returned `readyStreak` is what to pass back next time.
+ */
+export function planPromptDelivery(o: {
+  frame: readonly string[]
+  rules?: AttentionRules
+  mode: 'type' | 'submit'
+  readyStreak: number
+}): DeliveryDecision {
+  // A running turn (positional auto-submit already fired) — nothing left to do.
+  if (o.mode === 'submit' && turnRunning(o.frame, o.rules)) return { action: 'done', readyStreak: 0 }
+
+  // Not ready (boot splash, or a dialog we must never submit into): wait, and reset the streak so a
+  // momentary ready frame followed by a repaint does not count toward acting.
+  if (!promptSurfaceReady(o.frame, o.rules)) return { action: 'wait', readyStreak: 0 }
+
+  const readyStreak = o.readyStreak + 1
+  if (readyStreak < READY_CONFIRM) return { action: 'wait', readyStreak }
+
+  if (o.mode === 'type') return { action: 'type', readyStreak }
+
+  // submit mode: only where a working marker lets us verify the CLI did NOT auto-submit. Without one
+  // (codex) we cannot tell submitted from idle, so we never force an Enter — see the header.
+  if (!o.rules?.working) return { action: 'wait', readyStreak }
+  return { action: 'submit', readyStreak }
+}

--- a/packages/server/server/sessions/registry.ts
+++ b/packages/server/server/sessions/registry.ts
@@ -53,6 +53,11 @@ export interface SessionPatch {
   task?: string
   endedAt?: string
   conversationId?: string
+  /** The harness's own `/rename` name, persisted so the title survives the process — see
+   *  `ManagedSession.harnessName`. Written by the poller only when it CHANGES, one write per rename. */
+  harnessName?: string
+  /** Written alongside `harnessName`, never on its own — see `ManagedSession.harnessNameSince`. */
+  harnessNameSince?: number
 }
 
 export interface SessionRegistry {

--- a/packages/server/server/sessions/session-view.test.ts
+++ b/packages/server/server/sessions/session-view.test.ts
@@ -5,7 +5,8 @@ import type { HarnessProcess } from '../live-sessions'
 import type { ManagedSession, SessionActivity } from './types'
 import type { ReconciledSession } from './session-ref'
 import {
-  attentionCount, bellTransitions, buildSessionViews, needsAttention,
+  attentionCount, bellTransitions, buildSessionViews, collapseSupersededSessions,
+  needsAttention, type SessionView,
 } from './session-view'
 
 const managed = (id: string, over: Partial<ManagedSession> = {}): ManagedSession => ({
@@ -493,5 +494,138 @@ describe('a session that CHANGED DIRECTORY is still the row hosting it', () => {
       harnessSessions: index({ byPid: { 777: { pid: 777, tmux: 'agentop-gonefromregistry:@0.%0' } } }),
     })
     expect(views.filter(v => v.status === 'external')).toHaveLength(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// ONE — duplicate rows. A conversation reopened N times left N `exited` rows
+// beside its one live continuation, because the row key is the per-spawn
+// managedId, not the conversation. `collapseSupersededSessions` drops a
+// predecessor ONLY when it is provably dead (endedMs) AND superseded.
+// ---------------------------------------------------------------------------
+describe('collapseSupersededSessions', () => {
+  const sv = (id: string, o: Partial<SessionView> = {}): SessionView => ({
+    id, cwd: '/repo/a', status: 'exited', attached: false, approvalDetection: true,
+    searchFields: { name: '', folder: '', harness: '', note: '', task: '', prompt: '' },
+    ...o,
+  })
+
+  it('drops a retired predecessor when a LIVE row drives the same conversation', () => {
+    const rows = [
+      sv('live', { status: 'running', conversationId: 'c1', createdMs: 2000 }),
+      sv('dead', { status: 'exited', conversationId: 'c1', createdMs: 1000, endedMs: 1500 }),
+    ]
+    const out = collapseSupersededSessions(rows)
+    expect(out.map(v => v.id)).toEqual(['live'])
+  })
+
+  it('keeps the NEWEST ended row when nothing is live, and drops the older ended ones', () => {
+    const rows = [
+      sv('old1', { conversationId: 'c1', createdMs: 1000, endedMs: 1100 }),
+      sv('old2', { conversationId: 'c1', createdMs: 2000, endedMs: 2100 }),
+      sv('newest', { conversationId: 'c1', createdMs: 3000, endedMs: 3100 }),
+    ]
+    const out = collapseSupersededSessions(rows)
+    // The newest ended row survives — it is the reopenable representative of the conversation.
+    expect(out.map(v => v.id)).toEqual(['newest'])
+  })
+
+  // NEGATIVE — the guarantee the coordinator reads this list for.
+  it('NEVER drops a live row, even when it shares a conversation with another live row', () => {
+    const rows = [
+      sv('liveA', { status: 'running', conversationId: 'c1', createdMs: 1000 }),
+      sv('liveB', { status: 'running', conversationId: 'c1', createdMs: 2000 }),
+    ]
+    const out = collapseSupersededSessions(rows)
+    expect(out.map(v => v.id).sort()).toEqual(['liveA', 'liveB'])
+  })
+
+  it('NEVER drops a row it cannot prove is dead — a lost row with no end time is kept', () => {
+    const rows = [
+      sv('live', { status: 'running', conversationId: 'c1', createdMs: 2000 }),
+      // `lost` with no endedMs: the backend cannot see it, which is not proof the process is gone.
+      sv('unproven', { status: 'lost', conversationId: 'c1', createdMs: 1000 }),
+    ]
+    const out = collapseSupersededSessions(rows)
+    expect(out.map(v => v.id).sort()).toEqual(['live', 'unproven'])
+  })
+
+  it('never collapses genuinely distinct sessions — different conversations both stay', () => {
+    const rows = [
+      sv('a', { status: 'exited', conversationId: 'c1', createdMs: 1000, endedMs: 1100 }),
+      sv('b', { status: 'exited', conversationId: 'c2', createdMs: 1000, endedMs: 1100 }),
+    ]
+    const out = collapseSupersededSessions(rows)
+    expect(out.map(v => v.id).sort()).toEqual(['a', 'b'])
+  })
+
+  it('never groups rows with NO conversationId — a shared directory is not an identity', () => {
+    const rows = [
+      sv('a', { status: 'exited', createdMs: 1000, endedMs: 1100 }),
+      sv('b', { status: 'exited', createdMs: 2000, endedMs: 2100 }),
+    ]
+    const out = collapseSupersededSessions(rows)
+    expect(out.map(v => v.id).sort()).toEqual(['a', 'b'])
+  })
+
+  it('the whole pipeline: a reopen chain collapses to one row through buildSessionViews', () => {
+    const m = (id: string, o: Partial<ManagedSession> = {}): ManagedSession => ({
+      id, harness: 'claude', cwd: '/repo/a', createdAt: '2026-08-14T10:00:00.000Z',
+      conversationId: 'conv', ...o,
+    })
+    const reconciled: ReconciledSession[] = [
+      { id: 'r1', managed: m('r1', { createdAt: '2026-08-14T10:00:00.000Z', endedAt: '2026-08-14T11:00:00.000Z' }), status: 'lost' },
+      { id: 'r2', managed: m('r2', { createdAt: '2026-08-14T12:00:00.000Z', endedAt: '2026-08-14T13:00:00.000Z' }), status: 'lost' },
+      {
+        id: 'r3', managed: m('r3', { createdAt: '2026-08-14T14:00:00.000Z' }),
+        backend: { id: 'r3', createdMs: 5000, attached: false, alive: true, lastActivityMs: 5000 },
+        status: 'running',
+      },
+    ]
+    const views = buildSessionViews({ reconciled, activity: new Map([['r3', 'working']]), processes: [] })
+    const forConv = views.filter(v => v.conversationId === 'conv')
+    expect(forConv.map(v => v.id)).toEqual(['r3'])
+    expect(forConv[0]!.status).toBe('running')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// TWO — a title is an identity. The `/rename` name lived only in the harness's
+// own file, which it deletes on exit; the title then flipped and CTRL+F broke.
+// The poller persists the name into the registry, so buildSessionViews reads it
+// even when the live file is gone.
+// ---------------------------------------------------------------------------
+describe('title survives the process (persisted harness name)', () => {
+  const m = (id: string, o: Partial<ManagedSession> = {}): ManagedSession => ({
+    id, harness: 'claude', cwd: '/repo/a', createdAt: '2026-08-14T10:00:00.000Z', ...o,
+  })
+
+  it('a finished row (no live file) still carries its persisted /rename name', () => {
+    const [v] = buildSessionViews({
+      reconciled: [{
+        id: 'm1',
+        managed: m('m1', { label: 'Integrar CLI', harnessName: 'AIPE + agentop CLI', harnessNameSince: 42, endedAt: '2026-08-14T11:00:00.000Z' }),
+        status: 'lost',
+      }],
+      activity: new Map(),
+      processes: [],
+      // No harnessSessions entry — the process is gone, the file deleted.
+    })
+    expect(v!.harnessName).toBe('AIPE + agentop CLI')
+    expect(v!.harnessNameSince).toBe(42)
+  })
+
+  it('the LIVE file still wins while the session runs — persistence is only a fallback', () => {
+    const [v] = buildSessionViews({
+      reconciled: [{ id: 'm1', managed: m('m1', { harnessName: 'stale name', harnessNameSince: 1 }), status: 'lost' }],
+      activity: new Map(),
+      processes: [],
+      harnessSessions: {
+        byManagedId: new Map([['m1', { name: 'fresh name', nameSince: 99 }]]),
+        byPid: new Map(), byConversation: new Map(),
+      } as never,
+    })
+    expect(v!.harnessName).toBe('fresh name')
+    expect(v!.harnessNameSince).toBe(99)
   })
 })

--- a/packages/server/server/sessions/session-view.ts
+++ b/packages/server/server/sessions/session-view.ts
@@ -213,6 +213,77 @@ function rankOf(v: SessionView): number {
 }
 
 /**
+ * Collapse a session's RETIRED predecessors against its own continuation — PURE, and keyed on the
+ * one thing that is an identity rather than a guess: the harness's `conversationId`.
+ *
+ * ## Why this exists
+ *
+ * A session's durable identity is its CONVERSATION, but the registry keys a record by the per-spawn
+ * `managedId`. Every attach / reopen / restart mints a NEW managedId for the SAME conversation and
+ * retires the old record (`endedAt`) without removing it — so `reconcileSessions` returns one record
+ * per spawn and `buildSessionViews` draws one row per record. A conversation reopened five times
+ * therefore stood on screen as five `exited` rows beside its one live continuation, all wearing the
+ * same name. Measured here: 18 conversations held more than one record, 36 rows of pure history that
+ * a person reads as "this session is open many times over".
+ *
+ * ## What it may and may NOT drop — the guarantee
+ *
+ * The coordinator reads this list to decide whether to re-dispatch over work in flight, so a row it
+ * cannot prove is dead is NEVER hidden. A row is dropped only when BOTH hold:
+ *
+ *  1. it is PROVABLY dead — `endedMs` is set, which means the system retired or the user finished it;
+ *     a `lost` row with no end time (a reboot, say) is never touched, because "the backend cannot see
+ *     it right now" is not proof the process is gone; and
+ *  2. it is SUPERSEDED — the same conversation has either a LIVE row (running / unregistered) or a
+ *     strictly newer ended row. That sibling IS this session, continued, so the predecessor is its
+ *     own history, not a second session.
+ *
+ * Consequences, each deliberate:
+ *  - a LIVE row is never dropped (it has no `endedMs`);
+ *  - the newest ended row of a conversation with nothing live is KEPT — it is the reopenable
+ *    representative, and a finished session the user wants back must still be there;
+ *  - rows with NO `conversationId` are never grouped and never collapsed: two sessions that merely
+ *    share a directory or a label are genuinely distinct, and the list telling the truth about them
+ *    is the whole point — the fix is identity, never appearance.
+ *
+ * Two rows with the SAME `conversationId` cannot be distinct sessions: it is the harness's own id for
+ * one conversation. So this never merges two real sessions — only a session with its own past lives.
+ */
+export function collapseSupersededSessions(managed: readonly SessionView[]): SessionView[] {
+  const groups = new Map<string, SessionView[]>()
+  for (const v of managed) {
+    if (!v.conversationId) continue
+    const arr = groups.get(v.conversationId) ?? []
+    arr.push(v)
+    groups.set(v.conversationId, arr)
+  }
+
+  const drop = new Set<string>()
+  for (const group of groups.values()) {
+    if (group.length < 2) continue
+    const hasLive = group.some(v => v.status === 'running' || v.status === 'unregistered')
+    // The reopenable representative when nothing is live: the newest by start time, id as a
+    // deterministic tiebreak so the same fleet always keeps the same row.
+    const newest = group.reduce((a, b) => {
+      const am = a.createdMs ?? -Infinity
+      const bm = b.createdMs ?? -Infinity
+      if (bm !== am) return bm > am ? b : a
+      return b.id > a.id ? b : a
+    })
+    for (const v of group) {
+      // Rule 1: only a row proven ended may go. A live row (no `endedMs`) and a `lost` row with no
+      // recorded end are both kept, whatever else the group holds.
+      if (v.endedMs === undefined) continue
+      // Rule 2: dropped only when a continuation supersedes it — anything live retires every dead
+      // predecessor; otherwise all but the newest ended row.
+      if (hasLive || v !== newest) drop.add(v.id)
+    }
+  }
+
+  return managed.filter(v => !drop.has(v.id))
+}
+
+/**
  * An id for an external process that is STABLE across polls and unique per process.
  *
  * The start time is what does both jobs: it distinguishes two assistants of the same harness open
@@ -403,7 +474,16 @@ export function buildSessionViews(o: {
     // What the harness says about ITSELF, matched by the tmux session it recorded — the one exact
     // link between its record and this row.
     const own: HarnessSessionFile | undefined = o.harnessSessions?.byManagedId.get(r.id)
-    const ownName = chosenName(own)
+    // The live harness file when there is one, ELSE the name the poller persisted while there was.
+    // Claude deletes `~/.claude/sessions/<pid>.json` the instant the process ends, so a finished
+    // session's `/rename` name lives only in the registry copy — without this fallback the title
+    // flipped to a different source on finish and `CTRL+F` stopped finding the row by the name it
+    // wore a second earlier. A title is an identity; it must not change because the process died.
+    const ownName = chosenName(own) ?? r.managed?.harnessName
+    // The recency stamp travels with whichever name won: the live file's `nameSince` while alive,
+    // the persisted mirror once it is gone. `pickTitle` then settles the label-vs-harness contest
+    // identically in both states.
+    const ownNameSince = own?.nameSince ?? r.managed?.harnessNameSince
     // A session the user FINISHED reports `exited` whatever the backend still holds: the row exists
     // to be reopened, and calling it `running` because a dead tmux pane lingers would put it back
     // among the things you can talk to.
@@ -433,7 +513,7 @@ export function buildSessionViews(o: {
       ...(r.managed?.label ? { label: r.managed.label } : {}),
       ...(r.managed?.labelSince !== undefined ? { labelSince: r.managed.labelSince } : {}),
       ...(ownName ? { harnessName: ownName } : {}),
-      ...(ownName && own?.nameSince !== undefined ? { harnessNameSince: own.nameSince } : {}),
+      ...(ownName && ownNameSince !== undefined ? { harnessNameSince: ownNameSince } : {}),
       ...(r.managed?.note ? { note: r.managed.note } : {}),
       ...(r.managed?.model ? { model: r.managed.model } : {}),
       ...(r.managed?.effort ? { effort: r.managed.effort } : {}),
@@ -699,7 +779,10 @@ export function buildSessionViews(o: {
       }
     })
 
-  return [...managed, ...external, ...closed].sort((a, b) => {
+  // Retired predecessors are dropped LAST, so everything above — the external-twin dedup and the
+  // closed-history cover set — still reasons over the full managed list. Only the final rows the
+  // reader sees lose the superseded duplicates; the registry itself is untouched.
+  return [...collapseSupersededSessions(managed), ...external, ...closed].sort((a, b) => {
     const byRank = rankOf(a) - rankOf(b)
     if (byRank !== 0) return byRank
     return (b.createdMs ?? 0) - (a.createdMs ?? 0)

--- a/packages/server/server/sessions/sessions-host.test.ts
+++ b/packages/server/server/sessions/sessions-host.test.ts
@@ -31,6 +31,10 @@ function fakeBackend(o: {
     async spawn() {},
     async list() { return o.sessions },
     async capture(id) { o.onCapture?.(id); return o.frames?.[id] ?? [] },
+    async captureTerminal(id) {
+      const lines = o.frames?.[id] ?? []
+      return { lines, info: { cols: 80, rows: lines.length, cursorX: 0, cursorY: 0, alive: true, historySize: 0 } }
+    },
     async kill() { return true },
     attachCommand(id) { return ['tmux', 'attach', id] },
     async detachHint() { return 'Ctrl-b then d' },

--- a/packages/server/server/sessions/sessions-host.test.ts
+++ b/packages/server/server/sessions/sessions-host.test.ts
@@ -66,6 +66,42 @@ describe('createSessionsPoller', () => {
     expect(snap.attention).toBe(1)
   })
 
+  it('does NOT count a working session that goes quiet for a single poll — the reported false positive', async () => {
+    // The field report: the fleet said "waiting on you" about a session that had already gone back to
+    // work. It reproduces at the poller: a session working (its probed footer moving), then ONE poll
+    // where the frame is momentarily quiet — a repaint settling, a sub-turn finishing — reads `waiting`
+    // raw. Before this fix the counter jumped to 1 on that single frame and a person was summoned.
+    const frames: Record<string, string[]> = { a: ['working hard · esc to interrupt'] }
+    const p = poller({
+      backend: fakeBackend({ sessions: [backendSession('a')], frames }),
+      registry: [managed('a')],
+    })
+    // Establish the confirmed working state.
+    expect((await p.poll()).attention).toBe(0)
+    // The marker goes away and the frame stops moving for exactly one poll.
+    frames.a = ['❯ ']
+    const blip = await p.poll()
+    expect(blip.sessions[0]!.activity).toBe('working') // held — not summoned on one frame
+    expect(blip.attention).toBe(0)
+    expect(blip.rang).toEqual([])
+  })
+
+  it('the waiting count DROPS on the sample after work resumes', async () => {
+    // The transition the acceptance names: waiting -> back to working -> the count falls on the next
+    // sample. Clearing attention is the cheap direction, so it is believed at once.
+    const frames: Record<string, string[]> = { a: ['❯ '] }
+    const p = poller({
+      backend: fakeBackend({ sessions: [backendSession('a')], frames }),
+      registry: [managed('a')],
+    })
+    // Two quiet polls confirm waiting.
+    await p.poll()
+    expect((await p.poll()).attention).toBe(1)
+    // The session resumes — a moving footer.
+    frames.a = ['back at it · esc to interrupt']
+    expect((await p.poll()).attention).toBe(0) // fell on the very next sample
+  })
+
   it('reports a session working from its probed footer', async () => {
     const p = poller({
       backend: fakeBackend({
@@ -78,7 +114,7 @@ describe('createSessionsPoller', () => {
     expect((await p.poll()).attention).toBe(0)
   })
 
-  it('sees a frame that changed between two polls as working', async () => {
+  it('sees a frame that changed between two polls as working, and confirms waiting before it flips', async () => {
     const frames: Record<string, string[]> = { a: ['one'] }
     const p = poller({
       backend: fakeBackend({ sessions: [backendSession('a')], frames }),
@@ -86,8 +122,14 @@ describe('createSessionsPoller', () => {
     })
     expect((await p.poll()).sessions[0]!.activity).toBe('waiting')
     frames.a = ['two']
+    // A changed frame is movement, and movement is believed at once.
     expect((await p.poll()).sessions[0]!.activity).toBe('working')
-    // Third poll: unchanged again, so it settles back to waiting with no extra interval of lag.
+    // Now the frame goes quiet. The RAW reading is `waiting`, but a single quiet poll after work is
+    // not yet a fact — the fleet holds `working` rather than assert a person is needed on one frame.
+    // This one-interval confirmation is the whole point: it is what stopped the counter reporting a
+    // session that had just gone quiet (a repaint, a finished sub-turn) as "waiting on you".
+    expect((await p.poll()).sessions[0]!.activity).toBe('working')
+    // Seen quiet on two consecutive polls now — confirmed waiting.
     expect((await p.poll()).sessions[0]!.activity).toBe('waiting')
   })
 
@@ -120,7 +162,15 @@ describe('createSessionsPoller', () => {
     frames.a = ['done']
     expect((await p.poll()).sessions[0]!.activity).toBe('working')
 
-    // Next poll: the frame is unchanged and the session has settled.
+    // Next poll: the frame is unchanged, so the RAW reading is `waiting` — but it has been seen only
+    // once, so the fleet still shows `working` and the bell does NOT ring. The bell fires on the
+    // CONFIRMED transition, never on a single frame: that is what stops a one-frame quiet ringing a
+    // person for a session that is still working.
+    const held = await p.poll()
+    expect(held.sessions[0]!.activity).toBe('working')
+    expect(held.rang).toEqual([])
+
+    // The poll after that confirms the quiet — waiting is now believed, and the bell rings once.
     const settled = await p.poll()
     expect(settled.sessions[0]!.activity).toBe('waiting')
     expect(settled.rang).toEqual(['a'])

--- a/packages/server/server/sessions/sessions-host.test.ts
+++ b/packages/server/server/sessions/sessions-host.test.ts
@@ -294,3 +294,51 @@ describe('the dialog a blocked session is showing', () => {
     expect((await p.poll()).sessions[0]!.approvalLines).toBeUndefined()
   })
 })
+
+describe('persisting the harness /rename name', () => {
+  const index = (byManagedId: Record<string, Record<string, unknown>>) => async () => ({
+    byManagedId: new Map(Object.entries(byManagedId)),
+    byPid: new Map(), byConversation: new Map(),
+  } as never)
+
+  it('persists a name a person typed, exactly once, and only when it CHANGES', async () => {
+    const calls: { id: string; name: string; since?: number }[] = []
+    const p = createSessionsPoller({
+      backend: fakeBackend({ sessions: [backendSession('m1')], frames: { m1: ['x'] } }),
+      readRegistry: async () => [managed('m1')],
+      scanProcesses: async () => ({ procs: [] }),
+      now: () => NOW,
+      loadHarnessSessions: index({ m1: { name: 'MAIN', nameSince: 7, tmux: 'agentop-m1:@0.%0' } }),
+      recordHarnessName: async (id, name, since) => { calls.push({ id, name, ...(since !== undefined ? { since } : {}) }) },
+    })
+    await p.poll()
+    expect(calls).toEqual([{ id: 'm1', name: 'MAIN', since: 7 }])
+
+    // Registry now already holds the name — the next poll must not write again.
+    calls.length = 0
+    const p2 = createSessionsPoller({
+      backend: fakeBackend({ sessions: [backendSession('m1')], frames: { m1: ['x'] } }),
+      readRegistry: async () => [managed('m1', { harnessName: 'MAIN', harnessNameSince: 7 })],
+      scanProcesses: async () => ({ procs: [] }),
+      now: () => NOW,
+      loadHarnessSessions: index({ m1: { name: 'MAIN', nameSince: 7, tmux: 'agentop-m1:@0.%0' } }),
+      recordHarnessName: async (id, name, since) => { calls.push({ id, name, ...(since !== undefined ? { since } : {}) }) },
+    })
+    await p2.poll()
+    expect(calls).toEqual([])
+  })
+
+  it('never persists a name the harness invented for itself', async () => {
+    const calls: unknown[] = []
+    const p = createSessionsPoller({
+      backend: fakeBackend({ sessions: [backendSession('m1')], frames: { m1: ['x'] } }),
+      readRegistry: async () => [managed('m1')],
+      scanProcesses: async () => ({ procs: [] }),
+      now: () => NOW,
+      loadHarnessSessions: index({ m1: { name: 'agentistics-77', nameSource: 'derived', tmux: 'agentop-m1:@0.%0' } }),
+      recordHarnessName: async (...a) => { calls.push(a) },
+    })
+    await p.poll()
+    expect(calls).toEqual([])
+  })
+})

--- a/packages/server/server/sessions/sessions-host.ts
+++ b/packages/server/server/sessions/sessions-host.ts
@@ -15,6 +15,7 @@ import { createLimiter } from '../utils'
 import type { HarnessProcess } from '../live-sessions'
 import { rulesFor } from './attention-rules'
 import { approvalTail, attentionOf, digestFrame, frameTail } from './attention'
+import { EMPTY_CONFIRM_MEMORY, confirmActivities, type ConfirmMemory } from './attention-confirm'
 import { readRecentChatTurns, resolveChatTranscriptPath, type ChatTurn } from './chat-tail'
 import { parseDialogOptions, type DialogOption } from './dialog-choice'
 // Taking a running session back when its registry record is gone. See `session-adopt.ts`.
@@ -155,6 +156,11 @@ export function createSessionsPoller(o: {
   // first is how movement is detected; the second is what makes the bell a transition.
   let prevDigest = new Map<string, string>()
   let prevActivity = new Map<string, SessionActivity>()
+  // The raw per-poll reading is noisy: a session that just finished, or a pane a plugin repainted,
+  // reads `working` then `waiting` across two polls with nothing changed. `confirmActivities` turns
+  // that into a CONFIRMED reading — a needs-you state must be seen twice before the counter believes
+  // it, while a return to work is believed at once — so the "waiting on you" count stops lying.
+  let confirmMemory: ConfirmMemory = EMPTY_CONFIRM_MEMORY
   const prevProcStats = new Map<number, ProcStatSample>()
   let last: SessionSnapshot | null = null
   /**
@@ -340,9 +346,19 @@ export function createSessionsPoller(o: {
         }
       }
 
+      // Confirm the raw readings before anything downstream sees them: the count, the sort, the bell
+      // and the TUI all read `activity`, so confirming here is the one place that makes every surface
+      // honest at once. A needs-you state must hold for two polls to be believed; a return to work is
+      // believed immediately (see `attention-confirm.ts`). The dialog/approval frames captured above
+      // are keyed to the RAW `waiting-approval` reading and only reach a row once its CONFIRMED state
+      // is `waiting-approval` too — `buildSessionViews` gates them on `activity`.
+      const confirm = confirmActivities(confirmMemory, activity)
+      confirmMemory = confirm.memory
+      const confirmedActivity = confirm.activities
+
       const sessions = buildSessionViews({
         reconciled,
-        activity,
+        activity: confirmedActivity,
         tails,
         chatTails,
         approvals,

--- a/packages/server/server/sessions/sessions-host.ts
+++ b/packages/server/server/sessions/sessions-host.ts
@@ -22,6 +22,7 @@ import { planAdoptions } from './session-adopt'
 import { loadConversations, type Conversation } from './conversations'
 import { HEARTBEAT_MS, planCrashGroup, type CrashGroup } from './crash-group'
 import { emptyHarnessSessionIndex, type HarnessSessionIndex } from './harness-sessions'
+import { chosenName } from './harness-session-file'
 import { reconcileSessions } from './session-ref'
 import {
   attentionCount, bellTransitions, buildSessionViews, type SessionView,
@@ -121,6 +122,17 @@ export function createSessionsPoller(o: {
    * conversation.
    */
   recordConversation?: (id: string, conversationId: string) => Promise<unknown>
+  /**
+   * Persist the name a managed row was given INSIDE the harness (`/rename`), so the title survives
+   * the process.
+   *
+   * Mirror of `recordConversation`, and for the same reason: the harness deletes its own session
+   * file when the process ends, so a name that lived only there is lost the instant the session
+   * finishes — the displayed title then flips to a different source and `CTRL+F` can no longer find
+   * the row by the name it wore a moment ago. Called ONLY when the live, non-derived name disagrees
+   * with what the registry already holds, so it writes once per rename and not once per poll.
+   */
+  recordHarnessName?: (id: string, name: string, since?: number) => Promise<unknown>
   /**
    * Write registry records for sessions the backend is running and the registry has lost.
    *
@@ -277,6 +289,18 @@ export function createSessionsPoller(o: {
           const exact = harnessSessions.byManagedId.get(m.id)?.sessionId
           if (!exact || m.conversationId === exact) continue
           await o.recordConversation(m.id, exact).catch(() => undefined)
+        }
+      }
+
+      // The `/rename` name, captured WHILE there is still a harness file to read it from, so the
+      // title outlives the process. Only a name a PERSON typed (`chosenName` drops the harness's own
+      // invented `agentistics-77`), and only when it CHANGED — one write per rename, never per poll.
+      if (o.recordHarnessName) {
+        for (const m of registry) {
+          const file = harnessSessions.byManagedId.get(m.id)
+          const name = chosenName(file)
+          if (!name || (m.harnessName === name && m.harnessNameSince === file?.nameSince)) continue
+          await o.recordHarnessName(m.id, name, file?.nameSince).catch(() => undefined)
         }
       }
 

--- a/packages/server/server/sessions/spawn-spec.test.ts
+++ b/packages/server/server/sessions/spawn-spec.test.ts
@@ -30,19 +30,27 @@ describe('SPAWN_SPECS', () => {
 })
 
 describe('planSpawn', () => {
-  it('puts a claude prompt in the positional slot, after the flags', () => {
+  it('puts a claude prompt in the positional slot, after the flags, and marks it for submit', () => {
+    // Positional, so the text is in argv — but the backend must still SUBMIT it (an Enter) on a
+    // version that pre-fills without auto-submitting, without double-submitting one that does.
     const r = planSpawn({ harness: 'claude', cwd: '/tmp', prompt: 'fix the tests', model: 'opus', effort: 'high' })
-    expect(r).toEqual({ ok: true, plan: { argv: ['claude', '--model', 'opus', '--effort', 'high', 'fix the tests'] } })
+    expect(r).toEqual({
+      ok: true,
+      plan: { argv: ['claude', '--model', 'opus', '--effort', 'high', 'fix the tests'], initialPrompt: { mode: 'submit' } },
+    })
   })
 
-  it('puts a codex prompt in the positional slot', () => {
+  it('puts a codex prompt in the positional slot and marks it for submit', () => {
     const r = planSpawn({ harness: 'codex', cwd: '/tmp', prompt: 'implement X', model: 'o3' })
-    expect(r).toEqual({ ok: true, plan: { argv: ['codex', '--model', 'o3', 'implement X'] } })
+    expect(r).toEqual({
+      ok: true,
+      plan: { argv: ['codex', '--model', 'o3', 'implement X'], initialPrompt: { mode: 'submit' } },
+    })
   })
 
   it('types a kimi prompt in, because kimi has no interactive prompt flag', () => {
     const r = planSpawn({ harness: 'kimi', cwd: '/tmp', prompt: 'implement X' })
-    expect(r).toEqual({ ok: true, plan: { argv: ['kimi'], sendKeys: 'implement X' } })
+    expect(r).toEqual({ ok: true, plan: { argv: ['kimi'], initialPrompt: { mode: 'type', text: 'implement X' } } })
   })
 
   it('omits the prompt entirely when there is none', () => {
@@ -72,7 +80,7 @@ describe('planSpawn', () => {
 
   it('types a copilot prompt in, because its -p exits after answering', () => {
     const r = planSpawn({ harness: 'copilot', cwd: '/tmp', prompt: 'review this' })
-    expect(r).toEqual({ ok: true, plan: { argv: ['copilot'], sendKeys: 'review this' } })
+    expect(r).toEqual({ ok: true, plan: { argv: ['copilot'], initialPrompt: { mode: 'type', text: 'review this' } } })
   })
 
   it('accepts agy effort, which its own --help prints as a closed set', () => {

--- a/packages/server/server/sessions/spawn-spec.ts
+++ b/packages/server/server/sessions/spawn-spec.ts
@@ -18,7 +18,7 @@
 
 import type { HarnessId } from '@agentistics/core'
 import { HARNESS_SESSION_SOURCES } from './harness-session-file'
-import type { SpawnRequest, SpawnPlanResult, SpawnSpec } from './types'
+import type { InitialPrompt, SpawnRequest, SpawnPlanResult, SpawnSpec } from './types'
 
 export const SPAWN_SPECS: Record<HarnessId, SpawnSpec | null> = {
   // `Usage: claude [options] [command] [prompt]` / `Arguments: prompt  Your prompt`
@@ -173,11 +173,19 @@ export function planSpawn(req: SpawnRequest): SpawnPlanResult {
   if (req.model && spec.modelFlag) argv.push(spec.modelFlag, req.model)
   if (req.effort && spec.effortFlag) argv.push(spec.effortFlag, req.effort)
 
-  let sendKeys: string | undefined
+  // How the initial prompt will be DELIVERED once the session is up — see `initial-prompt.ts`. A
+  // `positional` prompt is in argv but may not have been auto-submitted (`submit`); a `send-keys`
+  // harness needs it typed (`type`); a `flag` harness runs it itself and needs no delivery.
+  let initialPrompt: InitialPrompt | undefined
   if (req.prompt) {
-    if (spec.prompt.kind === 'positional') argv.push(req.prompt)
-    else if (spec.prompt.kind === 'flag') argv.push(spec.prompt.flag, req.prompt)
-    else sendKeys = req.prompt
+    if (spec.prompt.kind === 'positional') {
+      argv.push(req.prompt)
+      initialPrompt = { mode: 'submit' }
+    } else if (spec.prompt.kind === 'flag') {
+      argv.push(spec.prompt.flag, req.prompt)
+    } else {
+      initialPrompt = { mode: 'type', text: req.prompt }
+    }
   }
 
   // The conversation this spawn is KNOWN to drive: the one we asked to reopen, or the one we just
@@ -189,7 +197,7 @@ export function planSpawn(req: SpawnRequest): SpawnPlanResult {
     ok: true,
     plan: {
       argv,
-      ...(sendKeys === undefined ? {} : { sendKeys }),
+      ...(initialPrompt ? { initialPrompt } : {}),
       ...(conversationId ? { conversationId } : {}),
     },
   }

--- a/packages/server/server/sessions/terminal-hub.test.ts
+++ b/packages/server/server/sessions/terminal-hub.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from 'bun:test'
+import { createTerminalHub, type TerminalSink } from './terminal-hub'
+import type { TerminalFrame } from './terminal-stream'
+import type { PaneInfo, TerminalCapture } from './types'
+
+const info = (over: Partial<PaneInfo> = {}): PaneInfo => ({
+  cols: 80, rows: 40, cursorX: 0, cursorY: 0, alive: true, historySize: 0, ...over,
+})
+const cap = (lines: string[], over: Partial<PaneInfo> = {}): TerminalCapture => ({ lines, info: info(over) })
+
+const flush = () => new Promise<void>(r => setTimeout(r, 0))
+
+/** A recording sink. */
+function sink() {
+  const frames: TerminalFrame[] = []
+  const ends: string[] = []
+  const s: TerminalSink = { onFrame: f => frames.push(f), onEnd: r => ends.push(r) }
+  return { s, frames, ends }
+}
+
+/**
+ * A harness whose "tmux" is a variable and whose interval is a captured callback, so ticks happen
+ * exactly when the test calls `tick()`. This is dependency injection, not filesystem mocking — the
+ * same shape `createSessionsPoller` is built with in this directory.
+ */
+function harness(opts: { managed?: boolean } = {}) {
+  let next: TerminalCapture | null = cap(['boot'])
+  let intervalFn: (() => void) | null = null
+  let cleared = false
+  let captureCalls = 0
+
+  const hub = createTerminalHub({
+    capture: async () => { captureCalls++; return next },
+    isManaged: async () => opts.managed ?? true,
+    historyLimit: 50_000,
+    viewLines: 200,
+    pollMs: 500,
+    setInterval: fn => { intervalFn = fn; return 1 as unknown as ReturnType<typeof setInterval> },
+    clearInterval: () => { cleared = true },
+  })
+
+  return {
+    hub,
+    set: (c: TerminalCapture | null) => { next = c },
+    tick: async () => { intervalFn?.(); await flush() },
+    intervalStarted: () => intervalFn !== null,
+    cleared: () => cleared,
+    captureCalls: () => captureCalls,
+  }
+}
+
+describe('createTerminalHub', () => {
+  it('one loop, one tmux read per tick, however many readers share a session', async () => {
+    const h = harness()
+    const a = sink()
+    const b = sink()
+    await h.hub.subscribe('s1', a.s)
+    await h.hub.subscribe('s1', b.s)
+    await flush()
+
+    expect(h.hub.activeLoops()).toBe(1) // ONE loop for two readers — no duplicated work
+    expect(h.hub.subscribers()).toBe(2)
+
+    const before = h.captureCalls()
+    h.set(cap(['moved']))
+    await h.tick()
+    // Exactly one more capture served BOTH readers.
+    expect(h.captureCalls()).toBe(before + 1)
+    expect(a.frames.at(-1)!.content).toBe('moved')
+    expect(b.frames.at(-1)!.content).toBe('moved')
+  })
+
+  it('sends an unchanged frame to nobody, and a changed one to everybody', async () => {
+    const h = harness()
+    const a = sink()
+    await h.hub.subscribe('s1', a.s)
+    await flush()
+    const seen = a.frames.length // the immediate first frame
+
+    h.set(cap(['boot'])) // identical to the first
+    await h.tick()
+    expect(a.frames.length).toBe(seen) // deduped — nothing sent
+
+    h.set(cap(['different']))
+    await h.tick()
+    expect(a.frames.length).toBe(seen + 1)
+    expect(a.frames.at(-1)!.seq).toBeGreaterThan(a.frames[0]!.seq) // seq advances only on change
+  })
+
+  it('hands a late reader the current screen immediately, without waiting for a change', async () => {
+    const h = harness()
+    const a = sink()
+    await h.hub.subscribe('s1', a.s)
+    await flush()
+
+    const b = sink()
+    await h.hub.subscribe('s1', b.s)
+    // b gets the last frame at subscribe time — no tick in between.
+    expect(b.frames).toHaveLength(1)
+    expect(b.frames[0]!.content).toBe('boot')
+  })
+
+  it('ends every reader cleanly when the session is gone, and stops the loop', async () => {
+    const h = harness()
+    const a = sink()
+    const b = sink()
+    await h.hub.subscribe('s1', a.s)
+    await h.hub.subscribe('s1', b.s)
+    await flush()
+
+    h.set(null) // tmux no longer has the session
+    await h.tick()
+
+    expect(a.ends).toEqual(['gone'])
+    expect(b.ends).toEqual(['gone'])
+    expect(h.hub.activeLoops()).toBe(0) // a dying session takes nothing else down and leaks nothing
+    expect(h.cleared()).toBe(true)
+  })
+
+  it('serves an EXITED but still-capturable pane as a dead-but-readable frame, not an end', async () => {
+    const h = harness()
+    const a = sink()
+    await h.hub.subscribe('s1', a.s)
+    await flush()
+
+    h.set(cap(['last words'], { alive: false }))
+    await h.tick()
+
+    expect(a.ends).toEqual([]) // NOT ended: the session is still there, just finished
+    expect(a.frames.at(-1)!.alive).toBe(false)
+    expect(a.frames.at(-1)!.cursor).toBeNull()
+    expect(a.frames.at(-1)!.content).toBe('last words')
+  })
+
+  it('refuses a session this machine does not manage — scope, before any loop starts', async () => {
+    const h = harness({ managed: false })
+    const a = sink()
+    await h.hub.subscribe('elsewhere', a.s)
+    await flush()
+
+    expect(a.ends).toEqual(['not-found'])
+    expect(a.frames).toEqual([])
+    expect(h.hub.activeLoops()).toBe(0)
+    expect(h.intervalStarted()).toBe(false)
+  })
+
+  it('stops capturing once the last reader leaves', async () => {
+    const h = harness()
+    const a = sink()
+    const b = sink()
+    const offA = await h.hub.subscribe('s1', a.s)
+    const offB = await h.hub.subscribe('s1', b.s)
+    await flush()
+
+    offA()
+    expect(h.hub.activeLoops()).toBe(1) // b is still watching
+    expect(h.cleared()).toBe(false)
+
+    offB()
+    expect(h.hub.activeLoops()).toBe(0) // nobody left — the loop is stopped
+    expect(h.cleared()).toBe(true)
+  })
+
+  it('is idempotent on a double unsubscribe', async () => {
+    const h = harness()
+    const a = sink()
+    const off = await h.hub.subscribe('s1', a.s)
+    await flush()
+    off()
+    off() // must not throw or double-count
+    expect(h.hub.activeLoops()).toBe(0)
+  })
+})

--- a/packages/server/server/sessions/terminal-hub.ts
+++ b/packages/server/server/sessions/terminal-hub.ts
@@ -1,0 +1,150 @@
+/**
+ * terminal-hub.ts — one capture loop per WATCHED session, shared by every reader of it.
+ *
+ * The criterion the spec sets is "follow the agent without hammering the server with a fleet of open
+ * sessions". Two properties deliver it, and both live here:
+ *
+ *  - **Viewer-gated.** A session is captured only while at least one browser is watching it. The
+ *    loop starts on the first subscriber and stops on the last. So the server's work scales with the
+ *    number of open TERMINALS (usually one), never with the size of the fleet.
+ *  - **Shared, deduped.** Many readers of the same session share ONE loop and ONE tmux read per
+ *    tick; an unchanged frame is sent to nobody. A reader that joins mid-stream is handed the last
+ *    frame immediately, so it sees the current screen without waiting for the next change.
+ *
+ * Injectable on purpose — the backend, the scope check and the clock are passed in — because that is
+ * how `createSessionsPoller` is built and tested in this same directory, and it lets the "one loop
+ * for N readers / dedup / death ends the stream" behaviour be proven without a tmux server. The
+ * decisions that could be silently wrong (what counts as a change, how a capture becomes a frame)
+ * live in the pure `terminal-stream.ts`; this module is the orchestration around them.
+ */
+
+import { buildFrame, captureDigest, type TerminalEndReason, type TerminalFrame } from './terminal-stream'
+import type { TerminalCapture } from './types'
+
+export interface TerminalSink {
+  onFrame(frame: TerminalFrame): void
+  onEnd(reason: TerminalEndReason): void
+}
+
+type TimerHandle = ReturnType<typeof setInterval>
+
+export interface TerminalHubDeps {
+  /** Read the pane, ANSI-preserved. `null` means the session is GONE (ends the stream). */
+  capture(id: string): Promise<TerminalCapture | null>
+  /** Scope gate: is this a session this machine manages and this user may already see? A stream for
+   *  anything else is refused before a loop ever starts — writing power never, reading power never,
+   *  widens past the fleet the dashboard already lists. */
+  isManaged(id: string): Promise<boolean>
+  /** The scrollback ceiling, carried into each frame for the "showing last N of M" honesty. */
+  historyLimit: number
+  /** How many lines of history each capture requests — decides a frame's `truncated` flag. */
+  viewLines: number
+  pollMs: number
+  /** Injectable so a test drives the loop by hand instead of by wall-clock. */
+  setInterval?: (fn: () => void, ms: number) => TimerHandle
+  clearInterval?: (h: TimerHandle) => void
+}
+
+interface Entry {
+  sinks: Set<TerminalSink>
+  handle: TimerHandle | null
+  /** Guards against a slow tmux read overlapping the next tick. */
+  busy: boolean
+  lastDigest: string | null
+  lastFrame: TerminalFrame | null
+  seq: number
+}
+
+export interface TerminalHub {
+  /** Start (or join) watching a session. The returned function unsubscribes; call it once. */
+  subscribe(id: string, sink: TerminalSink): Promise<() => void>
+  /** How many capture loops are running — for the route's cap and for tests. */
+  activeLoops(): number
+  /** Total readers across all sessions — for the route's cap. */
+  subscribers(): number
+}
+
+export function createTerminalHub(deps: TerminalHubDeps): TerminalHub {
+  const setIv: (fn: () => void, ms: number) => TimerHandle =
+    deps.setInterval ?? ((fn, ms) => setInterval(fn, ms) as TimerHandle)
+  const clearIv: (h: TimerHandle) => void = deps.clearInterval ?? clearInterval
+  const entries = new Map<string, Entry>()
+
+  function stop(id: string, entry: Entry): void {
+    if (entry.handle !== null) { clearIv(entry.handle); entry.handle = null }
+    entries.delete(id)
+  }
+
+  async function tick(id: string): Promise<void> {
+    const entry = entries.get(id)
+    if (!entry || entry.busy) return
+    entry.busy = true
+    try {
+      let cap: TerminalCapture | null
+      try {
+        cap = await deps.capture(id)
+      } catch {
+        // A read that THREW is not proof the session is gone (a transient tmux hiccup), so it does
+        // not end the stream — the next tick tries again. Only an explicit `null` means gone.
+        return
+      }
+      const still = entries.get(id)
+      if (!still) return // unsubscribed while the read was in flight
+      if (cap === null) {
+        for (const s of [...still.sinks]) { try { s.onEnd('gone') } catch { /* sink is done */ } }
+        stop(id, still)
+        return
+      }
+      const digest = captureDigest(cap.lines, cap.info)
+      if (digest === still.lastDigest) return // nothing changed — send nobody a frame
+      still.seq += 1
+      const frame = buildFrame(still.seq, cap.lines, cap.info, deps.historyLimit, deps.viewLines)
+      still.lastDigest = digest
+      still.lastFrame = frame
+      for (const s of [...still.sinks]) { try { s.onFrame(frame) } catch { /* sink is done */ } }
+    } finally {
+      const e = entries.get(id)
+      if (e) e.busy = false
+    }
+  }
+
+  return {
+    async subscribe(id, sink) {
+      if (!(await deps.isManaged(id))) {
+        try { sink.onEnd('not-found') } catch { /* sink is done */ }
+        return () => {}
+      }
+      let entry = entries.get(id)
+      if (!entry) {
+        entry = { sinks: new Set(), handle: null, busy: false, lastDigest: null, lastFrame: null, seq: 0 }
+        entries.set(id, entry)
+        // First tick immediately so the first reader is not waiting a whole interval for a screen
+        // that already exists, then on the cadence.
+        entry.handle = setIv(() => { void tick(id) }, deps.pollMs)
+        void tick(id)
+      } else if (entry.lastFrame) {
+        // A newcomer to a running loop gets the current screen now, not at the next change.
+        try { sink.onFrame(entry.lastFrame) } catch { /* sink is done */ }
+      }
+      entry.sinks.add(sink)
+
+      let done = false
+      return () => {
+        if (done) return
+        done = true
+        const e = entries.get(id)
+        if (!e) return
+        e.sinks.delete(sink)
+        if (e.sinks.size === 0) stop(id, e) // last reader left — stop hammering tmux
+      }
+    },
+    activeLoops() {
+      return entries.size
+    },
+    subscribers() {
+      let n = 0
+      for (const e of entries.values()) n += e.sinks.size
+      return n
+    },
+  }
+}

--- a/packages/server/server/sessions/terminal-stream.test.ts
+++ b/packages/server/server/sessions/terminal-stream.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'bun:test'
+import { buildFrame, captureDigest, encodeSse } from './terminal-stream'
+import type { PaneInfo } from './types'
+
+const info = (over: Partial<PaneInfo> = {}): PaneInfo => ({
+  cols: 80, rows: 40, cursorX: 5, cursorY: 2, alive: true, historySize: 0, ...over,
+})
+
+describe('captureDigest', () => {
+  it('is stable for an identical capture, so an unchanged frame is sent to nobody', () => {
+    expect(captureDigest(['a', 'b'], info())).toBe(captureDigest(['a', 'b'], info()))
+  })
+
+  it('changes when the CONTENT changes', () => {
+    expect(captureDigest(['a'], info())).not.toBe(captureDigest(['a', 'b'], info()))
+  })
+
+  it('changes when only the CURSOR moves — a still screen with a moved cursor still moved', () => {
+    expect(captureDigest(['a'], info({ cursorX: 5 }))).not.toBe(captureDigest(['a'], info({ cursorX: 6 })))
+  })
+
+  it('changes when a line scrolled off into history though the visible text looks the same', () => {
+    // historySize is part of the digest precisely so a tail-follower learns the pane moved.
+    expect(captureDigest(['x'], info({ historySize: 10 }))).not.toBe(captureDigest(['x'], info({ historySize: 11 })))
+  })
+
+  it('changes when the pane dies', () => {
+    expect(captureDigest(['x'], info({ alive: true }))).not.toBe(captureDigest(['x'], info({ alive: false })))
+  })
+})
+
+describe('buildFrame', () => {
+  const VIEW = 200
+
+  it('joins the lines with newlines and carries the geometry', () => {
+    const f = buildFrame(3, ['one', 'two'], info({ cols: 100, rows: 30 }), 50_000, VIEW)
+    expect(f.seq).toBe(3)
+    expect(f.content).toBe('one\ntwo')
+    expect(f.cols).toBe(100)
+    expect(f.rows).toBe(30)
+    expect(f.lines).toBe(2)
+    expect(f.historyLimit).toBe(50_000)
+  })
+
+  it('carries the cursor while alive', () => {
+    expect(buildFrame(1, ['x'], info({ cursorX: 7, cursorY: 4 }), 100, VIEW).cursor).toEqual({ x: 7, y: 4 })
+  })
+
+  it('drops the cursor once the pane is dead — a cursor on a frozen frame is the frozen-looks-alive lie', () => {
+    expect(buildFrame(1, ['x'], info({ alive: false }), 100, VIEW).cursor).toBeNull()
+    expect(buildFrame(1, ['x'], info({ alive: false }), 100, VIEW).alive).toBe(false)
+  })
+
+  it('flags truncation when the pane holds more history than the shipped window', () => {
+    // 300 lines of scrollback, only 200 shipped → there is more above the fold.
+    expect(buildFrame(1, ['a'], info({ historySize: 300 }), 50_000, VIEW).truncated).toBe(true)
+  })
+
+  it('does not flag truncation when the whole backlog fits the window', () => {
+    // 40 lines of scrollback, window of 200 → nothing is above the fold.
+    expect(buildFrame(1, ['a'], info({ historySize: 40 }), 50_000, VIEW).truncated).toBe(false)
+    expect(buildFrame(1, ['a'], info({ historySize: 0 }), 50_000, VIEW).truncated).toBe(false)
+  })
+})
+
+describe('encodeSse', () => {
+  it('frames one event with the trailing blank line the protocol needs', () => {
+    expect(encodeSse('frame', { seq: 1 })).toBe('event: frame\ndata: {"seq":1}\n\n')
+  })
+
+  it('preserves ANSI escapes through JSON, so colours survive the wire', () => {
+    const chunk = encodeSse('frame', { content: '\x1b[31mred\x1b[0m' })
+    expect(chunk).toContain('\\u001b[31mred')
+    expect(JSON.parse(chunk.split('data: ')[1]!.trim()).content).toBe('\x1b[31mred\x1b[0m')
+  })
+})

--- a/packages/server/server/sessions/terminal-stream.ts
+++ b/packages/server/server/sessions/terminal-stream.ts
@@ -1,0 +1,103 @@
+/**
+ * terminal-stream.ts — PURE. The shape of what the terminal channel puts on the wire, and the two
+ * decisions that can be silently wrong if written by feel: whether a new capture is worth sending
+ * (dedup) and how the pane's own facts become an honest frame.
+ *
+ * The transport is SSE (see `docs/terminal-channel.md` for the why), and the whole feature is a
+ * SNAPSHOT model: each frame is a complete, self-contained picture of the pane as it renders RIGHT
+ * NOW — colours and all — so a reader that joins late or reconnects needs no replay, and a
+ * line-rewrite or a spinner is already resolved to its final glyph by tmux before we ever see it.
+ * That is the same discipline `attention-rules.ts:5` states: what we show is what the pane really
+ * rendered, never a reconstruction from memory of what a CLI prints.
+ */
+
+import type { PaneInfo } from './types'
+
+/**
+ * How many lines of scrollback+screen each frame carries.
+ *
+ * A screenful plus a margin: enough that a fast burst between two polls is not lost and the browser
+ * has some history to scroll, bounded so a changed frame is tens of KB and not the whole 50k
+ * backlog. The frame SAYS when there is more above it (`truncated`), so this is a shipping budget,
+ * not a claim that this is all there is.
+ */
+export const TERMINAL_VIEW_LINES = 200
+
+/** Default cadence of the shared capture loop. Snappy enough to feel live, slow enough that one
+ *  watched session is two tmux reads a second and no more. Overridable for the real hub / tests. */
+export const TERMINAL_POLL_MS = 500
+
+/** One complete, self-contained picture of a pane. */
+export interface TerminalFrame {
+  /** Monotonic within one stream. A client can spot a gap, and a newcomer's first frame is its own
+   *  seq so "did anything change" is answerable without diffing content. */
+  seq: number
+  /** The rendered pane, `\n`-joined, WITH SGR escape sequences intact. */
+  content: string
+  cols: number
+  rows: number
+  /** Where the block cursor sits — `null` once the pane is dead, because a cursor on a frozen frame
+   *  is the frozen-but-looks-alive lie this channel exists to avoid. */
+  cursor: { x: number; y: number } | null
+  /** False once the hosted command has exited. The last frame stays readable; it is just marked. */
+  alive: boolean
+  /** How many lines `content` carries — the honest "you are seeing N lines" number. */
+  lines: number
+  /** The scrollback ceiling tmux keeps, so the UI can say "showing last N of up to M". */
+  historyLimit: number
+  /** True when there is more scrollback above than this frame carries. */
+  truncated: boolean
+}
+
+/** Why a stream ended. `gone` = the session is no longer in tmux; `not-found` = it was never a
+ *  session this machine manages (scope refusal); `error` = the backend could not be read. */
+export type TerminalEndReason = 'gone' | 'not-found' | 'error'
+
+/**
+ * A cheap, total fingerprint of a capture — content plus every fact a frame carries EXCEPT `seq`
+ * (which is derived from change) and `historyLimit`/`truncated` (which are derived from the rest).
+ * Two captures with the same digest render identically, so the second is not worth a frame.
+ *
+ * `historySize` is deliberately included: the screen can look unchanged while a line has scrolled
+ * off the top into history, and a reader watching the tail wants to know the pane moved.
+ */
+export function captureDigest(lines: string[], info: PaneInfo): string {
+  return [
+    info.cols, info.rows, info.cursorX, info.cursorY,
+    info.alive ? 1 : 0, info.historySize, lines.length,
+  ].join(',') + '\n' + lines.join('\n')
+}
+
+/**
+ * Shape a raw capture into a frame.
+ *
+ * `truncated` is honest about the one thing this snapshot cannot show: scrollback beyond the window
+ * we ship. We capture at most `viewLines` lines of history (`capture-pane -S -viewLines`), so there
+ * is more above the fold precisely when the pane holds MORE history than that. `historyLimit` is the
+ * ceiling tmux would ever keep, for the "showing last N of up to M" line.
+ */
+export function buildFrame(
+  seq: number,
+  lines: string[],
+  info: PaneInfo,
+  historyLimit: number,
+  viewLines: number,
+): TerminalFrame {
+  return {
+    seq,
+    content: lines.join('\n'),
+    cols: info.cols,
+    rows: info.rows,
+    cursor: info.alive ? { x: info.cursorX, y: info.cursorY } : null,
+    alive: info.alive,
+    lines: lines.length,
+    historyLimit,
+    truncated: info.historySize > viewLines,
+  }
+}
+
+/** Encode one SSE event. Kept here, pure and tested, because a stray newline in the framing breaks
+ *  the whole protocol and is exactly the kind of thing that is invisible until a client parses it. */
+export function encodeSse(event: string, data: unknown): string {
+  return `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`
+}

--- a/packages/server/server/sessions/terminal-web.ts
+++ b/packages/server/server/sessions/terminal-web.ts
@@ -1,0 +1,121 @@
+/**
+ * terminal-web.ts — the WEB dashboard's live terminal channel onto one session's pane.
+ *
+ * The sibling of `fleet-web.ts`, and deliberately LEANER than it. `fleet-web` routes through the
+ * Ink control host because the fleet's ACTIONS carry rules that must not be re-implemented in a
+ * browser (a numbered dialog is never answered by a bare confirm). Reading a screen carries no such
+ * rule — a capture is a capture — so this channel talks straight to the session backend and skips
+ * the React/Ink import graph entirely. It keeps exactly ONE rule of its own, the one that matters:
+ * SCOPE. A stream is opened only for a session THIS MACHINE MANAGES (its own registry), so the read
+ * power never reaches past the fleet the dashboard already lists — the same boundary the write path
+ * will inherit in Phase 2, established here where it is cheap.
+ *
+ * The heavy lifting (shared loop, dedup, death) is `terminal-hub.ts`; the framing is the pure
+ * `terminal-stream.ts`. This file is just the singleton wiring and the SSE plumbing. The whole
+ * surface is additionally gated by `localShell` in `capability-guard.ts` and 404'd on a central, so
+ * it is unreachable on an internet-exposed instance regardless of who is authenticated — a captured
+ * terminal is shell access with extra steps.
+ */
+
+import { resolveBackend } from './index'
+import { readRegistry } from './registry'
+import { createTerminalHub, type TerminalHub } from './terminal-hub'
+import { encodeSse, TERMINAL_POLL_MS, TERMINAL_VIEW_LINES } from './terminal-stream'
+import { HISTORY_LIMIT } from './tmux-cli'
+
+/**
+ * A ceiling on concurrent terminal streams for the whole process. Each holds a socket, a controller
+ * and (with the hub's sharing) at worst one capture loop, so an unbounded count is a free way to
+ * exhaust the server (OWASP API4) — the same reason `/api/events` caps its client set.
+ */
+export const MAX_TERMINAL_STREAMS = 100
+
+/**
+ * A comment line every so often to keep the connection warm. A terminal that is deduped to silence
+ * — a session sitting on a permission prompt sends no frames for minutes — is exactly the case a
+ * proxy or load balancer reaps as idle. An SSE comment (`: …`) is ignored by the client, so it
+ * costs nothing but the bytes.
+ */
+const KEEPALIVE_MS = 15_000
+
+const POLL_MS = Number(process.env.AGENTISTICS_TERMINAL_POLL_MS) > 0
+  ? Number(process.env.AGENTISTICS_TERMINAL_POLL_MS)
+  : TERMINAL_POLL_MS
+
+let hub: TerminalHub | null = null
+
+async function getHub(): Promise<TerminalHub> {
+  if (hub) return hub
+  // Resolved once: `resolveBackend` returns a constant object, and the hub then holds it.
+  const backend = await resolveBackend()
+  hub = createTerminalHub({
+    capture: id => backend.captureTerminal(id, TERMINAL_VIEW_LINES),
+    isManaged: async id => (await readRegistry()).some(m => m.id === id),
+    historyLimit: HISTORY_LIMIT,
+    viewLines: TERMINAL_VIEW_LINES,
+    pollMs: POLL_MS,
+  })
+  return hub
+}
+
+/** Scope check for the route, so a session outside this machine's fleet is a clean 404 rather than
+ *  a 200 stream that immediately says `not-found`. The hub re-checks on subscribe regardless. */
+export async function terminalSessionExists(id: string): Promise<boolean> {
+  return (await readRegistry()).some(m => m.id === id)
+}
+
+/** True when the process is already at its stream ceiling — the route answers 503. */
+export async function terminalAtCapacity(): Promise<boolean> {
+  return (await getHub()).subscribers() >= MAX_TERMINAL_STREAMS
+}
+
+/**
+ * Build the SSE body for one session's terminal. The caller wraps it in a Response with the CORS +
+ * event-stream headers (matching `/api/events`). Cleanup is tied to `signal`: when the browser
+ * disconnects, the subscription is dropped, and when the last reader of a session leaves the hub
+ * stops capturing it.
+ */
+export async function openTerminalStream(id: string, signal: AbortSignal): Promise<ReadableStream<Uint8Array>> {
+  const h = await getHub()
+  const enc = new TextEncoder()
+  let unsubscribe: (() => void) | null = null
+  let keepalive: ReturnType<typeof setInterval> | null = null
+
+  const teardown = () => {
+    unsubscribe?.()
+    unsubscribe = null
+    if (keepalive !== null) { clearInterval(keepalive); keepalive = null }
+  }
+
+  return new ReadableStream<Uint8Array>({
+    async start(controller) {
+      let closed = false
+      const send = (chunk: string) => {
+        if (closed) return
+        try { controller.enqueue(enc.encode(chunk)) } catch { closed = true }
+      }
+      const close = () => {
+        if (closed) return
+        closed = true
+        teardown()
+        try { controller.close() } catch { /* already closed */ }
+      }
+
+      // If the browser is already gone by the time we start, do nothing.
+      if (signal.aborted) { close(); return }
+
+      send(encodeSse('open', { id, viewLines: TERMINAL_VIEW_LINES, historyLimit: HISTORY_LIMIT }))
+      keepalive = setInterval(() => send(': keepalive\n\n'), KEEPALIVE_MS)
+
+      unsubscribe = await h.subscribe(id, {
+        onFrame: frame => send(encodeSse('frame', frame)),
+        onEnd: reason => { send(encodeSse('end', { reason })); close() },
+      })
+
+      signal.addEventListener('abort', close)
+    },
+    cancel() {
+      teardown()
+    },
+  })
+}

--- a/packages/server/server/sessions/tmux-cli.test.ts
+++ b/packages/server/server/sessions/tmux-cli.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from 'bun:test'
 import {
-  LIST_FORMAT, attachArgs, capturePaneArgs, idFromTmuxName, isSessionGoneError, killSessionArgs,
-  newSessionArgs, parsePrefix, parseTmuxList, sendKeysEnterArgs, sendKeysLiteralArgs,
+  LIST_FORMAT, PANE_INFO_FORMAT, attachArgs, capturePaneArgs, capturePaneAnsiArgs, idFromTmuxName,
+  isSessionGoneError, killSessionArgs, newSessionArgs, paneInfoArgs, parsePaneInfo, parsePrefix,
+  parseTmuxList, sendKeysEnterArgs, sendKeysLiteralArgs,
   sendKeysNamedArgs, trimCapture,
   tmuxName,
   serverOptionsArgs, HISTORY_LIMIT,
@@ -32,6 +33,10 @@ describe('the other argv builders', () => {
   it('builds them all against our socket and our session name', () => {
     expect(killSessionArgs('a1')).toEqual(['-L', 'agentop', 'kill-session', '-t', 'agentop-a1'])
     expect(capturePaneArgs('a1', 40)).toEqual(['-L', 'agentop', 'capture-pane', '-p', '-t', 'agentop-a1', '-S', '-40'])
+    // The ANSI variant is the plain one with `-e` added — colours survive to the browser. Getting
+    // this wrong is silent: without `-e` the terminal renders monochrome and looks fine.
+    expect(capturePaneAnsiArgs('a1', 40)).toEqual(['-L', 'agentop', 'capture-pane', '-p', '-e', '-t', 'agentop-a1', '-S', '-40'])
+    expect(paneInfoArgs('a1')).toEqual(['-L', 'agentop', 'display-message', '-p', '-t', 'agentop-a1', '-F', PANE_INFO_FORMAT])
     expect(sendKeysLiteralArgs('a1', 'hello there')).toEqual(['-L', 'agentop', 'send-keys', '-t', 'agentop-a1', '-l', 'hello there'])
     expect(sendKeysEnterArgs('a1')).toEqual(['-L', 'agentop', 'send-keys', '-t', 'agentop-a1', 'Enter'])
     expect(attachArgs('a1')).toEqual(['tmux', '-L', 'agentop', 'attach-session', '-t', 'agentop-a1'])
@@ -95,6 +100,30 @@ describe('trimCapture', () => {
 
   it('survives an all-blank frame', () => {
     expect(trimCapture(['', '', ''])).toEqual([])
+  })
+})
+
+describe('parsePaneInfo', () => {
+  it('reads the six numbers our PANE_INFO_FORMAT asks for', () => {
+    expect(parsePaneInfo('12\t3\t80\t40\t0\t500')).toEqual({
+      cols: 80, rows: 40, cursorX: 12, cursorY: 3, alive: true, historySize: 500,
+    })
+  })
+
+  it('reads pane_dead=1 as not alive', () => {
+    expect(parsePaneInfo('0\t0\t80\t40\t1\t0')!.alive).toBe(false)
+  })
+
+  it('returns null on a short or non-numeric line rather than a half-built PaneInfo', () => {
+    // A confident-wrong cursor or "alive" is worse than none: the channel refuses the frame's
+    // metadata instead of shipping a guess.
+    expect(parsePaneInfo('12\t3\t80')).toBeNull()
+    expect(parsePaneInfo('a\tb\tc\td\te\tf')).toBeNull()
+    expect(parsePaneInfo('')).toBeNull()
+  })
+
+  it('asks for exactly the fields it parses', () => {
+    expect(PANE_INFO_FORMAT).toBe('#{cursor_x}\t#{cursor_y}\t#{pane_width}\t#{pane_height}\t#{pane_dead}\t#{history_size}')
   })
 })
 

--- a/packages/server/server/sessions/tmux-cli.ts
+++ b/packages/server/server/sessions/tmux-cli.ts
@@ -13,7 +13,7 @@
  * Every field and flag below was probed against tmux 3.2a on 2026-08-12.
  */
 
-import type { BackendSession } from './types'
+import type { BackendSession, PaneInfo } from './types'
 
 export const TMUX_SOCKET = 'agentop'
 export const SESSION_PREFIX = 'agentop-'
@@ -43,6 +43,57 @@ export function killSessionArgs(id: string): string[] {
 
 export function capturePaneArgs(id: string, lines: number): string[] {
   return sock(['capture-pane', '-p', '-t', tmuxName(id), '-S', `-${lines}`])
+}
+
+/**
+ * The same read as `capturePaneArgs`, but `-e` keeps the SGR escape sequences in the output —
+ * colours, bold, reverse — so the browser terminal renders what a person would have seen on attach.
+ *
+ * A SEPARATE builder rather than a flag on the one above, and deliberately so: the plain capture
+ * feeds the readiness and approval REGEXES (`backend-tmux.ts`, `attention.ts`), and a frame carrying
+ * `\x1b[38;5;39m` in front of every word would break every one of those patterns silently. The two
+ * reads have opposite requirements, so they are two functions — the same reasoning that keeps
+ * `sendKeysLiteralArgs` and `sendKeysNamedArgs` apart.
+ */
+export function capturePaneAnsiArgs(id: string, lines: number): string[] {
+  return sock(['capture-pane', '-p', '-e', '-t', tmuxName(id), '-S', `-${lines}`])
+}
+
+/**
+ * One `display-message` read of the pane's geometry, cursor and liveness — the facts `capture-pane`
+ * cannot report. Tab-separated so `parsePaneInfo` can split it without guessing at spaces (a cwd or
+ * a title would carry them; these six numeric fields never do, but tab is free insurance).
+ *
+ * Must stay in lockstep with `parsePaneInfo` — the test asserts the exact format string for that
+ * reason, the same contract `LIST_FORMAT` keeps with `parseTmuxList`.
+ */
+export const PANE_INFO_FORMAT =
+  '#{cursor_x}\t#{cursor_y}\t#{pane_width}\t#{pane_height}\t#{pane_dead}\t#{history_size}'
+
+export function paneInfoArgs(id: string): string[] {
+  return sock(['display-message', '-p', '-t', tmuxName(id), '-F', PANE_INFO_FORMAT])
+}
+
+/**
+ * Parse the `PANE_INFO_FORMAT` line. `null` on anything that does not read as the six numbers it
+ * must be — a partial `PaneInfo` is worse than none, because the terminal channel would ship a
+ * confident wrong cursor or a wrong "alive". `pane_dead` is `1` once the hosted command has exited.
+ */
+export function parsePaneInfo(stdout: string): PaneInfo | null {
+  const line = stdout.split('\n')[0]?.trim() ?? ''
+  if (!line) return null
+  const parts = line.split('\t')
+  if (parts.length < 6) return null
+  const [cx, cy, w, h, dead, hist] = parts.map(Number)
+  if (![cx, cy, w, h, dead, hist].every(Number.isFinite)) return null
+  return {
+    cols: w!,
+    rows: h!,
+    cursorX: cx!,
+    cursorY: cy!,
+    alive: dead !== 1,
+    historySize: hist!,
+  }
 }
 
 /** `-l` sends the text literally, so a prompt containing `;` or `C-c` is typed, not interpreted. */

--- a/packages/server/server/sessions/types.ts
+++ b/packages/server/server/sessions/types.ts
@@ -152,6 +152,33 @@ export interface BackendInitialPrompt extends InitialPrompt {
   rules?: AttentionRules
 }
 
+/**
+ * The pane's live geometry and cursor, read alongside a capture.
+ *
+ * `capture-pane` renders the grid but says nothing about where the cursor is or whether the hosted
+ * command has exited, and both are things the terminal channel must tell the browser honestly: a
+ * frozen last frame that still shows a blinking cursor is exactly the `waiting` lie this house has
+ * a rule against. So the backend reads it in the same breath as the content (one `display-message`).
+ */
+export interface PaneInfo {
+  cols: number
+  rows: number
+  cursorX: number
+  cursorY: number
+  /** False once the hosted command has exited — the pane is dead but still capturable (remain-on-exit). */
+  alive: boolean
+  /** How many lines of scrollback tmux is holding above the visible screen, right now. */
+  historySize: number
+}
+
+/** One ANSI-preserving read of a pane: its rendered lines plus the geometry beside them. */
+export interface TerminalCapture {
+  /** Newest-last lines of the rendered frame, WITH the SGR escape sequences (`capture-pane -e`).
+   *  NOT trailing-trimmed: a full-screen TUI uses the whole grid and its blank rows are layout. */
+  lines: string[]
+  info: PaneInfo
+}
+
 /** One session as the BACKEND sees it — existence and liveness, no product metadata. */
 export interface BackendSession {
   id: string
@@ -309,6 +336,20 @@ export interface SessionBackend {
   list(): Promise<BackendSession[]>
   /** Newest-last lines of the last rendered frame, trailing blanks removed. */
   capture(id: string, lines: number): Promise<string[]>
+  /**
+   * An ANSI-PRESERVING read of the pane — its rendered lines with colour/attribute escapes intact,
+   * plus the geometry and cursor beside them — for the browser terminal channel.
+   *
+   * Distinct from `capture` on purpose: `capture` strips escapes because its callers pattern-match
+   * the text (readiness, approval detection), and a frame full of SGR codes would break those
+   * regexes. This one KEEPS them, because a terminal that loses its colours is a worse copy of the
+   * one a person would have got from `tmux attach`.
+   *
+   * `null` — never a throw — when the session is GONE (tmux no longer has it): the caller ends the
+   * stream cleanly rather than crashing. A pane that has merely EXITED still returns a capture with
+   * `info.alive === false`, so the last frame stays readable and is honestly marked dead.
+   */
+  captureTerminal(id: string, lines: number): Promise<TerminalCapture | null>
   /**
    * Type `text` into the session and submit it — what a person does at the keyboard.
    *

--- a/packages/server/server/sessions/types.ts
+++ b/packages/server/server/sessions/types.ts
@@ -214,6 +214,29 @@ export interface ManagedSession {
    * never as "no repository", so an older row simply behaves as it always did.
    */
   repo?: RepoFacts
+  /**
+   * The name the user gave this session FROM INSIDE the harness (Claude Code's `/rename`), captured
+   * while the session was alive so it OUTLIVES the process.
+   *
+   * A title is an identity: whatever a session is called while it runs, it stays called after it
+   * ends. But that name lives only in the harness's own `~/.claude/sessions/<pid>.json`, which Claude
+   * DELETES when the process exits — so a session that showed a `/rename` name while running lost it
+   * the instant it finished, the displayed title fell back to a different source, and `CTRL+F` could
+   * no longer find the row by the name it had a second earlier. The poller persists the LIVE,
+   * non-derived name here (via `chosenName`) the moment it sees it, so the title is stable across the
+   * running -> finished transition. Only a name a PERSON typed is stored: a harness-invented
+   * `agentistics-77` never reaches this field, so it can never displace an agentop label. See
+   * `pickTitle` and `harness-session-file.ts`.
+   *
+   * Absent for a session that was never `/rename`d, and on a row written by a build predating this —
+   * both read exactly as they did before (the live file, when present, still wins).
+   */
+  harnessName?: string
+  /** When `harnessName` was set inside the harness, epoch ms — the recency side of the title
+   *  contest, mirrored from the harness's own `nameSince` so `pickTitle` settles it the same way
+   *  whether the session is alive (live file) or finished (this persisted copy). Absent on a claude
+   *  older than 2.1.232, which writes the name with no timestamp. */
+  harnessNameSince?: number
 }
 
 /**

--- a/packages/server/server/sessions/types.ts
+++ b/packages/server/server/sessions/types.ts
@@ -86,10 +86,27 @@ export interface SpawnRequest {
   task?: string
 }
 
+/**
+ * How the initial prompt reaches the harness once it is READY to receive it — see `initial-prompt.ts`.
+ *
+ * `type`   — a `send-keys` harness (its only prompt flag exits): the text is typed in and submitted.
+ * `submit` — a `positional` harness: the text is already in argv; it may only need an Enter to submit
+ *            it, on a harness/version that pre-fills without auto-submitting. Verified by a working
+ *            marker so a CLI that DID auto-submit is never double-submitted.
+ *
+ * A `flag` harness (`--prompt-interactive`) runs the prompt by design and carries no delivery.
+ */
+export interface InitialPrompt {
+  mode: 'type' | 'submit'
+  /** The text to type. Present only for mode `type`. */
+  text?: string
+}
+
 export interface SpawnPlan {
   argv: string[]
-  /** Typed into the session once it is up, for a `send-keys` harness. */
-  sendKeys?: string
+  /** How to deliver the initial prompt once the harness is up — absent when there is no prompt, or a
+   *  `flag` harness that runs it itself. */
+  initialPrompt?: InitialPrompt
   /**
    * The conversation this spawn is KNOWN to drive — the id reopened, or the id assigned.
    *
@@ -119,7 +136,20 @@ export interface BackendSpawn {
   id: string
   cwd: string
   argv: string[]
-  sendKeys?: string
+  /**
+   * How to deliver the initial prompt once the harness is ready to receive it.
+   *
+   * The harness's screen RULES ride along so the backend can tell a live turn and a startup dialog
+   * from an idle prompt WITHOUT importing the harness table — it stays harness-agnostic, the caller
+   * resolves the rules. Absent when there is nothing to deliver.
+   */
+  initialPrompt?: BackendInitialPrompt
+}
+
+export interface BackendInitialPrompt extends InitialPrompt {
+  /** The harness's probed markers, for readiness / already-submitted detection. Absent = only the
+   *  input-surface heuristic gates readiness, and a `submit` is never forced (cannot verify safely). */
+  rules?: AttentionRules
 }
 
 /** One session as the BACKEND sees it — existence and liveness, no product metadata. */

--- a/packages/tui/src/control/i18n.ts
+++ b/packages/tui/src/control/i18n.ts
@@ -384,6 +384,14 @@ export interface ControlStrings {
   /** Named in words, never rendered as a zero — see `TranscriptSearch.unavailable`. */
   searchNoGrep: string
   searchNoTranscripts: string
+  /** The transcription depth is switched off — a choice, distinct from "none on this machine". */
+  searchTranscriptOff: string
+  /** The search-depth section in the view menu, and its three cumulative toggles + the "all" row. */
+  viewSearchDepth: string
+  searchDepthName: string
+  searchDepthPrompt: string
+  searchDepthTranscript: string
+  searchDepthAll: string
   searchCovered: (harnesses: string) => string
   searchFailed: (harnesses: string) => string
   /** How long ago, from a whole number of SECONDS — the caller does the clock arithmetic so this
@@ -909,6 +917,12 @@ const EN: ControlStrings = {
   searchRunning: 'reading transcripts…',
   searchNoGrep: 'transcripts not searched — grep is not available here',
   searchNoTranscripts: 'transcripts not searched — none on this machine',
+  searchTranscriptOff: 'transcription off',
+  viewSearchDepth: 'Search in',
+  searchDepthName: 'title',
+  searchDepthPrompt: 'first prompt',
+  searchDepthTranscript: 'transcription (full session)',
+  searchDepthAll: 'all',
   searchCovered: h => `transcripts: ${h}`,
   searchFailed: h => `could not read: ${h}`,
   sessionsAgo: (sec: number) => {
@@ -1360,6 +1374,12 @@ const PT: ControlStrings = {
   searchRunning: 'lendo transcripts…',
   searchNoGrep: 'transcripts não buscados — não há grep aqui',
   searchNoTranscripts: 'transcripts não buscados — nenhum nesta máquina',
+  searchTranscriptOff: 'transcrição desligada',
+  viewSearchDepth: 'Buscar em',
+  searchDepthName: 'título',
+  searchDepthPrompt: 'primeiro prompt',
+  searchDepthTranscript: 'transcrição (sessão completa)',
+  searchDepthAll: 'todos',
   searchCovered: h => `transcripts: ${h}`,
   searchFailed: h => `não deu pra ler: ${h}`,
   sessionsAgo: (sec: number) => {

--- a/packages/tui/src/control/search-scope.test.ts
+++ b/packages/tui/src/control/search-scope.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from 'bun:test'
 import {
-  emptyScopeCounts, matchScopes, scopeCounts, searchDepthText, type SearchFields,
+  activeScopes, allState, DEFAULT_SCOPE_SELECTION, emptyScopeCounts, matchScopes, normalizeSelection,
+  scopeCounts, searchDepthText, selectionFromScopes, selectionToScopes, toggleAllScopes, toggleScope,
+  transcriptScopeOn, SEARCH_SCOPES, SEARCH_TOGGLES,
+  type SearchFields, type SearchScope, type SearchScopeSelection,
 } from './search-scope'
 
 const fields = (o: Partial<SearchFields> = {}): SearchFields => ({
@@ -72,6 +75,7 @@ const words = {
   },
   noGrep: 'no grep here',
   noTranscripts: 'none on this machine',
+  transcriptOff: 'transcript off',
 }
 
 describe('searchDepthText', () => {
@@ -89,6 +93,14 @@ describe('searchDepthText', () => {
     expect(searchDepthText(emptyScopeCounts(), words, {})).toBe('transcript 0')
   })
 
+  test('a transcription depth switched OFF says so, distinct from "none on this machine"', () => {
+    const counts = { ...emptyScopeCounts(), name: 2 }
+    expect(searchDepthText(counts, words, { off: true })).toBe('name 2 · transcript off')
+    // …and it outranks a stale running/unavailable flag: nothing ran, so nothing is pending.
+    expect(searchDepthText(counts, words, { off: true, running: true, runningWord: 'reading…' }))
+      .toBe('name 2 · transcript off')
+  })
+
   test('an unsearchable transcript says WHY instead of showing a zero', () => {
     const counts = { ...emptyScopeCounts(), name: 2 }
     expect(searchDepthText(counts, words, { unavailable: 'no-grep' }))
@@ -101,5 +113,191 @@ describe('searchDepthText', () => {
     const counts = { ...emptyScopeCounts(), name: 2 }
     expect(searchDepthText(counts, words, { running: true, runningWord: 'reading…' }))
       .toBe('name 2 · reading…')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Selectable, cumulative search depth + the two-way "all" — finding (3).
+
+const sel = (o: Partial<SearchScopeSelection> = {}): SearchScopeSelection =>
+  ({ ...DEFAULT_SCOPE_SELECTION, ...o })
+
+describe('scope selection defaults', () => {
+  test('title and first prompt on, transcription OFF — the disk read is opt-in', () => {
+    expect(DEFAULT_SCOPE_SELECTION).toEqual({ title: true, prompt: true, transcript: false })
+  })
+
+  test('a stored selection missing a key reads as that key’s default, never as false', () => {
+    expect(normalizeSelection(undefined)).toEqual(DEFAULT_SCOPE_SELECTION)
+    expect(normalizeSelection({ transcript: true })).toEqual({ title: true, prompt: true, transcript: true })
+    expect(normalizeSelection({ title: false })).toEqual({ title: false, prompt: true, transcript: false })
+  })
+})
+
+describe('activeScopes', () => {
+  test('the structured scopes are always searched, whatever the toggles say', () => {
+    const off = activeScopes({ title: false, prompt: false, transcript: false })
+    for (const s of ['folder', 'harness', 'note', 'task'] as const) expect(off.has(s)).toBe(true)
+    // …and the three human depths are all off.
+    expect(off.has('name')).toBe(false)
+    expect(off.has('prompt')).toBe(false)
+    expect(off.has('transcript')).toBe(false)
+  })
+
+  test('each toggle turns on exactly its own scope — cumulative, several at once', () => {
+    expect(activeScopes(sel({ transcript: true })).has('transcript')).toBe(true)
+    const titleOnly = activeScopes({ title: true, prompt: false, transcript: false })
+    expect(titleOnly.has('name')).toBe(true)
+    expect(titleOnly.has('prompt')).toBe(false)
+  })
+
+  test('transcriptScopeOn is the single gate for the expensive disk search', () => {
+    expect(transcriptScopeOn(sel({ transcript: false }))).toBe(false)
+    expect(transcriptScopeOn(sel({ transcript: true }))).toBe(true)
+  })
+})
+
+describe('the "all" control is two-way and never contradicts the individuals', () => {
+  test('all shows ON exactly when every individual is checked', () => {
+    expect(allState({ title: true, prompt: true, transcript: true })).toBe('on')
+  })
+  test('all shows OFF when none is, and MIXED when some are', () => {
+    expect(allState({ title: false, prompt: false, transcript: false })).toBe('off')
+    expect(allState({ title: true, prompt: false, transcript: false })).toBe('mixed')
+    expect(allState(DEFAULT_SCOPE_SELECTION)).toBe('mixed')
+  })
+  test('checking all from mixed turns every individual on; from all-on it clears them', () => {
+    expect(toggleAllScopes({ title: true, prompt: false, transcript: false }))
+      .toEqual({ title: true, prompt: true, transcript: true })
+    expect(toggleAllScopes({ title: true, prompt: true, transcript: true }))
+      .toEqual({ title: false, prompt: false, transcript: false })
+    expect(toggleAllScopes({ title: false, prompt: false, transcript: false }))
+      .toEqual({ title: true, prompt: true, transcript: true })
+  })
+  test('turning the last individual on makes all read ON — the reverse direction, by derivation', () => {
+    const oneOff = { title: true, prompt: true, transcript: false }
+    expect(allState(oneOff)).toBe('mixed')
+    expect(allState(toggleScope(oneOff, 'transcript'))).toBe('on')
+  })
+})
+
+describe('matchScopes honours the active selection', () => {
+  const active = (s: SearchScopeSelection) => activeScopes(s)
+
+  test('a title-only match is invisible while the title toggle is off', () => {
+    const row = fields({ name: 'docker' })
+    expect(matchScopes(row, 'docker', {}, active(sel({ title: true })))).toEqual(['name'])
+    expect(matchScopes(row, 'docker', {}, active(sel({ title: false })))).toEqual([])
+  })
+
+  test('a transcript hit is dropped unless the transcription toggle is on — the perf guard', () => {
+    const row = fields()
+    expect(matchScopes(row, 'docker', { transcript: true }, active(sel({ transcript: false })))).toEqual([])
+    expect(matchScopes(row, 'docker', { transcript: true }, active(sel({ transcript: true })))).toEqual(['transcript'])
+  })
+
+  test('the always-on structured scopes still match with every toggle off', () => {
+    const row = fields({ note: 'docker note', task: 'docker task' })
+    const allOff = active({ title: false, prompt: false, transcript: false })
+    expect(matchScopes(row, 'docker', {}, allOff)).toEqual(['note', 'task'])
+  })
+
+  test('with no active set given, behaviour is unchanged — every scope is searched', () => {
+    const row = fields({ name: 'docker', prompt: 'docker build' })
+    expect(matchScopes(row, 'docker')).toEqual(['name', 'prompt'])
+  })
+
+  test('scopeCounts respects the active set too, so the depth line cannot exceed what was searched', () => {
+    const rows = [{ fields: fields({ name: 'docker' }), transcript: true }]
+    const counts = scopeCounts(rows, 'docker', activeScopes(sel({ title: false, transcript: false })))
+    expect(counts.name).toBe(0)
+    expect(counts.transcript).toBe(0)
+  })
+})
+
+// The CANONICAL persisted shape is the scope ARRAY (server contract, #240). The tui keeps its
+// on/off object internally and converts at the edge, so these pin that the two never disagree —
+// what makes SessionViewPrefs.searchScopes: SearchScope[] and the merge with dev typecheck.
+describe('selection <-> canonical scope array (the #240 array contract)', () => {
+  test('the default selection is exactly the default persisted set — all own fields, no transcript', () => {
+    // Same value the server derives (preferences.ts DEFAULT_SESSION_SEARCH_SCOPES = all but transcript).
+    expect(selectionToScopes(DEFAULT_SCOPE_SELECTION)).toEqual(
+      SEARCH_SCOPES.filter(s => s !== 'transcript') as SearchScope[],
+    )
+  })
+
+  test('the array is in canonical SEARCH_SCOPES order, whatever order the toggles imply', () => {
+    const scopes = selectionToScopes(sel({ title: true, prompt: true, transcript: true }))
+    expect(scopes).toEqual([...SEARCH_SCOPES])
+    // strictly increasing indices — never a shuffled set
+    const idx = scopes.map(s => SEARCH_SCOPES.indexOf(s))
+    expect(idx).toEqual([...idx].sort((a, b) => a - b))
+  })
+
+  test('every one of the 8 toggle combinations round-trips through the array unchanged', () => {
+    for (const title of [false, true]) {
+      for (const prompt of [false, true]) {
+        for (const transcript of [false, true]) {
+          const s = { title, prompt, transcript }
+          expect(selectionFromScopes(selectionToScopes(s))).toEqual(s)
+        }
+      }
+    }
+  })
+
+  test('the toggleable depths map to their own scopes; the always-on ones ride along', () => {
+    expect(selectionToScopes(sel({ title: true, prompt: false, transcript: false })))
+      .toEqual(['name', 'folder', 'harness', 'note', 'task'])
+    expect(selectionToScopes(sel({ title: false, prompt: false, transcript: false })))
+      .toEqual(['folder', 'harness', 'note', 'task'])
+    // reading back ignores the always-on scopes, so the toggles are recovered exactly
+    expect(selectionFromScopes(['folder', 'harness', 'note', 'task']))
+      .toEqual({ title: false, prompt: false, transcript: false })
+  })
+
+  test('absent, empty, or a pre-array (object) value all degrade to the default selection', () => {
+    expect(selectionFromScopes(undefined)).toEqual(DEFAULT_SCOPE_SELECTION)
+    // a value written by the pre-array build was an object, not an array — must not throw
+    expect(selectionFromScopes({ title: true, prompt: true, transcript: false } as never))
+      .toEqual(DEFAULT_SCOPE_SELECTION)
+  })
+
+  test('a returned default is a fresh object, never the shared constant', () => {
+    const got = selectionFromScopes(undefined)
+    got.title = false
+    expect(DEFAULT_SCOPE_SELECTION.title).toBe(true)
+  })
+
+  test('the array a selection persists is exactly what activeScopes searches', () => {
+    for (const t of [...SEARCH_TOGGLES]) {
+      const s = sel({ [t]: true })
+      expect(new Set(selectionToScopes(s))).toEqual(activeScopes(s))
+    }
+  })
+})
+
+// F2 — the transcript disk read (Sessions.tsx) keys on transcriptScopeOn(scopes), NOT the whole
+// object, so a title/first-prompt toggle never re-fires the ~255 ms grep. These pin the semantic
+// that fix rests on: the cheap depths leave the gate untouched; only transcription flips it.
+describe('F2: the disk-read gate moves only with the transcription depth', () => {
+  test('toggling title or first prompt leaves transcriptScopeOn unchanged', () => {
+    for (const on of [true, false]) {
+      const base = { title: true, prompt: false, transcript: on }
+      expect(transcriptScopeOn(toggleScope(base, 'title'))).toBe(on)
+      expect(transcriptScopeOn(toggleScope(base, 'prompt'))).toBe(on)
+    }
+  })
+
+  test('toggling transcription — and only that — flips the gate, so the read re-runs', () => {
+    expect(transcriptScopeOn(toggleScope({ title: true, prompt: true, transcript: false }, 'transcript')))
+      .toBe(true)
+    expect(transcriptScopeOn(toggleScope({ title: true, prompt: true, transcript: true }, 'transcript')))
+      .toBe(false)
+  })
+
+  test('the two-way "all" flips the gate too, since it carries transcription', () => {
+    // all-off -> all-on turns transcription on; all-on -> off turns it off.
+    expect(transcriptScopeOn(toggleAllScopes({ title: false, prompt: false, transcript: false }))).toBe(true)
+    expect(transcriptScopeOn(toggleAllScopes({ title: true, prompt: true, transcript: true }))).toBe(false)
   })
 })

--- a/packages/tui/src/control/search-scope.ts
+++ b/packages/tui/src/control/search-scope.ts
@@ -47,6 +47,122 @@ export function emptySearchFields(): SearchFields {
 }
 
 /**
+ * The user-facing, CUMULATIVE search-depth toggles — persisted, several active at once.
+ *
+ * The PE named three: the title, the opening prompt, and the full transcription. They gate the
+ * scopes in `TOGGLE_SCOPES`. The remaining structured scopes (`folder`/`harness`/`note`/`task`) are
+ * ALWAYS searched — they are cheap in-memory reads already in the row, and dropping them would
+ * silently narrow a search that works today. What the toggles exist for is the one scope worth NOT
+ * paying for by default: `transcript` reads the disk, so it is off until the user asks for it.
+ */
+export const SEARCH_TOGGLES = ['title', 'prompt', 'transcript'] as const
+export type SearchToggle = typeof SEARCH_TOGGLES[number]
+export type SearchScopeSelection = Record<SearchToggle, boolean>
+
+/** Which `SearchScope`s each toggle turns on. Disjoint, so the three read as three independent depths. */
+const TOGGLE_SCOPES: Record<SearchToggle, readonly SearchScope[]> = {
+  title: ['name'],
+  prompt: ['prompt'],
+  transcript: ['transcript'],
+}
+
+/** Searched no matter what the toggles say — cheap structured fields, never a disk read. */
+const ALWAYS_SCOPES: readonly SearchScope[] = ['folder', 'harness', 'note', 'task']
+
+/**
+ * Title and first prompt on, transcription OFF.
+ *
+ * Transcription is the only scope that reads the disk. Defaulting it off keeps typing responsive on
+ * a machine with hundreds of megabytes of transcripts, and turns its cost into an opt-in the user
+ * can see — the spec's own rule: a search that hangs the TUI is worse than one that only reads titles.
+ */
+export const DEFAULT_SCOPE_SELECTION: SearchScopeSelection = { title: true, prompt: true, transcript: false }
+
+/** A stored selection, defaulted field by field — a file missing a key reads as that key's default. */
+export function normalizeSelection(x: Partial<SearchScopeSelection> | undefined): SearchScopeSelection {
+  return {
+    title: x?.title ?? DEFAULT_SCOPE_SELECTION.title,
+    prompt: x?.prompt ?? DEFAULT_SCOPE_SELECTION.prompt,
+    transcript: x?.transcript ?? DEFAULT_SCOPE_SELECTION.transcript,
+  }
+}
+
+/** The scopes a selection actually searches — the toggled-on ones, plus the always-on structured set. */
+export function activeScopes(sel: SearchScopeSelection): Set<SearchScope> {
+  const out = new Set<SearchScope>(ALWAYS_SCOPES)
+  for (const t of SEARCH_TOGGLES) if (sel[t]) for (const s of TOGGLE_SCOPES[t]) out.add(s)
+  return out
+}
+
+/**
+ * The CANONICAL persisted shape — the cumulative scope ARRAY, in `SEARCH_SCOPES` order.
+ *
+ * `Preferences.sessionView.searchScopes` (server, `preferences.ts`) and
+ * `SessionViewPrefs.searchScopes` (this package) are BOTH `SearchScope[]`: the server owns the
+ * stored format and the tui produces and consumes it, so the two never disagree on the wire. The
+ * `SearchScopeSelection` object is only this screen's own on/off convenience — it is converted to
+ * the array on the way out (`selectionToScopes`) and back on the way in (`selectionFromScopes`), so
+ * nothing downstream ever sees the object. The array is exactly what `activeScopes` searches, which
+ * is what keeps the persisted set and the actual search in step.
+ */
+export function selectionToScopes(sel: SearchScopeSelection): SearchScope[] {
+  const set = activeScopes(sel)
+  return SEARCH_SCOPES.filter(s => set.has(s))
+}
+
+/**
+ * Recover the depth toggles from a persisted scope array — the inverse of `selectionToScopes` over
+ * the three USER-controlled depths (title→`name`, prompt, transcript).
+ *
+ * The always-searched structured scopes (folder/harness/note/task) carry no toggle, so they are
+ * ignored here exactly as they are in the UI — which is why the toggles round-trip through
+ * `selectionToScopes` even though the array also names them. Anything that is NOT an array — absent,
+ * or a value written by the pre-array build — reads as the default (title + first prompt on,
+ * transcription off), the same robustness the server's `resolveSessionSearchScopes` applies to a
+ * hand-edited or newer-binary file.
+ */
+export function selectionFromScopes(scopes: readonly SearchScope[] | undefined): SearchScopeSelection {
+  if (!Array.isArray(scopes)) return { ...DEFAULT_SCOPE_SELECTION }
+  const set = new Set<SearchScope>(scopes)
+  return { title: set.has('name'), prompt: set.has('prompt'), transcript: set.has('transcript') }
+}
+
+/** Whether the deep transcript search should run at all — the one scope worth not paying for. */
+export function transcriptScopeOn(sel: SearchScopeSelection): boolean {
+  return sel.transcript
+}
+
+export type AllState = 'on' | 'mixed' | 'off'
+
+/**
+ * The "all" control, DERIVED — on when every toggle is on, off when none is, mixed otherwise.
+ *
+ * Derived and never stored, so it can never contradict the individual toggles on screen: there is
+ * only one source, read two ways. This is the "when every individual is checked, all shows checked"
+ * half of the PE's two-way requirement.
+ */
+export function allState(sel: SearchScopeSelection): AllState {
+  const on = SEARCH_TOGGLES.filter(t => sel[t]).length
+  return on === SEARCH_TOGGLES.length ? 'on' : on === 0 ? 'off' : 'mixed'
+}
+
+/** Toggle one depth on or off. */
+export function toggleScope(sel: SearchScopeSelection, t: SearchToggle): SearchScopeSelection {
+  return { ...sel, [t]: !sel[t] }
+}
+
+/**
+ * The other half of the two-way "all": checking it turns every toggle on; from all-on it clears them.
+ *
+ * Paired with `allState` above, the two are one value read two ways, so "all" and the individuals
+ * can never disagree — the PE's requirement, met by construction rather than by keeping them in sync.
+ */
+export function toggleAllScopes(sel: SearchScopeSelection): SearchScopeSelection {
+  const next = allState(sel) !== 'on'
+  return { title: next, prompt: next, transcript: next }
+}
+
+/**
  * The scopes of one row that carry `query`, in `SEARCH_SCOPES` order.
  *
  * An empty query matches NOTHING rather than everything: the caller decides that an unfiltered
@@ -56,15 +172,22 @@ export function matchScopes(
   fields: SearchFields,
   query: string,
   found: { transcript?: boolean } = {},
+  /**
+   * The scopes the search is CURRENTLY looking in. Absent means every scope — the behaviour before
+   * depth was selectable, and what the tests without a selection still assert. A scope not in the
+   * set is not tested, so a title-only match is invisible while the title toggle is off.
+   */
+  active?: ReadonlySet<SearchScope>,
 ): SearchScope[] {
   const q = query.trim().toLowerCase()
   if (q === '') return []
+  const on = (scope: SearchScope) => active === undefined || active.has(scope)
 
   const hit: SearchScope[] = []
   for (const scope of OWN_SCOPES) {
-    if (fields[scope].toLowerCase().includes(q)) hit.push(scope)
+    if (on(scope) && fields[scope].toLowerCase().includes(q)) hit.push(scope)
   }
-  if (found.transcript) hit.push('transcript')
+  if (found.transcript && on('transcript')) hit.push('transcript')
   return hit
 }
 
@@ -73,8 +196,9 @@ export function matchesQuery(
   fields: SearchFields,
   query: string,
   found: { transcript?: boolean } = {},
+  active?: ReadonlySet<SearchScope>,
 ): boolean {
-  return query.trim() === '' || matchScopes(fields, query, found).length > 0
+  return query.trim() === '' || matchScopes(fields, query, found, active).length > 0
 }
 
 /** The words the depth line needs, supplied by the caller — this module holds no strings. */
@@ -82,6 +206,8 @@ export interface SearchScopeWords {
   scope: Record<SearchScope, string>
   noGrep: string
   noTranscripts: string
+  /** How the line names a transcription depth the user has switched OFF. */
+  transcriptOff: string
 }
 
 /** What the transcript half of the search is currently doing. */
@@ -89,6 +215,14 @@ export interface TranscriptState {
   running?: boolean
   runningWord?: string
   unavailable?: 'no-grep' | 'no-transcripts'
+  /**
+   * The transcription DEPTH is switched off, so no disk read was even attempted.
+   *
+   * Distinct from `no-transcripts` ("this machine has none") on purpose: one is a choice the user
+   * can reverse with a keypress, the other is a fact about the machine, and a line that confused
+   * them would send someone to look for a switch that is not the problem.
+   */
+  off?: boolean
 }
 
 /**
@@ -111,7 +245,11 @@ export function searchDepthText(
     if (counts[scope] > 0) parts.push(`${words.scope[scope]} ${counts[scope]}`)
   }
 
-  if (state.unavailable) {
+  if (state.off) {
+    // The depth the user turned off — said, not silently omitted, so the transcript is always
+    // accounted for one way or another (the same reason its count is always stated below).
+    parts.push(words.transcriptOff)
+  } else if (state.unavailable) {
     parts.push(state.unavailable === 'no-grep' ? words.noGrep : words.noTranscripts)
   } else if (state.running) {
     // Not `transcript 0`: the count is simply not in yet, and a zero that turns into 47 a moment
@@ -139,11 +277,12 @@ export function emptyScopeCounts(): ScopeCounts {
 export function scopeCounts(
   rows: readonly { fields: SearchFields; transcript?: boolean }[],
   query: string,
+  active?: ReadonlySet<SearchScope>,
 ): ScopeCounts {
   const counts = emptyScopeCounts()
   if (query.trim() === '') return counts
   for (const row of rows) {
-    for (const scope of matchScopes(row.fields, query, { transcript: row.transcript })) {
+    for (const scope of matchScopes(row.fields, query, { transcript: row.transcript }, active)) {
       counts[scope]++
     }
   }

--- a/packages/tui/src/control/sessions.ts
+++ b/packages/tui/src/control/sessions.ts
@@ -59,11 +59,13 @@ export function filterSessions(
   list: readonly ControlSession[],
   query: string,
   transcriptHits?: ReadonlySet<string>,
+  /** The scopes the search is looking in — see `search-scope.ts`. Absent means every scope. */
+  active?: ReadonlySet<SearchScope>,
 ): ControlSession[] {
   if (query.trim() === '') return [...list]
   return list.filter(v => matchesQuery(v.searchFields, query, {
     transcript: transcriptOf(v, transcriptHits),
-  }))
+  }, active))
 }
 
 /**
@@ -82,8 +84,9 @@ export function rowScopes(
   v: ControlSession,
   query: string,
   transcriptHits?: ReadonlySet<string>,
+  active?: ReadonlySet<SearchScope>,
 ): SearchScope[] {
-  return matchScopes(v.searchFields, query, { transcript: transcriptOf(v, transcriptHits) })
+  return matchScopes(v.searchFields, query, { transcript: transcriptOf(v, transcriptHits) }, active)
 }
 
 /** How deep the search went: how many rows carry the query in each scope. */
@@ -91,10 +94,12 @@ export function searchDepth(
   list: readonly ControlSession[],
   query: string,
   transcriptHits?: ReadonlySet<string>,
+  active?: ReadonlySet<SearchScope>,
 ): ScopeCounts {
   return scopeCounts(
     list.map(v => ({ fields: v.searchFields, transcript: transcriptOf(v, transcriptHits) })),
     query,
+    active,
   )
 }
 

--- a/packages/tui/src/control/tabs/Sessions.tsx
+++ b/packages/tui/src/control/tabs/Sessions.tsx
@@ -21,7 +21,11 @@ import type {
   TranscriptSearch,
 } from '../types'
 import type { ControlStrings } from '../i18n'
-import { searchDepthText } from '../search-scope'
+import {
+  activeScopes, allState, selectionFromScopes, selectionToScopes, toggleAllScopes, toggleScope,
+  transcriptScopeOn, SEARCH_TOGGLES, searchDepthText,
+  type SearchScopeSelection, type SearchToggle,
+} from '../search-scope'
 import { searchDepth } from '../sessions'
 import { sessionWordBook } from '../i18n'
 import type { TabChrome } from '../ControlCenter'
@@ -250,6 +254,21 @@ export function Sessions({
    */
   const [transcript, setTranscript] = useState<TranscriptSearch | null>(null)
   const [searchingText, setSearchingText] = useState(false)
+  /**
+   * Which search DEPTHS are active — title, first prompt, transcription — cumulative and persisted.
+   *
+   * Restored from `view.searchScopes` below (absent reads as the default: title + first prompt on,
+   * transcription off). The active SCOPE set derived from it gates both what the rows filter on and
+   * whether the expensive disk read runs at all.
+   */
+  const [scopes, setScopes] = useState<SearchScopeSelection>(() => selectionFromScopes(view?.searchScopes))
+  const active = useMemo(() => activeScopes(scopes), [scopes])
+  // The disk read below keys on THIS boolean, not the whole `scopes` object. Toggling title or
+  // first prompt makes a new `scopes` (they are in-memory scopes, searched instantly), and depending
+  // on the object re-fired the ~255 ms transcript grep on those cheap toggles for no new result. The
+  // deep read only has to re-run when the transcription depth itself flips — which is exactly what
+  // this value tracks.
+  const transcriptSearchOn = transcriptScopeOn(scopes)
 
   /**
    * Ask the disk, once the typing settles.
@@ -262,20 +281,29 @@ export function Sessions({
    */
   useEffect(() => {
     const q = query.trim()
-    if (q === '' || !host.searchTranscripts) { setTranscript(null); setSearchingText(false); return }
+    // The disk read is GATED on the transcription toggle — this is the performance answer. Reading
+    // hundreds of megabytes of transcripts on every query is what would hang the TUI, so it runs
+    // only when the user has switched that depth on; with it off, the in-memory scopes alone answer
+    // instantly and `transcript` stays null (the depth line then omits the transcript count rather
+    // than reporting a stale one).
+    if (q === '' || !host.searchTranscripts || !transcriptSearchOn) {
+      setTranscript(null); setSearchingText(false); return
+    }
 
     let cancelled = false
     setSearchingText(true)
     const timer = setTimeout(() => {
       host.searchTranscripts!(q)
         .then(r => { if (!cancelled) { setTranscript(r); setSearchingText(false) } })
-        // A failed deep search must not take the list with it: the six in-memory scopes are still
+        // A failed deep search must not take the list with it: the in-memory scopes are still
         // a perfectly good search, so the row count stays right and only the transcript half is lost.
         .catch(() => { if (!cancelled) { setTranscript(null); setSearchingText(false) } })
     }, TRANSCRIPT_DEBOUNCE_MS)
 
     return () => { cancelled = true; clearTimeout(timer); }
-  }, [query, host])
+    // Keyed on `transcriptSearchOn`, NOT `scopes`: a title/first-prompt toggle must not re-run the
+    // disk read, only a change to the transcription depth (or the query/host) may. See F2.
+  }, [query, host, transcriptSearchOn])
   const [showDone, setShowDone] = useState(view?.showDone ?? DEFAULT_SESSION_VIEW.showDone ?? false)
   /**
    * What the list is narrowed to, per dimension — the ONE source, and the whole answer.
@@ -399,6 +427,7 @@ export function Sessions({
         && (showDone || taskFilter !== null || !(v.task && done.has(v.task)))),
       query,
       transcript?.ids,
+      active,
     ),
     grouping,
     words,
@@ -413,7 +442,7 @@ export function Sessions({
      // Absent when nothing is marked, so the band is not merely empty — it does not exist.
      marked.size > 0 ? { ids: marked, label: s.sessionsMarkedBand } : undefined), [
     fleet?.sessions, fleet?.finishedTasks, fleet?.fell, done, grouping, cascade, query, transcript, filters,
-    showNamed, showDone, taskFilter, dimensionCtx, order, words, marked,
+    showNamed, showDone, taskFilter, dimensionCtx, order, words, marked, active,
   ])
 
   /**
@@ -422,16 +451,26 @@ export function Sessions({
    */
   const depth = useMemo(() => {
     if (query.trim() === '') return ''
+    const transcriptOn = transcriptScopeOn(scopes)
     return searchDepthText(
-      searchDepth(fleet?.sessions ?? [], query, transcript?.ids),
-      { scope: s.searchScope, noGrep: s.searchNoGrep, noTranscripts: s.searchNoTranscripts },
+      searchDepth(fleet?.sessions ?? [], query, transcript?.ids, active),
       {
-        running: searchingText,
-        runningWord: s.searchRunning,
-        ...(transcript?.unavailable ? { unavailable: transcript.unavailable } : {}),
+        scope: s.searchScope, noGrep: s.searchNoGrep,
+        noTranscripts: s.searchNoTranscripts, transcriptOff: s.searchTranscriptOff,
+      },
+      {
+        // With transcription switched off the disk read never ran; the line says so rather than
+        // claiming a count of zero or a search still in flight.
+        ...(transcriptOn
+          ? {
+              running: searchingText,
+              runningWord: s.searchRunning,
+              ...(transcript?.unavailable ? { unavailable: transcript.unavailable } : {}),
+            }
+          : { off: true }),
       },
     )
-  }, [fleet?.sessions, query, transcript, searchingText, s])
+  }, [fleet?.sessions, query, transcript, searchingText, s, active, scopes])
 
   const selectable = useMemo(() => selectableIndexes(rows), [rows])
 
@@ -1181,6 +1220,7 @@ export function Sessions({
     // empty set — see `SessionFilterState.marked`.
     setMarked(new Set(restoredFilters.marked))
     setOrder((view.sort as SessionOrder | undefined) ?? DEFAULT_ORDER)
+    setScopes(selectionFromScopes(view.searchScopes))
     setHideDetail(view.hideDetail ?? false)
     // The DEFAULT, never a literal — same rule, same reason as `onlyActive` above.
     setLayout(view.layout ?? DEFAULT_SESSION_VIEW.layout ?? 'list')
@@ -1226,9 +1266,12 @@ export function Sessions({
       cascade,
       ...(cardAnchor ? { cardAnchor } : {}),
       sort: order,
+      // The persisted shape is the canonical scope ARRAY (server contract, #240), derived from this
+      // screen's toggles at the edge so the object never crosses the boundary.
+      searchScopes: selectionToScopes(scopes),
     } as SessionViewPrefs)
   }, [grouping, cascade, filters, showNamed, showDone, hideDetail,
-      layout, cardAnchor, order, marked, onView, view])
+      layout, cardAnchor, order, marked, scopes, onView, view])
 
   useEffect(() => {
     if (!isActive) return
@@ -1545,12 +1588,15 @@ export function Sessions({
           grouping={grouping}
           showHistory={showHistory}
           showNamed={showNamed}
+          scopes={scopes}
           width={width}
           height={height}
           isActive={isActive}
           onGrouping={g => { setGrouping(g); setCursor(0) }}
           onShowClosed={() => pressShortcut('history')}
           onShowNamed={() => { setShowNamed(v => !v); setCursor(0) }}
+          onToggleScope={t => setScopes(sc => toggleScope(sc, t))}
+          onToggleAllScopes={() => setScopes(toggleAllScopes)}
           onClose={() => setAsk(null)}
         />
       </Box>
@@ -2978,6 +3024,25 @@ function Question({
 }
 
 /**
+ * The scroll window for the view menu — PURE, so the "does it actually scroll" guarantee is
+ * testable without a tty (an input-driven render test flakes under concurrent load; this does not).
+ *
+ * The menu draws a title and a hint above its rows, so the rows get `height - 2`. Over that budget
+ * it uses the SAME following window (`windowOffset`) every other list in this package uses, centred
+ * on the cursor — which is what keeps the row the cursor lands on drawn. Slicing from zero
+ * (`rows.slice(0, height - 2)`) left the Search-in depths below the fold and unreachable on a short
+ * terminal — the `Math.max(1, height - chrome)` trap CLAUDE.md names.
+ */
+export function viewMenuWindow(
+  rowCount: number,
+  cursorRow: number,
+  height: number,
+): { offset: number; body: number } {
+  const body = Math.max(1, height - 2)
+  return { offset: windowOffset(cursorRow, rowCount, body), body }
+}
+
+/**
  * Everything about WHAT the list shows, as ONE vertical panel.
  *
  * It replaced a cramped horizontal strip that cycled the grouping on a hidden key and had nowhere
@@ -2989,19 +3054,22 @@ function Question({
  * squeezing it under the list is what made it unreadable the first time.
  */
 function ViewOptions({
-  strings: s, grouping, showHistory, showNamed, width, height, isActive,
-  onGrouping, onShowClosed, onShowNamed, onClose,
+  strings: s, grouping, showHistory, showNamed, scopes, width, height, isActive,
+  onGrouping, onShowClosed, onShowNamed, onToggleScope, onToggleAllScopes, onClose,
 }: {
   strings: ControlStrings
   grouping: SessionGrouping
   showHistory: boolean
   showNamed: boolean
+  scopes: SearchScopeSelection
   width: number
   height: number
   isActive: boolean
   onGrouping: (g: SessionGrouping) => void
   onShowClosed: () => void
   onShowNamed: () => void
+  onToggleScope: (t: SearchToggle) => void
+  onToggleAllScopes: () => void
   onClose: () => void
 }) {
   // One flat list of rows so the cursor moves over exactly what is drawn — the same reason the
@@ -3011,7 +3079,13 @@ function ViewOptions({
     | { kind: 'group'; value: SessionGrouping }
     | { kind: 'closed' }
     | { kind: 'named' }
+    // The cumulative search depths, plus the two-way "all" — see `search-scope.ts`.
+    | { kind: 'scope'; toggle: SearchToggle }
+    | { kind: 'scopeAll' }
 
+  const scopeLabel: Record<SearchToggle, string> = {
+    title: s.searchDepthName, prompt: s.searchDepthPrompt, transcript: s.searchDepthTranscript,
+  }
   const rows: Row[] = [
     { kind: 'heading', label: s.viewGroupBy },
     ...GROUPINGS.map(g => ({ kind: 'group' as const, value: g })),
@@ -3020,6 +3094,9 @@ function ViewOptions({
     // Was the unfiled switch, which only meant anything while grouping by task. That bucket is now
     // a row in the task section, on every grouping; this is the widening that had no control at all.
     { kind: 'named' },
+    { kind: 'heading', label: s.viewSearchDepth },
+    ...SEARCH_TOGGLES.map(t => ({ kind: 'scope' as const, toggle: t })),
+    { kind: 'scopeAll' },
   ]
   const selectable = rows.map((r, i) => (r.kind === 'heading' ? -1 : i)).filter(i => i >= 0)
 
@@ -3037,15 +3114,28 @@ function ViewOptions({
     if (row.kind === 'group') return onGrouping(row.value)
     if (row.kind === 'closed') return onShowClosed()
     if (row.kind === 'named') return onShowNamed()
+    if (row.kind === 'scope') return onToggleScope(row.toggle)
+    if (row.kind === 'scopeAll') return onToggleAllScopes()
   }, { isActive })
 
-  const body = Math.max(1, height - 2)
+  // The list — every grouping, the two Show switches, and the Search-in depths — outgrows a short
+  // terminal, so it SCROLLS: `viewMenuWindow` is the same following window every other list here
+  // uses, and it keeps the cursor's row drawn. Slicing from zero left the depth rows below the fold.
+  const { offset, body } = viewMenuWindow(rows.length, cursorRow, height)
+  // The "all" glyph is TRI-STATE: a half-dot when only some depths are on, so it can never claim to
+  // be on while a depth is off. `allState` is derived from the very toggles above, so the two read
+  // as one — the PE's two-way requirement, met by there being only one source.
+  const all = allState(scopes)
+  const allGlyph = all === 'on' ? '● ' : all === 'off' ? '○ ' : '◐ '
 
   return (
     <Box flexDirection="column" width={width} flexShrink={0}>
       <Text bold>{truncate(s.viewTitle, width)}</Text>
       <Text dimColor>{truncate(s.viewHint, width)}</Text>
-      {rows.slice(0, body).map((row, i) => {
+      {rows.slice(offset, offset + body).map((row, localIndex) => {
+        // `i` is the row's index in the WHOLE list, not the visible slice, so the cursor comparison
+        // and the React keys stay correct once the window has scrolled off zero.
+        const i = offset + localIndex
         if (row.kind === 'heading') {
           return <Text key={`h${i}`} dimColor bold>{truncate(row.label, width)}</Text>
         }
@@ -3055,16 +3145,23 @@ function ViewOptions({
         // The dot means ON, always — for every row on this panel.
         const on = row.kind === 'group'
           ? row.value === grouping
-          : row.kind === 'closed' ? showHistory : showNamed
+          : row.kind === 'closed' ? showHistory
+          : row.kind === 'named' ? showNamed
+          : row.kind === 'scope' ? scopes[row.toggle]
+          : all === 'on'
         const label = row.kind === 'group'
           ? s.sessionsGroupings[row.value]
           : row.kind === 'closed' ? s.viewClosedOn
-          : s.toggleNamed
+          : row.kind === 'named' ? s.toggleNamed
+          : row.kind === 'scope' ? scopeLabel[row.toggle]
+          : s.searchDepthAll
+        // The "all" row wears the tri-state glyph; every other row is a plain on/off dot.
+        const glyph = row.kind === 'scopeAll' ? allGlyph : on ? '● ' : '○ '
         return (
           <Text key={`r${i}`} wrap="truncate">
             <Text color={active ? COLORS.accent : undefined}>{active ? '  ❯ ' : '    '}</Text>
             {/* Glyph plus word: which options are on must survive a terminal that drops colour. */}
-            <Text color={on ? COLORS.success : COLORS.muted}>{on ? '● ' : '○ '}</Text>
+            <Text color={on ? COLORS.success : COLORS.muted}>{glyph}</Text>
             <Text color={active ? COLORS.accent : undefined} bold={active}>
               {truncate(label, Math.max(1, width - 8))}
             </Text>

--- a/packages/tui/src/control/tabs/view-options.test.tsx
+++ b/packages/tui/src/control/tabs/view-options.test.tsx
@@ -1,0 +1,67 @@
+/**
+ * The "Search in" panel scrolls, so every option is reachable.
+ *
+ * `ViewOptions` is one flat list — Group by (every grouping), Show, and the Search-in depths with
+ * their two-way "all". Long enough to overflow a short terminal. It used to slice from zero
+ * (`rows.slice(0, height - 2)`), which left the depth rows BELOW THE FOLD: the cursor moved onto
+ * them and the screen never drew them, so the section this delivery added was unreachable exactly
+ * when the terminal was small — the `Math.max(1, height - chrome)` trap.
+ *
+ * The window arithmetic is pure (`viewMenuWindow`), so the guarantee is pinned here without a tty:
+ * whatever row the cursor lands on, that row is inside the visible window, and the window really is
+ * a window (smaller than the list) rather than the whole list drawn from the top. An input-driven
+ * render test proved the same thing but flaked under concurrent load, because ink reads stdin on a
+ * timer the full suite does not give it — the pure test cannot flake.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { viewMenuWindow } from './Sessions'
+
+// One heading + 8 groupings + one heading + closed + named + one heading + 3 depths + all = 17 rows.
+// The last selectable row (the two-way "all") is index 16; the "Search in" section is indices 12-16.
+const ROWS = 17
+const SEARCH_IN_SECTION = [12, 13, 14, 15, 16]
+
+// A cursor row is visible when it lies inside the [offset, offset + body) window the menu draws.
+const visible = (cursorRow: number, height: number) => {
+  const { offset, body } = viewMenuWindow(ROWS, cursorRow, height)
+  return cursorRow >= offset && cursorRow < offset + body
+}
+
+describe('viewMenuWindow — the "Search in" list scrolls', () => {
+  test('a short terminal cannot show the whole list — it is a window, not the top', () => {
+    const { offset, body } = viewMenuWindow(ROWS, 16, 10)
+    // 10 rows of terminal, minus the title and hint, is 8 — fewer than the 17 rows.
+    expect(body).toBe(8)
+    expect(body).toBeLessThan(ROWS)
+    // With the cursor at the bottom the window has scrolled off zero to keep it in view.
+    expect(offset).toBeGreaterThan(0)
+  })
+
+  test('every row the cursor can reach stays on screen, at every height that clips the list', () => {
+    for (const height of [6, 8, 10, 12, 16, 18]) {
+      for (let cursor = 0; cursor < ROWS; cursor++) {
+        expect(visible(cursor, height), `row ${cursor} hidden at height ${height}`).toBe(true)
+      }
+    }
+  })
+
+  test('the whole Search-in section is reachable — the regression that failed review', () => {
+    // At the height where the bug showed (10), each depth row is inside the window when selected.
+    for (const row of SEARCH_IN_SECTION) {
+      expect(visible(row, 10), `Search-in row ${row} unreachable`).toBe(true)
+    }
+  })
+
+  test('a tall terminal shows everything from the top — no needless scroll', () => {
+    const { offset, body } = viewMenuWindow(ROWS, 16, 40)
+    expect(offset).toBe(0)
+    expect(body).toBeGreaterThanOrEqual(ROWS)
+  })
+
+  test('a one-line terminal still yields a usable window, never a negative height', () => {
+    const { body } = viewMenuWindow(ROWS, 5, 1)
+    expect(body).toBe(1)
+    expect(visible(5, 1)).toBe(true)
+  })
+})

--- a/packages/tui/src/control/types.ts
+++ b/packages/tui/src/control/types.ts
@@ -8,7 +8,7 @@
  */
 
 import type { CliLang } from './lang'
-import type { SearchFields } from './search-scope'
+import type { SearchFields, SearchScope } from './search-scope'
 // The default ARRANGEMENT is derived from the dimension vocabulary rather than written out beside
 // it. `session-dimensions.ts` imports this file for TYPES only, so this is the one value direction.
 import {
@@ -812,6 +812,19 @@ export interface SessionViewPrefs {
    * useful — you marked the row because you were about to go into it.
    */
   marked?: string[]
+  /**
+   * WHICH scopes the session search looks in — the cumulative set (name, folder, harness, note,
+   * task, prompt, transcript), persisted like the rest of the arrangement so the depth someone chose
+   * survives a restart.
+   *
+   * A `SearchScope[]`, not this package's `SearchScopeSelection` object: the STORED format is the
+   * server's (`Preferences.sessionView.searchScopes` in `preferences.ts`, shipped in #240), and this
+   * type is the same contract read back through `cli-start.ts`. The tui converts to and from its own
+   * on/off toggles at the edge (`selectionToScopes` / `selectionFromScopes`), so the object never
+   * crosses this boundary. Absent reads as the default (title + first prompt on, transcription off)
+   * — never a literal here, for the same reason `layout` is not. See finding (3) in the journey.
+   */
+  searchScopes?: SearchScope[]
 }
 
 /**


### PR DESCRIPTION
Promove `dev` para `main`, disparando a release. Quatro entregas, todas com revisão de qualidade pré-aprovação e verificadas no binário compilado.

## O que vai

**`fix(sessions)` — o `waiting on you` parou de mentir** (#243)
A frota afirmava que uma sessão esperava por uma pessoa quando ela já tinha voltado a trabalhar. Agora `waiting`/`waiting-approval` só são cridos após **duas amostras concordantes**, enquanto a volta a `working`/`exited` é aceita na hora. A assimetria é deliberada: dizer "trabalhando" sobre algo parado apenas atrasa; dizer "precisa de você" sobre algo que anda desperdiça atenção humana e corrói a confiança no indicador.

**`fix(sessions)` — o prompt inicial passa a ser entregue** (#243)
Uma sessão detached criada com prompt subia, o prompt ficava no campo e nada era enviado — o agente ficava parado esperando algo que já havia chegado. A causa era um `sleep(1200ms)` fixo, que uma sessão lenta perdia. Agora a entrega acontece quando a sessão está pronta e **uma única vez**: nada de duplo submit, e o diálogo de startup nunca é respondido.

**`feat(sessions)` — canal de leitura do terminal ao vivo** (#244)
SSE com frames completos (sem replay na reconexão), ANSI preservado ponta a ponta por um caminho separado do que alimenta as regexes de estado, e morte honesta: um pane que saiu continua legível como `alive:false` em vez de congelar parecendo vivo. Um loop compartilhado por N leitores, ativo só enquanto alguém olha.

**`feat(tui)` — busca por escopos cumulativos** (#238)
Escopos selecionáveis com controle "todos" de mão dupla, persistidos como `SearchScope[]`.

## Verificação

Cada uma passou por gate independente, com o QA compilando o binário e dirigindo contra ele — não só teste unitário. Destaques: a leitura do terminal tem três camadas de proteção antes do handler (ler o terminal de um agente é ler tudo que passou por ele); vazamento entre sessões é estruturalmente impossível (hub keyed por id); e ficou provado por `grep` que o caminho ANSI não contamina as regexes de readiness/approval, que continuam no capture simples.

## Ressalva conhecida, não bloqueante

`backend-tmux.ts:155-160` — numa corrida de kill, o fallback pode emitir um frame otimista (`alive:true`, `cols:0`) por até um poll (500ms) antes do tick seguinte encerrar limpo. Auto-corrige e nunca lança.