### PR TITLE
feat(web): make the live session terminal interactive — consent-gated, honest line delivery

### DIFF
--- a/docs/terminal-channel.md
+++ b/docs/terminal-channel.md
@@ -7,10 +7,14 @@ doing without anyone opening a terminal and running `tmux attach`.
 This is the **server contract** the web dashboard consumes. The web side (the terminal panel and its
 emulator) must build on exactly this — it does not invent its own endpoint.
 
-**Phase 1 is read-only.** There is no write path yet: no keystrokes reach the session through this
-channel. A write channel (`Phase 2`) is a separate, later delivery with its own security contract;
-until it exists the web must show **no input box**, because a text field that does nothing is the
-same kind of lie as a frozen terminal that looks live.
+**This channel (Phase 1) is read-only.** No keystrokes reach the session through the *stream* — a
+`frame` only ever flows server → browser. The **write** half is a separate concern with its own
+contract: the line-oriented interactive composer built on `POST /api/fleet/act { action:'prompt' }`
+(**Phase 2**, web-only, no new endpoint) is documented in
+[`docs/terminal-interactive.md`](terminal-interactive.md); a raw keystroke channel (**Phase 2b**) is
+the escalation noted there. The rule the read channel set still holds: the web shows **no input box
+that does nothing** — the composer is offered only where a live, managed, typable row backs it, and it
+reports every line's delivery honestly.
 
 ## Transport, and why
 

