### PR TITLE
fix(cli): agentop upgrade downloads the version it announced, not the rolling flag

### DIFF
--- a/packages/server/server/upgrade.test.ts
+++ b/packages/server/server/upgrade.test.ts
@@ -21,23 +21,52 @@ import {
 // arm64 box replaces a working binary with one the kernel cannot exec.
 
 test('only the platform/arch pairs the release workflow publishes are self-installable', () => {
-  expect(resolveUpgradeAsset('linux', 'x64')).toEqual({
+  expect(resolveUpgradeAsset('linux', 'x64', '2.5.0')).toEqual({
     asset: 'agentop',
-    url: 'https://github.com/blpsoares/agentistics/releases/latest/download/agentop',
+    url: 'https://github.com/blpsoares/agentistics/releases/download/v2.5.0/agentop',
   })
-  expect(resolveUpgradeAsset('win32', 'x64')).toEqual({
+  expect(resolveUpgradeAsset('win32', 'x64', '2.5.0')).toEqual({
     asset: 'agentop.exe',
-    url: 'https://github.com/blpsoares/agentistics/releases/latest/download/agentop.exe',
+    url: 'https://github.com/blpsoares/agentistics/releases/download/v2.5.0/agentop.exe',
   })
 })
 
+// The whole bug: the command printed "Latest: v2.5.0" and then downloaded through GitHub's rolling
+// "Latest" FLAG, which a later release had taken without publishing the asset. Measured on the real
+// repo (2026-09-02): the flag URL answered 404 while the version-addressed one answered 206.
+test('the URL is addressed by VERSION, never by the rolling latest flag', () => {
+  for (const [platform, arch] of [['linux', 'x64'], ['win32', 'x64']] as const) {
+    const t = resolveUpgradeAsset(platform, arch, '1.23.1')!
+    expect(t.url).toContain('/releases/download/v1.23.1/')
+    expect(t.url).not.toContain('/releases/latest/download')
+  }
+})
+
+test('the URL carries the version it was GIVEN — never a default', () => {
+  // An upgrade that announces one version and fetches another is the failure this signature exists
+  // to make impossible, so `version` is required rather than optional.
+  expect(resolveUpgradeAsset('linux', 'x64', '9.9.9')!.url)
+    .toBe('https://github.com/blpsoares/agentistics/releases/download/v9.9.9/agentop')
+  expect(resolveUpgradeAsset('linux', 'x64', '1.0.0')!.url).toContain('/v1.0.0/')
+})
+
+test('the tag prefix is added once — the API reports a version, the tag is v<version>', () => {
+  expect(resolveUpgradeAsset('linux', 'x64', '2.6.1')!.url).toContain('/v2.6.1/')
+  expect(resolveUpgradeAsset('linux', 'x64', '2.6.1')!.url).not.toContain('/vv2.6.1/')
+})
+
+test('an unsupported platform is still refused whatever the version', () => {
+  // The platform gate runs BEFORE any download; a version can never talk it into one.
+  expect(resolveUpgradeAsset('darwin', 'arm64', '2.5.0')).toBeNull()
+})
+
 test('unsupported platform/arch combinations are refused', () => {
-  expect(resolveUpgradeAsset('linux', 'arm64')).toBeNull()   // Raspberry Pi / Ampere VM
-  expect(resolveUpgradeAsset('linux', 'arm')).toBeNull()
-  expect(resolveUpgradeAsset('darwin', 'arm64')).toBeNull()  // no macOS asset at all
-  expect(resolveUpgradeAsset('darwin', 'x64')).toBeNull()
-  expect(resolveUpgradeAsset('win32', 'arm64')).toBeNull()
-  expect(resolveUpgradeAsset('freebsd', 'x64')).toBeNull()
+  expect(resolveUpgradeAsset('linux', 'arm64', '2.5.0')).toBeNull()   // Raspberry Pi / Ampere VM
+  expect(resolveUpgradeAsset('linux', 'arm', '2.5.0')).toBeNull()
+  expect(resolveUpgradeAsset('darwin', 'arm64', '2.5.0')).toBeNull()  // no macOS asset at all
+  expect(resolveUpgradeAsset('darwin', 'x64', '2.5.0')).toBeNull()
+  expect(resolveUpgradeAsset('win32', 'arm64', '2.5.0')).toBeNull()
+  expect(resolveUpgradeAsset('freebsd', 'x64', '2.5.0')).toBeNull()
 })
 
 // --- download verification --------------------------------------------------

--- a/packages/server/server/upgrade.ts
+++ b/packages/server/server/upgrade.ts
@@ -9,7 +9,24 @@ import { AGENTISTICS_DATA_DIR } from './config.ts'
 import { cliStrings, type CliLang, type CliStrings } from './cli-i18n.ts'
 
 const GITHUB_REPO = 'blpsoares/agentistics'
-const RELEASE_BASE = `https://github.com/${GITHUB_REPO}/releases/latest/download`
+/**
+ * Where a release asset lives, addressed BY VERSION.
+ *
+ * It used to be `.../releases/latest/download`, which resolves through GitHub's rolling "Latest"
+ * FLAG rather than through the version this command just resolved and printed. Those are different
+ * things: the flag moves to whichever release GitHub considers latest, and a release that takes it
+ * without publishing the `agentop` asset makes the download 404 — while the announced version's
+ * binary sits there, present and unreachable.
+ *
+ * Measured on the real repo (linux/x64, 2026-09-02): the flag-addressed URL answered **404** while
+ * `.../releases/download/v2.5.0/agentop` answered **206**. The command printed "Latest: v2.5.0" and
+ * then failed to download v2.5.0 — the one thing an upgrade must never do is announce a version it
+ * is not fetching.
+ */
+function releaseAssetUrl(version: string, asset: string): string {
+  // The tag is `v<version>`; `version` arrives from the releases API without the prefix.
+  return `https://github.com/${GITHUB_REPO}/releases/download/v${version}/${asset}`
+}
 /** Where a user goes when self-install is refused (unsupported platform/arch). */
 export const RELEASES_PAGE = `https://github.com/${GITHUB_REPO}/releases`
 
@@ -46,11 +63,19 @@ export interface UpgradeTarget {
   url: string
 }
 
-/** Pure: the asset for a platform/arch pair, or null when self-install is not supported. */
-export function resolveUpgradeAsset(platformId: string, arch: string): UpgradeTarget | null {
+/**
+ * Pure: the asset for a platform/arch pair at a GIVEN VERSION, or null when self-install is not
+ * supported there.
+ *
+ * `version` is required rather than optional. An optional one would default to the rolling flag
+ * for any caller that forgot it, which is the defect this signature exists to make impossible —
+ * and both callers (the manual command and the unattended path) already hold the version they
+ * resolved.
+ */
+export function resolveUpgradeAsset(platformId: string, arch: string, version: string): UpgradeTarget | null {
   const key = `${platformId}/${arch}`
-  if (key === 'linux/x64') return { asset: 'agentop', url: `${RELEASE_BASE}/agentop` }
-  if (key === 'win32/x64') return { asset: 'agentop.exe', url: `${RELEASE_BASE}/agentop.exe` }
+  if (key === 'linux/x64') return { asset: 'agentop', url: releaseAssetUrl(version, 'agentop') }
+  if (key === 'win32/x64') return { asset: 'agentop.exe', url: releaseAssetUrl(version, 'agentop.exe') }
   return null
 }
 
@@ -87,10 +112,12 @@ export function verifyDownload(
 /**
  * Pure: does `agentop --version` output prove this binary is the release we expect?
  *
- * `>=` rather than `===` on purpose: the download URL points at the ROLLING `latest` release,
- * which is republished on every build, so it can legitimately be one bump ahead of the newest
- * version listed by the releases API. An OLDER (or unparseable) version means we downloaded
- * the wrong thing and must not install it.
+ * `>=` rather than `===`, and the reason CHANGED when the download URL stopped going through
+ * GitHub's rolling "Latest" flag: it used to be that the flag could legitimately be one bump ahead
+ * of the releases API. A version-addressed URL cannot be ahead of the version it names, so `>=` is
+ * now only a tolerance — an asset republished under its own tag after a rebuild still passes. An
+ * OLDER (or unparseable) version still means we downloaded the wrong thing and must not install
+ * it, which is the check that actually matters.
  */
 export function checkBinaryVersionOutput(
   out: string,
@@ -479,8 +506,11 @@ export function isInstalledBinary(execPath: string, scriptPath: string | undefin
 export async function startBackgroundUpgrade(version: string): Promise<BackgroundUpgradeResult> {
   // Never self-install over a dev checkout's runtime — see isInstalledBinary.
   if (!isInstalledBinary(process.execPath, process.argv[1])) return 'not-installed'
-  // No published asset for this platform/arch → an unattended install would brick it.
-  if (!resolveUpgradeAsset(process.platform, process.arch)) return 'unsupported'
+  // No published asset for this platform/arch → an unattended install would brick it. The version
+  // is threaded through here too, not just on the manual path: `runUpgrade` is what actually
+  // downloads, and both share it, so a gate that resolved a different URL from the one about to be
+  // fetched would be checking the wrong thing.
+  if (!resolveUpgradeAsset(process.platform, process.arch, version)) return 'unsupported'
   // A previously failing target backs off instead of re-downloading on every shell.
   if (!shouldAttemptUpgrade(readUpgradeFailure(), version, Date.now())) return 'backoff'
 
@@ -656,7 +686,7 @@ export async function runUpgrade(lang: CliLang = 'en'): Promise<number> {
   stampUpgradeLock(info.latest)
 
   // Platform/arch gate — refuse BEFORE downloading anything.
-  const target = resolveUpgradeAsset(process.platform, process.arch)
+  const target = resolveUpgradeAsset(process.platform, process.arch, info.latest)
   if (!target) {
     const id = `${process.platform}/${process.arch}`
     process.stderr.write(
@@ -686,8 +716,15 @@ export async function runUpgrade(lang: CliLang = 'en'): Promise<number> {
   }
 
   if (!resp.ok) {
-    console.error(`Download failed: HTTP ${resp.status}`)
-    recordUpgradeFailure(info.latest, `download failed: HTTP ${resp.status}`)
+    // A 404 on a VERSION-addressed URL is a different fact from a network failure, and now that
+    // the URL names a version it can say which one: the release exists but this platform's asset
+    // was not published for it. Naming both is what makes a missing binary reportable instead of
+    // looking like a broken connection.
+    const detail = resp.status === 404
+      ? `HTTP 404 — release v${info.latest} has no ${target.asset} asset`
+      : `HTTP ${resp.status}`
+    console.error(`Download failed: ${detail}`)
+    recordUpgradeFailure(info.latest, `download failed: ${detail}`)
     return 1
   }
 


### PR DESCRIPTION
## Summary

`agentop upgrade` announced one version and downloaded a different release. It printed
"Latest: v2.5.0" and then fetched `…/releases/latest/download/agentop`, which resolves through
GitHub's rolling **"Latest" flag** — so when a later release took that flag without publishing the
`agentop` asset, the download 404'd while the announced version's binary sat there, present and
unreachable.

The URL is now built from the version the command already resolved:
`…/releases/download/v<version>/<asset>`.

## Motivation

The two halves of one command disagreed about which release they meant, and the code says so on
both sides. `resolveLatestRelease` (`version.ts`) **deliberately ignores** the rolling release — its
own comment notes the repo publishes a non-semver `latest` tag, and `toSemver` drops it — so the
resolver always meant the newest *semver* release. The downloader always meant the *flag*. One of
them had to be wrong, and it was the one doing the fetching.

This blocks real work: the machine-side consent switch for central session management
(#307) ships in the binary, so a machine that cannot upgrade cannot turn the feature on at all.

Closes #290

## Test plan

- `bun tsc --noEmit` clean; `bun test` **4837 pass, 0 fail** across 280 files.
- Five unit tests on `resolveUpgradeAsset`: the exact URLs, a pin that it is addressed by version
  and **never** contains `/releases/latest/download`, that the version given is the version used,
  that the `v` prefix is added exactly once, and that the platform gate still refuses whatever the
  version.
- **Measured against the real repo** (linux/x64):
  - 2026-09-02, when the Issue was filed: flag URL **404**, `v2.5.0` URL **206**.
  - 2026-09-03, checked again while writing this: the flag has since been restored and both answer
    **206** — it now redirects to a release tagged literally `latest`, which currently carries the
    asset. The fix is not "restore the flag"; it is that the command must not depend on a flag it
    does not control and that its own version resolver ignores.
  - The version-addressed URL for the version the resolver picks (`v2.6.1`) answers **206**, so the
    fixed path works against the repo as it stands today.

## What is untouched

Every safety gate: `MIN_BINARY_BYTES`, `looksLikeExecutable`, `verifyDownload`, the platform/arch
pre-download refusal, and the failure backoff. `checkBinaryVersionOutput` keeps `>=`, but its
rationale changed and the comment now records why.

## Does anyone have to do anything by hand?

**No.** Measured 2026-09-03: the flag URL answers **206** with the full 92.624.072-byte asset, so
`agentop upgrade` works for everyone right now. The fix distributes itself through the very
mechanism it repairs, while that mechanism is still standing: people upgrade normally today, land
on a binary that no longer depends on the flag, and are immune the next time it breaks.

The manual fetch below is **only** for an installation caught during a window when the flag is
broken — the state this repo was in on 2026-09-02, and is not in today:

```
curl -fL -o ~/.local/bin/agentop \
  https://github.com/blpsoares/agentistics/releases/download/v<version>/agentop
chmod +x ~/.local/bin/agentop
```

That is the argument for merging this sooner rather than later: it has to ship while the flag is
working, or it cannot reach the people it protects.

## Out of scope

Per #290: the desktop updater / `latest.json`, and the CI-runner
`curl …/releases/latest/download/agentop` example in `docs/cli.md` — same fragility on different
surfaces, tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uc7HqjasyYjw2AfX3g93pa
