### PR TITLE
release: the chat pane stops attributing the harness's plumbing to the user

### DIFF
--- a/packages/server/server/sessions/chat-envelope.test.ts
+++ b/packages/server/server/sessions/chat-envelope.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'bun:test'
+import { classifyUserText } from './chat-envelope'
+
+describe('classifyUserText', () => {
+  it('keeps a plain message as the person’s, verbatim', () => {
+    expect(classifyUserText('  faz isso aí  ')).toEqual({ kind: 'person', text: 'faz isso aí' })
+  })
+
+  // The report this module exists for: the user circled one of these and said they did not send it.
+  it('does not attribute a task notification to the person', () => {
+    const r = classifyUserText('<task-notification>\n<task-id>bkl8s3c3q</task-id>\n</task-notification>')
+    expect(r.kind).toBe('system')
+    expect(r).not.toHaveProperty('text')
+  })
+
+  it('never carries the BODY of a system entry', () => {
+    // A <system-reminder> can be the whole of CLAUDE.md. The note names the kind; the body is gone.
+    const huge = `<system-reminder>${'x'.repeat(50_000)}</system-reminder>`
+    const r = classifyUserText(huge)
+    expect(r).toEqual({ kind: 'system', note: 'system reminder' })
+    expect(JSON.stringify(r).length).toBeLessThan(120)
+  })
+
+  it('treats every measured system envelope as system', () => {
+    for (const tag of [
+      'task-notification', 'system-reminder', 'local-command-caveat',
+      'local-command-stdout', 'bash-stdout', 'bash-stderr',
+    ]) {
+      expect(classifyUserText(`<${tag}>body</${tag}>`).kind).toBe('system')
+    }
+  })
+
+  it('UNWRAPS the envelopes the person really did perform', () => {
+    // Dropping these would erase a turn that happened — the user did run the command.
+    expect(classifyUserText('<command-name>/commit</command-name>'))
+      .toEqual({ kind: 'person', text: '/commit' })
+    expect(classifyUserText('<bash-input>ls -la</bash-input>'))
+      .toEqual({ kind: 'person', text: 'ls -la' })
+  })
+
+  it('unwraps a slash command spread across several envelope tags', () => {
+    const r = classifyUserText('<command-name>/review</command-name>\n<command-args>PR 314</command-args>')
+    expect(r).toEqual({ kind: 'person', text: '/review\n\nPR 314' })
+  })
+
+  it('an unrecognised tag stays the person’s — the safe direction', () => {
+    // A message that merely starts with `<` is theirs. A new envelope wrongly shown is the
+    // behaviour that already shipped; a real message wrongly hidden is gone.
+    expect(classifyUserText('<Foo /> renders twice, why?'))
+      .toEqual({ kind: 'person', text: '<Foo /> renders twice, why?' })
+    expect(classifyUserText('<diff>\n- a\n+ b\n</diff>').kind).toBe('person')
+  })
+
+  it('an empty entry is not an empty bubble under someone’s avatar', () => {
+    expect(classifyUserText('   ').kind).toBe('system')
+    expect(classifyUserText('<bash-input>   </bash-input>').kind).toBe('system')
+  })
+})

