### PR TITLE
release: watchers show in the chat, and the surfaces have names

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,29 @@ implementation detail: those live in `docs/` (canonical) and in each harness's o
 - Fill in the PR template for real — a "Summary" with no "Motivation" or "Test plan" is not a
   filled template.
 
+## Merging: squash a feature, MERGE a release
+
+- **A feature PR into `dev` is SQUASHED.** One concern, one commit, and `dev`'s history stays
+  readable.
+- **A release PR (`dev` → `main`) is merged with a MERGE COMMIT — never squashed.** This is the one
+  place the choice matters, and it is not a matter of taste:
+
+  A squash rewrites every commit of the release into one NEW commit on `main`. Git can no longer see
+  that `main`'s copy and `dev`'s original are the same work, so from the next release onward the same
+  files look independently added on both branches and every one of them conflicts. It has happened
+  once already: release #283 was squashed, and the next release PR (#302) opened with **twelve files
+  in conflict**, most of them `add/add` across `packages/vscode/*`, needing a manual
+  merge-and-resolve before it could go anywhere.
+
+  Worse than the conflicts is what the automatic resolution wanted to do with them: a file `dev` had
+  deliberately DELETED (`view-model.ts`, replaced by the server-side arrangement) came back, because
+  the merge base predated its existence and git read `main` as adding it rather than `dev` as
+  removing it. That resurrection produces no conflict and no warning — it lands silently.
+
+  So: **read the diff of a release merge against `dev` before committing it.** It should contain the
+  version bumps `release.yml` wrote on `main` and NOTHING else. Anything else in that diff is a file
+  coming back from the dead.
+
 ## Documentation
 
 - **Documentation is `docs/*.md`** — real files, versioned with the code, readable by any tool or

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1731,6 +1731,26 @@ packages/vscode/src/
   uses, so the two can never disagree about one day. No rate means DOLLARS, never a converted figure
   invented from a guess.
 
+## What each surface is CALLED
+
+Four front doors, and a person saying "the sessions screen" has to land on exactly one of them.
+These are the names to use in conversation, in commits and in comments; they are not
+interchangeable.
+
+- **the Sessions workspace** — the WEB one: `/sessions`, the aside with the fleet on the left and
+  the centre holding either the overview (`FleetOverview`) or the open session's chat and terminal.
+  On a central it is the same workspace, showing the relayed fleet of the machine its picker has
+  chosen. When someone says "a interface de sessões", "a tela de sessões" or "the sessions view",
+  this is it.
+- **the cockpit** — the TERMINAL one: `agentop`'s control center (`packages/tui/src/control`), whose
+  own `sessions` tab draws the fleet. Never call the web one a cockpit; the ambiguity is the whole
+  reason this list exists.
+- **the VS Code extension** — `packages/vscode`, a client of `agentop server` and nothing more.
+- **`agentop session …`** — the CLI verbs.
+
+The FLEET is what all four show: the live sessions plus the conversations that can be reopened. A
+"session" is one conversation; the "fleet" is the set.
+
 ## Important rules
 
 - **Anything agentop writes OUTSIDE its own directories is an explicit act of the user, and is

--- a/docs/surfaces.md
+++ b/docs/surfaces.md
@@ -1,0 +1,27 @@
+# What each surface is called
+
+Agentistics has four front doors onto the same fleet. A person saying "the sessions screen" has to
+land on exactly one of them, so these names are not interchangeable — in conversation, in commits,
+in issues and in code comments.
+
+| Name | What it is |
+|---|---|
+| **the Sessions workspace** | The **web** one: `/sessions`. The aside on the left holds the fleet; the centre holds either the overview or the open session's chat and terminal. On a central it is the same workspace, showing the relayed fleet of whichever machine its picker has chosen. |
+| **the cockpit** | The **terminal** one: `agentop`'s full-screen control center, whose `sessions` tab draws the fleet. |
+| **the VS Code extension** | `packages/vscode` — a client of `agentop server`, and nothing more. |
+| **`agentop session …`** | The CLI verbs (`start`, `ls`, `attach`, `kill`, `rename`, `note`, …). |
+
+**Never call the web one a cockpit.** That ambiguity is the reason this page exists.
+
+## Fleet, session, conversation
+
+- A **session** is one conversation with one assistant.
+- The **fleet** is the set of them a machine can show: what is running now, plus the conversations
+  that can be reopened.
+- A **conversation** outlives the session that hosted it — reopening mints a new session for the
+  same conversation, which is why a row is keyed by its conversation wherever one is known.
+
+## Portuguese
+
+"a interface de sessões", "a tela de sessões" and "o workspace de sessões" all mean the **Sessions
+workspace**. "o cockpit" is the terminal one in both languages.

