### PR TITLE
fix(web): an owner who is not the machine's account got no cell, no button and no reason

### DIFF
--- a/packages/web/src/pages/settings/MachinesSettings.tsx
+++ b/packages/web/src/pages/settings/MachinesSettings.tsx
@@ -583,8 +583,13 @@ function CentralMachinesView({ pt }: { pt: boolean }) {
   const machineView = (m: MachineInfo) => {
     const ownerIds = m.accountIds ?? (m.accountId ? [m.accountId] : [])
     const owners = m.owners ?? []
+    // The SAME test the server runs (`machineOwnedBy`): is the viewer one of the machine's own
+    // accounts? It is deliberately narrower than `canManage` — an instance owner administers every
+    // machine and owns only the ones linked to their account — and it is what turns the absent
+    // consent field from silence into a sentence.
+    const viewerOwnsMachine = ownerIds.includes(me?.id ?? '')
     return {
-      canManage: canManageFleet || ownerIds.includes(me?.id ?? ''),
+      canManage: canManageFleet || viewerOwnsMachine,
       ownerDisplay: owners.length === 0 ? '—' : (owners[0]?.name ?? '') + (owners.length > 1 ? ` +${owners.length - 1}` : ''),
       ownerEmailDisplay: owners.length > 0 ? (owners[0]?.email ?? '') : (pt ? 'sem conta' : 'no account'),
       teamNames: machineTeamIds(m).map(id => teamNameById.get(id) ?? id),
@@ -592,7 +597,7 @@ function CentralMachinesView({ pt }: { pt: boolean }) {
       statusLabel: m.online ? 'online' : 'offline',
       // Resolved HERE so the desktop row and the mobile card cannot say different things about
       // the same machine — the same reason every other value on this object is shared.
-      consent: machineConsentView(m.remoteConsent, m.online ?? false, pt ? 'pt' : 'en'),
+      consent: machineConsentView(m.remoteConsent, m.online ?? false, pt ? 'pt' : 'en', viewerOwnsMachine),
     }
   }
 

--- a/packages/web/src/pages/settings/machineConsentView.test.ts
+++ b/packages/web/src/pages/settings/machineConsentView.test.ts
@@ -82,3 +82,28 @@ describe('machineConsentView', () => {
       .not.toBe(machineConsentView({ sessions: true, screens: true, atMs: 1 }, true, 'en')!.text)
   })
 })
+
+describe('the viewer who may administer but may not ask', () => {
+  // An instance OWNER manages every machine (`canManageMachine` short-circuits on the role) and
+  // owns only the ones linked to their account (`machineOwnedBy` does not) — so the server omits
+  // `remoteConsent` and the row used to draw NOTHING. A working boundary that looks like a broken
+  // feature; reported as "the sessions don't appear and I'm the owner".
+  it('says WHY instead of drawing nothing', () => {
+    const v = machineConsentView(undefined, true, 'en', false)
+    expect(v).not.toBeNull()
+    expect(v!.tone).toBe('not-owner')
+    expect(v!.text).toMatch(/only by the accounts it is linked to/)
+    // Stating a limit is not lifting it: the row's button is gated on `granted`.
+    expect(v!.screens).toBe(false)
+  })
+
+  it('is really translated', () => {
+    expect(machineConsentView(undefined, true, 'pt', false)!.text).toMatch(/só podem ser vistas/)
+  })
+
+  it('keeps drawing nothing when the caller cannot tell', () => {
+    // A caller that does not pass the flag must not assert a reason it does not know.
+    expect(machineConsentView(undefined, true, 'en')).toBeNull()
+    expect(machineConsentView(undefined, true, 'en', true)).toBeNull()
+  })
+})

--- a/packages/web/src/pages/settings/machineConsentView.ts
+++ b/packages/web/src/pages/settings/machineConsentView.ts
@@ -8,7 +8,14 @@
  *
  * Four states, and the two that look alike are the reason this is its own module:
  *
