### PR TITLE
fix(web): the Sessions harness filter offers only what the fleet can show

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -1501,7 +1501,7 @@ export default function AppLayout() {
    * "nothing" is indistinguishable from one that is failing, and it was reported as exactly that.
    * An option is a promise that something might be behind it.
    */
-  const fleetOptions = useMemo(() => fleetFilterOptions(headerFleet.rows), [headerFleet.rows])
+  const fleetOptions = useMemo(() => fleetFilterOptions(headerFleet.rows, activeOnly), [headerFleet.rows, activeOnly])
   const headerFleetIndex = useFleetIndex(headerFleet.sessions)
   const selectedFleetSession = inSessionsWorkspace && selectedSessionId !== undefined
     ? headerFleet.rows.find(r => r.id === selectedSessionId || r.conversationId === selectedSessionId)
@@ -2771,12 +2771,7 @@ export default function AppLayout() {
                   modelGroups={modelGroups}
                   modelsInProject={modelsInProject}
                   users={usersWithMachines}
-                  // HARNESSES come from the FLEET in the Sessions workspace and from the metrics
-                  // everywhere else. The bar offered all six the metrics know while the list it
-                  // filters held three, so picking "antigravity" emptied it — not a broken filter,
-                  // but indistinguishable from one. Projects and models stay on the metrics list
-                  // deliberately: `matchesProject` accepts a row's name, its group OR its path.
-                  harnesses={inSessionsWorkspace ? (fleetOptions.harnesses as typeof availableHarnesses) : availableHarnesses}
+                  harnesses={availableHarnesses}
                   presence={data?.presence}
                   lang={lang}
                   compact
@@ -2882,7 +2877,22 @@ export default function AppLayout() {
                 modelGroups={modelGroups}
                 modelsInProject={modelsInProject}
                 users={usersWithMachines}
-                harnesses={availableHarnesses}
+                // HARNESSES come from the FLEET here and from the metrics everywhere else. The bar
+                // offered all six the metrics know while the list it filters holds whatever is
+                // running — three on this machine — so picking "antigravity" emptied the list.
+                // Nothing was broken; there were genuinely no antigravity rows. But a filter that
+                // can only ever answer "nothing" is indistinguishable from one that is failing,
+                // and it was reported as exactly that. An option is a promise that something might
+                // be behind it.
+                //
+                // This is the SECOND FiltersBar in this file. The first one (inside the collapsible
+                // block above) is the dashboard's; an earlier attempt put the override there and
+                // changed nothing on screen, which is how a fix can be written, typechecked, tested
+                // and still be in the wrong place. Verified in a browser this time.
+                //
+                // Projects and models stay on the metrics list deliberately: `matchesProject`
+                // accepts a row's name, its group OR its path, so those chips do find fleet rows.
+                harnesses={inSessionsWorkspace ? (fleetOptions.harnesses as typeof availableHarnesses) : availableHarnesses}
                 presence={data?.presence}
                 lang={lang}
                 teams={teamsList}

--- a/packages/web/src/lib/fleetFilter.test.ts
+++ b/packages/web/src/lib/fleetFilter.test.ts
@@ -166,3 +166,33 @@ describe('fleetFilterOptions', () => {
     expect(fleetFilterOptions(rows).repos).toEqual(['a/a', 'z/b'])
   })
 })
+
+describe('fleetFilterOptions — the activeOnly promise', () => {
+  const rows = [
+    repoRow('a', 'o/a', { harness: 'claude', state: 'working' }),
+    repoRow('b', 'o/b', { harness: 'codex', state: 'closed' }),
+  ]
+
+  it('offers only harnesses the CURRENT view can show', () => {
+    // With the switch on — how this workspace opens — a harness whose rows are all closed is
+    // withheld from the list, so picking it cannot empty it. Measured on a real machine: codex and
+    // copilot each had exactly one row, both closed, and both were offered.
+    expect(fleetFilterOptions(rows, true).harnesses).toEqual(['claude'])
+  })
+
+  it('brings them back when the switch is off', () => {
+    // The options are re-derived from the rows the switch stops withholding — nothing to remember.
+    expect(fleetFilterOptions(rows, false).harnesses).toEqual(['claude', 'codex'])
+    expect(fleetFilterOptions(rows).harnesses).toEqual(['claude', 'codex'])
+  })
+
+  it('withholds that harness\'s repos and models too, not just its name', () => {
+    const mixed = [
+      repoRow('a', 'o/live', { harness: 'claude', state: 'working', model: 'opus' }),
+      repoRow('b', 'o/dead', { harness: 'codex', state: 'exited', model: 'gpt' }),
+    ]
+    const o = fleetFilterOptions(mixed, true)
+    expect(o.repos).toEqual(['o/live'])
+    expect(o.models).toEqual(['opus'])
+  })
+})

--- a/packages/web/src/lib/fleetFilter.ts
+++ b/packages/web/src/lib/fleetFilter.ts
@@ -119,7 +119,23 @@ function matchesProject(r: ControlSession, projects: ReadonlySet<string>): boole
  * shapes for the same reason `matchesRepo` accepts both: the chip the user clicks may have come
  * from either vocabulary.
  */
-export function fleetFilterOptions(rows: readonly ControlSession[]): {
+export function fleetFilterOptions(
+  rows: readonly ControlSession[],
+  /**
+   * The fleet's own "only what is running" switch, applied BEFORE the options are collected.
+   *
+   * Without it the promise breaks one layer deeper, and it did: with the switch on — which is how
+   * this workspace opens — the bar still offered every harness in the whole fleet, including two
+   * whose rows were all `closed`. Picking one emptied the list again, for the same reason and with
+   * the same "the filter is broken" reading. Measured on this machine: codex and copilot each had
+   * exactly one row, both closed.
+   *
+   * An option has to promise what the CURRENT view can show, not what the fleet contains in the
+   * abstract. Turning the switch off brings those harnesses back by itself, because the options
+   * are re-derived from the rows it stops withholding.
+   */
+  activeOnly = false,
+): {
   harnesses: string[]
   repos: string[]
   projects: string[]
@@ -130,6 +146,7 @@ export function fleetFilterOptions(rows: readonly ControlSession[]): {
   const projects = new Set<string>()
   const models = new Set<string>()
   for (const r of rows) {
+    if (activeOnly && !ACTIVE.has(r.state)) continue
     if (r.harness) harnesses.add(r.harness)
     if (r.repo) repos.add(r.repo)
     if (r.project) projects.add(r.project)


### PR DESCRIPTION
## Summary

The Sessions filter bar offered harnesses the list could never show. Picking one emptied it, which
is indistinguishable from a broken filter — and was reported as exactly that.

## Motivation

Two mistakes, and the first is mine twice over.

**It was applied to the wrong component.** There are two `<FiltersBar>` calls in `App.tsx`; the
earlier attempt went to the first, which is the dashboard's, while the Sessions workspace renders
the second. It typechecked, it tested, it read correctly, and it changed nothing on screen — which
is why #307 carried it as "unfinished, still showing six at the last check" rather than as done.

**Then the same promise broke one layer deeper.** With the options derived from the whole fleet, the
bar still offered every harness the machine had ever run — including two whose rows were ALL
`closed` — while the list opens with "Active only" ON. Measured here: codex and copilot had exactly
one row each, both closed.

So `fleetFilterOptions` now takes `activeOnly` and collects from the rows the CURRENT view can show.
An option has to promise what is behind it now, not what the fleet contains in the abstract.

## Test plan

- `bun tsc --noEmit` clean; `bun test` **5151 pass, 0 fail** across 309 files.
- Three new unit tests on the `activeOnly` narrowing, including that a withheld harness takes its
  repos and models with it.
- **Driven in a real browser** (the MCP browser was unavailable, so the repo's own `playwright`
  package was used directly) — the two states, both verified:
  - Active only ON → only claude is running, so the Harnesses dimension is not offered at all
    (`FiltersBar` already hides a filter with one option).
  - Active only OFF → Harnesses returns, listing exactly claude, codex, copilot — the fleet's three.
- Neither state offers a value that resolves to an empty list, which is the point.

## What is deliberately NOT in this PR

The second half of the memory work — a floor on how often the `data.ts` cache may start a
background rebuild — was written, tested and then **removed**, because I could not measure any
benefit from it:

| store | with floor | without |
|---|---|---|
| 846 MB, 1.328 files | 15s CPU / 60s | 16s CPU / 60s |
| 7,4 MB, 6 files | 9,74s CPU / 40s | 10,16s CPU / 40s |

The existing `_revalidating` guard already serialises rebuilds, and in both harnesses the CPU was
dominated by other periodic work (the 5s fleet poll runs `tmux capture-pane` per session), so the
rebuild rate could not be isolated. The caller-side half — the live-report loop that was rebuilding
the whole corpus every 8 seconds — shipped in #307 and was measured to matter. Shipping a second
change I cannot show a benefit for would be guessing with a commit message attached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uc7HqjasyYjw2AfX3g93pa
