### PR TITLE
feat(web): audit the write channel, fit the session card, scroll the whole terminal

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -2859,7 +2859,6 @@ export default function AppLayout() {
           currency={currency}
           brlRate={brlRate}
           lang={lang}
-          central={teamSession?.central === true}
           workflows={data.workflows}
           onClose={() => setSelectedSession(null)}
         />

--- a/packages/web/src/components/RecentSessions.tsx
+++ b/packages/web/src/components/RecentSessions.tsx
@@ -12,7 +12,7 @@ import { getTerminalZoom, setTerminalZoom, subscribeTerminalZoom, ZOOM_STEP, ZOO
 import { getPinnedIds, isSessionPinned, togglePinnedSession, subscribePinnedSessions, pinnedServerSnapshot, MAX_PINNED } from '../lib/pinnedSessions'
 import { getOpenModalSession, setOpenModalSession, subscribeOpenModalSession } from '../lib/openModalSession'
 import { useIsMobile } from '../hooks/useIsMobile'
-import { encodeProjectDir, transcriptSource, transcriptUnavailableNote, type TranscriptMessage } from '../lib/sessionTranscript'
+import { encodeProjectDir } from '../lib/sessionTranscript'
 import { resumeCommand } from '../lib/resumeCommand'
 import { HARNESS_LABELS, HARNESS_COLORS } from '../lib/harness'
 import { format, parseISO } from 'date-fns'
@@ -1455,93 +1455,6 @@ function CardChips({ s, lang }: { s: SessionMeta; lang: 'pt' | 'en' }) {
   )
 }
 
-/** The transcript, read from the harness's own reader (`lib/sessionTranscript.ts`). Moved out of a
- *  floating popover and into the expanded body, where there is room to read it. */
-function useSessionMessages(s: SessionMeta, open: boolean, isLive: boolean, lang: 'pt' | 'en') {
-  const [messages, setMessages] = useState<TranscriptMessage[] | null>(null)
-  const [loading, setLoading] = useState(false)
-  const source = useMemo(
-    () => transcriptSource({ session_id: s.session_id, project_path: s.project_path, harness: s.harness }),
-    [s.session_id, s.project_path, s.harness],
-  )
-  const unavailable = source.kind === 'unavailable' ? transcriptUnavailableNote(source.harness, lang) : null
-
-  useEffect(() => {
-    if (!open) return
-    // A harness with NO reader says so, rather than reporting a confident emptiness produced by a
-    // request nobody answered.
-    if (source.kind === 'unavailable') { setMessages([]); setLoading(false); return }
-    let interval: ReturnType<typeof setInterval> | null = null
-    const fetchMsgs = () => {
-      fetch(source.url)
-        .then(r => (r.ok ? r.json() : null))
-        .then((msgs: unknown) => {
-          if (Array.isArray(msgs)) setMessages(msgs as TranscriptMessage[])
-          else setMessages(prev => prev ?? [])
-        })
-        .catch(() => setMessages(prev => prev ?? []))
-        .finally(() => setLoading(false))
-    }
-    if (messages === null) setLoading(true)
-    fetchMsgs()
-    const es = new EventSource('/api/events')
-    es.addEventListener('change', fetchMsgs)
-    if (isLive) interval = setInterval(fetchMsgs, 2000)
-    return () => { es.close(); if (interval) clearInterval(interval) }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open, s.session_id, s.harness, s.project_path, isLive, source])
-
-  return { messages, loading, unavailable }
-}
-
-function DetailsBlock({ s, open, isLive, lang }: { s: SessionMeta; open: boolean; isLive: boolean; lang: 'pt' | 'en' }) {
-  const { messages, loading, unavailable } = useSessionMessages(s, open, isLive, lang)
-  return (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
-      {s.first_prompt && (
-        <div>
-          <div style={{ fontSize: 11, fontWeight: 700, color: 'var(--text-tertiary)', textTransform: 'uppercase', marginBottom: 4 }}>
-            {lang === 'pt' ? 'Prompt Inicial' : 'First Prompt'}
-          </div>
-          <div style={{ fontSize: 12, color: 'var(--text-secondary)', fontStyle: 'italic', lineHeight: 1.5, whiteSpace: 'pre-wrap', wordBreak: 'break-word', maxHeight: 120, overflowY: 'auto' }}>
-            "{s.first_prompt}"
-          </div>
-        </div>
-      )}
-      <div>
-        <div style={{ fontSize: 11, fontWeight: 700, color: 'var(--text-tertiary)', textTransform: 'uppercase', marginBottom: 4 }}>
-          {lang === 'pt' ? 'Últimas mensagens' : 'Latest messages'}
-        </div>
-        {loading ? (
-          <div style={{ fontSize: 11, color: 'var(--text-tertiary)' }}>{lang === 'pt' ? 'Carregando...' : 'Loading...'}</div>
-        ) : !messages || messages.length === 0 ? (
-          <div style={{ fontSize: 11, color: 'var(--text-tertiary)', fontStyle: 'italic', lineHeight: 1.5 }}>
-            {unavailable ?? (lang === 'pt' ? 'Nenhuma mensagem recente' : 'No recent messages')}
-          </div>
-        ) : (
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 6, maxHeight: 200, overflowY: 'auto' }}>
-            {messages.slice(-4).map((m, mi) => (
-              <div key={mi} style={{ fontSize: 11, padding: '6px 8px', borderRadius: 6, background: 'var(--bg-card)', border: '1px solid var(--border-subtle)', display: 'flex', flexDirection: 'column', gap: 2 }}>
-                <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-                  <span style={{ fontWeight: 700, color: m.role === 'user' ? 'var(--accent-blue)' : 'var(--anthropic-orange)' }}>
-                    {m.role === 'user' ? 'User: ' : 'Assistant: '}
-                  </span>
-                  {m.timestamp && (
-                    <span style={{ fontSize: 10, color: 'var(--text-tertiary)' }}>
-                      {format(parseISO(typeof m.timestamp === 'string' ? m.timestamp : new Date(m.timestamp).toISOString()), 'HH:mm:ss')}
-                    </span>
-                  )}
-                </div>
-                <span style={{ color: 'var(--text-secondary)', whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>{m.content.slice(0, 220)}</span>
-              </div>
-            ))}
-          </div>
-        )}
-      </div>
-    </div>
-  )
-}
-
 /** The small buttons that open the metrics modal / the resume-command modal. Grouped so both card
  *  variants render them the same way. */
 function CardFooterButtons({ s, lang, onSelect, onResume }: {
@@ -1977,7 +1890,6 @@ function LiveSessionCard({ s, lang, onSelect, isPinned, state, fleetRow, onFleet
   const accent = fleetStateColor(fleetRow.state)
   const primary = primaryAction(fleetRow)
   const watchable = isWatchable(fleetRow.state)
-  const isLive = Boolean(isPinned || resumeCommand(s))
 
   // In the GRID, opening never expands inline (that would stretch the whole row to the tallest card)
   // — it opens the modal, so the layout never moves. In the LIST there is no grid to break, so it
@@ -1987,14 +1899,15 @@ function LiveSessionCard({ s, lang, onSelect, isPinned, state, fleetRow, onFleet
   const statusPill = <StatusPill color={accent} label={fleetRow.stateLabel} />
   const meta = <CardMeta s={s} fleetRow={fleetRow} lang={lang} />
 
-  // `large` = inside the modal (fill the height, no maximize button); `open` gates the transcript fetch.
-  const body = (large: boolean, open: boolean) => (
+  // The card is session CONTROL, not a session dossier: only the metric chips stay on it. The first
+  // prompt / latest-messages block and the "Session metrics" button moved off — the deep-dive lives
+  // one click away, in the drilldown reached from the kebab.
+  const body = (large: boolean) => (
     <>
       {watchable && <TerminalRegion id={fleetRow.id} theme={theme ?? 'dark'} lang={lang} fill={large} onMaximize={large ? undefined : () => setModalOpen(true)} />}
       <SessionActionsPanel ctrl={ctrl} />
-      <DetailsBlock s={s} open={open} isLive={isLive} lang={lang} />
       <CardChips s={s} lang={lang} />
-      <CardFooterButtons s={s} lang={lang} onSelect={onSelect} onResume={() => setShowResumeModal(true)} />
+      <CardFooterButtons s={s} lang={lang} onResume={() => setShowResumeModal(true)} />
     </>
   )
 
@@ -2003,7 +1916,7 @@ function LiveSessionCard({ s, lang, onSelect, isPinned, state, fleetRow, onFleet
       {showResumeModal && <ResumeCommandModal s={s} lang={lang} onClose={() => setShowResumeModal(false)} />}
       {modalOpen && (
         <CardModal statusPill={statusPill} harness={s.harness} title={titleOf(s)} meta={meta} lang={lang} onClose={() => setModalOpen(false)}>
-          {body(true, true)}
+          {body(true)}
         </CardModal>
       )}
       <CardShell
@@ -2017,13 +1930,21 @@ function LiveSessionCard({ s, lang, onSelect, isPinned, state, fleetRow, onFleet
           <>
             <PinButton sessionId={s.session_id} lang={lang} />
             {primary && <PrimaryButton primary={primary} lang={lang} onExpand={openCard} onPick={ctrl.pick} />}
-            <SessionActionsMenu ctrl={ctrl} onActivate={openCard} />
+            <SessionActionsMenu
+              ctrl={ctrl}
+              onActivate={openCard}
+              extraItems={onSelect ? [{
+                key: 'metrics',
+                label: lang === 'pt' ? 'Métricas da sessão' : 'Session metrics',
+                onClick: () => onSelect(s),
+              }] : undefined}
+            />
           </>
         }
         meta={meta}
         affordance={isGrid ? <Maximize2 size={15} /> : (expanded ? <ChevronUp size={16} /> : <ChevronDown size={16} />)}
       >
-        {body(false, expanded)}
+        {body(false)}
       </CardShell>
     </>
   )
@@ -2036,16 +1957,16 @@ function HistorySessionCard({ s, lang, onSelect, isPinned, state, viewMode }: Se
   const setModalOpen = (open: boolean) => setOpenModalSession(open ? s.session_id : null)
   const [showResumeModal, setShowResumeModal] = useState(false)
   const status = getStatusInfo(state, isPinned)
-  const isLive = Boolean(isPinned || resumeCommand(s))
   const time = s.start_time ? format(parseISO(s.start_time), 'MMM d, HH:mm') : ''
   const openCard = () => { if (isGrid) setModalOpen(true); else setExpanded(v => !v) }
 
   const statusPill = <StatusPill color={status.color} label={lang === 'pt' ? status.labelPt : status.labelEn} />
   const meta = <CardMeta s={s} lang={lang} />
-  const body = (open: boolean) => (
+  // History rows have no fleet controller, so no kebab to move "Session metrics" into — it stays a
+  // footer button here (unlike the live card, which routes it through SessionActionsMenu).
+  const body = () => (
     <>
       <CardChips s={s} lang={lang} />
-      <DetailsBlock s={s} open={open} isLive={isLive} lang={lang} />
       <CardFooterButtons s={s} lang={lang} onSelect={onSelect} onResume={() => setShowResumeModal(true)} />
     </>
   )
@@ -2055,7 +1976,7 @@ function HistorySessionCard({ s, lang, onSelect, isPinned, state, viewMode }: Se
       {showResumeModal && <ResumeCommandModal s={s} lang={lang} onClose={() => setShowResumeModal(false)} />}
       {modalOpen && (
         <CardModal statusPill={statusPill} harness={s.harness} title={titleOf(s)} meta={meta} lang={lang} onClose={() => setModalOpen(false)}>
-          {body(true)}
+          {body()}
         </CardModal>
       )}
       <CardShell
@@ -2074,7 +1995,7 @@ function HistorySessionCard({ s, lang, onSelect, isPinned, state, viewMode }: Se
         meta={meta}
         affordance={isGrid ? <Maximize2 size={15} /> : (expanded ? <ChevronUp size={16} /> : <ChevronDown size={16} />)}
       >
-        {body(expanded)}
+        {body()}
       </CardShell>
     </>
   )

--- a/packages/web/src/components/RecentSessions.tsx
+++ b/packages/web/src/components/RecentSessions.tsx
@@ -93,6 +93,9 @@ interface Props {
   title?: React.ReactNode
   subtitle?: React.ReactNode
   topActions?: React.ReactNode
+  /** Who a write-channel send is attributed to in the audit — the IAM display name where the
+   *  dashboard has a login, else the browser's own operator id (resolved in `promptAudit`). */
+  authorName?: string
 }
 
 /** `task` is deliberately absent: a task is a fact of the agentop session registry, not of a
@@ -453,7 +456,7 @@ function getSessionBucketKey(
 
 const PAGE_SIZE_OPTIONS = [5, 10, 20, 50]
 
-export function RecentSessions({ sessions, lang, onSelect, pinnedIds, activities, viewMode: externalViewMode, onViewModeChange, fleet, onFleetAction, theme, defaultGrouping, defaultStatus, title, subtitle, topActions }: Props) {
+export function RecentSessions({ sessions, lang, onSelect, pinnedIds, activities, viewMode: externalViewMode, onViewModeChange, fleet, onFleetAction, theme, defaultGrouping, defaultStatus, title, subtitle, topActions, authorName }: Props) {
   const t = T[lang]
 
   // Grouping state — 'project' on the history surfaces; the Sessions page opens on 'repo'.
@@ -861,6 +864,7 @@ export function RecentSessions({ sessions, lang, onSelect, pinnedIds, activities
                     state={activities?.[s.session_id]}
                     fleetRow={fleet?.get(s.session_id)}
                     onFleetAction={onFleetAction}
+                    authorName={authorName}
                     viewMode="list"
                     theme={theme}
                   />
@@ -972,6 +976,7 @@ export function RecentSessions({ sessions, lang, onSelect, pinnedIds, activities
                           state={activities?.[s.session_id]}
                           fleetRow={fleet?.get(s.session_id)}
                           onFleetAction={onFleetAction}
+                          authorName={authorName}
                           viewMode={viewMode}
                           theme={theme}
                         />
@@ -1058,6 +1063,7 @@ export function RecentSessions({ sessions, lang, onSelect, pinnedIds, activities
               state={activities?.[s.session_id]}
               fleetRow={fleet?.get(s.session_id)}
               onFleetAction={onFleetAction}
+              authorName={authorName}
               viewMode={viewMode}
               theme={theme}
             />
@@ -1359,6 +1365,8 @@ interface SessionCardProps {
     => Promise<{ ok: boolean; message: string }>
   viewMode?: 'list' | 'grid'
   theme?: 'dark' | 'light'
+  /** Who a write-channel send is attributed to (threaded to the actions controller for the audit). */
+  authorName?: string
 }
 
 function SessionCard(props: SessionCardProps) {
@@ -1588,8 +1596,15 @@ function CardShell({
         onClick={onToggle}
         style={{ display: 'flex', flexDirection: 'column', gap: 6, padding: '12px 16px', cursor: 'pointer', userSelect: 'none', minWidth: 0 }}
       >
-        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12, minWidth: 0 }}>
-          <div style={{ display: 'flex', alignItems: 'center', gap: 10, flex: 1, minWidth: 0 }}>
+        {/* The header WRAPS. In a grid column (~360px) the action cluster is `flexShrink:0` and wide
+            (a "Send a prompt" button + pin + kebab + maximize), so on one non-wrapping row it crushed
+            the title to nothing and clipped the harness badge — the fields did not fit the column.
+            With `flexWrap`, when the actions cannot sit beside the identity they drop to their own
+            row and the pill + badge + title keep a full-width line where the title is readable; on a
+            wide card everything stays on one row exactly as before. `marginLeft:auto` right-aligns
+            the actions on the shared row (replacing space-between, which mis-spaces a wrapped line). */}
+        <div style={{ display: 'flex', alignItems: 'center', gap: 12, rowGap: 8, minWidth: 0, flexWrap: 'wrap' }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 10, flex: '1 1 170px', minWidth: 0 }}>
             {statusPill}
             <HarnessBadge harness={harness} />
             <span
@@ -1599,7 +1614,7 @@ function CardShell({
               {title}
             </span>
           </div>
-          <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexShrink: 0 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexShrink: 0, marginLeft: 'auto' }}>
             {right}
             <span style={{ color: 'var(--text-tertiary)', display: 'inline-flex' }}>
               {affordance}
@@ -1947,7 +1962,7 @@ function CardModal({ statusPill, harness, title, meta, lang, onClose, children }
 
 // ---- the two card variants -----------------------------------------------------------------------
 
-function LiveSessionCard({ s, lang, onSelect, isPinned, state, fleetRow, onFleetAction, theme, viewMode }: SessionCardProps & {
+function LiveSessionCard({ s, lang, onSelect, isPinned, state, fleetRow, onFleetAction, theme, viewMode, authorName }: SessionCardProps & {
   fleetRow: FleetRow
   onFleetAction: NonNullable<SessionCardProps['onFleetAction']>
 }) {
@@ -1956,7 +1971,7 @@ function LiveSessionCard({ s, lang, onSelect, isPinned, state, fleetRow, onFleet
   const modalOpen = useOpenModalSession() === s.session_id
   const setModalOpen = (open: boolean) => setOpenModalSession(open ? s.session_id : null)
   const [showResumeModal, setShowResumeModal] = useState(false)
-  const ctrl = useSessionActionsController(fleetRow, lang, onFleetAction)
+  const ctrl = useSessionActionsController(fleetRow, lang, onFleetAction, authorName)
   // The state indicator reads the FLEET — the same source the primary action reads — so the pill,
   // the accent and the lead action can never contradict each other.
   const accent = fleetStateColor(fleetRow.state)

--- a/packages/web/src/components/SessionActions.tsx
+++ b/packages/web/src/components/SessionActions.tsx
@@ -25,10 +25,20 @@
  * against — a second rule set here would be the bug `task-reopen.ts` exists to have fixed once.
  */
 
-import React, { useEffect, useRef, useState } from 'react'
-import { AlertTriangle, Check, Copy, MoreVertical, Terminal, X } from 'lucide-react'
+import React, { useEffect, useRef, useState, useSyncExternalStore } from 'react'
+import { AlertTriangle, Check, Copy, History, MoreVertical, Send, Terminal, X } from 'lucide-react'
+import { format, parseISO } from 'date-fns'
 import { useIsMobile } from '../hooks/useIsMobile'
 import { PERFORMABLE, TEXT_VERBS, type FleetActionId, type FleetRow, type FleetVerb } from '../lib/fleet'
+import {
+  auditForSession,
+  getPromptAudit,
+  operatorId,
+  recordPromptSend,
+  resolveAuthor,
+  subscribePromptAudit,
+  type PromptAuditEntry,
+} from '../lib/promptAudit'
 
 const T = {
   pt: {
@@ -47,6 +57,12 @@ const T = {
     external: 'Esta sessão não foi iniciada pelo agentop — nada aqui pode agir sobre ela.',
     noTask: 'Esta sessão não está em nenhuma tarefa.',
     working: 'Executando…',
+    sendingTo: 'Escrevendo em',
+    auditTitle: 'Enviados a esta sessão',
+    auditEmpty: 'Nada foi enviado a esta sessão por este navegador ainda.',
+    auditOk: 'entregue',
+    auditFail: 'falhou',
+    by: 'por',
     placeholder: {
       prompt: 'Uma linha para digitar nesta sessão…',
       rename: 'Novo nome para esta sessão…',
@@ -70,6 +86,12 @@ const T = {
     external: 'This session was not started by agentop — nothing here can act on it.',
     noTask: 'This session is not filed under any task.',
     working: 'Running…',
+    sendingTo: 'Writing to',
+    auditTitle: 'Sent to this session',
+    auditEmpty: 'Nothing has been sent to this session from this browser yet.',
+    auditOk: 'delivered',
+    auditFail: 'failed',
+    by: 'by',
     placeholder: {
       prompt: 'One line to type into this session…',
       rename: 'A new name for this session…',
@@ -77,6 +99,12 @@ const T = {
       task: 'Which task this session belongs to…',
     } as Record<string, string>,
   },
+}
+
+/** Subscribe to the write-channel audit log, scoped to one session (newest first). */
+function usePromptAuditForSession(sessionId: string): PromptAuditEntry[] {
+  const all = useSyncExternalStore(subscribePromptAudit, getPromptAudit, getPromptAudit)
+  return auditForSession(all, sessionId)
 }
 
 /** Verbs that end work and are asked about before they run. */
@@ -105,7 +133,14 @@ export interface SessionActionsController {
   refuse: (action: FleetActionId, reason?: string) => void
 }
 
-export function useSessionActionsController(row: FleetRow, lang: 'pt' | 'en', act: ActFn): SessionActionsController {
+export function useSessionActionsController(
+  row: FleetRow,
+  lang: 'pt' | 'en',
+  act: ActFn,
+  /** The IAM display name where the dashboard has a login; else the send is attributed to this
+   *  browser's stable operator id. Threaded from the page so the audit records a real actor. */
+  authorName?: string,
+): SessionActionsController {
   const t = T[lang]
   const [active, setActive] = useState<FleetActionId | null>(null)
   const [text, setText] = useState('')
@@ -116,6 +151,21 @@ export function useSessionActionsController(row: FleetRow, lang: 'pt' | 'en', ac
     setBusy(true)
     setMsg(null)
     const out = await act({ id: row.id, action, ...extra })
+    // AUDIT the write channel. `prompt` is the one verb that types free text INTO the session, so
+    // every one — accepted or refused — leaves a record of who/which session/what/when + the
+    // outcome. Recorded AFTER the server answers, so `ok`/`message` are the truth, and only when
+    // there was actually text (an empty submit never reaches here). See `lib/promptAudit.ts`.
+    if (action === 'prompt' && extra?.text && extra.text.trim()) {
+      recordPromptSend({
+        author: resolveAuthor({ accountName: authorName, operatorId: operatorId() }),
+        sessionId: row.id,
+        sessionTitle: row.title,
+        harness: row.harness,
+        text: extra.text,
+        ok: out.ok,
+        message: out.message,
+      })
+    }
     setBusy(false)
     setActive(null)
     setText('')
@@ -270,6 +320,7 @@ export function SessionActionsPanel({ ctrl }: { ctrl: SessionActionsController }
   const btn = (kind: 'plain' | 'danger' | 'primary') => btnStyle(kind, touch, isMobile)
 
   const killVerb = row.verbs.find(v => v.action === 'kill')
+  const audit = usePromptAuditForSession(row.id)
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 10, minWidth: 0 }}>
@@ -324,6 +375,25 @@ export function SessionActionsPanel({ ctrl }: { ctrl: SessionActionsController }
 
       {/* The inline form for whichever text verb is active. */}
       {active && TEXT_VERBS.has(active) && (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 8, minWidth: 0 }}>
+        {/* WHICH session this writes to, named at the moment of typing. Several terminals share one
+            page, and a prompt sent to the wrong one is the accident this line exists to prevent. */}
+        {active === 'prompt' && (
+          <div
+            style={{
+              display: 'flex', alignItems: 'center', gap: 6, minWidth: 0, fontSize: 11, fontWeight: 600,
+              color: 'var(--anthropic-orange)', border: '1px solid rgba(232,105,11,0.35)',
+              background: 'rgba(232,105,11,0.08)', borderRadius: 8, padding: '5px 9px',
+            }}
+          >
+            <Send size={12} style={{ flexShrink: 0 }} />
+            <span style={{ color: 'var(--text-tertiary)', fontWeight: 500, flexShrink: 0 }}>{t.sendingTo}</span>
+            <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }} title={`${row.title} · ${row.id}`}>
+              {row.title}
+            </span>
+            <code style={{ fontFamily: 'var(--font-mono, monospace)', fontSize: 10, opacity: 0.75, flexShrink: 0 }}>{row.id}</code>
+          </div>
+        )}
         <form
           onSubmit={e => { e.preventDefault(); if (text.trim()) void ctrl.run(active, { text }) }}
           style={{ display: 'flex', gap: 8, flexWrap: 'wrap', alignItems: 'center', minWidth: 0 }}
@@ -348,6 +418,7 @@ export function SessionActionsPanel({ ctrl }: { ctrl: SessionActionsController }
             <X size={13} /> {t.cancel}
           </button>
         </form>
+        </div>
       )}
 
       {/* The confirm for a destructive verb (Stop session). */}
@@ -404,6 +475,64 @@ export function SessionActionsPanel({ ctrl }: { ctrl: SessionActionsController }
           {msg.text}
         </div>
       )}
+
+      {/* The write-channel AUDIT for this session: every prompt this browser sent here, with the
+          author, the exact text, the time, and whether it landed. A send can never disappear in
+          silence — the record outlives the transient result line above. */}
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 6, minWidth: 0 }}>
+        <div style={{ display: 'inline-flex', alignItems: 'center', gap: 6, fontSize: 11, fontWeight: 700, color: 'var(--text-tertiary)', textTransform: 'uppercase', letterSpacing: 0.2 }}>
+          <History size={12} /> {t.auditTitle}{audit.length > 0 ? ` · ${audit.length}` : ''}
+        </div>
+        {audit.length === 0 ? (
+          <div style={{ fontSize: 11, color: 'var(--text-tertiary)', fontStyle: 'italic' }}>{t.auditEmpty}</div>
+        ) : (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 4, maxHeight: 180, overflowY: 'auto' }}>
+            {audit.map(e => (
+              <div
+                key={e.id}
+                style={{
+                  fontSize: 11, padding: '6px 8px', borderRadius: 6, background: 'var(--bg-card)',
+                  border: '1px solid var(--border-subtle)', display: 'flex', flexDirection: 'column', gap: 3, minWidth: 0,
+                }}
+              >
+                <div style={{ display: 'flex', alignItems: 'center', gap: 6, flexWrap: 'wrap' }}>
+                  <span
+                    style={{
+                      display: 'inline-flex', alignItems: 'center', gap: 4, fontWeight: 700, fontSize: 10,
+                      padding: '1px 6px', borderRadius: 999,
+                      color: e.ok ? '#22c55e' : '#ef4444',
+                      background: e.ok ? 'rgba(34,197,94,0.12)' : 'rgba(239,68,68,0.12)',
+                      border: `1px solid ${e.ok ? 'rgba(34,197,94,0.3)' : 'rgba(239,68,68,0.3)'}`,
+                    }}
+                  >
+                    {e.ok ? <Check size={10} /> : <X size={10} />} {e.ok ? t.auditOk : t.auditFail}
+                  </span>
+                  <span style={{ color: 'var(--text-tertiary)', fontVariantNumeric: 'tabular-nums' }} title={e.at}>
+                    {auditTime(e.at)}
+                  </span>
+                  <span style={{ color: 'var(--text-tertiary)' }}>{t.by}</span>
+                  <span style={{ color: 'var(--text-secondary)', fontWeight: 600, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', maxWidth: 160 }} title={e.author}>
+                    {e.author}
+                  </span>
+                </div>
+                <span style={{ color: 'var(--text-primary)', whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>{e.text}</span>
+                {!e.ok && e.message && (
+                  <span style={{ color: '#ef4444', fontSize: 10 }}>{e.message}</span>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
     </div>
   )
+}
+
+/** A recorded send's time, shown compactly; the full ISO stays in the row's `title`. */
+function auditTime(iso: string): string {
+  try {
+    return format(parseISO(iso), 'HH:mm:ss')
+  } catch {
+    return iso
+  }
 }

--- a/packages/web/src/components/SessionActions.tsx
+++ b/packages/web/src/components/SessionActions.tsx
@@ -1,12 +1,16 @@
 /**
  * SessionActions — what you can do with ONE session, split into a MENU and a PANEL.
  *
- * It replaced a flat bar of eight buttons drawn under every card. A row is not a toolbar: the eight
- * verbs (`Answer its question`, `Send a prompt`, `Rename`, `Note`, `Task`, `Open whole task`,
- * `Finish task`, `Stop session`) now live behind a kebab MENU, and only the state's ONE lead action
- * stays on the row (decided by the pure `primaryAction`). The forms, the confirm, the dialog to
- * answer, the attach command and the result all render in the PANEL, inside the session's expanded
- * accordion.
+ * It replaced a flat bar of eight buttons drawn under every card. A row is not a toolbar: the fleet
+ * verbs (`Answer its question`, `Send a prompt`, `Rename`, `Note`, `Task`, `Stop session`) live
+ * behind a kebab MENU, and only the state's ONE lead action stays on the row (decided by the pure
+ * `primaryAction`). `Open whole task` / `Finish task` are DROPPED from the menu entirely (`HIDDEN_VERBS`
+ * below) — never rendered, never pickable — because the card is session control, not task
+ * bookkeeping; those two belong to the fleet cockpit. The menu also carries non-fleet items the CARD
+ * itself decides on (`extraItems`, e.g. "Session metrics") — listed above the fleet verbs, since a
+ * menu already opened to act on a session is also where you look to inspect it. The forms, the
+ * confirm, the dialog to answer, the attach command and the result all render in the PANEL, inside
+ * the session's expanded accordion.
  *
  * The rules the bar carried are kept, because they are what make this honest:
  *  - **A verb this row cannot take is DISABLED and refuses in a SENTENCE**, never silently inert —
@@ -109,6 +113,18 @@ function usePromptAuditForSession(sessionId: string): PromptAuditEntry[] {
 
 /** Verbs that end work and are asked about before they run. */
 const CONFIRM_VERBS: ReadonlySet<FleetActionId> = new Set<FleetActionId>(['kill'])
+
+/** Task bookkeeping verbs — deliberately never rendered in the menu. The card is session control,
+ *  not task management; these two belong to the fleet cockpit, not the dashboard. */
+const HIDDEN_VERBS: ReadonlySet<FleetActionId> = new Set<FleetActionId>(['openTask', 'finishTask'])
+
+/** A non-fleet item the card mixes into the menu (e.g. "Session metrics") — the menu is where you
+ *  act on a session, and also where you go to inspect it. */
+export interface SessionMenuExtraItem {
+  key: string
+  label: string
+  onClick: () => void
+}
 
 type ActFn = (req: { id: string; action: FleetActionId; text?: string; choice?: number })
   => Promise<{ ok: boolean; message: string }>
@@ -234,7 +250,11 @@ function btnStyle(kind: 'plain' | 'danger' | 'primary', touch: number, isMobile:
  * Picking one runs it or opens its form in the panel (via the shared controller) — and calls
  * `onActivate`, which the card uses to open the accordion so whatever the pick produced is visible.
  */
-export function SessionActionsMenu({ ctrl, onActivate }: { ctrl: SessionActionsController; onActivate: () => void }) {
+export function SessionActionsMenu({ ctrl, onActivate, extraItems }: {
+  ctrl: SessionActionsController
+  onActivate: () => void
+  extraItems?: SessionMenuExtraItem[]
+}) {
   const t = T[ctrl.lang]
   const [open, setOpen] = useState(false)
   const wrapRef = useRef<HTMLDivElement | null>(null)
@@ -279,7 +299,28 @@ export function SessionActionsMenu({ ctrl, onActivate }: { ctrl: SessionActionsC
             display: 'flex', flexDirection: 'column', gap: 2,
           }}
         >
-          {ctrl.row.verbs.map(v => {
+          {extraItems && extraItems.length > 0 && (
+            <>
+              {extraItems.map(item => (
+                <button
+                  key={item.key}
+                  role="menuitem"
+                  onClick={() => { item.onClick(); setOpen(false) }}
+                  style={{
+                    display: 'flex', alignItems: 'center', gap: 8, width: '100%',
+                    padding: isMobile ? '11px 10px' : '7px 10px', borderRadius: 6, border: 'none',
+                    background: 'transparent', cursor: 'pointer', textAlign: 'left',
+                    fontFamily: 'inherit', fontSize: isMobile ? 14 : 12, fontWeight: 500,
+                    color: 'var(--text-primary)',
+                  }}
+                >
+                  <span>{item.label}</span>
+                </button>
+              ))}
+              <div style={{ height: 1, background: 'var(--border-subtle)', margin: '4px 2px' }} />
+            </>
+          )}
+          {ctrl.row.verbs.filter(v => !HIDDEN_VERBS.has(v.action)).map(v => {
             const live = v.enabled && PERFORMABLE.has(v.action)
             return (
               <button

--- a/packages/web/src/components/SessionDrilldownModal.tsx
+++ b/packages/web/src/components/SessionDrilldownModal.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react'
 import { format, parseISO } from 'date-fns'
 import {
   X, Clock, FileCode, GitCommit, Wrench, MessageSquare, Bot, Zap, AlertTriangle,
-  CheckCircle, XCircle, Globe, Server, ExternalLink, Workflow as WorkflowIcon,
+  CheckCircle, XCircle, Globe, Workflow as WorkflowIcon,
 } from 'lucide-react'
 import type { SessionMeta, Lang, WorkflowRun } from '@agentistics/core'
 import { sessionTime } from '../lib/sessionTime'
@@ -14,7 +14,6 @@ import {
 import { blendedCostPerToken, blendedSessionCost } from '../hooks/useData'
 import { buildWorkflowSteps } from '../lib/workflowSteps'
 import { fmt as fmtShort, fmtFull, workflowTokens } from '@agentistics/core'
-import { HARNESS_LABELS, HARNESS_COLORS } from '../lib/harness'
 import { PrecisionToggle } from './PrecisionToggle'
 import { useIsMobile } from '../hooks/useIsMobile'
 import { splitInlinedHistory } from '../lib/transcriptSplit'
@@ -25,8 +24,6 @@ interface Props {
   currency: 'USD' | 'BRL'
   brlRate: number
   lang: Lang
-  /** true when this agentistics instance is running in central (hub) mode */
-  central?: boolean
   /** All dynamic-workflow runs (from /api/data); this modal shows the ones for THIS session. */
   workflows?: WorkflowRun[]
   onClose: () => void
@@ -84,7 +81,7 @@ function sessionCost(session: SessionMeta, globalModelUsage: Props['globalModelU
   return blendedSessionCost(session, blendedCostPerToken(globalModelUsage))
 }
 
-export function SessionDrilldownModal({ session, globalModelUsage, currency, brlRate, lang, central, workflows, onClose }: Props) {
+export function SessionDrilldownModal({ session, globalModelUsage, currency, brlRate, lang, workflows, onClose }: Props) {
   const pt = lang === 'pt'
   /** `Lang` narrowed for the token vocabulary — `lang` is widened elsewhere in this component. */
   const tokLang: Lang = pt ? 'pt' : 'en'
@@ -224,37 +221,6 @@ export function SessionDrilldownModal({ session, globalModelUsage, currency, brl
             </div>
           </div>
           <div style={{ display: 'flex', alignItems: 'center', gap: 6, flexShrink: 0 }}>
-            {!central && (
-              <button
-                onClick={() => {
-                  const isNay = session.project_path.includes('.agentistics/nay-chat')
-                  if (isNay) {
-                    window.dispatchEvent(new CustomEvent('agentistics:open-nay-chat', {
-                      detail: { sessionId: session.session_id },
-                    }))
-                  } else {
-                    const harness = session.harness ?? 'claude'
-                    // Match Claude's folder encoding: every non-alphanumeric char → '-'
-                    const encodedDir = session.project_path.replace(/[^a-zA-Z0-9-]/g, '-')
-                    window.dispatchEvent(new CustomEvent('agentistics:open-transcript', {
-                      detail: { harness, sessionId: session.session_id, project: { path: session.project_path, name: session.project_path.split('/').pop() ?? session.project_path, encodedDir } },
-                    }))
-                  }
-                }}
-                title={session.project_path.includes('.agentistics/nay-chat') ? 'Open in Nay Chat' : 'View transcript'}
-                style={{
-                  height: 30, padding: '0 10px',
-                  display: 'flex', alignItems: 'center', gap: 5,
-                  border: '1px solid var(--border)', borderRadius: 8,
-                  background: 'transparent',
-                  color: session.project_path.includes('.agentistics/nay-chat') ? 'var(--anthropic-orange)' : HARNESS_COLORS[session.harness ?? 'claude'],
-                  cursor: 'pointer', fontSize: 11, fontFamily: 'inherit', fontWeight: 500,
-                }}
-              >
-                <ExternalLink size={12} />
-                {session.project_path.includes('.agentistics/nay-chat') ? 'Nay' : HARNESS_LABELS[session.harness ?? 'claude']}
-              </button>
-            )}
             <button
               onClick={onClose}
               style={{
@@ -271,23 +237,6 @@ export function SessionDrilldownModal({ session, globalModelUsage, currency, brl
         </div>
 
         <div style={{ padding: isMobile ? '14px 16px' : '18px 22px', display: 'flex', flexDirection: 'column', gap: 18 }}>
-
-          {/* First prompt */}
-          {session.first_prompt && (
-            <div style={{
-              background: 'var(--bg-elevated)',
-              border: '1px solid var(--border-subtle)',
-              borderRadius: 10,
-              padding: '11px 14px',
-            }}>
-              <div style={{ fontSize: 10, fontWeight: 600, color: 'var(--text-tertiary)', textTransform: 'uppercase', letterSpacing: '0.04em', marginBottom: 5 }}>
-                {pt ? 'Prompt inicial' : 'First prompt'}
-              </div>
-              <div style={{ fontSize: 12, color: 'var(--text-secondary)', lineHeight: 1.5, fontStyle: 'italic', whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
-                "{session.first_prompt}"
-              </div>
-            </div>
-          )}
 
           {/* KPIs */}
           <div>
@@ -400,11 +349,11 @@ export function SessionDrilldownModal({ session, globalModelUsage, currency, brl
             </div>
           )}
 
-          {/* Capabilities chips */}
-          {(session.uses_mcp || session.uses_web_search || session.uses_web_fetch || session.uses_task_agent) && (
+          {/* Capabilities chips — no hardware/server icon here: MCP is a wiring detail, not a
+              session metric, and it read as a stray "hardware" glyph beside the real numbers. */}
+          {(session.uses_web_search || session.uses_web_fetch || session.uses_task_agent) && (
             <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
               {session.uses_task_agent && <Capability icon={<Bot size={10} />} label={pt ? 'Subagents' : 'Subagents'} color="var(--accent-purple, #a855f7)" />}
-              {session.uses_mcp && <Capability icon={<Server size={10} />} label="MCP" color="var(--accent-cyan, #06b6d4)" />}
               {session.uses_web_search && <Capability icon={<Globe size={10} />} label="Web search" color="var(--accent-blue, #3b82f6)" />}
               {session.uses_web_fetch && <Capability icon={<Globe size={10} />} label="Web fetch" color="var(--accent-blue, #3b82f6)" />}
             </div>

--- a/packages/web/src/components/SessionTerminal.tsx
+++ b/packages/web/src/components/SessionTerminal.tsx
@@ -54,6 +54,12 @@ const FONT_SIZE = 13
 const FONT_FAMILY =
   "'JetBrains Mono', 'Fira Code', 'SF Mono', 'Cascadia Code', Menlo, Consolas, 'Liberation Mono', monospace"
 
+/** The floor the fit-to-width auto-shrink may not cross. `11px` is not a made-up number — it is the
+ *  smallest body text already used throughout this dashboard (the metric chips, the card meta row).
+ *  Below it, letters stop being legible characters and become texture; the box scrolls sideways
+ *  instead (see `fit`'s doc comment). */
+const MIN_SCALE = 11 / FONT_SIZE
+
 /**
  * Has the renderer measured its cell dimensions yet? `resize()` schedules a viewport sync that reads
  * `renderService.dimensions`, and doing that before the first measured render (or after dispose)
@@ -120,13 +126,18 @@ export default function SessionTerminal({ frame, theme, showCursor, zoom = 1 }: 
    * Fit the natural cols×rows grid into the box by scaling the PIXELS — never by resizing the
    * buffer, so the column count (and therefore the line breaks) never change.
    *
-   * The base is fit-to-WIDTH: at zoom 1 every column is shown and nothing scrolls, however wide the
-   * pane — a 252-column pane is simply drawn smaller so it fits. There is deliberately NO lower
-   * bound: a floor would leave a very wide pane overflowing a narrow box (exactly the "cut on both
-   * ends" the accordion showed), and the zoom control is the user's way to enlarge instead — the
-   * readable path for a wide pane is the maximize MODAL, where the box is wide enough to hold it. It
-   * is never enlarged past 1:1. The user's zoom multiplies the base; above what the box holds, the
-   * box scrolls. At every scale the bytes on screen are exactly what `capture-pane` drew.
+   * The base is fit-to-WIDTH: at zoom 1 every column is shown — a 252-column pane is drawn smaller
+   * so it fits — but ONLY DOWN TO `MIN_SCALE`. Below that the card was shrinking a pane's own
+   * captured width into illegibility by DEFAULT, with nothing to blame it on: a 157-column capture
+   * (an ordinary width — this is not a wide-pane edge case) in a ~900px card measured a real 11px
+   * row height at "100%", and the same capture in a narrower card falls well under that. The zoom
+   * control could not fix it either, because "100%" there means "no extra zoom on top of the
+   * auto-shrink" — it reads the multiplier, not the rendered size, so the control looked fine while
+   * the text was not. Past `MIN_SCALE` the box SCROLLS horizontally instead of continuing to shrink
+   * (it already supports that — `overflow: auto` on both axes below) — the same trade this module
+   * already makes vertically for a tall capture (see `paint`'s `bufRows`). It is never enlarged past
+   * 1:1. The user's zoom still multiplies the base; above what the box holds, the box scrolls. At
+   * every scale the bytes on screen are exactly what `capture-pane` drew.
    */
   function fit() {
     const box = boxRef.current
@@ -143,7 +154,7 @@ export default function SessionTerminal({ frame, theme, showCursor, zoom = 1 }: 
     host.style.height = `${natH}px`
     const availW = box.clientWidth
     if (!availW) return
-    const base = Math.min(1, availW / natW)
+    const base = Math.max(MIN_SCALE, Math.min(1, availW / natW))
     const s = base * zoomRef.current
     host.style.transform = `scale(${s})`
     host.style.transformOrigin = 'top left'

--- a/packages/web/src/components/SessionTerminal.tsx
+++ b/packages/web/src/components/SessionTerminal.tsx
@@ -14,11 +14,18 @@
  * FIDELITY vs the box — the fix for the "scattered words" bug. The frame was captured at the pane's
  * OWN width (`f.cols`, routinely 157/200+) and every line is already hard-broken at that width by
  * tmux. Rendering it into an emulator of ANY other column count reflows those lines and scatters the
- * text — so the emulator is always resized to EXACTLY `f.cols × f.rows` and never fitted to the box.
- * A 157-column grid does not fit a card, so instead of reflowing (wrong) or clipping to a scroll
+ * text — so the emulator's COLUMN count is always EXACTLY `f.cols` and never fitted to the box. A
+ * 157-column grid does not fit a card, so instead of reflowing (wrong) or clipping to a scroll
  * window (what read as broken), the whole grid is SCALED to the box with a CSS transform: the layout
  * stays byte-for-byte what `capture-pane` drew, only smaller. `transform` is visual only — it never
- * changes the buffer's column count — so nothing wraps.
+ * changes the buffer's column count — so nothing wraps. The discriminant between a faithful and a
+ * broken terminal is therefore the pane's COLUMN count against the box, and the scale is what
+ * answers it; a session broke precisely when its columns overflowed a box the fit did not shrink.
+ *
+ * SCROLL — the emulator's ROW count is the whole capture (`max(f.rows, f.lines)`), not one screen,
+ * so every shipped line lives on the grid and the fixed-height box scrolls through all of it (see
+ * `paint`). Sizing it to the visible screen alone left the earlier lines in xterm's own scrollback,
+ * which a per-frame `reset()` wiped — so scrolling up never reached the start of the conversation.
  *
  * Timing: `resize()` throws asynchronously inside xterm if it runs before the renderer has measured
  * its cell dimensions (an unmeasured `Viewport.syncScrollArea` reads `dimensions` off `undefined`),
@@ -146,17 +153,34 @@ export default function SessionTerminal({ frame, theme, showCursor, zoom = 1 }: 
 
   function paint() {
     const term = termRef.current
+    const box = boxRef.current
     const { frame: f, showCursor: cur } = pendingRef.current
     if (!term || disposedRef.current || !readyRef.current || !f) return
 
-    // EXACTLY the pane's geometry — the one column count at which its lines do not reflow — but only
-    // when it CHANGED and the renderer has measured, so a resize never schedules a viewport sync it
-    // is not ready for (the async `dimensions` throw). If it is not ready this frame, skip the
-    // resize and paint at the current size; the next frame, or the ready-gate, catches up.
-    if (f.cols > 0 && f.rows > 0 && (f.cols !== geomRef.current.cols || f.rows !== geomRef.current.rows) && dimensionsReady(term)) {
+    // SCROLL model. A capture carries up to `TERMINAL_VIEW_LINES` (200) lines of scrollback+screen,
+    // routinely MORE than one pane-height. The emulator is therefore sized to hold EVERY shipped
+    // line at once (`bufRows`), never just the visible screen: the extra lines used to fall into
+    // xterm's own scrollback, which — with a full snapshot `reset()`+`write()` every frame — was
+    // wiped and snapped back to the bottom twice a second, so scrolling up never reached the
+    // conversation. With the whole capture on one grid, the fixed-height BOX (`overflow:auto`)
+    // scrolls through all of it and its scroll position survives every repaint. Columns are still
+    // EXACTLY `f.cols`, so nothing reflows — the fidelity fix is untouched. What is NOT in this 200
+    // is disclosed by the status line's `truncated`; that ceiling is the server's, stated, not hidden.
+    const bufRows = Math.max(f.rows, f.lines)
+
+    // Stick-to-bottom: remember whether the reader was already at the live edge BEFORE the repaint,
+    // so a new frame follows the tail for someone watching live, but never yanks a reader who has
+    // scrolled up to read history. A small threshold absorbs sub-pixel rounding from the scale.
+    const wasAtBottom = !box || (box.scrollTop + box.clientHeight >= box.scrollHeight - 4)
+
+    // EXACTLY the pane's column count — the one width at which its lines do not reflow — with the row
+    // count grown to the whole capture. Only when it CHANGED and the renderer has measured, so a
+    // resize never schedules a viewport sync it is not ready for (the async `dimensions` throw). If
+    // it is not ready this frame, paint at the current size; the next frame, or the ready-gate, catches up.
+    if (f.cols > 0 && bufRows > 0 && (f.cols !== geomRef.current.cols || bufRows !== geomRef.current.rows) && dimensionsReady(term)) {
       try {
-        term.resize(f.cols, f.rows)
-        geomRef.current = { cols: f.cols, rows: f.rows }
+        term.resize(f.cols, bufRows)
+        geomRef.current = { cols: f.cols, rows: bufRows }
       } catch {
         /* geometry can momentarily disagree with the DOM; the next frame corrects it */
       }
@@ -167,16 +191,19 @@ export default function SessionTerminal({ frame, theme, showCursor, zoom = 1 }: 
       // The write callback fires asynchronously; the terminal may have been disposed since (the
       // accordion collapsed, the id changed). Writing to a disposed terminal throws, so bail.
       if (disposedRef.current || termRef.current !== term) return
-      // After the content is laid out, place (or hide) the block cursor. Done in the write callback
-      // so it lands after xterm has parsed the snapshot, not racing it.
+      // After the content is laid out, place (or hide) the block cursor. The frame's cursor is
+      // relative to the VISIBLE screen (the last `f.rows`), so on a taller buffer it is offset down
+      // by the scrollback that precedes the live screen — otherwise the cursor lands in the history.
       if (cur && f.cursor) {
-        term.write(`\x1b[?25h\x1b[${f.cursor.y + 1};${f.cursor.x + 1}H`)
+        const cursorRow = f.cursor.y + Math.max(0, f.lines - f.rows)
+        term.write(`\x1b[?25h\x1b[${cursorRow + 1};${f.cursor.x + 1}H`)
       } else {
         term.write('\x1b[?25l')
       }
-      // Re-fit AFTER the write settles — the grid's natural size is only final once the new
-      // geometry has rendered.
+      // Re-fit AFTER the write settles — the grid's natural size is only final once the new geometry
+      // has rendered — then re-pin to the live edge if that is where the reader was.
       fit()
+      if (wasAtBottom && boxRef.current) boxRef.current.scrollTop = boxRef.current.scrollHeight
     })
   }
 

--- a/packages/web/src/lib/promptAudit.test.ts
+++ b/packages/web/src/lib/promptAudit.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from 'bun:test'
+import {
+  buildAuditEntry,
+  appendAudit,
+  auditForSession,
+  resolveAuthor,
+  parseStoredAudit,
+  MAX_AUDIT_ENTRIES,
+  MAX_AUDIT_TEXT,
+  type PromptAuditEntry,
+  type PromptAuditInput,
+} from './promptAudit'
+
+const INPUT: PromptAuditInput = {
+  author: 'op-abc123',
+  sessionId: 'agentop-3f5f',
+  sessionTitle: 'COORDENADOR',
+  harness: 'claude',
+  text: 'please run the tests',
+  ok: true,
+  message: 'Prompt sent to agentop-3f5f.',
+}
+
+const NOW = new Date('2026-08-30T12:34:56.000Z')
+
+describe('buildAuditEntry', () => {
+  it('captures who / which session / what / when and the outcome', () => {
+    const e = buildAuditEntry(INPUT, NOW, 'id-1')
+    expect(e).toEqual({
+      id: 'id-1',
+      at: '2026-08-30T12:34:56.000Z',
+      author: 'op-abc123',
+      sessionId: 'agentop-3f5f',
+      sessionTitle: 'COORDENADOR',
+      harness: 'claude',
+      text: 'please run the tests',
+      ok: true,
+      message: 'Prompt sent to agentop-3f5f.',
+    })
+  })
+
+  it('records a FAILED send just as faithfully as a success', () => {
+    const e = buildAuditEntry({ ...INPUT, ok: false, message: 'Could not send to agentop-3f5f.' }, NOW, 'id-2')
+    expect(e.ok).toBe(false)
+    expect(e.message).toBe('Could not send to agentop-3f5f.')
+  })
+
+  it('trims the text and caps a pasted blob', () => {
+    const e = buildAuditEntry({ ...INPUT, text: `  hello  ` }, NOW, 'id-3')
+    expect(e.text).toBe('hello')
+    const big = buildAuditEntry({ ...INPUT, text: 'x'.repeat(MAX_AUDIT_TEXT + 500) }, NOW, 'id-4')
+    expect(big.text.length).toBe(MAX_AUDIT_TEXT)
+  })
+
+  it('never records a blank author', () => {
+    const e = buildAuditEntry({ ...INPUT, author: '   ' }, NOW, 'id-5')
+    expect(e.author).toBe('unknown')
+  })
+})
+
+describe('appendAudit', () => {
+  const entry = (id: string): PromptAuditEntry => buildAuditEntry({ ...INPUT, text: id }, NOW, id)
+
+  it('prepends newest-first without mutating the input', () => {
+    const a = [entry('a')]
+    const b = appendAudit(a, entry('b'))
+    expect(b.map(e => e.id)).toEqual(['b', 'a'])
+    expect(a.map(e => e.id)).toEqual(['a']) // input untouched
+  })
+
+  it('caps the log, dropping the oldest', () => {
+    let list: PromptAuditEntry[] = []
+    for (let i = 0; i < MAX_AUDIT_ENTRIES + 10; i++) list = appendAudit(list, entry(`e${i}`))
+    expect(list.length).toBe(MAX_AUDIT_ENTRIES)
+    // newest first, so the first entry is the last appended and the oldest ones fell off
+    expect(list[0]?.id).toBe(`e${MAX_AUDIT_ENTRIES + 9}`)
+    expect(list.some(e => e.id === 'e0')).toBe(false)
+  })
+})
+
+describe('auditForSession', () => {
+  it('returns only the records for one session, in order', () => {
+    const list = [
+      buildAuditEntry({ ...INPUT, sessionId: 'b' }, NOW, '3'),
+      buildAuditEntry({ ...INPUT, sessionId: 'a' }, NOW, '2'),
+      buildAuditEntry({ ...INPUT, sessionId: 'b' }, NOW, '1'),
+    ]
+    expect(auditForSession(list, 'b').map(e => e.id)).toEqual(['3', '1'])
+    expect(auditForSession(list, 'a').map(e => e.id)).toEqual(['2'])
+    expect(auditForSession(list, 'zzz')).toEqual([])
+  })
+})
+
+describe('resolveAuthor', () => {
+  it('prefers an IAM display name when the dashboard has one', () => {
+    expect(resolveAuthor({ accountName: 'Ada Lovelace', operatorId: 'op-1' })).toBe('Ada Lovelace')
+  })
+  it('falls back to the browser operator id when there is no account', () => {
+    expect(resolveAuthor({ accountName: null, operatorId: 'op-1' })).toBe('op-1')
+    expect(resolveAuthor({ accountName: '   ', operatorId: 'op-1' })).toBe('op-1')
+    expect(resolveAuthor({ operatorId: 'op-1' })).toBe('op-1')
+  })
+})
+
+describe('parseStoredAudit', () => {
+  it('reads a well-formed stored log', () => {
+    const stored = JSON.stringify([buildAuditEntry(INPUT, NOW, 'id-1')])
+    expect(parseStoredAudit(stored).map(e => e.id)).toEqual(['id-1'])
+  })
+  it('treats null / junk / wrong-shape as an empty log rather than throwing', () => {
+    expect(parseStoredAudit(null)).toEqual([])
+    expect(parseStoredAudit('not json')).toEqual([])
+    expect(parseStoredAudit('{"not":"an array"}')).toEqual([])
+    expect(parseStoredAudit('[{"id":"x"}]')).toEqual([]) // missing required fields
+  })
+})

--- a/packages/web/src/lib/promptAudit.ts
+++ b/packages/web/src/lib/promptAudit.ts
@@ -1,0 +1,219 @@
+/**
+ * promptAudit.ts — the write channel's audit trail, kept in the browser on purpose.
+ *
+ * Sending a prompt into a live session is the one thing this dashboard does that CHANGES another
+ * process, so the PE's condition for allowing it was that every send leaves a record: who sent it,
+ * to which session, what, and when. This module is that record.
+ *
+ * WHY IT LIVES HERE, not on the server. The only audit trail the server has (`server/audit.ts`) is a
+ * Mongo-backed, team-security log — its actions are logins, account/token/team changes — and
+ * `writeAudit` no-ops entirely when there is no Mongo. The fleet write channel runs on a solo /
+ * machine install where that database does not exist, and its accountable actor is not an IAM
+ * account but whoever is at THIS browser driving the local dashboard. Extending the server's log to
+ * cover local session writes is a `packages/server` change and outside this package. So the honest
+ * place for the record is the browser that performed the send: a persisted, VISIBLE log rendered
+ * next to the terminal, so a send can never vanish in silence and its outcome is always on the
+ * record — which is also the "feedback of what happened" the same requirement asks for.
+ *
+ * The content is stored as typed (only length-capped): this is the operator's own log of their own
+ * sends on their own machine, and redacting "what did I send?" would defeat the record's whole
+ * purpose — unlike the server log, which is shared and therefore scrubs secret-shaped fields.
+ *
+ * The pure half (`buildAuditEntry` / `appendAudit` / `resolveAuthor`) is tested; the localStorage
+ * store is guarded exactly like `terminalZoom.ts` (private mode is a missing log, never a throw).
+ */
+
+const KEY = 'agentistics-prompt-audit-v1'
+const OPERATOR_KEY = 'agentistics-operator-id'
+
+/** Bound the log so one busy afternoon cannot grow it without limit — newest kept, oldest dropped. */
+export const MAX_AUDIT_ENTRIES = 200
+/** A prompt is one line; cap defensively so a pasted blob cannot bloat storage. */
+export const MAX_AUDIT_TEXT = 2000
+
+/** One recorded send of text into a session. */
+export interface PromptAuditEntry {
+  /** Unique within the log, so React keys and de-dup are stable. */
+  id: string
+  /** ISO-8601, UTC. `parseISO`-friendly, like every other timestamp on the wire. */
+  at: string
+  /** Who performed the send — an IAM display name where the dashboard has one, else this browser's
+   *  stable operator id. Never invented: see `resolveAuthor`. */
+  author: string
+  /** The fleet/tmux id the text was written to — the unambiguous target, not the display title. */
+  sessionId: string
+  /** The session's human title at the moment of the send, so the log reads without a fleet lookup. */
+  sessionTitle: string
+  harness: string
+  /** The exact text submitted into the session. */
+  text: string
+  /** The server's answer: true = accepted, false = refused/failed. A record is written either way. */
+  ok: boolean
+  /** The already-localized sentence the server returned, kept verbatim for the record. */
+  message: string
+}
+
+export interface PromptAuditInput {
+  author: string
+  sessionId: string
+  sessionTitle: string
+  harness: string
+  text: string
+  ok: boolean
+  message: string
+}
+
+/** Trim and cap the recorded text; a prompt is a line, not a document. */
+function clampText(text: string): string {
+  const t = text.trim()
+  return t.length > MAX_AUDIT_TEXT ? t.slice(0, MAX_AUDIT_TEXT) : t
+}
+
+/**
+ * Build one record from a completed send. `now` and `id` are injected so the builder is pure and the
+ * test is deterministic; the store passes `new Date()` and a real id.
+ */
+export function buildAuditEntry(input: PromptAuditInput, now: Date, id: string): PromptAuditEntry {
+  return {
+    id,
+    at: now.toISOString(),
+    author: input.author.trim() || 'unknown',
+    sessionId: input.sessionId,
+    sessionTitle: input.sessionTitle,
+    harness: input.harness,
+    text: clampText(input.text),
+    ok: input.ok,
+    message: input.message,
+  }
+}
+
+/**
+ * Prepend a record (newest first) and cap the log. Returns a NEW array so an external store can swap
+ * the reference and `useSyncExternalStore` re-renders; never mutates the input.
+ */
+export function appendAudit(
+  list: readonly PromptAuditEntry[],
+  entry: PromptAuditEntry,
+  max = MAX_AUDIT_ENTRIES,
+): PromptAuditEntry[] {
+  return [entry, ...list].slice(0, Math.max(1, max))
+}
+
+/** The records for one session, newest first (the input is already newest-first). */
+export function auditForSession(
+  list: readonly PromptAuditEntry[],
+  sessionId: string,
+): PromptAuditEntry[] {
+  return list.filter(e => e.sessionId === sessionId)
+}
+
+/**
+ * Who the send is attributed to. An IAM display name wins where the dashboard knows one (a central /
+ * IAM login); otherwise this browser's stable operator id, which at least tells two people sharing
+ * one local dashboard apart. Never invents a name it does not have — an empty account name falls
+ * through to the operator id rather than being recorded as blank.
+ */
+export function resolveAuthor(opts: { accountName?: string | null; operatorId: string }): string {
+  const name = (opts.accountName ?? '').trim()
+  return name || opts.operatorId
+}
+
+// ---- the persisted store (guarded; a store failure is a missing log, never a throw) --------------
+
+function isEntry(v: unknown): v is PromptAuditEntry {
+  if (typeof v !== 'object' || v === null) return false
+  const e = v as Record<string, unknown>
+  return typeof e.id === 'string'
+    && typeof e.at === 'string'
+    && typeof e.author === 'string'
+    && typeof e.sessionId === 'string'
+    && typeof e.sessionTitle === 'string'
+    && typeof e.harness === 'string'
+    && typeof e.text === 'string'
+    && typeof e.ok === 'boolean'
+    && typeof e.message === 'string'
+}
+
+/** Parse a stored log defensively: a corrupt or foreign value reads as an empty log, not a crash. */
+export function parseStoredAudit(raw: string | null): PromptAuditEntry[] {
+  if (raw == null) return []
+  try {
+    const v = JSON.parse(raw)
+    if (!Array.isArray(v)) return []
+    return v.filter(isEntry).slice(0, MAX_AUDIT_ENTRIES)
+  } catch {
+    return []
+  }
+}
+
+function readInitial(): PromptAuditEntry[] {
+  try {
+    return parseStoredAudit(localStorage.getItem(KEY))
+  } catch {
+    return []
+  }
+}
+
+let current: PromptAuditEntry[] = readInitial()
+const subscribers = new Set<() => void>()
+
+export function getPromptAudit(): PromptAuditEntry[] {
+  return current
+}
+
+export function subscribePromptAudit(fn: () => void): () => void {
+  subscribers.add(fn)
+  return () => subscribers.delete(fn)
+}
+
+function persist(): void {
+  try {
+    localStorage.setItem(KEY, JSON.stringify(current))
+  } catch {
+    /* storage may be unavailable (private mode); the in-memory log still drives this session */
+  }
+}
+
+function newId(): string {
+  try {
+    if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') return crypto.randomUUID()
+  } catch { /* fall through */ }
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`
+}
+
+/**
+ * Record one completed send and notify every reader. Returns the entry it wrote so the caller can
+ * show it immediately. Called AFTER the server answered, so `ok`/`message` are the real outcome.
+ */
+export function recordPromptSend(input: PromptAuditInput): PromptAuditEntry {
+  const entry = buildAuditEntry(input, new Date(), newId())
+  current = appendAudit(current, entry)
+  persist()
+  for (const fn of subscribers) fn()
+  return entry
+}
+
+export function clearPromptAudit(): void {
+  if (current.length === 0) return
+  current = []
+  persist()
+  for (const fn of subscribers) fn()
+}
+
+/**
+ * This browser's stable operator id — generated once and kept, so the same person's sends carry a
+ * consistent author across reloads and two people on one local dashboard are told apart. It is a
+ * pseudonymous handle, not a claim of a real name; when the dashboard has an IAM login,
+ * `resolveAuthor` prefers that.
+ */
+export function operatorId(): string {
+  try {
+    const existing = localStorage.getItem(OPERATOR_KEY)
+    if (existing && existing.trim()) return existing
+    const id = `op-${newId().slice(0, 8)}`
+    localStorage.setItem(OPERATOR_KEY, id)
+    return id
+  } catch {
+    return 'this-browser'
+  }
+}

--- a/packages/web/src/pages/SessionsPage.tsx
+++ b/packages/web/src/pages/SessionsPage.tsx
@@ -243,6 +243,9 @@ export default function SessionsPage() {
         activities={liveActivities}
         fleet={fleetIdx}
         onFleetAction={act}
+        // Who a prompt is attributed to in the write-channel audit: the IAM display name where the
+        // dashboard has a login, else the browser's own operator id (resolved in promptAudit).
+        authorName={ctx.me?.name}
         // The live terminal now lives INSIDE each session's card (expand a row to watch it), so the
         // machine's live work is what you see first: grouped by repo, only the active sessions.
         defaultGrouping="repo"


### PR DESCRIPTION
Console session card follow-up (journey j-20260830-ke, task terminal-interativo-e-grid). Three things, all inside `packages/web`.

## 1) Write channel + audit (the PE's condition for allowing it)
- **Audit.** Every "Send a prompt" now leaves a persisted, visible record — **who / which session / what / when / outcome** — rendered as a "Sent to this session" list in the card. `lib/promptAudit.ts` is pure and unit-tested (build/append/cap/session-scope/parse/author).
- **Why the record lives in the browser (decision).** The server's only audit trail (`server/audit.ts`) is a Mongo-backed *team-security* log (logins/accounts/tokens) whose `writeAudit` no-ops without Mongo — it is absent on the solo/machine install the fleet runs on, and its action set does not cover local session writes. Extending it is a `packages/server` change (out of scope). The fleet write is a per-browser action whose accountable actor is the dashboard operator at that browser, so the honest place for the record is that browser: a persisted, visible log. The "who" is the IAM display name where the dashboard has a login, else a stable per-browser operator id.
- **Unambiguous target.** The prompt form now names its session (**title + id**) at the point of typing, so with several terminals on one page it is clear which session receives the text.
- **Reuse, not a parallel path.** It goes through the existing `/api/fleet/act` `prompt` action (backend `sendTextTo` untouched) and its success/failure feedback. A **failed** send is recorded and shown as faithfully as a delivered one — silence after a send is impossible.

## 2) Card layout — fit a grid column
At a grid-column width (~360px) the collapsed header crammed `[state][badge][Send a prompt][kebab][maximize]` on one non-wrapping row: the **title vanished** and the harness badge was **clipped**. The header now **wraps** — the action cluster drops to its own row and the state + badge + title keep a readable line. List mode (wide) is unchanged.

## 3) Terminal — reach the whole conversation, faithfully
- **Scroll.** The emulator now holds the **entire capture** (`max(rows, lines)`), not one screen, so the fixed-height box scrolls through every shipped line and **reaches the start of the available conversation**. Earlier lines used to fall into xterm scrollback that a per-frame `reset()` wiped — the discriminant between a scrollable and a stuck terminal is a capture taller than one screen. The cursor is offset onto the live screen and the view **sticks to the tail** for a live session.
- **Fidelity discriminant (named).** A terminal broke when the pane's **column count** overflowed a box the fit did not shrink; the CSS scale (columns stay exactly `f.cols`) answers it. That fix is untouched.
- **Origin limit (declared).** The server ships at most `TERMINAL_VIEW_LINES` (200); beyond that the status line already discloses "showing the last N lines — there is older output above that is not shown".

## v2 — spec follow-up (this push)

After review, the PE narrowed the card to metrics-only and flagged the terminal's default readability.

**Card, stripped to metrics:**
- Removed the first-prompt / latest-messages block (`DetailsBlock`) from both the live and history card bodies — it wasn't a metric.
- Removed the "Claude Code" external-link button and the first-prompt block from the session-details drilldown modal, and removed the MCP capability chip (the `Server` lucide icon — a hardware-looking glyph with no business sitting beside real numbers).
- **Side effect, disclosed:** that button was the *only* UI entry point to the transcript viewer (`TranscriptModal`) and to Nay-chat from a session. The lookalike function in `RecentSessions.tsx` (`openSession`) was already dead code before this change, so removing the button removes that path from the UI entirely. Flag if the transcript viewer needs a new entry point — it wasn't one of the four call-outs, so it's reported rather than assumed.
- "Open whole task" / "Finish task" are no longer just disabled in the kebab — they're filtered out and never rendered (`HIDDEN_VERBS` in `SessionActions.tsx`). Confirmed with the PE: these disappear, they do not migrate anywhere.
- "Session metrics" moved off the card footer into the kebab menu (`SessionActionsMenu`'s new `extraItems`, listed above the fleet verbs). History cards (no fleet controller, no kebab) keep it as a footer button.

**Terminal — the "100% but tiny" bug, root cause named before fixing:**
Not a `FitAddon` (there isn't one) and not "too many captured lines" (the row count never enters the width-scale computation). The cause is the fit-to-width `transform: scale()` in `SessionTerminal.tsx`'s `fit()`, which had **no floor** — it shrinks the whole grid (font *and* line height together) by `boxWidth / paneNaturalWidth`, however small that ratio is. Measured live against a real session (Chrome headless, dev build proxied to the real fleet on :47291): an ordinary **157-column** capture (not a wide-pane edge case) in a **904px** card rendered at **11.07px** row height while the zoom control read "100%" — because that percentage is the *zoom multiplier*, never the actual rendered size, so the control looked correct while the text was not.

Fix: added `MIN_SCALE = 11/13` (11px — the smallest body text already used elsewhere in the dashboard) as a floor on the auto-shrink; past it the box scrolls horizontally instead of continuing to shrink (it already supported `overflow: auto` on both axes). Same session, same box, after the fix: scale floors at 0.846, row height **12.69px**, and the box now scrolls (content 1037px in a 904px box) rather than shrinking further.

**Pre-commit was skipped with `--no-verify` on this commit, authorized by the coordinator, one time.** The local husky hook runs the full monorepo `bun test`; `packages/server/server/adapters/claude.test.ts` — a file this diff does not touch, which scans the real `~/.claude` directory — timed out at its own 120s cap under this shared machine's concurrent multi-session load (`uptime` load average 27–58 on 22 cores at the time). It passes standalone in ~60s. `bun tsc --noEmit` and `bun test packages/web` (880/880) were run manually and are clean. **The gate is this PR's CI** (`.github/workflows/ci.yml`, clean runner, no such `~/.claude` data) — this PR is not reported as delivered until that CI is green.

## Verification
- `bun tsc --noEmit` clean; `bun test packages/web` 880/880 green (manual run, this commit).
- Headless Chrome (real fleet on :47291) at declared widths:
  - **1440 grid (3 cols, ~360px each):** title + "CLAUDE CODE" badge now visible; actions on row 2; no page overflow. List mode 1440 unchanged.
  - **Terminal:** scroll-to-top reaches a box-drawing table rendered with byte-aligned columns; scroll-to-bottom pins the live edge; the box scrolls (scrollHeight 574 > client 318).
  - **Audit:** the "Sent to this session" log renders a green *delivered* and a red *failed* entry, each with time/author/text; the prompt form shows "Writing to <title> <id>". The write POST was intercepted in the demo so **no text was ever sent to a live colleague session**.
  - **v2 kebab:** menu items for a live session are exactly `Session metrics, Answer its question, Send a prompt, Rename, Note, Task, Stop session` — no task open/finish entries.
  - **v2 drilldown:** "Session details" modal renders KPIs/token breakdown/tool usage/capabilities with no "Claude Code" link, no "First prompt" block, no "MCP" chip.
  - **v2 terminal:** before/after `fit()` measurements above, captured against the same live 157-column session.

## Scope
All changes are inside `packages/web`. `sendTextTo`/tmux backend untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
