### PR TITLE
fix(server): price sessions per model, not by one dominant rate

### DIFF
--- a/packages/server/server/otel-watcher.ts
+++ b/packages/server/server/otel-watcher.ts
@@ -39,7 +39,7 @@ import { ATTR_SERVICE_NAME } from '@opentelemetry/semantic-conventions'
 
 // Shared imports from the main codebase
 
-import { calcCost } from '@agentistics/core'
+import { calcCost, sessionCostUSD } from '@agentistics/core'
 import type { ModelUsage, HarnessId, SessionMeta } from '@agentistics/core'
 import type { OtelSnapshot } from '@agentistics/core'
 import { HOME_DIR, CLAUDE_DIR, PROJECTS_DIR, SESSION_META_DIR, STATS_CACHE_FILE, CONSOLIDATED_DIR } from './config'
@@ -122,16 +122,17 @@ async function buildHarnessSnapshots(): Promise<HarnessSnapshot[]> {
           const cacheWrite = s.cache_creation_input_tokens ?? 0
           totalInputTokens += inp + cacheRead + cacheWrite
           totalOutputTokens += out
-          // Build a ModelUsage-compatible shape for calcCost
-          const usage: ModelUsage = {
+          // Per-model breakdown (multi-model sessions, e.g. Antigravity, price correctly)
+          // instead of one dominant model's rate applied to the session's whole usage.
+          // No model at all → calcCost falls back to the default price, same as everywhere else.
+          totalCostUsd += sessionCostUSD(s) ?? calcCost({
             inputTokens: inp,
             outputTokens: out,
             cacheReadInputTokens: cacheRead,
             cacheCreationInputTokens: cacheWrite,
             webSearchRequests: 0,
             costUSD: 0,
-          }
-          totalCostUsd += calcCost(usage, s.model ?? '')
+          }, '')
         })
       )
     )

--- a/packages/server/server/sessions/conversations.test.ts
+++ b/packages/server/server/sessions/conversations.test.ts
@@ -1,0 +1,82 @@
+// packages/server/server/sessions/conversations.test.ts
+import { test, expect } from 'bun:test'
+import { sessionCostUSD, type SessionMeta } from '@agentistics/core'
+import { toConversation } from './conversations'
+
+let seq = 0
+function session(over: Partial<SessionMeta> = {}): SessionMeta {
+  seq++
+  return {
+    session_id: `s${seq}`,
+    project_path: '/home/dev/app',
+    start_time: '2026-07-01T10:00:00.000Z',
+    duration_minutes: 5,
+    user_message_count: 1,
+    assistant_message_count: 1,
+    tool_counts: {},
+    tool_output_tokens: {},
+    agent_file_reads: {},
+    languages: [],
+    git_commits: 0,
+    git_pushes: 0,
+    input_tokens: 1000,
+    output_tokens: 500,
+    first_prompt: 'hi',
+    user_interruptions: 0,
+    user_response_times: [],
+    tool_errors: 0,
+    tool_error_categories: {},
+    uses_task_agent: false,
+    uses_mcp: false,
+    uses_web_search: false,
+    uses_web_fetch: false,
+    lines_added: 0,
+    lines_removed: 0,
+    files_modified: 0,
+    message_hours: [],
+    user_message_timestamps: [],
+    harness: 'claude',
+    ...over,
+  }
+}
+
+test('prices a single-model session via its own model', () => {
+  const s = session({ model: 'claude-opus-4-7', input_tokens: 1_000_000, output_tokens: 0 })
+  const c = toConversation(s)
+  expect(c.costUSD).toBeCloseTo(sessionCostUSD(s)!, 6)
+})
+
+test('a multi-model session is priced per model, not by one dominant rate', () => {
+  // The reported bug: costUSD was computed via calcCost(totalUsage, s.model) — the WHOLE session's
+  // usage priced at one model's rate. An Antigravity parent whose subagent children folded in carry
+  // a `model_usage` breakdown spanning several models, so that read the cheap model's tokens at the
+  // expensive model's rate (or vice versa).
+  const s = session({
+    model: 'gemini-3.6-flash',
+    input_tokens: 1_000_000,
+    output_tokens: 0,
+    model_usage: {
+      'gemini-3.6-flash': {
+        inputTokens: 500_000, outputTokens: 0,
+        cacheReadInputTokens: 0, cacheCreationInputTokens: 0, webSearchRequests: 0, costUSD: 0,
+      },
+      'claude-opus-4-7': {
+        inputTokens: 500_000, outputTokens: 0,
+        cacheReadInputTokens: 0, cacheCreationInputTokens: 0, webSearchRequests: 0, costUSD: 0,
+      },
+    },
+  })
+  const c = toConversation(s)
+  // Per-model breakdown, via the same primitive `sessionCostUSD` uses — never a single dominant rate.
+  expect(c.costUSD).toBeCloseTo(sessionCostUSD(s)!, 6)
+  // A single-rate read (either model applied to the full 1M tokens) must disagree with the correct
+  // per-model figure — this is the assertion that would have caught the bug.
+  expect(c.costUSD).not.toBeCloseTo(1_000_000 / 1_000_000 * 3, 6) // pure-opus rate over the whole total
+  expect(c.costUSD).not.toBeCloseTo(0, 6)
+})
+
+test('no model and no usage yields no costUSD at all — never a confident 0', () => {
+  const s = session({ input_tokens: 0, output_tokens: 0, model: undefined })
+  const c = toConversation(s)
+  expect(c.costUSD).toBeUndefined()
+})

