### PR TITLE
fix(web): the top bar sat under the iPhone status bar, and a central said the wrong thing

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -2689,6 +2689,10 @@ export default function AppLayout() {
         // Beneath the fixed strip, never at the viewport top: one is window chrome and the other is
         // page chrome, and neither may slide under the other.
         top: isMobile ? 0 : TOPBAR_H,
+        // The status-bar band belongs to the BAR, not to the page under it: the header's own
+        // background and blur run up behind the clock, and its content starts below. Zero in a
+        // browser tab — see `--safe-top`.
+        ...(isMobile ? { paddingTop: 'var(--safe-top)' } : {}),
         zIndex: 100,
         backdropFilter: 'blur(12px)',
         WebkitBackdropFilter: 'blur(12px)',

--- a/packages/web/src/components/nav/SessionsAside.tsx
+++ b/packages/web/src/components/nav/SessionsAside.tsx
@@ -430,8 +430,8 @@ function EmptyReason({
     ? (pt ? 'Lendo as sessões desta máquina…' : 'Reading this machine’s sessions…')
     : unsupported
       ? (pt
-          ? 'Esta instalação não pode listar sessões — um central agrega várias máquinas e não hospeda as sessões de nenhuma delas.'
-          : 'This install cannot list sessions — a central aggregates many machines and hosts none of their sessions.')
+          ? 'Um central agrega várias máquinas e não hospeda as sessões de nenhuma delas, então esta lista está sempre vazia aqui. Para ver as sessões de uma máquina, abra Configurações → Máquinas e escolha a máquina — ela aparece lá se tiver liberado o acesso.'
+          : 'A central aggregates many machines and hosts none of their sessions, so this list is always empty here. To see a machine’s sessions, open Settings → Machines and pick the machine — it appears there if it has granted access.')
       : unavailable
         ? unavailable
         : filterNarrowed

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -216,6 +216,17 @@ html, body {
 :root {
   --mobile-nav-inset: env(safe-area-inset-bottom, 0px);
   --mobile-nav-h: calc(56px + var(--mobile-nav-inset));
+  /* The STATUS-BAR inset, and the twin of the one above.
+     Installed as a PWA the page owns the whole screen, so the topmost bar of every layout was
+     drawn UNDERNEATH the clock, the signal bars and the battery — ~47px on an iPhone 14 Pro. The
+     row was not merely ugly: the status bar takes the taps in that band, so the back arrow, the
+     chat/terminal tabs and the date presets could be seen and not pressed. In a browser tab the
+     inset is 0, which is why it only ever looked broken from the home screen — exactly how the
+     bottom inset hid for a release.
+     It is applied per topmost bar rather than to #root: a band on the root would push every
+     `position: sticky` offset down by the same amount and leave the bar's own background above it
+     transparent, which is the status bar showing the page's ground instead of the bar's. */
+  --safe-top: env(safe-area-inset-top, 0px);
 }
 
 .mobile-bottom-nav {

--- a/packages/web/src/pages/SessionsPage.tsx
+++ b/packages/web/src/pages/SessionsPage.tsx
@@ -41,7 +41,20 @@ export default function SessionsPage() {
 
   // Never on a central: it aggregates many machines and hosts none of their sessions, so the only
   // fleet it could read is its own box's, drawn under someone else's rows.
-  const { fleet, loading, unsupported, stale, act } = useFleet(pt ? 'pt' : 'en', !isCentral)
+  const { fleet, loading, unsupported: pollUnsupported, stale, act } = useFleet(pt ? 'pt' : 'en', !isCentral)
+  /**
+   * A CENTRAL cannot list a fleet, and must SAY so.
+   *
+   * `useFleet`'s second argument only stops the polling, and its `unsupported` is reported as false
+   * whenever polling is off — so on a central the page fell through every branch to "No sessions on
+   * this machine yet.", which is false twice over: a central hosts no sessions, and the machines'
+   * sessions it CAN reach are one screen away in Settings → Machines. The one sentence that would
+   * have said the true thing was switched off by the very flag that makes it true.
+   *
+   * The same N/A-versus-a-confident-0 rule the dashboard applies to harness capabilities: an empty
+   * list may never stand in for "this install cannot answer".
+   */
+  const unsupported = pollUnsupported || isCentral
   const rowIndex = useFleetIndex(fleet.sessions)
 
   // Matched on BOTH ids for the same reason `fleetIndex` is keyed on both: a managed row is named
@@ -95,6 +108,10 @@ export default function SessionsPage() {
           <div style={{
             display: 'flex', alignItems: 'center', gap: 8,
             minHeight: 44, padding: '0 10px', flexShrink: 0,
+            // Installed as a PWA this is the topmost thing on the screen, so it carries the
+            // status-bar band itself — without it the arrow and the tabs sat under the clock and
+            // the taps went to the status bar. See `--safe-top`.
+            paddingTop: 'var(--safe-top)',
             borderBottom: '1px solid var(--border)', background: 'var(--bg-surface)',
           }}>
             <button
@@ -189,7 +206,13 @@ export default function SessionsPage() {
             describe a live fleet row — `only` here matches the desktop Sessions call, minus the
             central-only dimensions (members/teams/machines/presence/tags) this workspace has never
             offered on either layout. */}
-        <div style={{ flexShrink: 0, borderBottom: '1px solid var(--border)', padding: '4px 8px' }}>
+        <div style={{
+          flexShrink: 0, borderBottom: '1px solid var(--border)', padding: '4px 8px',
+          // Same reason as the open-session bar above: the shared header is hidden on this layout,
+          // so this row IS the top of the screen and owns the status-bar band. The date presets
+          // were unpressable without it.
+          paddingTop: 'calc(4px + var(--safe-top))',
+        }}>
           <FiltersBar
             compact
             only={['harnesses', 'repos', 'projects', 'models']}


### PR DESCRIPTION
## Summary

Two things, both reported from a phone with screenshots.

**The top bar was under the iPhone status bar and could not be pressed.** `--mobile-nav-inset`
handled the home indicator; nothing handled the status bar. Installed as a PWA the page owns the
whole screen, so the topmost bar of every mobile layout was drawn underneath the clock, the signal
bars and the battery — and the status bar takes the taps in that band, so the back arrow, the
chat/terminal tabs and the date presets could be seen and not pressed. In a browser tab the inset
is 0, which is exactly how the bottom inset hid for a release too.

`--safe-top` is applied per topmost bar — the shared sticky header, the Sessions list's own filter
row, the open-session bar — rather than to `#root`: a band on the root would push every
`position: sticky` offset down by the same amount and leave the strip above the bar transparent,
which is the status bar showing the page's ground instead of the bar's.

**A central claimed to be a machine.** `useFleet`'s second argument only stops the polling, and its
`unsupported` is reported false whenever polling is off (`unsupported: enabled ? snapUnsupported :
false`) — so on a central the Sessions page fell through every branch to "No sessions on this
machine yet.". False twice over: a central hosts no sessions, and the machines' sessions it *can*
reach are one screen away in Settings → Machines. The one sentence that would have said the true
thing was switched off by the very flag that makes it true — the same N/A-versus-a-confident-0 rule
the dashboard applies to harness capabilities, and the reason a machine reported by the relay keeps
four distinct silences rather than an empty list.

The sentence now names that screen, and says the machine appears there only if it granted access:
the consent is the machine's, so promising the list would be a claim this page cannot make.

## Motivation

Both came out of using the dashboard from a home-screen PWA. The status-bar one is the more
expensive of the two — a control that is visible and inert is indistinguishable from a broken app,
and it was the only way back out of an open session.

## Test plan

- `bun tsc --noEmit` clean; `bun test` 5156 pass, 0 fail.
- Driven browser, iPhone 12, with a forced 47px inset (Playwright does not simulate the notch, so
  the value is injected):

  | | inset 0 | inset 47 |
  |---|---|---|
  | open-session back arrow, top | 0 | 47 |
  | its tab strip, top | 2 | 49 |
  | list `30d` preset, top | 14 | 61 |

  Every figure is unchanged at inset 0, which is every browser tab, and
  `document.documentElement.scrollWidth <= window.innerWidth` holds in both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uc7HqjasyYjw2AfX3g93pa