- * - **absent** — you may not ask. The row says nothing at all.
+ * - **absent** — you may not ask. It USED to say nothing at all, and that was the defect: an
+ *   instance OWNER manages every machine (`canManageMachine` short-circuits on the role) but owns
+ *   only the machines linked to their own account (`machineOwnedBy` deliberately does not), so an
+ *   owner opened the machine they administer, found no cell and no button, and had a feature that
+ *   was working correctly and looked broken. The boundary is right — reaching into a machine's
+ *   sessions is narrower than administering it — but a boundary nobody can see is one people
+ *   report as a bug, which is exactly what happened. It is now a SENTENCE (`tone: 'not-owner'`),
+ *   and the row still offers no button: stating a limit is not lifting it.
  * - **`null`** — this machine has not said. Not a refusal: a machine that is off, or one running a
  *   build that predates the announcement, is silent in exactly the same way. Reporting silence as
  *   "this machine refuses" would send someone to a switch to change something already set.
@@ -26,7 +33,7 @@ export interface MachineConsentFacts {
   atMs: number
 }
 
-export type MachineConsentTone = 'granted' | 'refused' | 'silent'
+export type MachineConsentTone = 'granted' | 'refused' | 'silent' | 'not-owner'
 
 export interface MachineConsentView {
   tone: MachineConsentTone
@@ -51,9 +58,28 @@ export function machineConsentView(
   consent: MachineConsentFacts | null | undefined,
   online: boolean,
   lang: 'en' | 'pt',
+  /**
+   * Does the VIEWER appear in this machine's own account list?
+   *
+   * Omitted by a caller that cannot tell, which keeps the old behaviour (draw nothing) rather than
+   * asserting a reason it does not know. Passed as `false` it produces the `not-owner` sentence —
+   * the machine is on screen because the viewer may administer it, and the reason its sessions are
+   * not is worth one line.
+   */
+  viewerOwnsMachine?: boolean,
 ): MachineConsentView | null {
-  if (consent === undefined) return null
   const pt = lang === 'pt'
+  if (consent === undefined) {
+    if (viewerOwnsMachine !== false) return null
+    return {
+      tone: 'not-owner',
+      screens: false,
+      short: pt ? 'outra conta' : 'another account',
+      text: pt
+        ? 'As sessões desta máquina só podem ser vistas pelas contas às quais ela está vinculada. Vincule sua conta a ela para chegar às sessões.'
+        : 'This machine’s sessions are reachable only by the accounts it is linked to. Link your account to it to reach them.',
+    }
+  }
   if (consent === null) {
     return {
       tone: 'silent',


### PR DESCRIPTION
## Summary

Reported as *"the sessions don't appear on the central and I'm the owner of that machine"*. Both
halves of that sentence are true at once, and that is the whole defect.

`canManageMachine` short-circuits on the role — an instance owner administers **every** machine, and
sees it, renames it, re-links it. `machineOwnedBy` deliberately does **not**: reaching into a
machine's sessions is narrower than administering it, so it is purely "is the viewer one of the
machine's own accounts". `iam-handlers.ts` therefore attaches `remoteConsent` only under the narrow
predicate, `machineConsentView` returned `null` for the absent field, and the row drew **nothing** —
no consent cell, no monitor button, no explanation. A boundary working exactly as designed,
presented as a missing feature.

Proven rather than inferred:

```
canManageMachine(owner, { accountIds: ['someone-else'] })  →  true
machineOwnedBy  (owner, { accountIds: ['someone-else'] })  →  false
```

The boundary is **not widened** — that would be a security change, and the narrow predicate is
right. It is STATED: `tone: 'not-owner'`, *"this machine's sessions are reachable only by the
accounts it is linked to"*, and the button stays absent, because stating a limit is not lifting it.

The flag is the same `ownerIds.includes(me.id)` the row already computed for `canManage`, so the
client and the server ask one question. A caller that does not pass it keeps drawing nothing — it
must not assert a reason it cannot know.

## Motivation

This also makes the remaining diagnosis self-service. "No button" was one symptom with five causes;
the cell now separates them: linked-and-granted, linked-and-refused, linked-but-silent, offline, and
this one.

## Test plan

`bun tsc --noEmit` clean; `bun test` 5167 pass, 0 fail. Three new cases in
`machineConsentView.test.ts`, including that a caller which does not pass the flag still draws
nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uc7HqjasyYjw2AfX3g93pa