### PR TITLE
release: promove dev→main — a sessão escondida deixa de se anunciar ao central

### DIFF
--- a/.github/workflows/project-add.yml
+++ b/.github/workflows/project-add.yml
@@ -3,8 +3,17 @@ name: Add to project
 on:
   issues:
     types: [opened]
-  pull_request:
+  # pull_request_target, not pull_request: a PR opened from a FORK gets no access to
+  # secrets, so ADD_TO_PROJECT_PAT arrived empty and the action died on its required
+  # input — every fork PR reported a red X for a board entry it could never make.
+  # pull_request_target runs in the context of the BASE repository, where the secret
+  # exists. It carries a write-scoped token, so it is only safe while this job does
+  # not check out the pull request's code: keep it that way — no actions/checkout here.
+  pull_request_target:
     types: [opened]
+
+permissions:
+  contents: read
 
 jobs:
   add-to-project:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,10 @@ jobs:
           # A FORCED release is never skipped. This guard exists so the workflow's own bump commit
           # does not trigger it again; the head of main is always that commit, so honouring it on a
           # manual dispatch would refuse every corrective release outright.
-          MSG=$(git log -1 --pretty=format:"%s")
+          # tformat:, like every other read in this file — see the note on the bump step. `$(…)`
+          # strips the trailing newline either way, which is exactly why the wrong form survives
+          # here unnoticed and gets copied into a loop where it drops a record.
+          MSG=$(git log -1 --pretty=tformat:"%s")
           if [ -n "${{ github.event.inputs.version }}" ]; then
             echo "skip=false" >> $GITHUB_OUTPUT
           elif echo "$MSG" | grep -q "chore: bump version"; then

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1903,3 +1903,24 @@ Do not mock the filesystem — the tested functions are pure and have no side ef
 
 - **pre-commit**: `bun tsc --noEmit` + `bun test`
 - **commit-msg**: commitlint enforces Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
+
+## The release's version bump — `versionBump.ts`, and the read that feeds it
+
+**The published version is decided by `bumpFromCommits` / `nextVersion` in `@agentistics/core`, and
+`.github/workflows/release.yml` only READS the commits and delegates.** The calculation was inline
+bash and nothing exercised it, so a defect was observable only in production, one release at a time
+— v1.23.1 shipped a `feat` as a patch. Two rules, both enforced by
+`packages/core/src/releaseWorkflow.lint.test.ts` (a grep over the workflows, the shape
+`tokens.lint.test.ts` uses over the product source):
+
+- **`git log --pretty=tformat:`, never `format:`.** `format:` omits the terminal newline on the LAST
+  record and `while IFS= read -r` silently drops a line without one, so the OLDEST commit of every
+  range went unclassified — and when that was the only `feat`, zero subjects were read. It is
+  harmless inside `$(…)`, which strips trailing newlines, and that is precisely why the wrong form
+  survives long enough to be copied into a loop. The lint bans the form outright in every workflow
+  and root shell script; `@git-format-intentional` plus a reason is the escape hatch.
+- **No bash bump default.** `bumpFromCommits` THROWS on an empty commit list, because a range that
+  has commits (`COMMIT_COUNT > 0`) yet yields none to classify is a reading defect, not a patch. A
+  `BUMP="patch"` floor in the shell converts that loud failure back into a quietly wrong release,
+  so the lint refuses one. A NON-empty list of only non-conventional subjects is a different thing
+  — the read worked, there is nothing to bump — and is a legitimate patch.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,6 +100,22 @@ docs: improve install instructions
 
 Commit messages are in **English**.
 
