### PR TITLE
fix(web): share ONE /api/events socket across all consumers

### DIFF
--- a/packages/web/src/components/TeamMembers.tsx
+++ b/packages/web/src/components/TeamMembers.tsx
@@ -3,6 +3,7 @@ import { Users, Plus, Trash2, Copy, CheckCheck, RefreshCw, AlertCircle, Pencil, 
 import type { MemberPresence } from '@agentistics/core'
 import { copyText } from '../lib/clipboard'
 import { useIsMobile } from '../hooks/useIsMobile'
+import { sharedEventStream } from '../lib/eventStream'
 
 /** Shared 5-column grid for the desktop members table (status · user · label · last-seen · actions).
  *  minmax(0,…) lets the flexible columns actually shrink so long values ellipsize instead of
@@ -172,12 +173,11 @@ export function TeamMembers({ lang, presence }: Props) {
   // Instant refresh on server events (a member connecting/disconnecting fires an
   // immediate SSE 'change'), with a 10s poll as a fallback for latency drift.
   useEffect(() => {
-    const es = new EventSource('/api/events')
-    const onChange = () => { void loadMembers(true) }
-    es.addEventListener('change', onChange)
-    es.onerror = () => { /* browser auto-reconnects; ignore */ }
+    // Share the app's one `/api/events` socket (see lib/eventStream.ts). The 10s poll stays as a
+    // latency-drift fallback.
+    const unsubscribe = sharedEventStream().subscribe('change', () => { void loadMembers(true) })
     const id = setInterval(() => { void loadMembers(true) }, 10_000)
-    return () => { es.removeEventListener('change', onChange); es.close(); clearInterval(id) }
+    return () => { unsubscribe(); clearInterval(id) }
   }, [loadMembers])
 
   // Load the central's include-offline-data policy.

--- a/packages/web/src/hooks/useData.ts
+++ b/packages/web/src/hooks/useData.ts
@@ -3,6 +3,7 @@ import type { AppData, Filters, DateRange, AgentInvocation, HarnessId, SessionMe
 import { calcStreak, calcCost, sessionModelUsage, sessionCostUSD, getModelPrice, MODEL_PRICING, HARNESS_CAPABILITIES, filterByUsers, filterByHarnesses, filterByTeams, filterByMachines, resolveMachineCacheScope, distinctHarnesses, mergeStatsCaches, repoShortName, HARNESS_ORDER, EMPTY_TOKENS, addTokens, sessionTokens, sessionTokenTotal, sumTokens, totalTokens, usageTokenTotal, usageTokens } from '@agentistics/core'
 import { subDays, isAfter, isBefore, parseISO, format, differenceInCalendarDays, addDays, getDay } from 'date-fns'
 import { makeTagFilter, type TagDef } from '../lib/tagMatch'
+import { sharedEventStream } from '../lib/eventStream'
 
 /**
  * True only for a non-empty string. `start_time`/`end_time`/`date` fields are typed as `string`
@@ -282,9 +283,9 @@ export function useData() {
   // when Claude writes new session data to ~/.claude/.
   useEffect(() => {
     if (!liveUpdates) return
-    const es = new EventSource('/api/events')
-    es.addEventListener('change', () => { void fetchData() })
-    return () => { es.close() }
+    // Share the app's one `/api/events` socket (see lib/eventStream.ts) rather than opening a
+    // second connection just for the dashboard's live refresh.
+    return sharedEventStream().subscribe('change', () => { void fetchData() })
   }, [liveUpdates, fetchData])
 
   // Fallback polling at the selected interval when live updates are enabled.

--- a/packages/web/src/hooks/useNotificationStream.ts
+++ b/packages/web/src/hooks/useNotificationStream.ts
@@ -1,5 +1,6 @@
 import { useEffect } from 'react'
 import { refreshNotifications } from '../lib/notifications'
+import { sharedEventStream } from '../lib/eventStream'
 
 /**
  * Loads the notification history from the server on mount, then subscribes to the SSE
@@ -22,10 +23,8 @@ import { refreshNotifications } from '../lib/notifications'
 export function useNotificationStream(_lang: 'pt' | 'en'): void {
   useEffect(() => {
     void refreshNotifications()
-    const es = new EventSource('/api/events')
-    const handler = () => { void refreshNotifications() }
-    es.addEventListener('notification', handler)
-    es.onerror = () => { /* browser auto-reconnects */ }
-    return () => { es.removeEventListener('notification', handler); es.close() }
+    // Share the app's one `/api/events` socket (see lib/eventStream.ts); the frame's `data` is
+    // ignored here as documented above — the event's arrival is the whole signal.
+    return sharedEventStream().subscribe('notification', () => { void refreshNotifications() })
   }, [])
 }

