### PR TITLE
fix(team): the live channel filters sessionActivities too (#214)

### DIFF
--- a/packages/server/server/share-rules.test.ts
+++ b/packages/server/server/share-rules.test.ts
@@ -1081,10 +1081,24 @@ const LIVE_SESSIONS = [
 const liveIndex = () => buildPathRepoIndex(LIVE_SESSIONS)
 
 test('an unrestricted connection gets the live snapshot untouched', () => {
-  const snap = { liveSessionIds: ['open-blocked', 'open-shared'], liveProcesses: [{ cwd: '/anywhere' }] }
+  const snap = {
+    liveSessionIds: ['open-blocked', 'open-shared'],
+    liveProcesses: [{ cwd: '/anywhere' }],
+    liveSessionActivities: { 'open-blocked': 'working', 'open-shared': 'waiting' } as const,
+  }
   const out = filterLiveShared(snap, LIVE_SESSIONS, denylistRules(normalizeDenied([])))
   expect(out.liveSessionIds).toEqual(['open-blocked', 'open-shared'])
   expect(out.liveProcesses).toHaveLength(1)
+  expect(out.liveSessionActivities).toEqual({ 'open-blocked': 'working', 'open-shared': 'waiting' })
+})
+
+test('a snapshot with no activities yields an empty map, never undefined', () => {
+  // The caller sends `shared.liveSessionActivities` verbatim; a missing map must still be a map,
+  // or the frame carries `undefined` where the central expects an object.
+  const snap = { liveSessionIds: ['open-shared'], liveProcesses: [] }
+  expect(filterLiveShared(snap, LIVE_SESSIONS, denylistRules(normalizeDenied([]))).liveSessionActivities).toEqual({})
+  const restricted = filterLiveShared(snap, LIVE_SESSIONS, denylistRules(normalizeDenied(['github.com/acme/secret'])), liveIndex())
+  expect(restricted.liveSessionActivities).toEqual({})
 })
 
 // The leak this exists to close: the uploader withheld the repo's metrics while the reverse
@@ -1125,6 +1139,74 @@ test('the alias folding that guards filterShared guards the live channel too', (
   // Denied under a different SSH/case spelling of the same remote.
   const out = filterLiveShared(snap, LIVE_SESSIONS, denylistRules(normalizeDenied(['git@github.com:Acme/Secret.git'])), liveIndex())
   expect(out.liveSessionIds).toEqual([])
+})
+
+// The leak issue #214 closed: `sessionActivities` travelled beside the two filtered fields and was
+// itself unfiltered, so a withheld repo's session announced its id AND its state every 8 seconds.
+test("a denied session's activity is dropped while the shared one's survives", () => {
+  const snap = {
+    liveSessionIds: ['open-blocked', 'open-shared'],
+    liveProcesses: [],
+    liveSessionActivities: { 'open-blocked': 'waiting-approval', 'open-shared': 'working' } as const,
+  }
+  const out = filterLiveShared(snap, LIVE_SESSIONS, denylistRules(normalizeDenied(['github.com/acme/secret'])), liveIndex())
+  expect(out.liveSessionActivities).toEqual({ 'open-shared': 'working' })
+})
+
+test('an activity keyed by a session we cannot find is dropped, like the id would be', () => {
+  const snap = {
+    liveSessionIds: [],
+    liveProcesses: [],
+    liveSessionActivities: { ghost: 'working' } as const,
+  }
+  const out = filterLiveShared(snap, LIVE_SESSIONS, denylistRules(normalizeDenied(['github.com/acme/secret'])), liveIndex())
+  expect(out.liveSessionActivities).toEqual({})
+})
+
+test('an allowlist keeps only the allowed session\'s activity', () => {
+  const snap = {
+    liveSessionIds: ['open-blocked', 'open-shared'],
+    liveProcesses: [],
+    liveSessionActivities: { 'open-blocked': 'working', 'open-shared': 'waiting' } as const,
+  }
+  const rules = { mode: 'allowlist' as const, sources: new Set(['repo:github.com/acme/public']) }
+  const out = filterLiveShared(snap, LIVE_SESSIONS, rules, liveIndex())
+  expect(out.liveSessionIds).toEqual(['open-shared'])
+  expect(out.liveSessionActivities).toEqual({ 'open-shared': 'waiting' })
+})
+
+test('an EMPTY allowlist shares no activity at all', () => {
+  const snap = {
+    liveSessionIds: ['open-shared'],
+    liveProcesses: [],
+    liveSessionActivities: { 'open-shared': 'working' } as const,
+  }
+  const out = filterLiveShared(snap, LIVE_SESSIONS, { mode: 'allowlist', sources: new Set() }, liveIndex())
+  expect(out.liveSessionActivities).toEqual({})
+})
+
+// Enumerated over the RESULT'S OWN KEYS rather than field by field: the point of moving the
+// activities into this function is that ONE function decides the whole outgoing frame, so a field
+// added to it later is covered by this test instead of needing another one — which is precisely
+// what did not happen when `sessionActivities` was added at the call site.
+test("nothing about a denied session appears in ANY field of the outgoing frame", () => {
+  const snap = {
+    liveSessionIds: ['open-blocked', 'open-shared'],
+    liveProcesses: [{ cwd: '/w/secret' }, { cwd: '/w/public' }],
+    liveSessionActivities: { 'open-blocked': 'waiting-approval', 'open-shared': 'working' } as const,
+  }
+  const out = filterLiveShared(snap, LIVE_SESSIONS, denylistRules(normalizeDenied(['github.com/acme/secret'])), liveIndex())
+
+  expect(Object.keys(out).sort()).toEqual(['liveProcesses', 'liveSessionActivities', 'liveSessionIds'])
+  for (const value of Object.values(out)) {
+    const json = JSON.stringify(value)
+    expect(json).not.toContain('open-blocked')
+    expect(json).not.toContain('secret')
+  }
+  // ...and the shared half is still there, or an all-empty frame would pass the check above.
+  expect(out.liveSessionIds).toEqual(['open-shared'])
+  expect(out.liveProcesses.map(p => p.cwd)).toEqual(['/w/public'])
+  expect(out.liveSessionActivities).toEqual({ 'open-shared': 'working' })
 })
 
 // --- the cross-check that keeps THIS file the single source of the sharing semantics ------------

--- a/packages/server/server/share-rules.ts
+++ b/packages/server/server/share-rules.ts
@@ -334,36 +334,63 @@ export function filterShared<T extends Pick<SessionMeta, 'git_remote' | 'project
  * name and activity you broadcast is not a privacy control. Every outbound path applies the
  * same rule, so this one runs through `sessionShared` like the uploader does.
  *
- * Fail-closed on BOTH halves, which is stricter than `filterShared` and deliberately so:
+ * Fail-closed on ALL THREE halves, which is stricter than `filterShared` and deliberately so:
  *
  * - A live id whose session we cannot find is dropped. It cannot be attributed to a repo, and
  *   the central could not render it anyway (it resolves live ids against the sessions it was
  *   pushed), so keeping it only ever leaked an identifier for a row nobody could see.
+ * - An ACTIVITY is keyed by `session_id` and is judged by that same predicate, key by key. It
+ *   used to be sent unfiltered beside the two filtered fields, so a withheld repo's session
+ *   announced its id AND its state (`working` / `waiting` / `waiting-approval` / `exited`) every
+ *   8 seconds — enough to count a hidden project's sessions and watch them work. That the
+ *   central most likely has no document to render it against is a statement about today's
+ *   rendering, not about the boundary.
  * - A process is reported only when its `cwd` resolves POSITIVELY to a repo that is not denied.
  *   A process has no session to attribute, and `cwd` is the sensitive field here — a path is
  *   often the repo name. Under restrictions an unrecognized directory is withheld rather than
  *   assumed innocent.
  *
+ * ONE function decides the WHOLE outgoing frame. The caller must never assemble a field of that
+ * message beside this result — that is exactly how the activities came to be sent unfiltered —
+ * so anything added to the live message is added here, where the rule already lives.
+ *
  * With no restrictions the snapshot passes through untouched — the common case pays nothing.
  */
 export function filterLiveShared<
   P extends { cwd: string },
+  A extends string = 'working' | 'waiting' | 'waiting-approval' | 'exited',
 >(
-  snapshot: { liveSessionIds: readonly string[]; liveProcesses: readonly P[] },
+  snapshot: {
+    liveSessionIds: readonly string[]
+    liveProcesses: readonly P[]
+    liveSessionActivities?: Readonly<Record<string, A>> | null
+  },
   sessions: readonly Pick<SessionMeta, 'session_id' | 'git_remote' | 'project_path'>[],
   rules: ShareRules,
   index?: PathRepoIndex,
-): { liveSessionIds: string[]; liveProcesses: P[] } {
+): { liveSessionIds: string[]; liveProcesses: P[]; liveSessionActivities: Record<string, A> } {
   // Only an unrestricted DENYLIST passes the snapshot through. An allowlist is always a
   // restriction — an empty one shares nothing — so it must never take this shortcut.
   if (rules.mode === 'denylist' && rules.sources.size === 0) {
-    return { liveSessionIds: [...snapshot.liveSessionIds], liveProcesses: [...snapshot.liveProcesses] }
+    return {
+      liveSessionIds: [...snapshot.liveSessionIds],
+      liveProcesses: [...snapshot.liveProcesses],
+      liveSessionActivities: { ...(snapshot.liveSessionActivities ?? {}) },
+    }
   }
   const byId = new Map(sessions.map(s => [s.session_id, s]))
-  const liveSessionIds = snapshot.liveSessionIds.filter(id => {
+  const idShared = (id: string): boolean => {
     const s = byId.get(id)
     return !!s && sessionShared(s, rules, index)
-  })
+  }
+  const liveSessionIds = snapshot.liveSessionIds.filter(idShared)
+  // Judged key by key against the rule, never by intersecting with `liveSessionIds` above: that
+  // would inherit whatever that list happens to hold rather than asking the question, and an
+  // activity for an id the snapshot did not list would then pass on a technicality.
+  const liveSessionActivities: Record<string, A> = {}
+  for (const [id, activity] of Object.entries(snapshot.liveSessionActivities ?? {})) {
+    if (idShared(id)) liveSessionActivities[id] = activity as A
+  }
   const liveProcesses = snapshot.liveProcesses.filter(p => {
     // Positive resolution only: `repoKeyOf` falls back to NO_REPO_KEY for an unknown path, which
     // under a denylist would read as "shared" whenever the user has not also denied the no-repo
@@ -374,7 +401,7 @@ export function filterLiveShared<
     const matched = rules.sources.has(repoSourceKey(key)) || rules.sources.has(projectSourceKey(p.cwd))
     return rules.mode === 'allowlist' ? matched : !matched
   })
-  return { liveSessionIds, liveProcesses }
+  return { liveSessionIds, liveProcesses, liveSessionActivities }
 }
 
 /**

--- a/packages/server/server/team-agent-client.ts
+++ b/packages/server/server/team-agent-client.ts
@@ -241,11 +241,14 @@ function startLiveReporting(connId: string, socket: WebSocket): void {
       const shared = shareRules.filterLiveShared(snap, data.sessions, rules, index)
 
       if (socket.readyState !== WebSocket.OPEN) return
+      // Every field comes off `shared` — nothing on this message is read from `snap` directly.
+      // The activities used to be, and a withheld repo's session announced its id and its state
+      // beside the two fields that were filtered.
       socket.send(JSON.stringify({
         type: 'live-sessions',
         sessionIds: shared.liveSessionIds,
         processes: shared.liveProcesses,
-        sessionActivities: snap.liveSessionActivities ?? {},
+        sessionActivities: shared.liveSessionActivities,
       }))
     } catch { /* transient — the next tick retries */ }
   }


