### PR TITLE
fix(core): the breaking-change marker is a footer, not prose

### DIFF
--- a/packages/core/src/versionBump.test.ts
+++ b/packages/core/src/versionBump.test.ts
@@ -25,6 +25,39 @@ describe('classifyCommit — a single commit', () => {
     expect(classifyCommit({ subject: 'fix: x', body: 'BREAKING-CHANGE: incompatible' })).toBe('major'))
 })
 
+describe('the marker is a FOOTER, not prose — the defect that shipped a false major', () => {
+  // The real body of a52ba8b ("fix(release): read every commit for the version bump and make it
+  // testable (#249)"). Its body describes the footer mechanism in PROSE, wrapping the token in
+  // backticks — a description of the mechanism, not a declaration of a break. A substring scan
+  // read it as breaking and rolled a whole major. This fixture is the exact offending sentence.
+  const a52ba8bBody = [
+    'The release workflow computed the semver bump from `git log --pretty=format:"%s"`',
+    'fed into a `while IFS= read -r` loop.',
+    '',
+    '- Extract the calculation to `@agentistics/core` (`versionBump.ts`).',
+    '  It also scans the commit BODY for a `BREAKING CHANGE` footer, which the old',
+    '  subject-only read could not see.',
+  ].join('\n')
+
+  test('a fix: whose body MENTIONS the footer token in prose (backticks) → patch, not major', () =>
+    expect(classifyCommit({ subject: 'fix(release): read every commit for the version bump and make it testable (#249)', body: a52ba8bBody })).toBe('patch'))
+
+  test('the honest pair: a real footer on its own line at the end → major', () =>
+    expect(classifyCommit({ subject: 'fix(release): rework the reader', body: 'why we did it\n\nBREAKING CHANGE: the reader signature changed' })).toBe('major'))
+
+  test('the token mid-paragraph (no line-leading colon token) → not breaking', () =>
+    expect(classifyCommit({ subject: 'fix: x', body: 'this introduces a BREAKING CHANGE for old clients somewhere' })).toBe('patch'))
+
+  test('the token inside backticks in prose → not breaking', () =>
+    expect(classifyCommit({ subject: 'feat: x', body: 'we now honour the `BREAKING CHANGE:` footer form' })).toBe('minor'))
+
+  test('the token in the SUBJECT but not as a footer → decided by the subject alone (no ! → not major)', () =>
+    expect(classifyCommit({ subject: 'fix: describe the BREAKING CHANGE handling' })).toBe('patch'))
+
+  test('a hyphen footer on its own line at the end → major', () =>
+    expect(classifyCommit({ subject: 'fix: x', body: 'context\n\nBREAKING-CHANGE: incompatible wire format' })).toBe('major'))
+})
+
 describe('bumpFromCommits — the defect that shipped v1.23.1', () => {
   test('a range whose ONLY commit is a feat → minor (the exact failing scenario)', () => {
     expect(bumpFromCommits([s('feat(web): live terminal panel (#246)')])).toBe('minor')

--- a/packages/core/src/versionBump.ts
+++ b/packages/core/src/versionBump.ts
@@ -32,8 +32,17 @@ export interface Commit {
   body?: string
 }
 
-/** A `BREAKING CHANGE` / `BREAKING-CHANGE` marker, per the Conventional Commits spec. */
-const BREAKING = /BREAKING[ -]CHANGE/i
+/**
+ * A breaking-change FOOTER, per the Conventional Commits spec: `BREAKING CHANGE:` (or the synonym
+ * `BREAKING-CHANGE:`) on a LINE OF ITS OWN, with the mandatory `:` separator. Anchored to the start
+ * of a line (`m` flag) so a mention in prose, mid-paragraph, or wrapped in backticks — which carries
+ * no line-leading token — is NOT a declaration. That distinction is the whole point: a substring
+ * scan read a52ba8b's own body (which describes the footer mechanism in backticked prose) as a
+ * break and rolled a false major. The colon after the token is what separates a footer from prose,
+ * so it is required. `[ \t]*` tolerates leading indentation without letting a token float into the
+ * middle of a line.
+ */
+const BREAKING_FOOTER = /^[ \t]*BREAKING[ -]CHANGE:/im
 /**
  * `type` or `type(scope)`, an optional `!`, then the mandatory `:` — matches `feat:`, `feat(web):`,
  * `feat!:`, `feat(web)!:`. Group 1 is the type; group 2 is the bang (present only when breaking).
@@ -51,8 +60,11 @@ export function classifyCommit(commit: Commit): SemverBump | null {
   const m = CONVENTIONAL.exec(subject)
   // A `!` before the colon marks a breaking change regardless of type (`feat!:`, `chore(x)!:`).
   if (m && m[2] === '!') return 'major'
-  // A `BREAKING CHANGE` marker in the subject or body is breaking too (the spec's footer form).
-  if (BREAKING.test(subject) || BREAKING.test(body)) return 'major'
+  // The spec's other breaking form is a FOOTER in the body — a line of its own, `BREAKING CHANGE:`
+  // (or `BREAKING-CHANGE:`). Only the footer counts: a mention in prose or inside backticks is a
+  // description, not a declaration. The subject carries no footer — its breaking form is the `!`
+  // above — so only the body is scanned.
+  if (BREAKING_FOOTER.test(body)) return 'major'
   if (m && m[1]!.toLowerCase() === 'feat') return 'minor'
   // A recognised conventional commit that is not a feature (fix, chore, docs, …) is a patch.
   if (m) return 'patch'


### PR DESCRIPTION
Closes #255

## Problem

`versionBump.classifyCommit` scanned the subject and body for the breaking-change marker as a bare substring. A commit that merely *describes* the footer mechanism in prose — with the token in backticks — read as a real break and rolled a whole major. That is how `a52ba8b`'s own body forced the false `v2.0.0`.

## Fix

Match only the footer form: the marker on a line of its own with its mandatory colon separator (`BREAKING-CHANGE` synonym included), anchored to the start of a line (`/^[ \t]*BREAKING[ -]CHANGE:/im`). A mention mid-paragraph or inside backticks no longer counts. The subject's breaking form stays the `!` before the colon; only the body is scanned for the footer.

## Tests

The fixture is the **real body of `a52ba8b`**, and the tests assert the honest pair:
- a `fix:` whose body mentions the footer token in backticked prose → **patch**
- a genuine footer on its own line at the end → **major**

so the fix cannot have merely switched detection off. Proven by mutation: reverting to the substring form reproves the four guarding cases.

## Verification

- `bun run stub && bun tsc --noEmit` — clean
- `bun test packages/core/src/versionBump.test.ts` — 37 pass
- `bun test` (full monorepo, incl. `tokens.lint.test.ts`) — 4614 pass, 0 fail

## Notes / out of scope

- The published `v2.0.0` tag is left untouched (product decision).
- Same substring-scan class elsewhere, not fixed here: GitHub's own `[skip ci]` scan (scans the whole message, not controllable from this repo) and `release.yml`'s `grep -q "chore: bump version"` skip-guard (matches the workflow's own generated commit; in the workflow file, outside `packages/core`).
- `bun.lock` and the bump commit not updating the lockfile are noted in the brief as separate journeys; not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)