### PR TITLE
fix(web): a pinned lens is revealed by the keyboard, never by the pointer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1799,6 +1799,12 @@ harness must not break.
 - **Left click, wheel and hover go to the PAGE; right click goes to the LENS.** That is why a pinned
   lens is still reachable: right click opens its menu in every pin state, which is where unpin and
   remove live. Pinned means immovable, not unreachable.
+- **A pinned lens is revealed by the KEYBOARD and never by the pointer** (`lensInteractive`, pure).
+  Every pointer path selects, so revealing on SELECTION meant the one gesture a mouse has for
+  reaching a pinned lens's menu also gave back its drag handle — the next drag moved a lens pinned
+  precisely so it would stop moving. `Tab`/`Ctrl+Shift+M` keep their reveal, because keyboard is the
+  only way a pinned lens is reachable at all. The reveal follows the SOURCE of the selection
+  (`A11yState.selectedVia`), never the selection itself.
 - **Interaction is forwarded by COORDINATE** (`lensPointToPage`, the exact inverse of the rendering
   geometry), never by making the clone live. The probe that finds the target must make the WHOLE
   magnifier layer transparent to hit-testing first — with two lenses stacked, hiding only the top

--- a/docs/accessibility-magnifiers.md
+++ b/docs/accessibility-magnifiers.md
@@ -55,6 +55,14 @@ left alone.
 is what makes the interaction learnable, and it is why a pinned lens is still reachable: right
 click opens its menu in every pin state, which is where unpin and remove live.
 
+**A pinned lens is revealed by the KEYBOARD and never by the pointer** (`lensInteractive`). Every
+pointer path selects, so reveal-on-selection meant that reaching a pinned lens's menu — the one way
+a mouse reaches unpin — handed its drag handle and control strip straight back, and the next drag
+moved a lens the user had pinned precisely so it would stop moving. `Tab` and `Ctrl+Shift+M` still
+cycle pinned lenses and still reveal them: keyboard is the only way they are reachable at all, and
+a selection someone had to press a key to make is not one they make while aiming at something else.
+So the reveal follows the SOURCE of the selection, never the selection.
+
 **Interaction is forwarded by coordinate, not by making the clone live.** The point acted on inside
 a lens is mapped back through the exact inverse of the rendering geometry (`lensPointToPage`) and
 the event is dispatched at the real page point. The probe that finds the target must make the WHOLE

--- a/packages/web/src/components/a11y/Lens.tsx
+++ b/packages/web/src/components/a11y/Lens.tsx
@@ -33,7 +33,8 @@
 import React, { useEffect, useRef } from 'react'
 import { Pin, PinOff, Move, X, Plus, Minus, Sliders, Globe } from 'lucide-react'
 import type { MagnifierLens } from '@agentistics/core'
-import { stageTransform, lensControls, lensPointToPage, fmtZoom, ZOOM_STEP, MAGNIFIER_LAYER_ID } from '../../lib/magnifier'
+import { stageTransform, lensControls, lensPointToPage, lensInteractive, fmtZoom, ZOOM_STEP, MAGNIFIER_LAYER_ID } from '../../lib/magnifier'
+import type { SelectionSource } from '../../lib/magnifier'
 import { createMirrorHost, type MirrorScheduler } from '../../lib/magnifierMirror'
 import type { A11yText } from './i18n'
 