### PR DESCRIPTION
## Summary

- `filterLiveShared` now filters `sessionActivities` alongside `liveSessionIds` and `liveProcesses`, so ONE function decides the whole outgoing live-channel frame.
- `team-agent-client.ts` reads every field of the `live-sessions` message off `shared`; nothing on that message comes from the raw snapshot any more.
- New tests in `share-rules.test.ts`, including one that enumerates the result's own keys and asserts nothing about a denied session appears in any of them.

## Motivation

Closes #214.

The member→central reverse channel filtered its session ids and its processes through the connection's sharing rules and then sent `sessionActivities` **unfiltered** beside them. A session in a repository or project the user had explicitly withheld from that central still announced its **id** and its **state** (`working` / `waiting` / `waiting-approval` / `exited`) every 8 seconds — enough to count a hidden project's sessions and watch them work.

That a central most likely holds no session document to render that state against is a statement about today's rendering, not about the boundary. The reverse channel is an outbound path like the uploader, and a repo withheld from one may not be announced by the other — the comment directly above the leaking code already said so.

The fix belongs in `share-rules.ts` and not at the call site: the sharing semantics live in one module, and moving the activities inside means the **next** field added to that message cannot repeat this.

## Changes

**`packages/server/server/share-rules.ts`**
- `filterLiveShared` takes `snapshot.liveSessionActivities` (optional) and returns `liveSessionActivities` beside the two fields it already filtered. Generic over the activity value type, defaulting to the existing union.
- Activities are judged **key by key** by the same predicate the ids are — deliberately not by intersecting with the filtered id list, which would inherit whatever that list happens to hold rather than asking the rule.
- The existing fail-closed rules stand unchanged: an activity keyed by a session we cannot find is dropped in both modes, and an allowlist (empty one included) never takes the pass-through shortcut.
- An unrestricted denylist still passes the whole snapshot through untouched — the common case pays nothing — and a missing map yields `{}`, never `undefined`.
- The doc comment records the leak and states that this function decides the whole frame.

