### PR TITLE
fix(web): measure a sticky's live position each scroll frame instead of guessing it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1796,6 +1796,13 @@ harness must not break.
   once and corrupted the mirror on every page, because this app's header is sticky everywhere. A
   transform is paint-only and cannot affect layout. Only WINDOW-scrolled stickies are moved at all —
   one inside an `overflow: auto` panel already reproduces correctly and is left alone.
+- **A sticky copy's transform is MEASURED every scroll frame, never extrapolated** (`stickyOffset`,
+  pure). The copy never engages inside the clone, so it paints at `flow − scroll` and the correction
+  is `live − (flow − scroll)`. Carrying the last sync's correction forward by the scroll delta
+  instead holds the copy still on screen: right while the element is STUCK, wrong the whole time it
+  is not — an unstuck sticky flows with the page and its copy froze where the last sync left it. The
+  live reads are shared across every lens by one cache `applyScroll` passes into each
+  `setScroll`, or N lenses cost N forced layouts per frame instead of one.
 - **Left click, wheel and hover go to the PAGE; right click goes to the LENS.** That is why a pinned
   lens is still reachable: right click opens its menu in every pin state, which is where unpin and
   remove live. Pinned means immovable, not unreachable.

--- a/docs/accessibility-magnifiers.md
+++ b/docs/accessibility-magnifiers.md
@@ -51,6 +51,17 @@ everywhere. A transform is paint-only and cannot affect layout. Only stickies wh
 WINDOW are moved at all; one inside an `overflow: auto` panel already reproduces correctly and is
 left alone.
 
+**And that transform is re-derived from a MEASUREMENT on every scroll, never extrapolated**
+(`stickyOffset`). A sticky copy inside the clone never engages — it has no scrolling ancestor — so
+it paints at `flow − scroll` and the correction is `live − (flow − scroll)`, where `live` is where
+the browser is painting the real element right now. Taking the last sync's correction and adding
+the scroll delta instead holds the copy still on screen, which is right while the element is STUCK
+and wrong for the whole time it is not: an unstuck sticky flows with the page, so its copy has to
+flow too, and it instead froze where the last sync left it until the next one landed. Measuring
+costs one `getBoundingClientRect` per window-scrolled sticky per frame, shared across every lens by
+one cache `applyScroll` passes down — otherwise each lens's write to its own clone invalidates
+layout before the next one reads, and the cost becomes one forced layout per lens.
+
 **Left click, wheel and hover go to the PAGE. Right click goes to the LENS.** That single sentence
 is what makes the interaction learnable, and it is why a pinned lens is still reachable: right
 click opens its menu in every pin state, which is where unpin and remove live.
@@ -112,7 +123,9 @@ the signed-in identity changes.
 
 - **Canvas / WebGL content may not mirror.** The session terminal is the case that matters. Stated
   in the settings screen rather than left to be discovered.
-- **A sticky element in its unstuck phase can lag** up to one heartbeat between full syncs.
+- **A sticky's FLOW position is only as fresh as the last full sync.** Its correction is measured
+  every frame, so both phases and the crossing between them are right immediately; what still waits
+  on a re-clone is the element having MOVED or RESIZED in the layout.
 - **No DOM test environment.** The pure modules are unit-tested; the mirror's effects and the
   forwarded interaction can only be verified in a browser.
 

