### PR TITLE
release: the mobile chat composer is on the screen again

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -2573,7 +2573,17 @@ export default function AppLayout() {
 
   return (
     <div style={{
-      minHeight: '100vh',
+      // `min-height` is NOT set in the sessions workspace, and that is the whole fix.
+      //
+      // CSS resolves `min-height` AFTER `height`, so a `min-height: 100vh` beats any smaller
+      // `height` — the column below asked for `calc(100dvh - var(--mobile-nav-h))` (608px on an
+      // iPhone 12) and computed 664px anyway, because this line said it may never be shorter than
+      // the full window. The composer sits at the bottom of that column, so those 56 lost pixels
+      // put it exactly underneath the fixed bottom nav: rendered, inside the viewport, and covered.
+      // Measured before the fix — input at 606-642, nav starting at 608.
+      //
+      // Everywhere else it stays, because a short page still has to fill the window.
+      ...(inSessionsWorkspace ? {} : { minHeight: '100vh' }),
       // The REAL cause of the session pane's header/composer "scrolling away" and landing at the
       // wrong spot: `<main>` below sets an explicit `height` for the sessions workspace, but a flex
       // item with `flex: 1 1 0%` computes its used size from the flex algorithm, not from its own
@@ -2583,7 +2593,26 @@ export default function AppLayout() {
       // bottom" call landed on an inner div that never actually had room to scroll. `position:
       // sticky` on the header/composer masked the visual symptom (they still track the PAGE's own
       // scroll) without fixing the underlying non-clipping — this fixes it at the source instead.
-      height: inSessionsWorkspace ? '100vh' : undefined,
+      // MOBILE GETS `dvh`, AND SUBTRACTS THE FIXED BOTTOM NAV — the desktop `100vh` is wrong on a
+      // phone twice over, and `<main>` below could not rescue it.
+      //
+      // `<main>` already asks for `calc(100dvh - var(--mobile-nav-h))`, which is the right figure.
+      // It never got it: `<main>` is `flex: 1 1 0%` inside THIS div, and a flex item's main-axis
+      // size comes from the flex algorithm distributing its CONTAINER's height, not from its own
+      // `height` — the very rule this comment block was written to record. So the child's careful
+      // arithmetic was overridden by the parent's `100vh`, and `100vh` on a phone is (a) taller
+      // than the visible area, because it does not shrink for the browser's collapsing URL bar,
+      // and (b) measured to the window's bottom edge, under the fixed 56px-plus-inset nav.
+      //
+      // The composer sits at the bottom of that column, so it was pushed below the fold and behind
+      // the nav — reported as "the input does not appear at all", with the conversation unable to
+      // scroll because the scrolling box never had a bounded height to scroll within.
+      //
+      // Fixing it HERE rather than on `<main>` is the point: the container is what the flex
+      // algorithm reads.
+      height: inSessionsWorkspace
+        ? (isMobile ? 'calc(100dvh - var(--mobile-nav-h))' : '100vh')
+        : undefined,
       background: 'var(--bg-base)', display: 'flex', flexDirection: 'column',
       paddingLeft: isMobile ? 0 : (sidebarCollapsed ? SIDEBAR_W_COLLAPSED : liveAsideWidth),
       paddingTop: isMobile ? 0 : TOPBAR_H,
@@ -3028,7 +3057,10 @@ export default function AppLayout() {
               // bar is NOT rendered in this workspace — see the header's own condition. While it
               // was, root content exceeded the viewport by that bar's height, the PAGE scrolled,
               // and the session's own header scrolled away with it.
-              height: isMobile ? 'calc(100dvh - var(--mobile-nav-h))' : `calc(100vh - ${TOPBAR_H}px)`,
+              // On MOBILE this fills the parent, which already subtracts the fixed nav (see the
+              // root's own note) — repeating the arithmetic here is what let the two disagree.
+              // Desktop still subtracts its own fixed top strip, which the root does not know about.
+              height: isMobile ? undefined : `calc(100vh - ${TOPBAR_H}px)`,
               minHeight: 0,
               display: 'flex', flexDirection: 'column', overflow: 'hidden',
             }

--- a/packages/web/src/pages/SessionsPage.tsx
+++ b/packages/web/src/pages/SessionsPage.tsx
@@ -18,7 +18,7 @@
  */
 
 import { useNavigate, useOutletContext, useParams, useSearchParams } from 'react-router-dom'
-import { ChevronLeft } from 'lucide-react'
+import { ChevronLeft, MessagesSquare, TerminalSquare } from 'lucide-react'
 import type { AppContext } from '../lib/app-context'
 import { useFleet, useFleetIndex } from '../lib/fleet'
 import { useIsMobile } from '../hooks/useIsMobile'
@@ -26,6 +26,7 @@ import { FleetOverview } from '../components/sessions/FleetOverview'
 import { FiltersBar } from '../components/FiltersBar'
 import { SessionPanel, type SessionView } from '../components/sessions/SessionPanel'
 import { SessionsAside } from '../components/nav/SessionsAside'
+import { SessionActions } from '../components/sessions/SessionActions'
 
 export default function SessionsPage() {
   const ctx = useOutletContext<AppContext>()
@@ -71,9 +72,11 @@ export default function SessionsPage() {
       theme={theme === 'light' ? 'light' : 'dark'}
       act={act}
       onGone={() => navigate('/sessions')}
-      // Only on desktop: mobile keeps its own self-contained header (see SessionPanel's module
-      // doc) since the shared one is hidden there for lack of room.
-      {...(isMobile ? {} : { view: sessionView, onViewChange: setSessionView })}
+      // CONTROLLED on both layouts now. Passing `onViewChange` is what suppresses SessionPanel's
+      // own header, and mobile draws the same three things in the row that already holds the back
+      // button — one bar instead of two stacked ones saying overlapping things.
+      view={sessionView}
+      onViewChange={setSessionView}
     />
   )
 
@@ -81,24 +84,100 @@ export default function SessionsPage() {
   // Mobile: one column at a time.
   // ---------------------------------------------------------------------------
   if (isMobile) {
-    if (panel) {
+    if (panel && selected) {
       return (
         <div style={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0 }}>
-          <button
-            onClick={() => navigate('/sessions')}
-            style={{
-              display: 'flex', alignItems: 'center', gap: 6,
-              // 44px: this is the mobile figure, and it is the only way back from this screen.
-              minHeight: 44, padding: '0 14px', flexShrink: 0,
-              border: 'none', borderBottom: '1px solid var(--border)',
-              background: 'var(--bg-surface)', color: 'var(--text-secondary)',
-              fontFamily: 'inherit', fontSize: 13, fontWeight: 600, cursor: 'pointer',
-            }}
-          >
-            <ChevronLeft size={16} />
-            {pt ? 'Sessões' : 'Sessions'}
-          </button>
-          <div style={{ flex: 1, minHeight: 0 }}>{panel}</div>
+          {/* ONE bar. It used to be two: this back row, and SessionPanel's own header directly
+              under it carrying the title, the tabs and the verbs. On a 390px screen that spent
+              ~100px of a 664px viewport on chrome before a single message — and the back arrow
+              already says where you are, so the word beside it was the least useful thing there.
+              The arrow keeps its own 44px target; the title takes the room the label gave up. */}
+          <div style={{
+            display: 'flex', alignItems: 'center', gap: 8,
+            minHeight: 44, padding: '0 10px', flexShrink: 0,
+            borderBottom: '1px solid var(--border)', background: 'var(--bg-surface)',
+          }}>
+            <button
+              onClick={() => navigate('/sessions')}
+              aria-label={pt ? 'Voltar para as sessões' : 'Back to sessions'}
+              style={{
+                display: 'flex', alignItems: 'center', justifyContent: 'center',
+                // 44px is the mobile figure, and this is the only way back from this screen.
+                width: 44, height: 44, flexShrink: 0, marginLeft: -6,
+                border: 'none', background: 'transparent', color: 'var(--text-secondary)',
+                cursor: 'pointer',
+              }}
+            >
+              <ChevronLeft size={20} />
+            </button>
+
+            <div style={{ minWidth: 0, flex: 1, display: 'flex', flexDirection: 'column' }}>
+              <span style={{
+                fontSize: 13, fontWeight: 650, color: 'var(--text-primary)',
+                overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+              }}>
+                {selected.title}
+              </span>
+              {/* The state stays, on its own line: it is the one fact that changes while you read,
+                  and the row below is a conversation that does not repeat it. */}
+              <span style={{
+                fontSize: 10.5, color: 'var(--text-tertiary)',
+                overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+              }}>
+                {selected.stateLabel}
+                {selected.project ? ` · ${selected.project}` : ''}
+              </span>
+            </div>
+
+            {/* Icons only — the words "Chat" and "Terminal" beside a title on a 390px screen push
+                the title to about six characters. The `aria-label` carries the name. */}
+            {selected.conversationBlind === undefined && (
+              <div role="tablist" style={{
+                display: 'flex', gap: 2, padding: 2, borderRadius: 9, flexShrink: 0,
+                background: 'var(--bg-elevated)', border: '1px solid var(--border-subtle)',
+              }}>
+                {([
+                  ['chat', <MessagesSquare key="c" size={15} />, pt ? 'Conversa' : 'Chat'],
+                  ['terminal', <TerminalSquare key="t" size={15} />, 'Terminal'],
+                ] as const).map(([id, icon, label]) => (
+                  <button
+                    key={id}
+                    role="tab"
+                    aria-selected={sessionView === id}
+                    aria-label={label}
+                    onClick={() => setSessionView(id)}
+                    style={{
+                      display: 'flex', alignItems: 'center', justifyContent: 'center',
+                      width: 38, height: 34, borderRadius: 7, border: 'none', cursor: 'pointer',
+                      background: sessionView === id ? 'var(--bg-surface)' : 'transparent',
+                      color: sessionView === id ? 'var(--anthropic-orange)' : 'var(--text-tertiary)',
+                    }}
+                  >
+                    {icon}
+                  </button>
+                ))}
+              </div>
+            )}
+
+            {rowIndex.get(selected.id) && (
+              <SessionActions
+                row={rowIndex.get(selected.id)!}
+                lang={pt ? 'pt' : 'en'}
+                act={act}
+                onGone={() => navigate('/sessions')}
+              />
+            )}
+          </div>
+          {/* `display: flex` is the load-bearing part, not `flex: 1`.
+              This div had `flex: 1, minHeight: 0` and no display, so it was a BLOCK. Its child —
+              SessionPanel's own `flex: 1 1 0%` column — was therefore not a flex item at all, and
+              a block child ignores its parent's height and grows to its content. Measured on an
+              iPhone 12 viewport: this div sat at the correct 620px while the panel inside it was
+              40.319px tall, which put the composer 40.305px down the page. The input was not
+              hidden — it was rendered far below the fold, and the conversation could not scroll
+              because the box that was supposed to scroll had no bounded height to scroll within.
+              `flex: 1` on a child means nothing until its PARENT is a flex container. */}
+          <div style={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column' }}>{panel}</div>
         </div>
       )
     }


### PR DESCRIPTION
## Summary

One fix: on a phone, the chat composer was not on the screen and the conversation would not scroll.

Ships as its own release because it is only reachable from a released build — the whole point is
what a phone renders, and the previous release (v2.7.0) has the broken layout.

## Motivation

Reported from a phone right after v2.7.0: "o input não aparece". It was never hidden — it was
rendered 40.305px down a page that had no business being that tall, and the box meant to scroll had
no bounded height to scroll within.

Three defects stacked (#310): a `display: block` wrapper that broke the flex chain, a
`min-height: 100vh` that beat the height making room for the fixed bottom nav, and two stacked
header bars spending ~100px of a 664px viewport before a single message.

## Test plan

- `bun tsc --noEmit` clean; `bun test packages/web` 1098 pass, 0 fail.
- Driven in a real mobile browser on **iPhone 12, Pixel 5 and iPhone SE**, against the branch's own
  server: input visible and not behind the nav, exactly one header, the page itself does not
  scroll, no horizontal overflow, the composer holds position while the conversation scrolls, and
  typing works.
- CI green on #310 before merge.

## Still open, carried forward

Unchanged from the v2.7.0 notes: the harness filter in the Sessions bar is unfinished (the
repository half is fixed and tested), the memory fix is the caller-side half only, and Phase 4 of
central session management (screens, and with them `approve`/`prompt`) is deliberately absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uc7HqjasyYjw2AfX3g93pa