**`packages/server/server/team-agent-client.ts`**
- `sessionActivities: snap.liveSessionActivities ?? {}` → `sessionActivities: shared.liveSessionActivities`, with a comment on why no field of this message may be read from `snap`.

**`packages/server/server/share-rules.test.ts`** — six tests added / extended:
- a denied session's activity is dropped while the shared one's survives;
- an activity keyed by a session we cannot find is dropped, like the id would be;
- an allowlist keeps only the allowed session's activity, and an **empty** allowlist keeps none;
- an unrestricted connection still gets the activities untouched;
- a snapshot with no activities yields an empty map, never `undefined`;
- **the enumerated one** the issue asked for: it walks the result's own keys, asserts the key set is exactly the three fields, and asserts neither the denied session's id nor its repo path appears in the JSON of **any** of them — then asserts the shared half is still present, so an all-empty frame cannot pass. A field added to the frame later is covered by this test instead of needing another one, which is precisely what did not happen when `sessionActivities` was added at the call site.

No doc change: `docs/` describes the rule ("every outbound path applies the same rule") and this restores the code to it rather than changing it.

## Test plan

- [x] `bun tsc --noEmit` — clean.
- [x] `bun test packages/server/server/share-rules.test.ts` — 125 pass, 0 fail.
- [x] `bun test` (full suite) — 4822 pass, 1 fail: `adapters/claude.test.ts` ("claude adapter tags every session as claude"), a pre-existing integration test that scans the real `~/.claude` tree and timed out at its own 120s limit on this machine. It imports none of the modules touched here.
- [x] Verified the enumerated test fails against the old behaviour: with `sessionActivities` unfiltered, `open-blocked` is present in the frame.