--- a/packages/web/src/lib/magnifier.test.ts
+++ b/packages/web/src/lib/magnifier.test.ts
@@ -11,6 +11,7 @@ import {
   lensControls,
   lensPointToPage,
   lensInteractive,
+  stickyOffset,
   MOVE_STEP_PX,
   MOVE_FINE_PX,
   RESIZE_STEP_PX,
@@ -496,5 +497,48 @@ describe('lensInteractive', () => {
   test('a pinned lens nobody selected is immovable however the last selection was made', () => {
     expect(lensInteractive({ pinned: true }, false, 'keyboard')).toBe(false)
     expect(lensInteractive({ pinned: true }, false, 'pointer')).toBe(false)
+  })
+})
+
+describe('stickyOffset', () => {
+  // An aside 400px down the document, `position: sticky; top: 12`. It flows until the page has
+  // scrolled 388px, and is stuck at viewport y=12 from there on.
+  const FLOW = { x: 0, y: 400 }
+  const liveAt = (scrollY: number) => ({ left: 0, top: Math.max(12, FLOW.y - scrollY) })
+
+  test('is ZERO through the whole unstuck phase — the copy flows with the page', () => {
+    // The regression. The rule this replaced returned the scroll DELTA here, which pins the copy
+    // where the last full sync left it while the live element scrolls away underneath.
+    for (const scrollY of [0, 100, 250, 388]) {
+      const got = stickyOffset(FLOW, liveAt(scrollY), { x: 0, y: scrollY })
+      expect(got.dy).toBe(0)
+    }
+  })
+
+  test('once stuck, it grows with the scroll so the copy stays at the live viewport position', () => {
+    // flow − scroll puts the copy at 400−600 = −200; the live element is stuck at 12.
+    expect(stickyOffset(FLOW, liveAt(600), { x: 0, y: 600 }).dy).toBe(212)
+    expect(stickyOffset(FLOW, liveAt(1000), { x: 0, y: 1000 }).dy).toBe(612)
+  })
+
+  test('the copy lands exactly on the live element in BOTH phases', () => {
+    for (const scrollY of [0, 200, 388, 389, 700]) {
+      const live = liveAt(scrollY)
+      const { dy } = stickyOffset(FLOW, live, { x: 0, y: scrollY })
+      // Where the copy ends up painted: its own flow position in the stage, plus the correction.
+      expect(FLOW.y - scrollY + dy).toBe(live.top)
+    }
+  })
+
+  test('crossing the threshold needs no full sync — one scroll step is enough', () => {
+    // 388 -> 389 is the frame the element engages on. Both are computed from the same rule, so
+    // neither waits on a re-clone to become correct.
+    expect(stickyOffset(FLOW, liveAt(388), { x: 0, y: 388 }).dy).toBe(0)
+    expect(stickyOffset(FLOW, liveAt(389), { x: 0, y: 389 }).dy).toBe(1)
+  })
+
+  test('the horizontal term follows the same rule', () => {
+    expect(stickyOffset({ x: 40, y: 0 }, { left: 40, top: 0 }, { x: 0, y: 0 }).dx).toBe(0)
+    expect(stickyOffset({ x: 40, y: 0 }, { left: 8, top: 0 }, { x: 120, y: 0 }).dx).toBe(88)
   })
 })

--- a/packages/web/src/lib/magnifier.ts
+++ b/packages/web/src/lib/magnifier.ts
@@ -364,3 +364,40 @@ export function newLens(style: LensStyle, vp: Viewport, taken: Set<string>): Mag
     pinned: false,
   }
 }
+
+/**
+ * Where a WINDOW-scrolled `position: sticky` copy must be painted inside the stage, as a
+ * stage-local translate.
+ *
+ * A sticky copy inside the clone has no scrolling ancestor, so it never engages: it paints at its
+ * ordinary FLOW position, which — the clone root being offset by `-scroll` — lands at stage-local
+ * `flow - scroll`, where `flow` is the element's position in DOCUMENT coordinates. The LIVE element
+ * is wherever the browser is actually painting it right now, in VIEWPORT coordinates, which is the
+ * same frame stage-local coordinates live in. So the correction is simply the gap between the two:
+ *
+ *     offset = live − (flow − scroll)
+ *
+ * **The live position must be MEASURED, never extrapolated from a scroll delta.** The previous rule
+ * took the offset computed at the last full sync and added however far the page had scrolled since,
+ * which holds the copy still on screen — exactly right while the element is STUCK (its viewport
+ * position genuinely does not change as you scroll) and exactly wrong while it is not. In its
+ * UNSTUCK phase a sticky element flows with the page like any other, so `live = flow − scroll` and
+ * the offset is ZERO; the delta rule instead returned the scroll distance, freezing the copy where
+ * the last sync left it while the real element scrolled away. The header of this dashboard is
+ * sticky on every page, so that is a lens showing a header nailed to the wrong place, and it
+ * stayed wrong until the next full sync happened to land.
+ *
+ * Both phases, and the crossing between them, come out right here for the same reason: nothing is
+ * assumed about which phase the element is in. That is what makes the sticky term correct on the
+ * frame it changes rather than a heartbeat later.
+ */
+export function stickyOffset(
+  flow: { x: number; y: number },
+  live: { left: number; top: number },
+  scroll: { x: number; y: number },
+): { dx: number; dy: number } {
+  return {
+    dx: live.left - (flow.x - scroll.x),
+    dy: live.top - (flow.y - scroll.y),
+  }
+}