--- a/packages/server/server/sessions/chat-envelope.ts
+++ b/packages/server/server/sessions/chat-envelope.ts
@@ -1,0 +1,108 @@
+/**
+ * chat-envelope.ts — PURE: is a `type: 'user'` transcript entry something the PERSON said?
+ *
+ * Claude Code writes several kinds of entry under the `user` role that no person typed. They are
+ * the harness talking to itself in the one channel the transcript has for input: a background task
+ * reporting back, a hook's output, a reminder injected before a turn, the stdout of a `!` command.
+ * `isHumanUserEntry` (jsonl.ts) does not separate them — it only excludes a pure `tool_result` —
+ * so the chat pane rendered every one of them in the user's own bubble, over their avatar.
+ *
+ * Reported by the user, who circled a `<task-notification>` block and said "I didn't send that
+ * message." They were right, and it is the same class of defect as `sessionLabel()` stripping
+ * `<local-command-caveat>` out of a title: the transcript's raw text is a wire format, and putting
+ * it on screen attributes the harness's plumbing to a human being.
+ *
+ * MEASURED on this machine, over the 40 most recently touched transcripts — 715 user entries
+ * carrying text, of which 116 (16%) were an envelope:
+ *
+ *   54  <task-notification>      a background task finished        SYSTEM
+ *   24  <system-reminder>        injected context for the turn     SYSTEM
+ *   11  <local-command-caveat>   "the messages below were…"        SYSTEM
+ *   11  <command-name>           a slash command the user ran      PERSON (unwrapped)
+ *    5  <local-command-stdout>   that command's output             SYSTEM
+ *    5  <bash-input>             a `!` line the user ran           PERSON (unwrapped)
+ *    5  <bash-stdout>            that line's output                SYSTEM
+ *    1  <command-message>        the slash command's own text      PERSON (unwrapped)
+ *
+ * The split is not cosmetic. `<command-name>` and `<bash-input>` ARE the person acting — dropping
+ * them would erase a turn that happened — so they are UNWRAPPED to the thing they typed (`/foo`,
+ * `!ls`) rather than shown as XML or hidden. Everything else is the harness, and is reported as a
+ * one-line note naming WHAT it was, never its body: a `<system-reminder>` can be the whole of
+ * CLAUDE.md, and a pane that renders it has stopped being a conversation.
+ *
+ * The list is a matched pair with the measurement above and nothing more — an envelope nobody has
+ * seen is not in it. An UNRECOGNISED entry is therefore treated as the person's, which is the safe
+ * direction: a real message wrongly hidden is gone, while a new envelope wrongly shown is the
+ * behaviour that already shipped.
+ */
+
+/** What a `user` entry turns out to be. */
+export type UserEntry =
+  /** The person typed this. `text` is theirs, verbatim. */
+  | { kind: 'person'; text: string }
+  /**
+   * The harness wrote this under the user role. `note` names the kind in one short phrase; the
+   * BODY is deliberately absent — see the header.
+   */
+  | { kind: 'system'; note: string }
+
+/**
+ * Envelopes the harness writes, and what each one is.
+ *
+ * `unwrap` marks the ones the person really did perform: the tag is stripped and what is inside is
+ * their action. The rest carry the words the pane shows in their place.
+ */
+const ENVELOPES: Array<{ tag: string; unwrap: boolean; note: string }> = [
+  { tag: 'task-notification', unwrap: false, note: 'background task reported back' },
+  { tag: 'system-reminder', unwrap: false, note: 'system reminder' },
+  { tag: 'local-command-caveat', unwrap: false, note: 'local-command caveat' },
+  { tag: 'local-command-stdout', unwrap: false, note: 'command output' },
+  { tag: 'bash-stdout', unwrap: false, note: 'command output' },
+  { tag: 'bash-stderr', unwrap: false, note: 'command output' },
+  { tag: 'command-name', unwrap: true, note: 'slash command' },
+  { tag: 'command-message', unwrap: true, note: 'slash command' },
+  { tag: 'command-args', unwrap: true, note: 'slash command' },
+  { tag: 'bash-input', unwrap: true, note: 'shell command' },
+]
+
+/** `<tag>…</tag>` (or a self-closing / unterminated one), anchored at the start. */
+function leadingTag(text: string): string | null {
+  const m = /^<([a-zA-Z][\w-]*)/.exec(text)
+  return m ? m[1]!.toLowerCase() : null
+}
+
+/** Strip every known envelope tag, keeping what was inside. */
+function unwrapAll(text: string): string {
+  let out = text
+  for (const { tag } of ENVELOPES) {
+    out = out
+      .replace(new RegExp(`</?${tag}>`, 'gi'), '\n')
+  }
+  return out.replace(/\n{3,}/g, '\n\n').trim()
+}
+
+/**
+ * Classify one user entry's text.
+ *
+ * Empty or whitespace-only input is `system` with an empty note, so a caller can drop it — an
+ * empty bubble under someone's avatar is the same false attribution in a smaller size.
+ */
+export function classifyUserText(text: string): UserEntry {
+  const trimmed = text.trim()
+  if (trimmed === '') return { kind: 'system', note: '' }
+
+  const tag = leadingTag(trimmed)
+  if (tag === null) return { kind: 'person', text: trimmed }
+
+  const env = ENVELOPES.find(e => e.tag === tag)
+  // An unrecognised tag is left alone: a message that merely STARTS with `<` (a diff, a snippet,
+  // "<Foo /> renders twice") is the person's, and hiding it would be the expensive mistake.
+  if (env === undefined) return { kind: 'person', text: trimmed }
+
+  if (!env.unwrap) return { kind: 'system', note: env.note }
+
+  const inner = unwrapAll(trimmed)
+  // An envelope the person performed but which unwraps to nothing has no text to show and is still
+  // not a message — the note names what it was.
+  return inner === '' ? { kind: 'system', note: env.note } : { kind: 'person', text: inner }
+}

