### PR TITLE
release: the central's session list is the machine's own list

### DIFF
--- a/packages/web/src/components/nav/SessionsAside.tsx
+++ b/packages/web/src/components/nav/SessionsAside.tsx
@@ -60,6 +60,22 @@ export interface SessionsAsideProps {
    * case it exists for is rows on screen that are no longer true.
    */
   stale?: string | null
+  /**
+   * What clicking a row does, when it is not "open it on THIS machine".
+   *
+   * The central's Sessions page draws the very same list for a machine's RELAYED rows, where
+   * `/sessions/:id` would open a local session that does not exist here. Absent on a machine,
+   * where the route is exactly right.
+   */
+  onOpenRow?: (row: ControlSession) => void
+  /**
+   * Withholds "New session".
+   *
+   * Starting one is a LOCAL act (`POST /api/fleet/new` spawns a process on the host), so a central
+   * drawing this list for someone else's machine must not offer it — a button whose only outcome
+   * is a refusal is a button that teaches the wrong thing.
+   */
+  hideNew?: boolean
 }
 
 /** The colour a state is said in. `running` is its own token, not `success`, which reads teal. */
@@ -114,6 +130,7 @@ function pinKeyOf(row: ControlSession): string {
 
 export function SessionsAside({
   lang, rows, loading, unsupported, unavailable, filters, activeOnly, finishedTasks, stale,
+  onOpenRow, hideNew,
 }: SessionsAsideProps) {
   const pt = lang === 'pt'
   const navigate = useNavigate()
@@ -209,6 +226,7 @@ export function SessionsAside({
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0, gap: 10, paddingTop: 4 }}>
+      {!hideNew && (
       <button
         onClick={() => setCreating(true)}
         style={{
@@ -229,6 +247,7 @@ export function SessionsAside({
         <Plus size={14} />
         {pt ? 'Nova sessão' : 'New session'}
       </button>
+      )}
 
       {creating && (
         <NewSessionModal
@@ -333,7 +352,7 @@ export function SessionsAside({
                   pinned
                   {...(tap ? { tap } : {})}
                   onPin={() => flip(s)}
-                  onOpen={() => navigate(`/sessions/${s.id}`)}
+                  onOpen={() => (onOpenRow ? onOpenRow(s) : navigate(`/sessions/${s.id}`))}
                 />
               ))}
             </div>
@@ -355,7 +374,7 @@ export function SessionsAside({
                 key={`${i}-${b.label}`}
                 label={b.label} rows={b.rows} pinned={pinned}
                 sessionId={sessionId} tap={tap} onPin={flip}
-                onOpen={s => navigate(`/sessions/${s.id}`)}
+                onOpen={s => (onOpenRow ? onOpenRow(s) : navigate(`/sessions/${s.id}`))}
               />
             ))}
           </>

--- a/packages/web/src/components/sessions/CentralSessions.tsx
+++ b/packages/web/src/components/sessions/CentralSessions.tsx
@@ -21,18 +21,29 @@
 
 import { useEffect, useMemo, useState } from 'react'
 import { MonitorSmartphone } from 'lucide-react'
+import type { Filters } from '@agentistics/core'
 import { MachineFleetPanel } from '../../pages/settings/MachineFleetPanel'
+import { SessionsAside } from '../nav/SessionsAside'
 import { centralMachineList, pickCentralMachine, type CentralMachine } from '../../lib/centralMachines'
+import { relayedToSessions, type RelayedRow } from '../../lib/relayedSessions'
 
 /** Remembers the machine you were last looking at, per browser. */
 const PICK_KEY = 'agentistics-central-machine'
 
-export function CentralSessions({ lang }: { lang: 'pt' | 'en' }) {
+export function CentralSessions({ lang, filters, activeOnly }: {
+  lang: 'pt' | 'en'
+  /** The SAME filters the header edits — the list narrows exactly as it does on a machine. */
+  filters: Filters
+  activeOnly: boolean
+}) {
   const pt = lang === 'pt'
   const [machines, setMachines] = useState<CentralMachine[] | null>(null)
   const [me, setMe] = useState<string>('')
   const [failed, setFailed] = useState(false)
   const [picked, setPicked] = useState<string | null>(null)
+  /** The chosen machine's relayed rows, for the list. `null` = not read yet. */
+  const [rows, setRows] = useState<RelayedRow[] | null>(null)
+  const [rowsFor, setRowsFor] = useState<string | null>(null)
 
   useEffect(() => {
     let live = true
@@ -66,6 +77,27 @@ export function CentralSessions({ lang }: { lang: 'pt' | 'en' }) {
     if (machines === null) return
     setPicked(prev => prev ?? pickCentralMachine(list, localStorage.getItem(PICK_KEY)))
   }, [machines, list])
+
+  // The rows the LIST draws. The panel below reads the same route for the verbs — one extra call
+  // per machine change, and the alternative was threading the answer out of the panel, which would
+  // make the panel's own hosts depend on a caller that does not exist for them.
+  useEffect(() => {
+    if (!picked) { setRows(null); return }
+    let live = true
+    setRows(null); setRowsFor(picked)
+    void (async () => {
+      try {
+        const res = await fetch(`/api/team/machine-fleet?machineId=${encodeURIComponent(picked)}`)
+        const body = res.ok ? await res.json() as { reply?: { rows?: RelayedRow[] } } : null
+        if (live) setRows(body?.reply?.rows ?? [])
+      } catch {
+        if (live) setRows([])
+      }
+    })()
+    return () => { live = false }
+  }, [picked])
+
+  const sessions = useMemo(() => relayedToSessions(rows ?? []), [rows])
 
   const choose = (id: string) => {
     setPicked(id)
@@ -122,7 +154,26 @@ export function CentralSessions({ lang }: { lang: 'pt' | 'en' }) {
       )}
 
       {picked
-        ? <MachineFleetPanel open machineId={picked} lang={pt ? 'pt' : 'en'} />
+        ? (
+          <>
+            {/* THE SAME LIST a machine draws — grouping, ordering, search, the state words and the
+                row's own shape are decided in one place for both. Its "new session" is withheld:
+                starting one spawns a process on the HOST, which a central cannot do for someone
+                else's machine. */}
+            <SessionsAside
+              lang={lang}
+              rows={sessions}
+              finishedTasks={[]}
+              loading={rows === null || rowsFor !== picked}
+              unsupported={false}
+              filters={filters}
+              activeOnly={activeOnly}
+              hideNew
+              onOpenRow={() => { /* the verbs are in the panel below — see its own header */ }}
+            />
+            <MachineFleetPanel open machineId={picked} lang={pt ? 'pt' : 'en'} />
+          </>
+        )
         : (
           <Note text={list.blocked.length > 0
             ? (pt

--- a/packages/web/src/lib/relayedSessions.test.ts
+++ b/packages/web/src/lib/relayedSessions.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'bun:test'
+import { relayedToSession, relayedToSessions } from './relayedSessions'
+
+const row = {
+  id: 's1', title: 'AGENTISTICS SESSIONS', harness: 'claude',
+  state: 'waiting', stateLabel: 'needs you',
+  project: 'agentistics', cwd: '~/agentistics',
+  task: 'sessions', note: 'careful', model: 'claude-opus-5', named: true,
+  verbs: [{ action: 'rename', label: 'Rename', enabled: true }],
+}
+
+describe('relayedToSession', () => {
+  it('passes the row through — the list draws the same fields it always did', () => {
+    const s = relayedToSession(row)
+    expect(s.title).toBe('AGENTISTICS SESSIONS')
+    expect(s.stateLabel).toBe('needs you')
+    expect(s.project).toBe('agentistics')
+    expect(s.model).toBe('claude-opus-5')
+    expect(s.named).toBe(true)
+  })
+
+  it('builds search from what ARRIVED, and leaves the prompt empty', () => {
+    // The opening prompt does not cross the wire. Searching by it would silently match nothing.
+    const s = relayedToSession(row)
+    expect(s.searchFields).toEqual({
+      name: 'AGENTISTICS SESSIONS', folder: '~/agentistics', harness: 'claude',
+      note: 'careful', task: 'sessions', prompt: '',
+    })
+  })
+
+  it('is actionable only when the MACHINE offered a verb it will accept', () => {
+    expect(relayedToSession(row).actionable).toBe(true)
+    expect(relayedToSession({ ...row, verbs: [{ action: 'kill', label: 'Kill', enabled: false }] }).actionable).toBe(false)
+    expect(relayedToSession({ ...row, verbs: [] }).actionable).toBe(false)
+    const { verbs: _drop, ...noVerbs } = row
+    expect(relayedToSession(noVerbs).actionable).toBe(false)
+  })
+
+  it('is never attached — a central has no terminal on that host', () => {
+    expect(relayedToSession(row).attached).toBe(false)
+  })
+
+  it('leaves a withheld field ABSENT rather than inventing one', () => {
+    const { note: _n, task: _t, model: _m, ...bare } = row
+    const s = relayedToSession(bare)
+    expect(s.note).toBeUndefined()
+    expect(s.task).toBeUndefined()
+    expect(s.model).toBeUndefined()
+    expect(s.searchFields.note).toBe('')
+  })
+
+  it('maps a list', () => {
+    expect(relayedToSessions([row, { ...row, id: 's2' }]).map(s => s.id)).toEqual(['s1', 's2'])
+  })
+})

--- a/packages/web/src/lib/relayedSessions.ts
+++ b/packages/web/src/lib/relayedSessions.ts
@@ -1,0 +1,65 @@
+/**
+ * relayedSessions.ts — PURE: one machine's relayed rows, in the shape the SESSION LIST already
+ * draws.
+ *
+ * The central's Sessions page first shipped with a list of its own, and that was the wrong call —
+ * "vc mudou completamente a listagem das sessões, na central deveria aparecer a listagem igual na
+ * machine". A second list is a second set of decisions about grouping, ordering, search, what a
+ * row shows and how a state is worded, and the two drift. The list is `SessionsAside`, here as
+ * everywhere.
+ *
+ * A `MachineFleetRow` is a `ControlSession` minus everything the allowlist deliberately withholds
+ * (`MACHINE_FLEET_ROW_KEYS`), so almost all of this is a pass-through. Three fields have to be
+ * SUPPLIED, and each is derived from what actually arrived rather than invented:
+ *
+ *  - `searchFields` — built from the row's own name, folder, harness, note and task. `prompt` is
+ *    EMPTY, because the opening prompt does not cross the wire: searching by it would silently
+ *    match nothing rather than say it cannot.
+ *  - `actionable` — true when the machine offered at least one verb it will accept. It is the
+ *    machine's own answer, narrowed by `machineActions.ts` before the row was built.
+ *  - `attached` — always false. Attaching means a terminal on the host, and a central has none.
+ *
+ * Nothing here fabricates a state, a title or a count. A field the relay withheld stays absent, and
+ * the list renders it the same way it renders a local row that lacks it.
+ */
+
+import type { ControlSession } from '@agentistics/tui/control/session-fleet'
+
+/** The subset of a relayed row this module reads. Structural, so the core type stays the source. */
+export interface RelayedRow {
+  id: string
+  title: string
+  harness: string
+  state: string
+  stateLabel: string
+  project: string
+  cwd: string
+  task?: string
+  note?: string
+  model?: string
+  conversationId?: string
+  named?: boolean
+  verbs?: Array<{ action: string; label: string; enabled: boolean; reason?: string }>
+}
+
+export function relayedToSession(row: RelayedRow): ControlSession {
+  return {
+    ...row,
+    state: row.state as ControlSession['state'],
+    searchFields: {
+      name: row.title,
+      folder: row.cwd,
+      harness: row.harness,
+      note: row.note ?? '',
+      task: row.task ?? '',
+      // Deliberately empty — see the header.
+      prompt: '',
+    },
+    actionable: (row.verbs ?? []).some(v => v.enabled),
+    attached: false,
+  } as ControlSession
+}
+
+export function relayedToSessions(rows: readonly RelayedRow[]): ControlSession[] {
+  return rows.map(relayedToSession)
+}

--- a/packages/web/src/pages/SessionsPage.tsx
+++ b/packages/web/src/pages/SessionsPage.tsx
@@ -108,7 +108,7 @@ export default function SessionsPage() {
         display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0,
         overflowY: 'auto', padding: isMobile ? '10px 12px' : '20px 24px',
       }}>
-        <CentralSessions lang={pt ? 'pt' : 'en'} />
+        <CentralSessions lang={pt ? 'pt' : 'en'} filters={filters} activeOnly={activeOnly} />
       </div>
     )
   }


### PR DESCRIPTION
## Summary

Two PRs: #326 (a revert) and #328.

- **The central draws the SAME session list a machine does.** The first version of that page had a
  list of its own — a second set of decisions about grouping, ordering, search and how a state is
  worded. It is `SessionsAside` now, fed by the machine's relayed rows through a pure adapter that
  derives the three missing fields from what actually arrived and invents nothing. "New session" is
  withheld, because starting one spawns a process on the host.
- **Reverted the bottom-nav drift compensation.** It over-corrected — 117pt where the gap was 59 —
  and clipped the nav's labels off the bottom of the screen. A cosmetic gap became an unusable
  navigation bar.

## Test plan

`bun tsc --noEmit` clean; `bun test` 5184 pass, 0 fail. Central page verified at 390px and 1440px
against a mocked estate; nav measured flush again. Figures in #328 and #326.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uc7HqjasyYjw2AfX3g93pa