--- a/docs/terminal-interactive.md
+++ b/docs/terminal-interactive.md
@@ -1,0 +1,113 @@
+# Interactive live terminal (Phase 2, web half)
+
+`docs/terminal-channel.md` describes the **read** channel — an SSE stream of a managed session's
+screen, read-only by design. This document is its **write** half: letting a person at the dashboard
+type into that session, and the four design decisions the feature turns on. The pure core is
+`packages/web/src/lib/terminalInput.ts`; the UI is `TerminalComposer` in `RecentSessions.tsx`.
+
+## What it is built on — no new endpoint
+
+There is exactly one web-reachable way to write into a managed session, and this feature uses it
+unchanged: `POST /api/fleet/act { id, action: 'prompt', text }` → the host's `promptSession`, which
+
+- refuses an empty line,
+- refuses when the session is on a dialog (`sessPromptBlocked`),
+- refuses when the session is not running,
+- otherwise types the line into the session **and submits it** (`sendText`, one `tmux send-keys`
+  followed by `Enter`), returning `{ ok, message }`.
+
+So the server already delivers a **whole line atomically** and answers honestly whether it landed.
+The web half is the browser-side state machine that keeps a person's typing honest against that one
+verb. It invents no route and requires no `packages/server` change.
+
+## The four decisions
+
+### 1. Consent — per session, in-memory, explicit, revocable
+
+Typing into a live session changes another running process (a coding agent mid-work). That is not
+something a viewer should do as a side effect of the terminal being on screen, so it is a deliberate
+opt-in: the region is **read-only until you press "Type into this session"**, and a **"Stop"** revokes
+it and drops any pending line.
+
+- **Per session.** Arming one session never arms its neighbour; several terminals share one page.
+- **In-memory, for this surface's lifetime.** It is not persisted — a reload or a re-open re-asks.
+  "Drive this session now" is a decision to re-make, not a durable grant a stale or returning tab
+  keeps. Re-arming costs one click.
+- **It is an INTENT gate, not a security boundary.** The server's `localShell` capability (403 on any
+  exposed profile), the scope check (only sessions this machine manages), and the dialog refusal
+  remain the real authority. The gate's job is to keep a human decision at the head of every
+  interactive session, not to guard the API — a hidden button is not a closed door, and this button
+  does not pretend to be one.
+
+### 2. Batched to a line, not key-by-key
+
+**Measured against what the backend can actually do:** the only web-reachable write is `sendText`,
+which types a line *and* presses Enter as one act. There is no endpoint for a single raw key —
+`sendKey` exists on the backend but is not web-exposed, and `sendText` cannot omit the Enter. So
+per-key is not merely expensive here, it is **unrepresentable** on the current server.
+
+It would also be the wrong shape even if it existed. One HTTP round-trip per keystroke means, at an
+ordinary ~5 keystrokes/second, ~5 requests/second per typist, each spawning a `tmux send-keys`
+process on the host; requests can complete **out of order** (nothing guarantees keystroke N lands
+before N+1); and it floods the audit (see decision 4). So the line is edited **locally** — the native
+`<input>` is the line editor, so backspace, cursor movement and paste are the browser's, free and
+correct — and **one** request carries the finished line, ordered by construction.
+
+Raw char-mode — Ctrl-C, arrow keys, Tab-completion in the target program, typing without an implicit
+submit, answering a raw (non-numbered) dialog by keypress — genuinely needs a new server keystroke
+channel. That is **Phase 2b** (see "Escalation" below) and is out of `packages/web`'s scope.
+
+### 3. Failure mid-typing — the load-bearing rule
+
+The terminal must never accept a key visually and fail to deliver it. This design **removes the
+failure surface** rather than papering over it:
+
+- Keys are **local until submit**. Nothing is delivered per key, so nothing per key can be lost. The
+  draft is drawn as a visibly distinct **local line** (an accent rule and a `›` prompt, not the
+  session's own colours) so local echo is never mistaken for the session having received it.
+- The one delivery is the line, and it moves through explicit states: **composing → sending →
+  delivered | failed**. On success the draft clears and the composer stays armed for the next line.
+  On failure the **exact line is kept**, marked *not delivered* with the server's own reason, ready
+  to edit and resend — it is never silently dropped.
+- While **sending** the composer is **locked** (no editing, no second submit), so two lines can never
+  race out of order.
+
+The state machine is `composerReducer` in `terminalInput.ts`, pinned by `terminalInput.test.ts`; the
+honesty rules live there, not in the JSX.
+
+### 4. Audit without noise
+
+Only the **atomic send** is auditable, through the existing browser-side write-channel record
+(`lib/promptAudit.ts` → `recordPromptSend`): who / which session / the exact line / when / the
+outcome. Local edits — typing, backspacing, revising a failed line — are **not** audited: they are not
+sends, and per-keystroke auditing is exactly the flood this decision warns against. One line,
+delivered-or-failed, is one audit entry — the granularity the write channel already recorded for the
+"Send a prompt" menu form. This feature adds nothing to that schema; it routes its sends through the
+same record, and the persisted log renders unchanged in the session's actions panel.
+
+## When the composer is not offered
+
+A row that cannot be typed into says why in one sentence and shows **no arming button** (the same rule
+the session menu applies — a control that does nothing is worse than an honest refusal).
+`interactionBlock(row.state)` decides:
+
+| Row state | Block | Sentence |
+|-----------|-------|----------|
+| `working`, `waiting` | none | typable — a queued line is picked up on the next turn |
+| `waiting-approval` | `awaiting-approval` | answer the dialog; you cannot type past it |
+| `exited`, `lost`, `closed` | `not-running` | no live process to receive the line |
+| `unknown` (external) | `external` | not started by agentop; nothing here can write to it |
+
+A session that goes un-typable *while armed* (killed, or falls onto a dialog) is disarmed
+automatically and shows the block sentence, so an armed composer can never sit over a session where
+every send would fail.
+
+## Escalation — Phase 2b (raw keystroke channel), `packages/server`
+
+Full char-mode interactivity (Ctrl-C, arrows, Esc, Tab, no-submit typing, answering raw dialogs by
+keypress) requires a server write endpoint that forwards individual keys to the backend's existing
+`sendKey` / `sendText` primitives **without** the implicit Enter — e.g. `POST /api/fleet/input
+{ id, key | text, submit? }`, gated by the same `localShell` capability and scope as the read stream,
+with its own audit decision. That is a `packages/server` change and was **not** made here; the web
+half above is complete and honest on its own for line-oriented interaction (sending a message or an
+answer to the agent), which is the dominant case.

--- a/packages/web/src/components/RecentSessions.tsx
+++ b/packages/web/src/components/RecentSessions.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, useEffect, useRef, lazy, Suspense, useSyncExternalStore } from 'react'
+import React, { useState, useMemo, useEffect, useRef, useReducer, lazy, Suspense, useSyncExternalStore } from 'react'
 import type { SessionMeta } from '@agentistics/core'
 import { sessionTime } from '../lib/sessionTime'
 import { formatProjectName, repoShortName, sessionLabel, sessionTokenTotal } from '@agentistics/core'
@@ -8,6 +8,13 @@ import { primaryAction, isWatchable, type PrimaryAction } from '../lib/sessionAc
 import { SessionActionsMenu, SessionActionsPanel, useSessionActionsController } from './SessionActions'
 import { useTerminalStream } from '../hooks/useTerminalStream'
 import { terminalStatus, type TerminalTone } from '../lib/terminalStream'
+import {
+  INITIAL_COMPOSER,
+  canSubmit,
+  composerReducer,
+  interactionBlock,
+} from '../lib/terminalInput'
+import { operatorId, recordPromptSend, resolveAuthor } from '../lib/promptAudit'
 import { getTerminalZoom, setTerminalZoom, subscribeTerminalZoom, ZOOM_STEP, ZOOM_MIN, ZOOM_MAX } from '../lib/terminalZoom'
 import { getPinnedIds, isSessionPinned, togglePinnedSession, subscribePinnedSessions, pinnedServerSnapshot, MAX_PINNED } from '../lib/pinnedSessions'
 import { getOpenModalSession, setOpenModalSession, subscribeOpenModalSession } from '../lib/openModalSession'
@@ -46,6 +53,7 @@ import {
   Send,
   RotateCcw,
   Hand,
+  Keyboard,
   ZoomIn,
   ZoomOut,
   Pin,
@@ -1617,13 +1625,19 @@ function TerminalZoomControls({ lang }: { lang: 'pt' | 'en' }) {
   )
 }
 