Reviewers may want to check: the choice to re-run the rule per activity key rather than intersect with `liveSessionIds`, and that the unrestricted-denylist shortcut still returns a copy (not the caller's map).

## Empirical verification — the running feature, not only the suite

The unit tests pass and fail without the fix, but they exercise a pure function. This ran the **real
member→central live channel end to end**, on an isolated machine (`HOME=/tmp/probe214/home`), with
nothing mocked: real `buildApiResponse`, real `getLiveSnapshot` reading `/proc`, the real event-channel
inbox, the real preferences read, the real rules resolution, a real WebSocket, and the real
`team-live` store on the receiving side.

**Fixture (a real machine, not fixtures in memory)**
- two real git repos — `github.com/acme/secret` (**withheld**) and `github.com/acme/public` (shared);
- two real Claude transcripts under `~/.claude/projects/…`, one per repo;
- two **real running processes** named `claude` (a copy of `sleep`) with their `cwd` in each repo, so
  host-process detection genuinely reports both sessions as live;
- a real `~/.agentistics/events.jsonl` so the two sessions carry **different** states —
  the withheld one `waiting-approval`, the shared one `working`;
- `preferences.json`: mode `member`, one connection at `http://127.0.0.1:47999`,
  `shareMode: denylist`, `sources: [{type: repo, value: https://github.com/acme/secret.git}]`;
- a real `Bun.serve` WebSocket server at `/api/team/agent` standing in for the central, capturing frames.

The driver called the production `startAgentClient()` — so the frame below was produced by
`openConnection` → `startLiveReporting`, exactly as it is in production.

**What the machine had to offer, before any rule (identical in both runs):**

```
liveSessionIds        : ["1111…1111","2222…2222"]
liveSessionActivities : {"1111…1111":"waiting-approval","2222…2222":"working"}
```

### BEFORE (the two files reverted to `HEAD~1`) — the leak, on the wire

```json
{
  "type": "live-sessions",
  "sessionIds": ["22222222-2222-4222-8222-222222222222"],
  "processes": [],
  "sessionActivities": {
    "11111111-1111-4111-8111-111111111111": "waiting-approval",
    "22222222-2222-4222-8222-222222222222": "working"
  }
}
```

`sessionIds` correctly withholds the secret repo's session — and `sessionActivities` announces that
same session's **id** and the fact that it is **sitting on a permission prompt**. Fed into the real
`team-live` store, `collectMemberLive()` on the central returns:

```json
{
  "liveSessionIds": ["22222222-2222-4222-8222-222222222222"],
  "liveProcesses": [],
  "liveSessionActivities": {
    "11111111-1111-4111-8111-111111111111": "waiting-approval",
    "22222222-2222-4222-8222-222222222222": "working"
  }
}
```

So the withheld session's state is not merely on the wire: it is **held by the central**.

### AFTER (this branch) — same fixture, same driver

```json
{
  "type": "live-sessions",
  "sessionIds": ["22222222-2222-4222-8222-222222222222"],
  "processes": [],
  "sessionActivities": {
    "22222222-2222-4222-8222-222222222222": "working"
  }
}
```

and the central holds exactly that. Verdict printed over **every** field of the frame
(`type, sessionIds, processes, sessionActivities`):

```
withheld session id in ANY field : no
withheld repo path in ANY field  : no
shared session id present        : yes      <- so an empty frame cannot pass as a pass
```

The same run was repeated with the other half of the rule — `shareMode: allowlist`,
`sources: [{type: project, value: /tmp/probe214/work/publicrepo}]` — with the same result: only the
allowed project's session and its activity leave the machine.

### What could NOT be exercised, and why

- **A real central.** The receiving end here is a WebSocket server plus the real `team-live` module,
  not a full central: `team-agent.ts`'s upgrade path authenticates the member against Mongo
  (token hashes, accounts), which needs a Mongo instance and a minted token. What that path adds
  after the socket is `recordMemberLive(...)` with the frame's own fields — which is exactly what the
  probe called, with the production function. The member half — the side that decides what leaves the
  machine, and the side this PR changes — is entirely the production code.
- **Real assistant processes.** The two live processes are a renamed `sleep`, not real `claude`
  instances. Host detection matches on `/proc/<pid>/comm` plus the cwd, so this is the same input the
  detector reads from a real assistant; running six real assistants for the same signal would not have
  changed what the detector saw.
- Everything else in the chain is the shipped code.

The probe script and its fixture were temporary and are not part of this PR; the recipe above is the
whole of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TKgT6cX9bTRMJ9LBwAeaqE