--- a/packages/web/src/lib/eventStream.test.ts
+++ b/packages/web/src/lib/eventStream.test.ts
@@ -1,0 +1,159 @@
+import { describe, test, expect } from 'bun:test'
+import { createEventStream, sharedEventStream, type EventSourceLike } from './eventStream'
+
+/**
+ * A fake EventSource that records how many times it was constructed and closed, and lets a test
+ * dispatch a named event to whatever listeners the stream attached. This is the unit-level stand-in
+ * for the browser socket; the production-build spy in the QA recipe measures the real thing.
+ */
+class FakeES implements EventSourceLike {
+  static constructed = 0
+  static live = 0
+  closed = false
+  onerror: ((ev: Event) => void) | null = null
+  private handlers = new Map<string, Set<(ev: Event) => void>>()
+  constructor(public url: string) { FakeES.constructed++; FakeES.live++ }
+  addEventListener(type: string, listener: (ev: Event) => void): void {
+    let set = this.handlers.get(type)
+    if (!set) { set = new Set(); this.handlers.set(type, set) }
+    set.add(listener)
+  }
+  removeEventListener(type: string, listener: (ev: Event) => void): void {
+    this.handlers.get(type)?.delete(listener)
+  }
+  close(): void { if (!this.closed) { this.closed = true; FakeES.live-- } }
+  /** Test-only: how many app-facing DOM listeners are attached for a type. */
+  handlerCount(type: string): number { return this.handlers.get(type)?.size ?? 0 }
+  /** Test-only: fire a named event to the attached listeners. */
+  emit(type: string): void {
+    for (const l of [...(this.handlers.get(type) ?? [])]) l({ type } as Event)
+  }
+}
+
+function freshFactory() {
+  FakeES.constructed = 0
+  FakeES.live = 0
+  const sockets: FakeES[] = []
+  const make = (u: string) => { const s = new FakeES(u); sockets.push(s); return s }
+  return { make, sockets }
+}
+
+describe('createEventStream — one shared socket', () => {
+  // A1 (mechanism): N subscribers, ONE underlying connection.
+  test('many subscribers open exactly one connection', () => {
+    const { make } = freshFactory()
+    const stream = createEventStream('/api/events', make)
+    stream.subscribe('change', () => {})
+    stream.subscribe('change', () => {})
+    stream.subscribe('notification', () => {})
+    expect(FakeES.constructed).toBe(1)
+    expect(FakeES.live).toBe(1)
+    expect(stream.subscriberCount).toBe(3)
+    expect(stream.connected).toBe(true)
+  })
+
+  test('the socket is opened lazily — no subscriber, no connection', () => {
+    const { make } = freshFactory()
+    const stream = createEventStream('/api/events', make)
+    expect(FakeES.constructed).toBe(0)
+    expect(stream.connected).toBe(false)
+  })
+
+  // A2 (mechanism): both consumers receive the same single event.
+  test('one emitted event reaches every subscriber of that type', () => {
+    const { make, sockets } = freshFactory()
+    const stream = createEventStream('/api/events', make)
+    let a = 0, b = 0
+    stream.subscribe('change', () => { a++ })
+    stream.subscribe('change', () => { b++ })
+    // Exactly one DOM listener is attached to the real socket for the type; it fans out.
+    expect(sockets[0]!.handlerCount('change')).toBe(1)
+    sockets[0]!.emit('change')
+    expect(a).toBe(1)
+    expect(b).toBe(1)
+  })
+
+  test('a listener only hears its own event type', () => {
+    const { make, sockets } = freshFactory()
+    const stream = createEventStream('/api/events', make)
+    let change = 0, notif = 0
+    stream.subscribe('change', () => { change++ })
+    stream.subscribe('notification', () => { notif++ })
+    sockets[0]!.emit('change')
+    expect(change).toBe(1)
+    expect(notif).toBe(0)
+    sockets[0]!.emit('notification')
+    expect(change).toBe(1)
+    expect(notif).toBe(1)
+  })
+
+  // A3: one consumer unmounting must not tear down the socket the other still uses.
+  test('unsubscribing one of two keeps the socket open for the remaining consumer', () => {
+    const { make, sockets } = freshFactory()
+    const stream = createEventStream('/api/events', make)
+    let remaining = 0
+    const off = stream.subscribe('change', () => {})
+    stream.subscribe('change', () => { remaining++ })
+    off() // the first consumer leaves
+    expect(stream.connected).toBe(true)
+    expect(sockets[0]!.closed).toBe(false)
+    expect(FakeES.live).toBe(1) // NOT closed and reopened
+    sockets[0]!.emit('change')
+    expect(remaining).toBe(1) // the survivor still receives
+  })
+
+  test('the last subscriber leaving closes the one socket', () => {
+    const { make, sockets } = freshFactory()
+    const stream = createEventStream('/api/events', make)
+    const off1 = stream.subscribe('change', () => {})
+    const off2 = stream.subscribe('notification', () => {})
+    off1()
+    expect(stream.connected).toBe(true)
+    off2()
+    expect(stream.connected).toBe(false)
+    expect(sockets[0]!.closed).toBe(true)
+    expect(FakeES.live).toBe(0)
+  })
+
+  test('resubscribing after full teardown opens a fresh single socket', () => {
+    const { make } = freshFactory()
+    const stream = createEventStream('/api/events', make)
+    stream.subscribe('change', () => {})()  // subscribe then immediately leave
+    expect(FakeES.constructed).toBe(1)
+    expect(stream.connected).toBe(false)
+    stream.subscribe('change', () => {})
+    expect(FakeES.constructed).toBe(2) // a new one, but still only ever one live
+    expect(FakeES.live).toBe(1)
+  })
+
+  test('calling an unsubscribe twice is a no-op (ref count cannot go negative)', () => {
+    const { make } = freshFactory()
+    const stream = createEventStream('/api/events', make)
+    const off = stream.subscribe('change', () => {})
+    stream.subscribe('change', () => {})
+    off()
+    off() // second call must not decrement again and close the survivor's socket
+    expect(stream.connected).toBe(true)
+    expect(stream.subscriberCount).toBe(1)
+  })
+
+  test('a transient socket error does not close or reopen the socket', () => {
+    const { make, sockets } = freshFactory()
+    const stream = createEventStream('/api/events', make)
+    stream.subscribe('change', () => {})
+    sockets[0]!.onerror?.({ type: 'error' } as Event) // browser would auto-reconnect this same object
+    expect(sockets[0]!.closed).toBe(false)
+    expect(FakeES.constructed).toBe(1)
+    expect(stream.connected).toBe(true)
+  })
+})
+
+describe('sharedEventStream — cross-chunk singleton', () => {
+  // The durable pitfall: a module-const is duplicated per Rollup chunk. Anchoring on globalThis
+  // makes repeated resolutions return the SAME instance, so however many chunks import it, one socket.
+  test('every call returns the identical instance', () => {
+    const a = sharedEventStream()
+    const b = sharedEventStream()
+    expect(a).toBe(b)
+  })
+})

