### PR TITLE
fix(team): the sharing rules bind the ACT half of the machine-fleet relay too (#340)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -960,6 +960,27 @@ harness working here must not break.
 - **Rules first, then reduce.** The member applies `cwdShared` BEFORE building the row, so a
   session in a withheld repository never becomes one — reducing first leaves no `cwd` to judge.
   `withheld` is a count of SESSIONS and is reported, never silently subtracted.
+- **The sharing rules bind the ACT half exactly as they bind the READ half, and for one release
+  they did not.** `buildMachineFleetReply` filtered rows through `cwdShared` from the day it
+  shipped; `performMachineAction` checked consent and the verb and then handed the id to
+  `runFleetAction`, which resolves against the machine's RAW fleet and registry — so a central
+  could `kill`, `rename`, `resume` or re-task a session in a repository the member had explicitly
+  withheld from it. **A rule enforced when you LOOK and not when you ACT is not a rule.** Both
+  halves now resolve through the one `sharedCwd` helper, and an id the machine cannot find is
+  refused for the same reason a row with no `cwd` is: the rule names directories, and an
+  unresolvable target has none to judge.
+- **The TASK verbs are refused outright on a RESTRICTED connection.** `openTask` expands to every
+  session filed under the row's task, over the whole registry, and a task routinely spans
+  repositories — so pressing it on a VISIBLE row spawned live assistants inside a withheld
+  directory and answered with a count of them. Refusing only when the task provably spans a
+  withheld row would be an ORACLE: repeated over the visible rows it maps which of them share work
+  with the hidden half, which is the same correlation as counting a hidden project's sessions. The
+  blunt refusal discloses nothing the reply does not already carry (`withheld` is a machine-level
+  count), and the verbs are dropped from the relayed row too — offering one the machine will refuse
+  is the control-that-reads-as-broken this file argues against everywhere else.
+- **Consent is ORTHOGONAL to the sharing rules, and that is the trap.** The two switches are
+  machine-wide; turning on "manage my sessions" says nothing about WHICH sessions, so without the
+  rule check above it silently re-opened the act surface over every withheld repository.
 - **`machineActions.ts` is CLOSED.** A verb it does not know is refused. A new `FleetActionId` must
   be listed there on purpose before a central can drive it. `approve`/`prompt` are excluded because
   neither can be offered without the screen — refused with a sentence naming why, never a disabled

--- a/docs/security.md
+++ b/docs/security.md
@@ -474,10 +474,30 @@ can offer five answers that do different work, and a keystroke that answers cann
 option it is taking. A button over a dialog nobody can read is the accident `parseDialogOptions`
 exists to prevent.
 
-**The machine is the authority, not the central.** Consent and the verb allowlist are re-read on
-the member on every request. The central's copy of those checks exists only to spare a round trip
-and answer the user instantly; a check that runs only on the party whose behaviour cannot be
-verified is not a check.
+**The machine is the authority, not the central.** Consent, the verb allowlist **and this
+connection's sharing rules** are re-read on the member on every request. The central's copy of
+those checks exists only to spare a round trip and answer the user instantly; a check that runs
+only on the party whose behaviour cannot be verified is not a check.
+
+**A withheld session cannot be acted on, and for one release it could be.** The two consent
+switches are machine-wide: they say whether sessions may be managed at all, and nothing about
+WHICH. The rules in §8 say which. Both must hold, and only the first one did — the read half
+filtered rows through `cwdShared` while the act half resolved the id against the machine's raw
+fleet, so a central could `kill`, `rename`, `resume` or re-task a session in a repository its
+member had explicitly withheld from it. A rule enforced when you look and not when you act is not
+a rule. `performMachineAction` now resolves the target through the same predicate the rows went
+through, and refuses an id it cannot resolve — an unresolvable target has no directory to judge,
+and passing it through would leave every verb reachable by naming an id the fleet does not list.
+
+**The task verbs are refused entirely while anything is withheld.** `openTask` acts on the piece of
+WORK a row is filed under, expanding across the whole registry, and a task routinely spans
+repositories — so on a restricted connection it reached sessions the central was never shown,
+started assistants in their directories and reported how many. Refusing only when a task provably
+spans a withheld row would answer, one visible row at a time, "does this one share work with the
+hidden half" — an oracle, and the same correlation §8 exists to deny. So the verbs are refused for
+every restricted connection and are absent from the relayed rows; the refusal names no repository
+and no count, disclosing nothing beyond the machine-level `withheld` figure the reply already
+carries. Open or finish the task on the machine itself.
 
 **The stated non-guarantee.** Whoever runs the central administers machines and can re-assign one
 to another account. This switch is what stops session access being on without its owner choosing

--- a/packages/server/server/sessions/machine-fleet.test.ts
+++ b/packages/server/server/sessions/machine-fleet.test.ts
@@ -10,7 +10,7 @@ function row(id: string, cwd: string, extra: Record<string, unknown> = {}) {
   }
 }
 
