### PR TITLE
release: promove dev→main — tmux renderiza em cor cheia (#271)

### DIFF
--- a/docs/session-manager.md
+++ b/docs/session-manager.md
@@ -360,9 +360,35 @@ wired up because the key could not be verified from the CLI itself, and agentop 
 
 ## Scrolling an attached session
 
-Sessions are hosted on agentop's own tmux socket (`-L agentop`), and agentop sets four options on
-it before the first one exists: `remain-on-exit` (a finished session stays listable with its last
-frame readable), `mouse on`, a `history-limit` of 50000 lines, and `status off`.
+Sessions are hosted on agentop's own tmux socket (`-L agentop`), and agentop sets its options on it
+as part of creating the first session: the colour profile (below), `remain-on-exit` (a finished
+session stays listable with its last frame readable), `mouse on`, a `history-limit` of 50000 lines,
+and `status off`.
+
+All of it goes in **one chained tmux invocation** with the `new-session` it precedes, and that is
+not a style choice. `set-option` does not start a tmux server — on a cold socket it fails outright —
+so applied as separate pre-flight calls the options were simply lost, and the very first session
+kept tmux's defaults (8 colours, no mouse, a 2000-line buffer) until a second session happened to
+warm the server. Chaining runs every command against the single server tmux starts for the batch,
+in order, so an option that must precede its pane actually does.
+
+**Colour — a pane inside tmux should render like the CLI does outside it.** tmux's own
+`default-terminal` is `screen`, which advertises 8 colours, so a CLI in the pane self-downgrades
+even when the terminal you attach from does 256 or truecolor (measured on tmux 3.2a: `tput colors`
+is 8 inside such a pane against 256 outside). agentop sets `default-terminal` to the richest
+256-colour terminfo entry that provably exists on the host — `tmux-256color`, else `screen-256color`
+— which takes the pane to 256; a host with neither keeps tmux's default rather than naming an entry
+that is not installed. This is safe for every client because tmux downsamples per attach.
+
+Truecolor is added only when the terminal that *invoked* the session declared it (`COLORTERM` =
+`truecolor`/`24bit`), and it is keyed to that terminal's own `$TERM`: a `terminal-features
+,<TERM>:RGB` capability (appended, so tmux's built-in features survive) plus `COLORTERM=truecolor`
+carried into the pane so the CLI actually emits 24-bit. Keying to the invoker's `$TERM` is the
+compatibility guarantee — a different, less capable client attaching later never matches it and is
+rendered at 256 rather than fed RGB it cannot show. `-2` (force-256 on attach) was evaluated and
+left out: its effect on the attaching client could not be measured on 3.2a, and agentop does not
+ship a flag it could not verify — the attaching client's depth follows its own `$TERM` terminfo,
+which is exactly the terminfo the CLI would use outside tmux.
 
 The status bar is off because every fact it carries is wrong here: it lists windows and an agentop
 session is one window with one pane, it shows the session name and that name is `agentop-<id>`
@@ -374,10 +400,10 @@ nothing else, so attaching to a session to read what it did was attaching to a s
 read. The trade is that dragging to select now goes to tmux rather than to your terminal: **hold
 shift** to select and copy the terminal's own way.
 
-The scrollback is set up front because it does not apply retroactively — a pane created before it
-keeps tmux's default 2000 for as long as it lives. Sessions started by an older agentop therefore
-keep the small buffer until they are reopened; the mouse, being a server option, applies to them
-immediately.
+The scrollback and `default-terminal` are set up front because neither applies retroactively — a
+pane created before them keeps tmux's default 2000-line buffer and 8-colour `screen` for as long as
+it lives. Sessions started by an older agentop therefore keep the small buffer and the flat colours
+until they are reopened; the mouse, being a live server option, applies to them immediately.
 
 None of this touches your own tmux: different socket, different server, different config.
 

--- a/packages/server/server/sessions/backend-tmux.ts
+++ b/packages/server/server/sessions/backend-tmux.ts
@@ -5,9 +5,10 @@
 
 import {
   attachArgs, capturePaneArgs, capturePaneAnsiArgs, idFromTmuxName, isSessionGoneError,
-  killSessionArgs, listSessionsArgs, newSessionArgs, paneInfoArgs, parsePaneInfo, parsePrefix,
-  parseTmuxList, serverOptionsArgs, sendKeysNamedArgs, sendKeysLiteralArgs, showPrefixArgs,
-  trimCapture,
+  killSessionArgs, listSessionsArgs, paneInfoArgs, parsePaneInfo, parsePrefix, parseTmuxList,
+  resolveDefaultTerminal, resolveTruecolorTerm, spawnArgs, sendKeysNamedArgs, sendKeysLiteralArgs,
+  showPrefixArgs, trimCapture,
+  type TerminalProfile,
 } from './tmux-cli'
 import { planPromptDelivery } from './initial-prompt'
 import type {
@@ -28,6 +29,38 @@ const DELIVER_DEADLINE_MS = Number(process.env.AGENTISTICS_DELIVER_DEADLINE_MS) 
   : 15_000
 /** How much of the pane to read to judge readiness — enough for the input box and its footer. */
 const DELIVER_CAPTURE_LINES = 40
+
+/** True when this host has the named terminfo entry (`infocmp` exits 0). Never throws. */
+async function terminfoHas(name: string): Promise<boolean> {
+  try {
+    const p = Bun.spawn(['infocmp', name], { stdout: 'ignore', stderr: 'ignore', stdin: 'ignore' })
+    return (await p.exited) === 0
+  } catch {
+    // No infocmp on PATH — treat every entry as absent, so agentop leaves tmux's own default rather
+    // than naming a terminfo entry it could not confirm exists.
+    return false
+  }
+}
+
+let profileCache: TerminalProfile | null = null
+
+/**
+ * Resolve the colour profile once per process: the terminfo entries do not change under us, and the
+ * invoking terminal's env (`TERM` / `COLORTERM`) is fixed for this run. The pure resolvers in
+ * `tmux-cli.ts` decide; this only does the IO they cannot.
+ */
+async function terminalProfile(): Promise<TerminalProfile> {
+  if (profileCache) return profileCache
+  const [tmux256color, screen256color] = await Promise.all([
+    terminfoHas('tmux-256color'),
+    terminfoHas('screen-256color'),
+  ])
+  profileCache = {
+    defaultTerminal: resolveDefaultTerminal({ tmux256color, screen256color }),
+    truecolorTerm: resolveTruecolorTerm({ TERM: process.env.TERM, COLORTERM: process.env.COLORTERM }),
+  }
+  return profileCache
+}
 
 async function tmux(args: string[]): Promise<{ code: number; out: string; err: string }> {
   try {
@@ -109,11 +142,16 @@ export const tmuxBackend: SessionBackend = {
   },
 
   async spawn(req: BackendSpawn) {
-    // Set BEFORE the session exists. `remain-on-exit` afterwards is a race the fast-failing case
-    // always wins, and `history-limit` afterwards does not apply to this pane at all — see
-    // `serverOptionsArgs`.
-    for (const args of serverOptionsArgs()) await tmux(args)
-    const { code, out } = await tmux(newSessionArgs({ id: req.id, cwd: req.cwd, argv: req.argv }))
+    // Options and `new-session` go in ONE chained invocation. They must be set BEFORE the session
+    // exists — `remain-on-exit` afterwards is a race the fast-failing case always wins,
+    // `history-limit` afterwards does not apply to this pane at all, and `default-terminal` (the
+    // colour fix) keeps tmux's 8-colour `screen` default for the life of a pane created before it.
+    // Applied as SEPARATE pre-flight calls they were lost on a cold socket, because `set-option`
+    // does not start a server — see `spawnArgs`.
+    const profile = await terminalProfile()
+    const { code, out } = await tmux(
+      spawnArgs(profile, { id: req.id, cwd: req.cwd, argv: req.argv }),
+    )
     if (code !== 0) throw new Error(out.trim() || `tmux new-session failed (code ${code})`)
     if (req.initialPrompt) {
       // Deliver the prompt only once the harness is READY — polled, not a fixed sleep — so a slow

--- a/packages/server/server/sessions/tmux-cli.test.ts
+++ b/packages/server/server/sessions/tmux-cli.test.ts
@@ -6,7 +6,16 @@ import {
   sendKeysNamedArgs, trimCapture,
   tmuxName,
   serverOptionsArgs, HISTORY_LIMIT,
+  resolveDefaultTerminal, resolveTruecolorTerm, spawnArgs,
+  type TerminalProfile,
 } from './tmux-cli'
+
+/** A colour-neutral profile: neither a 256-colour terminfo entry nor a truecolor invoker. */
+const NO_COLOR: TerminalProfile = { defaultTerminal: null, truecolorTerm: null }
+/** The common case on this host: tmux-256color present, invoker not (yet) truecolor. */
+const C256: TerminalProfile = { defaultTerminal: 'tmux-256color', truecolorTerm: null }
+/** A truecolor invoker on xterm-256color. */
+const TRUECOLOR: TerminalProfile = { defaultTerminal: 'tmux-256color', truecolorTerm: 'xterm-256color' }
 
 describe('names', () => {
   it('namespaces our sessions', () => {
@@ -26,6 +35,96 @@ describe('newSessionArgs', () => {
         '-L', 'agentop', 'new-session', '-d', '-s', 'agentop-a1', '-c', '/home/u/p',
         '--', 'claude', '--model', 'opus', 'fix it',
       ])
+  })
+
+  it('propagates COLORTERM into the pane when the invoker is truecolor, before the -- guard', () => {
+    // tmux does NOT set COLORTERM itself (measured on 3.2a): a detached CLI only emits 24-bit colour
+    // when it inherits COLORTERM=truecolor, and the pane inherits it from -e. It must land before
+    // `--`, or tmux reads it as one of the harness's own arguments.
+    const args = newSessionArgs({ id: 'a1', cwd: '/home/u/p', argv: ['claude'], truecolor: true })
+    expect(args).toEqual([
+      '-L', 'agentop', 'new-session', '-d', '-s', 'agentop-a1', '-c', '/home/u/p',
+      '-e', 'COLORTERM=truecolor', '--', 'claude',
+    ])
+    expect(args.indexOf('-e')).toBeLessThan(args.indexOf('--'))
+  })
+
+  it('adds nothing when the invoker is not truecolor', () => {
+    const args = newSessionArgs({ id: 'a1', cwd: '/home/u/p', argv: ['claude'], truecolor: false })
+    expect(args).not.toContain('-e')
+    expect(args).not.toContain('COLORTERM=truecolor')
+  })
+})
+
+describe('resolveDefaultTerminal', () => {
+  it('prefers tmux-256color when its terminfo entry is present', () => {
+    expect(resolveDefaultTerminal({ tmux256color: true, screen256color: true })).toBe('tmux-256color')
+    expect(resolveDefaultTerminal({ tmux256color: true, screen256color: false })).toBe('tmux-256color')
+  })
+
+  it('falls back to screen-256color when tmux-256color is absent', () => {
+    expect(resolveDefaultTerminal({ tmux256color: false, screen256color: true })).toBe('screen-256color')
+  })
+
+  it('leaves tmux to its own default rather than naming a terminfo entry that does not exist', () => {
+    // A default-terminal pointing at a missing entry is worse than none — it downgrades every pane.
+    expect(resolveDefaultTerminal({ tmux256color: false, screen256color: false })).toBeNull()
+  })
+})
+
+describe('resolveTruecolorTerm', () => {
+  it('trusts COLORTERM=truecolor and keys the capability to the invoker own $TERM', () => {
+    expect(resolveTruecolorTerm({ TERM: 'xterm-256color', COLORTERM: 'truecolor' })).toBe('xterm-256color')
+    expect(resolveTruecolorTerm({ TERM: 'alacritty', COLORTERM: '24bit' })).toBe('alacritty')
+  })
+
+  it('is case- and whitespace-tolerant on COLORTERM', () => {
+    expect(resolveTruecolorTerm({ TERM: 'xterm-256color', COLORTERM: ' TrueColor ' })).toBe('xterm-256color')
+  })
+
+  it('declares no truecolor when the invoker did not (compatibility: never force RGB)', () => {
+    // The exact state of this host at authoring time: TERM=screen, COLORTERM unset -> no truecolor.
+    expect(resolveTruecolorTerm({ TERM: 'screen', COLORTERM: '' })).toBeNull()
+    expect(resolveTruecolorTerm({ TERM: 'xterm-256color', COLORTERM: undefined })).toBeNull()
+    expect(resolveTruecolorTerm({ TERM: 'xterm-256color', COLORTERM: '256' })).toBeNull()
+  })
+
+  it('cannot key a capability with no $TERM to key it to', () => {
+    expect(resolveTruecolorTerm({ TERM: '', COLORTERM: 'truecolor' })).toBeNull()
+    expect(resolveTruecolorTerm({ TERM: undefined, COLORTERM: 'truecolor' })).toBeNull()
+  })
+})
+
+describe('spawnArgs', () => {
+  it('is ONE invocation: the socket once, options then new-session, chained by bare ";"', () => {
+    // `set-option` does not start a tmux server (measured on 3.2a), so options applied as separate
+    // calls before the first `new-session` are lost on a cold socket and the first session keeps
+    // tmux's 8-colour `screen` default. Chaining runs them against the single server tmux starts for
+    // the batch, in order, so `default-terminal` precedes the pane it configures.
+    const args = spawnArgs(C256, { id: 'a1', cwd: '/home/u/p', argv: ['claude', 'fix it'] })
+    expect(args.slice(0, 2)).toEqual(['-L', 'agentop'])
+    // -L appears exactly once, at the front; subcommands carry no socket flag of their own.
+    expect(args.filter(a => a === '-L')).toHaveLength(1)
+    // default-terminal is set BEFORE new-session in the sequence.
+    expect(args.indexOf('default-terminal')).toBeLessThan(args.indexOf('new-session'))
+    // The command list is exactly serverOptionsArgs + newSessionArgs, de-prefixed and ;-joined.
+    const cmds = [...serverOptionsArgs(C256), newSessionArgs({ id: 'a1', cwd: '/home/u/p', argv: ['claude', 'fix it'] })]
+    const expected: string[] = ['-L', 'agentop']
+    cmds.forEach((c, i) => { if (i) expected.push(';'); expected.push(...c.slice(2)) })
+    expect(args).toEqual(expected)
+  })
+
+  it('carries the truecolor pane env through to new-session', () => {
+    const args = spawnArgs(TRUECOLOR, { id: 'a1', cwd: '/p', argv: ['claude'] })
+    expect(args).toContain('COLORTERM=truecolor')
+    // terminal-features (client side) and COLORTERM (pane side) both present for a truecolor invoker.
+    expect(args.join(' ')).toContain('terminal-features ,xterm-256color:RGB')
+  })
+
+  it('still ends with the harness command after --, untouched', () => {
+    const args = spawnArgs(NO_COLOR, { id: 'a1', cwd: '/p', argv: ['claude', '--model', 'opus', 'go'] })
+    const dashdash = args.lastIndexOf('--')
+    expect(args.slice(dashdash + 1)).toEqual(['claude', '--model', 'opus', 'go'])
   })
 })
 
@@ -153,7 +252,7 @@ describe('isSessionGoneError', () => {
 })
 
 describe('serverOptionsArgs', () => {
-  const all = serverOptionsArgs()
+  const all = serverOptionsArgs(C256)
 
   it('touches only agentop own socket', () => {
     // The whole reason setting global options is safe: none of this reaches the user's tmux, their
@@ -179,12 +278,38 @@ describe('serverOptionsArgs', () => {
   })
 })
 
+describe('serverOptionsArgs — colour', () => {
+  it('sets default-terminal to the resolved 256-colour entry so panes are not capped at 8', () => {
+    // Measured on tmux 3.2a: tmux's default-terminal is `screen`, which advertises 8 colours, so a
+    // CLI inside the pane self-downgrades. tmux-256color takes tput colors from 8 to 256.
+    const term = serverOptionsArgs(C256).find(a => a.includes('default-terminal'))
+    expect(term).toEqual(['-L', 'agentop', 'set-option', '-g', 'default-terminal', 'tmux-256color'])
+  })
+
+  it('names no default-terminal when no 256-colour terminfo entry exists here', () => {
+    expect(serverOptionsArgs(NO_COLOR).some(a => a.includes('default-terminal'))).toBe(false)
+  })
+
+  it('appends a truecolor capability keyed to the invoker $TERM, preserving tmux built-ins', () => {
+    // `-ga` APPENDS so tmux's own terminal-features (clipboard, titles, …) survive; keying to the
+    // invoker's own $TERM is the compatibility guarantee — a differently-typed client attaching
+    // later never matches and renders at 256 rather than being fed RGB it cannot show.
+    const rgb = serverOptionsArgs(TRUECOLOR).find(a => a.includes('terminal-features'))
+    expect(rgb).toEqual(['-L', 'agentop', 'set-option', '-ga', 'terminal-features', ',xterm-256color:RGB'])
+  })
+
+  it('adds no truecolor capability when the invoker did not declare truecolor', () => {
+    expect(serverOptionsArgs(C256).some(a => a.includes('terminal-features'))).toBe(false)
+    expect(serverOptionsArgs(NO_COLOR).some(a => a.includes('terminal-features'))).toBe(false)
+  })
+})
+
 describe('the status bar', () => {
   it('is off — it costs a row to say nothing here', () => {
     // tmux's band lists windows, the session name and a clock. An agentop session is one window
     // with one pane, its name is `agentop-<id>` rather than anything a person chose, and the
     // cockpit already shows all of it.
-    const status = serverOptionsArgs().find(a => a.includes('status'))
+    const status = serverOptionsArgs(C256).find(a => a.includes('status'))
     expect(status).toEqual(['-L', 'agentop', 'set-option', '-g', 'status', 'off'])
   })
 })

--- a/packages/server/server/sessions/tmux-cli.ts
+++ b/packages/server/server/sessions/tmux-cli.ts
@@ -10,7 +10,8 @@
  * filter to stay out of their way. The prefix on the name is belt and braces for the case where a
  * user points their own tmux at our socket deliberately.
  *
- * Every field and flag below was probed against tmux 3.2a on 2026-08-12.
+ * Every field and flag below was probed against tmux 3.2a on 2026-08-12; the colour options
+ * (`default-terminal`, `terminal-features`, the pane's `COLORTERM`) were probed on 2026-09-01.
  */
 
 import type { BackendSession, PaneInfo } from './types'
@@ -32,9 +33,66 @@ export const LIST_FORMAT =
 
 const sock = (rest: string[]): string[] => ['-L', TMUX_SOCKET, ...rest]
 
-/** `--` matters: without it tmux parses the harness's own flags as its own. */
-export function newSessionArgs(o: { id: string; cwd: string; argv: string[] }): string[] {
-  return sock(['new-session', '-d', '-s', tmuxName(o.id), '-c', o.cwd, '--', ...o.argv])
+/**
+ * The colour profile agentop applies to its tmux, resolved from THIS host's terminfo and the
+ * INVOKING terminal's environment. It is data, not IO, so the argv builders stay pure and the
+ * resolution — which is terminfo-dependent (`resolveDefaultTerminal`) and env-dependent
+ * (`resolveTruecolorTerm`) — is tested on its own. See docs/session-manager.md for the why.
+ */
+export interface TerminalProfile {
+  /** tmux `default-terminal`, or null to leave tmux's own (`screen`, 8 colours) untouched. */
+  defaultTerminal: string | null
+  /**
+   * The invoking terminal's own `$TERM`, to key a truecolor (RGB) capability to — or null when the
+   * invoker did not DECLARE truecolor (`COLORTERM`). Keying it to that exact `$TERM` is the whole
+   * compatibility story: a different, less capable client attaching later never matches and is
+   * rendered at 256 rather than fed RGB it cannot show.
+   */
+  truecolorTerm: string | null
+}
+
+/**
+ * PURE: pick the richest 256-colour terminfo entry that PROVABLY exists on this host.
+ *
+ * tmux's own `default-terminal` is `screen`, which advertises 8 colours; a CLI inside such a pane
+ * self-downgrades even when the terminal you attach from does 256 or more (measured on 3.2a:
+ * `tput colors` 8 inside the pane vs whatever the real terminal reports outside it). `tmux-256color`
+ * takes the pane to 256. We never NAME an entry that is not installed — a `default-terminal`
+ * pointing at a missing terminfo entry downgrades every pane, which is worse than tmux's default —
+ * so the caller checks presence (`infocmp`) and a host with neither entry keeps tmux's default.
+ */
+export function resolveDefaultTerminal(has: { tmux256color: boolean; screen256color: boolean }): string | null {
+  if (has.tmux256color) return 'tmux-256color'
+  if (has.screen256color) return 'screen-256color'
+  return null
+}
+
+/**
+ * PURE: does the INVOKING terminal declare truecolor, and under which `$TERM`?
+ *
+ * The de-facto signal is `COLORTERM` = `truecolor` | `24bit`; nothing else is trusted, because
+ * forcing RGB onto a terminal that did not ask for it is exactly the incompatibility we must avoid
+ * (tmux would then emit 24-bit sequences a non-truecolor terminal cannot render). The capability is
+ * keyed to the invoker's `$TERM`, so with no `$TERM` there is nothing to key it to and we decline.
+ */
+export function resolveTruecolorTerm(env: { TERM?: string; COLORTERM?: string }): string | null {
+  const ct = (env.COLORTERM ?? '').trim().toLowerCase()
+  if (ct !== 'truecolor' && ct !== '24bit') return null
+  const term = (env.TERM ?? '').trim()
+  return term.length > 0 ? term : null
+}
+
+/**
+ * `--` matters: without it tmux parses the harness's own flags as its own.
+ *
+ * `-e COLORTERM=truecolor` (before `--`) is set only for a truecolor invoker: tmux does NOT set
+ * `COLORTERM` in a pane itself (measured on 3.2a), so a detached CLI only emits 24-bit colour when
+ * it inherits it. The client-side half — tmux actually forwarding RGB on attach — is the
+ * `terminal-features` capability in `serverOptionsArgs`.
+ */
+export function newSessionArgs(o: { id: string; cwd: string; argv: string[]; truecolor?: boolean }): string[] {
+  const env = o.truecolor ? ['-e', 'COLORTERM=truecolor'] : []
+  return sock(['new-session', '-d', '-s', tmuxName(o.id), '-c', o.cwd, ...env, '--', ...o.argv])
 }
 
 export function killSessionArgs(id: string): string[] {
@@ -147,9 +205,29 @@ export const HISTORY_LIMIT = 50_000
  * session you cannot read. It has a cost worth stating rather than discovering: with the mouse
  * captured, dragging to select goes to tmux instead of to the terminal, and SHIFT is the bypass —
  * the same trade the control center already documents for its own mouse mode.
+ *
+ * The COLOUR options come first and are conditional. `default-terminal` lifts the pane off tmux's
+ * 8-colour `screen` default (see `resolveDefaultTerminal`); it downsamples per attaching client, so
+ * it is safe unconditionally and only omitted when no 256-colour terminfo entry exists here. The
+ * truecolor `terminal-features` is appended (`-ga`, so tmux's built-in features survive) and keyed
+ * to the invoker's own `$TERM` — the compatibility guarantee: a client that did not declare
+ * truecolor never matches it. `-2` was evaluated and left out: on tmux 3.2a its effect on the
+ * attaching client could not be MEASURED (`client_colours` is unpopulated), and agentop does not
+ * ship a flag it could not verify — the attaching client's depth follows its own `$TERM` terminfo,
+ * which is exactly the terminfo the CLI would use OUTSIDE tmux.
+ *
+ * Only `default-terminal` must precede a pane to take effect (it does not apply retroactively), so
+ * these are set, like the others, before the first session — see the backend's spawn note.
  */
-export function serverOptionsArgs(): string[][] {
-  return [
+export function serverOptionsArgs(profile: TerminalProfile): string[][] {
+  const opts: string[][] = []
+  if (profile.defaultTerminal) {
+    opts.push(sock(['set-option', '-g', 'default-terminal', profile.defaultTerminal]))
+  }
+  if (profile.truecolorTerm) {
+    opts.push(sock(['set-option', '-ga', 'terminal-features', `,${profile.truecolorTerm}:RGB`]))
+  }
+  opts.push(
     // Keeps a finished session listable, with its last frame still capturable — the `exited` state.
     sock(['set-option', '-g', 'remain-on-exit', 'on']),
     sock(['set-option', '-g', 'mouse', 'on']),
@@ -161,7 +239,44 @@ export function serverOptionsArgs(): string[][] {
     // band costs a row of the assistant's screen to say nothing, in a colour that is hard to
     // ignore.
     sock(['set-option', '-g', 'status', 'off']),
+  )
+  return opts
+}
+
+/**
+ * The ONE tmux invocation that applies our server options AND creates the session, chained with a
+ * bare `;` between subcommands.
+ *
+ * Why one invocation rather than the options first and then `new-session`: `set-option` does NOT
+ * start a tmux server (measured on 3.2a — it exits non-zero, `error connecting to …`). So on a COLD
+ * socket the options applied before the first `new-session` were simply lost, and that first session
+ * kept tmux's 8-colour `screen` default — no 256 colours, no mouse, no scrollback — until a second
+ * session warmed the server. Chaining runs every command against the single server tmux starts for
+ * the batch, in order, so `default-terminal` (which does not apply retroactively) precedes the pane
+ * it must configure.
+ *
+ * `-L <socket>` is given ONCE, at the front; each `;` separates a subcommand that then carries no
+ * socket flag of its own. The `;` is a bare argv token because the caller execs tmux directly
+ * (`Bun.spawn`, no shell), so there is nothing to escape.
+ */
+export function spawnArgs(
+  profile: TerminalProfile,
+  o: { id: string; cwd: string; argv: string[] },
+): string[] {
+  // ONE profile drives both halves of truecolor: the client-side capability
+  // (`terminal-features` in serverOptionsArgs) and the pane-side `COLORTERM` here. Deriving the
+  // pane env from the profile — rather than a separate flag — is what keeps them from disagreeing.
+  const commands: string[][] = [
+    ...serverOptionsArgs(profile),
+    newSessionArgs({ id: o.id, cwd: o.cwd, argv: o.argv, truecolor: profile.truecolorTerm !== null }),
   ]
+  const chained: string[] = []
+  commands.forEach((cmd, i) => {
+    if (i > 0) chained.push(';')
+    // Each builder returns its own `-L <socket>` prefix; drop it so the socket is named once.
+    chained.push(...cmd.slice(2))
+  })
+  return sock(chained)
 }
 
 export function showPrefixArgs(): string[] {


### PR DESCRIPTION
Promoção da PR #271, gateada por QA independente.

**O defeito:** dentro do tmux do agentop as CLIs caíam para 8 cores e o PE não conseguia distinguir a própria mensagem enviada do resto do quadro. Palavras dele: *"ta tudo da mesma cor e fica impossivel de ler, dentro do tmux as clis estao renderizando diferente do que fora dele"*. Medido: `default-terminal=screen`, `terminal-overrides` vazio, `tput colors`=8.

**O conserto:** `serverOptionsArgs` passa a configurar o terminal — `TERM=tmux-256color`, 256 cores, e `terminal-features -ga` adicionando `xterm-256color:RGB` sem descartar os built-ins. Quando o terminal externo suporta truecolor, o painel herda `COLORTERM=truecolor`.

**Gate (Tyrus), em socket descartável:** baseline frio confirmou o defeito (TERM=screen, COLORS=8); com o argv encadeado, a **primeira** sessão já nasce com TERM=tmux-256color e COLORS=256, com as opções aplicadas. 4669 testes, tsc limpo, escopo restrito a `packages/server`.

## Limite declarado — importante

A prova cobre **sessão nova em socket frio**. Opção de servidor tmux **só afeta painéis criados depois**, e foi medido no socket real logo antes deste merge: as **8 sessões vivas continuam com `default-terminal=screen` e `tput colors=8`**.

**Para ver a diferença é preciso abrir uma sessão nova.** As que já estão abertas não mudam.