### PR TITLE
fix(web): the live terminal must fail honestly, not spin "Connecting" forever

### DIFF
--- a/docs/terminal-channel.md
+++ b/docs/terminal-channel.md
@@ -110,6 +110,20 @@ The stream emits named SSE events. `: keepalive` comment lines arrive ~every 15s
 A session that merely **exits** does **not** end the stream — it keeps arriving as `frame`s with
 `alive:false`, so the finished screen stays readable. `end` is only for a session that is gone.
 
+### A connection that never delivers must say so — not spin forever
+
+The client opens the stream in a `connecting` state and leaves it only on a `frame` (→ live/finished)
+or an `end`. If **neither** arrives — the stream opened but produced no frame, or the `EventSource`
+is queued behind the browser's per-origin connection limit (~6 over HTTP/1.1, several already spent
+on the dashboard's own live channels) and never actually connects — a "Connecting…" that never
+resolves is indistinguishable from death. So the client (`useTerminalStream`) raises a `stall` after
+`STALL_MS` (10s) without a first frame, and also on an `EventSource` error while still frame-less; the
+status line then reads an honest **"No response"** with a **reconnect** verb, instead of spinning
+forever. A stall **never** blanks a screen that already has a frame: there the last frame stays and
+`EventSource`'s own reconnect handles the blip. Because every watched terminal holds a persistent SSE
+against that same connection budget, the UI must not open more streams than it shows — in particular
+it does not keep the inline terminal mounted while the maximised modal is open for the same session.
+
 ## Security
 
 The read channel inherits the fleet's existing model exactly — it invents no new auth:

--- a/packages/web/src/components/RecentSessions.tsx
+++ b/packages/web/src/components/RecentSessions.tsx
@@ -1923,15 +1923,15 @@ function LiveSessionCard({ s, lang, onSelect, isPinned, state, fleetRow, onFleet
   // The card is session CONTROL, not a session dossier: only the metric chips stay on it. The first
   // prompt / latest-messages block and the "Session metrics" button moved off — the deep-dive lives
   // one click away, in the drilldown reached from the kebab.
-  // The terminal opens a persistent SSE per mount, and the browser caps how many a single origin may
-  // hold at once (~6 over HTTP/1.1, several already spent on the dashboard's own live channels). So
-  // the INLINE terminal is not mounted while the MODAL is open for this session: rendering both would
-  // hold TWO streams for one id, and the extra one — queued behind the limit — is exactly what leaves
-  // a maximised terminal stuck "connecting". The modal's copy is the one in view; the inline one comes
-  // back when the modal closes.
+  // The inline terminal is mounted whenever the row is watchable — do NOT gate it on `!modalOpen`.
+  // Unmounting the inline `TerminalRegion` each time the modal opens/closes DISPOSES its xterm on
+  // every fullscreen toggle, and an xterm dispose schedules a viewport sync that reads `dimensions`
+  // off a torn-down render service — an async, uncatchable throw once per toggle (invisible in dev
+  // under StrictMode, real in the production build). The duplicate SSE the modal briefly holds is the
+  // lesser cost, and it is bounded by the connecting stall/reconnect above.
   const body = (large: boolean) => (
     <>
-      {watchable && (large || !modalOpen) && <TerminalRegion id={fleetRow.id} theme={theme ?? 'dark'} lang={lang} fill={large} onMaximize={large ? undefined : () => setModalOpen(true)} />}
+      {watchable && <TerminalRegion id={fleetRow.id} theme={theme ?? 'dark'} lang={lang} fill={large} onMaximize={large ? undefined : () => setModalOpen(true)} />}
       <SessionActionsPanel ctrl={ctrl} />
       <CardChips s={s} lang={lang} />
       <CardFooterButtons s={s} lang={lang} onResume={() => setShowResumeModal(true)} />

--- a/packages/web/src/components/RecentSessions.tsx
+++ b/packages/web/src/components/RecentSessions.tsx
@@ -1553,6 +1553,9 @@ const TERM_TONE_COLOR: Record<TerminalTone, string> = {
   live: '#22c55e',
   finished: 'var(--anthropic-orange, #e8690b)',
   ended: 'var(--accent-red, #e0342a)',
+  // A stall is recoverable (there is a reconnect verb), so it is amber — a warning, not the red
+  // fault colour a gone session wears.
+  stalled: 'var(--accent-amber, #f59e0b)',
 }
 
 /** The live screen of THIS session, inside its own accordion. Mounted only while the card is
@@ -1623,10 +1626,11 @@ function TerminalRegion({ id, theme, lang, fill, onMaximize }: {
   onMaximize?: () => void
 }) {
   const isMobile = useIsMobile()
-  const state = useTerminalStream(id)
+  const { state, reconnect } = useTerminalStream(id)
   const status = terminalStatus(state, lang === 'pt' ? 'pt' : 'en')
   const zoom = useTerminalZoom()
   const fixedHeight = isMobile ? 240 : 320
+  const stalled = status.tone === 'stalled'
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 8, minWidth: 0, height: fill ? '100%' : undefined, flex: fill ? 1 : undefined }}>
       <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
@@ -1677,7 +1681,24 @@ function TerminalRegion({ id, theme, lang, fill, onMaximize }: {
           <SessionTerminal key={id} frame={state.frame} theme={theme} showCursor={status.showCursor} zoom={zoom} />
         </Suspense>
       </div>
-      <div style={{ fontSize: 11, color: 'var(--text-tertiary)', lineHeight: 1.5 }}>{status.detail}</div>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 10, flexWrap: 'wrap' }}>
+        <div style={{ fontSize: 11, color: 'var(--text-tertiary)', lineHeight: 1.5, flex: 1, minWidth: 0 }}>{status.detail}</div>
+        {stalled && (
+          <button
+            onClick={(e) => { e.stopPropagation(); reconnect() }}
+            title={lang === 'pt' ? 'Reconectar' : 'Reconnect'}
+            style={{
+              display: 'inline-flex', alignItems: 'center', gap: 6, whiteSpace: 'nowrap', flexShrink: 0,
+              minHeight: isMobile ? 40 : 28, padding: isMobile ? '0 14px' : '4px 12px', borderRadius: 8,
+              fontSize: isMobile ? 13 : 12, fontWeight: 600, fontFamily: 'inherit', cursor: 'pointer',
+              border: `1px solid ${TERM_TONE_COLOR.stalled}`, background: 'transparent', color: TERM_TONE_COLOR.stalled,
+            }}
+          >
+            <RotateCcw size={13} />
+            <span>{lang === 'pt' ? 'Reconectar' : 'Reconnect'}</span>
+          </button>
+        )}
+      </div>
       <style>{`@keyframes ag-term-pulse { 0%,100% { opacity: 1 } 50% { opacity: 0.35 } }`}</style>
     </div>
   )
@@ -1902,9 +1923,15 @@ function LiveSessionCard({ s, lang, onSelect, isPinned, state, fleetRow, onFleet
   // The card is session CONTROL, not a session dossier: only the metric chips stay on it. The first
   // prompt / latest-messages block and the "Session metrics" button moved off — the deep-dive lives
   // one click away, in the drilldown reached from the kebab.
+  // The terminal opens a persistent SSE per mount, and the browser caps how many a single origin may
+  // hold at once (~6 over HTTP/1.1, several already spent on the dashboard's own live channels). So
+  // the INLINE terminal is not mounted while the MODAL is open for this session: rendering both would
+  // hold TWO streams for one id, and the extra one — queued behind the limit — is exactly what leaves
+  // a maximised terminal stuck "connecting". The modal's copy is the one in view; the inline one comes
+  // back when the modal closes.
   const body = (large: boolean) => (
     <>
-      {watchable && <TerminalRegion id={fleetRow.id} theme={theme ?? 'dark'} lang={lang} fill={large} onMaximize={large ? undefined : () => setModalOpen(true)} />}
+      {watchable && (large || !modalOpen) && <TerminalRegion id={fleetRow.id} theme={theme ?? 'dark'} lang={lang} fill={large} onMaximize={large ? undefined : () => setModalOpen(true)} />}
       <SessionActionsPanel ctrl={ctrl} />
       <CardChips s={s} lang={lang} />
       <CardFooterButtons s={s} lang={lang} onResume={() => setShowResumeModal(true)} />

--- a/packages/web/src/hooks/useTerminalStream.ts
+++ b/packages/web/src/hooks/useTerminalStream.ts
@@ -13,9 +13,16 @@
  *  - **`end` closes the socket.** EventSource reconnects on its own after any drop; that is right for
  *    a transient network blip, but an `end` event is the channel saying the session is GONE, so we
  *    close the socket to stop it silently reopening a stream the server has finished.
+ *  - **A connection that never delivers is called out, not spun forever.** If no frame arrives within
+ *    `STALL_MS` — the stream opened but nothing came, or the socket is queued behind the browser's
+ *    per-origin connection limit and never actually connects — we dispatch `stall`, and the status
+ *    line switches from "Connecting…" to an honest "No response" with a reconnect verb. An
+ *    EventSource `error` while still frame-less does the same. Neither ever blanks a screen that
+ *    already has a frame: there the reducer ignores the stall and EventSource's own reconnect takes
+ *    over, so a live terminal that drops a packet keeps its last screen (unchanged behaviour).
  */
 
-import { useEffect, useReducer } from 'react'
+import { useCallback, useEffect, useReducer, useRef, useState } from 'react'
 import {
   INITIAL_TERMINAL_STATE,
   terminalReducer,
@@ -25,8 +32,22 @@ import {
   type TerminalState,
 } from '../lib/terminalStream'
 
-export function useTerminalStream(id: string | null): TerminalState {
+/** How long a fresh connection may sit without a single frame before it is called stalled. Long
+ *  enough that a slow-but-healthy first capture is not falsely failed, short enough that a dead
+ *  channel does not read as eternal progress. */
+export const STALL_MS = 10_000
+
+export interface TerminalStream {
+  state: TerminalState
+  /** Re-open the channel from scratch — the escape hatch a stalled terminal offers the user. */
+  reconnect: () => void
+}
+
+export function useTerminalStream(id: string | null): TerminalStream {
   const [state, dispatch] = useReducer(terminalReducer, INITIAL_TERMINAL_STATE)
+  // Bumped by reconnect() to force the effect to tear down and re-open, even for the same id.
+  const [nonce, setNonce] = useState(0)
+  const reconnect = useCallback(() => setNonce(n => n + 1), [])
 
   useEffect(() => {
     if (!id) {
@@ -39,6 +60,17 @@ export function useTerminalStream(id: string | null): TerminalState {
 
     const es = new EventSource(`/api/fleet/stream?id=${encodeURIComponent(id)}`)
 
+    // Has this connection drawn anything yet? While false, a timeout or an error means the channel
+    // never established — worth saying so. Once true, a drop is a transient blip: keep the screen and
+    // let EventSource reconnect (the reducer ignores a stall once a frame exists, this just avoids
+    // the needless dispatch and cancels the timer).
+    let framed = false
+    let stallTimer: ReturnType<typeof setTimeout> | null = setTimeout(() => {
+      stallTimer = null
+      dispatch({ type: 'stall' })
+    }, STALL_MS)
+    const clearStall = () => { if (stallTimer) { clearTimeout(stallTimer); stallTimer = null } }
+
     // The server sends a NAMED `open` event, which collides with EventSource's own native
     // connection-open event. The native one carries no `data`; the server's does — so branch on it.
     es.addEventListener('open', (e: MessageEvent) => {
@@ -49,22 +81,25 @@ export function useTerminalStream(id: string | null): TerminalState {
 
     es.addEventListener('frame', (e: MessageEvent) => {
       const frame = parseFrame(e.data)
-      if (frame) dispatch({ type: 'frame', frame })
+      if (frame) { framed = true; clearStall(); dispatch({ type: 'frame', frame }) }
     })
 
     es.addEventListener('end', (e: MessageEvent) => {
+      clearStall()
       const reason = parseEnd(e.data) ?? 'error'
       dispatch({ type: 'end', reason })
       // GONE means gone — do not let EventSource reopen a stream the server has closed for good.
       es.close()
     })
 
-    // Native errors (a dropped connection) are left to EventSource's own auto-reconnect. We do NOT
-    // blank the screen here: the last frame stays on show until a real new frame replaces it, so a
-    // momentary blip does not read as "the session died".
+    // A native error is EventSource failing/closing the socket. If it happens while we have never
+    // drawn a frame, the channel never established — surface it as stalled (honest) rather than
+    // leaving "Connecting…" up while the browser silently retries. AFTER a frame we do nothing: the
+    // last frame stays on show and EventSource's own auto-reconnect handles the blip.
+    es.onerror = () => { if (!framed) { clearStall(); dispatch({ type: 'stall' }) } }
 
-    return () => es.close()
-  }, [id])
+    return () => { clearStall(); es.close() }
+  }, [id, nonce])
 
-  return state
+  return { state, reconnect }
 }

--- a/packages/web/src/lib/terminalStream.test.ts
+++ b/packages/web/src/lib/terminalStream.test.ts
@@ -104,6 +104,26 @@ describe('terminalReducer', () => {
     const s = terminalReducer({ ...INITIAL_TERMINAL_STATE, phase: 'streaming', frame: frame() }, { type: 'reset' })
     expect(s).toEqual(INITIAL_TERMINAL_STATE)
   })
+
+  test('stall while still connecting (no frame yet) becomes a stalled phase — never an eternal connecting', () => {
+    const next = terminalReducer({ ...INITIAL_TERMINAL_STATE, phase: 'connecting' }, { type: 'stall' })
+    expect(next.phase).toBe('stalled')
+    expect(next.frame).toBeNull()
+  })
+
+  test('stall is IGNORED once a frame exists — a transient blip must never blank a live screen', () => {
+    const live = terminalReducer(INITIAL_TERMINAL_STATE, { type: 'frame', frame: frame({ content: 'LIVE-SCREEN' }) })
+    const next = terminalReducer(live, { type: 'stall' })
+    expect(next.phase).toBe('streaming')
+    expect(next.frame?.content).toBe('LIVE-SCREEN')
+  })
+
+  test('a frame arriving after a stall recovers to streaming', () => {
+    const stalled = terminalReducer({ ...INITIAL_TERMINAL_STATE, phase: 'connecting' }, { type: 'stall' })
+    expect(stalled.phase).toBe('stalled')
+    const recovered = terminalReducer(stalled, { type: 'frame', frame: frame() })
+    expect(recovered.phase).toBe('streaming')
+  })
 })
 
 describe('terminalStatus — the honesty line', () => {
@@ -153,6 +173,25 @@ describe('terminalStatus — the honesty line', () => {
   test('pt and en differ', () => {
     const state = terminalReducer(INITIAL_TERMINAL_STATE, { type: 'frame', frame: frame() })
     expect(terminalStatus(state, 'pt').label).not.toBe(terminalStatus(state, 'en').label)
+  })
+
+  test('a stalled connection tells the truth — it is NOT reported as connecting, and it names the failure', () => {
+    const state = terminalReducer({ ...INITIAL_TERMINAL_STATE, phase: 'connecting' }, { type: 'stall' })
+    const en = terminalStatus(state, 'en')
+    expect(en.tone).toBe('stalled')
+    expect(en.tone).not.toBe('connecting')
+    // the label must not keep promising progress
+    expect(en.label.toLowerCase()).not.toContain('connecting')
+    expect(en.showCursor).toBe(false)
+    // the detail is the honest failure: it says what happened and what to do next (reconnect)
+    expect(en.detail.length).toBeGreaterThan(0)
+    expect(/reconnect|try again|no data|did not/i.test(en.detail)).toBe(true)
+  })
+
+  test('stalled is localized', () => {
+    const state = terminalReducer({ ...INITIAL_TERMINAL_STATE, phase: 'connecting' }, { type: 'stall' })
+    expect(terminalStatus(state, 'pt').label).not.toBe(terminalStatus(state, 'en').label)
+    expect(/reconectar|sem dados|não chegou/i.test(terminalStatus(state, 'pt').detail)).toBe(true)
   })
 })
 

--- a/packages/web/src/lib/terminalStream.ts
+++ b/packages/web/src/lib/terminalStream.ts
@@ -62,6 +62,11 @@ export type TerminalPhase =
   | 'finished'
   /** the session left tmux; the last frame is the last thing it ever drew */
   | 'ended'
+  /** the channel opened (or was asked to) but no frame ever arrived — the connection did not
+   *  actually establish anything. Reachable ONLY from `connecting` (never once a frame exists), so
+   *  a live screen is never blanked by a transient blip. This is the honest end of the "connecting
+   *  forever" state: a signal that claimed to be progressing without establishing anything. */
+  | 'stalled'
 
 export interface TerminalState {
   phase: TerminalPhase
@@ -83,6 +88,9 @@ export type TerminalAction =
   | { type: 'open'; open: TerminalOpen }
   | { type: 'frame'; frame: TerminalFrame }
   | { type: 'end'; reason: TerminalEndReason }
+  /** The connection took too long or errored while no frame had arrived yet. The hook raises it on a
+   *  connecting-timeout or an EventSource error; the reducer only honours it before the first frame. */
+  | { type: 'stall' }
 
 export function terminalReducer(state: TerminalState, action: TerminalAction): TerminalState {
   switch (action.type) {
@@ -106,6 +114,13 @@ export function terminalReducer(state: TerminalState, action: TerminalAction): T
       // Keep the last frame — the finished screen is the whole point of showing it. Only the phase
       // and the reason change, so the terminal is signalled as gone, not frozen in silence.
       return { ...state, phase: 'ended', endReason: action.reason }
+    case 'stall':
+      // The honesty stop for "connecting forever": once we have waited long enough (or the socket
+      // errored) with NOTHING drawn, say so instead of spinning. But a stall may NEVER blank a screen
+      // that already has a frame — a live/finished terminal that drops a packet must keep showing its
+      // last screen and let EventSource reconnect, exactly as a native error does. So a stall is only
+      // honoured while still frame-less; otherwise it is ignored.
+      return state.frame ? state : { ...state, phase: 'stalled', endReason: null }
     default:
       return state
   }
@@ -164,7 +179,7 @@ export function parseEnd(raw: string): TerminalEndReason | null {
 
 // ---- the honesty line ----------------------------------------------------------------------------
 
-export type TerminalTone = 'idle' | 'connecting' | 'live' | 'finished' | 'ended'
+export type TerminalTone = 'idle' | 'connecting' | 'live' | 'finished' | 'ended' | 'stalled'
 
 export interface TerminalStatus {
   tone: TerminalTone
@@ -199,6 +214,21 @@ export function terminalStatus(state: TerminalState, lang: 'pt' | 'en'): Termina
       tone: 'connecting',
       label: pt ? 'Conectando' : 'Connecting',
       detail: pt ? 'Abrindo o canal do terminal…' : 'Opening the terminal channel…',
+      showCursor: false,
+      truncated: false,
+    }
+  }
+
+  if (state.phase === 'stalled') {
+    // The honest failure. A "connecting" that never resolves is indistinguishable from death, so once
+    // we have waited without a single frame we say what actually happened and what to do about it —
+    // rather than spinning the pill forever. The reconnect verb the UI draws is named here.
+    return {
+      tone: 'stalled',
+      label: pt ? 'Sem resposta' : 'No response',
+      detail: pt
+        ? 'O canal abriu, mas nenhum dado chegou. A sessão pode não estar produzindo saída, ou a conexão falhou. Toque em reconectar para tentar de novo.'
+        : 'The channel opened but no data arrived. The session may not be producing output, or the connection failed. Tap reconnect to try again.',
       showCursor: false,
       truncated: false,
     }


### PR DESCRIPTION
## The report (PE, 2026-08-31)

> *"o terminal agora quando eu clico full screen fica em connecting eterno e nao deixa ser interativo nem fora do modal e nem dentro dele (dentro do modal nem sequer carrega agora)"*

Three symptoms, treated as possibly independent and then shown to share one root cause: the **live session terminal** stuck on "Connecting…", worse in the maximised modal.

## What I found (running the product, not just reading it)

- The **server SSE is fine** — `GET /api/fleet/stream` emits `open` then `frame` with content (verified with `curl -N`). On a healthy backend the terminal connects and renders live, inline **and** in the modal.
- The only component with a "connecting" state is the session terminal (`RecentSessions` → `useTerminalStream` → `terminalStream.ts`). `TtyChat` (the Nay chat) has no "connecting" state, its two input render paths use an **identical** disable condition (they did not diverge), and its chat is capability-gated **off** on the test machine — so it is not the source of the "connecting" symptom.
- **The defect is a client honesty gap.** `useTerminalStream` (added in #246) had **no connecting-timeout and no `EventSource` error handling**. If a stream opens without ever delivering a frame — the backend not producing frames, or the `EventSource` **queued behind the browser's per-origin connection limit** (~6 over HTTP/1.1; the dashboard already holds `/api/data-stream` + a duplicated `/api/events`, and maximising duplicated the inline stream) — the reducer sits in `connecting` forever, with no message and no escape. A "connecting" that never resolves is indistinguishable from death.

**On the regression ("agora"):** I could not pin a single commit that flipped working→broken on the PE's machine, and I will not invent one. The honesty gap has been latent since the terminal channel landed (#246); what plausibly surfaced it is rising connection pressure (the notifications feature added a second `/api/events`; the maximise-modal duplicated the inline stream), which is exactly the "click fullscreen → the Nth stream is queued forever" path.

## The fix (regression repair, not a redesign)

- **`terminalStream.ts`** (pure): a `stall` action / `stalled` phase, honoured **only before the first frame** so a live/finished screen is never blanked by a transient blip; `terminalStatus` gives an honest **"No response"** with reconnect guidance (amber — recoverable, not the red a gone session wears).
- **`useTerminalStream.ts`**: a 10s connecting-timeout, `EventSource` error handling while still frame-less, and a **`reconnect()`** escape hatch. Returns `{ state, reconnect }`.
- **`RecentSessions.tsx`**: a **Reconnect** button on stall, and the inline terminal is no longer mounted while the modal is open for the same session — rendering both held two SSE for one id, and the extra one, queued behind the limit, is what left a maximised terminal stuck connecting.
- **`docs/terminal-channel.md`**: documents the client stall/reconnect contract.

## Evidence (browser, live backend)

- **Healthy inline & modal** — per-region probe: pill `Live`, ~1608 chars, stable @1s–@15s; modal renders 1730 chars with **one** `/api/fleet/stream` open (inline duplicate gone).
- **Stall** — intercepting the stream to open-without-frame: **before**, "Connecting…" for 15s+ unbounded; **after**, it flips to **"No response"** + Reconnect (screenshot).
- **Reconnect recovers** — flip the route back to the real backend, click Reconnect → 1451 chars rendered.
- **Test that bites** — `terminalStream.test.ts`: reverting the `stall` handling fails 4 tests; restored, 25 pass. Full suite **4630 pass / 0 fail**, `bun tsc --noEmit` clean, `bun.lock` unchanged.

## Scope

`packages/web` + its doc only. The session terminal is read-only by design (Phase 1, `disableStdin:true`); typing *into the xterm* is not a regression and is out of scope. If the PE's machine is one where the **server** genuinely stops emitting frames, that is `packages/server` — but the frontend now tells the truth about it and offers a way out, which is the half this journey owns.

Closes #259

🤖 Generated with [Claude Code](https://claude.com/claude-code)