-function deps(rows: Record<string, unknown>[], attention = 0, unavailable?: string): MachineFleetDeps {
+function deps_(rows: Record<string, unknown>[], attention = 0, unavailable?: string): MachineFleetDeps {
   return {
     readFleet: async () => ({ rows, attention, ...(unavailable ? { unavailable } : {}) }),
     readIndexSources: async () => ({
@@ -42,21 +42,21 @@ describe('buildMachineFleetReply', () => {
     // An empty list is a statement about the fleet; null is a statement about consent, and the
     // central keeps them as different sentences.
     return Promise.all([
-      buildMachineFleetReply({}, 'en', deps(ALL)),
-      buildMachineFleetReply({ allowRemoteSessions: false }, 'en', deps(ALL)),
+      buildMachineFleetReply({}, 'en', deps_(ALL)),
+      buildMachineFleetReply({ allowRemoteSessions: false }, 'en', deps_(ALL)),
       // A screen grant with no fleet grant agrees to nothing — resolveRemoteConsent's rule.
-      buildMachineFleetReply({ allowRemoteScreens: true }, 'en', deps(ALL)),
+      buildMachineFleetReply({ allowRemoteScreens: true }, 'en', deps_(ALL)),
     ]).then(rs => rs.forEach(r => expect(r).toBeNull()))
   })
 
   it('relays every row under an unrestricted denylist, and nothing is withheld', async () => {
-    const r = (await buildMachineFleetReply({ allowRemoteSessions: true }, 'en', deps(ALL)))!
+    const r = (await buildMachineFleetReply({ allowRemoteSessions: true }, 'en', deps_(ALL)))!
     expect(r.rows.map(x => x.id)).toEqual(['1', '2'])
     expect(r.withheld).toBe(0)
   })
 
   it('never relays the screen or the conversation, whatever the rules say', async () => {
-    const r = (await buildMachineFleetReply({ allowRemoteSessions: true }, 'en', deps(ALL)))!
+    const r = (await buildMachineFleetReply({ allowRemoteSessions: true }, 'en', deps_(ALL)))!
     for (const relayed of r.rows as unknown as Record<string, unknown>[]) {
       expect(relayed.lastLines).toBeUndefined()
       expect(relayed.chatTurns).toBeUndefined()
@@ -67,7 +67,7 @@ describe('buildMachineFleetReply', () => {
     const r = (await buildMachineFleetReply({
       allowRemoteSessions: true, shareMode: 'denylist',
       sources: [{ type: 'repo', value: 'github.com/o/beta' }],
-    }, 'en', deps(ALL)))!
+    }, 'en', deps_(ALL)))!
     expect(r.rows.map(x => x.id)).toEqual(['1'])
     // Reported rather than silently subtracted: "some sessions are not shared with this central"
     // is a sentence, not an absence.
@@ -78,7 +78,7 @@ describe('buildMachineFleetReply', () => {
     const r = (await buildMachineFleetReply({
       allowRemoteSessions: true, shareMode: 'allowlist',
       sources: [{ type: 'repo', value: 'github.com/o/beta' }],
-    }, 'en', deps(ALL)))!
+    }, 'en', deps_(ALL)))!
     expect(r.rows.map(x => x.id)).toEqual(['2'])
     expect(r.withheld).toBe(1)
   })
@@ -86,7 +86,7 @@ describe('buildMachineFleetReply', () => {
   it('an EMPTY allowlist relays nothing — it is the strictest rule, not the absence of one', async () => {
     const r = (await buildMachineFleetReply({
       allowRemoteSessions: true, shareMode: 'allowlist', sources: [],
-    }, 'en', deps(ALL)))!
+    }, 'en', deps_(ALL)))!
     expect(r.rows).toEqual([])
     expect(r.withheld).toBe(2)
   })
@@ -98,7 +98,7 @@ describe('buildMachineFleetReply', () => {
     const r = (await buildMachineFleetReply({
       allowRemoteSessions: true, shareMode: 'denylist',
       sources: [{ type: 'repo', value: 'github.com/o/beta' }],
-    }, 'en', deps(rows)))!
+    }, 'en', deps_(rows)))!
     expect(r.rows.map(x => x.id)).toEqual(['1'])
     expect(r.withheld).toBe(2)
   })
@@ -108,9 +108,9 @@ describe('buildMachineFleetReply', () => {
     const restricted = (await buildMachineFleetReply({
       allowRemoteSessions: true, shareMode: 'denylist',
       sources: [{ type: 'repo', value: 'github.com/o/beta' }],
-    }, 'en', deps(rows)))!
+    }, 'en', deps_(rows)))!
     expect(restricted.rows.map(x => x.id)).toEqual(['1'])
-    const open = (await buildMachineFleetReply({ allowRemoteSessions: true }, 'en', deps(rows)))!
+    const open = (await buildMachineFleetReply({ allowRemoteSessions: true }, 'en', deps_(rows)))!
     expect(open.rows.map(x => x.id)).toEqual(['1', '9'])
   })
 
