### PR TITLE
release: promove dev→main — canal de escrita ordenado do terminal (#281)

### DIFF
--- a/docs/terminal-channel.md
+++ b/docs/terminal-channel.md
@@ -11,8 +11,10 @@ emulator) must build on exactly this — it does not invent its own endpoint.
 `frame` only ever flows server → browser. The **write** half is a separate concern with its own
 contract: the line-oriented interactive composer built on `POST /api/fleet/act { action:'prompt' }`
 (**Phase 2**, web-only, no new endpoint) is documented in
-[`docs/terminal-interactive.md`](terminal-interactive.md); a raw keystroke channel (**Phase 2b**) is
-the escalation noted there. The rule the read channel set still holds: the web shows **no input box
+[`docs/terminal-interactive.md`](terminal-interactive.md); the raw key-by-key channel
+(**Phase 2b**, `WS /api/fleet/input`) is documented in
+[`docs/terminal-write-channel.md`](terminal-write-channel.md). The rule the read channel set still
+holds: the web shows **no input box
 that does nothing** — the composer is offered only where a live, managed, typable row backs it, and it
 reports every line's delivery honestly.
 

--- a/docs/terminal-interactive.md
+++ b/docs/terminal-interactive.md
@@ -102,12 +102,16 @@ A session that goes un-typable *while armed* (killed, or falls onto a dialog) is
 automatically and shows the block sentence, so an armed composer can never sit over a session where
 every send would fail.
 
-## Escalation — Phase 2b (raw keystroke channel), `packages/server`
+## Escalation — Phase 2b (raw keystroke channel), `packages/server` — DELIVERED
 
 Full char-mode interactivity (Ctrl-C, arrows, Esc, Tab, no-submit typing, answering raw dialogs by
 keypress) requires a server write endpoint that forwards individual keys to the backend's existing
-`sendKey` / `sendText` primitives **without** the implicit Enter — e.g. `POST /api/fleet/input
-{ id, key | text, submit? }`, gated by the same `localShell` capability and scope as the read stream,
-with its own audit decision. That is a `packages/server` change and was **not** made here; the web
-half above is complete and honest on its own for line-oriented interaction (sending a message or an
-answer to the agent), which is the dominant case.
+`sendKey` / `sendText` primitives **without** the implicit Enter. That server channel now exists as
+**`WS /api/fleet/input`** — a WebSocket rather than a POST, because per-keystroke HTTP arrives out of
+order; ordering is guaranteed by one connection per session plus a per-connection serial send queue,
+and every message is confirmed with an ack. It is gated by the same `localShell` capability and scope
+as the read stream, plus a same-origin (CSWSH) check, and audits one entry per channel opened rather
+than per keystroke. The full server contract — message shape, the closed key allowlist, why there is
+no local echo — is [`docs/terminal-write-channel.md`](terminal-write-channel.md). The line composer
+above **stays** and is unchanged: it remains the right tool for pasting a block and for when the
+socket drops.

