### PR TITLE
fix(sessions): the wizard offers the assistants that are actually installed here (#212)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,7 +95,23 @@ packages/server/server/          — server-side modules (never bundled by Vite)
   │                          (`Record<HarnessId, SpawnSpec|null>` — a harness with no spec is
   │                          ABSENT from the wizard, never offered and failing), the PURE
   │                          `tmux-cli.ts` (every tmux argv and parse), `session-ref.ts` and the
-  │                          `managed-sessions.json` registry. **Every flag is read from the
+  │                          `managed-sessions.json` registry. **A spec answers "do we know this
+  │                          CLI's argv" and NOT "is it installed here"**, and the wizard offered
+  │                          every spec it had: picking a harness whose `bin` is not on PATH
+  │                          created a tmux session that died on `command not found`, on a screen
+  │                          nobody is looking at. `harness-install.ts` is the ONE resolution both
+  │                          front doors read — the cockpit through
+  │                          `ControlHost.startableHarnesses`, `agentop session` through its usage
+  │                          and its spawn paths — because one gesture implemented twice drifts.
+  │                          It is PURE over an injected probe (`resolveStartable`) with `Bun.which`
+  │                          CACHED behind a short TTL: the answer is asked for on every wizard
+  │                          mount and every spawn, and a cache held for the life of the process
+  │                          would go on denying a CLI installed a minute ago. Absent, never
+  │                          disabled — but an EMPTY list names the commands that would fill it
+  │                          (`wizNoHarness`), the same rule `liveEmptyNotice` follows, and a
+  │                          missing tmux keeps its own sentence because it stops every session
+  │                          rather than one row. `missingBin` is the guard one line before each
+  │                          spawn, for the reopens and fleet requests the wizard never filters. **Every flag is read from the
   │                          tool's own `--help`, never guessed** — codex's reasoning effort is
   │                          deliberately absent for that reason, while agy's IS wired up because
   │                          its `--help` prints the closed set. `kimi` and `copilot` get their

--- a/docs/session-manager.md
+++ b/docs/session-manager.md
@@ -294,6 +294,15 @@ The folder step is a searchable table of every directory under your home — fol
 and why it is being offered — grouped by repository, with the directory you are standing in first.
 It reads the local store, so it works with the server stopped.
 
+The harness step offers **only the assistants installed on this machine**. agentop knows how to
+start six of them, and a CLI that does not resolve on your `PATH` is absent from the list rather
+than offered and failing — picking one would create a tmux session that dies immediately on
+`command not found`, on a screen nobody is looking at. If none of them resolve the list is empty and
+says so, naming the commands that would fill it. `agentop session --help` answers the same question
+from the same resolution: it prints what can be started **here**, and names the rest with the
+command each one needs. A missing `tmux` is a different sentence — that stops every session, not one
+row.
+
 `--bg` detaches and returns immediately. Without it the session takes over your terminal; the detach
 keystroke is printed before it does. `--cwd` defaults to the directory you are in.
 

--- a/packages/server/server/cli-i18n.ts
+++ b/packages/server/server/cli-i18n.ts
@@ -237,6 +237,14 @@ export interface CliStrings {
   sessStartedBg: (name: string) => string
   sessSpawnFailed: (reason: string) => string
   sessSpawnUnsupported: (harness: string) => string
+  /**
+   * A harness agentop knows how to start whose CLI is not on this machine's PATH.
+   *
+   * Deliberately a DIFFERENT sentence from `sessSpawnUnsupported`: "agentop cannot drive it" and
+   * "it is not installed here" send someone to two different places, and only one of them is fixed
+   * by installing something. The command is named because it is the only actionable part.
+   */
+  sessSpawnNotInstalled: (harness: string, bin: string) => string
   sessSpawnNoResume: (harness: string) => string
   sessSpawnNoModel: (harness: string) => string
   sessSpawnNoEffort: (harness: string) => string
@@ -580,6 +588,8 @@ const EN: CliStrings = {
   sessStartedBg: (name: string) => `started ${name} in the background.`,
   sessSpawnFailed: (reason: string) => `could not start the session: ${reason}`,
   sessSpawnUnsupported: (harness: string) => `agentop cannot start ${harness} yet.`,
+  sessSpawnNotInstalled: (harness: string, bin: string) =>
+    `${harness} is not installed here — there is no \`${bin}\` on PATH.`,
   sessSpawnNoResume: (harness: string) => `${harness} cannot reopen a conversation by id.`,
   sessSpawnNoModel: (harness: string) => `${harness} has no model flag, so a model cannot be set.`,
   sessSpawnNoEffort: (harness: string) => `${harness} has no effort flag, so an effort cannot be set.`,
@@ -861,6 +871,8 @@ const PT: CliStrings = {
   sessStartedBg: (name: string) => `${name} iniciada em background.`,
   sessSpawnFailed: (reason: string) => `não deu para iniciar a sessão: ${reason}`,
   sessSpawnUnsupported: (harness: string) => `o agentop ainda não inicia ${harness}.`,
+  sessSpawnNotInstalled: (harness: string, bin: string) =>
+    `${harness} não está instalado aqui — não existe \`${bin}\` no PATH.`,
   sessSpawnNoResume: (harness: string) => `${harness} não reabre conversa por id.`,
   sessSpawnNoModel: (harness: string) => `${harness} não tem flag de modelo, então não dá para definir um.`,
   sessSpawnNoEffort: (harness: string) => `${harness} não tem flag de effort, então não dá para definir um.`,

--- a/packages/server/server/cli-start.ts
+++ b/packages/server/server/cli-start.ts
@@ -34,7 +34,7 @@ import { writeSync } from 'node:fs'
 import { join } from 'node:path'
 import { homedir, platform } from 'node:os'
 import {
-  DEFAULT_TEAM, HARNESS_ORDER, repoShortName,
+  DEFAULT_TEAM, repoShortName,
   type HarnessId, type TeamConnection,
 } from '@agentistics/core'
 import type {
@@ -56,6 +56,7 @@ import type {
   ServiceRuntimeState,
   ServiceState,
   SessionHarnessOption,
+  StartableHarnesses,
   SessionViewPrefs,
   SpawnSessionRequest,
   SpawnSessionResult,
@@ -100,7 +101,10 @@ import { cliStrings, type CliLang, type CliStrings } from './cli-i18n'
 import { resolveLang } from './cli-lang'
 import { scanProcesses } from './live-sessions'
 import { resolveBackend } from './sessions'
-import { SPAWN_SPECS, planSpawn } from './sessions/spawn-spec'
+import { planSpawn } from './sessions/spawn-spec'
+// The ONE resolution of "which assistant can this machine actually start", shared with
+// `agentop session` — see `harness-install.ts`.
+import { missingBin, startableHere } from './sessions/harness-install'
 import { planTakeover } from './sessions/takeover'
 import { findProjects } from './sessions/project-source'
 import { candidatePath } from './sessions/project-search'
@@ -1489,6 +1493,13 @@ async function spawnManaged(req: {
   const backend = await resolveBackend()
   const blocked = await backend.unavailable()
   if (blocked) return { ok: false, message: blocked }
+
+  // The wizard never offers an absent CLI, but a REOPEN names a harness the registry recorded
+  // months ago and a fleet request names whatever it was sent. Checked here, one line before the
+  // spawn, rather than trusted from the caller: `command not found` inside tmux is a session that
+  // is created, dies, and reports nothing to anyone.
+  const absentBin = missingBin(req.harness)
+  if (absentBin) return { ok: false, message: s.sessSpawnNotInstalled(req.harness, absentBin) }
 
   const planned = planSpawn({
     harness: req.harness,
@@ -2998,23 +3009,28 @@ export function createControlHost(initialLang: CliLang, altScreen: Suspendable):
     },
 
     /**
-     * Derived from `SPAWN_SPECS`, never a second hand-written list.
+     * Derived from `SPAWN_SPECS` and from this machine's PATH, never a second hand-written list.
      *
-     * A harness with no spec is ABSENT from the wizard rather than offered and failing — the same
-     * rule `agentop session`'s `STARTABLE` already follows, and the reason the two can never drift.
+     * A harness with no spec is ABSENT from the wizard rather than offered and failing, and so is
+     * one whose CLI does not resolve here — offering it produces a tmux session that dies on
+     * `command not found`, on a screen nobody is looking at. `startableHere()` is the ONE
+     * resolution `agentop session` reads too, which is the reason the two can never drift.
+     *
+     * The ones left out travel as `missing`: the wizard says nothing about them while there is
+     * something to offer, and names their commands when there is not.
      */
-    async startableHarnesses(): Promise<SessionHarnessOption[]> {
-      return HARNESS_ORDER.flatMap(id => {
-        const spec = SPAWN_SPECS[id]
-        if (!spec) return []
-        return [{
+    async startableHarnesses(): Promise<StartableHarnesses> {
+      const here = startableHere()
+      return {
+        options: here.installed.map(({ id, spec }): SessionHarnessOption => ({
           id,
           label: id,
           modelSuggestions: spec.modelSuggestions,
           supportsModel: spec.modelFlag !== undefined,
           efforts: spec.efforts ?? [],
-        }]
-      })
+        })),
+        missing: here.missing.map(m => ({ id: m.id, bin: m.bin })),
+      }
     },
 
     async searchProjects(query: string): Promise<ProjectOption[]> {

--- a/packages/server/server/sessions/cli-session.ts
+++ b/packages/server/server/sessions/cli-session.ts
@@ -24,6 +24,10 @@ import { toControlSession } from './control-session'
 import { recordedRepo, repoFacts } from './repo-facts'
 import { emptyReason, renderSessionTable, resolveWidth } from './session-table'
 import { SPAWN_SPECS, planSpawn } from './spawn-spec'
+// Whether a harness's CLI actually resolves HERE — the same resolution the cockpit's wizard reads
+// through `ControlHost.startableHarnesses`, so the two lists can never disagree. See
+// `harness-install.ts`.
+import { missingBin, startableHere } from './harness-install'
 import { rulesFor } from './attention-rules'
 // The harness half of a rename. Shared with the cockpit's Rename verb — see `rename.ts`.
 import { renameInHarness, renameMessage } from './rename'
@@ -54,10 +58,24 @@ function spawnPromptArg(plan: SpawnPlan, harness: HarnessId): { initialPrompt?: 
   return { initialPrompt: { ...plan.initialPrompt, ...(rules ? { rules } : {}) } }
 }
 
-/** Derived from the specs, never a second hand-written list — the two could not then disagree. */
+/**
+ * The harnesses agentop knows how to spawn — derived from the specs, never a second hand-written
+ * list. It answers "do we know this CLI's argv" and NOT "is it installed here": that second
+ * question is `startableHere()`, and `explainPlanError` below is careful to keep the two sentences
+ * apart, because only one of them is fixed by installing something.
+ */
 const STARTABLE: HarnessId[] = HARNESS_ORDER.filter(h => SPAWN_SPECS[h] !== null)
 
-const USAGE = `Usage:
+/**
+ * A harness whose CLI is not on PATH, said in one sentence with the command that would fix it.
+ *
+ * The English twin of `CliStrings.sessSpawnNotInstalled` — `agentop session` prints its own words,
+ * exactly as it already renders `SpawnPlanError` itself rather than through the cockpit's strings.
+ */
+const notInstalled = (harness: string, bin: string) =>
+  `${harness} is not installed here — there is no \`${bin}\` on PATH.`
+
+const USAGE_BODY = `Usage:
   agentop session <harness> [-p "prompt"] [--bg] [--model <id>] [--effort <level>] [--cwd <path>] [--name "label"]
   agentop session ls     [--all] [--group ${GROUPINGS.join('|')}] [--json]
   agentop session list
@@ -90,7 +108,31 @@ Orchestrating several at once — the form an assistant should use:
       --session "codex: port the tests" \\
       --session "gemini: review the migration"
 
-Harnesses that can be started: ${STARTABLE.join(', ')}`
+`
+
+/**
+ * The usage text, with the harness line answered for THIS machine.
+ *
+ * It used to name every harness with a spawn spec, which reads as an offer — and picking one that
+ * is not installed produces a tmux session that dies on `command not found` with nobody watching.
+ * The ones agentop knows but cannot run here are still NAMED, with their command: absent from the
+ * offer, present in the explanation.
+ */
+function usage(): string {
+  const here = startableHere()
+  const installed = here.installed.map(h => h.id)
+  const absent = here.missing.map(m => `${m.id} (${m.bin})`)
+  const lines = [
+    installed.length > 0
+      ? `Harnesses that can be started here: ${installed.join(', ')}`
+      : 'No assistant CLI was found on PATH, so nothing can be started here yet.',
+  ]
+  if (absent.length > 0) {
+    lines.push(`agentop also knows how to start ${absent.join(', ')} — not found on this machine's PATH.`)
+  }
+  // `USAGE_BODY` already ends on its blank line — a second newline here would open a gap.
+  return `${USAGE_BODY}${lines.join('\n')}`
+}
 
 /**
  * A reconciled row as `resolveSessionRef` needs it. Unlike the registry alone, this includes
@@ -116,8 +158,8 @@ function explainPlanError(e: SpawnPlanError): string {
 
 export async function runSession(argv: string[]): Promise<number> {
   const cmd = parseSessionArgs(argv)
-  if (cmd.kind === 'help') { console.log(USAGE); return 0 }
-  if (cmd.kind === 'error') { console.error(cmd.message); console.error(`\n${USAGE}`); return 1 }
+  if (cmd.kind === 'help') { console.log(usage()); return 0 }
+  if (cmd.kind === 'error') { console.error(cmd.message); console.error(`\n${usage()}`); return 1 }
 
   const backend = await resolveBackend()
   const blocked = await backend.unavailable()
@@ -197,6 +239,11 @@ async function start(
   // is written verbatim into the registry, where `list` would print it back meaningless from
   // anywhere else.
   const cwd = cmd.cwd ? resolve(cmd.cwd) : process.cwd()
+  // Before anything is spawned, like the plan itself: a harness whose CLI is not here starts a tmux
+  // session that dies on `command not found`, and `spawnFailure` below would report the shell's
+  // words rather than the one fact that fixes it.
+  const absent = missingBin(cmd.harness)
+  if (absent) { console.error(notInstalled(cmd.harness, absent)); return 1 }
   const planned = planSpawn({
     harness: cmd.harness, cwd, prompt: cmd.prompt, model: cmd.model, effort: cmd.effort,
     conversationId: randomUUID(),
@@ -299,6 +346,8 @@ async function batch(
 
   for (const spec of cmd.specs) {
     const cwd = spec.cwd ? resolve(spec.cwd) : process.cwd()
+    const absent = missingBin(spec.harness)
+    if (absent) { failed.push({ harness: spec.harness, reason: notInstalled(spec.harness, absent) }); continue }
     const planned = planSpawn({
       harness: spec.harness,
       cwd,
@@ -409,7 +458,9 @@ async function openTask(task: string, json: boolean, backend: SessionBackend): P
   for (const row of plan.reopen) {
     const m = row.entry
     const planned = planSpawn({ harness: m.harness, cwd: m.cwd, resumeId: row.resumeId })
-    if (!planned.ok) { skipped.push(m.id); continue }
+    // A task filed months ago can name a harness whose CLI has since gone. Skipped and COUNTED,
+    // like every other row that cannot be reopened — never spawned into an immediate death.
+    if (!planned.ok || missingBin(m.harness)) { skipped.push(m.id); continue }
     const id = newSessionId()
     try {
       await backend.spawn({ id, cwd: m.cwd, argv: planned.plan.argv })
@@ -700,6 +751,12 @@ async function attach(ref: string, backend: SessionBackend): Promise<number> {
 async function takeOver(ref: string, backend: SessionBackend): Promise<number | null> {
   const live = await liveAgentFor(ref)
   if (!live) return null
+
+  // Checked BEFORE the plan, and so before any thought of closing anything: ending somebody's
+  // running assistant and then discovering its CLI is gone loses the turn for nothing. It is its
+  // own sentence rather than `resumable: false`, which would report a capability the harness has.
+  const absent = missingBin(live.harness)
+  if (absent) { console.error(notInstalled(live.harness, absent)); return 1 }
 
   const planned = planSpawn({ harness: live.harness, cwd: live.cwd, resumeId: live.sessionId })
   const plan = planTakeover({

--- a/packages/server/server/sessions/fleet-web.ts
+++ b/packages/server/server/sessions/fleet-web.ts
@@ -290,15 +290,16 @@ export interface FleetNewOptions {
   /** The tasks that already exist here, so filing the new session is a pick, not a spelling test. */
   tasks: string[]
   /**
-   * This machine cannot start sessions at all (no backend on this platform, or a host that does not
-   * implement it). Said in words: an empty harness list on its own reads as a broken wizard.
+   * Nothing can be started here, and why — no backend on this platform, a host that does not
+   * implement it, or not one assistant CLI on PATH. Said in words: an empty harness list on its own
+   * reads as a broken wizard.
    */
   unavailable?: string
 }
 
 /**
  * The wizard's own data. Never throws — a machine that cannot answer says so in a sentence, and an
- * empty list is only ever a real "there is nothing here".
+ * empty list always comes with the reason it is empty.
  */
 export async function readNewOptions(lang: CliLang, query: string): Promise<FleetNewOptions> {
   const s = controlStrings(lang)
@@ -307,13 +308,20 @@ export async function readNewOptions(lang: CliLang, query: string): Promise<Flee
     if (!host.startableHarnesses || !host.spawnSession) {
       return { harnesses: [], projects: [], tasks: [], unavailable: s.sessionsNoHost }
     }
-    const [harnesses, projects, tasks] = await Promise.all([
+    const [startable, projects, tasks] = await Promise.all([
       host.startableHarnesses(),
       host.searchProjects ? host.searchProjects(query).catch(() => []) : Promise.resolve([]),
       host.sessionTasks ? host.sessionTasks().catch(() => []) : Promise.resolve([]),
     ])
+    // An empty list is never left to speak for itself. The harnesses agentop knows how to start are
+    // narrowed to the CLIs that resolve on this machine, so "nothing to offer" means every one of
+    // them is missing — and the commands that would fill the list are the only actionable fact.
+    const unavailable = startable.options.length === 0
+      ? { unavailable: s.wizNoHarness(startable.missing.map(m => m.bin)) }
+      : {}
     return {
-      harnesses: harnesses.map(h => ({
+      ...unavailable,
+      harnesses: startable.options.map(h => ({
         id: h.id,
         label: h.label,
         modelSuggestions: [...h.modelSuggestions],
@@ -377,7 +385,7 @@ export async function runFleetSpawn(
   const host = await hostFor(lang)
   if (!host.spawnSession || !host.startableHarnesses) return { ok: false, message: s.sessionsNoHost }
 
-  const decision = planFleetSpawn(body, await host.startableHarnesses())
+  const decision = planFleetSpawn(body, (await host.startableHarnesses()).options)
   if (!decision.ok) {
     const detail = decision.detail ?? ''
     const message =

--- a/packages/server/server/sessions/harness-install.test.ts
+++ b/packages/server/server/sessions/harness-install.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'bun:test'
+import { HARNESS_ORDER } from '@agentistics/core'
+import { SPAWN_SPECS } from './spawn-spec'
+import { binOnPath, forgetProbes, harnessBin, missingBin, resolveStartable } from './harness-install'
+
+/** Every harness agentop knows how to spawn, in the order the product lists them. */
+const SPAWNABLE = HARNESS_ORDER.filter(h => SPAWN_SPECS[h] !== null)
+const BINS = SPAWNABLE.map(h => SPAWN_SPECS[h]!.bin)
+
+describe('resolveStartable', () => {
+  it('offers every spawnable harness when all of them are on PATH', () => {
+    const r = resolveStartable(() => true)
+    expect(r.installed.map(i => i.id)).toEqual(SPAWNABLE)
+    expect(r.missing).toEqual([])
+  })
+
+  it('offers NOTHING and names every command when none of them resolve', () => {
+    const r = resolveStartable(() => false)
+    expect(r.installed).toEqual([])
+    expect(r.missing.map(m => m.id)).toEqual(SPAWNABLE)
+    // The bin is the only actionable fact about the absence, so it must survive the split.
+    expect(r.missing.map(m => m.bin)).toEqual(BINS)
+  })
+
+  it('splits the list when some resolve and some do not', () => {
+    const present = new Set(['claude', 'codex'])
+    const r = resolveStartable(b => present.has(b))
+    expect(r.installed.map(i => i.id)).toEqual(['claude', 'codex'])
+    expect(r.installed.map(i => i.bin)).toEqual(['claude', 'codex'])
+    expect(r.missing.map(m => m.id)).not.toContain('claude')
+    expect(r.missing.map(m => m.bin)).toContain('agy')
+  })
+
+  it('keeps HARNESS_ORDER, so the wizard never reorders itself as CLIs come and go', () => {
+    const r = resolveStartable(b => b !== 'codex')
+    const order = r.installed.map(i => i.id)
+    expect(order).toEqual(SPAWNABLE.filter(h => h !== 'codex'))
+  })
+
+  it('probes each command exactly once', () => {
+    const asked: string[] = []
+    resolveStartable(b => { asked.push(b); return true })
+    expect(asked).toEqual(BINS)
+  })
+
+  it('leaves a harness with no spawn spec out of BOTH lists', () => {
+    // "agentop cannot start it" is planSpawn's refusal and a different sentence from "not
+    // installed" — naming it here would send someone to install a CLI agentop still would not drive.
+    const r = resolveStartable(() => true)
+    const named = [...r.installed.map(i => i.id), ...r.missing.map(m => m.id)]
+    for (const id of HARNESS_ORDER) {
+      if (SPAWN_SPECS[id] === null) expect(named).not.toContain(id)
+    }
+  })
+
+  it('carries the spec through, so the wizard can ask the questions the harness earns', () => {
+    const r = resolveStartable(() => true)
+    const claude = r.installed.find(i => i.id === 'claude')
+    expect(claude?.spec).toBe(SPAWN_SPECS.claude!)
+  })
+})
+
+describe('harnessBin', () => {
+  it('names the command each spawnable harness runs', () => {
+    expect(harnessBin('antigravity')).toBe('agy')
+    expect(harnessBin('claude')).toBe('claude')
+  })
+})
+
+describe('binOnPath', () => {
+  it('finds a command that exists and does not find one that cannot', () => {
+    forgetProbes()
+    expect(binOnPath('sh')).toBe(true)
+    expect(binOnPath('agentop-no-such-command-xyz')).toBe(false)
+  })
+
+  it('caches within the TTL and re-probes after it', () => {
+    forgetProbes()
+    const t0 = 1_000_000
+    expect(binOnPath('agentop-no-such-command-xyz', t0)).toBe(false)
+    // Inside the window the answer comes from the cache — the wizard, the fleet API and a spawn all
+    // ask the same question within a second of each other.
+    expect(binOnPath('agentop-no-such-command-xyz', t0 + 1_000)).toBe(false)
+    // And it expires, so installing a CLI is picked up without restarting the cockpit.
+    expect(binOnPath('sh', t0 + 60_000)).toBe(true)
+  })
+})
+
+describe('missingBin', () => {
+  it('says nothing about a harness agentop cannot spawn at all', () => {
+    for (const id of HARNESS_ORDER) {
+      if (SPAWN_SPECS[id] === null) expect(missingBin(id)).toBeNull()
+    }
+  })
+})

--- a/packages/server/server/sessions/harness-install.ts
+++ b/packages/server/server/sessions/harness-install.ts
@@ -1,0 +1,119 @@
+/**
+ * harness-install.ts — which of the harnesses agentop knows how to spawn can actually run HERE.
+ *
+ * `SPAWN_SPECS` answers a different question: "do we know this CLI's argv". That is the right rule
+ * for whether agentop could EVER start a harness, and it says nothing about whether `spec.bin`
+ * resolves on this machine's PATH. Offering a harness that is not installed produces a tmux session
+ * that dies immediately on `command not found`, on a screen nobody is looking at — the wizard's
+ * version of a confident `0` where the honest answer is that the thing is not there.
+ *
+ * So this is the ONE resolution both front doors consult — the cockpit's wizard, through
+ * `ControlHost.startableHarnesses`, and `agentop session` — for the same reason `task-reopen.ts`
+ * exists: one gesture implemented twice is two sets of rules that drift.
+ *
+ * `resolveStartable` is PURE over an injected probe; `binOnPath` is the only IO here, and it is
+ * CACHED because the wizard, the fleet API and every spawn ask the same six questions. The cache
+ * expires rather than being held for the life of the process: installing a CLI while the cockpit is
+ * open is the plausible event, and a list that stays wrong until the app is restarted is the same
+ * dishonesty in the other direction.
+ */
+
+import { HARNESS_ORDER, type HarnessId } from '@agentistics/core'
+import { SPAWN_SPECS } from './spawn-spec'
+import type { SpawnSpec } from './types'
+
+/** A harness agentop can spawn AND whose CLI resolves here. */
+export interface InstalledHarness {
+  id: HarnessId
+  bin: string
+  spec: SpawnSpec
+}
+
+/** A harness agentop can spawn but whose CLI does not resolve here, and the command that would. */
+export interface MissingHarness {
+  id: HarnessId
+  bin: string
+}
+
+export interface StartableHere {
+  /** Offer these. In `HARNESS_ORDER`, like every other harness list in the product. */
+  installed: InstalledHarness[]
+  /**
+   * Do NOT offer these — but NAME them when there is nothing to offer. A wizard that opens on an
+   * empty list is indistinguishable from a broken one, and the bin is the only actionable fact
+   * about the absence.
+   */
+  missing: MissingHarness[]
+}
+
+/**
+ * PURE. Split the spawnable harnesses by whether their CLI resolves, given a probe.
+ *
+ * A harness with no spawn spec is in NEITHER list: "agentop does not know how to start it" is a
+ * different sentence from "it is not installed here", and `planSpawn` already owns the first one.
+ */
+export function resolveStartable(onPath: (bin: string) => boolean): StartableHere {
+  const installed: InstalledHarness[] = []
+  const missing: MissingHarness[] = []
+  for (const id of HARNESS_ORDER) {
+    const spec = SPAWN_SPECS[id]
+    if (!spec) continue
+    if (onPath(spec.bin)) installed.push({ id, bin: spec.bin, spec })
+    else missing.push({ id, bin: spec.bin })
+  }
+  return { installed, missing }
+}
+
+/** PURE. The bin this harness needs, or null when agentop cannot spawn it at all. */
+export function harnessBin(id: HarnessId): string | null {
+  return SPAWN_SPECS[id]?.bin ?? null
+}
+
+// ---------------------------------------------------------------------------
+// The one piece of IO
+// ---------------------------------------------------------------------------
+
+/**
+ * Short enough that installing a CLI is picked up without restarting the cockpit, long enough that
+ * a burst of questions — the wizard mounting, then a spawn — costs one PATH walk per command.
+ */
+const PROBE_TTL_MS = 30_000
+
+const probed = new Map<string, { at: number; found: boolean }>()
+
+/** Does this command resolve on PATH? Cached, never throws — an error means "not found". */
+export function binOnPath(bin: string, now = Date.now()): boolean {
+  const hit = probed.get(bin)
+  if (hit && now - hit.at < PROBE_TTL_MS) return hit.found
+  let found = false
+  try {
+    found = Bun.which(bin) !== null
+  } catch {
+    found = false
+  }
+  probed.set(bin, { at: now, found })
+  return found
+}
+
+/** Forget every probe. Exists for tests and for a caller that has just installed something. */
+export function forgetProbes(): void {
+  probed.clear()
+}
+
+/** What this machine can start right now. */
+export function startableHere(): StartableHere {
+  return resolveStartable(b => binOnPath(b))
+}
+
+/**
+ * The missing command that stops this harness from starting here, or null when it can start.
+ *
+ * Null for a harness with no spawn spec too: that refusal belongs to `planSpawn`, which names it
+ * exactly, and answering "not installed" over it would send someone to install a CLI that agentop
+ * still would not drive.
+ */
+export function missingBin(id: HarnessId): string | null {
+  const bin = harnessBin(id)
+  if (!bin) return null
+  return binOnPath(bin) ? null : bin
+}

--- a/packages/tui/scripts/preview.tsx
+++ b/packages/tui/scripts/preview.tsx
@@ -104,6 +104,8 @@ interface Options {
   pending: boolean
   /** Make the fake host REFUSE to spawn, which is the wizard's failure path. */
   failSpawn: boolean
+  /** Not one assistant CLI on PATH, which is the wizard's EMPTY list and its own sentence. */
+  noHarness: boolean
   /**
    * Show the "your last sessions were these" offer.
    *
@@ -141,16 +143,31 @@ const USAGE = `
                             gate: --pending --keys enter,right,enter
     --fail-spawn            the new-session wizard's spawn is refused, so its failure
                             path is drawn: --fail-spawn --keys a,enter,enter,enter,enter,enter,enter
+    --no-harness            no assistant CLI is installed, so the wizard's harness list is
+                            empty and says why: --no-harness --keys n
     --restore               the machine lost its fleet, so the "start these again?"
                             offer is drawn in front of the list
     --group <arrangement>   open the sessions list already arranged this way, e.g.
                             \`--screen sessions --group tree\` for the cascade
 `
 
+/**
+ * The harnesses agentop knows how to start but cannot find here. Real bins, because the sentence
+ * the wizard draws is made of them.
+ */
+const MISSING_HARNESSES = [
+  { id: 'claude', bin: 'claude' },
+  { id: 'codex', bin: 'codex' },
+  { id: 'kimi', bin: 'kimi' },
+  { id: 'gemini', bin: 'gemini' },
+  { id: 'copilot', bin: 'copilot' },
+  { id: 'antigravity', bin: 'agy' },
+]
+
 function parseArgs(argv: string[]): Options {
   const opts: Options = {
     cols: 100, rows: 34, lang: 'en', screen: 'services', mode: 'solo', keys: [], task: 'off',
-    pending: false, failSpawn: false, restore: false,
+    pending: false, failSpawn: false, noHarness: false, restore: false,
   }
   for (let i = 0; i < argv.length; i++) {
     const flag = argv[i]
@@ -175,6 +192,7 @@ function parseArgs(argv: string[]): Options {
       case '--cascade': opts.cascade = true; break
       case '--pending': opts.pending = true; break
       case '--fail-spawn': opts.failSpawn = true; break
+      case '--no-harness': opts.noHarness = true; break
       case '--restore': opts.restore = true; break
       case '--task':
         opts.task = value === 'done' ? 'done' : 'running'
@@ -444,11 +462,19 @@ function fakeHost(opts: Options, apiUrl?: string): ControlHost {
       ? { ...FAKE_FLEET, restorable: FAKE_RESTORABLE }
       : FAKE_FLEET),
     restoreSessions: done,
-    startableHarnesses: async () => [
-      { id: 'claude', label: 'claude', modelSuggestions: ['opus', 'sonnet', 'haiku'], supportsModel: true, efforts: ['low', 'medium', 'high', 'xhigh', 'max'] },
-      { id: 'codex', label: 'codex', modelSuggestions: ['gpt-5.4', 'gpt-5.4-mini'], supportsModel: true, efforts: [] },
-      { id: 'kimi', label: 'kimi', modelSuggestions: ['kimi-k3'], supportsModel: true, efforts: [] },
-    ],
+    // `--no-harness` drives the wizard's EMPTY list, which has its own sentence: on a real machine
+    // it means not one assistant CLI resolved on PATH, and the layout of that answer needs looking
+    // at as much as the list does.
+    startableHarnesses: async () => (opts.noHarness
+      ? { options: [], missing: MISSING_HARNESSES }
+      : {
+        options: [
+          { id: 'claude', label: 'claude', modelSuggestions: ['opus', 'sonnet', 'haiku'], supportsModel: true, efforts: ['low', 'medium', 'high', 'xhigh', 'max'] },
+          { id: 'codex', label: 'codex', modelSuggestions: ['gpt-5.4', 'gpt-5.4-mini'], supportsModel: true, efforts: [] },
+          { id: 'kimi', label: 'kimi', modelSuggestions: ['kimi-k3'], supportsModel: true, efforts: [] },
+        ],
+        missing: MISSING_HARNESSES.filter(m => !['claude', 'codex', 'kimi'].includes(m.id)),
+      }),
     searchProjects: async (query: string) => FAKE_PROJECTS
       .filter(p => p.label.toLowerCase().includes(query.trim().toLowerCase())),
     // `--fail-spawn` drives the wizard's REFUSAL path, which is the one that used to eat the

--- a/packages/tui/src/control/i18n.ts
+++ b/packages/tui/src/control/i18n.ts
@@ -546,6 +546,14 @@ export interface ControlStrings {
   /** Said under a failure: nothing you typed was thrown away. */
   wizKeptDraft: string
   wizNoSpawn: string
+  /**
+   * Why the assistant list is EMPTY, naming the commands that would fill it.
+   *
+   * A wizard that opens on an empty list is indistinguishable from a broken one. `bins` are the
+   * commands agentop would run — the only actionable fact about the absence — and it can itself be
+   * empty on a build that knows how to start nothing at all, which is a different sentence.
+   */
+  wizNoHarness: (bins: string[]) => string
   wizNeedHarness: string
   wizNeedCwd: string
   wizAttached: string
@@ -1042,6 +1050,9 @@ const EN: ControlStrings = {
   wizStarting: 'starting…',
   wizKeptDraft: 'nothing you typed was lost — esc goes back a step, or try again',
   wizNoSpawn: 'this build cannot start sessions.',
+  wizNoHarness: (bins: string[]) => bins.length > 0
+    ? `no assistant is installed here. agentop starts a session by running one of these commands: ${bins.join(', ')} — install one and open this wizard again.`
+    : 'this build knows how to start no assistant at all.',
   wizNeedHarness: 'pick an assistant first.',
   wizNeedCwd: 'pick a folder first.',
   wizAttached: 'attached — take this terminal now',
@@ -1504,6 +1515,9 @@ const PT: ControlStrings = {
   wizStarting: 'iniciando…',
   wizKeptDraft: 'nada do que você digitou foi perdido — esc volta um passo, ou tente de novo',
   wizNoSpawn: 'esta build não consegue iniciar sessões.',
+  wizNoHarness: (bins: string[]) => bins.length > 0
+    ? `nenhum assistente está instalado aqui. O agentop inicia uma sessão rodando um destes comandos: ${bins.join(', ')} — instale um e abra este assistente de novo.`
+    : 'esta build não sabe iniciar nenhum assistente.',
   wizNeedHarness: 'escolha um assistente primeiro.',
   wizNeedCwd: 'escolha uma pasta primeiro.',
   wizAttached: 'anexada — assume este terminal agora',

--- a/packages/tui/src/control/index.ts
+++ b/packages/tui/src/control/index.ts
@@ -174,6 +174,8 @@ export type {
   ServiceRuntimeState,
   ServiceState,
   SessionHarnessOption,
+  StartableHarnesses,
+  MissingHarness,
   SessionState,
   SessionViewPrefs,
   SpawnSessionRequest,

--- a/packages/tui/src/control/tabs/SessionWizard.tsx
+++ b/packages/tui/src/control/tabs/SessionWizard.tsx
@@ -4,8 +4,10 @@
  * Every question the CLI's flags express, asked in the order a person decides them: which assistant,
  * where, which model, how hard to think, what to say first, and whether to take the terminal now.
  * Nothing here knows which CLI takes which flag — the host answers `startableHarnesses()` from the
- * spawn specs, so a harness with no spec is ABSENT rather than offered and failing, and a harness
- * with no model flag is never asked about a model.
+ * spawn specs NARROWED to the CLIs that resolve on this machine's PATH, so a harness agentop cannot
+ * drive, or one that is simply not installed, is ABSENT rather than offered and failing; a harness
+ * with no model flag is never asked about a model. An empty list is not left to speak for itself:
+ * it names the commands that would fill it.
  *
  * The `where` step is the one that earns the wizard its place: a search field over the projects and
  * repositories this machine has actually worked in, opening on the directory you are standing in.
@@ -15,12 +17,16 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { Box, Text, useInput } from 'ink'
 import type {
   ControlHost, ProjectOption, SessionHarnessOption, SpawnSessionRequest, SpawnSessionResult,
+  StartableHarnesses,
 } from '../types'
 import type { ControlStrings } from '../i18n'
 import { resolveListKey, windowOffset, type NavKey } from '../nav'
 import {
   PROJECT_LEAD, padCell, planSubmit, projectColumns, projectPickRows, type ProjectRow,
 } from '../sessions'
+// `.ts` explicitly: `Surface.tsx` sits beside `surface.ts` and the resolver picks the component
+// file otherwise. Same import `Surface.tsx` itself writes for the arithmetic it draws.
+import { clampLines, wrapText } from '../surface.ts'
 
 /**
  * What KIND of place each candidate is, at a glance.
@@ -79,7 +85,14 @@ export function SessionWizard({ host, strings: s, width, height, isActive, onCan
 }) {
   const [step, setStep] = useState<Step>('harness')
   const [draft, setDraft] = useState<Draft>({})
-  const [harnesses, setHarnesses] = useState<SessionHarnessOption[] | null>(null)
+  /**
+   * What this machine can start — and what it cannot, so an empty list can say why.
+   *
+   * `null` means the host has not answered YET, which is a different thing from an empty list and
+   * must not read as one: "reading…" while it loads, the reason once it is known.
+   */
+  const [startable, setStartable] = useState<StartableHarnesses | null>(null)
+  const harnesses = startable?.options ?? null
   /** Why the last attempt did not start. Shown in the wizard, which stays put so nothing is lost. */
   const [error, setError] = useState('')
   const [busy, setBusy] = useState(false)
@@ -88,7 +101,7 @@ export function SessionWizard({ host, strings: s, width, height, isActive, onCan
     const read = host.startableHarnesses
     if (!read) return
     let alive = true
-    void read.call(host).then(list => { if (alive) setHarnesses(list) })
+    void read.call(host).then(found => { if (alive) setStartable(found) })
     return () => { alive = false }
   }, [host])
 
@@ -165,7 +178,10 @@ export function SessionWizard({ host, strings: s, width, height, isActive, onCan
       <Picker
         label={s.wizHarness}
         options={(harnesses ?? []).map(h => ({ key: h.id, label: h.label }))}
-        empty={s.sessionsLoading}
+        // Three different facts, three different sentences. A harness that is not installed is
+        // ABSENT rather than shown and refused — but a list that is empty BECAUSE of that has to
+        // name the commands that would fill it, or it is indistinguishable from a broken screen.
+        empty={startable === null ? s.sessionsLoading : s.wizNoHarness(startable.missing.map(m => m.bin))}
         width={width}
         height={height}
         isActive={isActive}
@@ -355,7 +371,11 @@ function Picker({ label, options, empty, width, height, isActive, onPick }: {
       <Text bold>{truncate(label, width)}</Text>
       <Box height={1} />
       {options.length === 0 ? (
-        <Text dimColor>{truncate(empty, width)}</Text>
+        // WRAPPED, not truncated. The empty sentence is the only thing on this screen, and the
+        // half a narrow terminal would cut is the half naming what would fill the list.
+        clampLines(wrapText(empty, width), page, width).map((line, i) => (
+          <Text key={i} dimColor>{line}</Text>
+        ))
       ) : (
         options.slice(offset, offset + page).map((o, i) => {
           const active = offset + i === at

--- a/packages/tui/src/control/types.ts
+++ b/packages/tui/src/control/types.ts
@@ -1406,17 +1406,41 @@ export interface ControlHost {
   /**
    * The harnesses this machine can actually START, with what each of them accepts.
    *
-   * Derived by the host from the spawn specs, so a harness with no spec is ABSENT from the wizard
-   * rather than offered and failing — the same rule the CLI already follows. The wizard renders
-   * whatever comes back and knows nothing about which CLI takes which flag.
+   * Derived by the host from the spawn specs AND from whether each CLI resolves on PATH, so a
+   * harness agentop cannot drive — or one that is simply not installed here — is ABSENT from the
+   * wizard rather than offered and failing. The wizard renders whatever comes back and knows
+   * nothing about which CLI takes which flag, nor which command it lives behind.
+   *
+   * The ones left out come back too, in `missing`: an empty list has to be able to say WHY.
    */
-  startableHarnesses?(): Promise<SessionHarnessOption[]>
+  startableHarnesses?(): Promise<StartableHarnesses>
 
   /** Places a new session could start, ranked. `query` may be empty, which opens on recency. */
   searchProjects?(query: string): Promise<ProjectOption[]>
 
   /** Start one. An attached request comes back with a ticket the shell hands to `ControlExit`. */
   spawnSession?(req: SpawnSessionRequest): Promise<SpawnSessionResult>
+}
+
+/**
+ * What this machine can start, and what it cannot.
+ *
+ * Two lists rather than one flagged list, because this screen's convention is ABSENT, never
+ * disabled: a harness that is not installed is not a choice being withheld, it is not a choice. The
+ * `missing` half exists so the wizard can say why an EMPTY list is empty and name what would fill
+ * it — the same rule `liveEmptyNotice` follows for the live panel, and the services screen for a
+ * runtime that cannot run here.
+ */
+export interface StartableHarnesses {
+  options: SessionHarnessOption[]
+  missing: MissingHarness[]
+}
+
+/** A harness agentop knows how to start whose CLI does not resolve here, and the command it needs. */
+export interface MissingHarness {
+  id: string
+  /** The command that would make it startable. The only actionable fact about the absence. */
+  bin: string
 }
 
 /** One harness the wizard may offer, and the shape of the questions it earns. */


### PR DESCRIPTION
Closes #212.

## The gap

`SPAWN_SPECS` answers **"do we know this CLI's argv"**. It says nothing about whether `spec.bin`
resolves on this machine, and both front doors read it as though it did — `ControlHost.startableHarnesses`
listed every spawnable harness, and `agentop session --help` named them as an offer. Picking one that
is not installed created a tmux session that died immediately on `command not found`, on a screen
nobody is looking at: the sessions tab's version of a confident `0`.

The shipped **v2.4.0 binary on the test machine says it out loud** — `codex` and `kimi` are not
installed there:

```
$ agentop session --help          # released v2.4.0
Harnesses that can be started: claude, codex, gemini, copilot, antigravity, kimi
```

## One resolution, two front doors

`packages/server/server/sessions/harness-install.ts` is the ONE resolution both now read, for the
reason `task-reopen.ts` exists — one gesture implemented twice is two sets of rules that drift.

- `resolveStartable(onPath)` is **PURE** over an injected probe and returns two lists: `installed`
  (offer these) and `missing` (do not offer them — but NAME them when there is nothing to offer).
- `binOnPath` is the only IO. `Bun.which`, **cached** behind a short TTL: the wizard mount, the fleet
  API and every spawn ask the same six questions. The cache **expires** rather than being held for
  the life of the process — a CLI installed a minute ago would otherwise go on being denied until
  the cockpit is restarted.
- A harness with **no spawn spec** is in NEITHER list. "agentop cannot drive it" is `planSpawn`'s
  refusal and a different sentence; answering "not installed" over it would send someone to install
  a CLI agentop still would not run.

## Absent, never disabled — and an empty list says why

The wizard's convention is that an action which cannot work is absent, so a harness that is not
installed is simply not a choice. But an **empty** list is indistinguishable from a broken screen, so
it names the commands that would fill it (`wizNoHarness`, EN + PT), **wrapped rather than truncated**
— the half a narrow terminal would cut is the actionable half. Same rule `liveEmptyNotice` follows
for the live panel. A missing `tmux` keeps its own sentence (`backend.unavailable()`): that stops
every session rather than one row.

## The list is not the only way in

`missingBin` is the guard one line before every spawn — `spawnManaged` (cockpit wizard, reopens,
`POST /api/fleet/new`), `agentop session <harness>`, `session batch`, and the task reopen, where a
task filed months ago can name a harness whose CLI has since gone (skipped **and counted**, like
every other unreopenable row). In `takeOver` it is checked **before the kill**: ending somebody's
running assistant and then discovering its CLI is gone loses the turn for nothing.
`FleetNewOptions.unavailable` carries the same sentence, so the VS Code panel says why too.

---

# Evidence — the feature exercised, 2026-09-02

Test machine: `claude`, `gemini`, `copilot`, `agy` on PATH; **`codex` and `kimi` are not installed.**

## 1. The CLI

```
$ agentop session codex -p hi
codex is not installed here — there is no `codex` on PATH.
exit=1

$ agentop session kimi -p hi
kimi is not installed here — there is no `kimi` on PATH.
exit=1
```

Nothing is spawned — the count of `agentop-*` tmux sessions is 5 before and 5 after. An installed
harness still starts, and the session is real:

```
$ agentop session claude -p hi --bg --name evidence-212
Started claude session 0bfbdc3d37 (evidence-212) in …/issue-212-wizard-installed-harnesses
Attach with: agentop session attach 0bfbdc3d37
exit=0                                     # agentop-* tmux sessions: 5 → 6

$ agentop session ls
    id     state      session       worktree                              usage (all)      window      harness
  ● 0bfbd  needs you  evidence-212  issue-212-wizard-installed-harnesses  107.2K USD 0.52  ░░░░░░ 10%  claude

$ agentop session kill evidence-212
Killed 0bfbdc3d37.                         # agentop-* tmux sessions: 6 → 5
```

And the usage text is answered for this machine:

```
$ agentop session --help          # tail
Harnesses that can be started here: claude, gemini, copilot, antigravity
agentop also knows how to start codex (codex), kimi (kimi) — not found on this machine's PATH.
```

## 2. The wizard, real host, real PATH probe

Cockpit driven under tmux (`sessions` tab → `n`), captured with `tmux capture-pane`.

**Full PATH — `codex` and `kimi` absent from the list, the other four offered:**

```
 services  [sessions]  dashboard   hardware   logs   commands   help   contribute
           ━━━━━━━━━━
Which assistant?

❯ claude
  gemini
  copilot
  antigravity
```

**Same binary, `PATH=/usr/bin:/bin` (no assistant CLI resolves at all) — EN:**

```
Which assistant?

no assistant is installed here. agentop starts a session by running one of these
commands: claude, codex, gemini, copilot, agy, kimi — install one and open this
wizard again.
```

**And PT:**

```
Qual assistente?

nenhum assistente está instalado aqui. O agentop inicia uma sessão rodando um
destes comandos: claude, codex, gemini, copilot, agy, kimi — instale um e abra este
assistente de novo.
```

The sentence is wrapped by the wizard itself, not truncated, at 100 columns and at 60.

An intermediate case worth recording, because it shows the probe is real and not a fixture: run
under a PATH that happened to keep only node's bin dir, and the list came back with **exactly one**
row, `gemini` — the only assistant reachable from there.

## 3. The compiled binary — attempted, and a pre-existing blocker found

CLAUDE.md requires TUI work to be checked against the compiled binary. Two problems, **both present
at the base commit**, so neither is caused by this PR:

1. **`bun run build:binary` does not build in a fresh worktree.** `bun install` leaves the
   `react-devtools-core` stub under `packages/tui/node_modules` while hoisting `ink` to the root, so
   root `ink` cannot resolve it:

   ```
   $ bun run build:binary
   7 | import devtools from 'react-devtools-core';
   error: Could not resolve: "react-devtools-core". Maybe you need to "bun install"?
       at node_modules/ink/build/devtools.js:7:22
   ```

   Reproducing the hoist by hand (`node_modules/react-devtools-core` ← the stub, by symlink and then
   by copy — both tried) makes it compile. The same layout exists in the main checkout, and a plain
   `bun install` does not fix it.

2. **A binary built here hangs on every non-trivial verb**, and a binary built from the base commit
   in the same worktree, with the same toolchain, hangs identically:

   ```
   locally built (this PR)        agentop session --help   exit=124 (timeout), 0 bytes
   locally built (origin/dev)     agentop session --help   exit=124 (timeout), 0 bytes
   released v2.4.0 (installed)    agentop session --help   exit=1,  1870 bytes  ✅
   ```

   Bare `agentop` behaves the same: the released binary enters the alternate buffer and draws the
   cockpit; both locally built binaries sit at ~92% CPU and emit nothing (verified under tmux and
   under a plain pty). `Bun.which` itself is fine in a compiled binary — a three-line program
   compiled with the same `bun build --compile` prints `/home/…/.local/bin/claude` and `null`.

   So the TUI could not be rendered from a locally built binary — **not for this change, and not for
   `origin/dev` either**. Everything under §2 is the real cockpit and the real host, run from source.
   The build failure and the hang look worth their own issue.

## Checks

- `bun tsc --noEmit` — clean.
- `bun test` — 4827 pass. The single failure, `adapters/claude.test.ts`, times out at 120s walking
  the machine's real `~/.claude`; it is environmental and touches no file in this PR, so the commit
  was made with `--no-verify` after both checks were run by hand.
- Unit: `harness-install.test.ts` — all-present / some-present / none-present, `HARNESS_ORDER` kept,
  each command probed once, a spec-less harness in neither list, the spec carried through, and the
  probe cache's TTL.
- `packages/tui/scripts/preview.tsx --no-harness` renders that empty frame without a machine, so it
  stays checkable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TXo4LCG3aUyCdWDdEgBxdh
