### PR TITLE
fix(web): stop clamping the follow lens's region, so the page's edges stay readable

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1813,8 +1813,11 @@ harness must not break.
   region pans proportionally to the lens's position, which is what makes the page's outer band
   reachable (a centred region plus an on-screen-clamped lens leaves a ~150px dead band at 4×); it
   agrees exactly with the old centred rule at the viewport's centre. `'cursor'` for the FOLLOW lens:
-  centred and clamped, because its position IS the pointer and a pointer must show what is under it
-  or aiming becomes impossible.
+  centred on the pointer and NOT clamped, because its position IS the pointer and a pointer must
+  show what is under it or aiming becomes impossible. The clamp is gone on purpose: this lens is
+  never kept on screen, so sliding the region back inside the viewport while its frame stayed
+  half-off painted the page's outer band where nobody can see it — the same dead band `'pan'`
+  removes, reached by a different route.
 - **There is no cap on the number of lenses** — the cost is bounded by `mirrorSchedule.ts` instead:
   two re-clones per frame, least-recently-synced first, off-screen never, with a backoff when a
   measured cycle overruns. Twenty lenses cost ten frames, not one frame of twenty clones.

--- a/docs/accessibility-magnifiers.md
+++ b/docs/accessibility-magnifiers.md
@@ -75,9 +75,15 @@ hands the click to the one beneath.
   reachable at all: a centred region plus a lens clamped on screen leaves a dead band at every edge
   (~150px at 4×). At the viewport's centre it agrees exactly with the old centred rule, so nothing
   moves in normal use.
-- `'cursor'` for the **follow** lens — centred on the lens, clamped inside the viewport. Its
-  position IS the pointer, and a pointer must show what is under it or aiming becomes impossible.
-  With this, a plain pass-through click lands on the element the user is looking at.
+- `'cursor'` for the **follow** lens — centred on the pointer, and **not clamped**. Its position IS
+  the pointer, and a pointer must show what is under it or aiming becomes impossible; with this, a
+  plain pass-through click lands on the element the user is looking at. The clamp that used to slide
+  the region back inside the viewport is gone: this lens is never kept on screen (no `clampLens`),
+  so near an edge half its frame hangs off, and sliding the region while the frame stayed put pushed
+  the page's outer band into the half nobody can see — the same dead band `'pan'` exists to remove,
+  arriving by a different route. Unclamped, the edge is reached by putting the pointer on it. The
+  cost is that part of the lens then shows the blank beyond the page, which is what is actually
+  there.
 
 **Cost is bounded per frame, not per lens count** (`mirrorSchedule.ts`, pure and tested): at most
 two lenses re-clone per frame, least-recently-synced first, off-screen lenses never, and the

--- a/packages/web/src/lib/magnifier.test.ts
+++ b/packages/web/src/lib/magnifier.test.ts
@@ -206,41 +206,38 @@ describe('sourceRect — cursor anchor, so the follow lens shows exactly what is
     }
   })
 