--- a/docs/terminal-write-channel.md
+++ b/docs/terminal-write-channel.md
@@ -1,0 +1,117 @@
+# Ordered write channel (Phase 2b — server)
+
+`GET /api/fleet/stream` ([docs/terminal-channel.md](terminal-channel.md)) is the **read** half of the
+live terminal: a session's screen, server → browser, over SSE. This is the **write** half at the
+finest grain — a WebSocket that types into a managed session **key by key**, so the browser terminal
+can accept direct typing (`xterm.onData`) without scrambling the order and without lying about what
+was delivered.
+
+It is the **server contract** the web dashboard (`agentistics/web`) consumes. The web side wires
+`xterm.onData` to it; it invents no endpoint of its own.
+
+## Why a WebSocket, not the existing paths
+
+Two paths already write into a session, and neither fits key-by-key typing:
+
+- `POST /api/fleet/act { action:'prompt', text }` types a whole line **and always appends `Enter`**
+  (`sendTextTo`, `backend-tmux.ts`). It is the line composer ([docs/terminal-interactive.md](terminal-interactive.md))
+  and it **stays** — good for pasting a long block and for when the socket drops. Per keystroke it is
+  wrong: every character would submit a turn.
+- HTTP POSTs can arrive **out of order**. One POST per keystroke turns `"hello"` into `"hlelo"`
+  intermittently — a defect that passes a gate and shows up only in use.
+
+A WebSocket gives what per-keystroke typing needs: **one connection per session** (TCP preserves
+order on a single connection) and a live bidirectional channel for the per-message confirmation. The
+repo already runs WebSockets (`team-agent.ts`), so it is not new ground.
+
+Ordering is guaranteed by two things together, and neither alone is enough:
+
+1. one connection per session, and
+2. the server processing that connection's messages **strictly sequentially** — one `send-keys` at a
+   time, a per-connection FIFO queue that `await`s the previous send before the next
+   (`sessions/input-channel.ts`). Client timestamps are never trusted.
+
+## Request
+
+```
+GET  /api/fleet/input?id=<sessionId>
+Upgrade: websocket
+```
+
+- `id` — the **same** id carried by `GET /api/fleet`, `POST /api/fleet/act` and `GET /api/fleet/stream`.
+- The session must be one **this machine manages** (the registry); anything else is a `404` before
+  the upgrade, never a socket that opens and then says "not found".
+
+## Messages
+
+Client → server, one JSON object per WS message:
+
+```json
+{ "seq": 1, "kind": "text", "data": "l" }
+{ "seq": 2, "kind": "key",  "name": "C-c" }
+```
+
+- `seq` — the client's own monotonic counter (starts at 1). It is **echoed** in the ack, which is
+  what makes FIFO *verifiable* rather than assumed: a mismatch is a detected, surfaced failure.
+- `kind:"text"` carries `data`, sent **literally** with `tmux send-keys -l` — **no implicit `Enter`**.
+  Because it is literal, the raw bytes a browser's `xterm.onData` emits (printable characters *and*
+  escape sequences — arrows, etc.) pass through as themselves.
+- `kind:"key"` carries `name`, one key from a **closed allowlist**, sent as a *named* key
+  (`tmux send-keys`, no `-l`). The set is
+  `Enter BSpace Tab Up Down Left Right C-c C-d C-a C-e C-u C-w C-k`. A name outside it is refused —
+  defence in depth: the client keeps its own allowlist and the server does **not** trust it. Widening
+  the set is a deliberate code change in `KEY_ALLOWLIST` (`sessions/input-protocol.ts`), never a
+  client-supplied value.
+
+The `text`/`key` split is by construction: `text` never carries `Enter`; a submit is `kind:"key"`
+`name:"Enter"`. Confusing the two fails silently in tmux (`send-keys -l Enter` types five letters),
+which is exactly why the literal and named `send-keys` builders are kept apart.
+
+Server → client, **one ack per message**:
+
+```json
+{ "seq": 1, "ok": true }
+{ "seq": 2, "ok": false, "reason": "send_failed" }
+```
+
+- `reason` is present iff `ok` is false — a stable code (`bad_json`, `bad_message`, `empty_text`,
+  `text_too_long`, `bad_key`, `send_failed`, `error`) the client renders or maps/localizes.
+- **There is no local echo and no "ready" frame.** The WS open event is the go-ahead; a character
+  appears on screen only when the *session* draws it, read back over the existing SSE stream. That is
+  what makes "the UI never shows a keystroke that did not land" true **by construction** — a key that
+  never reached the process is never painted. It is the opposite of the defect the line composer
+  fixed at line scale.
+
+## Security — the same gates as `/api/fleet/act`, and no lower ones
+
+Typing key-by-key, control keys included, is **more** power than the line prompt, not less. The
+channel rides exactly the gates `/api/fleet` and `/api/fleet/act` carry:
+
+- **`localShell` capability** (`capability-guard.ts`) — refused (403) on any exposed profile,
+  **before** the upgrade. There is no deployment that should expose someone's keyboard to the network.
+- **404 on a central** (`TEAM_CENTRAL`) — a central hosts no sessions.
+- **Same-origin** — the upgrade is refused unless the browser's `Origin` is the dashboard's own (or
+  an allowlisted) origin (`wsInputOriginOk`). CSWSH protection: `localShell` being on does not stop a
+  malicious page in the user's own browser from opening a socket to `localhost`.
+- **Scope** — a socket opens only for a session the registry lists; the id is fixed at upgrade, so a
+  message can never redirect a keystroke to another session.
+- **Capacity** — `MAX_INPUT_SOCKETS` caps concurrent write sockets, like the read stream's cap.
+- **Audit** — one `fleet.input.open` entry per channel opened (a keyboard attached to a session),
+  never one per keystroke; a rejected upgrade is `fleet.input.denied`.
+
+## Modules
+
+| File | Role |
+|------|------|
+| `sessions/input-protocol.ts` | **pure** — message parse/validate, the closed key allowlist, ack shapes, the same-origin check |
+| `sessions/input-channel.ts` | **pure, injectable** — the per-connection serial queue (the order guarantee) and one ack per message |
+| `sessions/input-web.ts` | singleton wiring: scope check, capacity cap, WS lifecycle handlers; resolves the backend lazily to stay light |
+| `sessions/backend-tmux.ts` | `sendTextRaw` — literal `send-keys`, no `Enter` (the first half of `sendTextTo`, exposed) |
+| `index.ts` | the `/api/fleet/input` route + the shared WS handler dispatch |
+
+## Latency (measured, local, disposable tmux session)
+
+- **Write path (WS send → ack):** median ~9 ms, p95 ~130 ms — the channel's own contribution.
+- **End-to-end echo (key → visible on screen via SSE):** median ~380 ms — dominated by the **read**
+  channel's 500 ms poll (`TERMINAL_POLL_MS`), which this unit does not change. Fluid direct typing
+  would want that poll tuned; that is a read-channel decision, deliberately out of scope here.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentistics",
-  "version": "1.23.1",
+  "version": "2.3.2",
   "description": "Local analytics dashboard for AI coding assistants — tracks tokens, cost, sessions, and activity from ~/.claude/",
   "keywords": [
     "claude",

--- a/packages/agentop/package.json
+++ b/packages/agentop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentistics/agentop",
-  "version": "1.23.1",
+  "version": "2.3.2",
   "description": "agentop CLI — npm install for the same native binary distributed via install.sh (Linux x86_64 only)",
   "type": "commonjs",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentistics/core",
-  "version": "1.23.1",
+  "version": "2.3.2",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentistics/mcp",
-  "version": "1.23.1",
+  "version": "2.3.2",
   "description": "Agentistics MCP server — Claude Code analytics for Claude Desktop and Claude Code",
   "type": "module",
   "main": "./dist/agentistics-mcp.js",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentistics/server",
-  "version": "1.23.1",
+  "version": "2.3.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/server/server/audit.ts
+++ b/packages/server/server/audit.ts
@@ -29,6 +29,10 @@ export type AuditAction =
   | 'config.update' | 'bootstrap.consume'
   | 'capability.denied' | 'authz.denied' | 'rate.blocked'
   | 'stepup.granted' | 'stepup.failure' | 'stepup.missing'
+  // A live-terminal WRITE channel was opened (a keyboard attached to a session) or refused — ONE
+  // entry per channel, never per keystroke. `fleet.input.denied` records a rejected WS upgrade
+  // (e.g. a cross-origin attempt); the capability refusal is already `capability.denied`.
+  | 'fleet.input.open' | 'fleet.input.denied'
 
 export interface AuditEvent {
   action: AuditAction

--- a/packages/server/server/capability-guard.test.ts
+++ b/packages/server/server/capability-guard.test.ts
@@ -34,6 +34,9 @@ describe('routeCapability', () => {
     // The live terminal channel streams a session's SCREEN. It is a read, but a read of a coding
     // assistant's terminal, so it must be as unreachable on an exposed profile as the fleet itself.
     expect(routeCapability('/api/fleet/stream')).toBe('localShell')
+    // The live terminal WRITE channel (WS) types key-by-key into a session, control keys included —
+    // strictly more power than the line prompt, so it rides localShell too (A5: refused off `local`).
+    expect(routeCapability('/api/fleet/input')).toBe('localShell')
   })
 
   it('maps the local chat routes', () => {

--- a/packages/server/server/capability-guard.ts
+++ b/packages/server/server/capability-guard.ts
@@ -43,6 +43,11 @@ const EXACT: ReadonlyMap<string, keyof Capabilities> = new Map<string, keyof Cap
   // but it is a read of a coding assistant's terminal, so it rides the same `localShell` as
   // `/api/fleet`: there is no deployment that should stream someone's terminal to the internet.
   ['/api/fleet/stream', 'localShell'],
+  // The live terminal WRITE channel — a WebSocket that types key-by-key into a session, control keys
+  // (`C-c`, `C-d`) included. That is more power than `/api/fleet/act`'s line prompt and unambiguously
+  // shell access, so it rides the same `localShell` and is refused (403) before the upgrade on any
+  // exposed profile.
+  ['/api/fleet/input', 'localShell'],
 ])
 
 /** Prefix (no trailing slash) → capability. Matches `<prefix>` and `<prefix>/…` only. */

--- a/packages/server/server/index.ts
+++ b/packages/server/server/index.ts
@@ -73,6 +73,15 @@ import { LIMITS, readJsonLimited } from './limits'
 // and React, so this server names only `fleet-row.ts` — the two handlers load the implementation by
 // dynamic import. Naming `fleet-web` here even in a type position measurably pulled that graph in.
 import type { FleetActionRequest } from './sessions/fleet-row'
+// The live-terminal WRITE channel (Phase 2b). Statically importable — unlike `fleet-web`, this
+// module's own graph is light (registry + the two pure input modules) and resolves the heavy backend
+// LAZILY, so naming its WS handlers here does not pull the Ink/session-view graph into a server that
+// never opens this page. The handlers must be reachable synchronously from the shared `_wsHandlers`.
+import {
+  openInputSocket, onInputMessage, closeInputSocket,
+  createInputState, inputSessionExists, inputAtCapacity, type FleetInputState,
+} from './sessions/input-web'
+import { wsInputOriginOk } from './sessions/input-protocol'
 // Type only: the module itself reaches `cli-start` → `@agentistics/tui/control` → Ink, and is
 // loaded by dynamic import inside the two /api/fleet handlers.
 import { canSeeMemberNames } from './iam-view'
@@ -293,15 +302,27 @@ ensureClaudeChat().catch(err => console.warn('[claude-chat] failed to initialize
 // Bun HTTP server
 // ---------------------------------------------------------------------------
 
-type WSData = { user: string; memberId: string; isAgent?: boolean }
+// Two kinds of socket ride these handlers: the member↔central reverse channel (`isAgent`) and the
+// browser's live-terminal WRITE channel (`fleetInput`). They are disjoint — an agent socket never
+// carries `fleetInput` and vice versa — so each handler dispatches on which field is present.
+type WSData = { user: string; memberId: string; isAgent?: boolean; fleetInput?: FleetInputState }
 
 // Shared WS + request handlers, so the binary can bind the SAME logic to two ports below:
 // PORT (47291 = api + mcp) and WEB_PORT (47292 = the web dashboard you open).
 const _wsHandlers = {
-  open(ws: ServerWebSocket<WSData>) { if (!ws.data.isAgent) return; registerAgent(ws) },
-  message(ws: ServerWebSocket<WSData>, msg: string | Buffer) { if (!ws.data.isAgent) return; onAgentMessage(ws, msg) },
+  open(ws: ServerWebSocket<WSData>) {
+    if (ws.data.fleetInput) { openInputSocket(ws); return }
+    if (!ws.data.isAgent) return; registerAgent(ws)
+  },
+  message(ws: ServerWebSocket<WSData>, msg: string | Buffer) {
+    if (ws.data.fleetInput) { onInputMessage(ws, msg); return }
+    if (!ws.data.isAgent) return; onAgentMessage(ws, msg)
+  },
   pong(ws: ServerWebSocket<WSData>) { if (!ws.data.isAgent) return; onAgentPong(ws) },
-  close(ws: ServerWebSocket<WSData>) { if (!ws.data.isAgent) return; unregisterAgent(ws) },
+  close(ws: ServerWebSocket<WSData>) {
+    if (ws.data.fleetInput) { closeInputSocket(ws); return }
+    if (!ws.data.isAgent) return; unregisterAgent(ws)
+  },
 }
 
 /**
@@ -1014,7 +1035,7 @@ async function handleRequestInner(req: Request, server: Server<WSData>): Promise
     // take. A central never answers it: it aggregates many machines and hosts none of their
     // sessions, so a fleet read there would be this box's own processes under someone else's page.
     // `capability-guard.ts` has already refused both paths on an exposed profile.
-    if (url.pathname === '/api/fleet' || url.pathname === '/api/fleet/act' || url.pathname === '/api/fleet/stream') {
+    if (url.pathname === '/api/fleet' || url.pathname === '/api/fleet/act' || url.pathname === '/api/fleet/stream' || url.pathname === '/api/fleet/input') {
       if (TEAM_CENTRAL) {
         return new Response(JSON.stringify({ error: 'fleet_central' }), {
           status: 404,
@@ -1087,6 +1108,60 @@ async function handleRequestInner(req: Request, server: Server<WSData>): Promise
           'Connection': 'keep-alive',
           'X-Accel-Buffering': 'no',
         },
+      })
+    }
+
+    // The live terminal WRITE channel (Phase 2b): a WebSocket that types key-by-key into one session
+    // — literal characters with NO implicit Enter, and named control keys (`C-c`). Ordering is
+    // guaranteed by ONE connection per session (TCP order) plus a per-connection serial queue on the
+    // server (sessions/input-channel.ts), and every message is confirmed by an ack. It already rides
+    // the SAME gates as `/api/fleet/act`: `localShell` (capability-guard, refused before this block)
+    // and the central-404 above — typing into a session is more power than its line prompt, not less.
+    // This handler adds the two checks a WS UPGRADE needs on top of those: SAME-ORIGIN (CSWSH —
+    // `localShell` being on does not stop a malicious page in the user's own browser from opening a
+    // socket to localhost) and SCOPE (the session must be one this machine manages), plus the ceiling.
+    if (url.pathname === '/api/fleet/input') {
+      const id = url.searchParams.get('id')
+      if (!id) {
+        return new Response(JSON.stringify({ error: 'bad_request' }), {
+          status: 400,
+          headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
+        })
+      }
+      if (!wsInputOriginOk({ origin: req.headers.get('origin'), host: url.host, allowlist: ALLOWED_ORIGINS, dev: !SERVE_STATIC })) {
+        void writeAudit({ action: 'fleet.input.denied', ip: clientIp, meta: { id, reason: 'origin' } })
+        return new Response(JSON.stringify({ error: 'forbidden_origin' }), {
+          status: 403,
+          headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
+        })
+      }
+      if (!(await inputSessionExists(id))) {
+        return new Response(JSON.stringify({ error: 'not_found' }), {
+          status: 404,
+          headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
+        })
+      }
+      if (inputAtCapacity()) {
+        return new Response(JSON.stringify({ error: 'too_many_streams' }), {
+          status: 503,
+          headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
+        })
+      }
+      const upgraded = server.upgrade(req, {
+        // user/memberId are the agent-socket fields; a write socket carries none, and `fleetInput`
+        // is what the shared WS handlers dispatch on. The session id is fixed HERE — a message can
+        // never redirect a keystroke to another session.
+        data: { user: '', memberId: '', fleetInput: createInputState(id) },
+      })
+      if (upgraded) {
+        // ONE audit entry per channel opened — a keyboard was attached to a session — never one per
+        // keystroke, which would drown the log (the coalesced per-keystroke record is the web unit's).
+        void writeAudit({ action: 'fleet.input.open', ip: clientIp, meta: { id } })
+        return // handshake handed off to the shared websocket handlers
+      }
+      return new Response(JSON.stringify({ error: 'upgrade_failed' }), {
+        status: 500,
+        headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
       })
     }
 

--- a/packages/server/server/sessions/backend-tmux.ts
+++ b/packages/server/server/sessions/backend-tmux.ts
@@ -162,6 +162,12 @@ export const tmuxBackend: SessionBackend = {
 
   sendText: sendTextTo,
 
+  async sendTextRaw(id: string, text: string) {
+    // Literal only, NO Enter — the first half of `sendTextTo`. This is what the browser's key-by-key
+    // channel needs: a character appears without submitting a turn.
+    return (await tmux(sendKeysLiteralArgs(id, text))).code === 0
+  },
+
   async sendKey(id: string, key: string) {
     return (await tmux(sendKeysNamedArgs(id, key))).code === 0
   },

--- a/packages/server/server/sessions/input-channel.test.ts
+++ b/packages/server/server/sessions/input-channel.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, test } from 'bun:test'
+import { createInputChannel, type InputChannelDeps } from './input-channel'
+import type { InputAck } from './input-protocol'
+
+/** A recording harness: what the channel sent, in what order, and every ack it emitted. */
+function harness(over: Partial<InputChannelDeps> = {}) {
+  const sent: string[] = []
+  const keys: string[] = []
+  const acks: InputAck[] = []
+  const deps: InputChannelDeps = {
+    async sendText(text) { sent.push(text); return true },
+    async sendKey(key) { keys.push(key); return true },
+    emit(ack) { acks.push(ack) },
+    ...over,
+  }
+  return { deps, sent, keys, acks }
+}
+
+const textMsg = (seq: number, data: string) => JSON.stringify({ seq, kind: 'text', data })
+const keyMsg = (seq: number, name: string) => JSON.stringify({ seq, kind: 'key', name })
+
+/** Let the internal promise chain settle. */
+const settle = () => new Promise<void>(r => setTimeout(r, 0))
+
+describe('createInputChannel — ordering', () => {
+  test('a burst of 40 one-char text messages is sent in exact order despite random send delays', async () => {
+    const chars = 'abcdefghijklmnopqrstuvwxyz0123456789!@#$'.split('') // 40 distinct chars
+    expect(chars.length).toBe(40)
+    const sent: string[] = []
+    const acks: InputAck[] = []
+    const deps: InputChannelDeps = {
+      // A random delay per send is the whole point: if the channel did not await the previous send,
+      // a slow one would land after a fast follower and the order would scramble.
+      async sendText(text) {
+        await new Promise(r => setTimeout(r, Math.random() * 5))
+        sent.push(text)
+        return true
+      },
+      async sendKey() { return true },
+      emit(a) { acks.push(a) },
+    }
+    const ch = createInputChannel(deps)
+    chars.forEach((c, i) => ch.submit(textMsg(i, c)))
+
+    // Wait for all 40 acks.
+    for (let i = 0; i < 200 && acks.length < 40; i++) await settle()
+
+    expect(sent).toEqual(chars)
+    expect(acks.map(a => a.seq)).toEqual(chars.map((_, i) => i))
+    expect(acks.every(a => a.ok)).toBe(true)
+  })
+})
+
+describe('createInputChannel — confirmations', () => {
+  test('every submit gets exactly one ack, mapped by seq', async () => {
+    const { deps, acks } = harness()
+    const ch = createInputChannel(deps)
+    ch.submit(textMsg(10, 'a'))
+    ch.submit(keyMsg(11, 'C-c'))
+    ch.submit(textMsg(12, 'b'))
+    for (let i = 0; i < 50 && acks.length < 3; i++) await settle()
+    expect(acks).toEqual([
+      { seq: 10, ok: true },
+      { seq: 11, ok: true },
+      { seq: 12, ok: true },
+    ])
+  })
+
+  test('a text message routes to sendText, a key message routes to sendKey', async () => {
+    const { deps, sent, keys } = harness()
+    const ch = createInputChannel(deps)
+    ch.submit(textMsg(1, 'x'))
+    ch.submit(keyMsg(2, 'C-c'))
+    for (let i = 0; i < 50; i++) await settle()
+    expect(sent).toEqual(['x'])
+    expect(keys).toEqual(['C-c'])
+  })
+})
+
+describe('createInputChannel — honest failure', () => {
+  test('a backend send that returns false acks as failure, never silent success', async () => {
+    const { deps, acks } = harness({ async sendText() { return false } })
+    const ch = createInputChannel(deps)
+    ch.submit(textMsg(1, 'a'))
+    for (let i = 0; i < 50 && acks.length < 1; i++) await settle()
+    expect(acks).toEqual([{ seq: 1, ok: false, reason: 'send_failed' }])
+  })
+
+  test('a backend send that THROWS acks as failure and the chain keeps going', async () => {
+    let calls = 0
+    const acks: InputAck[] = []
+    const deps: InputChannelDeps = {
+      async sendText() { calls++; if (calls === 1) throw new Error('backend down'); return true },
+      async sendKey() { return true },
+      emit(a) { acks.push(a) },
+    }
+    const ch = createInputChannel(deps)
+    ch.submit(textMsg(1, 'a')) // throws
+    ch.submit(textMsg(2, 'b')) // must still be processed
+    for (let i = 0; i < 50 && acks.length < 2; i++) await settle()
+    expect(acks).toEqual([
+      { seq: 1, ok: false, reason: 'send_failed' },
+      { seq: 2, ok: true },
+    ])
+  })
+
+  test('a malformed message is acked with its parse reason and no send happens', async () => {
+    const { deps, sent, keys, acks } = harness()
+    const ch = createInputChannel(deps)
+    ch.submit('{not json')
+    ch.submit(JSON.stringify({ seq: 4, kind: 'key', name: 'C-x' })) // outside the allowlist
+    for (let i = 0; i < 50 && acks.length < 2; i++) await settle()
+    expect(acks).toEqual([
+      { seq: null, ok: false, reason: 'bad_json' },
+      { seq: 4, ok: false, reason: 'bad_key' },
+    ])
+    expect(sent).toEqual([])
+    expect(keys).toEqual([])
+  })
+})

--- a/packages/server/server/sessions/input-channel.ts
+++ b/packages/server/server/sessions/input-channel.ts
@@ -1,0 +1,65 @@
+/**
+ * input-channel.ts — the ORDER guarantee and the per-message confirmation, injectable and pure of IO.
+ *
+ * One channel per WebSocket connection (one connection per session). TCP already delivers a single
+ * connection's messages in order; this module is the second half of the guarantee the spec demands:
+ * the server processes them STRICTLY SEQUENTIALLY — one `send-keys` at a time — so a slow send can
+ * never let a later keystroke overtake it. That is why key-by-key typing here does not scramble the
+ * way per-keystroke HTTP POSTs would.
+ *
+ * The mechanism is a promise chain: each `submit` is appended after the previous handler, and every
+ * handler is `await`ed before the next runs. The chain is defended so it can never break — a handler
+ * that would throw is caught and answered with a failure ack, and the tail is reset to a resolved
+ * promise, so one bad message does not wedge the connection.
+ *
+ * The backend and the ack sink are injected (`sendText` / `sendKey` pre-bound to the session,
+ * `emit`), exactly as `terminal-hub.ts` injects its capture and clock — which is what lets the
+ * ordering and the honest-failure behaviour be proven without a tmux server.
+ */
+import { ackFail, ackOk, parseInputMessage, type InputAck } from './input-protocol'
+
+export interface InputChannelDeps {
+  /** Type literal text into the session with NO submit — `sendKeysLiteralArgs`, pre-bound to the id. */
+  sendText(text: string): Promise<boolean>
+  /** Press one NAMED key (`C-c`, `Enter`) — `sendKeysNamedArgs`, pre-bound to the id. */
+  sendKey(key: string): Promise<boolean>
+  /** Deliver one ack back to the client. */
+  emit(ack: InputAck): void
+}
+
+export interface InputChannel {
+  /** Enqueue one raw client message. Returns immediately; the ack arrives via `emit`. */
+  submit(raw: string): void
+}
+
+export function createInputChannel(deps: InputChannelDeps): InputChannel {
+  // The serial tail. Every submit chains onto it; `.then` here (rather than resolving in parallel) is
+  // the ordering guarantee itself.
+  let tail: Promise<void> = Promise.resolve()
+
+  async function handle(raw: string): Promise<void> {
+    const parsed = parseInputMessage(raw)
+    if (!parsed.ok) {
+      deps.emit(ackFail(parsed.seq, parsed.reason))
+      return
+    }
+    const m = parsed.msg
+    let ok = false
+    try {
+      ok = m.kind === 'text' ? await deps.sendText(m.text) : await deps.sendKey(m.key)
+    } catch {
+      // A backend that threw is not a reason to report success and not a reason to tear the socket
+      // down: the keystroke did not land, so the client is told so and the next one is still handled.
+      ok = false
+    }
+    deps.emit(ok ? ackOk(m.seq) : ackFail(m.seq, 'send_failed'))
+  }
+
+  return {
+    submit(raw) {
+      // `catch(() => {})` guarantees the tail stays resolvable — `handle` already swallows send
+      // errors, but this is the belt to that braces so a future edit cannot silently freeze the queue.
+      tail = tail.then(() => handle(raw)).catch(() => {})
+    },
+  }
+}

--- a/packages/server/server/sessions/input-protocol.test.ts
+++ b/packages/server/server/sessions/input-protocol.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  KEY_ALLOWLIST,
+  MAX_INPUT_TEXT,
+  ackFail,
+  ackOk,
+  encodeAck,
+  parseInputMessage,
+  wsInputOriginOk,
+} from './input-protocol'
+
+describe('parseInputMessage', () => {
+  test('accepts a text message and keeps the literal data verbatim', () => {
+    const r = parseInputMessage(JSON.stringify({ seq: 1, kind: 'text', data: 'h' }))
+    expect(r).toEqual({ ok: true, msg: { seq: 1, kind: 'text', text: 'h' } })
+  })
+
+  test('a text message may carry a raw control byte (xterm.onData sends these)', () => {
+    const r = parseInputMessage(JSON.stringify({ seq: 7, kind: 'text', data: '[A' }))
+    expect(r.ok).toBe(true)
+    if (r.ok) expect(r.msg).toEqual({ seq: 7, kind: 'text', text: '[A' })
+  })
+
+  test('accepts a named key from the closed set', () => {
+    const r = parseInputMessage(JSON.stringify({ seq: 2, kind: 'key', name: 'C-c' }))
+    expect(r).toEqual({ ok: true, msg: { seq: 2, kind: 'key', key: 'C-c' } })
+  })
+
+  test('rejects invalid JSON with bad_json and a null seq', () => {
+    const r = parseInputMessage('{not json')
+    expect(r).toEqual({ ok: false, seq: null, reason: 'bad_json' })
+  })
+
+  test('rejects a non-object payload', () => {
+    expect(parseInputMessage('42')).toEqual({ ok: false, seq: null, reason: 'bad_message' })
+    expect(parseInputMessage('null')).toEqual({ ok: false, seq: null, reason: 'bad_message' })
+    expect(parseInputMessage('"a"')).toEqual({ ok: false, seq: null, reason: 'bad_message' })
+  })
+
+  test('rejects a missing or non-numeric seq — an ack needs a real seq to map', () => {
+    expect(parseInputMessage(JSON.stringify({ kind: 'text', data: 'a' })))
+      .toEqual({ ok: false, seq: null, reason: 'bad_message' })
+    expect(parseInputMessage(JSON.stringify({ seq: 'x', kind: 'text', data: 'a' })))
+      .toEqual({ ok: false, seq: null, reason: 'bad_message' })
+    expect(parseInputMessage(JSON.stringify({ seq: Infinity, kind: 'text', data: 'a' })))
+      .toEqual({ ok: false, seq: null, reason: 'bad_message' })
+  })
+
+  test('rejects an unknown kind but echoes the seq so the client can map the failure', () => {
+    expect(parseInputMessage(JSON.stringify({ seq: 5, kind: 'nope', data: 'a' })))
+      .toEqual({ ok: false, seq: 5, reason: 'bad_message' })
+  })
+
+  test('rejects empty text — an empty send that "succeeds" would be a lie', () => {
+    expect(parseInputMessage(JSON.stringify({ seq: 3, kind: 'text', data: '' })))
+      .toEqual({ ok: false, seq: 3, reason: 'empty_text' })
+  })
+
+  test('rejects text that is not a string', () => {
+    expect(parseInputMessage(JSON.stringify({ seq: 3, kind: 'text', data: 9 })))
+      .toEqual({ ok: false, seq: 3, reason: 'bad_message' })
+  })
+
+  test('rejects text over the length ceiling', () => {
+    const big = 'a'.repeat(MAX_INPUT_TEXT + 1)
+    expect(parseInputMessage(JSON.stringify({ seq: 4, kind: 'text', data: big })))
+      .toEqual({ ok: false, seq: 4, reason: 'text_too_long' })
+  })
+
+  test('accepts text exactly at the ceiling', () => {
+    const atLimit = 'a'.repeat(MAX_INPUT_TEXT)
+    const r = parseInputMessage(JSON.stringify({ seq: 4, kind: 'text', data: atLimit }))
+    expect(r.ok).toBe(true)
+  })
+
+  test('rejects a key name OUTSIDE the closed allowlist — defence in depth', () => {
+    for (const name of ['C-c; rm', 'a b', 'F1', 'Escape', 'Home', 'M-Up', 'PageDown', '', 'C-x']) {
+      const r = parseInputMessage(JSON.stringify({ seq: 6, kind: 'key', name }))
+      expect(r).toEqual({ ok: false, seq: 6, reason: 'bad_key' })
+    }
+  })
+
+  test('rejects a non-string key name', () => {
+    expect(parseInputMessage(JSON.stringify({ seq: 6, kind: 'key', name: 3 })))
+      .toEqual({ ok: false, seq: 6, reason: 'bad_key' })
+  })
+
+  test('KEY_ALLOWLIST is exactly the agreed closed set', () => {
+    expect([...KEY_ALLOWLIST].sort()).toEqual(
+      ['BSpace', 'C-a', 'C-c', 'C-d', 'C-e', 'C-k', 'C-u', 'C-w', 'Down', 'Enter', 'Left', 'Right', 'Tab', 'Up'],
+    )
+    for (const k of KEY_ALLOWLIST) {
+      expect(parseInputMessage(JSON.stringify({ seq: 1, kind: 'key', name: k })).ok).toBe(true)
+    }
+  })
+})
+
+describe('ack shapes', () => {
+  test('ackOk / ackFail carry the seq and the outcome, and reason only on failure', () => {
+    expect(ackOk(1)).toEqual({ seq: 1, ok: true })
+    expect(ackFail(2, 'send_failed')).toEqual({ seq: 2, ok: false, reason: 'send_failed' })
+    expect(ackFail(null, 'bad_json')).toEqual({ seq: null, ok: false, reason: 'bad_json' })
+  })
+
+  test('encodeAck is a valid JSON string echoing the seq', () => {
+    expect(JSON.parse(encodeAck(ackOk(3)))).toEqual({ seq: 3, ok: true })
+    expect(JSON.parse(encodeAck(ackFail(4, 'send_failed')))).toEqual({ seq: 4, ok: false, reason: 'send_failed' })
+  })
+})
+
+describe('wsInputOriginOk — CSWSH protection', () => {
+  const base = { host: 'localhost:47292', allowlist: [] as string[], dev: false }
+
+  test('accepts the request’s own origin (same-origin dashboard), prod or dev', () => {
+    expect(wsInputOriginOk({ ...base, origin: 'http://localhost:47292' })).toBe(true)
+    expect(wsInputOriginOk({ ...base, origin: 'https://localhost:47292' })).toBe(true)
+  })
+
+  test('accepts an allowlisted origin', () => {
+    expect(wsInputOriginOk({ ...base, origin: 'http://desk.example', allowlist: ['http://desk.example'] })).toBe(true)
+  })
+
+  test('accepts a localhost dev origin only in dev', () => {
+    expect(wsInputOriginOk({ ...base, origin: 'http://localhost:5173', dev: true })).toBe(true)
+    expect(wsInputOriginOk({ ...base, origin: 'http://localhost:5173', dev: false })).toBe(false)
+  })
+
+  test('rejects a foreign origin — the CSWSH case', () => {
+    expect(wsInputOriginOk({ ...base, origin: 'http://evil.example' })).toBe(false)
+  })
+
+  test('accepts a missing Origin — a non-browser client; browsers always send one', () => {
+    expect(wsInputOriginOk({ ...base, origin: null })).toBe(true)
+  })
+})

--- a/packages/server/server/sessions/input-protocol.ts
+++ b/packages/server/server/sessions/input-protocol.ts
@@ -1,0 +1,157 @@
+/**
+ * input-protocol.ts — PURE contract for the live terminal's WRITE channel.
+ *
+ * The read channel (`terminal-stream.ts`) turns a capture into a frame; this is its write-side
+ * sibling: it turns one raw WebSocket message from the browser into a validated keystroke, and
+ * shapes the confirmation that goes back. No IO — the queue that runs the sends is `input-channel.ts`
+ * and the socket wiring is `input-web.ts`.
+ *
+ * ## Wire contract (agreed with the CONSUMER, `agentistics/web`)
+ *
+ * Client → server, one JSON object per WS message:
+ *
+ *   { "seq": 1, "kind": "text", "data": "l"   }   // literal characters, typed with `-l`, NO Enter
+ *   { "seq": 2, "kind": "key",  "name": "C-c" }   // one NAMED key from the CLOSED set below
+ *
+ * Server → client, one ack per message:
+ *
+ *   { "seq": 1, "ok": true }
+ *   { "seq": 2, "ok": false, "reason": "send_failed" }
+ *
+ * - `seq` is the client's own monotonic counter, ECHOED in the ack — the mapping a browser needs to
+ *   show "not delivered" against the exact keystroke, and the thing that makes FIFO VERIFIABLE rather
+ *   than assumed: a mismatch is a detected, surfaced failure, not a silently swallowed one. Every
+ *   message is answered by exactly one ack; without that, key-by-key typing would repeat the lie
+ *   PR #269 fixed for line sends.
+ * - `reason` is present iff `ok` is false — a stable code the client renders (or maps/localizes).
+ * - There is NO local echo: a character appears on screen only when the SESSION draws it, read back
+ *   over the existing SSE `/api/fleet/stream`. That is what makes "the UI never shows an undelivered
+ *   keystroke" true BY CONSTRUCTION — a key that never reached the process is never painted.
+ *
+ * The `text`/`key` split is by construction: `text` NEVER carries `Enter`; a submit is a `key`
+ * (`Enter`). Confusing the two fails silently in tmux (`send-keys -l Enter` types five letters), which
+ * is exactly why `sendKeysLiteralArgs` and `sendKeysNamedArgs` are separate downstream.
+ */
+import { originAllowed } from '../cors'
+
+/** A `text` payload longer than this is refused. A browser paste goes through the #269 line composer;
+ *  direct typing is small, and 8 KiB is generous headroom for a batched `xterm.onData` chunk. */
+export const MAX_INPUT_TEXT = 8192
+
+/**
+ * The CLOSED set of named keys this channel will send — defence in depth.
+ *
+ * The client keeps its own allowlist; the server does NOT trust it and validates membership here.
+ * Everything ordinary a browser's `xterm.onData` emits — printable characters AND raw escape
+ * sequences (arrows, function keys) — travels as `kind:"text"` and is typed verbatim with `-l`; the
+ * `key` path exists only for the SEMANTIC control keys where a NAMED send is the correct, verifiable
+ * mechanism (A4: `C-c` must go through `sendKeysNamedArgs`, not literal text). A name outside this set
+ * is refused rather than passed to `send-keys`, so the write channel can never be talked into an
+ * arbitrary key sequence. To widen it, add the tmux key name here — deliberately a code change, not a
+ * client-supplied value.
+ */
+export const KEY_ALLOWLIST: ReadonlySet<string> = new Set([
+  'Enter', 'BSpace', 'Tab',
+  'Up', 'Down', 'Left', 'Right',
+  'C-c', 'C-d', 'C-a', 'C-e', 'C-u', 'C-w', 'C-k',
+])
+
+export type InputMessage =
+  | { seq: number; kind: 'text'; text: string }
+  | { seq: number; kind: 'key'; key: string }
+
+/** Every stable failure reason a client may receive. */
+export type InputReason =
+  | 'bad_json'
+  | 'bad_message'
+  | 'empty_text'
+  | 'text_too_long'
+  | 'bad_key'
+  | 'send_failed'
+  | 'error'
+
+export type ParseResult =
+  | { ok: true; msg: InputMessage }
+  // `seq` is null when the message was too malformed to carry one; otherwise it is echoed so the
+  // browser can map even a rejection to the keystroke that caused it.
+  | { ok: false; seq: number | null; reason: InputReason }
+
+export type InputAck =
+  | { seq: number | null; ok: true }
+  | { seq: number | null; ok: false; reason: InputReason }
+
+export function ackOk(seq: number | null): InputAck {
+  return { seq, ok: true }
+}
+
+export function ackFail(seq: number | null, reason: InputReason): InputAck {
+  return { seq, ok: false, reason }
+}
+
+export function encodeAck(ack: InputAck): string {
+  return JSON.stringify(ack)
+}
+
+/**
+ * Validate one raw client message into a typed keystroke, or a mapped rejection.
+ *
+ * Never throws — a malformed message from a browser is an ordinary outcome, answered with an ack, not
+ * an error that tears down the socket.
+ */
+export function parseInputMessage(raw: string): ParseResult {
+  let obj: unknown
+  try {
+    obj = JSON.parse(raw)
+  } catch {
+    return { ok: false, seq: null, reason: 'bad_json' }
+  }
+  if (typeof obj !== 'object' || obj === null || Array.isArray(obj)) {
+    return { ok: false, seq: null, reason: 'bad_message' }
+  }
+  const rec = obj as Record<string, unknown>
+
+  // A seq that is not a finite number cannot map an ack to a keystroke, so the whole message is
+  // refused with a null seq — there is nothing meaningful to echo.
+  const rawSeq = rec.seq
+  if (typeof rawSeq !== 'number' || !Number.isFinite(rawSeq)) {
+    return { ok: false, seq: null, reason: 'bad_message' }
+  }
+  const seq = rawSeq
+
+  const kind = rec.kind
+  if (kind === 'text') {
+    const data = rec.data
+    if (typeof data !== 'string') return { ok: false, seq, reason: 'bad_message' }
+    if (data.length === 0) return { ok: false, seq, reason: 'empty_text' }
+    if (data.length > MAX_INPUT_TEXT) return { ok: false, seq, reason: 'text_too_long' }
+    return { ok: true, msg: { seq, kind: 'text', text: data } }
+  }
+  if (kind === 'key') {
+    const name = rec.name
+    if (typeof name !== 'string' || !KEY_ALLOWLIST.has(name)) {
+      return { ok: false, seq, reason: 'bad_key' }
+    }
+    return { ok: true, msg: { seq, kind: 'key', key: name } }
+  }
+  return { ok: false, seq, reason: 'bad_message' }
+}
+
+/**
+ * Same-origin (or allowlisted) gate for the WS UPGRADE — CSWSH protection.
+ *
+ * `localShell` being on (local profile) does not stop a malicious page in the user's own browser from
+ * opening a socket to `localhost`, so the Origin must be checked exactly as `csrf.ts` checks it for
+ * unsafe methods. A browser ALWAYS sends `Origin` on a WS handshake, so a MISSING origin is a
+ * non-browser client (a CLI, a test) and is allowed — it cannot be a cross-site page.
+ */
+export function wsInputOriginOk(input: {
+  origin: string | null
+  host: string
+  allowlist: string[]
+  dev: boolean
+}): boolean {
+  const { origin, host } = input
+  if (!origin) return true
+  if (origin === `https://${host}` || origin === `http://${host}`) return true
+  return originAllowed(origin, input.allowlist, input.dev)
+}

--- a/packages/server/server/sessions/input-web.ts
+++ b/packages/server/server/sessions/input-web.ts
@@ -1,0 +1,108 @@
+/**
+ * input-web.ts — the WEB dashboard's WRITE channel onto one session's pane, over a WebSocket.
+ *
+ * The write-side sibling of `terminal-web.ts` (the read SSE stream). Same two-layer shape: the
+ * ORDER guarantee and the per-message confirmation are the pure `input-channel.ts`; the contract is
+ * the pure `input-protocol.ts`; this file is only the singleton wiring and the socket plumbing.
+ *
+ * It keeps the same ONE rule the read channel keeps — SCOPE. A socket is opened only for a session
+ * THIS MACHINE MANAGES (its own registry), so the write power never reaches past the fleet the
+ * dashboard already lists. Everything harder is upstream of it: `index.ts` refuses the upgrade unless
+ * `localShell` is granted (capability-guard) and the Origin is same-origin (CSWSH), and 404s it on a
+ * central. A captured terminal is shell access with extra steps; typing into one is the shell itself,
+ * so it rides the very same gates, and no lower ones.
+ *
+ * The backend is resolved LAZILY via a dynamic import, exactly as `terminal-web.ts` reaches it
+ * dynamically: it keeps this module's own static graph light (registry + the two pure input modules),
+ * so `index.ts` can name these handlers without pulling the session-view/Ink graph into the server
+ * that never opens this page.
+ */
+
+import { readRegistry } from './registry'
+import { createInputChannel, type InputChannel } from './input-channel'
+import { encodeAck } from './input-protocol'
+import type { SessionBackend } from './types'
+
+/**
+ * A ceiling on concurrent write sockets for the whole process — each holds a socket and a serial
+ * queue, so an unbounded count is a free way to exhaust the server (OWASP API4), the same reason the
+ * read stream caps at `MAX_TERMINAL_STREAMS`.
+ */
+export const MAX_INPUT_SOCKETS = 100
+
+/** The per-connection state carried on `ws.data`. The channel is built on `open`. */
+export interface FleetInputState {
+  readonly id: string
+  channel: InputChannel | null
+}
+
+/** The shape this module needs from a socket — structural, so `index.ts` owns the full `WSData`. */
+interface InputSocket {
+  data: { fleetInput?: FleetInputState }
+  send(data: string): unknown
+}
+
+let backendPromise: Promise<SessionBackend> | null = null
+function getBackend(): Promise<SessionBackend> {
+  // `./index` reaches the session-view graph; loading it only here (never at module top) is what
+  // keeps a static import of this file cheap.
+  if (!backendPromise) backendPromise = import('./index').then(m => m.resolveBackend())
+  return backendPromise
+}
+
+let openSockets = 0
+
+/** Build the state stamped onto `ws.data` at upgrade time; the channel is created on `open`. */
+export function createInputState(id: string): FleetInputState {
+  return { id, channel: null }
+}
+
+/** Scope check for the route: a session outside this machine's fleet is a clean 404, never an upgrade. */
+export async function inputSessionExists(id: string): Promise<boolean> {
+  return (await readRegistry()).some(m => m.id === id)
+}
+
+/** True when the process is already at its write-socket ceiling — the route answers 503. */
+export function inputAtCapacity(): boolean {
+  return openSockets >= MAX_INPUT_SOCKETS
+}
+
+/** For tests / diagnostics: how many write sockets are open right now. */
+export function inputSocketCount(): number {
+  return openSockets
+}
+
+/**
+ * On open: build the serial channel bound to this session. The channel's sends resolve the backend
+ * lazily and go to `sendTextRaw` (literal, NO Enter) / `sendKey` (named), and each ack is written
+ * straight back on this socket. There is no "ready" frame and no local echo: the WS open event is the
+ * client's go-ahead, and a character appears only when the SESSION draws it (read back over SSE), so
+ * the UI can never paint a keystroke that did not land.
+ */
+export function openInputSocket(ws: InputSocket): void {
+  const state = ws.data.fleetInput
+  if (!state) return
+  openSockets++
+  const { id } = state
+  state.channel = createInputChannel({
+    sendText: async text => (await getBackend()).sendTextRaw(id, text),
+    sendKey: async key => (await getBackend()).sendKey(id, key),
+    emit: ack => { try { ws.send(encodeAck(ack)) } catch { /* socket already closed */ } },
+  })
+}
+
+/** On message: hand the raw bytes to the channel, which parses, orders, sends and acks. */
+export function onInputMessage(ws: InputSocket, raw: string | Buffer): void {
+  const state = ws.data.fleetInput
+  if (!state?.channel) return
+  const text = typeof raw === 'string' ? raw : raw.toString('utf8')
+  state.channel.submit(text)
+}
+
+/** On close: release the channel and the capacity slot. Idempotent — a double close cannot go negative. */
+export function closeInputSocket(ws: InputSocket): void {
+  const state = ws.data.fleetInput
+  if (!state || !state.channel) return
+  state.channel = null
+  openSockets = Math.max(0, openSockets - 1)
+}

--- a/packages/server/server/sessions/sessions-host.test.ts
+++ b/packages/server/server/sessions/sessions-host.test.ts
@@ -39,6 +39,7 @@ function fakeBackend(o: {
     attachCommand(id) { return ['tmux', 'attach', id] },
     async detachHint() { return 'Ctrl-b then d' },
     async sendText() { return true },
+    async sendTextRaw() { return true },
     async sendKey() { return true },
   }
 }

--- a/packages/server/server/sessions/types.ts
+++ b/packages/server/server/sessions/types.ts
@@ -363,6 +363,16 @@ export interface SessionBackend {
    */
   sendText(id: string, text: string): Promise<boolean>
   /**
+   * Type literal text into the session WITHOUT submitting — the first half of `sendText`, exposed on
+   * its own for the browser's key-by-key write channel (`input-web.ts`), where an implicit `Enter`
+   * would turn every keystroke into a submitted turn.
+   *
+   * Uses the SAME `sendKeysLiteralArgs` builder `sendText` uses, minus the trailing named `Enter`, so
+   * this exposes an existing path rather than adding a mechanism. `false` when the backend could not
+   * deliver it; never a throw, for the same reason as `sendText`.
+   */
+  sendTextRaw(id: string, text: string): Promise<boolean>
+  /**
    * Press ONE named key — the backend's own vocabulary (`Enter`, `Escape`).
    *
    * Separate from `sendText` because the two are opposites and confusing them fails silently: sent

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentistics/tui",
-  "version": "1.23.1",
+  "version": "2.3.2",
   "private": true,
   "type": "module",
   "main": "src/control/index.ts",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentistics/web",
-  "version": "1.23.1",
+  "version": "2.3.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/specs/ordered-write-channel/plan.md
+++ b/specs/ordered-write-channel/plan.md
@@ -1,0 +1,86 @@
+# Plan — Ordered write channel (`canal-de-escrita-ordenado`)
+
+Implements `spec.md`. Server-only (`packages/server`). Test-first.
+
+## Modules
+
+All new files live under `packages/server/server/sessions/`, beside their siblings
+`terminal-web.ts` / `terminal-hub.ts` / `terminal-stream.ts` (the read channel), whose
+split (pure core + injectable orchestration + impure singleton wiring) this mirrors.
+
+### 1. `input-protocol.ts` — PURE (tested: `input-protocol.test.ts`)
+
+The message contract and the transport gate, with no IO:
+
+- `parseInputMessage(raw: string): ParseResult` — JSON-parse + validate shape, kind,
+  bounds; returns a typed `InputMessage` or `{ ok:false, seq, reason }`.
+- `InputMessage = { seq; kind:'text'; text } | { seq; kind:'key'; key }`.
+- `ackOk(seq)` / `ackFail(seq, reason)` / `encodeAck(ack)` — the server→client shapes.
+- `readyEvent(id)` / `encode(...)` for the `ready` frame.
+- `wsInputOriginOk({ origin, host, allowlist, dev })` — same-origin/allowlist check
+  (delegates to `cors.originAllowed`, plus the request's own host, mirroring
+  `csrf.ts`'s Origin fallback). CSWSH protection.
+- Constants: `MAX_INPUT_TEXT`, `MAX_KEY_LEN`, `KEY_PATTERN`.
+
+### 2. `input-channel.ts` — PURE orchestration, injectable (tested: `input-channel.test.ts`)
+
+The **ordering guarantee** and the **per-message confirmation**:
+
+- `createInputChannel(deps)` where `deps = { sendText(text), sendKey(key), emit(ack) }`
+  (send fns are pre-bound to the session in the wiring layer).
+- Maintains a promise chain: each `submit(raw)` chains onto the previous, so handling
+  is strictly serial (one send `await`ed before the next). The chain never breaks — a
+  handler that would throw is caught and acked as failure.
+- Parses via `input-protocol`, routes `text`→`sendText` / `key`→`sendKey`, and emits
+  exactly one ack per submit (`send_failed` when the backend returns `false` or throws).
+
+Tested with fake, delayed/failing send fns: order preserved under random delays,
+N submits ⇒ N mapped acks, failure surfaced, `key` routed to `sendKey`.
+
+### 3. `backend-tmux.ts` + `types.ts` — expose literal-only send
+
+Add `sendTextRaw(id, text): Promise<boolean>` to `SessionBackend` and `tmuxBackend`:
+`(await tmux(sendKeysLiteralArgs(id, text))).code === 0`. It reuses the exact argv
+builder the existing `sendTextTo` uses for its first half — **exposing** the literal
+path without the trailing `Enter`, not a new mechanism. `windowsBackend` inherits it
+by spread.
+
+### 4. `input-web.ts` — IMPURE singleton wiring (verified by integration, not unit)
+
+Mirrors `terminal-web.ts`:
+
+- `MAX_INPUT_SOCKETS = 100`; a live count for the capacity cap.
+- `inputSessionExists(id)` — scope check via `readRegistry()`.
+- `inputAtCapacity()`.
+- `openInputSocket(ws)` / `onInputMessage(ws, raw)` / `closeInputSocket(ws)` — the
+  three WS lifecycle handlers. `open` sends the `ready` frame and builds an
+  `InputChannel` bound to the session id (its `sendText`/`sendKey` resolve the backend
+  and call `sendTextRaw` / `sendKey`); `message` forwards raw bytes to the channel;
+  `close` decrements the count. Channel state is held on `ws.data`.
+
+### 5. `index.ts` — the route + WS dispatch
+
+- Register `/api/fleet/input` in `capability-guard.ts` under `localShell`.
+- Add `/api/fleet/input` to the `TEAM_CENTRAL` fleet-404 block.
+- New route block: resolve `id`, check `wsInputOriginOk`, `inputSessionExists` (404),
+  `inputAtCapacity` (503), then `server.upgrade(req, { data: { fleetInput: state } })`.
+- Extend `WSData` with an optional `fleetInput` variant and branch the shared
+  `_wsHandlers` (`open`/`message`/`close`) to the `input-web` handlers when present —
+  leaving the existing `isAgent` reverse-channel untouched.
+
+## Order of work (RED → GREEN each)
+
+1. `input-protocol.test.ts` → `input-protocol.ts`.
+2. `input-channel.test.ts` → `input-channel.ts`.
+3. `sendTextRaw` on the backend + interface (argv builder already tested).
+4. `input-web.ts` wiring + `index.ts` route/dispatch + capability-guard registration.
+5. `bun tsc --noEmit` + `bun test` (package), then boot `bun run dev:api` and prove
+   A1–A8 against a real disposable tmux session on a non-standard port.
+
+## Verification (real, not just tests)
+
+Boot the server, create a disposable managed session, open the WS from a small client,
+and demonstrate: a char with no Enter (A1), a 40-char burst in order ×5 (A2), acks per
+message (A3), `C-c` interrupting `sleep 60` (A4), refusal with `localShell` off (A5),
+failure ack after killing the session (A6), the old prompt path intact (A7), and SSE
+read coexisting with the WS write (A8). Tear down the server and the session.

--- a/specs/ordered-write-channel/spec.md
+++ b/specs/ordered-write-channel/spec.md
@@ -1,0 +1,105 @@
+# Spec — Ordered write channel for the live terminal (`canal-de-escrita-ordenado`)
+
+Journey `j-20260901-e9`, unit `agentistics/server`. This spec is derived from and
+subordinate to the approved task spec at
+`.aipe/journeys/j-20260901-e9/task-specs/agentistics__server.md`; where they differ,
+the task spec wins.
+
+## Problem
+
+The live terminal (PR #269) can only be written to through
+`POST /api/fleet/act {action:'prompt'}`, which types a line **and always appends
+`Enter`** (`sendTextTo`, `backend-tmux.ts`). That is proper for a line composer and
+improper for typing key-by-key: every keystroke would submit a turn, and HTTP POSTs
+can arrive out of order, so `"hello"` becomes `"hlelo"` intermittently.
+
+The backend can already send a single named key (`sendKey` → `sendKeysNamedArgs`,
+e.g. `C-c`) and literal text (`sendKeysLiteralArgs`), but **no `/api/fleet/*` route
+reaches either without the forced `Enter`**. The capability exists; the path does not.
+
+This unit delivers **only the server path**. The browser terminal is another unit
+(`agentistics/web`) and consumes this contract.
+
+## Solution shape
+
+A **WebSocket** endpoint, `GET /api/fleet/input?id=<sessionId>`, upgraded per session:
+
+- **One connection per session.** TCP preserves order on a single connection.
+- **Server processes messages strictly sequentially** — one `send-keys` at a time,
+  a per-connection FIFO queue that `await`s the previous send before the next.
+  Client timestamps are never trusted.
+- **Every message is confirmed.** The server replies with one ack per message
+  (`ok:true` / `ok:false` + reason), so the browser can honestly show "not delivered"
+  — the key-scale version of the lie #269 fixed.
+- **Two message kinds:** `text` (literal characters via `sendKeysLiteralArgs`, **no
+  implicit `Enter`**) and `key` (one named key via `sendKeysNamedArgs`, e.g. `C-c`).
+
+## Wire contract (consumed by `agentistics/web`)
+
+Client → server (one JSON object per WS message):
+
+```json
+{ "seq": 1, "type": "text", "data": "h" }
+{ "seq": 2, "type": "key",  "key": "C-c" }
+```
+
+Server → client:
+
+```json
+{ "type": "ready", "id": "3f5f" }              // once, on open
+{ "type": "ack", "seq": 1, "ok": true }
+{ "type": "ack", "seq": 2, "ok": false, "reason": "send_failed" }
+```
+
+- `seq` is a client-assigned finite number, echoed back in the ack — the mapping
+  between a message and its confirmation. An unparseable message acks with
+  `seq: null` and a reason.
+- `data` for `text` is non-empty and at most `MAX_INPUT_TEXT` (8192) bytes; `-l`
+  means it is typed verbatim (no shell, no interpretation), so raw control bytes a
+  browser's `xterm.onData` emits pass through as themselves.
+- `key` for `key` matches `^[A-Za-z0-9]+(-[A-Za-z0-9]+)*$` (≤ 32 chars): `C-c`,
+  `Enter`, `Up`, `M-Up`. It is sent as a *named* key, never as literal text.
+- Reason codes: `bad_json`, `bad_message`, `empty_text`, `text_too_long`, `bad_key`,
+  `send_failed`, `error`.
+
+**Which control keys the user may send is the web unit's decision** (its per-session
+consent gate, #269). The server exposes the mechanism behind the security boundary
+below; it does not police individual keys beyond making the token well-formed.
+
+## Security boundary (does not loosen)
+
+The new path inherits **exactly** the gates `/api/fleet` and `/api/fleet/act` carry:
+
+- **`localShell` capability** (`capability-guard.ts`) — refused (403) on any exposed
+  profile, checked before the upgrade. Typing key-by-key, control keys included, is
+  shell access with extra steps.
+- **404 on a central** (`TEAM_CENTRAL`) — a central hosts no sessions.
+- **Cookie auth** where it applies (central path), via the same auth gate.
+- **Same-origin only.** The upgrade is refused unless the browser's `Origin` is the
+  dashboard's own origin or an allowlisted one — CSWSH protection, because
+  `localShell` being on (local profile) does not stop a malicious page in the user's
+  browser from opening a socket to `localhost`.
+- **Scope.** The socket is opened only for a session **this machine manages** (the
+  registry), the same boundary the read channel enforces. The session id is fixed at
+  upgrade; a message can never redirect a keystroke to another session.
+- **Capacity cap** (`MAX_INPUT_SOCKETS`), like the read stream's cap, so open sockets
+  cannot exhaust the process.
+
+## Acceptance (mirrors the task spec A1–A8)
+
+- **A1** — a single `text` char appears in the session with no implicit `Enter`.
+- **A2** — 40+ one-char messages sent fast arrive in exact order, none lost/dup/reordered.
+- **A3** — every message is answered by exactly one ack, mapped by `seq`.
+- **A4** — a `key` `C-c` interrupts a long process via `sendKeysNamedArgs`.
+- **A5** — no `localShell` (or, where it applies, no auth) ⇒ connection refused, nothing written.
+- **A6** — a failed send acks as failure with a reason, never a silent success.
+- **A7** — `POST /api/fleet/act {action:'prompt'}` still types + `Enter` as before.
+- **A8** — the read SSE stream and the write WS coexist without interfering.
+
+## Out of scope
+
+- `packages/web` (the `xterm.onData` wiring, client consent, coalesced audit, the two
+  presentations).
+- Removing or changing `POST /api/fleet/act {action:'prompt'}`.
+- The read channel `GET /api/fleet/stream` (stays SSE, unchanged).
+- Redesigning auth or the capability model.


### PR DESCRIPTION
Promoção da PR #281, gateada por QA independente com evidência **item a item**.

## O que entra

`WS /api/fleet/input` — o canal que permite digitar **tecla a tecla** no terminal ao vivo, preservando a ordem e confirmando cada envio.

Até aqui só existia um caminho de escrita: `POST /api/fleet/act {action:'prompt'}`, que **sempre anexa `Enter`** — impróprio por natureza para digitação, já que cada tecla viraria uma submissão. E `sendKey` (teclas nomeadas como `C-c`) existia no backend e era **inalcançável pelo web**.

## O desenho

- **Ordem** garantida por uma conexão por sessão mais fila serial no servidor (`await` do `send-keys` antes do próximo) — não por timestamp de cliente.
- **Ack por mensagem**, ecoando o `seq`, com `ok` e `reason` verbatim. É o que sustenta o "não entregue" honesto na tela.
- **Sem eco local**: o caractere só aparece quando a sessão o desenha, pelo SSE. Torna a honestidade estrutural — uma tecla que não chegou nunca aparece. (Eco local foi descartado com argumento decisivo: em campo de senha o processo não ecoa de propósito, e um eco local vazaria o caractere.)
- **Allowlist fechada validada no servidor**, defesa em profundidade — o servidor não confia no cliente.
- Mesmos gates de `/api/fleet/act` (`localShell`, escopo, auth) mais **checagem same-origin no upgrade** (CSWSH). Auditoria de **uma entrada por canal aberto**, nunca por tecla.

## O gate — oito critérios, todos exercidos ao vivo

Contra sessão tmux descartável real, com o servidor de verdade verificado intacto antes e depois:

- **A1** caractere sem submeter, com o **argv inspecionado** confirmando ausência de `Enter`; depois `Enter` explícito submetendo — provando que não foi acaso.
- **A2/A3** cinco rodadas de rajada de 42 caracteres: ordem exata, **210/210 acks pareados por seq**, sem embaralhar, perder ou duplicar.
- **A4** `sleep 60` real morto por `C-c` em ~62ms, confirmado por `ps -p` no pid.
- **A5** duas instâncias extras: `exposure=lan` sem opt-in → 403; central sem cookie → 401. Ambas recusaram **antes** de tocar o tmux.
- **A6** backend morto → `{ok:false, reason:send_failed}` em texto e tecla, conexão aberta.
- **A7/A8** `prompt` intacto; SSE convivendo com o WS.

4706 testes, `tsc` limpo, docs em `docs/terminal-write-channel.md`.

## Número conhecido, decisão já tomada

ack de escrita **~9ms**; eco tecla→tela **~380ms**, dominado pelo poll de 500ms do canal de **leitura** (`TERMINAL_POLL_MS`), fora do escopo desta unidade. O PE decidiu baixá-lo — jornada `j-20260901-ik` escrita e aprovada.