### PR TITLE
release: a central's sessions live in the aside

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -79,6 +79,8 @@ import { HARNESS_LABELS } from './lib/harness'
 import { format, parseISO, parse } from 'date-fns'
 import { ToggleSwitch } from './components/ToggleSwitch'
 import { fleetFilterOptions } from './lib/fleetFilter'
+import { CentralSessions } from './components/sessions/CentralSessions'
+import { setFleetSourceCentral } from './lib/fleet'
 
 // Team session state
 interface TeamSessionState {
@@ -687,7 +689,7 @@ function MobileBottomNav({
     badge?: string
   }
   // The switch's badge, from the SHARED fleet poll (see lib/fleet.ts) — no extra request.
-  const { fleet: mobileFleet } = useFleet(lang === 'pt' ? 'pt' : 'en', !isCentral)
+  const { fleet: mobileFleet } = useFleet(lang === 'pt' ? 'pt' : 'en')
   const attention = mobileFleet.attention
 
   const navTiles: Tile[] = [
@@ -1026,7 +1028,7 @@ function SideNav({ lang, harnesses, isCentral, hasWorkflows, collapsed, width, o
   // for the moment you are looking at the dashboard and a session starts needing you. `useFleet`
   // shares one poll across every consumer, so this costs no extra request. Never on a central: it
   // aggregates many machines and hosts none of their sessions.
-  const { fleet, loading: fleetLoading, unsupported: fleetUnsupported, stale: fleetStale } = useFleet(pt ? 'pt' : 'en', !isCentral)
+  const { fleet, loading: fleetLoading, unsupported: fleetUnsupported, stale: fleetStale } = useFleet(pt ? 'pt' : 'en')
   const attention = fleet.attention
   const mode = modeOfPath(location.pathname)
   // A resize in progress. Only used to suspend the collapse animation — see the aside's `transition`.
@@ -1077,6 +1079,10 @@ function SideNav({ lang, harnesses, isCentral, hasWorkflows, collapsed, width, o
           is withheld: a 64px rail cannot show a session's title, and a list of unlabelled dots is a
           list nobody can read. The rail keeps the switch, which is how you get back. */}
       {mode === 'sessions' && !collapsed ? (
+        <>
+        {/* On a central the workspace is ABOUT a machine, so the choice sits above the list it
+            governs. Absent on a machine, which is its own. */}
+        {isCentral && <div style={{ padding: '0 2px 8px' }}><CentralSessions lang={pt ? 'pt' : 'en'} /></div>}
         <SessionsAside
           lang={pt ? 'pt' : 'en'}
           rows={fleet.rows}
@@ -1087,7 +1093,9 @@ function SideNav({ lang, harnesses, isCentral, hasWorkflows, collapsed, width, o
           activeOnly={sessionsActiveOnly}
           {...(fleet.unavailable ? { unavailable: fleet.unavailable } : {})}
           stale={fleetStale}
+          {...(isCentral ? { hideNew: true } : {})}
         />
+        </>
       ) : (
       <nav className="ag-noscroll" style={{ display: 'flex', flexDirection: 'column', gap: 5, overflowY: 'auto', overflowX: 'hidden', flex: 1, paddingTop: 4 }}>
         {items.map(item => {
@@ -1492,7 +1500,10 @@ export default function AppLayout() {
    * subscription `SideNav` already holds.
    */
   const { sessionId: selectedSessionId } = useParams()
-  const { fleet: headerFleet, act: headerFleetAct } = useFleet(lang === 'pt' ? 'pt' : 'en', !isCentral)
+  // A CENTRAL's fleet is the RELAY's, for the machine the aside's picker chose. Set once, here,
+  // because the poller is module-scoped and every surface reads the same snapshot.
+  useEffect(() => { setFleetSourceCentral(isCentral) }, [isCentral])
+  const { fleet: headerFleet, act: headerFleetAct } = useFleet(lang === 'pt' ? 'pt' : 'en')
   /**
    * What the SESSIONS filter bar may offer — derived from the FLEET, never from the dashboard's
    * metrics. The two are different universes: the metrics knew six harnesses on this machine while

--- a/packages/web/src/components/sessions/CentralSessions.tsx
+++ b/packages/web/src/components/sessions/CentralSessions.tsx
@@ -1,51 +1,37 @@
 /**
- * CentralSessions.tsx — the SESSIONS page of a central: pick a machine you can reach, and manage
- * its sessions there.
+ * CentralSessions.tsx — on a CENTRAL, which machine the Sessions workspace is looking at.
  *
- * A central hosts no sessions of its own, so this page used to say exactly that and stop. True and
- * useless: the person came to manage the sessions of the machines they have access to, and the one
- * surface that could was a drawer behind Settings → Machines — which is not where anybody looks for
- * a session.
+ * It is a PICKER and nothing else. The list is `SessionsAside` and the overview is the centre, both
+ * exactly as they are on a machine: `useFleet` fetches the chosen machine's relayed fleet and hands
+ * back the same shape a local one does, so neither surface knows which kind of install it is.
  *
- * ONE MACHINE AT A TIME, and deliberately so. Each read makes that machine build a real fleet (a
- * tmux round trip per session), so fetching every machine on page load would tax a whole estate to
- * fill a list most of which nobody is reading. The picker is the consent for the cost.
+ * That is the second attempt. The first drew its own list in the CENTRE of the page while the real
+ * aside said "no sessions on this machine yet" — the same sessions in two shapes, in the wrong
+ * place, which is what "qual parte vc n entendeu de visualizacao identica" meant.
  *
- * The list, the verbs and every refusal are `MachineFleetPanel` — the same component the drawer
- * hosts. A second implementation would be a second set of rules about what a relayed row may show
- * and which verbs it may offer.
+ * ONE MACHINE AT A TIME, deliberately: each poll makes that machine build a real fleet (a tmux
+ * round trip per session), so fetching the whole estate would tax every machine to fill a list
+ * nobody is reading. The chip carries online/offline, because whether a machine can answer NOW is
+ * worth knowing before choosing it rather than after waiting.
  *
- * A machine that CANNOT be reached is named with its reason rather than left out: an empty picker
- * is one symptom with five causes, and the person looking at it is the one who needs to know which.
+ * A machine that cannot be reached is NAMED with its reason, never left out: an empty picker is one
+ * symptom with several causes, and the person looking at it is the one who needs to know which.
  */
 
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useState, useSyncExternalStore } from 'react'
 import { MonitorSmartphone } from 'lucide-react'
-import type { Filters } from '@agentistics/core'
-import { MachineFleetPanel } from '../../pages/settings/MachineFleetPanel'
-import { SessionsAside } from '../nav/SessionsAside'
 import { centralMachineList, pickCentralMachine, type CentralMachine } from '../../lib/centralMachines'
-import { relayedToSessions, type RelayedRow } from '../../lib/relayedSessions'
+import {
+  centralMachineServerSnapshot, getCentralMachine, setCentralMachine, subscribeCentralMachine,
+} from '../../lib/centralMachinePick'
 
-/** Remembers the machine you were last looking at, per browser. */
-const PICK_KEY = 'agentistics-central-machine'
 
-export function CentralSessions({ lang, filters, activeOnly }: {
-  lang: 'pt' | 'en'
-  /** The SAME filters the header edits — the list narrows exactly as it does on a machine. */
-  filters: Filters
-  activeOnly: boolean
-}) {
+export function CentralSessions({ lang }: { lang: 'pt' | 'en' }) {
   const pt = lang === 'pt'
   const [machines, setMachines] = useState<CentralMachine[] | null>(null)
   const [me, setMe] = useState<string>('')
   const [failed, setFailed] = useState(false)
-  const [picked, setPicked] = useState<string | null>(null)
-  /** The chosen machine's relayed rows, for the list. `null` = not read yet. */
-  const [rows, setRows] = useState<RelayedRow[] | null>(null)
-  const [rowsFor, setRowsFor] = useState<string | null>(null)
-  /** The row whose verbs are open. One at a time — this is the list, not a control panel. */
-  const [openRow, setOpenRow] = useState<string | null>(null)
+  const picked = useSyncExternalStore(subscribeCentralMachine, getCentralMachine, centralMachineServerSnapshot)
 
   useEffect(() => {
     let live = true
@@ -74,38 +60,15 @@ export function CentralSessions({ lang, filters, activeOnly }: {
     [machines, me, pt],
   )
 
-  // Settled once, when the list first arrives, and then owned by the picker.
+  // Settled once, when the list first arrives, and then owned by the picker. A remembered machine
+  // that has since gone quiet must not leave the workspace pointed at an entry no longer offered.
   useEffect(() => {
     if (machines === null) return
-    setPicked(prev => prev ?? pickCentralMachine(list, localStorage.getItem(PICK_KEY)))
+    const next = pickCentralMachine(list, getCentralMachine())
+    if (next !== getCentralMachine()) setCentralMachine(next)
   }, [machines, list])
 
-  // The rows the LIST draws. The panel below reads the same route for the verbs — one extra call
-  // per machine change, and the alternative was threading the answer out of the panel, which would
-  // make the panel's own hosts depend on a caller that does not exist for them.
-  useEffect(() => {
-    setOpenRow(null)
-    if (!picked) { setRows(null); return }
-    let live = true
-    setRows(null); setRowsFor(picked)
-    void (async () => {
-      try {
-        const res = await fetch(`/api/team/machine-fleet?machineId=${encodeURIComponent(picked)}`)
-        const body = res.ok ? await res.json() as { reply?: { rows?: RelayedRow[] } } : null
-        if (live) setRows(body?.reply?.rows ?? [])
-      } catch {
-        if (live) setRows([])
-      }
-    })()
-    return () => { live = false }
-  }, [picked])
-
-  const sessions = useMemo(() => relayedToSessions(rows ?? []), [rows])
-
-  const choose = (id: string) => {
-    setPicked(id)
-    try { localStorage.setItem(PICK_KEY, id) } catch { /* private mode — the choice is a convenience */ }
-  }
+  const choose = (id: string) => setCentralMachine(id)
 
   if (failed) {
     return (
@@ -155,60 +118,6 @@ export function CentralSessions({ lang, filters, activeOnly }: {
           })}
         </div>
       )}
-
-      {picked
-        ? (
-          <>
-            {/* THE SAME LIST a machine draws — grouping, ordering, search, the state words and the
-                row's own shape are decided in one place for both. Its "new session" is withheld:
-                starting one spawns a process on the HOST, which a central cannot do for someone
-                else's machine. */}
-            <SessionsAside
-              lang={lang}
-              rows={sessions}
-              finishedTasks={[]}
-              loading={rows === null || rowsFor !== picked}
-              unsupported={false}
-              filters={filters}
-              activeOnly={activeOnly}
-              hideNew
-              onOpenRow={r => setOpenRow(prev => (prev === r.id ? null : r.id))}
-            />
-
-            {/* Tapping a row opens ITS verbs, and nothing else. The panel used to draw the whole
-                fleet again underneath the list — the same sessions in a second shape, which is
-                what made the page read as two different listings. */}
-            {openRow && (
-              <div style={{
-                display: 'flex', flexDirection: 'column', gap: 8,
-                padding: '10px 12px', borderRadius: 10,
-                border: '1px solid var(--border)', background: 'var(--bg-elevated)',
-              }}>
-                <button
-                  onClick={() => setOpenRow(null)}
-                  style={{
-                    alignSelf: 'flex-start', minHeight: 32, padding: '4px 10px', borderRadius: 7,
-                    border: '1px solid var(--border-subtle)', background: 'transparent',
-                    color: 'var(--text-tertiary)', fontFamily: 'inherit', fontSize: 11.5,
-                    cursor: 'pointer',
-                  }}
-                >
-                  {pt ? 'Fechar' : 'Close'}
-                </button>
-                <MachineFleetPanel open machineId={picked} lang={pt ? 'pt' : 'en'} onlyRow={openRow} hideHeader />
-              </div>
-            )}
-          </>
-        )
-        : (
-          <Note text={list.blocked.length > 0
-            ? (pt
-              ? 'Nenhuma máquina desta central está permitindo gerenciar sessões daqui agora.'
-              : 'No machine on this central is currently allowing session management from here.')
-            : (pt
-              ? 'Nenhuma máquina para gerenciar ainda.'
-              : 'No machines to manage yet.')} />
-        )}
 
       {/* The ones that cannot be reached, each with the reason — never silently absent. */}
       {list.blocked.length > 0 && (

--- a/packages/web/src/lib/centralMachinePick.ts
+++ b/packages/web/src/lib/centralMachinePick.ts
@@ -1,0 +1,47 @@
+/**
+ * centralMachinePick.ts — which machine a CENTRAL's Sessions workspace is looking at.
+ *
+ * Module scope, not React state, for the same reason `fleet.ts`'s poller is: the picker draws in
+ * the aside and the fleet is fetched by the poller, and two copies of "which machine" is how a list
+ * ends up describing one machine while a header counts another.
+ *
+ * Remembered per browser, so reopening the app lands where you left it.
+ */
+
+const KEY = 'agentistics-central-machine'
+
+let picked: string | null = null
+let loaded = false
+const listeners = new Set<() => void>()
+
+function load(): void {
+  if (loaded) return
+  loaded = true
+  try { picked = localStorage.getItem(KEY) } catch { picked = null }
+}
+
+export function getCentralMachine(): string | null {
+  load()
+  return picked
+}
+
+export function setCentralMachine(id: string | null): void {
+  load()
+  if (picked === id) return
+  picked = id
+  try {
+    if (id) localStorage.setItem(KEY, id)
+    else localStorage.removeItem(KEY)
+  } catch { /* private mode — the memory is a convenience, the selection still works */ }
+  for (const fn of listeners) fn()
+}
+
+export function subscribeCentralMachine(fn: () => void): () => void {
+  listeners.add(fn)
+  return () => { listeners.delete(fn) }
+}
+
+/** `useSyncExternalStore`'s server snapshot — there is no machine before hydration. */
+export function centralMachineServerSnapshot(): string | null {
+  return null
+}

--- a/packages/web/src/lib/fleet.ts
+++ b/packages/web/src/lib/fleet.ts
@@ -17,6 +17,8 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 import type { ControlSession } from '@agentistics/tui/control/session-fleet'
 import { fleetSeedNotice, fleetStaleNotice } from './fleetStale'
 import { cacheIsUsable, stripVolatile } from './fleetCache'
+import { getCentralMachine } from './centralMachinePick'
+import { relayedToSessions, type RelayedRow } from './relayedSessions'
 
 /** Mirrors `SessionAction` in `@agentistics/tui/control/sessions`, minus the verbs a page cannot do. */
 export type FleetActionId =
@@ -182,7 +184,69 @@ function emit(): void {
   for (const l of listeners) l()
 }
 
+/**
+ * On a CENTRAL there is no local fleet, and the workspace still has to work.
+ *
+ * The poller fetches the RELAYED fleet of whichever machine the aside's picker has chosen, and maps
+ * it into the very same shape a machine returns. That is what lets the aside, the overview in the
+ * centre and the header's counters stay one implementation: they read `fleet`, and none of them has
+ * to know which kind of install it is. The alternative — a second list drawn in the centre while
+ * the real aside said "no sessions on this machine yet" — is exactly what shipped and was wrong.
+ */
+let pollCentral = false
+
+export function setFleetSourceCentral(on: boolean): void {
+  if (pollCentral === on) return
+  pollCentral = on
+  snapshot = EMPTY; snapLoading = true; cachedAt = 0
+  emit()
+  if (timer !== null) void pollOnce()
+}
+
+async function pollCentralOnce(): Promise<void> {
+  const machineId = getCentralMachine()
+  if (!machineId) {
+    // No machine chosen is not a failed poll and not an empty fleet — the picker above the list
+    // is what answers it, so this reports "nothing to show" and stops.
+    snapshot = EMPTY; snapUnsupported = false; snapLoading = false; snapFailures = 0
+    emit(); return
+  }
+  try {
+    const res = await fetch(`/api/team/machine-fleet?machineId=${encodeURIComponent(machineId)}&lang=${pollLang}`)
+    if (!res.ok) { snapFailures++; return }
+    const body = await res.json() as { reply?: { rows?: RelayedRow[]; withheld?: number }; reason?: string }
+    if (!body.reply) {
+      // A named refusal is a complete ANSWER, exactly as a machine's 403 is: it clears the failure
+      // count rather than reading as silence. The picker states the reason in words.
+      snapshot = EMPTY; snapUnsupported = true; snapFailures = 0; snapLastOkMs = Date.now()
+      return
+    }
+    snapUnsupported = false
+    const rows = relayedToSessions(body.reply.rows ?? [])
+    snapshot = {
+      rows,
+      // `FleetRow` is the shaped view the panel reads; the relayed row already carries the same
+      // fields the list needs, and the verbs it may take came decided from the machine.
+      sessions: rows as unknown as FleetRow[],
+      attention: rows.filter(r => r.state === 'waiting' || r.state === 'waiting-approval').length,
+      // A relayed fleet carries no task list of its own: tasks are a local grouping, and a
+      // FINISHED task is a statement the machine's own user made. Neither is invented here.
+      tasks: [],
+      finishedTasks: [],
+    }
+    snapFailures = 0
+    snapLastOkMs = Date.now()
+    cachedAt = 0
+  } catch {
+    snapFailures++
+  } finally {
+    snapLoading = false
+    emit()
+  }
+}
+
 async function pollOnce(): Promise<void> {
+  if (pollCentral) return pollCentralOnce()
   try {
     const res = await fetch(`/api/fleet?lang=${pollLang}`)
     if (res.status === 403 || res.status === 404) {

--- a/packages/web/src/pages/SessionsPage.tsx
+++ b/packages/web/src/pages/SessionsPage.tsx
@@ -27,7 +27,6 @@ import { FiltersBar } from '../components/FiltersBar'
 import { SessionPanel, type SessionView } from '../components/sessions/SessionPanel'
 import { SessionsAside } from '../components/nav/SessionsAside'
 import { SessionActions } from '../components/sessions/SessionActions'
-import { CentralSessions } from '../components/sessions/CentralSessions'
 
 export default function SessionsPage() {
   const ctx = useOutletContext<AppContext>()
@@ -42,7 +41,7 @@ export default function SessionsPage() {
 
   // Never on a central: it aggregates many machines and hosts none of their sessions, so the only
   // fleet it could read is its own box's, drawn under someone else's rows.
-  const { fleet, loading, unsupported: pollUnsupported, stale, act } = useFleet(pt ? 'pt' : 'en', !isCentral)
+  const { fleet, loading, unsupported: pollUnsupported, stale, act } = useFleet(pt ? 'pt' : 'en')
   /**
    * A CENTRAL cannot list a fleet, and must SAY so.
    *
@@ -55,7 +54,10 @@ export default function SessionsPage() {
    * The same N/A-versus-a-confident-0 rule the dashboard applies to harness capabilities: an empty
    * list may never stand in for "this install cannot answer".
    */
-  const unsupported = pollUnsupported || isCentral
+  // NOT `|| isCentral` any more: on a central the fleet is answered by the RELAY for the machine
+  // the aside's picker has chosen, so `unsupported` is again exactly what the poller reports —
+  // including the machine's own named refusal.
+  const unsupported = pollUnsupported
   const rowIndex = useFleetIndex(fleet.sessions)
 
   // Matched on BOTH ids for the same reason `fleetIndex` is keyed on both: a managed row is named
@@ -93,25 +95,6 @@ export default function SessionsPage() {
       onViewChange={setSessionView}
     />
   )
-
-  // ---------------------------------------------------------------------------
-  // A CENTRAL manages OTHER machines' sessions here.
-  //
-  // It hosts none of its own, so this page used to say exactly that and stop — true, and useless
-  // to somebody who came to manage the sessions of the machines they can reach. `CentralSessions`
-  // is the picker plus the relayed fleet, and it takes the whole page on both layouts: the local
-  // fleet, its filters and its "new session" button all describe a machine this install is not.
-  // ---------------------------------------------------------------------------
-  if (isCentral) {
-    return (
-      <div style={{
-        display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0,
-        overflowY: 'auto', padding: isMobile ? '10px 12px' : '20px 24px',
-      }}>
-        <CentralSessions lang={pt ? 'pt' : 'en'} filters={filters} activeOnly={activeOnly} />
-      </div>
-    )
-  }
 
   // ---------------------------------------------------------------------------
   // Mobile: one column at a time.


### PR DESCRIPTION
## Summary

One PR: #332.

The central's Sessions page drew the machine's fleet in the centre while the real aside said "no
sessions on this machine yet". `useFleet` now serves a central directly — the relayed fleet of the
machine the picker chose, in the same shape a local poll returns — so the aside, the centre overview
and the header counters are one implementation that never learns which kind of install it is.

## Test plan

`bun tsc --noEmit` clean; `bun test` 5184 pass, 0 fail. Verified at 1600px against a mocked central.
Figures in #332.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uc7HqjasyYjw2AfX3g93pa