--- a/packages/web/src/lib/magnifierMirror.ts
+++ b/packages/web/src/lib/magnifierMirror.ts
@@ -21,6 +21,7 @@ import {
   type MirrorLensState,
   type MirrorScheduleConfig,
 } from './mirrorSchedule'
+import { stickyOffset } from './magnifier'
 
 export interface MirrorHost {
   /** Re-clone and reconcile now. */
@@ -28,15 +29,21 @@ export interface MirrorHost {
   /**
    * Move the existing clone to match the window's current scroll position, without re-cloning.
    * The DOM has not changed, so a full `syncNow()` would be wasted work for a pure scroll event —
-   * this rewrites the root offset `syncNow()` derives from `window.scrollX/Y`, AND extends every
-   * window-scrolled sticky copy's own correction by the same scroll delta — see this function's
-   * body for the derivation of why the sticky term needs it (the `position: fixed` predecessor of
-   * this fix did not, which is exactly what changed). What is still only ever right as of the last
-   * full sync is everything else `reconcile` computes (content, form state, canvas pixels, and a
-   * sticky's correction if the element itself moved or resized) — the same eventual-consistency
-   * the mirror already has there, bounded by the heartbeat interval.
+   * this rewrites the root offset `syncNow()` derives from `window.scrollX/Y`, and recomputes every
+   * window-scrolled sticky copy's correction from a FRESH measurement of the live element it
+   * mirrors (`stickyOffset`; see this function's body for why a scroll delta cannot stand in for
+   * that measurement). What is still only ever right as of the last full sync is everything else
+   * `reconcile` computes — content, form state, canvas pixels, and a sticky's own FLOW position if
+   * the element moved or resized — the same eventual-consistency the mirror already has there,
+   * bounded by the heartbeat interval.
+   *
+   * `liveRects` is a per-scroll-event measurement cache SHARED by every lens, since they all mirror
+   * the same `#root` and therefore the same live sticky elements. Without it, N lenses cost N
+   * forced layouts per scroll event (each one's write to its own clone invalidates layout before
+   * the next one reads); with it, the first lens measures and the rest hit the map. Omit it and one
+   * is created for this call alone — correct, just not shared.
    */
-  setScroll(x: number, y: number): void
+  setScroll(x: number, y: number, liveRects?: Map<Element, DOMRect | null>): void
   destroy(): void
 }
 
@@ -221,13 +228,12 @@ export function createMirrorHost(stage: HTMLElement): MirrorHost {
   let alive = true
   // The currently-inserted clone, kept so `setScroll` can reposition it without re-cloning.
   let clone: HTMLElement | null = null
-  // Every window-scrolled sticky copy's correction as of the LAST full sync — a stage-local
-  // (dx, dy) transform, plus the scroll position it was computed against. `setScroll` extends
-  // each one by how far the scroll has moved since, so a stuck copy stays anchored between syncs
-  // without a re-clone. See `setScroll`'s own comment for the derivation.
-  let stickyBases: Map<HTMLElement, { dx: number; dy: number }> = new Map()
-  let baseScrollX = 0
-  let baseScrollY = 0
+  // Every window-scrolled sticky, linked to its copy in the current clone, with the copy's UNSTUCK
+  // FLOW position in DOCUMENT coordinates as measured by the last full sync. `setScroll` re-derives
+  // each correction from that flow position plus a fresh reading of where the LIVE element sits
+  // right now — see `stickyOffset` for why the live side has to be measured rather than
+  // extrapolated. Only `flow` is a snapshot, and only layout can invalidate it.
+  let stickyLinks: { live: Element; copy: HTMLElement; flow: { x: number; y: number } }[] = []
   return {
     syncNow() {
       if (!alive) return
@@ -297,6 +303,7 @@ export function createMirrorHost(stage: HTMLElement): MirrorHost {
       // whatever the stage's transform is at paint time, without needing to be recomputed.
       const stageRect = stage.getBoundingClientRect()
       const scale = stage.offsetWidth > 0 ? stageRect.width / stage.offsetWidth : 1
+      const links: { live: Element; copy: HTMLElement; flow: { x: number; y: number } }[] = []
       const corrections: { copy: HTMLElement; dx: number; dy: number }[] = []
       for (const [live, copyEl] of stickyCopies) {
         const liveRect = windowStickies.get(live)
@@ -304,50 +311,67 @@ export function createMirrorHost(stage: HTMLElement): MirrorHost {
         const copyRect = copyEl.getBoundingClientRect()
         const copyLocalX = (copyRect.left - stageRect.left) / scale
         const copyLocalY = (copyRect.top - stageRect.top) / scale
-        corrections.push({ copy: copyEl, dx: liveRect.left - copyLocalX, dy: liveRect.top - copyLocalY })
+        // Stage-local IS the viewport frame (the clone root carries the `-scroll` offset), so the
+        // copy's own DOCUMENT flow position is simply its stage-local position plus the scroll it
+        // was measured at. That is the one term `setScroll` cannot re-derive without a re-clone,
+        // so it is the one term recorded here.
+        const flow = { x: copyLocalX + scrollX, y: copyLocalY + scrollY }
+        links.push({ live, copy: copyEl, flow })
+        const { dx, dy } = stickyOffset(flow, liveRect, { x: scrollX, y: scrollY })
+        corrections.push({ copy: copyEl, dx, dy })
       }
-      const newBases = new Map<HTMLElement, { dx: number; dy: number }>()
       for (const { copy, dx, dy } of corrections) {
         copy.style.transform = `translate(${dx}px, ${dy}px)`
-        newBases.set(copy, { dx, dy })
       }
       // Caveat, stated rather than hidden: a `transform` on a sticky copy makes THAT copy a
       // containing block for any `position: fixed` descendant of its own — same family of caveat
       // as the previous fix's, just moved from the stage to the sticky itself. None of the
       // window-scrolled stickies in this codebase today (the page header, the settings/custom-page
       // asides, a panel's own pinned edge) contain a `position: fixed` descendant.
-      stickyBases = newBases
-      baseScrollX = scrollX
-      baseScrollY = scrollY
+      stickyLinks = links
 
       clone = next
     },
-    setScroll(x, y) {
+    setScroll(x, y, liveRects) {
       if (!alive || !clone) return
       clone.style.left = `${-x}px`
       clone.style.top = `${-y}px`
 
-      // Derivation: a window-scrolled sticky copy is an ORDINARY in-flow descendant of the clone
-      // root (unlike the old `position: fixed` fix, `position: sticky` never escapes flow for
-      // containing-block purposes) — so when the root's `left`/`top` above move by
-      // `-(x - baseScrollX), -(y - baseScrollY)`, the copy's own underlying flow position shifts by
-      // that exact same amount, same as any other normally-flowing descendant. Left uncorrected,
-      // the copy would scroll away with the content instead of staying put, unlike the LIVE element
-      // it mirrors (which is genuinely stuck to the viewport while scrolling). So each sticky's
-      // transform is extended by `(x - baseScrollX, y - baseScrollY)` — the scroll delta since the
-      // sync that computed its base correction — which cancels the root's shift term-for-term and
-      // keeps the copy's FINAL painted position exactly where the last full sync put it, matching
-      // how "stuck" content actually behaves between syncs.
-      const dxScroll = x - baseScrollX
-      const dyScroll = y - baseScrollY
-      for (const [copy, base] of stickyBases) {
-        copy.style.transform = `translate(${base.dx + dxScroll}px, ${base.dy + dyScroll}px)`
+      if (stickyLinks.length === 0) return
+
+      // A window-scrolled sticky copy is an ORDINARY in-flow descendant of the clone root (unlike
+      // the `position: fixed` predecessor of this fix, `position: sticky` never escapes flow), so
+      // the root's `left`/`top` above just moved it along with everything else — it now paints at
+      // stage-local `flow - scroll`. Where it BELONGS is wherever the browser is painting the live
+      // element right now, and that is the term this used to guess: it took the offset from the
+      // last full sync and added the scroll delta, which holds the copy still on screen. Right
+      // while the element is stuck, wrong the whole time it is not — an unstuck sticky flows with
+      // the page, so its copy has to flow too, and instead it froze where the last sync left it
+      // until the next one landed. This dashboard's header is sticky on every page.
+      //
+      // So MEASURE. `stickyOffset` does the arithmetic; all this does is keep the reads and the
+      // writes in two batches, and share the reads with every other lens through `liveRects` —
+      // otherwise each lens's write to its own clone invalidates layout before the next one reads,
+      // and a scroll event costs one forced layout per lens instead of one in total.
+      const rects = liveRects ?? new Map<Element, DOMRect | null>()
+      for (const { live } of stickyLinks) {
+        if (rects.has(live)) continue
+        // A live element that has left the document measures as all zeros, which would slam its
+        // copy to the stage's origin. It cannot be corrected at all until the next full sync
+        // re-links the tree, so it is skipped and its copy keeps the transform it has.
+        rects.set(live, live.isConnected ? live.getBoundingClientRect() : null)
+      }
+      for (const { live, copy, flow } of stickyLinks) {
+        const liveRect = rects.get(live)
+        if (!liveRect) continue
+        const { dx, dy } = stickyOffset(flow, liveRect, { x, y })
+        copy.style.transform = `translate(${dx}px, ${dy}px)`
       }
     },
     destroy() {
       alive = false
       clone = null
-      stickyBases = new Map()
+      stickyLinks = []
       stage.replaceChildren()
     },
   }
@@ -426,7 +450,11 @@ export function startMirrorScheduler(): MirrorScheduler {
       for (const e of entries.values()) e.dirty = true
     },
     applyScroll(x, y) {
-      for (const e of entries.values()) e.host.setScroll(x, y)
+      // ONE measurement cache for the whole event: every lens mirrors the same `#root`, so they
+      // ask about the same live sticky elements. The first lens measures, the rest read the map —
+      // which is what keeps a scroll event at one forced layout however many lenses are open.
+      const liveRects = new Map<Element, DOMRect | null>()
+      for (const e of entries.values()) e.host.setScroll(x, y, liveRects)
     },
     stop() {
       stopped = true


### PR DESCRIPTION
## Summary

- A window-scrolled `position: sticky` copy's correction is now **measured** from the live element on every scroll frame, instead of being carried forward from the last full sync by the scroll delta.
- Both sticky phases — and the frame the element crosses between them — are correct immediately rather than a heartbeat later.
- The live reads are shared across every lens by one cache, so a scroll frame costs **one** forced layout however many lenses are open.

## Motivation

Closes #358.

The old rule held the copy still on screen. That is right while the element is STUCK (its viewport position genuinely does not change as you scroll) and wrong for the whole time it is not: an unstuck sticky flows with the page, so its copy has to flow too, and it instead froze where the last sync left it while the real element scrolled away.

Written out, a copy inside the clone never engages (no scrolling ancestor), so it paints at `flow − scroll`, and the correction it needs is:

```
offset = live − (flow − scroll)
```

`live` is the one term a scroll event cannot derive — it depends on which phase the element is in — so it is measured. `flow` is the one term a scroll cannot re-derive without a re-clone, so `syncNow` records it. Nothing is assumed about the phase, which is what makes the crossing right on the frame it happens.

## Changes

- `packages/web/src/lib/magnifier.ts` — new pure `stickyOffset(flow, live, scroll)`, carrying the derivation and the reason the live side cannot be extrapolated.
- `packages/web/src/lib/magnifierMirror.ts` — `stickyBases` (a per-copy dx/dy plus a base scroll) becomes `stickyLinks` (live element ↔ copy, plus the copy's flow position in document coordinates). `setScroll` takes an optional shared `liveRects` cache, reads in one batch and writes in another; `applyScroll` creates one cache per frame. A live element that has left the document measures as all zeros, so it is skipped and its copy keeps its transform until the next sync re-links the tree.
- `docs/accessibility-magnifiers.md`, `CLAUDE.md` — the rule beside the transform-not-position one it extends; the "unstuck phase can lag" limitation is replaced by the narrower one that remains (a sticky's FLOW position is still only as fresh as the last full sync — i.e. the element having MOVED or RESIZED still waits on a re-clone).

## Test plan

- [x] `bun test` — 5476 pass, 0 fail (5 new in `magnifier.test.ts`).
- [x] `bun tsc --noEmit` clean.
- [x] **Mutation-checked**: making `stickyOffset` extrapolate from the base measurement instead of reading `live` fails four of the five new tests, so they are not vacuous.
- [ ] Reviewer, by eye: open a lens over the Settings or Custom page aside and scroll from the top. The aside inside the lens should flow up with the page until it sticks, then hold — matching the real one beside it — with no jump when the next sync lands.

⚠️ **Not yet confirmed visually.** The arithmetic is proven and the tests hold, but this is a rendering fix and nobody has watched it on a real page yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HYbpvG4keakBcmoo3wQhpL