@@ -119,7 +119,7 @@ describe('buildMachineFleetReply', () => {
     // the same name.
     const r = (await buildMachineFleetReply({
       allowRemoteSessions: true, shareMode: 'allowlist', sources: [],
-    }, 'en', deps(ALL, 3)))!
+    }, 'en', deps_(ALL, 3)))!
     expect(r.rows).toEqual([])
     expect(r.attention).toBe(3)
   })
@@ -127,29 +127,56 @@ describe('buildMachineFleetReply', () => {
   it('relays only the verbs a central may drive — approve and prompt never appear', async () => {
     // Narrowed BEFORE the reduction, so a verb this machine would refuse never reaches the button.
     // Offering one and refusing it on the click is the control that reads as broken.
-    const r = (await buildMachineFleetReply({ allowRemoteSessions: true }, 'en', deps(WITH_VERBS)))!
+    const r = (await buildMachineFleetReply({ allowRemoteSessions: true }, 'en', deps_(WITH_VERBS)))!
     expect(r.rows[0]!.verbs!.map(v => v.action)).toEqual(['rename', 'kill'])
   })
 
   it('the screen consent does NOT unlock approve or prompt — they are not implemented', async () => {
-    const r = (await buildMachineFleetReply({ allowRemoteSessions: true, allowRemoteScreens: true }, 'en', deps(WITH_VERBS)))!
+    const r = (await buildMachineFleetReply({ allowRemoteSessions: true, allowRemoteScreens: true }, 'en', deps_(WITH_VERBS)))!
     expect(r.rows[0]!.verbs!.map(v => v.action)).toEqual(['rename', 'kill'])
   })
 
   it("carries the machine's own sentence about an incomplete list", async () => {
-    const r = (await buildMachineFleetReply({ allowRemoteSessions: true }, 'en', deps(ALL, 0, 'tmux is not installed')))!
+    const r = (await buildMachineFleetReply({ allowRemoteSessions: true }, 'en', deps_(ALL, 0, 'tmux is not installed')))!
     expect(r.unavailable).toBe('tmux is not installed')
+  })
+
+  it('drops the TASK verbs from a row when the connection is restricted', async () => {
+    // A verb this machine will refuse must never appear on the row — the same rule the screen
+    // verbs already follow. Offering it and refusing on the click is the control that reads as
+    // broken.
+    const rows = [row('1', '/home/me/alpha', {
+      verbs: [
+        { action: 'rename', label: 'Rename', enabled: true },
+        { action: 'openTask', label: 'Open task', enabled: true },
+        { action: 'finishTask', label: 'Finish task', enabled: true },
+      ],
+    })]
+    const restricted = (await buildMachineFleetReply({
+      allowRemoteSessions: true,
+      shareMode: 'denylist',
+      sources: [{ type: 'repo', value: 'github.com/o/beta' }],
+    }, 'en', deps_(rows)))!
+    expect(restricted.rows[0]!.verbs?.map(v => v.action)).toEqual(['rename'])
+    // ...and keeps them when nothing is withheld.
+    const open = (await buildMachineFleetReply({ allowRemoteSessions: true }, 'en', deps_(rows)))!
+    expect(open.rows[0]!.verbs?.map(v => v.action)).toEqual(['rename', 'openTask', 'finishTask'])
   })
 })
 
 describe('performMachineAction', () => {
   const ran: { id: string; action: string; text?: string }[] = []
-  const deps = {
-    runAction: async (_l: never, r: { id: string; action: string; text?: string }) => {
-      ran.push(r)
-      return { ok: true, message: 'done' }
-    },
-  } as never
+  // `s1` sits in alpha, `s2` in beta, and they share the task "refactor" — the shape the leak
+  // needed: one row a restricted central may see, one it may not, filed under one piece of work.
+  const ACT_ROWS = [
+    row('s1', '/home/me/alpha', { task: 'refactor' }),
+    row('s2', '/home/me/beta', { task: 'refactor' }),
+  ]
+  const runAction = async (_l: never, r: { id: string; action: string; text?: string }) => {
+    ran.push(r)
+    return { ok: true, message: 'done' }
+  }
+  const deps = { ...deps_(ACT_ROWS), runAction } as never
 
   it('performs a screenless verb once the machine has agreed', async () => {
     for (const action of ['rename', 'note', 'task', 'interrupt', 'kill', 'resume', 'openTask', 'finishTask']) {
@@ -192,6 +219,96 @@ describe('performMachineAction', () => {
     ran.length = 0
     await performMachineAction({ allowRemoteSessions: true }, 'en', { action: 'rename', id: 's1', text: 'new name' }, deps)
     expect(ran[0]).toEqual({ id: 's1', action: 'rename', text: 'new name' })
+  })
+
+  // ---- the sharing rules, on the ACT half ----------------------------------------------------
+  //
+  // The read half filtered rows through `cwdShared` from the day it shipped; this half checked
+  // consent and the verb and then resolved the id against the machine's RAW fleet. Every test
+  // below fails if that check is removed.
+
+  const DENY_BETA = {
+    allowRemoteSessions: true,
+    shareMode: 'denylist' as const,
+    sources: [{ type: 'repo' as const, value: 'github.com/o/beta' }],
+  }
+
+  it('refuses a verb aimed at a session this connection cannot see, and never runs it', async () => {
+    // `s2` lives in the withheld repo. Before the fix this reached `runFleetAction`, which resolves
+    // the id against the unfiltered registry — a bare tmux kill, a rename, a resume in that cwd.
+    for (const action of ['kill', 'rename', 'note', 'task', 'interrupt', 'resume']) {
+      ran.length = 0
+      const r = await performMachineAction(DENY_BETA, 'en', { action, id: 's2', text: 'x' }, deps)
+      expect(r.ok).toBe(false)
+      expect(r.message).toMatch(/not shared with this central/)
+      expect(ran).toEqual([])
+    }
+  })
+
+  it('still performs the same verbs on a session it DOES share', async () => {
+    // The rule narrows; it must not break the feature for the rows the central was shown.
+    ran.length = 0
+    const r = await performMachineAction(DENY_BETA, 'en', { action: 'kill', id: 's1' }, deps)
+    expect(r.ok).toBe(true)
+    expect(ran).toEqual([{ id: 's1', action: 'kill', text: undefined }])
+  })
+
+  it('fails CLOSED on an id the machine cannot find', async () => {
+    // An id with no row is an id with no directory, and the rule names directories. Passing it
+    // through would leave every verb reachable by naming an id the fleet does not list.
+    ran.length = 0
+    const r = await performMachineAction(DENY_BETA, 'en', { action: 'kill', id: 'ghost' }, deps)
+    expect(r.ok).toBe(false)
+    expect(ran).toEqual([])
+  })
+
+  it('refuses the TASK verbs on a restricted connection, without saying whether this task spans one', async () => {
+    // `openTask` expands over the whole registry, so pressing it on the VISIBLE `s1` reopened `s2`
+    // in the withheld repo. Refused for every restricted connection rather than only when it
+    // provably spans: the narrower check is an oracle for which visible rows share work with the
+    // hidden half.
+    for (const action of ['openTask', 'finishTask']) {
+      ran.length = 0
+      const r = await performMachineAction(DENY_BETA, 'en', { action, id: 's1' }, deps)
+      expect(r.ok).toBe(false)
+      expect(r.message).toMatch(/task on the machine itself/)
+      expect(ran).toEqual([])
+      // The refusal may not name the hidden row, its repo, or a count of them.
+      expect(r.message).not.toMatch(/beta|s2/)
+    }
+  })
+
+  it('leaves an UNRESTRICTED connection paying nothing — task verbs included', async () => {
+    // The common case: a denylist that names nothing reads the fleet not at all.
+    let read = 0
+    const counting = {
+      ...deps_(ACT_ROWS),
+      readFleet: async (l: never) => { read++; return await deps_(ACT_ROWS).readFleet(l) },
+      runAction,
+    } as never
+    for (const action of ['kill', 'openTask']) {
+      const r = await performMachineAction({ allowRemoteSessions: true }, 'en', { action, id: 's1' }, counting)
+      expect(r.ok).toBe(true)
+    }
+    expect(read).toBe(0)
+  })
+
+  it('an ALLOWLIST restricts even when it names nothing', async () => {
+    // The strictest rule there is — it must never take the unrestricted shortcut.
+    const r = await performMachineAction(
+      { allowRemoteSessions: true, shareMode: 'allowlist', sources: [] },
+      'en', { action: 'kill', id: 's1' }, deps,
+    )
+    expect(r.ok).toBe(false)
+  })
+
+  it('refuses in the asked-for language on both new refusals', async () => {
+    for (const req of [{ action: 'kill', id: 's2' }, { action: 'openTask', id: 's1' }]) {
+      const en = await performMachineAction(DENY_BETA, 'en', req, deps)
+      const pt = await performMachineAction(DENY_BETA, 'pt', req, deps)
+      expect(en.message).not.toBe(pt.message)
+      expect(pt.message.length).toBeGreaterThan(10)
+    }
   })
 
   it('every refusal is worded, in the asked-for language', async () => {

--- a/packages/server/server/sessions/machine-fleet.ts
+++ b/packages/server/server/sessions/machine-fleet.ts
@@ -39,6 +39,44 @@ export interface MachineFleetDeps {
 }
 
 /**
+ * The two verbs whose subject is the piece of WORK rather than the row: they expand to every
+ * session filed under the row's task, across the whole registry, and a task is a unit of work that
+ * routinely spans repositories. See `performMachineAction` for why a restricted connection cannot
+ * be offered them at all.
+ */
+const TASK_WIDE_ACTIONS: readonly string[] = ['openTask', 'finishTask']
+
+/**
+ * This connection's directory test, or `null` when the connection restricts NOTHING.
+ *
+ * `null` rather than a predicate that always returns true, so the callers can tell "everything is
+ * shared" from "this directory is shared" and skip building an index nobody will consult — the
+ * unrestricted case is the common one and pays nothing, exactly as `filterLiveShared`'s own
+ * shortcut does.
+ *
+ * It is ONE function because the read half and the act half must agree about a directory. They did
+ * not: the read half filtered rows through `cwdShared` while the act half had no rules check at
+ * all, so a central could drive verbs against sessions it was never shown.
+ */
+async function sharedCwd(
+  conn: Pick<TeamConnection, 'shareMode' | 'sources'>,
+  readIndexSources: MachineFleetDeps['readIndexSources'],
+): Promise<((cwd: string) => boolean) | null> {
+  const shareRules = await import('../share-rules')
+  const rules = shareRules.shareRulesOf(conn.shareMode, conn.sources)
+  // An allowlist ALWAYS restricts (an empty one shares nothing), so this cannot be gated on a
+  // non-empty source set the way an unrestricted denylist's could — same clause as the live
+  // snapshot's, and for the same reason.
+  if (rules.mode !== 'allowlist' && rules.sources.size === 0) return null
+  const src = await readIndexSources()
+  const index = shareRules.buildPathRepoIndex(src.sessions as never, src.projects)
+  // A row with NO directory cannot be judged against a rule that names directories, so it is
+  // withheld whenever any rule is in force. Sharing what cannot be checked is the fail-open
+  // direction, and this channel is the sharpest one the product has.
+  return cwd => !!cwd && shareRules.cwdShared(cwd, rules, index)
+}
+
+/**
  * Build the reply for ONE connection's request.
  *
  * Returns `null` when this machine has not agreed — the caller sends nothing at all rather than an
@@ -53,34 +91,24 @@ export async function buildMachineFleetReply(
   const consent = resolveRemoteConsent(conn.allowRemoteSessions, conn.allowRemoteScreens)
   if (!consent.sessions) return null
 
-  const shareRules = await import('../share-rules')
-  const rules = shareRules.shareRulesOf(conn.shareMode, conn.sources)
-  // An allowlist ALWAYS restricts (an empty one shares nothing), so the index cannot be gated on a
-  // non-empty source set the way an unrestricted denylist's could — same clause as the live
-  // snapshot's, and for the same reason.
-  const restricted = rules.mode === 'allowlist' || rules.sources.size > 0
-
+  const isShared = await sharedCwd(conn, deps.readIndexSources)
   const fleet = await deps.readFleet(lang)
-  let index: import('../share-rules').PathRepoIndex | undefined
-  if (restricted) {
-    const src = await deps.readIndexSources()
-    index = shareRules.buildPathRepoIndex(src.sessions as never, src.projects)
-  }
 
   const rows: MachineFleetRow[] = []
   let withheld = 0
   for (const row of fleet.rows) {
     const cwd = typeof row.cwd === 'string' ? row.cwd : ''
-    // A row with NO directory cannot be judged against a rule that names directories, so it is
-    // withheld whenever any rule is in force. Sharing what cannot be checked is the fail-open
-    // direction, and this channel is the sharpest one the product has.
-    const shared = restricted ? (!!cwd && shareRules.cwdShared(cwd, rules, index)) : true
-    if (!shared) { withheld++; continue }
+    if (isShared && !isShared(cwd)) { withheld++; continue }
     // Narrowed to what may be driven from a central BEFORE the reduction, so a verb this machine
     // will refuse never even appears on the row. Offering one and refusing it on the click is the
-    // control-that-reads-as-broken this codebase keeps arguing against.
+    // control-that-reads-as-broken this codebase keeps arguing against. The task verbs go with the
+    // rest on a RESTRICTED connection for exactly that reason — `performMachineAction` refuses
+    // them there, so offering them would be that same broken control.
     const verbs = Array.isArray(row.verbs)
-      ? (row.verbs as { action?: unknown }[]).filter(v => typeof v?.action === 'string' && remoteActionAllowed(v.action, consent))
+      ? (row.verbs as { action?: unknown }[]).filter(v =>
+        typeof v?.action === 'string'
+        && remoteActionAllowed(v.action, consent)
+        && !(isShared && TASK_WIDE_ACTIONS.includes(v.action)))
       : undefined
     rows.push(reduceMachineFleetRow({ ...row, ...(verbs ? { verbs } : {}) }))
   }
@@ -110,12 +138,21 @@ export async function buildMachineFleetReply(
  *
  * The refusal wording is this machine's, in this machine's language, because every other refusal
  * the user meets already is.
+ *
+ * **THE SHARING RULES ARE PART OF THAT AUTHORITY, and they were missing here.** The read half
+ * (`buildMachineFleetReply`) filtered rows through `cwdShared`; this half checked consent and the
+ * verb and then resolved the id against the machine's RAW fleet, so a central could `kill`,
+ * `rename`, `resume` or re-task a session in a repository the member had explicitly withheld from
+ * it. A rule that is enforced when you LOOK and not when you ACT is not a rule. So the target is
+ * resolved and judged by the same predicate the rows were, and an unresolvable row is refused
+ * rather than passed through: an id this machine cannot find is an id whose directory cannot be
+ * judged.
  */
 export async function performMachineAction(
-  conn: Pick<TeamConnection, 'allowRemoteSessions' | 'allowRemoteScreens'>,
+  conn: Pick<TeamConnection, 'allowRemoteSessions' | 'allowRemoteScreens' | 'shareMode' | 'sources'>,
   lang: CliLang,
   req: { action: string; id: string; text?: string },
-  deps: { runAction: (lang: CliLang, req: { id: string; action: string; text?: string }) => Promise<MachineActionReply> },
+  deps: MachineFleetDeps & { runAction: (lang: CliLang, req: { id: string; action: string; text?: string }) => Promise<MachineActionReply> },
 ): Promise<MachineActionReply> {
   const pt = lang === 'pt'
   const consent = resolveRemoteConsent(conn.allowRemoteSessions, conn.allowRemoteScreens)
@@ -145,5 +182,42 @@ export async function performMachineAction(
           : 'This action cannot be performed from a central.'),
     }
   }
+
+  const isShared = await sharedCwd(conn, deps.readIndexSources)
+  if (isShared) {
+    // A TASK verb expands to every session filed under the row's task, over the whole registry
+    // (`host.openTask` → `readRegistry().filter(m => m.task === task)`), and a task routinely spans
+    // repositories. Pressing it on a VISIBLE row therefore reached withheld ones — spawning real
+    // assistants in a directory the user hid, and answering with a count of them.
+    //
+    // It is refused for EVERY restricted connection rather than only when the task provably spans a
+    // withheld row, and that is deliberate: the narrower check is an ORACLE. Repeated over the rows
+    // a central can see, "does this one span something hidden?" maps which of them share work with
+    // the hidden half — the same correlation as counting a hidden project's sessions, which is the
+    // leak this whole boundary exists to prevent. The refusal discloses nothing the reply does not
+    // already carry: `withheld` is a machine-level count the central is given anyway.
+    if (TASK_WIDE_ACTIONS.includes(req.action)) {
+      return {
+        ok: false,
+        message: pt
+          ? 'Esta máquina não compartilha toda a sua frota com esta central, e uma tarefa pode abranger sessões que ela não vê. Abra ou encerre a tarefa na própria máquina.'
+          : 'This machine does not share its whole fleet with this central, and a task can span sessions this central cannot see. Open or finish the task on the machine itself.',
+      }
+    }
+    const fleet = await deps.readFleet(lang)
+    const target = fleet.rows.find(r => r.id === req.id)
+    const cwd = typeof target?.cwd === 'string' ? target.cwd : ''
+    // Fail closed on BOTH halves. A row this machine cannot find is refused for the same reason a
+    // row with no directory is: the rule names directories, and there is nothing here to judge.
+    if (!target || !isShared(cwd)) {
+      return {
+        ok: false,
+        message: pt
+          ? 'Esta sessão não é compartilhada com esta central.'
+          : 'This session is not shared with this central.',
+      }
+    }
+  }
+
   return await deps.runAction(lang, { id: req.id, action: req.action, text: req.text })
 }

--- a/packages/server/server/share-rules.ts
+++ b/packages/server/server/share-rules.ts
@@ -350,9 +350,16 @@ export function filterShared<T extends Pick<SessionMeta, 'git_remote' | 'project
  *   often the repo name. Under restrictions an unrecognized directory is withheld rather than
  *   assumed innocent.
  *
- * ONE function decides the WHOLE outgoing frame. The caller must never assemble a field of that
- * message beside this result — that is exactly how the activities came to be sent unfiltered —
- * so anything added to the live message is added here, where the rule already lives.
+ * ONE function decides the whole `live-sessions` FRAME. The caller must never assemble a field of
+ * that message beside this result — that is exactly how the activities came to be sent unfiltered
+ * — so anything added to the live message is added here, where the rule already lives.
+ *
+ * **It is not, and never was, a statement about the SOCKET.** `live-sessions` was the only
+ * member→central send when this was written; the machine-fleet relay now sends three more
+ * (`sessions/machine-fleet.ts`), and they carry their own application of `cwdShared` — the read
+ * half filtering rows, the act half refusing a verb aimed at a row this connection cannot see. Both
+ * halves of that relay must keep going through `cwdShared`; the act half once did not, and a
+ * central could drive `kill` / `rename` / `resume` against a withheld session.
  *
  * With no restrictions the snapshot passes through untouched — the common case pays nothing.
  */

--- a/packages/server/server/team-agent-client.ts
+++ b/packages/server/server/team-agent-client.ts
@@ -543,38 +543,19 @@ async function answerFleetRequest(connId: string, socket: WebSocket, raw: string
     const conn = readTeamConnections(await readPreferences()).find(c => c.id === connId)
     if (!conn) return
 
-    // `op: 'act'` — perform one verb. The consent and the verb allowlist are re-checked by
-    // `performMachineAction` on THIS machine; nothing the central decided is trusted here.
-    if (msg.op === 'act') {
-      const [{ performMachineAction }, { runFleetAction }, { resolveLang }] = await Promise.all([
-        import('./sessions/machine-fleet'),
-        import('./sessions/fleet-web'),
-        import('./cli-lang'),
-      ])
-      const lang = await resolveLang()
-      const reply = await performMachineAction(conn, lang, {
-        action: typeof msg.action === 'string' ? msg.action : '',
-        id: typeof msg.id === 'string' ? msg.id : '',
-        ...(typeof msg.text === 'string' ? { text: msg.text } : {}),
-      }, {
-        // `runFleetAction` is the SAME path the machine's own web Sessions page calls, so every
-        // refusal the cockpit makes is made here too — there is no second implementation of what a
-        // row may take.
-        runAction: (l, r) => runFleetAction(l, r as never),
-      })
-      if (socket.readyState !== WebSocket.OPEN) return
-      socket.send(JSON.stringify({ type: 'fleet-reply', rid: msg.rid, reply }))
-      return
-    }
-    const [{ buildMachineFleetReply }, { readFleet }, { buildApiResponse }, { resolveLang }] = await Promise.all([
+    const [{ buildMachineFleetReply, performMachineAction }, { readFleet, runFleetAction }, { buildApiResponse }, { resolveLang }] = await Promise.all([
       import('./sessions/machine-fleet'),
       import('./sessions/fleet-web'),
       import('./data'),
       import('./cli-lang'),
     ])
     const lang = await resolveLang()
-    const reply = await buildMachineFleetReply(conn, lang, {
-      readFleet: async l => {
+    // ONE set of sources for both halves. The act half needs them too — it resolves the target
+    // against the very fleet the read half filters, so that a verb can only reach a row this
+    // connection was allowed to see — and building them twice is how the two halves came to
+    // disagree about a directory in the first place.
+    const fleetDeps = {
+      readFleet: async (l: typeof lang) => {
         const payload = await readFleet(l)
         // The VERBS live on the presentation half (`sessions`, a FleetRow[]) and everything else on
         // the raw half (`rows`, a ControlSession[]); they are the same rows in the same order.
@@ -595,7 +576,29 @@ async function answerFleetRequest(connId: string, socket: WebSocket, raw: string
         const data = await buildApiResponse()
         return { sessions: data.sessions, projects: data.projects.map(p => ({ path: p.path, gitRemote: p.gitRemote })) }
       },
-    })
+    }
+
+    // `op: 'act'` — perform one verb. The consent, the verb allowlist AND this connection's
+    // sharing rules are re-checked by `performMachineAction` on THIS machine; nothing the central
+    // decided is trusted here.
+    if (msg.op === 'act') {
+      const reply = await performMachineAction(conn, lang, {
+        action: typeof msg.action === 'string' ? msg.action : '',
+        id: typeof msg.id === 'string' ? msg.id : '',
+        ...(typeof msg.text === 'string' ? { text: msg.text } : {}),
+      }, {
+        ...fleetDeps,
+        // `runFleetAction` is the SAME path the machine's own web Sessions page calls, so every
+        // refusal the cockpit makes is made here too — there is no second implementation of what a
+        // row may take.
+        runAction: (l, r) => runFleetAction(l, r as never),
+      })
+      if (socket.readyState !== WebSocket.OPEN) return
+      socket.send(JSON.stringify({ type: 'fleet-reply', rid: msg.rid, reply }))
+      return
+    }
+
+    const reply = await buildMachineFleetReply(conn, lang, fleetDeps)
     // A machine that has not agreed sends NOTHING. An empty reply would read as "no sessions",
     // which is a statement about the fleet rather than about consent.
     if (!reply) return


### PR DESCRIPTION
## Summary

- The per-connection sharing rules bound the **read** half of the machine-fleet relay and not the **act** half. A central could `kill`, `rename`, `resume`, `note` or re-task a session in a repository its member had explicitly withheld from it.
- One verb reached withheld sessions **without the central needing to know their ids at all**, spawned real assistants in the hidden directory, and reported a count of them.
- One helper (`sharedCwd`) now resolves the connection's directory predicate for **both** halves, so they cannot disagree about a directory again.

Closes #340.

## Motivation

`buildMachineFleetReply` filtered rows through `cwdShared` from the day it shipped. `performMachineAction` checked consent and the verb allowlist and then handed the id straight to `runFleetAction`, which resolves against the machine's **raw** fleet and registry. `share-rules` was not imported on that path at all. **A rule enforced when you LOOK and not when you ACT is not a rule.**

The worst case needed no hidden id. `openTask` (`fleet-web.ts:221-233`) takes the id of a **visible** row, reads that row's `task`, and calls `host.openTask(task)`, which does `readRegistry().filter(m => m.task === task)` over the **whole registry**. A task is a unit of work that routinely spans repositories, so:

1. the member withholds `github.com/acme/secret` from a central;
2. a session there and a session in a shared repo are both filed under `refactor`;
3. the operator sees only the shared row — correct, the read path filters;
4. they press **Open task**, and the member spawns live assistants inside the withheld repository's working directory and answers `reopened 3 session(s) of "refactor". 1 could not be reopened.`

That sentence discloses that the task holds sessions the central was told nothing about, and how many. `finishTask` is the same shape.

Secondary, and the same root cause: `kill` is a bare `backend.kill(id)` with no registry lookup; `resume` spawns an assistant using the withheld row's own `cwd`. Ids are 40-bit hex and not enumerable, but a central that held a row **before** the user tightened the rules keeps a permanently valid handle — tightening a rule stopped new disclosure and did not revoke the ability to act on what was already seen.

This is the same class as #214 at a new call site. #288 fixed the `live-sessions` frame and its guarantee rested on that frame being the only member→central send; #307 added three more and carried the rules into one of them.

## Changes

**`packages/server/server/sessions/machine-fleet.ts`**
- New `sharedCwd(conn, readIndexSources)` — the connection's directory test, or `null` when nothing is restricted. `null` rather than an always-true predicate so callers can tell "everything is shared" from "this directory is shared" and skip building an index nobody will consult; the unrestricted case still reads no fleet and pays nothing, exactly as `filterLiveShared`'s own shortcut does. `buildMachineFleetReply` now uses it too, so there is one resolution instead of two.
- `performMachineAction` takes the connection's `shareMode`/`sources` and the fleet deps, resolves the target row, and refuses when it is not shared. **Fails closed on both halves**: an id the machine cannot find is refused for the same reason a row with no `cwd` is — the rule names directories and an unresolvable target has none to judge. Without that, every verb stays reachable by naming an id the fleet does not list.
- The **task verbs are refused for every restricted connection**, not only when the task provably spans a withheld row. The narrower check is an **oracle**: repeated over the visible rows it maps which of them share work with the hidden half — the same correlation §8 exists to deny. The refusal names no repository and no count, so it discloses nothing beyond the machine-level `withheld` figure the reply already carries.
- Those verbs are also dropped from the relayed row when the connection is restricted — offering one the machine will refuse is the control-that-reads-as-broken this codebase argues against everywhere else.

**`packages/server/server/team-agent-client.ts`**
- One `fleetDeps` object built once and given to both halves; the `act` branch moved below it. Building the sources twice is how the two halves came to disagree in the first place.

**`packages/server/server/share-rules.ts`**
- `filterLiveShared`'s doc comment claimed to decide "the WHOLE outgoing frame". True of `live-sessions`, which was the only member→central send when it was written; three more have since been added. It now names its frame and cross-references `machine-fleet.ts` as the second outbound path, with the act-half regression recorded.

**`CLAUDE.md` + `docs/security.md` §8c** — updated in the same PR, per AGENTS.md. Both record the act/read asymmetry, why the task verbs are refused bluntly, and that **consent is orthogonal to the sharing rules**: the two switches are machine-wide and say nothing about WHICH sessions, so turning on "manage my sessions" silently re-opened the act surface over every withheld repository.

## Test plan

`packages/server/server/sessions/machine-fleet.test.ts`, 8 tests added. The fixture is the shape the leak needed: `s1` in a shared repo, `s2` in a withheld one, both filed under the task `refactor`.

- a verb aimed at a withheld session is refused **and never runs** — asserted over all six row-scoped verbs;
- the same verbs still work on a shared session (the rule narrows; it must not break the feature);
- an id the machine cannot find fails closed;
- the task verbs are refused, and the refusal mentions neither the withheld repo nor a count;
- an **unrestricted** connection reads the fleet zero times — the common case pays nothing;
- an **empty allowlist** still restricts (it never takes the unrestricted shortcut);
- both new refusals differ between EN and PT;
- the read half drops the task verbs from a restricted row and keeps them otherwise.

**The tests pin the fix rather than describing it**: with the guard removed, 5 of them fail; restored, all 27 in the file pass.

```
guard removed:  22 pass, 5 fail
guard restored: 27 pass, 0 fail
```

Full suite and typecheck on the branch:

```
bun tsc --noEmit   → clean
bun test           → 5213 pass, 0 fail, 70402 expect() calls (315 files)
```

Not touched: `bun.lock` shows unrelated drift on this checkout (`1.23.1` → `2.5.0` package versions the release workflow bumped without re-syncing the lockfile). Left alone — it belongs to its own issue, not to this one.

## What this does NOT change

No screen or chat content ever left the machine on these paths and none does now — `reduceMachineFleetRow`'s key allowlist holds, `/api/fleet/stream`, `attachment-web.ts` and `chat-web.ts` stay `localShell`-guarded and off the reverse channel, and `GET /api/team/session-chat` is still a 410. `remote-consent` carries two booleans and no session data. #288's own logic is untouched: the diff of `filterLiveShared` from `85238a2e` to today is a pure extraction of `cwdShared` with identical semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
