### PR TITLE
fix(server): upgrade endereça a versão resolvida, não o apelido "latest" (paralela à #291)

### DIFF
--- a/packages/server/server/cli-i18n.ts
+++ b/packages/server/server/cli-i18n.ts
@@ -389,6 +389,10 @@ export interface CliStrings {
   upgradeLockUnavailable: string
   upgradeUnsupported: (target: string) => string
   upgradeManualHow: (url: string) => string
+  /** The release exists and does not carry this asset — NOT a network failure. */
+  upgradeAssetMissing: (version: string, asset: string, url: string) => string
+  /** The network (or the server) failed — NOT a statement about what the release contains. */
+  upgradeDownloadFailed: (reason: string, url: string) => string
   upgradeVerifyFailed: (reason: string) => string
   upgradeRolledBack: (backup: string) => string
   upgradeUntouched: string
@@ -677,6 +681,10 @@ const EN: CliStrings = {
   upgradeLockUnavailable: 'Could not write the upgrade lock; continuing without it.',
   upgradeUnsupported: (target) => `No agentop release is published for ${target}, so it cannot upgrade itself.`,
   upgradeManualHow: (url) => `Download the right binary for your platform and replace it by hand: ${url}`,
+  upgradeAssetMissing: (version, asset, url) =>
+    `Release v${version} does not carry the ${asset} asset (HTTP 404 at ${url}). ` +
+    `Your network is fine — that version was published without this binary.`,
+  upgradeDownloadFailed: (reason, url) => `Could not download ${url}: ${reason}. This looks like a network failure, not a missing release asset.`,
   upgradeVerifyFailed: (reason) => `Upgrade aborted: ${reason}.`,
   upgradeRolledBack: (backup) => `The previous binary was restored from ${backup}.`,
   upgradeUntouched: 'The installed binary was left untouched.',
@@ -958,6 +966,10 @@ const PT: CliStrings = {
   upgradeLockUnavailable: 'Não consegui escrever o lock de upgrade; seguindo sem ele.',
   upgradeUnsupported: (target) => `Não existe release do agentop para ${target}, então ele não pode se atualizar sozinho.`,
   upgradeManualHow: (url) => `Baixe o binário da sua plataforma e troque na mão: ${url}`,
+  upgradeAssetMissing: (version, asset, url) =>
+    `A release v${version} não tem o anexo ${asset} (HTTP 404 em ${url}). ` +
+    `Sua rede está bem — essa versão foi publicada sem esse binário.`,
+  upgradeDownloadFailed: (reason, url) => `Não consegui baixar ${url}: ${reason}. Isso é falha de rede, não anexo faltando na release.`,
   upgradeVerifyFailed: (reason) => `Upgrade abortado: ${reason}.`,
   upgradeRolledBack: (backup) => `O binário anterior foi restaurado de ${backup}.`,
   upgradeUntouched: 'O binário instalado não foi tocado.',

--- a/packages/server/server/upgrade.test.ts
+++ b/packages/server/server/upgrade.test.ts
@@ -1,6 +1,12 @@
 import { test, expect } from 'bun:test'
 import {
   resolveUpgradeAsset,
+  releaseAssetName,
+  releaseAssetUrl,
+  releaseTag,
+  downloadUpgradeAsset,
+  downloadFailureMessage,
+  downloadFailureReason,
   verifyDownload,
   looksLikeExecutable,
   checkBinaryVersionOutput,
@@ -12,7 +18,10 @@ import {
   upgradeBackoffMs,
   UPGRADE_BACKOFF_STEPS_MS,
   MIN_BINARY_BYTES,
+  type UpgradeTarget,
 } from './upgrade'
+import { cliStrings } from './cli-i18n'
+import { resolveLatestRelease } from './version'
 
 // --- platform/arch gate -----------------------------------------------------
 // .github/workflows/release.yml publishes exactly two compiled assets: `agentop`
@@ -21,23 +30,140 @@ import {
 // arm64 box replaces a working binary with one the kernel cannot exec.
 
 test('only the platform/arch pairs the release workflow publishes are self-installable', () => {
-  expect(resolveUpgradeAsset('linux', 'x64')).toEqual({
+  expect(resolveUpgradeAsset('linux', 'x64', '2.5.0')).toEqual({
     asset: 'agentop',
-    url: 'https://github.com/blpsoares/agentistics/releases/latest/download/agentop',
+    url: 'https://github.com/blpsoares/agentistics/releases/download/v2.5.0/agentop',
+    version: '2.5.0',
   })
-  expect(resolveUpgradeAsset('win32', 'x64')).toEqual({
+  expect(resolveUpgradeAsset('win32', 'x64', '2.5.0')).toEqual({
     asset: 'agentop.exe',
-    url: 'https://github.com/blpsoares/agentistics/releases/latest/download/agentop.exe',
+    url: 'https://github.com/blpsoares/agentistics/releases/download/v2.5.0/agentop.exe',
+    version: '2.5.0',
   })
 })
 
 test('unsupported platform/arch combinations are refused', () => {
-  expect(resolveUpgradeAsset('linux', 'arm64')).toBeNull()   // Raspberry Pi / Ampere VM
-  expect(resolveUpgradeAsset('linux', 'arm')).toBeNull()
-  expect(resolveUpgradeAsset('darwin', 'arm64')).toBeNull()  // no macOS asset at all
-  expect(resolveUpgradeAsset('darwin', 'x64')).toBeNull()
-  expect(resolveUpgradeAsset('win32', 'arm64')).toBeNull()
-  expect(resolveUpgradeAsset('freebsd', 'x64')).toBeNull()
+  expect(resolveUpgradeAsset('linux', 'arm64', '2.5.0')).toBeNull()   // Raspberry Pi / Ampere VM
+  expect(resolveUpgradeAsset('linux', 'arm', '2.5.0')).toBeNull()
+  expect(resolveUpgradeAsset('darwin', 'arm64', '2.5.0')).toBeNull()  // no macOS asset at all
+  expect(resolveUpgradeAsset('darwin', 'x64', '2.5.0')).toBeNull()
+  expect(resolveUpgradeAsset('win32', 'arm64', '2.5.0')).toBeNull()
+  expect(resolveUpgradeAsset('freebsd', 'x64', '2.5.0')).toBeNull()
+  // The gate is answerable WITHOUT a version — that is why the asset name is its own function.
+  expect(releaseAssetName('linux', 'arm64')).toBeNull()
+  expect(releaseAssetName('linux', 'x64')).toBe('agentop')
+})
+
+// --- the address is the RESOLVED VERSION, never GitHub's "Latest" flag -------
+// 2026-09-02 13:57 UTC: the extension's `vscode-v1.0.0` release (a `.vsix` and nothing else) was
+// published, took the "Latest" flag, and `/releases/latest/download/agentop` began answering 404
+// on every machine — while v2.5.0's binary sat published and intact. The two notions of "latest"
+// disagreed, and the download was reading the movable one.
+
+test('a release tag is normalized whether or not the version carries its v', () => {
+  expect(releaseTag('2.5.0')).toBe('v2.5.0')
+  expect(releaseTag('v2.5.0')).toBe('v2.5.0')
+  expect(releaseTag(' 2.5.0 ')).toBe('v2.5.0')
+  expect(releaseAssetUrl('v2.5.0', 'agentop'))
+    .toBe('https://github.com/blpsoares/agentistics/releases/download/v2.5.0/agentop')
+})
+
+test('no download URL is derived from the movable `latest` alias', () => {
+  for (const version of ['2.5.0', 'v2.5.0', '10.0.1']) {
+    for (const [platformId, arch] of [['linux', 'x64'], ['win32', 'x64']] as const) {
+      const target = resolveUpgradeAsset(platformId, arch, version)!
+      expect(target.url).not.toContain('releases/latest/download')
+      expect(target.url).toContain(`/releases/download/${releaseTag(version)}/`)
+    }
+  }
+})
+
+test('the release flagged "Latest" holding no agentop asset does not move the download', async () => {
+  // The releases API answer as it stood during the incident: the extension release was published
+  // most recently (so GitHub flags it "Latest") and carries no binary; v2.5.0 is the real newest
+  // agentop. `resolveLatestRelease` — what `getVersionInfo()` runs — ignores the non-semver tag.
+  const releases = [
+    { tag_name: 'vscode-v1.0.0', body: 'VS Code extension' },
+    { tag_name: 'v2.5.0', body: '' },
+    { tag_name: 'v2.4.0', body: '' },
+  ]
+  const resolved = resolveLatestRelease(releases, '2.4.0')
+  expect(resolved.latest).toBe('2.5.0')
+  expect(resolved.hasUpdate).toBe(true)
+
+  // The download must address THAT version — the fact the command already had in hand.
+  const target = resolveUpgradeAsset('linux', 'x64', resolved.latest)!
+  const asked: string[] = []
+  const spy = (async (url: any) => {
+    asked.push(String(url))
+    // Only the version-addressed URL carries the binary; the "latest" alias is the 404 of the incident.
+    if (String(url).includes('releases/latest/download')) {
+      return new Response('Not Found', { status: 404 })
+    }
+    return new Response(new Uint8Array([0x7f, 0x45, 0x4c, 0x46]))
+  }) as unknown as typeof fetch
+
+  const result = await downloadUpgradeAsset(target, spy)
+  expect(asked).toEqual(['https://github.com/blpsoares/agentistics/releases/download/v2.5.0/agentop'])
+  expect(result.ok).toBe(true)
+  expect(result.ok === true && Array.from(result.bytes)).toEqual([0x7f, 0x45, 0x4c, 0x46])
+})
+
+test('the module holds no `latest` download alias for either path to pick up again', async () => {
+  const src = await Bun.file(new URL('./upgrade.ts', import.meta.url)).text()
+  // Comments are stripped: the alias is NAMED in the prose that records the incident, and a trap
+  // that forbade writing it down would forbid explaining it. What must not come back is the CODE.
+  const code = src
+    .split('\n')
+    .filter(line => !/^\s*(\/\/|\/?\*)/.test(line))
+    .join('\n')
+  // RELEASES_PAGE (`/releases`) is a page for a PERSON and stays; the download ALIAS may not
+  // reappear — the manual path and the automatic one both take their address from this module.
+  expect(code).not.toContain('releases/latest/download')
+  // And there is exactly ONE place a download URL is built, so the two paths cannot diverge.
+  expect(code.split('/releases/download/').length - 1).toBe(1)
+})
+
+// --- a missing asset and a broken network are different sentences ------------
+
+const linuxTarget = (): UpgradeTarget => resolveUpgradeAsset('linux', 'x64', '2.5.0')!
+
+test('a 404 is reported as that version lacking the asset, never as a bare HTTP code', async () => {
+  const spy = (async () => new Response('Not Found', { status: 404 })) as unknown as typeof fetch
+  const result = await downloadUpgradeAsset(linuxTarget(), spy)
+  expect(result).toEqual({ ok: false, kind: 'missing-asset', status: 404 })
+
+  const target = linuxTarget()
+  const msg = downloadFailureMessage(result as any, target, cliStrings('en'))
+  expect(msg).toContain('v2.5.0')
+  expect(msg).toContain('agentop')
+  expect(msg).toContain(target.url)
+  // A person reading only this line must not conclude their connection failed.
+  expect(msg).toContain('network is fine')
+  expect(downloadFailureReason(result as any, target)).toBe('release v2.5.0 has no agentop asset (HTTP 404)')
+
+  const pt = downloadFailureMessage(result as any, target, cliStrings('pt'))
+  expect(pt).toContain('não tem o anexo agentop')
+})
+
+test('a network failure says so, and is not dressed up as a missing asset', async () => {
+  const spy = (async () => { throw new Error('The operation timed out') }) as unknown as typeof fetch
+  const result = await downloadUpgradeAsset(linuxTarget(), spy)
+  expect(result).toEqual({ ok: false, kind: 'network', message: 'The operation timed out' })
+
+  const msg = downloadFailureMessage(result as any, linuxTarget(), cliStrings('en'))
+  expect(msg).toContain('The operation timed out')
+  expect(msg).toContain('network failure')
+  expect(msg).not.toContain('does not carry')
+  expect(downloadFailureReason(result as any, linuxTarget())).toBe('download failed: The operation timed out')
+})
+
+test('a non-404 HTTP answer is neither of the two — it keeps its status', async () => {
+  const spy = (async () => new Response('nope', { status: 503 })) as unknown as typeof fetch
+  const result = await downloadUpgradeAsset(linuxTarget(), spy)
+  expect(result).toEqual({ ok: false, kind: 'http', status: 503 })
+  expect(downloadFailureMessage(result as any, linuxTarget(), cliStrings('en'))).toContain('HTTP 503')
+  expect(downloadFailureReason(result as any, linuxTarget())).toBe('download failed: HTTP 503')
 })
 
 // --- download verification --------------------------------------------------
@@ -79,8 +205,8 @@ test('verifyDownload rejects truncated payloads and non-executables', () => {
 
 test('the downloaded binary must identify itself as the expected version (or newer)', () => {
   expect(checkBinaryVersionOutput('agentop v1.7.0\n', '1.7.0')).toEqual({ ok: true, found: '1.7.0' })
-  // The download URL is the ROLLING `latest` release, which can be one bump ahead of the
-  // newest version the releases API lists — newer is fine, older is not.
+  // A release whose asset was compiled from a later commit reports the higher number — newer is
+  // fine, older is not: that is the direction this check exists to catch.
   expect(checkBinaryVersionOutput('agentop v1.7.1\n', '1.7.0')).toEqual({ ok: true, found: '1.7.1' })
   expect(checkBinaryVersionOutput('agentop v1.6.9\n', '1.7.0')).toEqual({ ok: false, found: '1.6.9' })
   // Nothing usable printed → the file did not run (wrong arch, corrupt, killed).

--- a/packages/server/server/upgrade.ts
+++ b/packages/server/server/upgrade.ts
@@ -9,8 +9,8 @@ import { AGENTISTICS_DATA_DIR } from './config.ts'
 import { cliStrings, type CliLang, type CliStrings } from './cli-i18n.ts'
 
 const GITHUB_REPO = 'blpsoares/agentistics'
-const RELEASE_BASE = `https://github.com/${GITHUB_REPO}/releases/latest/download`
-/** Where a user goes when self-install is refused (unsupported platform/arch). */
+/** Where a user goes when self-install is refused (unsupported platform/arch). It is a page for
+ *  a PERSON to read, never the origin of a binary — see the note above `releaseAssetUrl`. */
 export const RELEASES_PAGE = `https://github.com/${GITHUB_REPO}/releases`
 
 const _ESC = '\x1b'
@@ -42,16 +42,53 @@ const MACHINE_IMAGE = 'agentistics-machine'
 export interface UpgradeTarget {
   /** Release asset name, as published by the workflow. */
   asset: string
-  /** Full download URL for that asset. */
+  /** Full download URL for that asset, addressed by the RESOLVED version. */
   url: string
+  /** The version that URL points at — the one `getVersionInfo()` already resolved. */
+  version: string
 }
 
-/** Pure: the asset for a platform/arch pair, or null when self-install is not supported. */
-export function resolveUpgradeAsset(platformId: string, arch: string): UpgradeTarget | null {
+/** Pure: the asset name for a platform/arch pair, or null when self-install is not supported.
+ *  Separate from the URL so the platform GATE can be asked without naming a version. */
+export function releaseAssetName(platformId: string, arch: string): string | null {
   const key = `${platformId}/${arch}`
-  if (key === 'linux/x64') return { asset: 'agentop', url: `${RELEASE_BASE}/agentop` }
-  if (key === 'win32/x64') return { asset: 'agentop.exe', url: `${RELEASE_BASE}/agentop.exe` }
+  if (key === 'linux/x64') return 'agentop'
+  if (key === 'win32/x64') return 'agentop.exe'
   return null
+}
+
+/** Pure: the release tag the workflow publishes for a version (`2.5.0` and `v2.5.0` both → `v2.5.0`). */
+export function releaseTag(version: string): string {
+  return `v${version.trim().replace(/^v/i, '')}`
+}
+
+/**
+ * Pure: where ONE asset of ONE RESOLVED VERSION lives.
+ *
+ * **There are two notions of "latest" and they can disagree.** `/releases/latest/download/…` is
+ * an alias for whichever release carries GitHub's "Latest" FLAG, and GitHub moves that flag to the
+ * most recently PUBLISHED release — not the highest version, and not necessarily a release that
+ * carries this asset at all. On 2026-09-02 13:57 UTC the extension's `vscode-v1.0.0` release (whose
+ * only attachment is a `.vsix`) took the flag, and `agentop upgrade` answered `HTTP 404` on every
+ * machine while v2.5.0's binary sat published and intact.
+ *
+ * `runUpgrade` has the firm notion in hand before it downloads anything — `getVersionInfo()` has
+ * already resolved `info.latest` by reading the releases API and picking the highest semver — so the
+ * download addresses THAT version by tag. No future publication in this repository can move it.
+ */
+export function releaseAssetUrl(version: string, asset: string): string {
+  return `https://github.com/${GITHUB_REPO}/releases/download/${releaseTag(version)}/${asset}`
+}
+
+/**
+ * Pure: the download target for a platform/arch pair AT A RESOLVED VERSION, or null when
+ * self-install is not supported here. `version` is required on purpose: a target that could be
+ * built without one is a target that can go back to asking GitHub who "latest" is.
+ */
+export function resolveUpgradeAsset(platformId: string, arch: string, version: string): UpgradeTarget | null {
+  const asset = releaseAssetName(platformId, arch)
+  if (!asset) return null
+  return { asset, url: releaseAssetUrl(version, asset), version: releaseTag(version).slice(1) }
 }
 
 // ---------------------------------------------------------------------------
@@ -87,9 +124,10 @@ export function verifyDownload(
 /**
  * Pure: does `agentop --version` output prove this binary is the release we expect?
  *
- * `>=` rather than `===` on purpose: the download URL points at the ROLLING `latest` release,
- * which is republished on every build, so it can legitimately be one bump ahead of the newest
- * version listed by the releases API. An OLDER (or unparseable) version means we downloaded
+ * `>=` rather than `===`, and it stays that way now that the download is addressed by the resolved
+ * version: a release whose asset was compiled from a later commit reports the higher number, and
+ * refusing that would abort an upgrade over a discrepancy that is not a fault. What this check
+ * exists to catch is the other direction — an OLDER (or unparseable) version means we downloaded
  * the wrong thing and must not install it.
  */
 export function checkBinaryVersionOutput(
@@ -116,6 +154,83 @@ export function tempBinaryPath(currentBin: string, unique: string): string {
 /** Pure: where the replaced binary is kept so a failed install can be rolled back. */
 export function backupBinaryPath(currentBin: string): string {
   return `${currentBin}.bak`
+}
+
+// ---------------------------------------------------------------------------
+// The download, and what its failure MEANS
+//
+// A bare `Download failed: HTTP 404` is the message that made this defect expensive: it reads as
+// "the network is broken" to everyone who sees it, while what it actually said was "that version's
+// release does not carry this asset". Those two send a person to completely different places — one
+// to their connection, the other to the release page — so the outcome is classified and each kind
+// gets its own sentence.
+// ---------------------------------------------------------------------------
+
+export type DownloadResult =
+  | { ok: true; bytes: Uint8Array }
+  /** The URL resolved, the server answered, and that version has no such asset. */
+  | { ok: false; kind: 'missing-asset'; status: number }
+  /** The server answered, but with something else (5xx, a proxy page, a rate limit). */
+  | { ok: false; kind: 'http'; status: number }
+  /** Nothing was answered, or the transfer died mid-stream — a network fact, not a release one. */
+  | { ok: false; kind: 'network'; message: string }
+
+/**
+ * Fetches one release asset. `fetchImpl` is injectable so a test can state exactly which URL the
+ * command asks for — the whole point of this journey is which address the bytes come from.
+ *
+ * Reading the body is guarded together with the fetch: the transfer is ~140 MB, so the timeout
+ * firing mid-stream (or a reset connection) is the MOST likely failure of the whole command, and
+ * outside the guard it rejected out of `runUpgrade`, skipping `recordUpgradeFailure` — the backoff
+ * never learned about the one failure it exists to throttle.
+ */
+export async function downloadUpgradeAsset(
+  target: UpgradeTarget,
+  fetchImpl: typeof fetch = fetch,
+): Promise<DownloadResult> {
+  let resp: Response
+  try {
+    resp = await fetchImpl(target.url, {
+      headers: { 'User-Agent': `agentistics/${CURRENT_VERSION}` },
+      signal: AbortSignal.timeout(120_000),
+    })
+  } catch (err: any) {
+    return { ok: false, kind: 'network', message: err?.message ?? String(err) }
+  }
+  if (!resp.ok) {
+    return resp.status === 404
+      ? { ok: false, kind: 'missing-asset', status: resp.status }
+      : { ok: false, kind: 'http', status: resp.status }
+  }
+  try {
+    return { ok: true, bytes: new Uint8Array(await resp.arrayBuffer()) }
+  } catch (err: any) {
+    return { ok: false, kind: 'network', message: err?.message ?? String(err) }
+  }
+}
+
+/** Pure: the sentence a person reads. Names the version and the asset when the release is the
+ *  problem, and says it is the network when it is the network — never one wearing the other's word. */
+export function downloadFailureMessage(
+  result: Extract<DownloadResult, { ok: false }>,
+  target: UpgradeTarget,
+  s: CliStrings,
+): string {
+  if (result.kind === 'missing-asset') return s.upgradeAssetMissing(target.version, target.asset, target.url)
+  const reason = result.kind === 'http' ? `HTTP ${result.status}` : result.message
+  return s.upgradeDownloadFailed(reason, target.url)
+}
+
+/** Pure: the compact, language-free reason recorded for the backoff state. */
+export function downloadFailureReason(
+  result: Extract<DownloadResult, { ok: false }>,
+  target: UpgradeTarget,
+): string {
+  if (result.kind === 'missing-asset') {
+    return `release v${target.version} has no ${target.asset} asset (HTTP ${result.status})`
+  }
+  if (result.kind === 'http') return `download failed: HTTP ${result.status}`
+  return `download failed: ${result.message}`
 }
 
 // ---------------------------------------------------------------------------
@@ -475,12 +590,18 @@ export function isInstalledBinary(execPath: string, scriptPath: string | undefin
  *
  * Refuses (without downloading anything) when self-install is unsupported on this
  * platform/arch, and when the same version already failed recently (backoff).
+ *
+ * The child it spawns is `agentop upgrade`, so the bytes come from `runUpgrade` and there is ONE
+ * downloader — but the target is resolved HERE too, for the same `version` the caller decided on,
+ * and written into the log. Nobody watches this path, so an address that diverged from the manual
+ * one would be invisible until it broke; the log line is what makes it readable.
  */
 export async function startBackgroundUpgrade(version: string): Promise<BackgroundUpgradeResult> {
   // Never self-install over a dev checkout's runtime — see isInstalledBinary.
   if (!isInstalledBinary(process.execPath, process.argv[1])) return 'not-installed'
   // No published asset for this platform/arch → an unattended install would brick it.
-  if (!resolveUpgradeAsset(process.platform, process.arch)) return 'unsupported'
+  const target = resolveUpgradeAsset(process.platform, process.arch, version)
+  if (!target) return 'unsupported'
   // A previously failing target backs off instead of re-downloading on every shell.
   if (!shouldAttemptUpgrade(readUpgradeFailure(), version, Date.now())) return 'backoff'
 
@@ -491,7 +612,10 @@ export async function startBackgroundUpgrade(version: string): Promise<Backgroun
   try {
     // Guaranteed by isInstalledBinary above: execPath IS agentop, so it takes the
     // subcommand directly (no script argument to forward).
-    appendFileSync(AUTO_UPGRADE_LOG, `\n=== ${new Date().toISOString()} — auto-installing v${version} ===\n`)
+    appendFileSync(
+      AUTO_UPGRADE_LOG,
+      `\n=== ${new Date().toISOString()} — auto-installing v${version} from ${target.url} ===\n`,
+    )
     const fd = openSync(AUTO_UPGRADE_LOG, 'a')
     const { spawn } = await import('node:child_process')
     const child = spawn(process.execPath, ['upgrade'], {
@@ -655,8 +779,10 @@ export async function runUpgrade(lang: CliLang = 'en'): Promise<number> {
   }
   stampUpgradeLock(info.latest)
 
-  // Platform/arch gate — refuse BEFORE downloading anything.
-  const target = resolveUpgradeAsset(process.platform, process.arch)
+  // Platform/arch gate — refuse BEFORE downloading anything. The target is addressed by the
+  // version `getVersionInfo()` just resolved (`info.latest`, the one printed below), never by
+  // GitHub's movable "Latest" flag — see `releaseAssetUrl`.
+  const target = resolveUpgradeAsset(process.platform, process.arch, info.latest)
   if (!target) {
     const id = `${process.platform}/${process.arch}`
     process.stderr.write(
@@ -671,41 +797,22 @@ export async function runUpgrade(lang: CliLang = 'en'): Promise<number> {
     `\n  ${_D}Current:${_R} ${_WH}v${info.current}${_R}\n` +
     `  ${_D}Latest: ${_R} ${_GR}${_B}v${info.latest}${_R}\n\n`,
   )
-  process.stdout.write(`Downloading ${target.asset}...\n`)
+  process.stdout.write(`Downloading ${target.asset} (${target.url})...\n`)
 
-  let resp: Response
-  try {
-    resp = await fetch(target.url, {
-      headers: { 'User-Agent': `agentistics/${CURRENT_VERSION}` },
-      signal: AbortSignal.timeout(120_000),
-    })
-  } catch (err: any) {
-    console.error(`Download failed: ${err.message}`)
-    recordUpgradeFailure(info.latest, `download failed: ${err?.message ?? String(err)}`)
-    return 1
-  }
-
-  if (!resp.ok) {
-    console.error(`Download failed: HTTP ${resp.status}`)
-    recordUpgradeFailure(info.latest, `download failed: HTTP ${resp.status}`)
+  const downloaded = await downloadUpgradeAsset(target)
+  if (!downloaded.ok) {
+    process.stderr.write(`\n  ${_RD}${downloadFailureMessage(downloaded, target, s)}${_R}\n`)
+    if (downloaded.kind === 'missing-asset') {
+      process.stderr.write(`  ${s.upgradeManualHow(RELEASES_PAGE)}\n`)
+    }
+    process.stderr.write('\n')
+    // The backoff must still learn about EVERY one of these, or the throttle stops existing.
+    recordUpgradeFailure(info.latest, downloadFailureReason(downloaded, target))
     return 1
   }
 
   const currentBin = process.execPath
-  // Reading the body must be guarded too, not just the fetch: the transfer is ~140 MB, so the
-  // 120s timeout firing mid-stream (or a reset connection) is the MOST likely failure of the whole
-  // command. Outside the guard it rejected out of runUpgrade, skipping recordUpgradeFailure — so
-  // the backoff never learned about the one failure it exists to throttle, and the user got a raw
-  // stack trace instead of a message.
-  let bytes: Uint8Array
-  try {
-    bytes = new Uint8Array(await resp.arrayBuffer())
-  } catch (err: any) {
-    console.error(`Download failed: ${err?.message ?? String(err)}`)
-    recordUpgradeFailure(info.latest, `download interrupted: ${err?.message ?? String(err)}`)
-    return 1
-  }
-  const installed = await installDownloadedBinary(bytes, currentBin, info.latest, s)
+  const installed = await installDownloadedBinary(downloaded.bytes, currentBin, info.latest, s)
 
   if (!installed.ok) {
     if (installed.keptTmp) {


### PR DESCRIPTION
> **Colisão de sessões — leia antes de mergear.** A PR #291 (mesma unidade
> `j-20260902-cq/server`, sessão anterior) já corrige este mesmo defeito, com
> qualidade equivalente. **Mergeie UMA das duas, não as duas** — elas tocam as
> mesmas linhas e vão conflitar. Esta aqui existe porque a sessão foi despachada
> de novo sobre uma base mais nova (`origin/dev` = 3e02662, a #291 saiu de
> 1432f18) e a descoberta da #291 só aconteceu no `push`. Nada da #291 foi
> sobrescrito.

## Causa

`agentop upgrade` respondia `Download failed: HTTP 404` em toda máquina desde
2026-09-02 13:57 UTC. O binário estava publicado e íntegro — o que quebrou foi o
endereço.

O download vinha de `/releases/latest/download/agentop`. Esse `latest` não é a
versão mais nova: é a release que carrega a flag "Latest", e o GitHub move essa
flag para a **publicada mais recentemente**. Às 13:51 a PR #285 foi mergeada; às
13:57 o CI publicou `vscode-v1.0.0`, cujo único anexo é o `.vsix` da extensão.
Ela tomou a flag, e o caminho passou a apontar para uma release sem `agentop`.

O defeito de fundo é maior que o incidente: **existem duas noções de "latest" que
podem discordar, e o código confiava na frágil tendo a firme na mão.**
`getVersionInfo()` já havia resolvido `info.latest` antes do download, e o
download descartava esse fato para perguntar de novo ao GitHub quem era o
"latest".

## Correção

- `releaseAssetUrl(version, asset)` é o **único** lugar onde uma URL de download
  é montada, e ela endereça a versão resolvida
  (`/releases/download/v2.5.0/agentop`). `RELEASE_BASE` deixou de existir.
- `resolveUpgradeAsset(platform, arch, version)` passa a **exigir** a versão — um
  alvo que pudesse ser montado sem ela é um alvo que volta a perguntar ao GitHub.
  O gate de plataforma ganhou `releaseAssetName()`, que responde sem versão.
- O caminho automático (`startBackgroundUpgrade`) resolve o mesmo alvo e escreve
  a URL no `auto-upgrade.log`. Ninguém olha para ele, então uma divergência ali
  ficaria invisível até quebrar.
- `downloadUpgradeAsset()` classifica a falha — anexo ausente naquela versão,
  outro status HTTP, ou falha de rede — e cada uma tem sua frase (EN/PT). O
  `fetch` é injetável, então um teste declara **exatamente qual URL** o comando
  pede.

**O que não mudou:** `MIN_BINARY_BYTES`, `looksLikeExecutable` e `verifyDownload`
seguem intactos; toda falha de download continua chamando
`recordUpgradeFailure`, então o backoff continua existindo; o gate de plataforma
continua recusando antes de baixar qualquer byte; `RELEASES_PAGE` segue apontando
para a página de releases, que é link para pessoa.

## Provas

**A URL que o comando realmente pede** (spy no `fetch`, contra o repositório real,
com a condição do incidente ainda viva):

```
getVersionInfo resolved: current=2.3.2 latest=2.5.0 hasUpdate=true
resolveUpgradeAsset → asset=agentop version=2.5.0
URL REQUESTED: https://github.com/blpsoares/agentistics/releases/download/v2.5.0/agentop
fetch spy saw: ["https://github.com/blpsoares/agentistics/releases/download/v2.5.0/agentop"]
download outcome: {"ok":true}
```

A condição segue viva neste momento:

```
404  https://github.com/blpsoares/agentistics/releases/latest/download/agentop
200  https://github.com/blpsoares/agentistics/releases/download/v2.5.0/agentop
```

**Mensagem com o anexo ausente** (404 real, forçado contra o repositório):

```
Release v9.9.9 does not carry the agentop asset (HTTP 404 at
https://github.com/blpsoares/agentistics/releases/download/v9.9.9/agentop).
Your network is fine — that version was published without this binary.
```

contra a de rede, que não se disfarça de anexo faltando:

```
Could not download .../v9.9.9/agentop: getaddrinfo ENOTFOUND github.com.
This looks like a network failure, not a missing release asset.
```

**Sobras de `releases/latest/download` em `packages/server`** — todas em prosa ou
em teste, nenhuma alimenta download:

```
upgrade.ts:68        comentário que registra o incidente
upgrade.test.ts:59   comentário do mesmo
upgrade.test.ts:75   asserção de que a URL NÃO a contém
upgrade.test.ts:100  o spy que devolve 404 para o alias
upgrade.test.ts:122  a trava de regressão sobre o fonte do módulo
```

**Trava de regressão:** um teste lê o fonte de `upgrade.ts`, tira os comentários,
e falha se `releases/latest/download` reaparecer no **código** ou se existir mais
de um lugar montando URL de download.

**Verde:** `bun tsc --noEmit` limpo · `bun test packages/server` → 2532 pass / 0
fail em 168 arquivos · `bun run build` limpo.

## Achado fora de escopo (não corrigido aqui)

A mesma fragilidade afeta outros pontos, que não são `packages/server`:

- `packages/desktop/tauri.conf.json:31` — o updater do app desktop lê
  `/releases/latest/download/latest.json`. **Mesma classe de defeito**: se uma
  release sem `latest.json` tomar a flag, o updater do desktop quebra igual.
- `packages/web/src/components/TeamRepos.tsx:56,70`, `docs/cli.md:567`,
  `docs/github-actions.md:82`, `docs/examples/agentistics-actions.yml:58` — os
  `curl` de instalação. Estão **404 agora**, pelo mesmo motivo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SyRzQnRF53QXXHGeqvvY5p