@@ -84,8 +85,9 @@ interface Props {
   /** 1-based position among this page's lenses — what a listener hears, never the internal id. */
   index: number
   selected: boolean
-  /** True while a pinned lens is temporarily revealed by keyboard selection. */
-  revealed: boolean
+  /** How the current selection was made — a PINNED lens is revealed for the keyboard and never
+   *  for the pointer. See `lensInteractive`. */
+  selectedVia: SelectionSource
   /** True while `lens` lives in `globalLenses` — it follows the user across every page. */
   global: boolean
   text: A11yText
@@ -100,7 +102,7 @@ interface Props {
 }
 
 export function Lens({
-  lens, index, selected, revealed, global, text, isMobile, scheduler, onChange, onSelect, onRemove, onContextMenu, onOpenMenu,
+  lens, index, selected, selectedVia, global, text, isMobile, scheduler, onChange, onSelect, onRemove, onContextMenu, onOpenMenu,
 }: Props) {
   const stageRef = useRef<HTMLDivElement | null>(null)
   // The magnified area's own frame — see `elementBehindLens` below for why forwarding needs it.
@@ -128,7 +130,7 @@ export function Lens({
   }, [lens.id, scheduler])
 
   const t = stageTransform(lens, { width: window.innerWidth, height: window.innerHeight })
-  const interactive = !lens.pinned || revealed
+  const interactive = lensInteractive(lens, selected, selectedVia)
   const control = isMobile ? 44 : 26
   // The header strip is `overflow: hidden` inside the frame, so on a small lens the rightmost
   // controls (pin, remove) would otherwise be clipped away — invisible and unreachable, not

--- a/packages/web/src/components/a11y/MagnifierLayer.tsx
+++ b/packages/web/src/components/a11y/MagnifierLayer.tsx
@@ -154,7 +154,7 @@ export function MagnifierLayer({ ctx, hasHeaderSlot }: { ctx: AppContext; hasHea
         const first = a11y.lenses[0]
         if (!first) return
         e.preventDefault()
-        a11y.select(first.id)
+        a11y.select(first.id, 'keyboard')
         a11y.announce(text.announce(text.lensLabel(ordinal(first.id)), first.zoom, first.width, first.height, first.x, first.y, first.pinned))
         return
       }
@@ -171,7 +171,7 @@ export function MagnifierLayer({ ctx, hasHeaderSlot }: { ctx: AppContext; hasHea
         const next = a11y.lenses[(idx + (e.shiftKey ? -1 : 1) + n) % n]
         if (!next) return
         e.preventDefault()
-        a11y.select(next.id)
+        a11y.select(next.id, 'keyboard')
         a11y.announce(text.announce(text.lensLabel(ordinal(next.id)), next.zoom, next.width, next.height, next.x, next.y, next.pinned))
         return
       }
@@ -264,7 +264,7 @@ export function MagnifierLayer({ ctx, hasHeaderSlot }: { ctx: AppContext; hasHea
           lens={lens}
           index={i + 1}
           selected={a11y.selectedId === lens.id}
-          revealed={a11y.selectedId === lens.id}
+          selectedVia={a11y.selectedVia}
           global={globalIds.has(lens.id)}
           text={text}
           isMobile={isMobile}

--- a/packages/web/src/hooks/useAccessibility.ts
+++ b/packages/web/src/hooks/useAccessibility.ts
@@ -16,6 +16,7 @@ import { useLocation } from 'react-router-dom'
 import type { AccessibilityPrefs, LensStyle, MagnifierLens } from '@agentistics/core'
 import { DEFAULT_ACCESSIBILITY_PREFS, mintLensId, sanitizeAccessibilityPrefs } from '@agentistics/core'
 import { clampLens, newLens, pageKey } from '../lib/magnifier'
+import type { SelectionSource } from '../lib/magnifier'
 
 const SAVE_DEBOUNCE_MS = 400
 
@@ -33,6 +34,14 @@ export interface A11yState {
    */
   lenses: MagnifierLens[]
   selectedId: string | null
+  /**
+   * How `selectedId` came to be selected. It is not decoration: `lensInteractive` reveals a PINNED
+   * lens for the keyboard and never for the pointer, because every pointer path selects — reaching
+   * a pinned lens's menu with a right click would otherwise hand its drag handle straight back.
+   * Meaningless while `selectedId` is null, and left as it was rather than reset, since nothing
+   * reads it then.
+   */
+  selectedVia: SelectionSource
   followOn: boolean
   /**
    * True while every PLACED lens on this page is hidden — a "let me see the page underneath for
@@ -68,7 +77,9 @@ export interface A11yState {
    */
   setLensGlobal(id: string, global: boolean): void
   setAllPinned(pinned: boolean): void
-  select(id: string | null): void
+  /** `via` says how — see `selectedVia`. It defaults to `'pointer'`, the answer that reveals
+   *  nothing, so a new call site has to ASK for the reveal rather than inherit it. */
+  select(id: string | null, via?: SelectionSource): void
   toggleFollow(): void
   toggleLensesHidden(): void
   announce(text: string): void
@@ -86,6 +97,7 @@ export function useAccessibility(identity: string | undefined): A11yState {
   const [prefs, setPrefs] = useState<AccessibilityPrefs>(DEFAULT_ACCESSIBILITY_PREFS)
   const [loaded, setLoaded] = useState(false)
   const [selectedId, setSelectedId] = useState<string | null>(null)
+  const [selectedVia, setSelectedVia] = useState<SelectionSource>('pointer')
   const [followOn, setFollowOn] = useState(false)
   const [lensesHidden, setLensesHidden] = useState(false)
   const [announcement, setAnnouncement] = useState('')
@@ -200,6 +212,7 @@ export function useAccessibility(identity: string | undefined): A11yState {
     page,
     lenses,
     selectedId,
+    selectedVia,
     followOn,
     lensesHidden,
     announcement,
@@ -305,7 +318,7 @@ export function useAccessibility(identity: string | undefined): A11yState {
       else byPage[page] = nextPage
       commit({ ...cur, lensesByPage: byPage, globalLenses: nextGlobal })
     },
-    select: setSelectedId,
+    select: (id, via = 'pointer') => { setSelectedId(id); setSelectedVia(via) },
     toggleFollow: () => setFollowOn(v => !v),
     // Deliberately NOT routed through `commit()` — see the `lensesHidden` doc comment above. This
     // is UI state exactly like `followOn`, never a preference.

--- a/packages/web/src/lib/magnifier.test.ts
+++ b/packages/web/src/lib/magnifier.test.ts
@@ -10,6 +10,7 @@ import {
   newLens,
   lensControls,
   lensPointToPage,
+  lensInteractive,
   MOVE_STEP_PX,
   MOVE_FINE_PX,
   RESIZE_STEP_PX,
@@ -468,5 +469,32 @@ describe('newLens', () => {
     expect(made.x).toBe(300)
     expect(made.y).toBe(250)
     expect(made.pinned).toBe(false)
+  })
+})
+
+describe('lensInteractive', () => {
+  test('an unpinned lens is always movable, selected or not, by either source', () => {
+    for (const via of ['pointer', 'keyboard'] as const) {
+      for (const selected of [true, false]) {
+        expect(lensInteractive({ pinned: false }, selected, via)).toBe(true)
+      }
+    }
+  })
+
+  test('a pinned lens stays immovable when the POINTER selected it', () => {
+    // This is the regression: right-clicking a pinned lens to reach its menu selects it, and
+    // selection alone used to hand back the drag handle and the control strip.
+    expect(lensInteractive({ pinned: true }, true, 'pointer')).toBe(false)
+  })
+
+  test('a pinned lens is revealed when the KEYBOARD selected it', () => {
+    // Tab and Ctrl+Shift+M cycle pinned lenses on purpose — keyboard is the only way they are
+    // reachable at all, so the reveal has to survive there or the pin becomes a one-way door.
+    expect(lensInteractive({ pinned: true }, true, 'keyboard')).toBe(true)
+  })
+
+  test('a pinned lens nobody selected is immovable however the last selection was made', () => {
+    expect(lensInteractive({ pinned: true }, false, 'keyboard')).toBe(false)
+    expect(lensInteractive({ pinned: true }, false, 'pointer')).toBe(false)
   })
 })

--- a/packages/web/src/lib/magnifier.ts
+++ b/packages/web/src/lib/magnifier.ts
@@ -325,6 +325,35 @@ export function lensControls(innerWidthPx: number, controlPx: number, labelPx: n
   return controls
 }
 
+/** How the current selection was made. The pointer and the keyboard do NOT reach a pinned lens
+ *  alike — see `lensInteractive`. */
+export type SelectionSource = 'keyboard' | 'pointer'
+
+/**
+ * Whether a lens may be MOVED and RESIZED right now — and therefore whether its control strip is
+ * drawn at all.
+ *
+ * PINNED MEANS IMMOVABLE TO THE POINTER. That is the whole of what the user asked the pin for:
+ * once a lens is placed and sized, "simplesmente não sofre efeito de cliques". Selection alone
+ * used to lift it, and every pointer path selects — right-clicking a pinned lens to reach its menu
+ * (the one way a mouse reaches unpin and remove) handed the strip and the drag straight back, so
+ * the gesture for reading a pinned lens's settings was also the gesture that un-pinned it in
+ * practice: the next drag moved it.
+ *
+ * The KEYBOARD is the exception, and it has to be: `Tab` and `Ctrl+Shift+M` cycle every lens
+ * including the pinned ones, because keyboard is the only way they are reachable at all, and a
+ * selection a person had to press a key to make is not one they make by accident while aiming at
+ * something else. So the reveal follows the SOURCE of the selection, never the selection itself.
+ */
+export function lensInteractive(
+  lens: Pick<MagnifierLens, 'pinned'>,
+  selected: boolean,
+  via: SelectionSource,
+): boolean {
+  if (!lens.pinned) return true
+  return selected && via === 'keyboard'
+}
+
 /** A new lens, centred in the viewport, with an id no sibling holds. */
 export function newLens(style: LensStyle, vp: Viewport, taken: Set<string>): MagnifierLens {
   return {


### PR DESCRIPTION
## Summary

- A pinned magnifier lens no longer gets its drag handle and control strip back when the pointer selects it — right-clicking to reach its menu stops un-pinning it in practice.
- The reveal now follows the **source** of the selection (`A11yState.selectedVia`), not the selection. `Tab` and `Ctrl+Shift+M` keep it.
- The decision is a pure, tested function (`lensInteractive`) rather than an expression inside the component.

## Motivation

Closes #356.

Pinning is supposed to make a lens immovable — the request was that a placed, sized lens "simplesmente não sofre efeito de cliques". The reveal that lets the keyboard reach a pinned lens was keyed on selection alone, and **every** pointer path selects. Right click is the only gesture a mouse has for reaching the menu where unpin and remove live, so the gesture for reading a pinned lens's settings was also the one that handed its drag back: the next drag moved it.

The keyboard genuinely needs the reveal — `Tab`/`Ctrl+Shift+M` cycle pinned lenses on purpose, because keyboard is the only way they are reachable at all, and a selection someone had to press a key to make is not one they make while aiming at something else. So the fix is to distinguish the two sources, not to drop the reveal.

## Changes

- `packages/web/src/lib/magnifier.ts` — new `SelectionSource` type and `lensInteractive(lens, selected, via)`, pure, carrying the reasoning in its header.
- `packages/web/src/hooks/useAccessibility.ts` — `selectedVia` state; `select(id, via?)` records how, defaulting to `'pointer'` so a new call site has to **ask** for the reveal rather than inherit it.
- `packages/web/src/components/a11y/MagnifierLayer.tsx` — the two keyboard selections pass `'keyboard'`; `Lens` receives `selectedVia` in place of `revealed`.
- `packages/web/src/components/a11y/Lens.tsx` — `interactive` comes from `lensInteractive`. Click/wheel/hover forwarding is untouched: a pinned, unrevealed lens still passes them through, which is what the pin is for.
- `docs/accessibility-magnifiers.md`, `CLAUDE.md` — the invariant written down beside the one it qualifies.

## Test plan

- [x] `bun test` — 5471 pass, 0 fail (4 new in `magnifier.test.ts`).
- [x] `bun tsc --noEmit` clean.
- [x] **Mutation-checked**: reverting `lensInteractive` to the pre-fix `return selected` fails exactly the pointer test, so the test is not vacuous.
- [ ] Reviewer: pin a lens, right-click it — the menu opens, the strip stays gone, the lens does not drag. Then `Ctrl+Shift+M` / `Tab` onto it — the strip returns and the arrow keys move it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HYbpvG4keakBcmoo3wQhpL