### PR TITLE
fix: clear filters clears everything it counted, and hardware returns to Sessions

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -2819,6 +2819,29 @@ export default function AppLayout() {
         <HideLensesButton ctx={appCtx} />
       </div>
 
+      {/* HARDWARE, on this route too. The whole action cluster is hidden in the sessions workspace
+          — correctly, for the totals and the page-data Live toggle, neither of which describes a
+          fleet that polls itself — and this button went with it. It answers "what is this machine
+          doing right now", which is MORE relevant here than anywhere else: this is the screen where
+          you watch that machine run several assistants at once. Reported as missing.
+          It sits on the LIST side of the rule below, because it is about the machine and not about
+          the session you have open. */}
+      {!isCentral && (
+        <button
+          onClick={() => setHardwareOpen(true)}
+          title={lang === 'pt' ? 'Recursos de hardware' : 'Hardware resources'}
+          aria-label={lang === 'pt' ? 'Recursos de hardware' : 'Hardware resources'}
+          aria-haspopup="dialog"
+          style={{
+            width: 30, height: 30, flexShrink: 0, display: 'flex', alignItems: 'center',
+            justifyContent: 'center', borderRadius: 8, border: '1px solid var(--border)',
+            background: 'transparent', color: 'var(--text-tertiary)', cursor: 'pointer',
+          }}
+        >
+          <Cpu size={14} />
+        </button>
+      )}
+
       {/* A RULE, not more gap. Everything to the left narrows the LIST; everything to the right is
           about the session you have open — two different questions that were sitting in one
           undifferentiated row of controls, which is what "entulhado" describes. A one-pixel line

--- a/packages/web/src/components/FiltersBar.tsx
+++ b/packages/web/src/components/FiltersBar.tsx
@@ -272,6 +272,26 @@ export function FiltersBar({ only, filters, onChange, projects, sessionCountByPr
    *  which is what every page but Top usage wants. */
   const allows = (dim: NonNullable<typeof only>[number]): boolean => !only || only.includes(dim)
 
+  /**
+   * CLEARING IS THE COUNT'S EXACT INVERSE, and it was not.
+   *
+   * The badge counts `activeOnly` (the sessions workspace's own switch) among the dimensions, and
+   * the clear button did not turn it off — so on a fleet narrowed by nothing else, pressing "clear
+   * filters" removed nothing, left the badge at 1, and read as a dead control. Reported as exactly
+   * that.
+   *
+   * One function, called by both clear buttons, sitting next to the count so the two are read
+   * together. Anything added to the list below has to be answered here.
+   */
+  const clearAllFilters = () => {
+    onChange({
+      ...filters,
+      users: [], harnesses: [], presence: undefined, repos: [], tags: [],
+      projects: [], models: [], teams: [], machines: [],
+    })
+    onActiveOnlyChange?.(false)
+  }
+
   // Number of dimensions currently active — shown as the badge on the "+ Filter" button.
   const activeFilterCount = [
     (filters.users?.length ?? 0) > 0,
@@ -509,7 +529,7 @@ export function FiltersBar({ only, filters, onChange, projects, sessionCountByPr
               </button>
             )}
             <button
-              onClick={() => onChange({ ...filters, users: [], harnesses: [], presence: undefined, repos: [], tags: [], projects: [], models: [], teams: [], machines: [] })}
+              onClick={clearAllFilters}
               style={{
                 marginLeft: compact ? 'auto' : 0,
                 display: 'inline-flex', alignItems: 'center', gap: 4,
@@ -800,7 +820,7 @@ export function FiltersBar({ only, filters, onChange, projects, sessionCountByPr
                 {lang === 'pt' ? 'Filtros ativos' : 'Active filters'}
               </span>
               <button
-                onClick={() => onChange({ ...filters, users: [], harnesses: [], presence: undefined, repos: [], tags: [], projects: [], models: [], teams: [], machines: [] })}
+                onClick={clearAllFilters}
                 style={{
                   display: 'inline-flex', alignItems: 'center', gap: 4,
                   background: 'transparent', border: 'none', cursor: 'pointer',


### PR DESCRIPTION
## Summary

Two controls that appeared to do nothing.

- **Clear filters** did not turn off `activeOnly` — which the badge DOES count among the active
  dimensions. On a fleet narrowed by nothing else, pressing it removed nothing and left the badge
  reading 1. Clearing is now the count's exact inverse, in one function sitting beside the count so
  the two are read together.
- **Hardware is back on the Sessions route.** The whole action cluster is hidden there, correctly —
  stored-metrics totals and a page-data Live toggle, neither of which describes a fleet that polls
  itself — and this button went with it. It answers "what is this machine doing right now", which
  matters most on the one screen where you watch that machine run several assistants at once.

## Test plan

- `bun tsc --noEmit` clean; `bun test` green.
- Driven in a real browser: `Filter 1` with the clear row before, `Filter` with no count and no row
  after; the hardware button present on `/sessions` and opening its modal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169AqN9y1YGiog3T4qTLVfA
