### PR TITLE
docs(server): terminal keystroke echo is already comfortable — measure, don't guess

### DIFF
--- a/docs/terminal-channel.md
+++ b/docs/terminal-channel.md
@@ -40,6 +40,34 @@ Tuning constants live in `packages/server/server/sessions/terminal-stream.ts`
 (`TERMINAL_VIEW_LINES`, `TERMINAL_POLL_MS`) and `terminal-web.ts` (`MAX_TERMINAL_STREAMS`,
 `KEEPALIVE_MS`). The poll cadence is overridable with `AGENTISTICS_TERMINAL_POLL_MS`.
 
+### Tuning: two different "echo" cases, and why `TERMINAL_POLL_MS` is not lowered
+
+**Keystroke echo is already comfortable and does not need this constant touched.** A delivered
+keystroke on the write channel ([docs/terminal-write-channel.md](terminal-write-channel.md)) calls
+`hub.nudge(id)` (`terminal-hub.ts`), which captures the pane immediately instead of waiting for the
+next tick — three cheap reads over ~200ms rather than one on the clock. Measured against a real,
+disposable tmux session: median ~7.7 ms, worst ~31 ms (n=15) from the WS send to the character
+appearing in an SSE `frame`. That is already an order of magnitude inside anything a person can
+perceive as "instant"; chasing it lower buys nothing.
+
+**Continuous output with no keystroke is a separate case the nudge cannot reach**, because nothing
+calls `nudge` when a process prints on its own (an agent streaming its reply, a long build). That
+case stays bound by the plain tick: measured median ~275 ms, worst ~500 ms at the default 500 ms
+cadence (same method — a loop printing a timestamped line every 300ms inside the pane, no WS input
+involved).
+
+Lowering the base `TERMINAL_POLL_MS` would shrink that second number, but unlike `nudge` it is not a
+burst — it is a **per watched session, all the time** cost that every open terminal panel pays for as
+long as it stays open, active or not. Measured (isolated tmux socket, 9 concurrently watched idle
+panes — this machine's real fleet size the day this was measured): ~11% of one core at the current
+500 ms; ~41% at 150 ms; ~47% at 100 ms. A drop large enough to meaningfully shrink the
+continuous-output number costs a real, standing fraction of a core for as long as a few panels stay
+open — for a case that is not the one people report as uncomfortable (nobody is waiting on a
+round-trip; they are watching text scroll in). So the constant stays at 500 ms. If continuous-output
+lag becomes a stated priority, the cheaper lever is the same shape as `nudge` — a short burst
+triggered by the pane actually changing, not a lower floor every watched session pays regardless of
+activity — not implemented here because it is not what this measurement was asked to fix.
+
 ## Request
 
 ```

--- a/docs/terminal-write-channel.md
+++ b/docs/terminal-write-channel.md
@@ -112,6 +112,10 @@ channel rides exactly the gates `/api/fleet` and `/api/fleet/act` carry:
 ## Latency (measured, local, disposable tmux session)
 
 - **Write path (WS send → ack):** median ~9 ms, p95 ~130 ms — the channel's own contribution.
-- **End-to-end echo (key → visible on screen via SSE):** median ~380 ms — dominated by the **read**
-  channel's 500 ms poll (`TERMINAL_POLL_MS`), which this unit does not change. Fluid direct typing
-  would want that poll tuned; that is a read-channel decision, deliberately out of scope here.
+- **End-to-end echo (key → visible on screen via SSE):** median ~7.7 ms, worst ~31 ms (n=15). A
+  delivered keystroke calls `nudgeTerminal()` (`terminal-web.ts`), which makes the read channel
+  capture the pane immediately instead of waiting for the next `TERMINAL_POLL_MS` tick — see
+  [terminal-channel.md](terminal-channel.md) for the mechanism and for the *different* case (a
+  process printing with nobody typing) that the nudge does not cover and the poll still dominates.
+  This superseded an earlier measurement of this section (~380 ms, poll-dominated) taken before the
+  nudge existed.


### PR DESCRIPTION
## Summary

- The task asked to bring key→screen terminal echo into a comfortable typing range without blowing up CPU across several watched sessions. Measured against a real disposable tmux session on `dev`: it already is — `nudge` (shipped alongside the WS write channel, `terminal-hub.ts` `hub.nudge` / `terminal-web.ts` `nudgeTerminal`) captures the pane immediately after a keystroke instead of waiting for the 500ms tick. Median ~7.7ms, worst ~31ms (n=15). `docs/terminal-write-channel.md` still carried the pre-nudge number (~380ms); corrected.
- Separately measured the case `nudge` does not cover, as asked: continuous output with no keystroke (an agent streaming its own reply) stays bound by the plain 500ms tick — median ~275ms, worst ~500ms.
- Measured the CPU cost of lowering the base poll to close that second gap (isolated tmux socket — never the production `agentop` one — 9 concurrently watched idle panes, matching today's real fleet size): ~11% of one core at 500ms, ~41% at 150ms, ~47% at 100ms — a standing cost every open terminal panel pays regardless of activity.
- Given the literal ask (typing comfort) is already met by a wide margin, and the remaining gap is a different, unscoped concern whose cheap fix would be a `nudge`-shaped burst on pane movement rather than a lower floor, `TERMINAL_POLL_MS` is left unchanged. Documented both findings in `docs/terminal-channel.md` (tuning section) and `docs/terminal-write-channel.md` (latency section) so the decision and its evidence survive the session.

No behavior change — docs only. No linked issue; this task was dispatched directly (journey j-20260901-ik), not from a GitHub issue.

## Test plan
- [x] `bun run stub`
- [x] `bun tsc --noEmit` — clean
- [x] `bun test` — 4794 pass / 0 fail
- [x] `git diff --exit-code bun.lock` — no drift
- [x] Live-measured against a real disposable tmux session (isolated port/data-dir server instance), not simulated

🤖 Generated with [Claude Code](https://claude.com/claude-code)