### PR TITLE
release: promove dev→main — abertura honesta do app (#265)

### DIFF
--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -14,9 +14,55 @@
     <title>Agentistics</title>
     <!-- Inter is self-hosted (see src/index.css @font-face + public/fonts). No external
          origin here, so the CSP can stay strict and no visitor IP leaves the instance. -->
+    <!-- Pre-React guard. index.css and the app bundle are separate requests that arrive AFTER this
+         document, so until they land the browser paints a bare, unstyled #root — a flash of blank
+         (or the UA's default light/blue chrome) before React ever mounts. These inline rules paint
+         the app's own dark ground on the very first frame and show a boot loader in #root, so the
+         opening is the app loading rather than a silent screen. It is CSP-safe (only inline <style>,
+         which `style-src 'self' 'unsafe-inline'` allows — no inline <script>), and it removes itself
+         with no JS: React's createRoot fills #root, and `#root:not(:empty) ~ #ag-preboot` then hides
+         the loader the instant real content commits. -->
+    <style>
+      html, body { margin: 0; background: #0a0a0f; color-scheme: dark; }
+      #ag-preboot {
+        position: fixed; inset: 0; z-index: 2147483647;
+        display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 16px;
+        background: #0a0a0f;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+      }
+      #ag-preboot .ag-preboot-bars { display: flex; align-items: flex-end; gap: 5px; height: 34px; }
+      #ag-preboot .ag-preboot-bars span {
+        width: 5px; height: 100%; border-radius: 3px;
+        background: #D97706; transform-origin: bottom;
+        animation: ag-preboot-pulse 1s ease-in-out infinite;
+      }
+      #ag-preboot .ag-preboot-bars span:nth-child(2) { animation-delay: .12s; }
+      #ag-preboot .ag-preboot-bars span:nth-child(3) { animation-delay: .24s; }
+      #ag-preboot .ag-preboot-bars span:nth-child(4) { animation-delay: .36s; }
+      #ag-preboot .ag-preboot-bars span:nth-child(5) { animation-delay: .48s; }
+      #ag-preboot .ag-preboot-label {
+        font-size: 13px; font-weight: 600; letter-spacing: .02em; color: rgba(255, 255, 255, .55);
+      }
+      @keyframes ag-preboot-pulse {
+        0%, 100% { transform: scaleY(.4); opacity: .5; }
+        50%      { transform: scaleY(1);  opacity: 1;  }
+      }
+      /* The moment React commits any content into #root it stops being :empty, and the following
+         sibling loader is hidden. `:not(:empty)` + `~` are universally supported — no `:has` needed. */
+      #root:not(:empty) ~ #ag-preboot { display: none; }
+      @media (prefers-reduced-motion: reduce) {
+        #ag-preboot .ag-preboot-bars span { animation: none; opacity: .85; }
+      }
+    </style>
   </head>
   <body>
     <div id="root"></div>
+    <!-- Sibling AFTER #root (not a child) so React's createRoot never warns about pre-existing
+         children, and the `:has` rule above can hide it once #root holds real content. -->
+    <div id="ag-preboot" role="status" aria-label="Loading agentistics">
+      <div class="ag-preboot-bars" aria-hidden="true"><span></span><span></span><span></span><span></span><span></span></div>
+      <div class="ag-preboot-label">agentistics</div>
+    </div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -16,6 +16,7 @@ import {
 import { useData, useDerivedStats, LIVE_INTERVAL_OPTIONS, LIVE_INTERVAL_OPTIONS_RISKY } from './hooks/useData'
 import { usePlanBasis } from './hooks/usePlanBasis'
 import { planScopeHarnesses, planScopeNote } from './lib/costBasis'
+import { bootLoading } from './lib/bootPhase'
 import { DEFAULT_CARD_ORDER, migrateCardOrder, type CardId } from './lib/cardOrder'
 import { BillingIntroModal } from './components/BillingIntroModal'
 import type { LoadProgress } from './hooks/useData'
@@ -2195,11 +2196,14 @@ export default function AppLayout() {
   // must resolve the session and show the login screen FIRST — otherwise the
   // expected 401 surfaces as a "failed to load" error and the login never shows.
   if (teamSession === undefined) {
-    return <div style={{ minHeight: '100vh', background: 'var(--bg-base)' }} />
+    // Still resolving the session — show the honest boot loader, not a silent blank. We also can't
+    // yet tell a 403 auth-hold from a real error (that needs `teamSession.central`), so holding the
+    // loader here is correct as well as honest.
+    return <LoadingScreen lang={lang} loadProgress={loadProgress} />
   }
   // Central: account-based IAM gate (bootstrap → login → app).
   if (teamSession.central) {
-    if (iam === undefined) return <div style={{ minHeight: '100vh', background: 'var(--bg-base)' }} />
+    if (iam === undefined) return <LoadingScreen lang={lang} loadProgress={loadProgress} />
     if (iam.needsBootstrap) return <OwnerSetup lang={lang} onDone={() => { reloadIam(); refetch() }} />
     if (!iam.authed) return <Login onAuthed={() => { reloadIam(); refetch() }} />
     // Changing a password is step-up-protected (`server/stepup.ts`), and this screen is returned
@@ -2226,9 +2230,8 @@ export default function AppLayout() {
     return <TeamLogin onAuthed={() => { setTeamSession(s => ({ ...(s ?? { required: true }), required: true, authed: true })); refetch() }} />
   }
 
-  if (loading) {
-    return <LoadingScreen lang={lang} loadProgress={loadProgress} />
-  }
+  // Errors are checked BEFORE the boot loader below: an error means the load settled (`complete()`
+  // cleared `loading`), and it must win — otherwise a failed load would spin the loader forever.
 
   // A 403 on a central is an AUTH state, not a broken server: the gate refuses data until the
   // enrolment (or the sign-in) it is waiting for happens, and the effect above is already
@@ -2278,7 +2281,16 @@ export default function AppLayout() {
     )
   }
 
-  if (!data || !derived) return null
+  // The boot loader stays until the app can actually paint: data fetched, derived stats computed,
+  // AND the first-run prefs (archive choice) resolved. `loading` alone flipped false the instant
+  // /api/data resolved, and the gaps here used to return a SILENT BLANK — the loader vanishing
+  // before the data was ready. `bootLoading` is the single predicate deciding this.
+  if (bootLoading({ loading, hasData: !!data, hasDerived: !!derived, prefsLoaded: archiveChoice !== undefined })) {
+    return <LoadingScreen lang={lang} loadProgress={loadProgress} />
+  }
+  // `bootLoading` already guaranteed both are present; this explicit guard is what narrows them for
+  // TypeScript below. It is not reachable as a blank — it returns the loader too, never `null`.
+  if (!data || !derived) return <LoadingScreen lang={lang} loadProgress={loadProgress} />
 
   // Capture non-null derived for use in nested functions (TypeScript can't narrow closures)
   const d = derived
@@ -2310,11 +2322,10 @@ export default function AppLayout() {
     (filters.models.length > 0 ? 1 : 0) +
     (harnessFilterActive ? 1 : 0)
 
-  // Block the app until the user makes the first-run archive choice. While prefs OR the
-  // team-session flag are still loading render a neutral background to avoid a flash.
-  if (archiveChoice === undefined || teamSession === undefined) {
-    return <div style={{ minHeight: '100vh', background: 'var(--bg-base)' }} />
-  }
+  // Block the app until the user makes the first-run archive choice. `archiveChoice` is guaranteed
+  // resolved here (undefined would have kept `bootLoading` on the loader above) and `teamSession` is
+  // non-undefined since the auth gate at the top — so `null` is the one remaining case: "loaded, not
+  // yet chosen", which is the consent prompt, never a silent blank.
   // A central never shows the archive consent gate: it aggregates members' computed metrics
   // (stored in Mongo) and any self-contributed host data defaults server-side — there's nothing
   // for the operator to consent to here, so the blocking prompt would only annoy.

--- a/packages/web/src/lib/bootPhase.test.ts
+++ b/packages/web/src/lib/bootPhase.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'bun:test'
+import { bootLoading, type BootSignals } from './bootPhase'
+
+// The whole app already had a boot loader, but it was gated on `loading` (the /api/data fetch)
+// ALONE. `loading` flips false the instant that one fetch resolves — yet the app still cannot
+// paint until the derived stats are computed AND the first-run preferences (the archive choice)
+// have resolved. Those in-between moments returned a SILENT BLANK screen: the loader vanished
+// before the data was ready. `bootLoading` is the single predicate that keeps the loader on until
+// every one of those signals is ready.
+
+const ready: BootSignals = { loading: false, hasData: true, hasDerived: true, prefsLoaded: true }
+
+describe('bootLoading', () => {
+  it('is false only when EVERYTHING the first paint needs is ready', () => {
+    expect(bootLoading(ready)).toBe(false)
+  })
+
+  it('stays true while the /api/data fetch is in flight', () => {
+    expect(bootLoading({ ...ready, loading: true })).toBe(true)
+  })
+
+  it('stays true when data has not arrived yet', () => {
+    expect(bootLoading({ ...ready, hasData: false })).toBe(true)
+  })
+
+  it('stays true when derived stats are not computed yet', () => {
+    expect(bootLoading({ ...ready, hasDerived: false })).toBe(true)
+  })
+
+  // THE regression this function exists for: the fetch settled (loading:false, data present) but
+  // the first-run prefs are still loading, so the app is NOT ready — the loader must remain, never
+  // a blank.
+  it('stays true after the fetch settles while first-run prefs are still loading', () => {
+    expect(bootLoading({ loading: false, hasData: true, hasDerived: true, prefsLoaded: false })).toBe(true)
+  })
+
+  it('is true if any single signal is not ready, in every combination', () => {
+    const keys: (keyof BootSignals)[] = ['loading', 'hasData', 'hasDerived', 'prefsLoaded']
+    for (const k of keys) {
+      const s = { ...ready }
+      // loading is inverted meaning (true = not ready); the others are false = not ready.
+      ;(s as any)[k] = k === 'loading' ? true : false
+      expect(bootLoading(s)).toBe(true)
+    }
+  })
+})

--- a/packages/web/src/lib/bootPhase.ts
+++ b/packages/web/src/lib/bootPhase.ts
@@ -1,0 +1,30 @@
+/**
+ * bootPhase.ts — the one predicate that decides whether the app is still BOOTING.
+ *
+ * The dashboard already showed a boot loader (`LoadingScreen`), but it was gated on `loading` — the
+ * `/api/data` fetch — ALONE. That flag flips false the moment that single fetch resolves, while the
+ * app still cannot paint real content until the derived stats are computed AND the first-run
+ * preferences (the archive choice) have resolved. Each of those in-between moments returned a SILENT
+ * BLANK screen (a bare `min-height:100vh` dark div): the loader vanished before the data was ready,
+ * which is exactly the "loader some antes de os dados estarem prontos" report.
+ *
+ * Keeping this rule in one pure, tested function means the render gate can never again decide it in
+ * one place and forget it in the next.
+ */
+
+export interface BootSignals {
+  /** The `/api/data` fetch is in flight. */
+  loading: boolean
+  /** `data !== null` — the payload has arrived. */
+  hasData: boolean
+  /** The derived stats (`useDerivedStats`) have been computed from `data`. */
+  hasDerived: boolean
+  /** The first-run preferences have resolved — `archiveChoice !== undefined` (null counts as
+   *  resolved: it means "loaded, not yet chosen", which is the consent gate, not a loading state). */
+  prefsLoaded: boolean
+}
+
+/** True while the boot loader must stay on screen — the app is not yet ready to paint content. */
+export function bootLoading(s: BootSignals): boolean {
+  return s.loading || !s.hasData || !s.hasDerived || !s.prefsLoaded
+}


### PR DESCRIPTION
Promoção da PR #265, gateada por QA independente.

**O que vai:** guarda pré-React em CSS puro (sem JS) que pinta o fundo escuro e mostra o loader no primeiro quadro, sumindo sozinho quando o React monta; e o loader honesto, que só sai quando dados, derivados e preferências estão prontos — quatro pontos que devolviam `<div>` vazia em silêncio agora mostram o loader, e erro é checado ANTES dele, então nunca gira para sempre.

**Gate:** 891 testes no pacote, tsc limpo, build limpo, e o quadro pré-React confirmado em Chrome real — pinta escuro com o loader visível e some por CSS puro quando o `#root` recebe conteúdo.

**Achado declarado:** as violações de CSP que o PE viu **não são da aplicação** — verificado na fonte: `font-src 'self'` com cinco Inter woff2 self-hosted em `/fonts/*`, zero fontes `data:`. Vêm de extensão do navegador.