--- a/packages/web/src/lib/eventStream.ts
+++ b/packages/web/src/lib/eventStream.ts
@@ -1,0 +1,129 @@
+/**
+ * eventStream — ONE shared connection to the `/api/events` SSE broadcast for the whole app.
+ *
+ * The browser caps simultaneous connections per origin; every extra socket to the same
+ * broadcast endpoint spends a slot the rest of the page needs. `/api/events` carries only
+ * NAMED, body-less signals (`change`, `notification`) — the arrival is the whole message, the
+ * `data` frame is deliberately ignored by every consumer — so a single connection fanned out
+ * to N listeners is exactly equivalent to N connections: each listener still hears every event.
+ * Before this, three independent consumers (`useData`, `useNotificationStream`, `TeamMembers`)
+ * each opened their own `EventSource('/api/events')`, so opening the dashboard cost two-plus
+ * connection slots where one is enough.
+ *
+ * WHY the instance is anchored on `globalThis` and NOT a module-level `const`:
+ * Rollup DUPLICATES a small shared module into each chunk that imports it. A
+ * `const stream = createEventStream(...)` at module scope therefore becomes ONE INSTANCE PER
+ * CHUNK — three importing chunks, three sockets, the very bug this file exists to remove. The
+ * bug is invisible under `bun run dev` (one module graph) and only appears on the production
+ * build. Anchoring the single instance on `globalThis` makes it a true cross-chunk singleton,
+ * so however many chunks Rollup emits, there is exactly one socket.
+ *
+ * Lifecycle: ref-counted. The socket is opened lazily on the first subscriber and closed only
+ * when the LAST subscriber leaves. A consumer unmounting while another stays mounted never
+ * tears down the shared socket — that classic socket-dedup failure mode is what the ref count
+ * prevents.
+ */
+
+/** A subscriber's callback. The SSE frame is passed through, but every current consumer treats
+ *  the event's mere arrival as the signal and ignores the payload (see `useNotificationStream`). */
+export type EventStreamListener = (ev: MessageEvent) => void
+
+/** The minimal EventSource surface this module uses — narrow enough for a test fake to implement. */
+export interface EventSourceLike {
+  addEventListener(type: string, listener: (ev: Event) => void): void
+  removeEventListener(type: string, listener: (ev: Event) => void): void
+  close(): void
+  onerror: ((ev: Event) => void) | null
+}
+
+export interface SharedEventStream {
+  /** Subscribe to a named event. Returns an unsubscribe function; calling it twice is a no-op. */
+  subscribe(type: string, listener: EventStreamListener): () => void
+  /** Live subscriber count — for tests and diagnostics only. */
+  readonly subscriberCount: number
+  /** Whether the underlying socket is currently open — for tests and diagnostics only. */
+  readonly connected: boolean
+}
+
+/**
+ * Build a ref-counted shared stream over a single connection created by `makeES(url)`.
+ *
+ * Pure and dependency-free: the socket factory is injected, so a test drives it with a fake
+ * EventSource and never touches the DOM. The app calls {@link sharedEventStream}, which supplies
+ * the real `EventSource` and the `globalThis` anchor.
+ */
+export function createEventStream(
+  url: string,
+  makeES: (url: string) => EventSourceLike,
+): SharedEventStream {
+  let es: EventSourceLike | null = null
+  let refCount = 0
+  // One Set of app listeners per event type…
+  const listeners = new Map<string, Set<EventStreamListener>>()
+  // …and exactly one real DOM listener per type on the underlying socket, which fans out.
+  const domHandlers = new Map<string, (ev: Event) => void>()
+
+  function attachDom(type: string): void {
+    if (!es || domHandlers.has(type)) return
+    const handler = (ev: Event) => {
+      const set = listeners.get(type)
+      if (!set) return
+      // Copy so a listener that unsubscribes during dispatch can't mutate the set mid-iteration.
+      for (const l of [...set]) l(ev as MessageEvent)
+    }
+    domHandlers.set(type, handler)
+    es.addEventListener(type, handler)
+  }
+
+  function ensureOpen(): void {
+    if (es) return
+    es = makeES(url)
+    // The browser auto-reconnects the SAME EventSource on a transient error; keep it, do not
+    // close and reopen — the DOM listeners stay attached across the reconnect.
+    es.onerror = () => { /* browser auto-reconnects; ignore */ }
+    for (const type of listeners.keys()) attachDom(type)
+  }
+
+  function closeSocket(): void {
+    if (es) {
+      for (const [type, handler] of domHandlers) es.removeEventListener(type, handler)
+      es.close()
+    }
+    es = null
+    domHandlers.clear()
+  }
+
+  return {
+    subscribe(type, listener) {
+      let set = listeners.get(type)
+      if (!set) { set = new Set(); listeners.set(type, set) }
+      set.add(listener)
+      refCount++
+      ensureOpen()
+      attachDom(type)
+
+      let active = true
+      return () => {
+        if (!active) return
+        active = false
+        set!.delete(listener)
+        refCount--
+        if (refCount <= 0) closeSocket()
+      }
+    },
+    get subscriberCount() { return refCount },
+    get connected() { return es !== null },
+  }
+}
+
+const GLOBAL_KEY = '__agentistics_event_stream__'
+
+/**
+ * The app's one shared `/api/events` stream. Anchored on `globalThis` so it survives Rollup
+ * chunk duplication (see the file header). Every consumer calls this and subscribes; none
+ * constructs an `EventSource('/api/events')` of its own.
+ */
+export function sharedEventStream(): SharedEventStream {
+  const g = globalThis as unknown as Record<string, SharedEventStream | undefined>
+  return (g[GLOBAL_KEY] ??= createEventStream('/api/events', (u) => new EventSource(u)))
+}