-function TerminalRegion({ id, theme, lang, fill, onMaximize }: {
+function TerminalRegion({ id, theme, lang, fill, onMaximize, row, act, authorName }: {
   id: string; theme: 'dark' | 'light'; lang: 'pt' | 'en'
   /** Fill the available height (in the modal) instead of a fixed card-sized box. */
   fill?: boolean
   /** When set, a maximize button opens the modal — where the box is wide enough to read a wide pane
    *  at a larger scale. Absent inside the modal itself (already maximized). */
   onMaximize?: () => void
+  /** The live fleet row this terminal is showing. When present with `act`, the region becomes
+   *  INTERACTIVE — a consent-gated line composer under the screen (see `TerminalComposer`). */
+  row?: FleetRow
+  act?: (req: { id: string; action: FleetActionId; text?: string; choice?: number })
+    => Promise<{ ok: boolean; message: string }>
+  authorName?: string
 }) {
   const isMobile = useIsMobile()
   const { state, reconnect } = useTerminalStream(id)
@@ -1699,9 +1713,220 @@ function TerminalRegion({ id, theme, lang, fill, onMaximize }: {
           </button>
         )}
       </div>
+      {/* Phase 2 — the WRITE half: a consent-gated line composer, present only when this region is
+          driving a live fleet row the page can act on. Read-only terminals (history rows, or a page
+          with no `act`) render no composer, so a field that does nothing is never shown. */}
+      {row && act && (
+        <TerminalComposer row={row} act={act} authorName={authorName} lang={lang} isMobile={isMobile} />
+      )}
       <style>{`@keyframes ag-term-pulse { 0%,100% { opacity: 1 } 50% { opacity: 0.35 } }`}</style>
     </div>
   )
+}
+
+/**
+ * TerminalComposer — the interactive write channel under the live terminal.
+ *
+ * It renders the four decisions of `lib/terminalInput.ts` (all localized here, the logic pure there):
+ *  - CONSENT: read-only until you press "Type into this session"; a "Stop typing" revokes it.
+ *  - BATCHED: a native input is the local line editor; ONE `prompt` request carries the finished line.
+ *  - HONEST DELIVERY: the draft is a visibly-distinct LOCAL line; on submit it goes sending →
+ *    delivered (cleared) | failed (kept verbatim, with the server's reason). A key is never accepted
+ *    then lost — nothing is delivered per key, and the one line's outcome is always on screen.
+ *  - AUDIT: the delivered-or-failed line is recorded through `recordPromptSend`; keystrokes are not.
+ */
+function TerminalComposer({ row, act, authorName, lang, isMobile }: {
+  row: FleetRow
+  act: (req: { id: string; action: FleetActionId; text?: string; choice?: number })
+    => Promise<{ ok: boolean; message: string }>
+  authorName?: string
+  lang: 'pt' | 'en'
+  isMobile: boolean
+}) {
+  const [composer, dispatch] = useReducer(composerReducer, INITIAL_COMPOSER)
+  // A brief "delivered" confirmation; the durable record lives in the audit panel below the card.
+  const [flash, setFlash] = useState(false)
+  const inputRef = useRef<HTMLInputElement | null>(null)
+  const t = COMPOSER_T[lang]
+
+  // A session that has just gone un-typable (killed, or fell onto a dialog) must not keep an armed
+  // composer that can only fail — disarm it and say why in the block notice below.
+  const block = interactionBlock(row.state)
+  useEffect(() => {
+    if (block && composer.armed) dispatch({ type: 'disarm' })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [block])
+
+  async function send() {
+    if (!canSubmit(composer)) return
+    const text = composer.draft
+    dispatch({ type: 'submit' })
+    setFlash(false)
+    const out = await act({ id: row.id, action: 'prompt', text })
+    // AUDIT the atomic line — accepted or refused — through the one write-channel record. Local edits
+    // reached here as nothing; only this send is a record (decision 4).
+    recordPromptSend({
+      author: resolveAuthor({ accountName: authorName, operatorId: operatorId() }),
+      sessionId: row.id,
+      sessionTitle: row.title,
+      harness: row.harness,
+      text,
+      ok: out.ok,
+      message: out.message,
+    })
+    dispatch({ type: 'sent', ok: out.ok, message: out.message })
+    if (out.ok) {
+      setFlash(true)
+      inputRef.current?.focus()
+    }
+  }
+
+  // A row that cannot be typed into says why, in one sentence, and offers no arming button — the same
+  // rule the session menu applies: a control that does nothing is worse than an honest refusal.
+  if (block) {
+    return (
+      <div style={{ fontSize: 11, color: 'var(--text-tertiary)', display: 'inline-flex', alignItems: 'center', gap: 6, flexWrap: 'wrap' }}>
+        <Keyboard size={12} style={{ opacity: 0.6 }} />
+        <span>{t.block[block]}</span>
+      </div>
+    )
+  }
+
+  if (!composer.armed) {
+    return (
+      <div style={{ display: 'flex', alignItems: 'center', gap: 10, flexWrap: 'wrap' }}>
+        <button
+          onClick={(e) => { e.stopPropagation(); dispatch({ type: 'arm' }); setFlash(false); setTimeout(() => inputRef.current?.focus(), 0) }}
+          style={{
+            display: 'inline-flex', alignItems: 'center', gap: 6, whiteSpace: 'nowrap', flexShrink: 0,
+            minHeight: isMobile ? 44 : 28, padding: isMobile ? '0 16px' : '4px 12px', borderRadius: 8,
+            fontSize: isMobile ? 13 : 12, fontWeight: 600, fontFamily: 'inherit', cursor: 'pointer',
+            border: '1px solid var(--anthropic-orange)', background: 'transparent', color: 'var(--anthropic-orange)',
+          }}
+        >
+          <Keyboard size={13} /> <span>{t.arm}</span>
+        </button>
+        <span style={{ fontSize: 11, color: 'var(--text-tertiary)' }}>{t.readonly}</span>
+      </div>
+    )
+  }
+
+  const sending = composer.status === 'sending'
+  const failed = composer.status === 'failed'
+  return (
+    <div
+      onClick={(e) => e.stopPropagation()}
+      style={{
+        display: 'flex', flexDirection: 'column', gap: 6, minWidth: 0,
+        // A LOCAL DRAFT, drawn distinctly from the session's own output so local echo is never
+        // mistaken for the session having received it.
+        borderLeft: '2px solid var(--anthropic-orange)', paddingLeft: 10,
+      }}
+    >
+      <div style={{ display: 'inline-flex', alignItems: 'center', gap: 6, minWidth: 0, fontSize: 11, fontWeight: 600, color: 'var(--anthropic-orange)' }}>
+        <Send size={11} style={{ flexShrink: 0 }} />
+        <span style={{ color: 'var(--text-tertiary)', fontWeight: 500, flexShrink: 0 }}>{t.writingTo}</span>
+        <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }} title={`${row.title} · ${row.id}`}>{row.title}</span>
+        <code style={{ fontFamily: 'var(--font-mono, monospace)', fontSize: 10, opacity: 0.75, flexShrink: 0 }}>{row.id}</code>
+      </div>
+      <form
+        onSubmit={(e) => { e.preventDefault(); void send() }}
+        style={{ display: 'flex', gap: 8, flexWrap: 'wrap', alignItems: 'center', minWidth: 0 }}
+      >
+        <span style={{ color: 'var(--anthropic-orange)', fontFamily: 'var(--font-mono, monospace)', fontWeight: 700, flexShrink: 0 }}>›</span>
+        <input
+          ref={inputRef}
+          value={composer.draft}
+          disabled={sending}
+          onChange={(e) => dispatch({ type: 'edit', draft: e.target.value })}
+          placeholder={t.placeholder}
+          aria-label={t.arm}
+          // No inline font-size: index.css guarantees >= 16px on mobile; overriding it zooms iOS.
+          style={{
+            flex: '1 1 220px', minWidth: 0, minHeight: isMobile ? 44 : 28, padding: '0 10px', borderRadius: 8,
+            border: '1px solid var(--border)', background: 'var(--bg-elevated)', color: 'var(--text-primary)',
+            fontFamily: 'var(--font-mono, monospace)', outline: 'none', opacity: sending ? 0.6 : 1,
+          }}
+        />
+        <button
+          type="submit"
+          disabled={!canSubmit(composer)}
+          style={{
+            display: 'inline-flex', alignItems: 'center', gap: 6, whiteSpace: 'nowrap', flexShrink: 0,
+            minHeight: isMobile ? 44 : 28, padding: isMobile ? '0 16px' : '4px 12px', borderRadius: 8,
+            fontSize: isMobile ? 13 : 12, fontWeight: 600, fontFamily: 'inherit',
+            cursor: canSubmit(composer) ? 'pointer' : 'default', opacity: canSubmit(composer) ? 1 : 0.5,
+            border: '1px solid var(--anthropic-orange)', background: 'var(--anthropic-orange)', color: '#fff',
+          }}
+        >
+          <Send size={13} /> <span>{sending ? t.sending : t.send}</span>
+        </button>
+        <button
+          type="button"
+          onClick={() => dispatch({ type: 'disarm' })}
+          style={{
+            display: 'inline-flex', alignItems: 'center', gap: 6, whiteSpace: 'nowrap', flexShrink: 0,
+            minHeight: isMobile ? 44 : 28, padding: isMobile ? '0 14px' : '4px 10px', borderRadius: 8,
+            fontSize: isMobile ? 13 : 12, fontWeight: 600, fontFamily: 'inherit', cursor: 'pointer',
+            border: '1px solid var(--border)', background: 'var(--bg-card)', color: 'var(--text-secondary)',
+          }}
+        >
+          <Hand size={13} /> <span>{t.stop}</span>
+        </button>
+      </form>
+      {/* HONEST DELIVERY — the one place the line's fate is reported. */}
+      {sending && <div style={{ fontSize: 11, color: 'var(--text-tertiary)' }}>{t.delivering}</div>}
+      {failed && (
+        <div role="status" style={{ fontSize: 11, color: '#ef4444', lineHeight: 1.5 }}>
+          <strong>{t.notDelivered}</strong> {composer.error} <span style={{ color: 'var(--text-tertiary)' }}>· {t.retryHint}</span>
+        </div>
+      )}
+      {flash && !sending && !failed && (
+        <div role="status" style={{ fontSize: 11, color: '#22c55e', display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+          <Check size={12} /> {t.delivered}
+        </div>
+      )}
+    </div>
+  )
+}
+
+const COMPOSER_T = {
+  pt: {
+    arm: 'Digitar nesta sessão',
+    readonly: 'Somente leitura até você começar a digitar.',
+    stop: 'Parar',
+    writingTo: 'Escrevendo em',
+    placeholder: 'Uma linha para enviar a esta sessão…',
+    send: 'Enviar',
+    sending: 'Enviando…',
+    delivering: 'Entregando a linha…',
+    delivered: 'Entregue à sessão.',
+    notDelivered: 'Não entregue:',
+    retryHint: 'a linha foi mantida; revise e reenvie.',
+    block: {
+      external: 'Esta sessão não foi iniciada pelo agentop — nada aqui pode escrever nela.',
+      'not-running': 'Esta sessão não está rodando — não há processo para receber o que você digitar.',
+      'awaiting-approval': 'Esta sessão está esperando uma resposta numa caixa de diálogo. Responda o diálogo — não dá para digitar por cima dele.',
+    } as Record<string, string>,
+  },
+  en: {
+    arm: 'Type into this session',
+    readonly: 'Read-only until you start typing.',
+    stop: 'Stop',
+    writingTo: 'Writing to',
+    placeholder: 'One line to send to this session…',
+    send: 'Send',
+    sending: 'Sending…',
+    delivering: 'Delivering the line…',
+    delivered: 'Delivered to the session.',
+    notDelivered: 'Not delivered:',
+    retryHint: 'the line was kept; edit and resend.',
+    block: {
+      external: 'This session was not started by agentop — nothing here can write to it.',
+      'not-running': 'This session is not running — there is no process to receive what you type.',
+      'awaiting-approval': 'This session is waiting on a dialog answer. Answer the dialog — you cannot type past it.',
+    } as Record<string, string>,
+  },
 }
 
 // ---- the primary lead action ---------------------------------------------------------------------
@@ -1931,7 +2156,7 @@ function LiveSessionCard({ s, lang, onSelect, isPinned, state, fleetRow, onFleet
   // lesser cost, and it is bounded by the connecting stall/reconnect above.
   const body = (large: boolean) => (
     <>
-      {watchable && <TerminalRegion id={fleetRow.id} theme={theme ?? 'dark'} lang={lang} fill={large} onMaximize={large ? undefined : () => setModalOpen(true)} />}
+      {watchable && <TerminalRegion id={fleetRow.id} theme={theme ?? 'dark'} lang={lang} fill={large} onMaximize={large ? undefined : () => setModalOpen(true)} row={fleetRow} act={onFleetAction} authorName={authorName} />}
       <SessionActionsPanel ctrl={ctrl} />
       <CardChips s={s} lang={lang} />
       <CardFooterButtons s={s} lang={lang} onResume={() => setShowResumeModal(true)} />

--- a/packages/web/src/lib/terminalInput.test.ts
+++ b/packages/web/src/lib/terminalInput.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'bun:test'
+import {
+  INITIAL_COMPOSER,
+  canEdit,
+  canSubmit,
+  composerReducer,
+  interactionBlock,
+  type ComposerState,
+} from './terminalInput'
+
+const armed: ComposerState = { armed: true, draft: '', status: 'idle', error: null }
+
+describe('consent (decision 1) — explicit, per-session, revocable', () => {
+  it('starts disarmed and empty', () => {
+    expect(INITIAL_COMPOSER).toEqual({ armed: false, draft: '', status: 'idle', error: null })
+  })
+
+  it('refuses to edit or submit while disarmed', () => {
+    // A viewer who never armed the session cannot type into it, even by dispatching directly.
+    expect(canEdit(INITIAL_COMPOSER)).toBe(false)
+    expect(canSubmit(INITIAL_COMPOSER)).toBe(false)
+    expect(composerReducer(INITIAL_COMPOSER, { type: 'edit', draft: 'ls' })).toEqual(INITIAL_COMPOSER)
+    expect(composerReducer(INITIAL_COMPOSER, { type: 'submit' })).toEqual(INITIAL_COMPOSER)
+  })
+
+  it('arm turns typing on and starts from a clean line', () => {
+    expect(composerReducer(INITIAL_COMPOSER, { type: 'arm' })).toEqual(armed)
+    expect(canEdit(armed)).toBe(true)
+  })
+
+  it('arm never wipes a line already in progress', () => {
+    const typing: ComposerState = { armed: true, draft: 'half a command', status: 'idle', error: null }
+    expect(composerReducer(typing, { type: 'arm' })).toEqual(typing)
+  })
+
+  it('disarm revokes consent and drops the draft (a revoked session keeps no pending line)', () => {
+    const typing: ComposerState = { armed: true, draft: 'rm -rf', status: 'failed', error: 'nope' }
+    expect(composerReducer(typing, { type: 'disarm' })).toEqual(INITIAL_COMPOSER)
+  })
+})
+
+describe('batched-to-a-line + lock (decision 2) — one atomic send, never mid-flight', () => {
+  it('will not submit an empty or whitespace-only line', () => {
+    expect(canSubmit(armed)).toBe(false)
+    expect(canSubmit({ ...armed, draft: '   ' })).toBe(false)
+    expect(canSubmit({ ...armed, draft: 'echo hi' })).toBe(true)
+  })
+
+  it('locks editing and submitting while a send is in flight (no reorder, no race)', () => {
+    const sending: ComposerState = { armed: true, draft: 'echo hi', status: 'sending', error: null }
+    expect(canEdit(sending)).toBe(false)
+    expect(canSubmit(sending)).toBe(false)
+    expect(composerReducer(sending, { type: 'edit', draft: 'echo hi more' })).toEqual(sending)
+    expect(composerReducer(sending, { type: 'submit' })).toEqual(sending)
+  })
+
+  it('submit moves a non-empty line into the sending state', () => {
+    const ready: ComposerState = { ...armed, draft: 'echo hi' }
+    expect(composerReducer(ready, { type: 'submit' })).toEqual({ ...ready, status: 'sending', error: null })
+  })
+})
+
+describe('honest delivery (decision 3) — a key is never accepted-then-lost', () => {
+  it('a delivered line clears the draft and stays armed for the next line', () => {
+    const sending: ComposerState = { armed: true, draft: 'echo hi', status: 'sending', error: null }
+    expect(composerReducer(sending, { type: 'sent', ok: true, message: 'delivered' })).toEqual({
+      armed: true, draft: '', status: 'idle', error: null,
+    })
+  })
+
+  it('a FAILED line is preserved verbatim and marked failed with the reason (never silently dropped)', () => {
+    const sending: ComposerState = { armed: true, draft: 'echo hi', status: 'sending', error: null }
+    expect(composerReducer(sending, { type: 'sent', ok: false, message: 'session is not running' })).toEqual({
+      armed: true, draft: 'echo hi', status: 'failed', error: 'session is not running',
+    })
+  })
+
+  it('editing after a failure clears the failed marker (a fresh attempt), keeping the text', () => {
+    const failed: ComposerState = { armed: true, draft: 'echo hi', status: 'failed', error: 'boom' }
+    expect(composerReducer(failed, { type: 'edit', draft: 'echo hi!' })).toEqual({
+      armed: true, draft: 'echo hi!', status: 'idle', error: null,
+    })
+    // a failed line can be re-submitted as-is
+    expect(canSubmit(failed)).toBe(true)
+  })
+
+  it('a send result that lands after the user disarmed is ignored (no resurrection)', () => {
+    const disarmedMidFlight = INITIAL_COMPOSER
+    expect(composerReducer(disarmedMidFlight, { type: 'sent', ok: true, message: 'delivered' })).toEqual(INITIAL_COMPOSER)
+    expect(composerReducer(disarmedMidFlight, { type: 'sent', ok: false, message: 'boom' })).toEqual(INITIAL_COMPOSER)
+  })
+
+  it('a result only lands while a send is actually in flight', () => {
+    // An 'idle' armed composer (nothing sending) ignores a stray result.
+    expect(composerReducer(armed, { type: 'sent', ok: false, message: 'boom' })).toEqual(armed)
+  })
+})
+
+describe('interactionBlock — when the row cannot be typed into', () => {
+  it('maps each fleet state to its block reason (or null when typable)', () => {
+    expect(interactionBlock('working')).toBe(null)
+    expect(interactionBlock('waiting')).toBe(null)
+    expect(interactionBlock('waiting-approval')).toBe('awaiting-approval')
+    expect(interactionBlock('exited')).toBe('not-running')
+    expect(interactionBlock('lost')).toBe('not-running')
+    expect(interactionBlock('closed')).toBe('not-running')
+    expect(interactionBlock('unknown')).toBe('external')
+  })
+})

--- a/packages/web/src/lib/terminalInput.ts
+++ b/packages/web/src/lib/terminalInput.ts
@@ -1,0 +1,145 @@
+/**
+ * terminalInput.ts — the pure core of the INTERACTIVE live terminal (Phase 2, web half).
+ *
+ * The read channel (`terminalStream.ts`) shows what a managed session is drawing. This module is the
+ * WRITE intent: it turns a person composing a line at the terminal into an honest, auditable send
+ * through the one write verb the server already exposes — `POST /api/fleet/act { action:'prompt' }`,
+ * which types a line into the session AND submits it, atomically, refusing when the session is on a
+ * dialog and answering ok/fail. This module invents no endpoint; it is the browser-side state machine
+ * that keeps that write honest.
+ *
+ * FOUR DECISIONS, resolved explicitly (the assignment's own list) — see docs/terminal-interactive.md:
+ *
+ * 1. CONSENT — per session, in-memory, explicit, revocable. Typing into a live coding agent changes
+ *    another running process, so it is a deliberate opt-in (`arm`), never a side effect of the
+ *    terminal being on screen. It is PER SESSION (arming one never arms its neighbour) and held only
+ *    for this surface's lifetime — a reload or a re-open re-asks, because "drive this session now" is
+ *    a decision to re-make, not a durable grant a stale tab keeps. `disarm` revokes it and drops any
+ *    pending line. This is an INTENT gate, not a security boundary — the server's `localShell`
+ *    capability + scope + dialog refusal remain the real authority; the gate keeps a human decision
+ *    at the head of every interactive session.
+ *
+ * 2. BATCHED TO A LINE, not key-by-key. The only web-reachable write is `sendText`, which types a
+ *    line and presses Enter as one act; there is no endpoint for a single raw key (`sendKey` is not
+ *    web-exposed and `sendText` cannot omit the Enter). So per-key is not merely expensive here, it is
+ *    unrepresentable. It would also be wrong even if it existed: one HTTP round-trip per keystroke
+ *    floods the audit and risks reordering (requests can complete out of order). The line is edited
+ *    LOCALLY (the native input is the line editor — backspace, cursor, paste are the browser's) and
+ *    ONE request carries the finished line, ordered by construction. Raw char-mode (Ctrl-C, arrows,
+ *    no-submit typing) needs a new server keystroke channel and is the documented Phase-2b escalation.
+ *
+ * 3. FAILURE MID-TYPING — the load-bearing rule: the terminal must never accept a key visually and
+ *    fail to deliver it. This design removes the failure surface rather than papering over it: keys
+ *    are LOCAL until submit, so nothing is delivered per key and nothing per key can be lost. The one
+ *    delivery is the line, and it moves through explicit states — composing → sending → delivered |
+ *    failed. A FAILED send does NOT clear the draft: the exact line stays, marked failed with the
+ *    server's own reason, ready to retry. While `sending` the composer is LOCKED, so two lines can
+ *    never race out of order. The local draft is drawn distinctly from the session's own output, so
+ *    local echo is never mistaken for the session having received it.
+ *
+ * 4. AUDIT WITHOUT NOISE — only the atomic send is auditable (through the existing `promptAudit`
+ *    record: who / session / text / when / outcome). Local edits (typing, backspacing) are NOT
+ *    audited: they are not sends, and per-keystroke auditing is exactly the flood the assignment
+ *    warns against. One line delivered-or-failed is one audit entry — the granularity the write
+ *    channel already records; this module adds nothing to that schema.
+ *
+ * Everything here is pure and reducer-shaped so the honesty rules above are pinned by tests
+ * (`terminalInput.test.ts`), not left to the JSX.
+ */
+
+/** A key was pressed; nothing has been sent yet. `sending` is the one line in flight; `failed` keeps
+ *  the line that did not land. `idle` after a delivered line means "clean, ready for the next". */
+export type SendStatus = 'idle' | 'sending' | 'failed'
+
+export interface ComposerState {
+  /** Decision 1 — the explicit, per-session, revocable consent to type. */
+  armed: boolean
+  /** Decision 2 — the local line buffer (cooked mode). Never sent until `submit`. */
+  draft: string
+  /** Decision 3 — the honest delivery state of the one line in flight. */
+  status: SendStatus
+  /** The server's verbatim refusal, kept while `failed` so the reason is on screen. */
+  error: string | null
+}
+
+export const INITIAL_COMPOSER: ComposerState = { armed: false, draft: '', status: 'idle', error: null }
+
+export type ComposerAction =
+  | { type: 'arm' }
+  | { type: 'disarm' }
+  | { type: 'edit'; draft: string }
+  | { type: 'submit' }
+  | { type: 'sent'; ok: boolean; message: string }
+
+/** Typing is allowed only while armed and not mid-send (the lock that prevents a reorder). */
+export function canEdit(state: ComposerState): boolean {
+  return state.armed && state.status !== 'sending'
+}
+
+/** A line may be sent only while armed, not mid-send, and with something non-blank to send. */
+export function canSubmit(state: ComposerState): boolean {
+  return state.armed && state.status !== 'sending' && state.draft.trim().length > 0
+}
+
+export function composerReducer(state: ComposerState, action: ComposerAction): ComposerState {
+  switch (action.type) {
+    case 'arm':
+      // Idempotent: arming an already-armed composer never wipes a line in progress.
+      return state.armed ? state : { armed: true, draft: '', status: 'idle', error: null }
+
+    case 'disarm':
+      // Revoking consent drops the pending line too — a session you stopped driving keeps nothing.
+      return INITIAL_COMPOSER
+
+    case 'edit':
+      // Local editing only when it is allowed; typing after a failure clears the failed marker so the
+      // revised line reads as a fresh attempt (its text is kept).
+      if (!canEdit(state)) return state
+      return { ...state, draft: action.draft, status: 'idle', error: null }
+
+    case 'submit':
+      if (!canSubmit(state)) return state
+      return { ...state, status: 'sending', error: null }
+
+    case 'sent':
+      // A result only means anything while a send is actually in flight AND consent still stands: a
+      // result that lands after the user disarmed must not resurrect a line or an armed state.
+      if (!state.armed || state.status !== 'sending') return state
+      return action.ok
+        ? { armed: true, draft: '', status: 'idle', error: null }
+        : { ...state, status: 'failed', error: action.message }
+
+    default:
+      return state
+  }
+}
+
+/** The fleet-row states the interactive terminal understands (mirrors `FleetRow['state']`). */
+export type FleetRowState =
+  | 'working' | 'waiting' | 'waiting-approval' | 'exited' | 'lost' | 'unknown' | 'closed'
+
+/**
+ * Why a row cannot be typed into right now, or `null` when it can.
+ *
+ * - `external` — not an agentop-managed session; nothing here can write to it.
+ * - `not-running` — exited / lost / closed; there is no live process to receive the line.
+ * - `awaiting-approval` — the session is on a dialog, and the server refuses a prompt into one (the
+ *   person must answer the dialog, not type past it). A `working` or `waiting` session IS typable —
+ *   a queued line is picked up on the next turn.
+ */
+export type InteractionBlock = 'external' | 'not-running' | 'awaiting-approval' | null
+
+export function interactionBlock(state: FleetRowState): InteractionBlock {
+  switch (state) {
+    case 'unknown':
+      return 'external'
+    case 'exited':
+    case 'lost':
+    case 'closed':
+      return 'not-running'
+    case 'waiting-approval':
+      return 'awaiting-approval'
+    default:
+      return null
+  }
+}


### PR DESCRIPTION
Closes #268.

## Summary
The live session terminal was read-only (Phase 1). This adds its **write** half **entirely in `packages/web`**, built on the one write verb the server already exposes — `POST /api/fleet/act { action:'prompt' }` (types a line into the session, submits it, refuses on a dialog / when not running, answers ok/fail). **No `packages/server` change.**

New pure core `lib/terminalInput.ts` (consent + local line buffer + honest delivery state machine, 14 tests) drives a `TerminalComposer` under the live terminal in `RecentSessions.tsx`.

## The four decisions (assignment), resolved explicitly — see `docs/terminal-interactive.md`
1. **Consent** — per-session, in-memory, explicit, revocable (arm/disarm). An *intent* gate on top of the server's `localShell` capability + scope + dialog refusal, not a security boundary. Reload re-asks; arming one session never arms its neighbour.
2. **Batched to a line, not key-by-key** — the native input is the local line editor; **one** request carries the finished line. Per-key is *unrepresentable* on the current backend (`sendText` always submits, `sendKey` is not web-exposed) and would flood the audit and risk reordering.
3. **Failure mid-typing (the load-bearing rule)** — keys are **local until submit**, so nothing is delivered per key and nothing per key can be lost. A line goes composing → sending → **delivered | failed**; a **failed line is kept verbatim** with the server's reason (never silently dropped); the composer **locks while sending** so lines can't race. The draft is drawn distinctly (accent rule + `›`) so local echo is never mistaken for session output.
4. **Audit without noise** — only the atomic send is recorded (existing `promptAudit`); local edits are not.

A row that can't be typed into (external / not-running / awaiting-approval) shows the reason and **no arming button**; an armed composer disarms itself if the row goes un-typable. Full raw char-mode (Ctrl-C, arrows, no-submit) needs a server keystroke channel — documented as the **Phase 2b escalation**.

## Motivation
Making the terminal interactive is this journey's dedicated goal (Phase 1 shipped it read-only by design). The four decisions had to be resolved deliberately, not by omission — decision #1 (consent) was genuinely absent before this.

## Test plan
- `bun test packages/web` — **905 pass** (incl. new `terminalInput.test.ts`, 14 tests covering all four decisions).
- `bun test` (full, pre-commit) — **4650 pass, 0 fail**.
- `bun tsc --noEmit` — clean; `bun.lock` unchanged.
- **Visual (headless Chrome, real backend, `/api/fleet/act` + `/api/fleet/stream` intercepted so no real prompt reaches a live session):** arm → type → **Send ⇒ delivered notice + draft cleared**; **Send (forced fail) ⇒ 'Not delivered' + line kept verbatim + failed audit entry**; **no console/page errors** (no xterm regression).

## Docs
`docs/terminal-interactive.md` (new) + a pointer from `docs/terminal-channel.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JUjakx99hLCRMSixpLDsRZ