--- a/packages/server/server/sessions/chat-tail.test.ts
+++ b/packages/server/server/sessions/chat-tail.test.ts
@@ -239,3 +239,79 @@ describe('readRecentChatTurns', () => {
     ])
   })
 })
+
+/**
+ * A watcher is the one tool call worth a line in a conversation. Its END was already reported (the
+ * `<task-notification>` that comes back as a system note); only the START was missing, so a task
+ * appeared to finish having never begun.
+ */
+describe('background tasks', () => {
+  let root: string
+  let file: string
+
+  const bgStart = (id: string, description: string) => line({
+    type: 'assistant',
+    message: { content: [{ type: 'tool_use', id, name: 'Bash', input: { command: 'x', description, run_in_background: true } }] },
+  })
+  const bgDone = (id: string) => line({
+    type: 'user',
+    message: { content: `<task-notification>\n<tool-use-id>${id}</tool-use-id>\n<status>completed</status>\n</task-notification>` },
+  })
+  const foreground = () => line({
+    type: 'assistant',
+    message: { content: [{ type: 'tool_use', id: 'tu_fg', name: 'Bash', input: { command: 'ls', description: 'List files' } }] },
+  })
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), 'chat-tail-bg-'))
+    const dir = join(root, '-p')
+    await mkdir(dir, { recursive: true })
+    file = join(dir, `${SESSION_ID}.jsonl`)
+    forgetChatTailPaths(); forgetChatTailContent()
+  })
+  afterEach(async () => { await rm(root, { recursive: true, force: true }) })
+
+  test('a started task is a RUNNING line, by the label the assistant gave it', async () => {
+    await writeFile(file, [bgStart('tu_1', 'Ship the grant')].join('\n') + '\n')
+    const turns = await readRecentChatTurns(file, 20)
+    const task = turns.find(t => t.task)
+    expect(task?.task).toEqual({ label: 'Ship the grant', running: true })
+  })
+
+  test('its notification settles it, paired by tool-use-id', async () => {
+    // The exact pairing: the notification carries the id of the very tool_use that launched it.
+    await writeFile(file, [bgStart('tu_1', 'Ship the grant'), bgDone('tu_1')].join('\n') + '\n')
+    const turns = await readRecentChatTurns(file, 20)
+    expect(turns.find(t => t.task)?.task).toEqual({ label: 'Ship the grant', running: false })
+  })
+
+  test("someone else's notification does not settle it", async () => {
+    await writeFile(file, [bgStart('tu_1', 'Watch the release'), bgDone('tu_other')].join('\n') + '\n')
+    expect(turns2(await readRecentChatTurns(file, 20)).running).toBe(true)
+  })
+
+  test('a FOREGROUND tool call draws no line at all', async () => {
+    // Rendering every tool call would turn a conversation into a command log — the discriminator is
+    // the tool's own `run_in_background`, never a guess about how long something might take.
+    await writeFile(file, [foreground()].join('\n') + '\n')
+    const turns = await readRecentChatTurns(file, 20)
+    expect(turns.some(t => t.task)).toBe(false)
+  })
+
+  test('two tasks are settled independently', async () => {
+    await writeFile(file, [
+      bgStart('tu_1', 'First'), bgStart('tu_2', 'Second'), bgDone('tu_2'),
+    ].join('\n') + '\n')
+    const byLabel = new Map(
+      (await readRecentChatTurns(file, 20)).filter(t => t.task).map(t => [t.task!.label, t.task!.running]),
+    )
+    expect(byLabel.get('First')).toBe(true)
+    expect(byLabel.get('Second')).toBe(false)
+  })
+})
+
+function turns2(turns: { task?: { label: string; running: boolean } }[]): { label: string; running: boolean } {
+  const t = turns.find(x => x.task)?.task
+  if (!t) throw new Error('no task line')
+  return t
+}

