### PR TITLE
fix(sessions): act on the selected session by identity, flat search, cursor follows the marked row

### DIFF
--- a/packages/tui/scripts/preview.tsx
+++ b/packages/tui/scripts/preview.tsx
@@ -626,6 +626,33 @@ const FAKE_FLEET: ControlSessions = {
       state: 'unknown', stateLabel: 'external', actionable: false,
       startedAt: Date.now() - 40 * 60_000, attached: false,
     },
+    // Several conversations under ONE name, all off — the DUPLICATE-NAME case (a coordinator
+    // reopened again and again). They share a title and a project, and are told apart ONLY by the
+    // never-dropped `id` column and the per-row "ended" time. This is the awkward case behind the
+    // "why do I see the same session five times" report: rendered here, the rows are distinct
+    // (distinct ids co1/co2/co3), which is the proof that identical-LOOKING rows can only come from
+    // records that share an id — a de-dup question upstream, not a drawing one here.
+    {
+      id: 'closed:co1', title: 'COORDENADOR AIPE-ELETROMIDIA', harness: 'claude',
+      cwd: '/home/dev/aipe-eletromidia', project: 'aipe-eletromidia',
+      state: 'closed', stateLabel: 'closed', actionable: false,
+      resume: { sessionId: 'co1', title: 'COORDENADOR AIPE-ELETROMIDIA' },
+      startedAt: Date.now() - 9 * 60 * 60_000, endedAt: Date.now() - 8 * 60 * 60_000, attached: false,
+    },
+    {
+      id: 'closed:co2', title: 'COORDENADOR AIPE-ELETROMIDIA', harness: 'claude',
+      cwd: '/home/dev/aipe-eletromidia', project: 'aipe-eletromidia',
+      state: 'closed', stateLabel: 'closed', actionable: false,
+      resume: { sessionId: 'co2', title: 'COORDENADOR AIPE-ELETROMIDIA' },
+      startedAt: Date.now() - 5 * 60 * 60_000, endedAt: Date.now() - 4 * 60 * 60_000, attached: false,
+    },
+    {
+      id: 'closed:co3', title: 'COORDENADOR AIPE-ELETROMIDIA', harness: 'claude',
+      cwd: '/home/dev/aipe-eletromidia', project: 'aipe-eletromidia',
+      state: 'closed', stateLabel: 'closed', actionable: false,
+      resume: { sessionId: 'co3', title: 'COORDENADOR AIPE-ELETROMIDIA' },
+      startedAt: Date.now() - 1 * 60 * 60_000, endedAt: Date.now() - 30 * 60_000, attached: false,
+    },
     {
       id: 'closed:1', title: 'wire up the billing basis', harness: 'claude',
       cwd: '/home/dev/agentistics', project: 'agentistics', task: 'billing',

--- a/packages/tui/src/control/sessions.test.ts
+++ b/packages/tui/src/control/sessions.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'bun:test'
 import {
   attentionOf, detailLines, groupSessions, rowWidth, treeGuides, selectableIndexes, sessionActions, sessionCells,
+  selectedRow, idAtRow, searchArrangement,
   sessionRows, sortSessions, summaryCells, actionLabels, enabledActionIndexes,
   sessionColumns, sessionsCockpit, asideRows, asideSelectable, projectCounts, projectColumns,
   projectPickRows, groupProjects, asideSections, asideFold, scrollBar, THUMB, TRACK, sessionNamed,
@@ -82,6 +83,92 @@ describe('sortSessions', () => {
   it('breaks a tie on the newest', () => {
     const list = [session('old', { startedAt: 1 }), session('new', { startedAt: 2 })]
     expect(sortSessions(list).map(s => s.id)).toEqual(['new', 'old'])
+  })
+})
+
+describe('selectedRow — the cursor follows the session by IDENTITY', () => {
+  // The rows a `groupSessions('none', …)` would draw for these sessions, flattened. No headings, so
+  // every row is selectable — a spacer/heading in the middle is exercised separately below.
+  const rowsOf = (...ids: string[]): SessionRow[] =>
+    ids.map(id => ({ kind: 'session', session: session(id) }))
+
+  it('returns the index of the glued id even after the list reorders under the cursor', () => {
+    // The user selected 'b' (at position 1). A poll reorders the fleet so 'b' is now last.
+    const before = rowsOf('a', 'b', 'c')
+    const after = rowsOf('c', 'a', 'b')
+    const sel = selectableIndexes(after)
+    // Glued to 'b', the resolved row is wherever 'b' now IS — position 2 — not the old position 1.
+    expect(selectedRow(after, sel, 'b', 1)).toBe(2)
+    // And the session at that row is provably 'b', not whoever slid into position 1.
+    expect(idAtRow(after, sel, selectedRow(after, sel, 'b', 1))).toBe('b')
+    // Sanity: the OLD, position-based reading would have selected 'a' — the wrong session.
+    expect(idAtRow(after, sel, 1)).toBe('a')
+    void before
+  })
+
+  it('falls back to the clamped numeric position only when the glued id is gone', () => {
+    const rows = rowsOf('a', 'b', 'c')
+    const sel = selectableIndexes(rows)
+    // 'z' ended and is no longer in the list — the cursor holds its last position, clamped.
+    expect(selectedRow(rows, sel, 'z', 1)).toBe(1)
+    // A position past the end clamps rather than pointing at nothing.
+    expect(selectedRow(rows, sel, 'z', 9)).toBe(2)
+  })
+
+  it('with no glue id, behaves as the plain clamped cursor', () => {
+    const rows = rowsOf('a', 'b', 'c')
+    const sel = selectableIndexes(rows)
+    expect(selectedRow(rows, sel, undefined, 0)).toBe(0)
+    expect(selectedRow(rows, sel, undefined, 5)).toBe(2)
+  })
+
+  it('returns -1 on an empty list', () => {
+    expect(selectedRow([], [], 'a', 0)).toBe(-1)
+    expect(selectedRow([], [], undefined, 3)).toBe(-1)
+  })
+
+  it('resolves the id through headings and spacers, not raw row indices', () => {
+    // A grouped list: heading, sessions, spacer, heading, session. `selectable` skips the chrome.
+    const rows: SessionRow[] = [
+      { kind: 'heading', label: 'live', count: 2 },
+      { kind: 'session', session: session('a') },
+      { kind: 'session', session: session('b') },
+      { kind: 'spacer' },
+      { kind: 'heading', label: 'closed', count: 1 },
+      { kind: 'session', session: session('c') },
+    ]
+    const sel = selectableIndexes(rows)
+    // 'c' is the third selectable row (index 2 into `selectable`), at raw row 5.
+    expect(selectedRow(rows, sel, 'c', 0)).toBe(2)
+    expect(idAtRow(rows, sel, 2)).toBe('c')
+  })
+
+  it('a mark that moves a row to the top carries the selection with it', () => {
+    // Simulates bug (4): the fleet is [a,b,c]; the user marks 'c', which the marked band lifts to
+    // the top → [c,a,b]. Glued to 'c', the resolved index follows it to row 0 — the cursor tracks
+    // the row, never the position it used to hold.
+    const after = rowsOf('c', 'a', 'b') // the marked band lifted 'c' from position 2
+    const sel = selectableIndexes(after)
+    expect(selectedRow(after, sel, 'c', 2)).toBe(0)
+    expect(idAtRow(after, sel, selectedRow(after, sel, 'c', 2))).toBe('c')
+  })
+})
+
+describe('searchArrangement — search is flat and newest-first, and only while searching', () => {
+  const userOrder = { by: 'name', dir: 'asc' } as const
+
+  it('forces a flat, recent-desc list while a query is active', () => {
+    const eff = searchArrangement(true, 'task', true, userOrder)
+    expect(eff.grouping).toBe('none')
+    expect(eff.cascade).toBe(false)
+    expect(eff.order).toEqual({ by: 'recent', dir: 'desc' })
+  })
+
+  it("returns the user's own arrangement untouched when there is no query — so exiting restores it", () => {
+    const eff = searchArrangement(false, 'task', true, userOrder)
+    expect(eff.grouping).toBe('task')
+    expect(eff.cascade).toBe(true)
+    expect(eff.order).toBe(userOrder)
   })
 })
 

--- a/packages/tui/src/control/sessions.ts
+++ b/packages/tui/src/control/sessions.ts
@@ -479,6 +479,71 @@ export function selectableIndexes(rows: readonly SessionRow[]): number[] {
   return out
 }
 
+/**
+ * The session id at a selectable POSITION, or undefined when the position names no row.
+ *
+ * `at` indexes `selectable` (the session rows), not `rows` (which also holds headings and spacers);
+ * this is the one place that resolves the two so no call site has to do the double indirection by
+ * hand and get it subtly wrong.
+ */
+export function idAtRow(
+  rows: readonly SessionRow[],
+  selectable: readonly number[],
+  at: number,
+): string | undefined {
+  const row = rows[selectable[at] ?? -1]
+  return row?.kind === 'session' ? row.session.id : undefined
+}
+
+/**
+ * WHICH row the selection is on — resolved by IDENTITY, not by a raw position.
+ *
+ * The list re-sorts under the cursor constantly: the fleet polls every five seconds, and marking a
+ * row lifts it to the top band. A selection kept as a bare index therefore names a DIFFERENT session
+ * one frame later — and a destructive verb (`x` kills, and the loss is silent) fired in that frame
+ * hits the wrong one. That is exactly why the MARK set is kept by id; the cursor must be too.
+ *
+ * Given the id the cursor is glued to, this returns that session's CURRENT index, wherever the sort
+ * left it. Only when the glued id is no longer in the list — the session ended, a filter dropped it —
+ * does it fall back to the last numeric position, clamped into range, which is what keeps the cursor
+ * sensible on the row that slid into its place. `-1` on an empty list, as before.
+ */
+export function selectedRow(
+  rows: readonly SessionRow[],
+  selectable: readonly number[],
+  glueId: string | undefined,
+  cursor: number,
+): number {
+  if (selectable.length === 0) return -1
+  if (glueId !== undefined) {
+    const found = selectable.findIndex(r => {
+      const row = rows[r]
+      return row?.kind === 'session' && row.session.id === glueId
+    })
+    if (found >= 0) return found
+  }
+  return Math.min(Math.max(0, cursor), selectable.length - 1)
+}
+
+/**
+ * The arrangement to DRAW while a search is active — one flat list, newest first.
+ *
+ * Grouping a search spreads its hits across bands and cascades and makes you sweep the whole screen
+ * for them; the answer to "where did that session go" is a single flat list ordered by last
+ * activity. This applies ONLY while a query is present: with none, it returns the user's own
+ * grouping, cascade and order untouched — which is what makes leaving the search restore the
+ * arrangement with nothing to undo, because the stored state was never changed to begin with.
+ */
+export function searchArrangement(
+  querying: boolean,
+  grouping: SessionGrouping,
+  cascade: boolean,
+  order: SessionOrder,
+): { grouping: SessionGrouping; cascade: boolean; order: SessionOrder } {
+  if (!querying) return { grouping, cascade, order }
+  return { grouping: 'none', cascade: false, order: { by: 'recent', dir: 'desc' } }
+}
+
 // ---------------------------------------------------------------------------
 // the row
 // ---------------------------------------------------------------------------

--- a/packages/tui/src/control/tabs/Sessions.tsx
+++ b/packages/tui/src/control/tabs/Sessions.tsx
@@ -84,7 +84,7 @@ import { Question as WrappedText } from '../Surface'
 import { SessionWizard } from './SessionWizard'
 import { TaskChoice } from '../TaskChoice'
 import {
-  GROUPINGS, breadcrumb, detailLines, groupSessions, selectableIndexes, sessionCells, sessionRows,
+  GROUPINGS, breadcrumb, detailLines, groupSessions, selectableIndexes, selectedRow, idAtRow, searchArrangement, sessionCells, sessionRows,
   QUESTION_ROWS, askRows, fitApprovalPreview, actionLabels, asideRows, asideSelectable,
   asideRowKey, resolveAsideCursor,
   enabledActionIndexes, filterSessions,
@@ -242,6 +242,29 @@ export function Sessions({
    */
   const [cardAnchor, setCardAnchor] = useState<string | undefined>(view?.cardAnchor)
   const [cursor, setCursor] = useState(0)
+  /**
+   * The session id the cursor is GLUED to — the selection's identity, not its position.
+   *
+   * The list re-sorts under the cursor every five seconds (a poll) and the instant a row is marked
+   * (the marked band lifts it to the top). A cursor kept only as a number therefore names a
+   * DIFFERENT session one frame later, and `x` — which kills, silently — fired in that frame hit the
+   * wrong one. `marked` is kept by id for exactly this reason; the cursor now is too. Held in a ref,
+   * not state: it must be readable at the moment of the keypress and updating it must never itself
+   * force a render.
+   */
+  const glueRef = useRef<string | undefined>(undefined)
+  /**
+   * Send the cursor to the TOP and drop the glue, so the top row is selected by position again.
+   *
+   * The gesture behind every filter/grouping/search change: those reset to the top, and keeping the
+   * old glue would hold the selection on the previous session wherever it now sits instead. The
+   * reconcile effect re-adopts the top session's id immediately after, so the cursor still follows
+   * THAT row through the next reorder.
+   */
+  const toTop = useCallback(() => {
+    setCursor(0)
+    glueRef.current = undefined
+  }, [])
   const [ask, setAsk] = useState<Ask | null>(null)
   const [query, setQuery] = useState('')
   /**
@@ -334,8 +357,8 @@ export function Sessions({
   const projectFilter = filters.project?.[0] ?? null
   const pressShortcut = useCallback((k: StatusShortcut) => {
     setFilters(f => ({ ...f, status: applyShortcut(f.status ?? ACTIVE_STATES, k) }))
-    setCursor(0)
-  }, [])
+    toTop()
+  }, [toTop])
   /** Pick ONE value on a dimension, or clear it — the task and project sections' gesture. */
   const scopeTo = useCallback((id: SessionDimensionId, value: string | null) => {
     setFilters(f => {
@@ -344,8 +367,8 @@ export function Sessions({
       else next[id] = [value]
       return next
     })
-    setCursor(0)
-  }, [])
+    toTop()
+  }, [toTop])
   const [hideDetail, setHideDetail] = useState(view?.hideDetail ?? false)
   /**
    * The rows the user MARKED — a highlighter, not a selection.
@@ -412,6 +435,11 @@ export function Sessions({
   const words = useMemo(() => sessionWordBook(s), [s])
   // The only fact a `keyOf` needs that is not on the session itself.
   const dimensionCtx = useMemo(() => ({ marked }), [marked])
+  // While a search is active the list is drawn FLAT and newest-first, whatever the user's grouping
+  // is — a grouped search scatters its hits across bands and makes you hunt the screen for them.
+  // It is an override on the DRAWING only: the stored grouping/cascade/order are untouched, so
+  // clearing the query restores the arrangement with nothing to put back. See `searchArrangement`.
+  const searchView = searchArrangement(query.trim() !== '', grouping, cascade, order)
   const rows = useMemo(() => sessionRows(groupSessions(
     filterSessions(
       (fleet?.sessions ?? []).filter(v =>
@@ -429,12 +457,12 @@ export function Sessions({
       transcript?.ids,
       active,
     ),
-    grouping,
+    searchView.grouping,
     words,
     fleet?.finishedTasks ?? [],
-    order,
+    searchView.order,
     dimensionCtx,
-    cascade,
+    searchView.cascade,
     // The heading is passed only when something ACTUALLY fell. `sessionRows` treats an absent word
     // as "there is no such section", so on an ordinary machine the reading order is unchanged
     // rather than carrying an empty block that exists to say nothing.
@@ -482,13 +510,50 @@ export function Sessions({
   )
   const badges = useMemo(() => cardBadges(rows), [rows])
 
-  // Clamped on every render rather than corrected in an effect: a session that ends between two
-  // polls shortens the list under the cursor, and a stored index would point past the end for one
-  // frame — which is the frame the user presses enter on.
-  const at = selectable.length === 0 ? -1 : Math.min(cursor, selectable.length - 1)
+  // Resolved by IDENTITY every render: the row the glued session is on NOW, wherever the sort left
+  // it. `cursor` survives only as the fallback for when that session is gone — a session that ends
+  // between two polls shortens the list, and the clamp then lands the cursor on the row that took
+  // its place rather than past the end. See `selectedRow`.
+  const at = selectedRow(rows, selectable, glueRef.current, cursor)
   const selected: ControlSession | undefined = at < 0
     ? undefined
     : (rows[selectable[at]!] as Extract<SessionRow, { kind: 'session' }>).session
+
+  /**
+   * Move the cursor to a selectable position AND glue it to whatever session is there.
+   *
+   * Every navigation goes through here rather than a bare `setCursor`, so the identity and the
+   * number are set together and can never disagree — the moment they do is the moment `x` kills the
+   * wrong session.
+   */
+  const moveTo = useCallback((index: number) => {
+    const max = selectable.length - 1
+    if (max < 0) return
+    const clamped = Math.max(0, Math.min(index, max))
+    setCursor(clamped)
+    glueRef.current = idAtRow(rows, selectable, clamped)
+  }, [rows, selectable])
+
+  /**
+   * Keep the glue honest across every reorder the user did not cause.
+   *
+   * Runs after each render. When the glued session is still on screen it is a no-op; when it is
+   * absent (first render, or after `toTop` dropped it, or the session ended) it ADOPTS the currently
+   * resolved row, so the cursor follows a concrete session by identity from then on. It also syncs
+   * the numeric `cursor` to the resolved index so navigation deltas and the persisted page start
+   * from the right row. Setting a ref never re-renders; the one `setCursor` is guarded and converges.
+   */
+  useEffect(() => {
+    if (at < 0) { glueRef.current = undefined; return }
+    const here = idAtRow(rows, selectable, at)
+    const present = glueRef.current !== undefined
+      && selectable.some(r => {
+        const row = rows[r]
+        return row?.kind === 'session' && row.session.id === glueRef.current
+      })
+    if (!present) glueRef.current = here
+    if (at !== cursor) setCursor(at)
+  }, [rows, selectable, at, cursor])
 
   // The detail pane asks for exactly what it has to say, and the list absorbs the difference. A
   // pane sized to a constant leaves dead rows under it — air under a pane is a fault, and a list
@@ -916,8 +981,8 @@ export function Sessions({
     setShowDone(true)
     setOrder({ by: 'recent', dir: 'desc' })
     setQuery('')
-    setCursor(0)
-  }, [])
+    toTop()
+  }, [toTop])
 
   const resetView = useCallback(() => {
     setGrouping(groupingOf(DEFAULT_SESSION_VIEW.grouping))
@@ -932,15 +997,15 @@ export function Sessions({
     setLayout(DEFAULT_SESSION_VIEW.layout ?? 'list')
     setMarked(new Set(DEFAULT_MARKED))
     setQuery('')
-    setCursor(0)
-  }, [])
+    toTop()
+  }, [toTop])
 
   /** Run whatever an aside row means — the same path a key and a click both take. */
   const runAside = useCallback((index: number) => {
     const row = asideList[index]
     if (!row) return
     if (row.kind === 'action') { if (row.enabled) runAction(row.action); return }
-    if (row.kind === 'group') { setGrouping(row.value); setCursor(0); return }
+    if (row.kind === 'group') { setGrouping(row.value); toTop(); return }
     if (row.kind === 'layout') { setLayout(row.value); return }
     if (row.kind === 'task') { scopeTo('task', row.all ? null : row.name); return }
     if (row.kind === 'project') { scopeTo('project', row.name || null); return }
@@ -950,24 +1015,24 @@ export function Sessions({
       setOrder(o => (o.by === row.value
         ? { by: o.by, dir: o.dir === 'desc' ? 'asc' : 'desc' }
         : { by: row.value, dir: DEFAULT_ORDER.dir }))
-      setCursor(0)
+      toTop()
       return
     }
     if (row.kind === 'state') {
       // The never-empty rule lives in `toggleValue` now, where the keyboard reaches it too.
       setFilters(f => ({ ...f, status: toggleValue(f.status ?? ACTIVE_STATES, row.value) }))
-      setCursor(0)
+      toTop()
       return
     }
     if (row.kind !== 'toggle') return
     if (row.toggle === 'history') return pressShortcut('history')
     if (row.toggle === 'active') return pressShortcut('active')
-    setCursor(0)
+    toTop()
     if (row.toggle === 'cascade') return setCascade(v => !v)
     if (row.toggle === 'done') return setShowDone(v => !v)
     if (row.toggle === 'named') return setShowNamed(v => !v)
     return setHideDetail(v => !v)
-  }, [asideList, runAction, resetView, pressShortcut, scopeTo])
+  }, [asideList, runAction, resetView, pressShortcut, scopeTo, toTop])
 
   useInput((input, key) => {
     const nav: NavKey = {
@@ -1059,7 +1124,7 @@ export function Sessions({
     // could only be undone by opening the field and clearing it, and the field re-submitted the old
     // query on an empty enter — so a typo in the search box was a list that could not be got back.
     if (key.escape) {
-      if (query) { setQuery(''); setCursor(0); return }
+      if (query) { setQuery(''); toTop(); return }
       if (projectFilter !== null) { scopeTo('project', null); return }
       if (taskFilter !== null) { scopeTo('task', null); return }
       return
@@ -1171,7 +1236,7 @@ export function Sessions({
     // grid would send the cursor from the top-left card to the bottom-RIGHT one.
     if (grid && selectable.length > 0) {
       const here = Math.max(0, at)
-      const to = (n: number) => setCursor(Math.max(0, Math.min(n, selectable.length - 1)))
+      const to = (n: number) => moveTo(n)
       // Band to band rather than by `cols`: with grouping on, a band holding a one-card group is
       // shorter than the grid is wide, and stepping by `cols` jumped clean over the band below it.
       const step = (dy: number) => to(cardStep(pages, here, dy))
@@ -1191,7 +1256,7 @@ export function Sessions({
 
     if (selectable.length > 0) {
       const next = resolveListKey(nav, Math.max(0, at), selectable.length)
-      if (next !== at) setCursor(next)
+      if (next !== at) moveTo(next)
     }
   }, { isActive: isActive && ask === null })
 
@@ -1240,8 +1305,8 @@ export function Sessions({
     if (anchored.current || cards.length === 0 || !view?.cardAnchor) return
     anchored.current = true
     const index = cards.findIndex(v => v.id === view.cardAnchor)
-    if (index >= 0) setCursor(index)
-  }, [cards, view?.cardAnchor])
+    if (index >= 0) moveTo(index)
+  }, [cards, view?.cardAnchor, moveTo])
 
   // Written whenever any part of the arrangement moves, rather than at each call site: four setters
   // that each had to remember to persist is four places for one to be forgotten. It waits for the
@@ -1337,7 +1402,7 @@ export function Sessions({
     if (wheel !== 0) {
       if (selectable.length === 0) return
       const next = Math.min(Math.max(0, Math.max(0, at) + wheel), selectable.length - 1)
-      return setCursor(next)
+      return moveTo(next)
     }
     if (!isActivation(p)) return
 
@@ -1419,7 +1484,7 @@ export function Sessions({
           // else to set and nothing that can fall out of step.
           if (hit) {
             const next = pages[hit === 'next' ? pageAt + 1 : pageAt - 1]
-            if (next) setCursor(Math.min(next.items[0] ?? 0, selectable.length - 1))
+            if (next) moveTo(next.items[0] ?? 0)
           }
           return
         }
@@ -1430,7 +1495,7 @@ export function Sessions({
           x: gx,
           y: gy,
         })
-        if (index !== null && index < selectable.length) setCursor(index)
+        if (index !== null && index < selectable.length) moveTo(index)
         return
       }
       // The column HEADER is paid for as well as the summary row. Without it every click in the
@@ -1440,7 +1505,7 @@ export function Sessions({
       if (row < 0 || row >= rows.length) return
       const found = selectable.indexOf(row)
       if (found < 0) return
-      setCursor(found)
+      moveTo(found)
       // The X at the right edge. It SELECTS the row first and then asks — so the confirmation names
       // the session under the pointer, never the one that happened to be selected before.
       const entry = rows[row]
@@ -1592,9 +1657,9 @@ export function Sessions({
           width={width}
           height={height}
           isActive={isActive}
-          onGrouping={g => { setGrouping(g); setCursor(0) }}
+          onGrouping={g => { setGrouping(g); toTop() }}
           onShowClosed={() => pressShortcut('history')}
-          onShowNamed={() => { setShowNamed(v => !v); setCursor(0) }}
+          onShowNamed={() => { setShowNamed(v => !v); toTop() }}
           onToggleScope={t => setScopes(sc => toggleScope(sc, t))}
           onToggleAllScopes={() => setScopes(toggleAllScopes)}
           onClose={() => setAsk(null)}
@@ -1978,7 +2043,7 @@ export function Sessions({
               // that stopped this being live: a narrowing list moves rows out from under the
               // selection, so keeping the old index points at whatever slid into that slot. Row 0
               // is the best match to look at anyway.
-              onQuery={q => { setQuery(q); setCursor(0) }}
+              onQuery={q => { setQuery(q); toTop() }}
               fleet={fleet}
             />
           ) : (


### PR DESCRIPTION
## Summary

Three interaction defects in the cockpit's **Sessions** tab (`packages/tui`), plus the diagnosis of a fourth.

### (1) `x` closed the WRONG session — blocking & destructive
The list re-sorts under the cursor constantly (the fleet polls every 5s; marking a row lifts it to the top band), but the cursor was a **raw numeric index**. So the session under the cursor when you decided to press `x` was not always the one that index named a frame later — and `x` kills silently, so the wrong session was closed and the person believed they'd closed the right one. `marked` is already kept by **id** for exactly this reason; the cursor now is too.

- `selectedRow` / `idAtRow` (pure, `sessions.ts`) resolve the selection by the glued session **id**, wherever the sort left it, falling back to the clamped position only when that id has left the list. The action reads the same `selected`, so it targets an **identity, never a position**.
- `Sessions.tsx`: a `glueRef` holds the selected id; every navigation goes through `moveTo` (index **and** id together), every reset through `toTop` (drops the glue), and a reconcile effect re-adopts + keeps the numeric cursor in step across reorders.

### (4) SPACE marks → row goes to top, and the selection follows the row
Same fix. The marked band already leads; now the cursor **follows the marked session to the top** rather than jumping to whoever slid into its old position — which would have been (1) reintroduced.

### (3) Ctrl+F search is flat & newest-first while active; grouping returns on exit
`searchArrangement` (pure) draws the list flat + recent-desc **while a query is present**, overriding the DRAWING only — the stored grouping/cascade/order are untouched, so clearing the query restores the arrangement with nothing to put back.

### (2) Duplicate-looking sessions — diagnosis (see Test plan)
Not a TUI code change: the list already renders one row per record and distinguishes distinct records by a never-dropped `id` column and per-row ended-time (reproduced in `preview.tsx`). Identical-looking rows can therefore only come from records that share an `id`, which is produced upstream in `packages/server` (`session-view.ts` keys closed rows `closed:${sessionId}` and applies `collapseSupersededSessions` only to `managed`, not the `closed` list). That is across this unit's frontier and is being escalated to the coordinator with the reproduction.

## Motivation
`x` destroying an in-flight sibling session — silently, on the wrong target — is the highest-severity defect on this screen. The root cause (selection by position, not identity) also underlies the marking side effect, so both are fixed by one mechanism.

## Test plan
- `bun test packages/tui` — **781 pass** (new: `selectedRow`/`idAtRow` reorder cases proving the action reaches the selected id even when the list reorders between draw and keypress; `searchArrangement`).
- `bun test` (pre-commit) — **4488 pass, 0 fail**; `bun tsc --noEmit` clean; `bun test packages/core/src/tokens.lint.test.ts` green.
- `bun run build:binary` — green (compile-time devtools stub OK).
- **Driven on the compiled binary** against the live fleet: marking a session lifts it to the top band with the cursor still on it (and back on unmark); Ctrl+F collapses the grouped list to a flat, newest-first one and restores the grouping on clear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)