### PR TITLE
fix(web): one session list on the central, and a row you can act on

### DIFF
--- a/packages/web/src/components/sessions/CentralSessions.tsx
+++ b/packages/web/src/components/sessions/CentralSessions.tsx
@@ -44,6 +44,8 @@ export function CentralSessions({ lang, filters, activeOnly }: {
   /** The chosen machine's relayed rows, for the list. `null` = not read yet. */
   const [rows, setRows] = useState<RelayedRow[] | null>(null)
   const [rowsFor, setRowsFor] = useState<string | null>(null)
+  /** The row whose verbs are open. One at a time — this is the list, not a control panel. */
+  const [openRow, setOpenRow] = useState<string | null>(null)
 
   useEffect(() => {
     let live = true
@@ -82,6 +84,7 @@ export function CentralSessions({ lang, filters, activeOnly }: {
   // per machine change, and the alternative was threading the answer out of the panel, which would
   // make the panel's own hosts depend on a caller that does not exist for them.
   useEffect(() => {
+    setOpenRow(null)
     if (!picked) { setRows(null); return }
     let live = true
     setRows(null); setRowsFor(picked)
@@ -169,9 +172,32 @@ export function CentralSessions({ lang, filters, activeOnly }: {
               filters={filters}
               activeOnly={activeOnly}
               hideNew
-              onOpenRow={() => { /* the verbs are in the panel below — see its own header */ }}
+              onOpenRow={r => setOpenRow(prev => (prev === r.id ? null : r.id))}
             />
-            <MachineFleetPanel open machineId={picked} lang={pt ? 'pt' : 'en'} />
+
+            {/* Tapping a row opens ITS verbs, and nothing else. The panel used to draw the whole
+                fleet again underneath the list — the same sessions in a second shape, which is
+                what made the page read as two different listings. */}
+            {openRow && (
+              <div style={{
+                display: 'flex', flexDirection: 'column', gap: 8,
+                padding: '10px 12px', borderRadius: 10,
+                border: '1px solid var(--border)', background: 'var(--bg-elevated)',
+              }}>
+                <button
+                  onClick={() => setOpenRow(null)}
+                  style={{
+                    alignSelf: 'flex-start', minHeight: 32, padding: '4px 10px', borderRadius: 7,
+                    border: '1px solid var(--border-subtle)', background: 'transparent',
+                    color: 'var(--text-tertiary)', fontFamily: 'inherit', fontSize: 11.5,
+                    cursor: 'pointer',
+                  }}
+                >
+                  {pt ? 'Fechar' : 'Close'}
+                </button>
+                <MachineFleetPanel open machineId={picked} lang={pt ? 'pt' : 'en'} onlyRow={openRow} hideHeader />
+              </div>
+            )}
           </>
         )
         : (

--- a/packages/web/src/pages/settings/MachineFleetPanel.tsx
+++ b/packages/web/src/pages/settings/MachineFleetPanel.tsx
@@ -33,12 +33,22 @@ import { useIsMobile } from '../../hooks/useIsMobile'
 import { machineFleetPanelView } from './machineFleetView'
 import { OVERLAY_TOP } from '../../lib/mobileOverlay'
 
-export function MachineFleetPanel({ open, machineId, lang }: {
+export function MachineFleetPanel({ open, machineId, lang, onlyRow, hideHeader }: {
   /** False keeps the panel silent: the request makes the machine build a real fleet (a tmux round
    *  trip per session), so it is never issued behind something nobody is looking at. */
   open: boolean
   machineId: string
   lang: 'en' | 'pt'
+  /**
+   * Render the verbs of ONE row and nothing else.
+   *
+   * The central's Sessions page draws the fleet with `SessionsAside` — the real list — and opens
+   * this for whichever row was tapped. Without it the page showed the fleet TWICE, in two
+   * different shapes, which is what "tá listando as sessões de outra forma" meant.
+   */
+  onlyRow?: string
+  /** Withholds the "asking the machine / refresh" strip, when a host already has one. */
+  hideHeader?: boolean
 }) {
   const pt = lang === 'pt'
   const isMobile = useIsMobile()
@@ -108,13 +118,15 @@ export function MachineFleetPanel({ open, machineId, lang }: {
   }
 
   const view = machineFleetPanelView(answer, lang)
-  const rows = answer?.reply?.rows ?? []
+  const allRows = answer?.reply?.rows ?? []
+  const rows = onlyRow ? allRows.filter(r => r.id === onlyRow) : allRows
 
   // A FRAGMENT: the list and the "type the words" dialog are siblings, and the drawer used to be
   // the thing holding them together.
   return (
     <>
       <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+        {!hideHeader && (
         <div style={{ display: 'flex', alignItems: 'center', gap: 10, flexWrap: 'wrap' }}>
           <strong style={{ fontSize: 13 }}>
             {loading ? (pt ? 'Perguntando à máquina…' : 'Asking the machine…') : view.text}
@@ -137,11 +149,12 @@ export function MachineFleetPanel({ open, machineId, lang }: {
             {pt ? 'Atualizar' : 'Refresh'}
           </button>
         </div>
+        )}
 
         {/* The machine's own caveat, and what its sharing rules withheld. Two different facts, and
             neither is a fault — one is a limit the machine reported, the other is the user's own
             rule. Neither wears an alarm colour. */}
-        {view.notes.map(note => (
+        {!hideHeader && view.notes.map(note => (
           <p key={note} style={{ margin: 0, fontSize: 11.5, lineHeight: 1.5, color: 'var(--text-secondary)' }}>
             {note}
           </p>


### PR DESCRIPTION
## Summary

Two defects I introduced, both reported off a **working relay** — the first end-to-end proof that
the machine-fleet path answers a real client.

- **The fleet was drawn twice, in two shapes.** `MachineFleetPanel` kept rendering its own list of
  every session underneath `SessionsAside`, so the page showed the real list and then the old
  panel's list again. The panel now takes `onlyRow` and renders the verbs of one row, plus
  `hideHeader` where the host already has that strip.
- **A row could not be acted on.** `onOpenRow` was a no-op placeholder, so tapping a session did
  nothing. It opens that row's verbs now, one at a time, with a way to close — the list is a list,
  not a control panel with every button on screen at once.

## Test plan

`bun tsc --noEmit` clean; `bun test` 5184 pass, 0 fail. Verified against the mocked-central harness:
tapping a row opens its verbs and a Close; a row that was **not** tapped appears exactly once on the
page, where before every session appeared twice.

## Not in this PR

The permission model. The reported rule — session access exclusive to the machine's owner account
and to accounts explicitly granted *session management*, distinct from linking an account to a
machine — is a change to a security boundary, and the migration default decides whether existing
setups lose access or keep an unintended one. That is a question for the user, not a guess.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uc7HqjasyYjw2AfX3g93pa