--- a/packages/server/server/sessions/conversations.ts
+++ b/packages/server/server/sessions/conversations.ts
@@ -11,7 +11,7 @@
  */
 
 import type { HarnessId, SessionMeta } from '@agentistics/core'
-import { calcCost, resolveContextWindow, sessionLabel } from '@agentistics/core'
+import { resolveContextWindow, sessionCostUSD, sessionLabel } from '@agentistics/core'
 import { loadConsolidated } from '../consolidate'
 import { sessionAtCwd } from '../live-sessions'
 import { SPAWN_SPECS } from './spawn-spec'
@@ -70,6 +70,10 @@ export function toConversation(s: SessionMeta): Conversation {
   const window = s.context_window ?? resolveContextWindow(s.model)?.tokens
   const total = (s.input_tokens ?? 0) + (s.output_tokens ?? 0)
     + (s.cache_read_input_tokens ?? 0) + (s.cache_creation_input_tokens ?? 0)
+  // Per-model when the session spans several (an Antigravity parent with its subagent children
+  // folded in carries a `model_usage` breakdown) — never one dominant model's rate applied to the
+  // session's whole usage.
+  const costUSD = total > 0 ? sessionCostUSD(s) : null
   return {
     sessionId: s.session_id,
     harness,
@@ -88,20 +92,10 @@ export function toConversation(s: SessionMeta): Conversation {
     ...(s.context_tokens && window
       ? { contextTokens: s.context_tokens, contextWindow: window }
       : {}),
-    // Through `calcCost`, never an inline rate: CLAUDE.md makes that the single source of truth, and
-    // a second arithmetic here would disagree with the dashboard the first time a price changed.
-    ...(total > 0 && s.model
-      ? {
-          costUSD: calcCost({
-            inputTokens: s.input_tokens ?? 0,
-            outputTokens: s.output_tokens ?? 0,
-            cacheReadInputTokens: s.cache_read_input_tokens ?? 0,
-            cacheCreationInputTokens: s.cache_creation_input_tokens ?? 0,
-            webSearchRequests: 0,
-            costUSD: 0,
-          }, s.model),
-        }
-      : {}),
+    // Through `sessionCostUSD`/`calcCost`, never an inline rate: CLAUDE.md makes that the single
+    // source of truth, and a second arithmetic here would disagree with the dashboard the first
+    // time a price changed.
+    ...(costUSD !== null ? { costUSD } : {}),
   }
 }
 


### PR DESCRIPTION
## Summary
- `otel-watcher.ts`'s per-harness OTel snapshot summed a session's whole token usage and priced it with `calcCost` at one model's rate; now goes through `sessionCostUSD`, which prices per model when the session carries a `model_usage` breakdown (e.g. an Antigravity parent with its subagent children folded in), falling back to the default-price `calcCost` call only when the session has no model at all — same convention as `tags-aggregate.ts` / `tags-detail.ts` / `member-metrics.ts`.
- Found the same "dominant model" pattern in `sessions/conversations.ts`'s `toConversation()` (feeds the fleet screen's "last conversations" cost) and fixed it the same way.
- Scanned the rest of `packages/server` for the same shape of bug (grepped every `calcCost` call site): `tags-aggregate.ts`, `tags-detail.ts`, `member-metrics.ts` already use `sessionCostUSD` correctly; `agent-metrics.ts` and `workflow-agent.ts` price per-invocation usage against that invocation's own (or the session's single) model, which is the correct granularity for data the JSONL actually carries — no fix needed there.
- **Reported, not fixed** (out of scope per the assignment — this is the `web` journey's territory): `packages/server/server/member-metrics.ts` declares `MemberMetrics.totalsFromCache?: boolean` but never sets it, so it always sums the visible sessions and never falls back to the deep `userStatsCaches`/`machineStatsCaches` history the way its documented twin `packages/web/src/lib/member-metrics.ts` does (which sets `totalsFromCache: true` at line 371). The server copy is currently not wired into any route/consumer, so this is dead code today, but if/when it is wired up it will under-report history for members backed mostly by pre-consolidate sessions.

## Test plan
- [x] `bun run stub && bun tsc --noEmit` — clean
- [x] `bun test` — 4438 pass / 0 fail
- [x] New regression test `packages/server/server/sessions/conversations.test.ts`: confirmed RED against the pre-fix code (`3.25` expected vs `1.5` received for a synthetic multi-model session), then GREEN after the fix
- [x] Verified parity on this machine's real `~/.agentistics/sessions/<harness>/*.json` for every harness (claude/codex/gemini/copilot/antigravity/kimi): old vs new total cost matches exactly (no session here happens to carry a multi-model breakdown yet, so the fix is a pure superset of correctness)
- [x] `bun run packages/server/bin/cli.ts session ls --all --json` and `session list --json` against real consolidated data — no crashes, exercises the changed `toConversation()` path end-to-end

Closes #none — task `custo-por-modelo-nao-por-dominante`, no linked issue (adding `no-issue-needed` if required).

🤖 Generated with [Claude Code](https://claude.com/claude-code)