+**The type decides the published version.** `.github/workflows/release.yml` reads every commit in
+the range and hands it to `bumpFromCommits` in `@agentistics/core` (`versionBump.ts`) — the one
+tested implementation of the rule: a `!` or a `BREAKING CHANGE:` footer is a major, `feat` is a
+minor, anything else is a patch. So a mistyped `chore:` over a real feature ships it as a
+correction, and nobody reading the versions learns it landed.
+
+Two rules exist because getting them wrong published v1.23.1 for a feature (#248):
+
+- **Read git with `--pretty=tformat:`, never `format:`.** `format:` omits the terminal newline on
+  the last record and `while read` drops it, so the OLDEST commit of the range goes unclassified.
+  It is safe inside `$(…)`, which is exactly why the wrong form survives long enough to be copied
+  into a loop. `releaseWorkflow.lint.test.ts` fails the build on either form.
+- **The workflow never decides the bump itself.** `bumpFromCommits` throws when it is handed
+  nothing to classify, so an unreadable range fails the job loudly. A bash `patch` default would
+  turn that same failure back into a quietly wrong number.
+
 ## Submitting a PR
 
 1. Fork the repo and create a branch from `dev` (ongoing work targets `dev`; `main` receives

--- a/packages/core/src/releaseWorkflow.lint.test.ts
+++ b/packages/core/src/releaseWorkflow.lint.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from 'bun:test'
+import { readFileSync, readdirSync, existsSync } from 'node:fs'
+import { join } from 'node:path'
+
+/**
+ * The reading defect that shipped v1.23.1 as a patch, kept from coming back.
+ *
+ * `git log --pretty=format:` omits the terminal newline on the LAST record, and a
+ * `while IFS= read -r` loop silently drops a final line without one — so the OLDEST commit in
+ * every range went unclassified. A range whose only `feat` was that commit fell through to the
+ * bash `patch` default and a feature was published as a correction. Reproduced on this repo's
+ * own history: `fd283a1d..548aa5c8` holds exactly one commit, `feat(vscode): …`, and the old
+ * reader classified ZERO of it.
+ *
+ * `versionBump.test.ts` pins the arithmetic. It cannot see the SHELL, and the shell is where the
+ * defect lived: the calculation was never wrong, the commits simply never reached it. Nothing in
+ * YAML objects to `format:` — it is one character from the correct form, it is what every
+ * StackOverflow answer prints, and it fails only on the oldest record of a range, which is the
+ * one case a hand test rarely covers. So the guard is a grep over the workflows themselves, the
+ * same shape `tokens.lint.test.ts` uses over the product source.
+ *
+ * Two things are asserted:
+ *
+ *  1. **no workflow or shell script reads with `--pretty=format:` / `--format=format:`.**
+ *     `tformat:` terminates every record and is correct everywhere `format:` is — including
+ *     inside `$(…)`, which strips trailing newlines and so hides the difference until somebody
+ *     copies the line into a loop. Banning the form outright is what makes the rule teachable;
+ *     a rule that says "only in a loop" has to be re-argued at every call site.
+ *  2. **the release workflow DELEGATES the bump to `@agentistics/core`** and carries no bash
+ *     default of its own. The silent `patch` floor is the other half of the defect: a read that
+ *     returned nothing became a patch release instead of a failed job. `bumpFromCommits` throws
+ *     on an empty list precisely so that cannot happen, and that guarantee is worth nothing if
+ *     the workflow ever goes back to deciding the bump itself.
+ *
+ * Escape hatch for (1): `@git-format-intentional` with a reason on the same or the preceding
+ * line — which turns a silent mistake into a decision somebody wrote down.
+ */
+
+const ROOT = join(import.meta.dir, '..', '..', '..')
+const WORKFLOW_DIR = join(ROOT, '.github', 'workflows')
+const SHELL_SCRIPTS = ['install.sh', 'central.sh', 'start.sh']
+const MARKER = '@git-format-intentional'
+
+/** The non-terminating pretty format, in every spelling git accepts (quoted or bare). */
+const NON_TERMINATING = /--(?:pretty|format)=["']?format:/g
+
+/** The line a character offset falls on, 1-based — so a failure names a place to go. */
+function lineAt(src: string, index: number): number {
+  return src.slice(0, index).split('\n').length
+}
+
+/** True when the offending line, or the one above it, carries the marker with something after it. */
+function excused(src: string, index: number): boolean {
+  const lines = src.split('\n')
+  const n = lineAt(src, index) - 1
+  for (const line of [lines[n], lines[n - 1]]) {
+    if (!line) continue
+    const at = line.indexOf(MARKER)
+    if (at >= 0 && line.slice(at + MARKER.length).trim().length > 0) return true
+  }
+  return false
+}
+
+function scanned(): { rel: string; src: string }[] {
+  const out: { rel: string; src: string }[] = []
+  if (existsSync(WORKFLOW_DIR)) {
+    for (const name of readdirSync(WORKFLOW_DIR)) {
+      if (!/\.ya?ml$/.test(name)) continue
+      out.push({ rel: `.github/workflows/${name}`, src: readFileSync(join(WORKFLOW_DIR, name), 'utf8') })
+    }
+  }
+  for (const name of SHELL_SCRIPTS) {
+    const p = join(ROOT, name)
+    if (existsSync(p)) out.push({ rel: name, src: readFileSync(p, 'utf8') })
+  }
+  return out
+}
+
+describe('git log is read with a TERMINATING format', () => {
+  it('finds the files it is meant to police', () => {
+    const files = scanned().map((f) => f.rel)
+    expect(files).toContain('.github/workflows/release.yml')
+    expect(files.length).toBeGreaterThan(1)
+  })
+
+  it('no workflow or shell script uses --pretty=format: (the form that drops the last record)', () => {
+    const offenders: string[] = []
+    for (const { rel, src } of scanned()) {
+      // Prose ABOUT the defect is the whole reason these files are readable; only real
+      // invocations count, so a `#`-commented line is skipped.
+      for (const m of src.matchAll(NON_TERMINATING)) {
+        const line = src.split('\n')[lineAt(src, m.index) - 1] ?? ''
+        if (/^\s*#/.test(line)) continue
+        if (excused(src, m.index)) continue
+        offenders.push(`${rel}:${lineAt(src, m.index)}  ${line.trim()}`)
+      }
+    }
+    expect(
+      offenders,
+      `--pretty=format: omits the terminal newline on the last record, so \`while read\` drops the\n` +
+        `OLDEST commit of the range (issue #248: a feat shipped as a patch). Use --pretty=tformat:.\n` +
+        `If this call site genuinely cannot drop a record, say so with ${MARKER} and a reason.\n\n` +
+        offenders.join('\n'),
+    ).toEqual([])
+  })
+})
+
+describe('the release workflow delegates the bump instead of deciding it in bash', () => {
+  const src = readFileSync(join(WORKFLOW_DIR, 'release.yml'), 'utf8')
+
+  it('calls the tested implementation in @agentistics/core', () => {
+    expect(src).toContain('bumpFromCommits')
+    expect(src).toContain('nextVersion')
+    expect(src).toContain('@agentistics/core')
+  })
+
+  it('carries no bash bump default of its own — the silent patch floor is what shipped the wrong number', () => {
+    const floors = src
+      .split('\n')
+      .map((line, i) => [i + 1, line] as const)
+      .filter(([, line]) => !/^\s*#/.test(line))
+      .filter(([, line]) => /^\s*(?:local\s+)?BUMP=["']?(?:patch|minor|major)\b/.test(line))
+      .map(([n, line]) => `.github/workflows/release.yml:${n}  ${line.trim()}`)
+    expect(
+      floors,
+      'the bump must come from bumpFromCommits (which THROWS on an unreadable range), never from a\n' +
+        'bash default that turns a failed read into a quiet patch release.\n\n' + floors.join('\n'),
+    ).toEqual([])
+  })
+})

--- a/packages/server/server/share-rules.test.ts
+++ b/packages/server/server/share-rules.test.ts
@@ -1081,10 +1081,24 @@ const LIVE_SESSIONS = [
 const liveIndex = () => buildPathRepoIndex(LIVE_SESSIONS)
 
 test('an unrestricted connection gets the live snapshot untouched', () => {
-  const snap = { liveSessionIds: ['open-blocked', 'open-shared'], liveProcesses: [{ cwd: '/anywhere' }] }
+  const snap = {
+    liveSessionIds: ['open-blocked', 'open-shared'],
+    liveProcesses: [{ cwd: '/anywhere' }],
+    liveSessionActivities: { 'open-blocked': 'working', 'open-shared': 'waiting' } as const,
+  }
   const out = filterLiveShared(snap, LIVE_SESSIONS, denylistRules(normalizeDenied([])))
   expect(out.liveSessionIds).toEqual(['open-blocked', 'open-shared'])
   expect(out.liveProcesses).toHaveLength(1)
+  expect(out.liveSessionActivities).toEqual({ 'open-blocked': 'working', 'open-shared': 'waiting' })
+})
+
+test('a snapshot with no activities yields an empty map, never undefined', () => {
+  // The caller sends `shared.liveSessionActivities` verbatim; a missing map must still be a map,
+  // or the frame carries `undefined` where the central expects an object.
+  const snap = { liveSessionIds: ['open-shared'], liveProcesses: [] }
+  expect(filterLiveShared(snap, LIVE_SESSIONS, denylistRules(normalizeDenied([]))).liveSessionActivities).toEqual({})
+  const restricted = filterLiveShared(snap, LIVE_SESSIONS, denylistRules(normalizeDenied(['github.com/acme/secret'])), liveIndex())
+  expect(restricted.liveSessionActivities).toEqual({})
 })
 
 // The leak this exists to close: the uploader withheld the repo's metrics while the reverse
@@ -1125,6 +1139,74 @@ test('the alias folding that guards filterShared guards the live channel too', (
   // Denied under a different SSH/case spelling of the same remote.
   const out = filterLiveShared(snap, LIVE_SESSIONS, denylistRules(normalizeDenied(['git@github.com:Acme/Secret.git'])), liveIndex())
   expect(out.liveSessionIds).toEqual([])
+})
+
+// The leak issue #214 closed: `sessionActivities` travelled beside the two filtered fields and was
+// itself unfiltered, so a withheld repo's session announced its id AND its state every 8 seconds.
+test("a denied session's activity is dropped while the shared one's survives", () => {
+  const snap = {
+    liveSessionIds: ['open-blocked', 'open-shared'],
+    liveProcesses: [],
+    liveSessionActivities: { 'open-blocked': 'waiting-approval', 'open-shared': 'working' } as const,
+  }
+  const out = filterLiveShared(snap, LIVE_SESSIONS, denylistRules(normalizeDenied(['github.com/acme/secret'])), liveIndex())
+  expect(out.liveSessionActivities).toEqual({ 'open-shared': 'working' })
+})
+
+test('an activity keyed by a session we cannot find is dropped, like the id would be', () => {
+  const snap = {
+    liveSessionIds: [],
+    liveProcesses: [],
+    liveSessionActivities: { ghost: 'working' } as const,
+  }
+  const out = filterLiveShared(snap, LIVE_SESSIONS, denylistRules(normalizeDenied(['github.com/acme/secret'])), liveIndex())
+  expect(out.liveSessionActivities).toEqual({})
+})
+
+test('an allowlist keeps only the allowed session\'s activity', () => {
+  const snap = {
+    liveSessionIds: ['open-blocked', 'open-shared'],
+    liveProcesses: [],
+    liveSessionActivities: { 'open-blocked': 'working', 'open-shared': 'waiting' } as const,
+  }
+  const rules = { mode: 'allowlist' as const, sources: new Set(['repo:github.com/acme/public']) }
+  const out = filterLiveShared(snap, LIVE_SESSIONS, rules, liveIndex())
+  expect(out.liveSessionIds).toEqual(['open-shared'])
+  expect(out.liveSessionActivities).toEqual({ 'open-shared': 'waiting' })
+})
+
+test('an EMPTY allowlist shares no activity at all', () => {
+  const snap = {
+    liveSessionIds: ['open-shared'],
+    liveProcesses: [],
+    liveSessionActivities: { 'open-shared': 'working' } as const,
+  }
+  const out = filterLiveShared(snap, LIVE_SESSIONS, { mode: 'allowlist', sources: new Set() }, liveIndex())
+  expect(out.liveSessionActivities).toEqual({})
+})
+
+// Enumerated over the RESULT'S OWN KEYS rather than field by field: the point of moving the
+// activities into this function is that ONE function decides the whole outgoing frame, so a field
+// added to it later is covered by this test instead of needing another one — which is precisely
+// what did not happen when `sessionActivities` was added at the call site.
+test("nothing about a denied session appears in ANY field of the outgoing frame", () => {
+  const snap = {
+    liveSessionIds: ['open-blocked', 'open-shared'],
+    liveProcesses: [{ cwd: '/w/secret' }, { cwd: '/w/public' }],
+    liveSessionActivities: { 'open-blocked': 'waiting-approval', 'open-shared': 'working' } as const,
+  }
+  const out = filterLiveShared(snap, LIVE_SESSIONS, denylistRules(normalizeDenied(['github.com/acme/secret'])), liveIndex())
+
+  expect(Object.keys(out).sort()).toEqual(['liveProcesses', 'liveSessionActivities', 'liveSessionIds'])
+  for (const value of Object.values(out)) {
+    const json = JSON.stringify(value)
+    expect(json).not.toContain('open-blocked')
+    expect(json).not.toContain('secret')
+  }
+  // ...and the shared half is still there, or an all-empty frame would pass the check above.
+  expect(out.liveSessionIds).toEqual(['open-shared'])
+  expect(out.liveProcesses.map(p => p.cwd)).toEqual(['/w/public'])
+  expect(out.liveSessionActivities).toEqual({ 'open-shared': 'working' })
 })
 
 // --- the cross-check that keeps THIS file the single source of the sharing semantics ------------

--- a/packages/server/server/share-rules.ts
+++ b/packages/server/server/share-rules.ts
@@ -334,36 +334,63 @@ export function filterShared<T extends Pick<SessionMeta, 'git_remote' | 'project
  * name and activity you broadcast is not a privacy control. Every outbound path applies the
  * same rule, so this one runs through `sessionShared` like the uploader does.
  *
- * Fail-closed on BOTH halves, which is stricter than `filterShared` and deliberately so:
+ * Fail-closed on ALL THREE halves, which is stricter than `filterShared` and deliberately so:
  *
  * - A live id whose session we cannot find is dropped. It cannot be attributed to a repo, and
  *   the central could not render it anyway (it resolves live ids against the sessions it was
  *   pushed), so keeping it only ever leaked an identifier for a row nobody could see.
+ * - An ACTIVITY is keyed by `session_id` and is judged by that same predicate, key by key. It
+ *   used to be sent unfiltered beside the two filtered fields, so a withheld repo's session
+ *   announced its id AND its state (`working` / `waiting` / `waiting-approval` / `exited`) every
+ *   8 seconds — enough to count a hidden project's sessions and watch them work. That the
+ *   central most likely has no document to render it against is a statement about today's
+ *   rendering, not about the boundary.
  * - A process is reported only when its `cwd` resolves POSITIVELY to a repo that is not denied.
  *   A process has no session to attribute, and `cwd` is the sensitive field here — a path is
  *   often the repo name. Under restrictions an unrecognized directory is withheld rather than
  *   assumed innocent.
  *
+ * ONE function decides the WHOLE outgoing frame. The caller must never assemble a field of that
+ * message beside this result — that is exactly how the activities came to be sent unfiltered —
+ * so anything added to the live message is added here, where the rule already lives.
+ *
  * With no restrictions the snapshot passes through untouched — the common case pays nothing.
  */
 export function filterLiveShared<
   P extends { cwd: string },
+  A extends string = 'working' | 'waiting' | 'waiting-approval' | 'exited',
 >(
-  snapshot: { liveSessionIds: readonly string[]; liveProcesses: readonly P[] },
+  snapshot: {
+    liveSessionIds: readonly string[]
+    liveProcesses: readonly P[]
+    liveSessionActivities?: Readonly<Record<string, A>> | null
+  },
   sessions: readonly Pick<SessionMeta, 'session_id' | 'git_remote' | 'project_path'>[],
   rules: ShareRules,
   index?: PathRepoIndex,
-): { liveSessionIds: string[]; liveProcesses: P[] } {
+): { liveSessionIds: string[]; liveProcesses: P[]; liveSessionActivities: Record<string, A> } {
   // Only an unrestricted DENYLIST passes the snapshot through. An allowlist is always a
   // restriction — an empty one shares nothing — so it must never take this shortcut.
   if (rules.mode === 'denylist' && rules.sources.size === 0) {
-    return { liveSessionIds: [...snapshot.liveSessionIds], liveProcesses: [...snapshot.liveProcesses] }
+    return {
+      liveSessionIds: [...snapshot.liveSessionIds],
+      liveProcesses: [...snapshot.liveProcesses],
+      liveSessionActivities: { ...(snapshot.liveSessionActivities ?? {}) },
+    }
   }
   const byId = new Map(sessions.map(s => [s.session_id, s]))
-  const liveSessionIds = snapshot.liveSessionIds.filter(id => {
+  const idShared = (id: string): boolean => {
     const s = byId.get(id)
     return !!s && sessionShared(s, rules, index)
-  })
+  }
+  const liveSessionIds = snapshot.liveSessionIds.filter(idShared)
+  // Judged key by key against the rule, never by intersecting with `liveSessionIds` above: that
+  // would inherit whatever that list happens to hold rather than asking the question, and an
+  // activity for an id the snapshot did not list would then pass on a technicality.
+  const liveSessionActivities: Record<string, A> = {}
+  for (const [id, activity] of Object.entries(snapshot.liveSessionActivities ?? {})) {
+    if (idShared(id)) liveSessionActivities[id] = activity as A
+  }
   const liveProcesses = snapshot.liveProcesses.filter(p => {
     // Positive resolution only: `repoKeyOf` falls back to NO_REPO_KEY for an unknown path, which
     // under a denylist would read as "shared" whenever the user has not also denied the no-repo
@@ -374,7 +401,7 @@ export function filterLiveShared<
     const matched = rules.sources.has(repoSourceKey(key)) || rules.sources.has(projectSourceKey(p.cwd))
     return rules.mode === 'allowlist' ? matched : !matched
   })
-  return { liveSessionIds, liveProcesses }
+  return { liveSessionIds, liveProcesses, liveSessionActivities }
 }
 
 /**

--- a/packages/server/server/team-agent-client.ts
+++ b/packages/server/server/team-agent-client.ts
@@ -241,11 +241,14 @@ function startLiveReporting(connId: string, socket: WebSocket): void {
       const shared = shareRules.filterLiveShared(snap, data.sessions, rules, index)
 
       if (socket.readyState !== WebSocket.OPEN) return
+      // Every field comes off `shared` — nothing on this message is read from `snap` directly.
+      // The activities used to be, and a withheld repo's session announced its id and its state
+      // beside the two fields that were filtered.
       socket.send(JSON.stringify({
         type: 'live-sessions',
         sessionIds: shared.liveSessionIds,
         processes: shared.liveProcesses,
-        sessionActivities: snap.liveSessionActivities ?? {},
+        sessionActivities: shared.liveSessionActivities,
       }))
     } catch { /* transient — the next tick retries */ }
   }


### PR DESCRIPTION
## Summary

Promotes `dev` → `main`. Three commits, all reviewed. The one that matters to anyone running a
member machine is the first: **a session in a withheld repository was still announcing its id and
its state to the central every 8 seconds.**

- **fix(team)** `85238a2` — the live channel filters `sessionActivities` too (#288, closes #214).
  `filterLiveShared` now decides the WHOLE outgoing live-channel frame; `team-agent-client.ts` reads
  every field of the `live-sessions` message off `shared`, nothing from the raw snapshot.
- **ci(project-add)** `02e1cb0` — a fork's PR reaches the board instead of a red X it cannot avoid
  (#296). `pull_request_target` runs in the base repo's context, where the secret exists.
- **test(release)** `a294002` — enforce the terminating git-log read so the dropped-commit bump
  cannot return (#289, refs #248), plus the last `--pretty=format:` in the repo switched to
  `tformat:`.

## The privacy fix, stated precisely

The member→central reverse channel filtered its session ids and its processes through the
connection's sharing rules and then sent `sessionActivities` **unfiltered** beside them — enough to
count a hidden project's sessions and watch them work. The fix belongs in `share-rules.ts` and not
at the call site: the sharing semantics live in one module, so the next field added to that message
cannot repeat it. Activities are judged key by key by the same predicate the ids are, deliberately
not by intersecting with the filtered id list.

Verified: reverting only `share-rules.ts` to its pre-fix state fails 7 tests, including the
enumerated one that walks the result's own keys and asserts neither the denied session's id nor its
repo path appears in any of them.

## Version

`ci` + `fix` + `test`, no `feat`, no breaking footer → **patch**. 2.6.0 → 2.6.1.

## Review

All three were reviewed before merge and carry known follow-up nits, none blocking:

- #296 — `types:` omits `reopened`; `permissions: contents: read` could be `permissions: {}` (the
  repo's default workflow token is already read-only, so the commit message's "drops the elevated
  default" is inaccurate); the action is pinned to a mutable tag (pre-existing — the `issues`
  trigger already exposed the same PAT).
- #289 — the bash-default guard (rule 2) is anchored to line-start `BUMP=`, so `BUMP=${BUMP:-patch}`
  and `echo "bump=patch" >> $GITHUB_OUTPUT` evade it; the shell half of rule 1 is a hardcoded
  three-file list rather than a directory walk, so `packages/server/scripts/*.sh` and `.husky/*` are
  unscanned.
- #288 — the "one function decides the whole frame" invariant is a comment, not a test: the
  enumeration covers `filterLiveShared`'s result, not the frame literal in `team-agent-client.ts`.

Two open PRs were deliberately NOT included: #295 (two fixes outstanding — a band-stripped `meta`
reused inside `CardModal`, and copy pointing at a resume command that cannot work for Gemini) and
#292 (request changes — the cockpit kills the holder before the not-installed guard, and the probe
reads the agentop process's PATH rather than the tmux server's).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CUVhjYkcjA1C5dypE7KYJY