### PR DESCRIPTION
## What

Three consumers each opened their own `EventSource('/api/events')` — `useData` (the live-refresh `change` listener), `useNotificationStream` (`notification`), and `TeamMembers` (`change`). The browser caps simultaneous connections per origin, so opening the dashboard spent two-plus connection slots on the same broadcast endpoint where one is enough. Nothing the user sees changes: `/api/events` carries only named, body-less signals, so one connection fanned out to N listeners is exactly equivalent to N connections.

## How

New `lib/eventStream.ts`: a ref-counted shared stream over a single connection.

- **Anchored on `globalThis`, not a module-level `const`.** Rollup duplicates a small shared module into each importing chunk, so a module-scope singleton becomes one instance *per chunk* — the exact bug this removes, invisible under `bun run dev` and only visible on the production build (the prior attempt shipped this way). The `globalThis` anchor is a true cross-chunk singleton.
- **Ref-counted lifecycle.** The socket opens on the first subscriber and closes only when the last leaves, so a consumer unmounting never tears down the socket another still uses (the classic socket-dedup failure mode).
- One DOM listener per event type on the underlying socket, fanned out to every app subscriber.

The three consumers now call `sharedEventStream().subscribe(type, handler)`. No change to the `/api/events` protocol/contract; no `packages/server` change.