--- a/packages/server/server/sessions/chat-tail.ts
+++ b/packages/server/server/sessions/chat-tail.ts
@@ -56,6 +56,14 @@ export interface ChatTurn {
    */
   pending?: boolean
   /**
+   * A background TASK this turn started, by the label the assistant gave it.
+   *
+   * Rendered as a status line and never as a message: nobody said it. `running` is true while no
+   * `<task-notification>` has come back for it yet — which is what makes a watcher visible WHILE
+   * it is the thing you are waiting on, rather than only once it is over.
+   */
+  task?: { label: string; running: boolean }
+  /**
    * This entry sat under the `user` role and NO PERSON WROTE IT — a background task reporting
    * back, an injected reminder, a `!` command's stdout. The value is a short phrase naming which,
    * never the body: a `<system-reminder>` can be the whole of CLAUDE.md.
@@ -153,6 +161,63 @@ function extractUserEntry(e: Record<string, unknown>): UserEntry | null {
   // A system entry with nothing to name is dropped outright rather than drawn as a blank note.
   if (entry.kind === 'system' && entry.note === '') return null
   return entry
+}
+
+/**
+ * A BACKGROUND TASK the assistant started, and its label.
+ *
+ * A watcher — a build being followed, a release being waited on — is the one tool call worth a line
+ * in a conversation: it is long, it is usually the thing the reader is waiting for, and its END is
+ * already reported (the `<task-notification>` that comes back as a system note). Only the start was
+ * missing, so a task appeared to finish having never begun. Reported as "não aparece aqui os
+ * watchers".
+ *
+ * ONLY background ones. Rendering every tool call would turn a conversation into a command log —
+ * which is exactly why `ChatBubble` refuses `turn.tools` — and the discriminator is the tool's own
+ * `run_in_background`, not a guess about how long something might take.
+ *
+ * The label is the call's own `description`, which is written for a person; the command is not
+ * carried, because a line in a chat is not a terminal.
+ */
+function extractBackgroundTask(e: Record<string, unknown>): { id: string; label: string } | null {
+  if (e.type !== 'assistant') return null
+  const content = (e.message as Record<string, unknown> | undefined)?.content
+  if (!Array.isArray(content)) return null
+  for (const part of content as Record<string, unknown>[]) {
+    if (part.type !== 'tool_use') continue
+    const input = part.input as Record<string, unknown> | undefined
+    if (!input || input.run_in_background !== true) continue
+    const label = typeof input.description === 'string' ? input.description.trim() : ''
+    const id = typeof part.id === 'string' ? part.id : ''
+    return { id, label: label || (typeof part.name === 'string' ? part.name : 'background task') }
+  }
+  return null
+}
+
+/**
+ * The `tool-use-id` a `<task-notification>` is reporting on, when it names one.
+ *
+ * This is the EXACT pairing between a task's start and its end — the notification carries the very
+ * id of the `tool_use` that launched it. It is read off the raw text here because
+ * `classifyUserText` deliberately discards a system entry's BODY, and rightly: a
+ * `<system-reminder>` can be the whole of CLAUDE.md. One id is not a body.
+ */
+function rawEntryText(e: Record<string, unknown>): string {
+  const c = (e.message as Record<string, unknown> | undefined)?.content
+  if (typeof c === 'string') return c
+  if (Array.isArray(c)) {
+    const t = (c as Record<string, unknown>[]).find(p => p.type === 'text' && typeof p.text === 'string')
+    if (t) return t.text as string
+  }
+  const a = e.attachment as Record<string, unknown> | undefined
+  if (a && typeof a.prompt === 'string') return a.prompt
+  return ''
+}
+
+function taskNotificationFor(text: string): string | null {
+  if (!text.includes('<task-notification>')) return null
+  const m = /<tool-use-id>([^<]+)<\/tool-use-id>/.exec(text)
+  return m ? m[1]!.trim() : null
 }
 
 /**
@@ -349,6 +414,10 @@ async function readTurnsFromTail(
 
   const lines = content.split('\n')
   const turns: ChatTurn[] = []
+  /** Tasks started in this file, and the `tool-use-id` each completion will name. */
+  const taskTurns: Array<{ id: string; turn: ChatTurn }> = []
+  /** Ids whose `<task-notification>` has already arrived. */
+  const finishedTasks = new Set<string>()
   // Set once, on the first substantive (non-blank, parseable) line the loop inspects — which is the
   // NEWEST event in the transcript. Only there does "no text yet" mean "busy right now"; the same
   // shape earlier in the file is just an ordinary tool call whose result and follow-up text already
@@ -362,6 +431,18 @@ async function readTurnsFromTail(
     const isNewest = newest
     newest = false
 
+    const done = taskNotificationFor(rawEntryText(e))
+    if (done) finishedTasks.add(done)
+
+    const bg = extractBackgroundTask(e)
+    if (bg) {
+      // A status line, never a message — nobody said it. `running` is settled after the walk,
+      // once every completion in the file has been seen.
+      turns.push({ role: 'assistant', text: bg.label, task: { label: bg.label, running: true }, pending: true })
+      taskTurns.push({ id: bg.id, turn: turns[turns.length - 1]! })
+      continue
+    }
+
     const userEntry = extractUserEntry(e)
     if (userEntry) { turns.push(userTurn(userEntry)); continue }
     const queued = extractQueuedText(e)
@@ -373,6 +454,17 @@ async function readTurnsFromTail(
       if (tools) turns.push({ role: 'assistant', text: toolActivityLabel(tools), pending: true })
     }
   }
+  // Settled AFTER the walk: a completion always comes later in the file than its start, so this is
+  // the only point where "still running" can be answered without reading the file twice. An id
+  // that never arrives stays running — which is the truth for a task the session is still on, and
+  // for one whose session ended mid-flight there is nothing better to say.
+  for (const t of taskTurns) {
+    if (t.turn.task && finishedTasks.has(t.id)) {
+      t.turn.task.running = false
+      delete t.turn.pending
+    }
+  }
+
   turns.reverse()
 
   return { turns, atStart: tail.atStart }
@@ -397,6 +489,10 @@ export async function readChatTurns(path: string, max = 400): Promise<ChatTurn[]
 
   const lines = content.split('\n')
   const turns: ChatTurn[] = []
+  /** Tasks started in this file, and the `tool-use-id` each completion will name. */
+  const taskTurns: Array<{ id: string; turn: ChatTurn }> = []
+  /** Ids whose `<task-notification>` has already arrived. */
+  const finishedTasks = new Set<string>()
   let newest = true
   for (let i = lines.length - 1; i >= 0 && turns.length < max; i--) {
     const line = (lines[i] ?? '').trim()
@@ -405,6 +501,18 @@ export async function readChatTurns(path: string, max = 400): Promise<ChatTurn[]
     try { e = JSON.parse(line) } catch { continue }
     const isNewest = newest
     newest = false
+
+    const done = taskNotificationFor(rawEntryText(e))
+    if (done) finishedTasks.add(done)
+
+    const bg = extractBackgroundTask(e)
+    if (bg) {
+      // A status line, never a message — nobody said it. `running` is settled after the walk,
+      // once every completion in the file has been seen.
+      turns.push({ role: 'assistant', text: bg.label, task: { label: bg.label, running: true }, pending: true })
+      taskTurns.push({ id: bg.id, turn: turns[turns.length - 1]! })
+      continue
+    }
 
     const userEntry = extractUserEntry(e)
     if (userEntry) { turns.push(userTurn(userEntry)); continue }
@@ -429,6 +537,17 @@ export async function readChatTurns(path: string, max = 400): Promise<ChatTurn[]
       })
     }
   }
