### PR TITLE
fix(web): a message sent mid-turn now appears, and a nameless assistant row has a name

### DIFF
--- a/packages/server/server/sessions/chat-tail.ts
+++ b/packages/server/server/sessions/chat-tail.ts
@@ -155,6 +155,33 @@ function extractUserEntry(e: Record<string, unknown>): UserEntry | null {
   return entry
 }
 
+/**
+ * A message the person typed WHILE the assistant was working.
+ *
+ * Claude Code does not store these as `type: 'user'`. They are QUEUED, and land as an `attachment`
+ * of type `queued_command` carrying the prompt — so the chat pane, which only ever read user
+ * entries, showed the assistant answering a question nobody could see it being asked. Reported
+ * exactly that way: "esse ultimo prompt que te mandei n apareceu na interface de sessao".
+ *
+ * It is the PERSON's own words, typed by them, and it is rendered as theirs. It is read here and
+ * not through `classifyUserText`'s envelope table because it is not an envelope: nothing wraps the
+ * text, the entry's SHAPE is what identifies it.
+ */
+function extractQueuedText(e: Record<string, unknown>): string | null {
+  if (e.type !== 'attachment') return null
+  const a = e.attachment as Record<string, unknown> | undefined
+  if (!a || a.type !== 'queued_command') return null
+  const prompt = a.prompt
+  if (typeof prompt === 'string') return prompt.trim() || null
+  if (!Array.isArray(prompt)) return null
+  const text = (prompt as Record<string, unknown>[])
+    .filter(part => part.type === 'text' && typeof part.text === 'string')
+    .map(part => part.text as string)
+    .join('\n')
+    .trim()
+  return text || null
+}
+
 /** The turn one classified entry becomes. */
 function userTurn(entry: UserEntry): ChatTurn {
   return entry.kind === 'person'
@@ -337,6 +364,8 @@ async function readTurnsFromTail(
 
     const userEntry = extractUserEntry(e)
     if (userEntry) { turns.push(userTurn(userEntry)); continue }
+    const queued = extractQueuedText(e)
+    if (queued) { turns.push({ role: 'user', text: queued }); continue }
     const assistantText = extractAssistantText(e)
     if (assistantText) { turns.push({ role: 'assistant', text: assistantText }); continue }
     if (isNewest) {
@@ -379,6 +408,8 @@ export async function readChatTurns(path: string, max = 400): Promise<ChatTurn[]
 
     const userEntry = extractUserEntry(e)
     if (userEntry) { turns.push(userTurn(userEntry)); continue }
+    const queued = extractQueuedText(e)
+    if (queued) { turns.push({ role: 'user', text: queued }); continue }
 
     // An assistant event can carry text, thinking and tool calls at once, and all three belong to
     // the same turn. Emitted together rather than as separate rows: they happened together, and

--- a/packages/web/src/components/sessions/FleetOverview.tsx
+++ b/packages/web/src/components/sessions/FleetOverview.tsx
@@ -95,7 +95,11 @@ export function FleetOverview({ lang, rows, loading, unsupported, unavailable }:
           // Names the UNIVERSE: "of 23 total" sat a few centimetres from a header reading "961
           // sessions" and invited the reader to compare two counts of different things. This one
           // is the fleet on this machine; that one is the whole metrics history.
-          note={pt ? `de ${s.total} nesta máquina` : `of ${s.total} on this machine`}
+          // "on this machine" was a claim this number cannot make: the list holds the live fleet
+          // plus a BOUNDED window of recent conversations (`DEFAULT_CLOSED_LIMIT`), not the
+          // machine's whole history — a machine with a thousand stored conversations reads 306
+          // here. It names the LIST, which is what it actually counts.
+          note={pt ? `de ${s.total} nesta lista` : `of ${s.total} in this list`}
         />
         <Stat
           icon={<Bell size={15} />} tone="var(--anthropic-orange)"
@@ -134,14 +138,22 @@ export function FleetOverview({ lang, rows, loading, unsupported, unavailable }:
         {s.harnesses.length === 1 && (
           <p style={{ margin: '0 0 10px', fontSize: 11.5, lineHeight: 1.5, color: 'var(--text-tertiary)' }}>
             {pt
-              ? 'Só assistentes com sessão nesta máquina aparecem aqui. O histórico dos outros está no painel.'
-              : 'Only assistants with a session on this machine appear here. The others’ history is on the dashboard.'}
+              ? 'Só assistentes presentes nesta lista aparecem aqui — ela cobre o que está rodando mais as conversas recentes, não todo o histórico. O total de cada assistente está no painel e na comparação.'
+              : 'Only assistants present in this list appear here — it covers what is running plus recent conversations, not the whole history. Each assistant’s total is on the dashboard and on Compare.'}
           </p>
         )}
         <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
           {s.harnesses.map(h => {
             const color = (HARNESS_COLORS as Record<string, string>)[h.harness] ?? 'var(--text-tertiary)'
-            const label = (HARNESS_LABELS as Record<string, string>)[h.harness] ?? h.harness
+            // A session whose harness could not be NAMED still exists and is still counted — an
+            // assistant found running that no adapter recognises reports an empty harness. It used
+            // to render as a bar with a BLANK label beside it, which reads as a fault in the panel
+            // rather than a fact about the fleet. The row says what it is instead; dropping it
+            // would make the percentages beside it stop adding up.
+            const label = (HARNESS_LABELS as Record<string, string>)[h.harness]
+              ?? (h.harness.trim() === ''
+                ? (pt ? 'assistente não identificado' : 'unidentified assistant')
+                : h.harness)
             const pct = s.total === 0 ? 0 : Math.round((h.count / s.total) * 100)
             return (
               <div key={h.harness} style={{ display: 'flex', alignItems: 'center', gap: 12 }}>


### PR DESCRIPTION
## Summary

Three reports, all from the running product.

**A message sent mid-turn never appeared in the chat.** It is not stored as a `type: 'user'` entry
at all — Claude Code queues it and writes it as an `attachment` of type `queued_command` carrying
the prompt. The pane only ever read user entries, so it showed the assistant answering a question
nobody could see it being asked. Verified against this session's own transcript: the two mid-turn
messages that prompted the report come back as the user's own turns, and did not before. Read by
**shape**, not through `chat-envelope.ts`'s table — nothing wraps the text, and it is the person's
own words either way.

**A bar with no label.** A session whose harness cannot be named reports an empty string, and
"BY ASSISTANT" drew a blank row — which reads as a fault in the panel rather than a fact about the
fleet. It says "unidentified assistant" now, and is **not** dropped: the session exists, it is live,
and removing it would make the percentages beside it stop adding up.

**"not all the harnesses I've used appear here"** — true, and the panel was overclaiming.
`of N on this machine` counts the **list**: the live fleet plus a bounded window of recent
conversations (`DEFAULT_CLOSED_LIMIT`), not the machine's history. A machine with a thousand stored
conversations reads 306 there, and an assistant whose last session predates that window is
legitimately absent. Both sentences now name the list and point at the dashboard and Compare, where
the totals actually live.

## Test plan

`bun tsc --noEmit` clean; tests pass. The mid-turn fix is verified against a real transcript through
the running server (`/api/fleet/chat`), not a fixture: 1 hit for each of the two reported messages,
0 before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uc7HqjasyYjw2AfX3g93pa