### PR TITLE
feat(web): live terminal panel for the sessions tab (machine mode)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -46,14 +46,14 @@
     },
     "packages/agentop": {
       "name": "@agentistics/agentop",
-      "version": "1.22.3",
+      "version": "1.22.4",
       "bin": {
         "agentop": "bin/agentop.js",
       },
     },
     "packages/core": {
       "name": "@agentistics/core",
-      "version": "1.22.3",
+      "version": "1.22.4",
       "dependencies": {
         "@opentelemetry/api": "^1.9.1",
         "date-fns": "^4.1.0",
@@ -71,7 +71,7 @@
     },
     "packages/mcp": {
       "name": "@agentistics/mcp",
-      "version": "1.22.3",
+      "version": "1.22.4",
       "bin": {
         "agentistics-mcp": "dist/agentistics-mcp.js",
       },
@@ -81,7 +81,7 @@
     },
     "packages/server": {
       "name": "@agentistics/server",
-      "version": "1.22.3",
+      "version": "1.22.4",
       "dependencies": {
         "@agentistics/core": "workspace:*",
         "@agentistics/tui": "workspace:*",
@@ -91,7 +91,7 @@
     },
     "packages/tui": {
       "name": "@agentistics/tui",
-      "version": "1.22.3",
+      "version": "1.22.4",
       "dependencies": {
         "@agentistics/core": "workspace:*",
         "es-toolkit": "^1.50.0",
@@ -105,10 +105,11 @@
     },
     "packages/web": {
       "name": "@agentistics/web",
-      "version": "1.22.3",
+      "version": "1.22.4",
       "dependencies": {
         "@agentistics/core": "workspace:*",
         "@opentelemetry/api": "^1.9.1",
+        "@xterm/xterm": "5.5.0",
         "date-fns": "^4.1.0",
         "html2canvas": "^1.4.1",
         "jspdf": "^4.2.1",
@@ -618,6 +619,8 @@
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
 
     "@vitejs/plugin-react": ["@vitejs/plugin-react@6.0.1", "", { "dependencies": { "@rolldown/pluginutils": "1.0.0-rc.7" }, "peerDependencies": { "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0", "babel-plugin-react-compiler": "^1.0.0", "vite": "^8.0.0" }, "optionalPeers": ["@rolldown/plugin-babel", "babel-plugin-react-compiler"] }, "sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ=="],
+
+    "@xterm/xterm": ["@xterm/xterm@5.5.0", "", {}, "sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A=="],
 
     "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
 

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@agentistics/core": "workspace:*",
     "@opentelemetry/api": "^1.9.1",
+    "@xterm/xterm": "^5.5.0",
     "date-fns": "^4.1.0",
     "html2canvas": "^1.4.1",
     "jspdf": "^4.2.1",

--- a/packages/web/src/components/SessionTerminal.tsx
+++ b/packages/web/src/components/SessionTerminal.tsx
@@ -1,0 +1,98 @@
+/**
+ * SessionTerminal — the xterm.js emulator that renders one terminal frame.
+ *
+ * This module statically imports `@xterm/xterm` (and its CSS), and is itself loaded through
+ * `React.lazy` by the panel, so the emulator's weight lands in its OWN chunk — downloaded only when
+ * a viewer actually opens a terminal, never on the initial dashboard load.
+ *
+ * Each `frame` from the channel is a COMPLETE snapshot (tmux `capture-pane` already resolved every
+ * spinner, redraw and cursor move into final glyphs), so rendering is `reset()` then `write()` — we
+ * never append. The cursor is placed from the frame's own `cursor` field and hidden entirely on a
+ * dead frame, because the channel sends `cursor: null` once the pane is dead and a cursor blinking
+ * on a finished screen is exactly the "looks alive" lie this feature must not tell.
+ */
+
+import { useEffect, useRef } from 'react'
+import { Terminal } from '@xterm/xterm'
+import '@xterm/xterm/css/xterm.css'
+import { xtermTheme, type TerminalFrame } from '../lib/terminalStream'
+
+interface Props {
+  frame: TerminalFrame | null
+  theme: 'dark' | 'light'
+  /** Draw the block cursor at the frame's position. False on a finished/gone screen. */
+  showCursor: boolean
+}
+
+const FONT_SIZE = 12
+const FONT_FAMILY =
+  "'JetBrains Mono', 'Fira Code', 'SF Mono', 'Cascadia Code', Menlo, Consolas, 'Liberation Mono', monospace"
+
+export default function SessionTerminal({ frame, theme, showCursor }: Props) {
+  const hostRef = useRef<HTMLDivElement | null>(null)
+  const termRef = useRef<Terminal | null>(null)
+
+  // Create the emulator once.
+  useEffect(() => {
+    const host = hostRef.current
+    if (!host) return
+    const term = new Terminal({
+      fontFamily: FONT_FAMILY,
+      fontSize: FONT_SIZE,
+      // Read-only: Phase 1 has no write channel, so the terminal accepts no input at all. A cursor
+      // is drawn for fidelity, but nothing typed here reaches the session.
+      disableStdin: true,
+      cursorBlink: false,
+      cursorStyle: 'block',
+      scrollback: 5000,
+      convertEol: false,
+      theme: xtermTheme(theme),
+    })
+    term.open(host)
+    termRef.current = term
+    return () => {
+      term.dispose()
+      termRef.current = null
+    }
+  }, [])
+
+  // Keep the palette in step with the dashboard theme.
+  useEffect(() => {
+    const term = termRef.current
+    if (term) term.options.theme = xtermTheme(theme)
+  }, [theme])
+
+  // Paint each frame as a full snapshot.
+  useEffect(() => {
+    const term = termRef.current
+    if (!term || !frame) return
+
+    if (frame.cols > 0 && frame.rows > 0) {
+      try {
+        term.resize(frame.cols, frame.rows)
+      } catch {
+        /* geometry can momentarily disagree with the DOM; the next frame corrects it */
+      }
+    }
+
+    term.reset()
+    term.write(frame.content, () => {
+      // After the content is laid out, place (or hide) the block cursor. Done in the write callback
+      // so it lands after xterm has parsed the snapshot, not racing it.
+      if (showCursor && frame.cursor) {
+        term.write(`\x1b[?25h\x1b[${frame.cursor.y + 1};${frame.cursor.x + 1}H`)
+      } else {
+        term.write('\x1b[?25l')
+      }
+    })
+  }, [frame, showCursor])
+
+  return (
+    <div
+      ref={hostRef}
+      // The pane is exactly cols×rows wide; on a narrow screen it scrolls inside this box rather
+      // than pushing the page body sideways (the repo's responsive rule).
+      style={{ width: '100%', height: '100%', overflow: 'auto' }}
+    />
+  )
+}

--- a/packages/web/src/components/SessionTerminal.tsx
+++ b/packages/web/src/components/SessionTerminal.tsx
@@ -10,6 +10,13 @@
  * never append. The cursor is placed from the frame's own `cursor` field and hidden entirely on a
  * dead frame, because the channel sends `cursor: null` once the pane is dead and a cursor blinking
  * on a finished screen is exactly the "looks alive" lie this feature must not tell.
+ *
+ * Timing: `resize()` throws asynchronously inside xterm if it runs before the renderer has measured
+ * its cell dimensions (an unmeasured `Viewport.syncScrollArea` reads `dimensions` off `undefined`),
+ * and a `try/catch` cannot catch that — the throw is scheduled, not synchronous. The renderer
+ * measures on its FIRST render, so we gate the first paint on xterm's own `onRender` event (with a
+ * timeout as a belt-and-braces fallback). Frames that arrive before then are held and painted on
+ * ready.
  */
 
 import { useEffect, useRef } from 'react'
@@ -31,6 +38,35 @@ const FONT_FAMILY =
 export default function SessionTerminal({ frame, theme, showCursor }: Props) {
   const hostRef = useRef<HTMLDivElement | null>(null)
   const termRef = useRef<Terminal | null>(null)
+  const readyRef = useRef(false)
+  // The latest frame + cursor intent, so the ready-gate can paint whatever is current once xterm
+  // has measured itself, even if several frames arrived during that first animation frame.
+  const pendingRef = useRef<{ frame: TerminalFrame | null; showCursor: boolean }>({ frame: null, showCursor: false })
+
+  function paint() {
+    const term = termRef.current
+    const { frame: f, showCursor: cur } = pendingRef.current
+    if (!term || !readyRef.current || !f) return
+
+    if (f.cols > 0 && f.rows > 0) {
+      try {
+        term.resize(f.cols, f.rows)
+      } catch {
+        /* geometry can momentarily disagree with the DOM; the next frame corrects it */
+      }
+    }
+
+    term.reset()
+    term.write(f.content, () => {
+      // After the content is laid out, place (or hide) the block cursor. Done in the write callback
+      // so it lands after xterm has parsed the snapshot, not racing it.
+      if (cur && f.cursor) {
+        term.write(`\x1b[?25h\x1b[${f.cursor.y + 1};${f.cursor.x + 1}H`)
+      } else {
+        term.write('\x1b[?25l')
+      }
+    })
+  }
 
   // Create the emulator once.
   useEffect(() => {
@@ -48,43 +84,45 @@ export default function SessionTerminal({ frame, theme, showCursor }: Props) {
       convertEol: false,
       theme: xtermTheme(theme),
     })
-    term.open(host)
     termRef.current = term
+
+    // Gate the first paint on the renderer having measured its cells (its first render). Registered
+    // BEFORE open() so the initial render is caught; a timeout is the fallback if it never fires.
+    const markReady = () => {
+      if (readyRef.current) return
+      readyRef.current = true
+      paint()
+    }
+    const disposeRender = term.onRender(markReady)
+    term.open(host)
+    const fallback = setTimeout(markReady, 80)
+
     return () => {
+      clearTimeout(fallback)
+      disposeRender.dispose()
+      readyRef.current = false
       term.dispose()
       termRef.current = null
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
-  // Keep the palette in step with the dashboard theme.
+  // Keep the palette in step with the dashboard theme. Updating `options.theme` recolours future
+  // output but does not repaint what is already on screen, so a theme flip would leave the current
+  // frame blank until the next one arrived — re-paint it now so the switch is instant.
   useEffect(() => {
     const term = termRef.current
-    if (term) term.options.theme = xtermTheme(theme)
+    if (!term) return
+    term.options.theme = xtermTheme(theme)
+    paint()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [theme])
 
-  // Paint each frame as a full snapshot.
+  // Paint each frame as a full snapshot (held until the ready-gate opens on first mount).
   useEffect(() => {
-    const term = termRef.current
-    if (!term || !frame) return
-
-    if (frame.cols > 0 && frame.rows > 0) {
-      try {
-        term.resize(frame.cols, frame.rows)
-      } catch {
-        /* geometry can momentarily disagree with the DOM; the next frame corrects it */
-      }
-    }
-
-    term.reset()
-    term.write(frame.content, () => {
-      // After the content is laid out, place (or hide) the block cursor. Done in the write callback
-      // so it lands after xterm has parsed the snapshot, not racing it.
-      if (showCursor && frame.cursor) {
-        term.write(`\x1b[?25h\x1b[${frame.cursor.y + 1};${frame.cursor.x + 1}H`)
-      } else {
-        term.write('\x1b[?25l')
-      }
-    })
+    pendingRef.current = { frame, showCursor }
+    paint()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [frame, showCursor])
 
   return (

--- a/packages/web/src/components/SessionTerminalPanel.tsx
+++ b/packages/web/src/components/SessionTerminalPanel.tsx
@@ -1,0 +1,229 @@
+/**
+ * SessionTerminalPanel — the live terminal, as a PANEL inside the sessions tab.
+ *
+ * It never takes over the page: it is a bordered box above the sessions list, with its own selector
+ * of the live sessions, so the list stays visible and switchable underneath. Picking a session
+ * streams its terminal; picking another switches cleanly (a fresh `key` per id → a brand-new
+ * emulator, so no byte of one session's screen can survive onto the next).
+ *
+ * Two honesty sources are shown, kept deliberately separate:
+ *  - the AGENT's activity (working / needs you) comes from the fleet row's own state, which — per
+ *    PR #243 — already needs two concordant samples before it says `waiting`. This panel never
+ *    recomputes that from the terminal frames.
+ *  - what the SCREEN is (live / finished / gone, how many lines, truncated) comes from the channel's
+ *    own frame fields. A finished or gone session is labelled as such, not frozen in silence.
+ *
+ * Phase 1 is read-only: there is deliberately NO input box, not even a disabled one — the write
+ * channel does not exist yet, and a text field that does nothing is the same lie as a frozen screen.
+ */
+
+import { Suspense, lazy, useEffect, useState } from 'react'
+import { Terminal as TerminalIcon, X } from 'lucide-react'
+import type { Lang } from '@agentistics/core'
+import type { FleetRow } from '../lib/fleet'
+import { watchableFleetRows, terminalStatus, type TerminalTone } from '../lib/terminalStream'
+import { useTerminalStream } from '../hooks/useTerminalStream'
+import { useIsMobile } from '../hooks/useIsMobile'
+
+const SessionTerminal = lazy(() => import('./SessionTerminal'))
+
+interface Props {
+  /** The live fleet — the same rows the sessions list decorates. */
+  rows: readonly FleetRow[]
+  lang: Lang
+  theme: 'dark' | 'light'
+}
+
+const TONE_COLOR: Record<TerminalTone, string> = {
+  idle: 'var(--text-tertiary)',
+  connecting: 'var(--text-tertiary)',
+  live: '#22c55e',
+  finished: 'var(--anthropic-orange, #e8690b)',
+  ended: 'var(--accent-red, #e0342a)',
+}
+
+function stateDotColor(state: FleetRow['state']): string {
+  if (state === 'working') return '#22c55e'
+  if (state === 'waiting' || state === 'waiting-approval') return 'var(--anthropic-orange, #e8690b)'
+  if (state === 'exited') return 'var(--text-tertiary)'
+  return 'var(--text-tertiary)'
+}
+
+export function SessionTerminalPanel({ rows, lang, theme }: Props) {
+  const pt = lang === 'pt'
+  const isMobile = useIsMobile()
+  const watchable = watchableFleetRows(rows)
+  const [watchedId, setWatchedId] = useState<string | null>(null)
+
+  // If the watched session leaves the fleet AND we have not opened its stream yet, forget it. Once a
+  // stream is open we keep showing it (it will report `gone` honestly) even after it leaves the list.
+  const stillListed = watchable.some(r => r.id === watchedId)
+
+  const state = useTerminalStream(watchedId)
+  const status = terminalStatus(state, pt ? 'pt' : 'en')
+
+  // Nothing to offer and nothing being watched → render nothing; the page already explains why the
+  // fleet may be empty. (Keep showing if a stream is live, even after its row leaves the list.)
+  const hasStream = watchedId !== null && state.phase !== 'idle'
+  if (watchable.length === 0 && !hasStream) return null
+
+  const watchedRow = rows.find(r => r.id === watchedId)
+
+  return (
+    <div
+      style={{
+        border: '1px solid var(--border-subtle)',
+        borderRadius: 12,
+        background: 'var(--bg-elevated)',
+        padding: isMobile ? 12 : 16,
+        marginBottom: 12,
+      }}
+    >
+      {/* Header: title + the SCREEN honesty pill + close */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: 10, flexWrap: 'wrap', marginBottom: 10 }}>
+        <span style={{ color: 'var(--anthropic-orange)', display: 'inline-flex' }}>
+          <TerminalIcon size={16} />
+        </span>
+        <span style={{ fontSize: 14, fontWeight: 600, color: 'var(--text-primary)' }}>
+          {pt ? 'Terminal ao vivo' : 'Live terminal'}
+        </span>
+        {hasStream && (
+          <span
+            style={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 6,
+              fontSize: 11,
+              fontWeight: 600,
+              color: TONE_COLOR[status.tone],
+              border: `1px solid ${TONE_COLOR[status.tone]}`,
+              borderRadius: 999,
+              padding: '2px 8px',
+            }}
+          >
+            <span
+              style={{
+                width: 7,
+                height: 7,
+                borderRadius: '50%',
+                background: TONE_COLOR[status.tone],
+                // Pulse only while genuinely live; a still dot on a finished/gone screen would imply life.
+                animation: status.tone === 'live' ? 'ag-term-pulse 1.6s ease-in-out infinite' : undefined,
+              }}
+            />
+            {status.label}
+          </span>
+        )}
+        {hasStream && (
+          <button
+            onClick={() => setWatchedId(null)}
+            title={pt ? 'Parar de assistir' : 'Stop watching'}
+            aria-label={pt ? 'Parar de assistir' : 'Stop watching'}
+            style={{
+              marginLeft: 'auto',
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 4,
+              background: 'transparent',
+              border: '1px solid var(--border-subtle)',
+              borderRadius: 8,
+              color: 'var(--text-secondary)',
+              cursor: 'pointer',
+              padding: isMobile ? '8px 10px' : '4px 8px',
+              minHeight: isMobile ? 44 : undefined,
+              fontFamily: 'inherit',
+              fontSize: 12,
+            }}
+          >
+            <X size={13} />
+            {!isMobile && <span>{pt ? 'Fechar' : 'Close'}</span>}
+          </button>
+        )}
+      </div>
+
+      {/* Selector — pick which live session to watch. The list below stays untouched. */}
+      <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap', marginBottom: hasStream ? 10 : 0 }}>
+        {watchable.map(r => {
+          const active = r.id === watchedId
+          return (
+            <button
+              key={r.id}
+              onClick={() => setWatchedId(active ? null : r.id)}
+              title={`${r.title} — ${r.stateLabel}`}
+              style={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: 7,
+                maxWidth: 260,
+                padding: isMobile ? '8px 12px' : '6px 10px',
+                minHeight: isMobile ? 44 : undefined,
+                borderRadius: 8,
+                border: `1px solid ${active ? 'var(--anthropic-orange)' : 'var(--border-subtle)'}`,
+                background: active ? 'rgba(232,105,11,0.10)' : 'transparent',
+                color: active ? 'var(--text-primary)' : 'var(--text-secondary)',
+                cursor: 'pointer',
+                fontFamily: 'inherit',
+                fontSize: 12,
+                fontWeight: active ? 600 : 500,
+              }}
+            >
+              <span
+                style={{ width: 8, height: 8, borderRadius: '50%', background: stateDotColor(r.state), flexShrink: 0 }}
+              />
+              <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{r.title}</span>
+            </button>
+          )
+        })}
+      </div>
+
+      {hasStream && (
+        <>
+          {/* The AGENT's activity — read from the fleet's own (two-sample-verified) state, never
+              recomputed from the frames. Absent once the row has left the fleet. */}
+          {watchedRow && (
+            <div style={{ display: 'flex', alignItems: 'center', gap: 7, fontSize: 12, color: 'var(--text-secondary)', marginBottom: 8 }}>
+              <span style={{ width: 8, height: 8, borderRadius: '50%', background: stateDotColor(watchedRow.state), flexShrink: 0 }} />
+              <span style={{ fontWeight: 600, color: 'var(--text-primary)' }}>{watchedRow.title}</span>
+              <span style={{ color: 'var(--text-tertiary)' }}>·</span>
+              <span>{watchedRow.stateLabel}</span>
+              {watchedRow.project && (
+                <>
+                  <span style={{ color: 'var(--text-tertiary)' }}>·</span>
+                  <span style={{ color: 'var(--text-tertiary)' }}>{watchedRow.project}</span>
+                </>
+              )}
+            </div>
+          )}
+
+          <div
+            style={{
+              height: isMobile ? 300 : 380,
+              borderRadius: 8,
+              overflow: 'hidden',
+              border: '1px solid var(--border-subtle)',
+              background: theme === 'light' ? '#ffffff' : '#0e1116',
+            }}
+          >
+            <Suspense
+              fallback={
+                <div style={{ padding: 16, fontSize: 12, color: 'var(--text-tertiary)', fontFamily: 'monospace' }}>
+                  {pt ? 'Carregando o emulador…' : 'Loading the emulator…'}
+                </div>
+              }
+            >
+              {/* key={watchedId}: a new session gets a brand-new emulator, so no content leaks across. */}
+              <SessionTerminal key={watchedId ?? 'none'} frame={state.frame} theme={theme} showCursor={status.showCursor} />
+            </Suspense>
+          </div>
+
+          {/* The SCREEN honesty line — what you are actually looking at, in words. */}
+          <div style={{ fontSize: 11, color: 'var(--text-tertiary)', lineHeight: 1.5, marginTop: 8 }}>
+            {status.detail}
+          </div>
+        </>
+      )}
+
+      <style>{`@keyframes ag-term-pulse { 0%,100% { opacity: 1 } 50% { opacity: 0.35 } }`}</style>
+    </div>
+  )
+}

--- a/packages/web/src/hooks/useTerminalStream.ts
+++ b/packages/web/src/hooks/useTerminalStream.ts
@@ -1,0 +1,70 @@
+/**
+ * useTerminalStream — the EventSource wiring for the live terminal read channel.
+ *
+ * The pure decisions (what each event means, what the user is told) live in `lib/terminalStream.ts`.
+ * This hook is the thin, impure glue: open `GET /api/fleet/stream?id=<id>` as SSE, funnel its named
+ * `open`/`frame`/`end` events through the reducer, and tear the connection down when the id changes
+ * or the component unmounts.
+ *
+ * Two things it is careful about:
+ *  - **No leak between sessions.** When `id` changes it dispatches `connecting` FIRST (which drops
+ *    the previous frame) before opening the new stream, so one session's screen can never be shown
+ *    under another session's name for even a single render.
+ *  - **`end` closes the socket.** EventSource reconnects on its own after any drop; that is right for
+ *    a transient network blip, but an `end` event is the channel saying the session is GONE, so we
+ *    close the socket to stop it silently reopening a stream the server has finished.
+ */
+
+import { useEffect, useReducer } from 'react'
+import {
+  INITIAL_TERMINAL_STATE,
+  terminalReducer,
+  parseOpen,
+  parseFrame,
+  parseEnd,
+  type TerminalState,
+} from '../lib/terminalStream'
+
+export function useTerminalStream(id: string | null): TerminalState {
+  const [state, dispatch] = useReducer(terminalReducer, INITIAL_TERMINAL_STATE)
+
+  useEffect(() => {
+    if (!id) {
+      dispatch({ type: 'reset' })
+      return
+    }
+
+    // Fresh id → clear any previous session's frame before a single byte of the new one arrives.
+    dispatch({ type: 'connecting' })
+
+    const es = new EventSource(`/api/fleet/stream?id=${encodeURIComponent(id)}`)
+
+    // The server sends a NAMED `open` event, which collides with EventSource's own native
+    // connection-open event. The native one carries no `data`; the server's does — so branch on it.
+    es.addEventListener('open', (e: MessageEvent) => {
+      if (!e.data) return
+      const open = parseOpen(e.data)
+      if (open) dispatch({ type: 'open', open })
+    })
+
+    es.addEventListener('frame', (e: MessageEvent) => {
+      const frame = parseFrame(e.data)
+      if (frame) dispatch({ type: 'frame', frame })
+    })
+
+    es.addEventListener('end', (e: MessageEvent) => {
+      const reason = parseEnd(e.data) ?? 'error'
+      dispatch({ type: 'end', reason })
+      // GONE means gone — do not let EventSource reopen a stream the server has closed for good.
+      es.close()
+    })
+
+    // Native errors (a dropped connection) are left to EventSource's own auto-reconnect. We do NOT
+    // blank the screen here: the last frame stays on show until a real new frame replaces it, so a
+    // momentary blip does not read as "the session died".
+
+    return () => es.close()
+  }, [id])
+
+  return state
+}

--- a/packages/web/src/lib/terminalStream.test.ts
+++ b/packages/web/src/lib/terminalStream.test.ts
@@ -140,6 +140,14 @@ describe('terminalStatus — the honesty line', () => {
     const st = terminalStatus(state, 'en')
     expect(st.tone).toBe('ended')
     expect(st.showCursor).toBe(false)
+    expect(st.detail.toLowerCase()).toContain('last thing it drew') // there IS a last frame to show
+  })
+
+  test('a session gone BEFORE any frame does not promise a screen it never has', () => {
+    const state = terminalReducer({ ...INITIAL_TERMINAL_STATE, phase: 'connecting' }, { type: 'end', reason: 'gone' })
+    const st = terminalStatus(state, 'en')
+    expect(st.tone).toBe('ended')
+    expect(st.detail.toLowerCase()).toContain('no screen to show')
   })
 
   test('pt and en differ', () => {
@@ -164,11 +172,13 @@ describe('watchableFleetRows', () => {
     expect(watchableFleetRows(rows).map(r => r.id)).toEqual(['a', 'b', 'c'])
   })
 
-  test('drops rows that have no tmux pane to read', () => {
+  test('drops rows that have no live pane worth offering — incl. exited/closed/lost', () => {
     const rows = [
       row({ id: 'a', state: 'working' }),
+      row({ id: 'exited', state: 'exited' }),
       row({ id: 'closed', state: 'closed' }),
       row({ id: 'lost', state: 'lost' }),
+      row({ id: 'unknown', state: 'unknown' }),
     ]
     expect(watchableFleetRows(rows).map(r => r.id)).toEqual(['a'])
   })

--- a/packages/web/src/lib/terminalStream.test.ts
+++ b/packages/web/src/lib/terminalStream.test.ts
@@ -1,0 +1,184 @@
+import { describe, test, expect } from 'bun:test'
+import {
+  INITIAL_TERMINAL_STATE,
+  terminalReducer,
+  parseOpen,
+  parseFrame,
+  parseEnd,
+  terminalStatus,
+  watchableFleetRows,
+  xtermTheme,
+  type TerminalFrame,
+  type TerminalState,
+} from './terminalStream'
+
+const frame = (over: Partial<TerminalFrame> = {}): TerminalFrame => ({
+  seq: 1,
+  content: 'hello',
+  cols: 80,
+  rows: 24,
+  cursor: { x: 0, y: 0 },
+  alive: true,
+  lines: 1,
+  historyLimit: 50000,
+  truncated: false,
+  ...over,
+})
+
+describe('parseOpen / parseFrame / parseEnd', () => {
+  test('parseOpen reads the documented shape', () => {
+    expect(parseOpen('{"id":"3f5f","viewLines":200,"historyLimit":50000}')).toEqual({
+      id: '3f5f',
+      viewLines: 200,
+      historyLimit: 50000,
+    })
+  })
+
+  test('parseFrame keeps SGR escapes intact and the cursor', () => {
+    const raw = JSON.stringify(frame({ content: '[35mclaude[0m', cursor: { x: 6, y: 12 } }))
+    const f = parseFrame(raw)!
+    expect(f.content).toBe('[35mclaude[0m')
+    expect(f.cursor).toEqual({ x: 6, y: 12 })
+    expect(f.alive).toBe(true)
+  })
+
+  test('parseFrame accepts a null cursor on a dead frame', () => {
+    const f = parseFrame(JSON.stringify(frame({ alive: false, cursor: null })))!
+    expect(f.cursor).toBeNull()
+    expect(f.alive).toBe(false)
+  })
+
+  test('malformed payloads return null rather than throwing', () => {
+    expect(parseOpen('not json')).toBeNull()
+    expect(parseFrame('{"seq":1}')).toBeNull() // missing content
+    expect(parseFrame('42')).toBeNull()
+    expect(parseEnd('{"reason":"whatever"}')).toBeNull() // not an allowed reason
+  })
+
+  test('parseEnd reads the three allowed reasons', () => {
+    expect(parseEnd('{"reason":"gone"}')).toBe('gone')
+    expect(parseEnd('{"reason":"not-found"}')).toBe('not-found')
+    expect(parseEnd('{"reason":"error"}')).toBe('error')
+  })
+})
+
+describe('terminalReducer', () => {
+  test('connecting clears any previous frame — no leak between sessions', () => {
+    const dirty: TerminalState = {
+      phase: 'streaming',
+      open: { id: 'a', viewLines: 200, historyLimit: 50000 },
+      frame: frame({ content: 'SESSION-A-SECRET' }),
+      endReason: null,
+    }
+    const next = terminalReducer(dirty, { type: 'connecting' })
+    expect(next.frame).toBeNull()
+    expect(next.open).toBeNull()
+    expect(next.phase).toBe('connecting')
+    expect(next.endReason).toBeNull()
+  })
+
+  test('a live frame moves to streaming', () => {
+    const next = terminalReducer({ ...INITIAL_TERMINAL_STATE, phase: 'connecting' }, { type: 'frame', frame: frame() })
+    expect(next.phase).toBe('streaming')
+    expect(next.frame?.content).toBe('hello')
+  })
+
+  test('an alive:false frame is FINISHED, not streaming, but stays readable', () => {
+    const next = terminalReducer(
+      { ...INITIAL_TERMINAL_STATE, phase: 'streaming' },
+      { type: 'frame', frame: frame({ alive: false, cursor: null, content: 'done' }) },
+    )
+    expect(next.phase).toBe('finished')
+    expect(next.frame?.content).toBe('done')
+  })
+
+  test('end keeps the last frame and records the reason', () => {
+    const streaming = terminalReducer(INITIAL_TERMINAL_STATE, { type: 'frame', frame: frame({ content: 'last screen' }) })
+    const ended = terminalReducer(streaming, { type: 'end', reason: 'gone' })
+    expect(ended.phase).toBe('ended')
+    expect(ended.endReason).toBe('gone')
+    expect(ended.frame?.content).toBe('last screen') // the last thing it drew stays on screen
+  })
+
+  test('reset returns to idle', () => {
+    const s = terminalReducer({ ...INITIAL_TERMINAL_STATE, phase: 'streaming', frame: frame() }, { type: 'reset' })
+    expect(s).toEqual(INITIAL_TERMINAL_STATE)
+  })
+})
+
+describe('terminalStatus — the honesty line', () => {
+  test('idle prompts for a selection', () => {
+    const st = terminalStatus(INITIAL_TERMINAL_STATE, 'en')
+    expect(st.tone).toBe('idle')
+  })
+
+  test('a live frame says it is the CURRENT screen and shows the cursor', () => {
+    const state = terminalReducer(INITIAL_TERMINAL_STATE, { type: 'frame', frame: frame({ lines: 42 }) })
+    const st = terminalStatus(state, 'en')
+    expect(st.tone).toBe('live')
+    expect(st.showCursor).toBe(true)
+    expect(st.label.toLowerCase()).toContain('live')
+    expect(st.detail).toContain('42')
+  })
+
+  test('truncated history is disclosed, not hidden', () => {
+    const state = terminalReducer(INITIAL_TERMINAL_STATE, { type: 'frame', frame: frame({ truncated: true, lines: 200 }) })
+    const st = terminalStatus(state, 'en')
+    expect(st.truncated).toBe(true)
+  })
+
+  test('a finished session never shows a cursor and reads as finished', () => {
+    const state = terminalReducer(INITIAL_TERMINAL_STATE, { type: 'frame', frame: frame({ alive: false, cursor: null }) })
+    const st = terminalStatus(state, 'en')
+    expect(st.tone).toBe('finished')
+    expect(st.showCursor).toBe(false)
+  })
+
+  test('a gone session is signalled, not frozen — and draws no cursor', () => {
+    const streaming = terminalReducer(INITIAL_TERMINAL_STATE, { type: 'frame', frame: frame() })
+    const state = terminalReducer(streaming, { type: 'end', reason: 'gone' })
+    const st = terminalStatus(state, 'en')
+    expect(st.tone).toBe('ended')
+    expect(st.showCursor).toBe(false)
+  })
+
+  test('pt and en differ', () => {
+    const state = terminalReducer(INITIAL_TERMINAL_STATE, { type: 'frame', frame: frame() })
+    expect(terminalStatus(state, 'pt').label).not.toBe(terminalStatus(state, 'en').label)
+  })
+})
+
+describe('watchableFleetRows', () => {
+  const row = (over: Record<string, unknown> = {}) => ({
+    id: 'x', title: 't', harness: 'claude', cwd: '/', project: 'p',
+    state: 'working', stateLabel: 'working', actionable: true, attachCommand: '', verbs: [],
+    ...over,
+  }) as never
+
+  test('keeps sessions that have a live pane', () => {
+    const rows = [
+      row({ id: 'a', state: 'working' }),
+      row({ id: 'b', state: 'waiting' }),
+      row({ id: 'c', state: 'waiting-approval' }),
+    ]
+    expect(watchableFleetRows(rows).map(r => r.id)).toEqual(['a', 'b', 'c'])
+  })
+
+  test('drops rows that have no tmux pane to read', () => {
+    const rows = [
+      row({ id: 'a', state: 'working' }),
+      row({ id: 'closed', state: 'closed' }),
+      row({ id: 'lost', state: 'lost' }),
+    ]
+    expect(watchableFleetRows(rows).map(r => r.id)).toEqual(['a'])
+  })
+})
+
+describe('xtermTheme', () => {
+  test('light and dark are different, opaque backgrounds', () => {
+    const d = xtermTheme('dark')
+    const l = xtermTheme('light')
+    expect(d.background).not.toBe(l.background)
+    expect(typeof d.foreground).toBe('string')
+  })
+})

--- a/packages/web/src/lib/terminalStream.ts
+++ b/packages/web/src/lib/terminalStream.ts
@@ -237,6 +237,15 @@ export function terminalStatus(state: TerminalState, lang: 'pt' | 'en'): Termina
 
   // ended
   const reason = state.endReason
+  // "the screen below is the last thing it drew" is only true when there IS a last frame; a session
+  // that was already gone when we opened the stream left nothing to show, so say that instead.
+  const goneDetail = state.frame
+    ? (pt
+        ? 'A sessão saiu do tmux; a tela abaixo é a última coisa que ela desenhou.'
+        : 'The session left tmux; the screen below is the last thing it drew.')
+    : (pt
+        ? 'A sessão já não estava mais no tmux; não há tela para mostrar.'
+        : 'The session was already gone from tmux; there is no screen to show.')
   const detail =
     reason === 'not-found'
       ? (pt
@@ -244,9 +253,7 @@ export function terminalStatus(state: TerminalState, lang: 'pt' | 'en'): Termina
           : 'This session is no longer managed by this machine.')
       : reason === 'error'
         ? (pt ? 'O canal do terminal não pôde ser lido.' : 'The terminal channel could not be read.')
-        : (pt
-            ? 'A sessão saiu do tmux; a tela abaixo é a última coisa que ela desenhou.'
-            : 'The session left tmux; the screen below is the last thing it drew.')
+        : goneDetail
   return {
     tone: 'ended',
     label: pt ? 'Sessão encerrada' : 'Session gone',
@@ -259,16 +266,18 @@ export function terminalStatus(state: TerminalState, lang: 'pt' | 'en'): Termina
 // ---- which rows can be watched -------------------------------------------------------------------
 
 /**
- * The fleet states that actually have a live tmux pane to read. `closed` (read from the store, never
- * had a pane), `lost` (its tmux went away) and `unknown` have nothing to stream — offering them
- * would only draw an immediate `end: gone`. `exited` keeps its pane while tmux holds the session, so
- * it stays watchable: the finished screen is worth seeing.
+ * The fleet states that unambiguously have a LIVE tmux pane to read: an assistant that is running
+ * or waiting on a person. Everything else has nothing worth offering to watch — `closed` (read from
+ * the store, never had a pane) and `lost` (its tmux went away) would draw an immediate `end: gone`,
+ * and `exited` is a finished conversation whose pane is, on a real machine, almost always already
+ * gone from tmux; including it buried the live sessions under dozens of dead history rows. A session
+ * that exits WHILE being watched still reports its finished screen honestly through the open stream
+ * — this filter only governs what the selector OFFERS, not what a live stream may show.
  */
 const WATCHABLE_STATES: ReadonlySet<FleetRow['state']> = new Set<FleetRow['state']>([
   'working',
   'waiting',
   'waiting-approval',
-  'exited',
 ])
 
 export function watchableFleetRows(rows: readonly FleetRow[]): FleetRow[] {

--- a/packages/web/src/lib/terminalStream.ts
+++ b/packages/web/src/lib/terminalStream.ts
@@ -1,0 +1,359 @@
+/**
+ * terminalStream.ts — the browser's half of the live terminal read channel.
+ *
+ * The server contract is `docs/terminal-channel.md` (`GET /api/fleet/stream?id=<sessionId>`, SSE,
+ * Phase 1 read-only). This module owns the PURE half of consuming it: parsing the `open`/`frame`/
+ * `end` events, the reducer that turns a stream of events into a view-model, and the HONESTY line
+ * that says — in words — whether what you are looking at is the live screen, a finished session, or
+ * a session that is gone. A frozen terminal that looks alive is the same kind of lie as a false
+ * `waiting`, so the difference between those three is drawn from the channel's own fields
+ * (`alive`, `truncated`, `lines`, the `end` reason), never guessed from a still screen.
+ *
+ * The emulator wiring (xterm) and the EventSource live in `useTerminalStream.ts` / `SessionTerminal`.
+ * They are kept out of here so this — the part that decides what the user is told — stays pure and
+ * tested.
+ */
+
+import type { FleetRow } from './fleet'
+
+export interface TerminalOpen {
+  id: string
+  viewLines: number
+  historyLimit: number
+}
+
+export interface TerminalCursor {
+  x: number
+  y: number
+}
+
+export interface TerminalFrame {
+  /** Monotonic within one stream; advances only when the screen changed. */
+  seq: number
+  /** The rendered pane, `\n`-joined, WITH SGR escape sequences intact. Feed to the emulator. */
+  content: string
+  cols: number
+  rows: number
+  /** Block-cursor position, or null once the pane is dead — never draw a cursor on a dead frame. */
+  cursor: TerminalCursor | null
+  /** false once the hosted command has exited. The last frame stays readable, shown as finished. */
+  alive: boolean
+  /** How many lines `content` carries — the honest "you are seeing N lines" number. */
+  lines: number
+  /** The scrollback ceiling tmux keeps. */
+  historyLimit: number
+  /** true when there is more scrollback above than this frame carries. */
+  truncated: boolean
+}
+
+/** Why the stream closed. Only a session GONE from tmux ends the stream; a mere exit does not. */
+export type TerminalEndReason = 'gone' | 'not-found' | 'error'
+
+const END_REASONS: ReadonlySet<string> = new Set<TerminalEndReason>(['gone', 'not-found', 'error'])
+
+export type TerminalPhase =
+  /** nothing selected to watch */
+  | 'idle'
+  /** stream (re)opening; no frame drawn yet */
+  | 'connecting'
+  /** a live frame is on screen (the hosted command is running) */
+  | 'streaming'
+  /** the command exited; the last screen it drew stays readable (stream still open) */
+  | 'finished'
+  /** the session left tmux; the last frame is the last thing it ever drew */
+  | 'ended'
+
+export interface TerminalState {
+  phase: TerminalPhase
+  open: TerminalOpen | null
+  frame: TerminalFrame | null
+  endReason: TerminalEndReason | null
+}
+
+export const INITIAL_TERMINAL_STATE: TerminalState = {
+  phase: 'idle',
+  open: null,
+  frame: null,
+  endReason: null,
+}
+
+export type TerminalAction =
+  | { type: 'reset' }
+  | { type: 'connecting' }
+  | { type: 'open'; open: TerminalOpen }
+  | { type: 'frame'; frame: TerminalFrame }
+  | { type: 'end'; reason: TerminalEndReason }
+
+export function terminalReducer(state: TerminalState, action: TerminalAction): TerminalState {
+  switch (action.type) {
+    case 'reset':
+      return INITIAL_TERMINAL_STATE
+    case 'connecting':
+      // A fresh connection — for a NEW id, or a reconnect. Drop the previous session's frame
+      // entirely: carrying it over for even one render would leak one session's screen onto the
+      // next, which is the one thing this feature may never do.
+      return { phase: 'connecting', open: null, frame: null, endReason: null }
+    case 'open':
+      return { ...state, open: action.open, phase: state.frame ? state.phase : 'connecting' }
+    case 'frame':
+      return {
+        ...state,
+        frame: action.frame,
+        endReason: null,
+        phase: action.frame.alive ? 'streaming' : 'finished',
+      }
+    case 'end':
+      // Keep the last frame — the finished screen is the whole point of showing it. Only the phase
+      // and the reason change, so the terminal is signalled as gone, not frozen in silence.
+      return { ...state, phase: 'ended', endReason: action.reason }
+    default:
+      return state
+  }
+}
+
+// ---- parsers -------------------------------------------------------------------------------------
+
+function parseJson(raw: string): unknown {
+  try {
+    return JSON.parse(raw)
+  } catch {
+    return null
+  }
+}
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null
+}
+
+export function parseOpen(raw: string): TerminalOpen | null {
+  const v = parseJson(raw)
+  if (!isRecord(v) || typeof v.id !== 'string') return null
+  return {
+    id: v.id,
+    viewLines: typeof v.viewLines === 'number' ? v.viewLines : 0,
+    historyLimit: typeof v.historyLimit === 'number' ? v.historyLimit : 0,
+  }
+}
+
+export function parseFrame(raw: string): TerminalFrame | null {
+  const v = parseJson(raw)
+  if (!isRecord(v) || typeof v.content !== 'string') return null
+  let cursor: TerminalCursor | null = null
+  if (isRecord(v.cursor) && typeof v.cursor.x === 'number' && typeof v.cursor.y === 'number') {
+    cursor = { x: v.cursor.x, y: v.cursor.y }
+  }
+  const num = (x: unknown, fallback = 0) => (typeof x === 'number' && Number.isFinite(x) ? x : fallback)
+  return {
+    seq: num(v.seq),
+    content: v.content,
+    cols: num(v.cols),
+    rows: num(v.rows),
+    cursor,
+    alive: v.alive !== false, // default to live unless explicitly false
+    lines: num(v.lines),
+    historyLimit: num(v.historyLimit),
+    truncated: v.truncated === true,
+  }
+}
+
+export function parseEnd(raw: string): TerminalEndReason | null {
+  const v = parseJson(raw)
+  if (!isRecord(v) || typeof v.reason !== 'string' || !END_REASONS.has(v.reason)) return null
+  return v.reason as TerminalEndReason
+}
+
+// ---- the honesty line ----------------------------------------------------------------------------
+
+export type TerminalTone = 'idle' | 'connecting' | 'live' | 'finished' | 'ended'
+
+export interface TerminalStatus {
+  tone: TerminalTone
+  /** Short label for the pill beside the terminal. */
+  label: string
+  /** One sentence saying what you are actually looking at. */
+  detail: string
+  /** True only for a live frame with a real cursor — never on a dead or gone screen. */
+  showCursor: boolean
+  /** True when there is more scrollback than the frame carries; the UI discloses it. */
+  truncated: boolean
+}
+
+export function terminalStatus(state: TerminalState, lang: 'pt' | 'en'): TerminalStatus {
+  const pt = lang === 'pt'
+  const f = state.frame
+  const lines = f?.lines ?? 0
+  const truncated = Boolean(f?.truncated)
+
+  if (state.phase === 'idle') {
+    return {
+      tone: 'idle',
+      label: pt ? 'Nenhuma sessão' : 'No session',
+      detail: pt ? 'Escolha uma sessão viva para ver o terminal dela.' : 'Pick a live session to watch its terminal.',
+      showCursor: false,
+      truncated: false,
+    }
+  }
+
+  if (state.phase === 'connecting') {
+    return {
+      tone: 'connecting',
+      label: pt ? 'Conectando' : 'Connecting',
+      detail: pt ? 'Abrindo o canal do terminal…' : 'Opening the terminal channel…',
+      showCursor: false,
+      truncated: false,
+    }
+  }
+
+  // A disclosure appended to any live/finished detail: are we seeing everything, or the latest slice?
+  const scope = truncated
+    ? (pt
+        ? `mostrando as últimas ${lines} linhas — há saída mais antiga acima que não cabe aqui`
+        : `showing the last ${lines} lines — there is older output above that is not shown`)
+    : (pt
+        ? `mostrando ${lines} linha${lines === 1 ? '' : 's'}`
+        : `showing ${lines} line${lines === 1 ? '' : 's'}`)
+
+  if (state.phase === 'streaming') {
+    return {
+      tone: 'live',
+      label: pt ? 'Ao vivo' : 'Live',
+      detail: pt ? `A tela atual do agente — ${scope}.` : `The agent's current screen — ${scope}.`,
+      showCursor: Boolean(f?.cursor),
+      truncated,
+    }
+  }
+
+  if (state.phase === 'finished') {
+    return {
+      tone: 'finished',
+      label: pt ? 'Encerrada' : 'Finished',
+      detail: pt
+        ? `O comando terminou; esta é a última tela que ele desenhou — ${scope}.`
+        : `The command exited; this is the last screen it drew — ${scope}.`,
+      showCursor: false,
+      truncated,
+    }
+  }
+
+  // ended
+  const reason = state.endReason
+  const detail =
+    reason === 'not-found'
+      ? (pt
+          ? 'Esta sessão deixou de ser gerenciada por esta máquina.'
+          : 'This session is no longer managed by this machine.')
+      : reason === 'error'
+        ? (pt ? 'O canal do terminal não pôde ser lido.' : 'The terminal channel could not be read.')
+        : (pt
+            ? 'A sessão saiu do tmux; a tela abaixo é a última coisa que ela desenhou.'
+            : 'The session left tmux; the screen below is the last thing it drew.')
+  return {
+    tone: 'ended',
+    label: pt ? 'Sessão encerrada' : 'Session gone',
+    detail,
+    showCursor: false,
+    truncated,
+  }
+}
+
+// ---- which rows can be watched -------------------------------------------------------------------
+
+/**
+ * The fleet states that actually have a live tmux pane to read. `closed` (read from the store, never
+ * had a pane), `lost` (its tmux went away) and `unknown` have nothing to stream — offering them
+ * would only draw an immediate `end: gone`. `exited` keeps its pane while tmux holds the session, so
+ * it stays watchable: the finished screen is worth seeing.
+ */
+const WATCHABLE_STATES: ReadonlySet<FleetRow['state']> = new Set<FleetRow['state']>([
+  'working',
+  'waiting',
+  'waiting-approval',
+  'exited',
+])
+
+export function watchableFleetRows(rows: readonly FleetRow[]): FleetRow[] {
+  return rows.filter(r => WATCHABLE_STATES.has(r.state))
+}
+
+// ---- emulator theme ------------------------------------------------------------------------------
+
+/** The 16-colour ANSI palette + surface colours xterm renders with, per dashboard theme. */
+export interface XtermTheme {
+  background: string
+  foreground: string
+  cursor: string
+  cursorAccent: string
+  selectionBackground: string
+  black: string
+  red: string
+  green: string
+  yellow: string
+  blue: string
+  magenta: string
+  cyan: string
+  white: string
+  brightBlack: string
+  brightRed: string
+  brightGreen: string
+  brightYellow: string
+  brightBlue: string
+  brightMagenta: string
+  brightCyan: string
+  brightWhite: string
+}
+
+/**
+ * Two palettes tuned to the dashboard's own dark/light surfaces. The ANSI 16 are a standard,
+ * legible set (close to the "one dark"/"one light" families) so a coding assistant's coloured
+ * output reads the same as it does in a real terminal, in both themes.
+ */
+export function xtermTheme(theme: 'dark' | 'light'): XtermTheme {
+  if (theme === 'light') {
+    return {
+      background: '#ffffff',
+      foreground: '#1c1c1c',
+      cursor: '#1c1c1c',
+      cursorAccent: '#ffffff',
+      selectionBackground: 'rgba(0,0,0,0.14)',
+      black: '#3a3a3a',
+      red: '#c4271c',
+      green: '#187a2f',
+      yellow: '#8a6d00',
+      blue: '#1a56c4',
+      magenta: '#9a2ab5',
+      cyan: '#0a7d8c',
+      white: '#d0d0d0',
+      brightBlack: '#7a7a7a',
+      brightRed: '#e0342a',
+      brightGreen: '#20a03e',
+      brightYellow: '#b08a00',
+      brightBlue: '#2f6fe0',
+      brightMagenta: '#b83fd0',
+      brightCyan: '#159bab',
+      brightWhite: '#1c1c1c',
+    }
+  }
+  return {
+    background: '#0e1116',
+    foreground: '#d7dae0',
+    cursor: '#e8690b',
+    cursorAccent: '#0e1116',
+    selectionBackground: 'rgba(255,255,255,0.20)',
+    black: '#3b4048',
+    red: '#e06c75',
+    green: '#98c379',
+    yellow: '#e5c07b',
+    blue: '#61afef',
+    magenta: '#c678dd',
+    cyan: '#56b6c2',
+    white: '#abb2bf',
+    brightBlack: '#5c6370',
+    brightRed: '#ef7078',
+    brightGreen: '#a5d68a',
+    brightYellow: '#f0ca8e',
+    brightBlue: '#74bbf3',
+    brightMagenta: '#d19ae6',
+    brightCyan: '#6cc7d1',
+    brightWhite: '#ffffff',
+  }
+}

--- a/packages/web/src/pages/SessionsPage.tsx
+++ b/packages/web/src/pages/SessionsPage.tsx
@@ -16,6 +16,7 @@ import { Bell, BellOff, Clock, Settings, Sparkles } from 'lucide-react'
 import type { SessionMeta } from '@agentistics/core'
 import type { AppContext } from '../lib/app-context'
 import { RecentSessions } from '../components/RecentSessions'
+import { SessionTerminalPanel } from '../components/SessionTerminalPanel'
 import { useFleet, useFleetIndex } from '../lib/fleet'
 import { useIsMobile } from '../hooks/useIsMobile'
 import {
@@ -33,7 +34,7 @@ const LIVE_POLL_MS = 4000
 
 export default function SessionsPage() {
   const ctx = useOutletContext<AppContext>()
-  const { data, derived, lang, setSelectedSession, isCentral } = ctx
+  const { data, derived, lang, theme, setSelectedSession, isCentral } = ctx
   const pt = lang === 'pt'
   const navigate = useNavigate()
   const isMobile = useIsMobile()
@@ -232,6 +233,13 @@ export default function SessionsPage() {
                 : 'Session control is not available on this install, so the sessions below are listed as history only.')
             : fleet.unavailable}
         </div>
+      )}
+
+      {/* The live terminal of a selected session — a panel WITHIN the tab, machine mode only. Gated
+          on the same fleet availability the list uses, which is exactly what the stream channel
+          gates on too (a central 404s, an exposed profile 403s). The list below stays visible. */}
+      {!isCentral && !fleetUnsupported && !fleet.unavailable && (
+        <SessionTerminalPanel rows={fleet.sessions} lang={lang} theme={theme} />
       )}
 
       <RecentSessions


### PR DESCRIPTION
## What

The machine-mode **Sessions** tab gains the live terminal of a selected session — so you can see what an agent is drawing on screen without opening a terminal and running `tmux attach`.

Wave 2 of j-20260828-8d. Consumes the Phase-1 read channel Victor delivered in #244 (`GET /api/fleet/stream`, SSE), documented in `docs/terminal-channel.md`. **No new endpoint invented** — the web builds on exactly that contract.

## How

- **`lib/terminalStream.ts`** (pure, TDD) — the `open`/`frame`/`end` payload parsers, the event reducer, the "watchable rows" filter, the xterm theme, and the **honesty status**: live vs finished vs gone, derived from the channel's own frame fields (`alive`, `truncated`, `lines`, the `end` reason), never guessed from a still screen.
- **`SessionTerminal`** — a real emulator (**xterm.js**), `React.lazy`-loaded into its own chunk. Each `frame` is a full snapshot → `reset()` + `write()` (never append); the cursor is placed from the frame and hidden on a dead frame. First paint is gated on xterm's `onRender` (its renderer measures cells there — otherwise `resize()` throws asynchronously in `Viewport.syncScrollArea`); a theme flip re-paints the current frame so it never blanks.
- **`SessionTerminalPanel`** — a panel *inside* the tab (never takes it over): a selector of the live sessions + the terminal + the honesty line. Switching sessions mounts a fresh emulator (`key` per id) so **no screen leaks across**. The agent-activity badge reads the fleet's own (two-sample-verified, #243) state — the panel never recomputes an optimistic state from the frames.
- **No input box.** Phase 2 (the write channel) is not authorized yet; a text field that does nothing is the same lie as a frozen terminal.

Gated on the fleet being supported (`useFleet`), which is exactly what the stream gates on too: a central 404s, an exposed profile 403s.

## Bundle cost

The emulator is a **separate lazy chunk** — `SessionTerminal-*.js` **288.5 kB / 68.3 kB gzip** (+ 2.85 kB / 0.77 kB gzip CSS), fetched only when a terminal is opened. **Zero cost to the initial dashboard load.**

## Verification (driven against a real session)

Ran the dev build on spare ports against this machine's own live agentop fleet (the server route from #244 is on `dev`):

- **ANSI correct** — watched live `working`/`waiting` sessions: colours, bold, box-drawing, syntax-highlighted code all render.
- **Switch without leak** — switching sessions fully replaces the screen; no bytes carry across (React `key` per id + reducer clears the frame on connect).
- **Dead session signalled** — a gone session shows a red **"Session gone"** pill (not "Live"), not a frozen screen. Unit-tested for `finished` (`alive:false`) and `gone`/`not-found`/`error`.
- **Both themes** — dark and light both render (light required a repaint-on-theme-change fix).
- **No site-origin console errors** — the initial xterm `dimensions` race was fixed with the `onRender` gate.
- **Responsive** — at phone width the terminal is contained in its box and scrolls internally; the page body never overflows horizontally (measured `pageOverflow: false`); 44px touch targets via `useIsMobile()`.
- `bun test packages/web` → **850 pass**; `bun tsc --noEmit` → clean; `bun run build` → green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