--- a/packages/server/server/sessions/chat-tail.ts
+++ b/packages/server/server/sessions/chat-tail.ts
@@ -25,6 +25,7 @@ import { join } from 'node:path'
 import { PROJECTS_DIR } from '../config'
 import { UUID_RE } from '../git'
 import { isHumanUserEntry } from '../jsonl'
+import { classifyUserText, type UserEntry } from './chat-envelope'
 
 export interface ChatTurn {
   role: 'user' | 'assistant'
@@ -54,6 +55,17 @@ export interface ChatTurn {
    * colours — it is not a message either side wrote.
    */
   pending?: boolean
+  /**
+   * This entry sat under the `user` role and NO PERSON WROTE IT — a background task reporting
+   * back, an injected reminder, a `!` command's stdout. The value is a short phrase naming which,
+   * never the body: a `<system-reminder>` can be the whole of CLAUDE.md.
+   *
+   * It is a turn rather than a drop so the conversation stays legible — an assistant reply with
+   * nothing above it reads as the assistant talking to itself — and it is rendered unattributed,
+   * like `pending`, because the one thing it may never do is appear over the user's avatar. See
+   * `chat-envelope.ts` for the measured list and why two of those envelopes are the person's.
+   */
+  system?: string
 }
 
 /** Resolved paths and one-time-scan misses, keyed by conversation id. Never re-scanned once known. */
@@ -121,16 +133,33 @@ export function forgetChatTailContent(): void {
   contentCache.clear()
 }
 
-function extractUserText(e: Record<string, unknown>): string | null {
+/**
+ * What a `user` entry actually is — the person, the harness, or neither.
+ *
+ * `isHumanUserEntry` only excludes a pure `tool_result`; every other envelope the harness writes
+ * under this role reached the pane as the user's own message. `chat-envelope.ts` is the split.
+ */
+function extractUserEntry(e: Record<string, unknown>): UserEntry | null {
   if (!isHumanUserEntry(e)) return null
   const msgContent = (e.message as Record<string, unknown> | undefined)?.content
-  if (typeof msgContent === 'string') return msgContent.trim() || null
-  if (Array.isArray(msgContent)) {
-    const text = (msgContent as Record<string, unknown>[])
+  let raw: string | undefined
+  if (typeof msgContent === 'string') raw = msgContent
+  else if (Array.isArray(msgContent)) {
+    raw = (msgContent as Record<string, unknown>[])
       .find(p => p.type === 'text' && typeof p.text === 'string')?.text as string | undefined
-    return text?.trim() || null
   }
-  return null
+  if (raw === undefined || raw.trim() === '') return null
+  const entry = classifyUserText(raw)
+  // A system entry with nothing to name is dropped outright rather than drawn as a blank note.
+  if (entry.kind === 'system' && entry.note === '') return null
+  return entry
+}
+
+/** The turn one classified entry becomes. */
+function userTurn(entry: UserEntry): ChatTurn {
+  return entry.kind === 'person'
+    ? { role: 'user', text: entry.text }
+    : { role: 'user', text: entry.note, system: entry.note }
 }
 
 function extractAssistantText(e: Record<string, unknown>): string | null {
@@ -306,8 +335,8 @@ async function readTurnsFromTail(
     const isNewest = newest
     newest = false
 
-    const userText = extractUserText(e)
-    if (userText) { turns.push({ role: 'user', text: userText }); continue }
+    const userEntry = extractUserEntry(e)
+    if (userEntry) { turns.push(userTurn(userEntry)); continue }
     const assistantText = extractAssistantText(e)
     if (assistantText) { turns.push({ role: 'assistant', text: assistantText }); continue }
     if (isNewest) {
@@ -348,8 +377,8 @@ export async function readChatTurns(path: string, max = 400): Promise<ChatTurn[]
     const isNewest = newest
     newest = false
 
-    const userText = extractUserText(e)
-    if (userText) { turns.push({ role: 'user', text: userText }); continue }
+    const userEntry = extractUserEntry(e)
+    if (userEntry) { turns.push(userTurn(userEntry)); continue }
 
     // An assistant event can carry text, thinking and tool calls at once, and all three belong to
     // the same turn. Emitted together rather than as separate rows: they happened together, and

--- a/packages/web/src/components/sessions/ChatBubble.tsx
+++ b/packages/web/src/components/sessions/ChatBubble.tsx
@@ -25,7 +25,7 @@ import remarkGfm from 'remark-gfm'
 // message written across several lines renders as one run-on paragraph — which is what "the
 // messages are not formatted" turned out to mean. `HarnessChat` has always used it.
 import remarkBreaks from 'remark-breaks'
-import { CornerUpLeft, User } from 'lucide-react'
+import { Clock, CornerUpLeft, User } from 'lucide-react'
 import { HARNESS_COLORS, HARNESS_LABELS } from '../../lib/harness'
 import { splitImageAttachments } from '../../lib/attachmentPreview'
 import { attachmentUrl } from '../../lib/attachmentUrl'
@@ -36,6 +36,14 @@ export interface ChatTurn {
   role: 'user' | 'assistant'
   text: string
   pending?: boolean
+  /**
+   * This sat under the `user` role and no person wrote it — a background task reporting back, an
+   * injected reminder, a `!` command's stdout. The value NAMES the kind; it is never the body.
+   *
+   * It may not render as a message: it went out over the user's own avatar, and one of them was
+   * circled in a screenshot with "I didn't send that". See `chat-envelope.ts`.
+   */
+  system?: string
   /** Carried by the transcript; deliberately not rendered here. See the header. */
   tools?: Array<{ name: string; detail?: string }>
   /** Carried by the transcript; deliberately not rendered here. See the header. */
@@ -49,6 +57,16 @@ export interface ChatBubbleProps {
   harness: string
   /** Read off the terminal screen and not yet committed to the transcript. Labelled as such. */
   provisional?: boolean
+  /**
+   * SENT, and the session has not taken it yet.
+   *
+   * The echo already knew this — it is retired the moment the transcript carries the same text —
+   * and drew a bubble identical to a delivered one, so a message queued behind a working turn was
+   * indistinguishable from one already read. On a session mid-turn that wait is minutes, and the
+   * reader's only options were to assume or to send it again. Dim plus a word, never a spinner:
+   * the message IS there, it is the reading that has not happened.
+   */
+  awaiting?: boolean
   /**
    * Quote THIS turn in the composer. Absent where the session cannot be written to — a reply
    * control on a row that will refuse the message is a control that teaches the wrong thing.
@@ -68,7 +86,24 @@ export interface ChatBubbleProps {
  * `onReply` is a fresh closure per render in the parent, so this alone would not have been enough —
  * see `SessionChat.tsx`'s `useCallback` on it.
  */
-export const ChatBubble = memo(function ChatBubble({ turn, lang, harness, provisional, onReply }: ChatBubbleProps) {
+/**
+ * The Portuguese for each note `chat-envelope.ts` produces.
+ *
+ * The server composes these in English because it has no language — every other already-localized
+ * refusal in this product is worded by the machine, but a note like this is chrome, not a machine's
+ * answer. An unmapped note falls through untranslated rather than being dropped: a missing
+ * translation is a small thing, a missing line is the defect this exists to fix.
+ */
+const SYSTEM_NOTE_PT: Record<string, string> = {
+  'background task reported back': 'tarefa em segundo plano respondeu',
+  'system reminder': 'lembrete do sistema',
+  'local-command caveat': 'aviso de comando local',
+  'command output': 'saída de comando',
+  'slash command': 'comando de barra',
+  'shell command': 'comando de shell',
+}
+
+export const ChatBubble = memo(function ChatBubble({ turn, lang, harness, provisional, awaiting, onReply }: ChatBubbleProps) {
   const pt = lang === 'pt'
   const mine = turn.role === 'user'
   const [lightboxIndex, setLightboxIndex] = useState<number | null>(null)
@@ -81,6 +116,26 @@ export const ChatBubble = memo(function ChatBubble({ turn, lang, harness, provis
   // A turn that said nothing AND attached nothing is not a message. Tool calls and reasoning are
   // the work between messages, and the row's state already reports that the session is working.
   if (text.trim() === '' && images.length === 0) return null
+
+  // NOT a message, and not drawn as one: no avatar, no bubble, no side. A dim centred note naming
+  // what the harness put in the transcript, so the reply below it still has something above it
+  // while nobody is credited with having typed it.
+  if (turn.system) {
+    return (
+      <div style={{
+        display: 'flex', justifyContent: 'center', padding: '2px 0',
+      }}>
+        <span style={{
+          fontSize: 10.5, lineHeight: 1.4, color: 'var(--text-tertiary)',
+          padding: '3px 10px', borderRadius: 999,
+          background: 'var(--bg-elevated)', border: '1px solid var(--border-subtle)',
+          maxWidth: '90%', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+        }}>
+          {pt ? SYSTEM_NOTE_PT[turn.system] ?? turn.system : turn.system}
+        </span>
+      </div>
+    )
+  }
 
   const color = (HARNESS_COLORS as Record<string, string>)[harness] ?? 'var(--text-secondary)'
   const name = (HARNESS_LABELS as Record<string, string>)[harness] ?? harness
@@ -117,6 +172,10 @@ export const ChatBubble = memo(function ChatBubble({ turn, lang, harness, provis
         background: mine ? 'var(--bg-elevated)' : 'var(--bg-card)',
         border: '1px solid var(--border-subtle)',
         borderRadius: 14, padding: '11px 14px', position: 'relative',
+        // Faded while the session has not read it. The TEXT stays fully legible — this is a
+        // statement about delivery, not about the message being less important to read back.
+        opacity: awaiting ? 0.62 : 1,
+        transition: 'opacity 0.2s',
       }}>
         {!mine && (
           <div style={{
@@ -179,6 +238,20 @@ export const ChatBubble = memo(function ChatBubble({ turn, lang, harness, provis
             }}
           >
             <ReactMarkdown remarkPlugins={[remarkGfm, remarkBreaks]}>{text}</ReactMarkdown>
+          </div>
+        )}
+
+        {/* The label sits INSIDE the bubble, under the text: it is a fact about this message, and
+            a line floating beside the bubble would read as another message. `role="status"` so a
+            screen reader is told, since the fading alone says nothing to one. */}
+        {awaiting && (
+          <div role="status" style={{
+            display: 'flex', alignItems: 'center', gap: 5,
+            fontSize: 10, color: 'var(--text-tertiary)',
+            alignSelf: mine ? 'flex-end' : 'flex-start',
+          }}>
+            <Clock size={10} style={{ flexShrink: 0 }} />
+            <span>{pt ? 'aguardando a sessão ler' : 'waiting for the session to read it'}</span>
           </div>
         )}
       </div>

--- a/packages/web/src/components/sessions/SessionChat.tsx
+++ b/packages/web/src/components/sessions/SessionChat.tsx
@@ -512,8 +512,18 @@ export function SessionChat({ session, row, lang, act }: SessionChatProps) {
             />
           ))}
 
+          {/* An echo IS an unread message by definition — it is retired the instant the transcript
+              carries the same text — so it is drawn as one: faded, with the wait said in words
+              under it. It used to be indistinguishable from a delivered message, and on a session
+              mid-turn the wait is minutes. */}
           {echo.map((text, i) => (
-            <ChatBubble key={`echo-${i}`} turn={{ role: 'user', text }} lang={lang} harness={session.harness} />
+            <ChatBubble
+              key={`echo-${i}`}
+              turn={{ role: 'user', text }}
+              lang={lang}
+              harness={session.harness}
+              awaiting
+            />
           ))}
 
           {/* `live` (the screen read off the terminal frame) is deliberately NOT rendered here any


### PR DESCRIPTION
## Summary

One PR: #318.

- **A `<task-notification>` was drawn in the user's own bubble**, over their avatar — reported with
  a screenshot and "I didn't send that message." Claude Code writes several kinds of entry under the
  `user` role that no person typed, and `isHumanUserEntry` only excluded a pure `tool_result`.
  Measured on one real machine: **16% of the user turns the pane rendered were the harness talking
  to itself.** The two envelopes that ARE the person acting (a slash command, a `!` line) are
  unwrapped to what they typed; the rest become a one-line unattributed note naming the kind, never
  its body.
- **A queued message now says it is queued.** Sent to a working session, it looked identical to one
  already read — for minutes. Faded, with the wait in words under it, `role="status"`.

## Motivation

Both are the pane making claims about who said what: one credited the harness's plumbing to a
person, the other let an unread message look read.

## Test plan

`bun tsc --noEmit` clean; `bun test` 5164 pass, 0 fail. Verified against a live session: before, 3
raw `<task-notification>` blocks served as user turns; after, 3 system notes, 0 leaked envelopes, 0
notes inside a user bubble. Full figures in #318.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uc7HqjasyYjw2AfX3g93pa