-  test('left/top edge: the region is shifted back inside, starting at 0 — never past it, never resized', () => {
-    // A wrong implementation this would catch: one that clamps the region's ORIGIN to
-    // `[0, Infinity)` only (no upper bound) — it would also read 0 here, but the sibling
-    // right/bottom test below is what that variant fails.
+  test('AT THE EDGES TOO — the centre still shows the point under the cursor, at every corner', () => {
+    // The regression. The region used to be clamped back inside the viewport while the FRAME kept
+    // hanging off the screen, so the page's outer band was painted into the half nobody can see
+    // and the reader could not reach it at all. These are the positions that clamp engaged at.
     const vp = { width: 1200, height: 900 }
-    const l = lens({ x: 0, y: 0, width: 200, height: 200, borderWidth: 5, zoom: 0.5 })
-    const s = sourceRect(l, vp, 'cursor')
-    expect(s.x).toBe(0)
-    expect(s.y).toBe(0)
-    // Size asserted CONCRETELY — (200 - 2*5) / 0.5 = 380 — not as `vp.width - s.width`, which a
-    // shrink-to-fit implementation (one that resizes the region to end exactly at the edge
-    // instead of just sliding it) would satisfy trivially.
-    expect(s.width).toBe(380)
-    expect(s.height).toBe(380)
+    const W = 800
+    const H = 600
+    for (const [cx, cy] of [[0, 0], [5, 5], [100, 80], [vp.width, vp.height], [vp.width - 3, 40]] as const) {
+      const l = lens({ x: cx - W / 2, y: cy - H / 2, width: W, height: H, zoom: 2, borderWidth: 4 })
+      const got = lensPointToPage(l, vp, l.width / 2, l.height / 2, 'cursor')
+      expect(got.x).toBeCloseTo(cx, 5)
+      expect(got.y).toBeCloseTo(cy, 5)
+    }
   })
 
-  test('right/bottom edge: the region is shifted back inside, ending exactly at the viewport edge — never resized', () => {
+  test('the region is NOT clamped into the viewport — it follows the pointer past the edge', () => {
+    // Asserted as a concrete origin rather than "is negative": the region is
+    // (200 - 2*5) / 0.5 = 380 wide and centred on a cursor at (100, 100), so it starts at -90.
+    // A clamped implementation reads 0 here, which is exactly the bug.
     const vp = { width: 1200, height: 900 }
-    const l = lens({ x: 1000, y: 700, width: 200, height: 200, borderWidth: 5, zoom: 0.5 })
+    const l = lens({ x: 100 - 100, y: 100 - 100, width: 200, height: 200, borderWidth: 5, zoom: 0.5 })
     const s = sourceRect(l, vp, 'cursor')
-    // Same concrete size as the left/top-edge case — the clamp only ever slides the region.
     expect(s.width).toBe(380)
     expect(s.height).toBe(380)
-    expect(s.x).toBe(vp.width - 380)
-    expect(s.y).toBe(vp.height - 380)
+    expect(s.x).toBe(-90)
+    expect(s.y).toBe(-90)
   })
 
-  test('a region larger than the viewport is centred, not pinned to whichever edge the lens is nearest', () => {
-    // A wrong implementation this would catch: clamping the desired origin into
-    // `[0, vpSize - regionSize]` unconditionally, with no separate "centre it" branch — when
-    // `regionSize > vpSize` that range is inverted (its upper bound is negative), so
-    // `Math.min(Math.max(desired, 0), negative)` collapses to 0 regardless of the lens's position,
-    // which is indistinguishable from "pinned to the left/top edge". Centring instead makes the
-    // result the SAME for two very different lens positions, which a pinned-edge implementation
-    // could never produce for both.
+  test('a region larger than the viewport follows the pointer as well — no special case', () => {
+    // It used to be centred on the VIEWPORT here, which detached the image from the cursor at the
+    // one zoom range (below 1x) where the region can outgrow the screen. Two different cursor
+    // positions must give two different regions, each centred on its own cursor.
     const vp = { width: 1024, height: 900 }
     const width = 2000
     const height = 200
@@ -248,10 +245,10 @@ describe('sourceRect — cursor anchor, so the follow lens shows exactly what is
     const zoom = ZOOM_MIN
     const interior = (width - 2 * borderWidth) / zoom
     expect(interior).toBeGreaterThan(vp.width)
-    const left = sourceRect(lens({ x: 0, y: 300, width, height, borderWidth, zoom }), vp, 'cursor')
-    const right = sourceRect(lens({ x: vp.width - 1, y: 300, width, height, borderWidth, zoom }), vp, 'cursor')
-    expect(left.x).toBeCloseTo((vp.width - interior) / 2)
-    expect(right.x).toBeCloseTo((vp.width - interior) / 2)
+    for (const cx of [0, vp.width - 1]) {
+      const s = sourceRect(lens({ x: cx - width / 2, y: 300, width, height, borderWidth, zoom }), vp, 'cursor')
+      expect(s.x + interior / 2).toBeCloseTo(cx, 5)
+    }
   })
 })
 

--- a/packages/web/src/lib/magnifier.ts
+++ b/packages/web/src/lib/magnifier.ts
@@ -89,7 +89,7 @@ export type SourceAnchor = 'pan' | 'cursor'
 
 /**
  * The viewport region a lens magnifies: shrunk by the zoom, then read into position by `anchor`
- * (see `SourceAnchor` above) — PANNED for a placed lens, CENTRED-and-clamped for the cursor-
+ * (see `SourceAnchor` above) — PANNED for a placed lens, CENTRED on the pointer for the cursor-
  * following one.
  *
  * What the lens actually SHOWS is its content box — `box-sizing: border-box` makes that
@@ -102,9 +102,12 @@ export function sourceRect(lens: LensStyle & { x: number; y: number }, vp: Viewp
   const width = (lens.width - 2 * lens.borderWidth) / lens.zoom
   const height = (lens.height - 2 * lens.borderWidth) / lens.zoom
 
-  const axis = anchor === 'cursor' ? cursorAxis : panAxis
-  const x = axis(lens.x, lens.width, width, vp.width)
-  const y = axis(lens.y, lens.height, height, vp.height)
+  const x = anchor === 'cursor'
+    ? cursorAxis(lens.x, lens.width, width)
+    : panAxis(lens.x, lens.width, width, vp.width)
+  const y = anchor === 'cursor'
+    ? cursorAxis(lens.y, lens.height, height)
+    : panAxis(lens.y, lens.height, height, vp.height)
 
   return { x, y, width, height }
 }
@@ -145,21 +148,31 @@ function panAxis(lensPos: number, lensSize: number, regionSize: number, vpSize: 
 }
 
 /**
- * One axis of the CURSOR anchor — for the follow lens, whose position IS the pointer. The region
- * is centred on the lens's own centre (`lensPos + lensSize/2 - regionSize/2`), which is what
- * makes `lensPointToPage`'s inverse map the lens's visual centre back to the exact viewport point
- * the lens sits over — the property that makes aiming through it possible at all.
+ * One axis of the CURSOR anchor — for the follow lens, whose position IS the pointer. The region is
+ * centred on the lens's own centre, and that is the whole rule: `lensPointToPage`'s inverse then
+ * maps the lens's visual centre back to the exact viewport point the cursor sits on, everywhere on
+ * the page, which is the property that makes aiming through it possible at all.
  *
- * That centred position is then CLAMPED into `[0, vpSize - regionSize]`, shifting it back inside
- * the viewport rather than letting it run off an edge — never by resizing the region, which would
- * change the magnification. When the region is as large as (or larger than) the viewport itself
- * (reachable below 1x zoom) that clamp range is empty or inverted, so the region is centred on
- * the viewport instead — the same "nothing to clamp against" case `panAxis` handles.
+ * IT IS DELIBERATELY NOT CLAMPED INTO THE VIEWPORT, and that is a fix rather than an oversight.
+ * This lens is centred on the pointer and is NOT kept on screen (see `FollowLens` — unlike a placed
+ * lens it has no `clampLens`), so near an edge half of its frame hangs off the screen. Sliding the
+ * REGION back inside while the FRAME stayed where it was pushed the page's own outer band into the
+ * half nobody can see: with an 800px lens at 2x, a cursor at x=100 showed the band from x=195
+ * onwards and painted everything left of it off-screen — reported as "at the edges I cannot see the
+ * real content", the same complaint `panAxis` answers for a placed lens, arriving here by a
+ * different route. Unclamped, the point under the cursor is at the lens's centre at every position,
+ * so the edge is reached by putting the pointer on it and the corner by putting the pointer in it.
+ *
+ * The cost is stated: at an edge, part of the lens shows the area BEYOND the page, which is blank.
+ * That is honest — there is nothing there — and it is how a pointer-anchored OS magnifier behaves.
+ * Showing blank where there is nothing beats hiding content that exists.
+ *
+ * A region larger than the viewport (reachable below 1x zoom) needs no special case here for the
+ * same reason: centring it on the cursor is exactly right, and it was the clamp — not the size —
+ * that ever made a branch necessary.
  */
-function cursorAxis(lensPos: number, lensSize: number, regionSize: number, vpSize: number): number {
-  if (regionSize >= vpSize) return (vpSize - regionSize) / 2
-  const desired = lensPos + lensSize / 2 - regionSize / 2
-  return Math.min(Math.max(desired, 0), vpSize - regionSize)
+function cursorAxis(lensPos: number, lensSize: number, regionSize: number): number {
+  return lensPos + lensSize / 2 - regionSize / 2
 }
 
 /**


### PR DESCRIPTION
## Summary

- The cursor-following lens no longer slides its magnified region back inside the viewport, so the page's outer band is reachable again.
- The point under the cursor is now at the lens's centre at **every** position, not only away from the edges.
- `cursorAxis` becomes one line with no branches.

## Motivation

Closes #360. Reported from a running build, with a screenshot.

This lens is centred on the pointer and is deliberately **not** kept on screen — unlike a placed lens it has no `clampLens`, because its position IS the pointer — so near an edge half its frame hangs off. The region was clamped anyway. Frame half-off, region pushed in: the page's own outer band got painted into the half nobody can see. Measured, an 800px lens at 2× with the cursor at x=100 showed the page from x=195 onwards.

That is the same dead band `panAxis` exists to remove for a placed lens (#354), arriving by a different route.

The region-larger-than-the-viewport branch goes with it: it existed only because the clamp range inverts below 1× zoom, and centring that region on the cursor is right for exactly the same reason as every other size.

**The cost, stated rather than hidden:** at an edge, part of the lens shows the blank beyond the page. There is nothing there, and showing blank where there is nothing beats hiding content that exists. It is also how a pointer-anchored OS magnifier behaves.

## Changes

- `packages/web/src/lib/magnifier.ts` — `cursorAxis` drops the clamp and the size branch; `sourceRect` calls the two axis rules directly, since they no longer share an arity. The reasoning lives in `cursorAxis`'s header.
- `packages/web/src/lib/magnifier.test.ts` — three tests **replaced**, not added: the ones removed asserted the clamp itself, which is the behaviour being fixed. The new ones assert the property that matters — the centre shows the point under the cursor at (0,0), at (5,5), at the far corner and past the edge — plus the unclamped origin and the large-region case.
- `docs/accessibility-magnifiers.md`, `CLAUDE.md` — the anchor rule updated to say centred-and-unclamped, with why.

## Test plan

- [x] `bun test` — 5471 pass, 0 fail.
- [x] `bun tsc --noEmit` clean.
- [x] **Mutation-checked**: restoring the clamped rule fails all three new tests.
- [ ] Reviewer, by eye: `Ctrl+Shift+Z` with a large lens at 2× or more, then move the pointer into each corner. The content under the pointer stays at the lens's centre, and the page's edge is readable; the area beyond the page shows as blank.

⚠️ **Not yet confirmed visually** — the arithmetic is proven and the tests hold, but this is a rendering fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HYbpvG4keakBcmoo3wQhpL