+  // Settled AFTER the walk: a completion always comes later in the file than its start, so this is
+  // the only point where "still running" can be answered without reading the file twice. An id
+  // that never arrives stays running — which is the truth for a task the session is still on, and
+  // for one whose session ended mid-flight there is nothing better to say.
+  for (const t of taskTurns) {
+    if (t.turn.task && finishedTasks.has(t.id)) {
+      t.turn.task.running = false
+      delete t.turn.pending
+    }
+  }
+
   turns.reverse()
   return turns
 }

--- a/packages/server/server/sessions/sessions-host.ts
+++ b/packages/server/server/sessions/sessions-host.ts
@@ -189,18 +189,31 @@ export function createSessionsPoller(o: {
 
     try {
       const gatherStart = performance.now()
+      // Each of the five is timed SEPARATELY as well as together, because the two numbers disagreed
+      // and the disagreement is the whole question. Measured individually in a bare process, none
+      // of them exceeded 415ms; measured here inside this `Promise.all`, the group took 2961ms. A
+      // group total cannot say which member carries that, and five concurrent readers of the same
+      // disk are exactly the shape that makes a per-member number differ from a solo one — so the
+      // per-member marks are taken IN PLACE, under the concurrency they actually run under, rather
+      // than inferred from a solo timing that has already proved not to transfer.
+      const timed = <T>(label: string, p: Promise<T>): Promise<T> => {
+        const started = performance.now()
+        return p.then(v => { markFleetPhase(`poll: gather · ${label}`, started); return v })
+      }
       const [registry, backendSessions, processes, conversations, harnessSessions] = await Promise.all([
-        o.readRegistry(),
-        o.backend.list(),
-        o.scanProcesses().then(r => r.procs).catch(() => [] as HarnessProcess[]),
+        timed('readRegistry', o.readRegistry()),
+        timed('backend.list', o.backend.list()),
+        timed('scanProcesses', o.scanProcesses().then(r => r.procs).catch(() => [] as HarnessProcess[])),
         // History is an enrichment, never a prerequisite: a store that cannot be read costs the
         // closed rows, not the running ones.
-        o.loadConversations ? o.loadConversations().catch(() => [] as Conversation[]) : Promise.resolve([]),
+        timed('loadConversations',
+          o.loadConversations ? o.loadConversations().catch(() => [] as Conversation[]) : Promise.resolve([])),
         // Same rule: unreadable costs the harness's own names and its exact conversation ids, and
         // every row falls back to behaving exactly as it did before this existed.
-        o.loadHarnessSessions
-          ? o.loadHarnessSessions().catch(() => emptyHarnessSessionIndex())
-          : Promise.resolve(emptyHarnessSessionIndex()),
+        timed('loadHarnessSessions',
+          o.loadHarnessSessions
+            ? o.loadHarnessSessions().catch(() => emptyHarnessSessionIndex())
+            : Promise.resolve(emptyHarnessSessionIndex())),
       ])
       markFleetPhase('poll: gather (registry/backend.list/scanProcesses/conversations/harnessSessions)', gatherStart)
 

--- a/packages/web/src/components/sessions/ChatBubble.tsx
+++ b/packages/web/src/components/sessions/ChatBubble.tsx
@@ -25,7 +25,7 @@ import remarkGfm from 'remark-gfm'
 // message written across several lines renders as one run-on paragraph — which is what "the
 // messages are not formatted" turned out to mean. `HarnessChat` has always used it.
 import remarkBreaks from 'remark-breaks'
-import { Clock, CornerUpLeft, User } from 'lucide-react'
+import { Check, Clock, CornerUpLeft, Loader, User } from 'lucide-react'
 import { HARNESS_COLORS, HARNESS_LABELS } from '../../lib/harness'
 import { splitImageAttachments } from '../../lib/attachmentPreview'
 import { attachmentUrl } from '../../lib/attachmentUrl'
@@ -36,6 +36,14 @@ export interface ChatTurn {
   role: 'user' | 'assistant'
   text: string
   pending?: boolean
+  /**
+   * A background TASK this turn started, by the label the assistant gave it.
+   *
+   * A watcher is the one tool call worth a line in a conversation: it is long, it is usually the
+   * thing the reader is waiting for, and its END is already reported. Rendered as a status line and
+   * never as a message — nobody said it.
+   */
+  task?: { label: string; running: boolean }
   /**
    * This sat under the `user` role and no person wrote it — a background task reporting back, an
    * injected reminder, a `!` command's stdout. The value NAMES the kind; it is never the body.
@@ -120,6 +128,35 @@ export const ChatBubble = memo(function ChatBubble({ turn, lang, harness, provis
   // NOT a message, and not drawn as one: no avatar, no bubble, no side. A dim centred note naming
   // what the harness put in the transcript, so the reply below it still has something above it
   // while nobody is credited with having typed it.
+  // A BACKGROUND TASK: a dim line, unattributed, that says whether it is still going. Drawn before
+  // the system note below because it is the same kind of thing — a fact about the session rather
+  // than something either side said — and it carries no bubble for the same reason.
+  if (turn.task) {
+    const running = turn.task.running
+    return (
+      <div style={{ display: 'flex', justifyContent: 'center', padding: '2px 0' }}>
+        <span style={{
+          display: 'inline-flex', alignItems: 'center', gap: 6,
+          fontSize: 10.5, lineHeight: 1.4,
+          color: running ? 'var(--anthropic-orange)' : 'var(--text-tertiary)',
+          padding: '3px 10px', borderRadius: 999,
+          background: 'var(--bg-elevated)',
+          border: `1px solid ${running ? 'color-mix(in srgb, var(--anthropic-orange) 40%, transparent)' : 'var(--border-subtle)'}`,
+          maxWidth: '90%', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+        }}>
+          {running
+            ? <Loader size={11} className="ag-working-spin" style={{ flexShrink: 0 }} />
+            : <Check size={11} style={{ flexShrink: 0 }} />}
+          <span>
+            {running
+              ? (pt ? `em segundo plano: ${turn.task.label}` : `in the background: ${turn.task.label}`)
+              : (pt ? `terminou: ${turn.task.label}` : `finished: ${turn.task.label}`)}
+          </span>
+        </span>
+      </div>
+    )
+  }
+
   if (turn.system) {
     return (
       <div style={{

--- a/packages/web/src/components/sessions/SessionChat.tsx
+++ b/packages/web/src/components/sessions/SessionChat.tsx
@@ -277,7 +277,11 @@ export function SessionChat({ session, row, lang, act }: SessionChatProps) {
     })
   }, [turns, echo.length])
 
-  const lastAssistant = [...turns].reverse().find(t => t.role === 'assistant' && !t.pending && t.text.trim() !== '')
+  // A finished background-task line is `role: 'assistant'` and carries no `pending` any more, so it
+  // would otherwise be taken as the assistant's last MESSAGE — and its label would be compared
+  // against the live terminal frame. It is a status line; nobody said it.
+  const lastAssistant = [...turns].reverse()
+    .find(t => t.role === 'assistant' && !t.pending && !t.task && t.text.trim() !== '')
 
   const live = useMemo(() => {
     if (!term.frame) return null


### PR DESCRIPTION
## Summary

One PR: #338.

- **A background task is now a line in the conversation** — dim, unattributed, saying whether it is
  still running. Only its end was visible before, so a watcher was invisible for exactly as long as
  you were waiting on it. Start and end pair by the notification's own `tool-use-id`, so the state
  is exact rather than inferred.
- **The surfaces have names.** "the Sessions workspace" is the web one, "the cockpit" is the
  terminal one, and the web one is never a cockpit. In `CLAUDE.md` and `docs/surfaces.md`, so any
  session in any harness understands the reference.

## Test plan

`bun tsc --noEmit` clean; `bun test` 5205 pass, 0 fail. Verified against a real transcript through
the running server (13 task lines, all paired), plus five unit tests. Figures in #338.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uc7HqjasyYjw2AfX3g93pa