### PR TITLE
fix(web): every full-screen dialog drew its close button under the iOS status bar

### DIFF
--- a/packages/web/src/components/HardwareModal.tsx
+++ b/packages/web/src/components/HardwareModal.tsx
@@ -33,6 +33,7 @@ import {
 import type { HarnessId, Lang } from '@agentistics/core'
 import { HARNESS_LABELS } from '../lib/harness'
 import { useIsMobile } from '../hooks/useIsMobile'
+import { OVERLAY_TOP } from '../lib/mobileOverlay'
 import {
   metricsReasonText,
   serviceBadge,
@@ -601,7 +602,7 @@ export function HardwareModal({ lang, onClose }: { lang: Lang; onClose: () => vo
       style={{
         position: 'fixed', inset: 0, zIndex: 1100, background: 'rgba(0,0,0,0.55)',
         display: 'flex', alignItems: isMobile ? 'stretch' : 'center', justifyContent: 'center',
-        padding: isMobile ? 0 : (maximized ? 0 : 24),
+        padding: isMobile ? OVERLAY_TOP : (maximized ? 0 : 24),
       }}
     >
       <div

--- a/packages/web/src/components/ProjectsModal.tsx
+++ b/packages/web/src/components/ProjectsModal.tsx
@@ -3,6 +3,7 @@ import { createPortal } from 'react-dom'
 import { Search, X, Check } from 'lucide-react'
 import { formatProjectName } from '@agentistics/core'
 import { useIsMobile } from '../hooks/useIsMobile'
+import { OVERLAY_TOP } from '../lib/mobileOverlay'
 
 interface Props {
   projects: { path: string; sessions: { sessionId: string; created: string }[] }[]
@@ -130,7 +131,7 @@ export function ProjectsModal({ projects, sessionCountByProject, selected, onApp
     display: 'flex',
     alignItems: isMobile ? 'stretch' : 'center',
     justifyContent: 'center',
-    padding: isMobile ? 0 : '16px',
+    padding: isMobile ? OVERLAY_TOP : '16px',
   }
 
   const modalStyle: React.CSSProperties = {

--- a/packages/web/src/components/RecentSessions.tsx
+++ b/packages/web/src/components/RecentSessions.tsx
@@ -24,6 +24,7 @@ import { encodeProjectDir } from '../lib/sessionTranscript'
 import { resumeCommand } from '../lib/resumeCommand'
 import { HARNESS_LABELS, HARNESS_COLORS } from '../lib/harness'
 import { format, parseISO } from 'date-fns'
+import { OVERLAY_TOP } from '../lib/mobileOverlay'
 import {
   ChevronLeft,
   ChevronRight,
@@ -2154,7 +2155,7 @@ function CardModal({ statusPill, harness, title, meta, lang, onClose, children }
       onClick={onClose}
       style={{
         position: 'fixed', inset: 0, zIndex: 9998, background: 'rgba(0,0,0,0.7)', backdropFilter: 'blur(4px)',
-        display: 'flex', alignItems: isMobile ? 'stretch' : 'center', justifyContent: 'center', padding: isMobile ? 0 : 24,
+        display: 'flex', alignItems: isMobile ? 'stretch' : 'center', justifyContent: 'center', padding: isMobile ? OVERLAY_TOP : 24,
       }}
     >
       <div

--- a/packages/web/src/components/SessionDrilldownModal.tsx
+++ b/packages/web/src/components/SessionDrilldownModal.tsx
@@ -17,6 +17,7 @@ import { fmt as fmtShort, fmtFull, workflowTokens } from '@agentistics/core'
 import { PrecisionToggle } from './PrecisionToggle'
 import { useIsMobile } from '../hooks/useIsMobile'
 import { splitInlinedHistory } from '../lib/transcriptSplit'
+import { OVERLAY_TOP } from '../lib/mobileOverlay'
 
 interface Props {
   session: SessionMeta
@@ -137,7 +138,7 @@ export function SessionDrilldownModal({ session, globalModelUsage, currency, brl
         position: 'fixed', inset: 0, zIndex: 350,
         background: 'rgba(0,0,0,0.65)',
         display: 'flex', alignItems: isMobile ? 'stretch' : 'center', justifyContent: 'center',
-        padding: isMobile ? 0 : 24,
+        padding: isMobile ? OVERLAY_TOP : 24,
         backdropFilter: 'blur(4px)',
       }}
     >

--- a/packages/web/src/components/TranscriptModal.tsx
+++ b/packages/web/src/components/TranscriptModal.tsx
@@ -4,6 +4,7 @@ import type { HarnessId } from '@agentistics/core'
 import { HARNESS_LABELS, HARNESS_COLORS } from '../lib/harness'
 import { HarnessChat } from './HarnessChat'
 import { useIsMobile } from '../hooks/useIsMobile'
+import { OVERLAY_TOP } from '../lib/mobileOverlay'
 
 interface TranscriptTarget {
   harness: HarnessId
@@ -42,7 +43,7 @@ export function TranscriptModal({ lang }: { lang: 'pt' | 'en' }) {
         position: 'fixed', inset: 0, zIndex: 600,
         background: 'rgba(0,0,0,0.6)', backdropFilter: 'blur(4px)',
         display: 'flex', alignItems: 'center', justifyContent: 'center',
-        padding: isMobile ? 0 : 24,
+        padding: isMobile ? OVERLAY_TOP : 24,
         animation: 'ttyChatFadeIn 0.15s ease-out',
       }}
       onClick={(e) => { if (!isMobile && e.target === e.currentTarget) setTarget(null) }}

--- a/packages/web/src/components/team/NoticesModal.tsx
+++ b/packages/web/src/components/team/NoticesModal.tsx
@@ -9,6 +9,7 @@ import { buildRestrictionTable, type RestrictionRow, type RestrictionMachine } f
 import {
   describeSources, proposalAge, proposalPlan, type ProposalView, type KeyWarningView,
 } from './proposalNotices'
+import { OVERLAY_TOP } from '../../lib/mobileOverlay'
 
 /**
  * NoticesModal — everything another machine of this account is waiting on a decision about.
@@ -167,7 +168,7 @@ export function NoticesModal({
       style={{
         position: 'fixed', inset: 0, zIndex: 2000, display: 'flex',
         alignItems: isMobile ? 'stretch' : 'center', justifyContent: 'center',
-        background: 'rgba(0,0,0,0.6)', padding: isMobile ? 0 : 16,
+        background: 'rgba(0,0,0,0.6)', padding: isMobile ? OVERLAY_TOP : 16,
       }}
     >
       <div

--- a/packages/web/src/components/team/RemoteSessionsBlock.tsx
+++ b/packages/web/src/components/team/RemoteSessionsBlock.tsx
@@ -16,6 +16,7 @@ import { useIsMobile } from '../../hooks/useIsMobile'
 import { ToggleSwitch } from '../ToggleSwitch'
 import { remotePanelView, consentPatchFor } from './remoteSessionsState'
 import type { ConnectionStatusEntry } from './statusTypes'
+import { OVERLAY_TOP } from '../../lib/mobileOverlay'
 
 type Lang = 'en' | 'pt'
 
@@ -229,7 +230,7 @@ function ConfirmShare({ which, lang, isMobile, machineName, account, onCancel, o
       style={{
         position: 'fixed', inset: 0, zIndex: 10000,
         display: 'flex', alignItems: 'center', justifyContent: 'center',
-        background: 'rgba(0,0,0,0.55)', padding: isMobile ? 0 : 24,
+        background: 'rgba(0,0,0,0.55)', padding: isMobile ? OVERLAY_TOP : 24,
       }}
     >
       <div

--- a/packages/web/src/lib/mobileOverlay.test.ts
+++ b/packages/web/src/lib/mobileOverlay.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'bun:test'
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+import { overlayPadding } from './mobileOverlay'
+
+describe('overlayPadding', () => {
+  it('reserves the status bar on a full-screen mobile dialog', () => {
+    expect(overlayPadding(true, 24)).toBe('var(--safe-top) 0 0')
+  })
+
+  it('leaves the desktop padding alone', () => {
+    expect(overlayPadding(false, 24)).toBe('24px')
+    expect(overlayPadding(false, '16px')).toBe('16px')
+  })
+})
+
+/**
+ * The lint. A full-screen mobile overlay that pads with a bare `0` puts its own close button under
+ * the status bar, where the taps do not reach it — a control that is visible and inert, which is
+ * indistinguishable from a broken app.
+ */
+describe('no full-screen mobile overlay hardcodes a zero top padding', () => {
+  const ROOT = join(import.meta.dir, '..')
+
+  function walk(dir: string, out: string[] = []): string[] {
+    for (const e of readdirSync(dir)) {
+      const p = join(dir, e)
+      if (statSync(p).isDirectory()) walk(p, out)
+      else if (p.endsWith('.tsx')) out.push(p)
+    }
+    return out
+  }
+
+  it('greps the web source', () => {
+    const offenders: string[] = []
+    for (const file of walk(ROOT)) {
+      const src = readFileSync(file, 'utf8')
+      src.split('\n').forEach((line, i) => {
+        // `padding: isMobile ? 0 : …` on an overlay. The escape hatch is the helper.
+        if (/padding:\s*(?:is)?[Mm]obile\s*\?\s*0\b/.test(line) && !line.includes('@overlay-intentional')) {
+          offenders.push(`${file.slice(ROOT.length + 1)}:${i + 1}`)
+        }
+      })
+    }
+    expect(offenders).toEqual([])
+  })
+})

--- a/packages/web/src/lib/mobileOverlay.ts
+++ b/packages/web/src/lib/mobileOverlay.ts
@@ -1,0 +1,37 @@
+/**
+ * mobileOverlay.ts — PURE: the padding a FULL-SCREEN dialog needs on a phone.
+ *
+ * A modal that fills the screen on mobile draws its own title bar at y=0, which in an installed iOS
+ * PWA is underneath the clock and the battery — and the status bar takes the taps there, so the
+ * dialog's CLOSE button is visible and unpressable. Reported as "várias partes da interface estão
+ * impossíveis de clicar", with the Hardware modal's title colliding with the clock in the
+ * screenshot.
+ *
+ * The inset goes on the OVERLAY rather than on each dialog's header: the overlay already owns the
+ * dark ground, so the band above the dialog stays covered while the dialog itself starts below the
+ * status bar. One property, and the dialog's own layout is untouched.
+ *
+ * It is `--safe-top`, which is 0 in every browser tab — so this changes nothing anywhere the bug
+ * does not exist.
+ *
+ * `overlayPadding` is the one place this decision lives, and `mobileOverlay.lint.test.ts` fails the
+ * build on a full-screen mobile overlay that hardcodes `0` instead of calling it. Eight of them
+ * existed when this was written; the next one is the reason the lint is here rather than a comment.
+ */
+
+/**
+ * @param isMobile  the `useIsMobile()` reading
+ * @param desktop   what the overlay pads with when it is NOT full-screen (a number is px)
+ */
+export function overlayPadding(isMobile: boolean, desktop: number | string): string {
+  return isMobile ? 'var(--safe-top) 0 0' : (typeof desktop === 'number' ? `${desktop}px` : desktop)
+}
+
+/**
+ * The same decision as a constant, for the overwhelmingly common inline shape
+ * `padding: isMobile ? OVERLAY_TOP : 24`.
+ *
+ * Top only: a full-screen dialog wants its left, right and bottom edges flush with the screen —
+ * the bottom inset is the home indicator, and these dialogs own their own footers.
+ */
+export const OVERLAY_TOP = 'var(--safe-top) 0 0'

--- a/packages/web/src/pages/settings/Drawer.tsx
+++ b/packages/web/src/pages/settings/Drawer.tsx
@@ -48,6 +48,11 @@ export function Drawer({ open, title, onClose, children, footer, dirty = false, 
       style={{
         position: 'fixed', inset: 0, zIndex: 1000, display: 'flex',
         justifyContent: 'flex-end', background: 'rgba(0,0,0,0.5)',
+        // On a phone the panel is the full height, so its title bar and its close button start at
+        // y=0 — under the status bar in an installed PWA, where the taps do not reach them. The
+        // inset goes on the OVERLAY: the dark ground keeps covering the band, and the panel starts
+        // below it. `--safe-top` is 0 in a browser tab.
+        paddingTop: isMobile ? 'var(--safe-top)' : 0,
       }}
     >
       <div

--- a/packages/web/src/pages/settings/MachineFleetPanel.tsx
+++ b/packages/web/src/pages/settings/MachineFleetPanel.tsx
@@ -31,6 +31,7 @@ import { Loader2, RefreshCw } from 'lucide-react'
 import type { MachineActionReply, MachineFleetAnswer, MachineFleetRow } from '@agentistics/core'
 import { useIsMobile } from '../../hooks/useIsMobile'
 import { machineFleetPanelView } from './machineFleetView'
+import { OVERLAY_TOP } from '../../lib/mobileOverlay'
 
 export function MachineFleetPanel({ open, machineId, lang }: {
   /** False keeps the panel silent: the request makes the machine build a real fleet (a tmux round
@@ -263,7 +264,7 @@ export function MachineFleetPanel({ open, machineId, lang }: {
         <div style={{
           position: 'fixed', inset: 0, zIndex: 10000,
           display: 'flex', alignItems: 'center', justifyContent: 'center',
-          background: 'rgba(0,0,0,0.55)', padding: isMobile ? 0 : 24,
+          background: 'rgba(0,0,0,0.55)', padding: isMobile ? OVERLAY_TOP : 24,
         }}>
           <div style={{
             width: isMobile ? '100%' : 420, maxWidth: '100%',


### PR DESCRIPTION
## Summary

Reported as *"várias partes da interface estão impossíveis de clicar"*, with a screenshot of the
Hardware modal: its title overlapping the clock, its refresh and close buttons sitting on the signal
bars and the battery. A modal that fills the screen on mobile draws its own title bar at y=0, which
in an installed PWA is underneath the status bar — and the status bar takes the taps there, so the
one control that gets you OUT of the dialog is visible and inert.

Nine surfaces, found by grep rather than by eye: `HardwareModal`, `ProjectsModal`,
`RecentSessions`, `SessionDrilldownModal`, `TranscriptModal`, `NoticesModal`,
`RemoteSessionsBlock`, `MachineFleetPanel`, and the settings `Drawer` — which is where a machine's
own panels live, so the feature the user had been sent to could not be closed either.

The inset goes on the **overlay**, never on each dialog's header: the overlay already owns the dark
ground, so the band above the dialog stays covered while the dialog starts below the status bar. One
property, no dialog's internal layout touched, and `--safe-top` is 0 in every browser tab.

**The lint is the point.** `mobileOverlay.ts` holds the decision once and
`mobileOverlay.lint.test.ts` greps the web source and fails the build on a full-screen mobile
overlay padded with a bare `0`. Eight existed when it was written; reading the files by hand had
found six. `@overlay-intentional` is the escape hatch.

## Test plan

- `bun tsc --noEmit` clean; `bun test` 5178 pass, 0 fail (3 new).
- Measured at 390px with a forced 59px inset: the dialog's panel starts at 59, its first button at
  69 — both clear of the status bar. With the inset at 0, panel 0 and button 10, exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uc7HqjasyYjw2AfX3g93pa