## Verification (spec A1–A5)

**A1 — one connection (live prod-build spy + dist inspection).** Injected an `EventSource`/`WebSocket` spy as the first script on the production build, proxied `/api/*` to a real backend, read live sockets:
- **Base (before):** 2 live `/api/events` sockets on the home page.
- **After:** **1** live `/api/events` socket.
- Build artifact: base `dist` carries the `/api/events` literal in **3 chunks / 3 occurrences**; after, **1 chunk / 1 occurrence**.

**A2 — both consumers share the one socket.** Dispatching `change` and `notification` on the single live socket instance triggered `/api/data` (data hook) **and** `/api/notifications` (notification hook) refetches; socket stayed open. Neither starves the other.

**A3 — teardown safety.** `eventStream.test.ts` (biting: mutating the ref-count guard to always-close fails 3 tests). Live: the single socket stayed `readyState 1` across all event dispatch — never closed and reopened.

**A4 — partial/empty payloads.** Well-formed empty payload → the empty dashboard state renders (nav present, no data), 1 socket, no error. Malformed payloads (`{}`) → the app's error boundary (Reload + explanation), **never a blank/dead screen**, and **no `object is not iterable`** (the reproduced error was `Cannot read properties of undefined (reading 'dailyActivity')`, caught by the boundary). **This PR does not touch the `object is not iterable` crash** — the diff changes only `/api/events` subscription wiring, nothing in the data-parsing/`useMemo` surface where that class of error originates.

**A5 — `bun tsc --noEmit` (0 errors), `bun test packages/web/src` (952 pass / 0 fail), `bun run build` (clean).**

🤖 Generated with [Claude Code](https://claude.com/claude-code)