### PR TITLE
fix(sessions): reopen actually reopens — the id is carried, and the service can reach the harnesses

### DIFF
--- a/packages/server/server/service-manager.ts
+++ b/packages/server/server/service-manager.ts
@@ -22,6 +22,8 @@
  * Nothing here touches the filesystem, `process`, or the network — facts in, file contents out.
  */
 
+import { servicePath } from './sessions/service-path'
+
 /** An init system this product can register a mode with. */
 export type ServiceManagerId = 'systemd' | 'launchd' | 'pm2'
 
@@ -122,7 +124,7 @@ export interface ServiceSpec {
  * registry. The one-shot form leaves restarting to Docker's own `restart: unless-stopped`, which
  * is what actually keeps those containers up.
  */
-export function systemdUnit(spec: ServiceSpec): string {
+export function systemdUnit(spec: ServiceSpec, callerPath?: string): string {
   const lines = [
     '[Unit]',
     `Description=${spec.description}`,
@@ -131,6 +133,17 @@ export function systemdUnit(spec: ServiceSpec): string {
     '',
     '[Service]',
   ]
+  // THE PATH THE HARNESSES LIVE ON. A user service inherits systemd's minimal PATH, and every
+  // coding assistant is installed in a per-user bin directory outside it — so without this the
+  // server cannot spawn a single one, and every reopen answers `ok` while its pane dies at once.
+  // See `sessions/service-path.ts` for the measurement, and for why it is the INSTALLING SHELL's
+  // PATH rather than a list of directories guessed here.
+  const path = servicePath(callerPath ?? process.env.PATH)
+  if (path) {
+    lines.push("# systemd's own PATH reaches none of the per-user bin directories the coding")
+    lines.push('# assistants are installed in — see sessions/service-path.ts.')
+    lines.push(`Environment=PATH=${path}`)
+  }
   if (spec.keepsRunning) {
     lines.push('Type=simple', `ExecStart=${spec.command}`, 'Restart=on-failure', 'RestartSec=5')
   } else {

--- a/packages/server/server/sessions/service-path.test.ts
+++ b/packages/server/server/sessions/service-path.test.ts
@@ -1,0 +1,39 @@
+import { expect, test } from 'bun:test'
+import { servicePath, SYSTEM_PATH } from './service-path'
+
+test('the harness directories reach the unit — the bug this exists for', () => {
+  const out = servicePath('/home/u/.local/bin:/home/u/.bun/bin:/usr/bin:/bin')
+  expect(out).toBe('/home/u/.local/bin:/home/u/.bun/bin:/usr/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/sbin')
+})
+
+test('it is ADDITIVE — the system directories are never lost', () => {
+  const out = servicePath('/home/u/.local/bin')!
+  for (const d of SYSTEM_PATH) expect(out.split(':')).toContain(d)
+})
+
+test('relative and empty entries are dropped', () => {
+  // A service has no meaningful working directory: `.` on its PATH lets whatever directory it
+  // started in supply a binary.
+  const out = servicePath('.:/home/u/.local/bin::relative/bin')!
+  expect(out.split(':')).not.toContain('.')
+  expect(out.split(':')).not.toContain('')
+  expect(out.split(':')).not.toContain('relative/bin')
+  expect(out.split(':')[0]).toBe('/home/u/.local/bin')
+})
+
+test('duplicates collapse, keeping the first position', () => {
+  expect(servicePath('/home/u/bin:/usr/bin:/home/u/bin')!.split(':').filter(d => d === '/home/u/bin'))
+    .toHaveLength(1)
+})
+
+test('a trailing slash is the same directory', () => {
+  const out = servicePath('/home/u/bin/:/home/u/bin')!
+  expect(out.split(':').filter(d => d.startsWith('/home/u/bin'))).toEqual(['/home/u/bin'])
+})
+
+test('nothing to add writes NO line at all', () => {
+  // A unit restating the default is a line somebody has to read and then discard.
+  expect(servicePath('/usr/bin:/bin')).toBeNull()
+  expect(servicePath('')).toBeNull()
+  expect(servicePath(undefined)).toBeNull()
+})

--- a/packages/server/server/sessions/service-path.ts
+++ b/packages/server/server/sessions/service-path.ts
@@ -1,0 +1,67 @@
+/**
+ * service-path.ts — PURE: the PATH a background service needs in order to reach the harnesses.
+ *
+ * A user service inherits systemd's own minimal PATH — measured on this machine:
+ *
+ *     /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin
+ *
+ * and EVERY coding assistant lives outside it:
+ *
+ *     claude   ~/.local/bin        agy      ~/.local/bin
+ *     codex    ~/.bun/bin          gemini   ~/.bun/bin
+ *     copilot  ~/.volta/bin        kimi     ~/.kimi-code/bin
+ *
+ * So a server started by systemd could not spawn a single one of them. Every reopen answered `ok`
+ * with a new id — the registry record was written, the row appeared — and the tmux pane died at
+ * once (`status 1`, `claude: No such file or directory`). From the outside: "clicar em reopen n ta
+ * funcionando… simplesmente n funciona, nao reabre". The same server run from a shell works
+ * perfectly, which is why this survived a day of use: yesterday it was a dev process with the
+ * user's PATH, today it is a service.
+ *
+ * THE INSTALLING SHELL IS THE ONLY THING THAT KNOWS. `agentop autostart` is typed in a terminal
+ * whose PATH already reaches every harness that terminal can run — that is the whole definition of
+ * "installed for this user". So the unit records THAT PATH rather than a list of directories this
+ * file guesses at: guessing means naming `~/.bun/bin` and missing whatever the next tool uses, and
+ * being wrong silently, which is the failure this replaces.
+ *
+ * Two rules:
+ *
+ * - RELATIVE AND EMPTY ENTRIES ARE DROPPED. A service has no meaningful working directory, so `.`
+ *   or `` in a PATH is either useless or a way for whatever directory the service happens to start
+ *   in to supply a binary. `$PATH` entries like that are common in interactive shells.
+ * - IT IS ADDITIVE, never a replacement: the system directories stay, appended after the user's, so
+ *   a unit still finds `sh`, `git` and `docker` if the caller's PATH somehow lacks them.
+ */
+
+/** The directories a systemd user service gets when nothing sets PATH. Kept so it is never lost. */
+export const SYSTEM_PATH = [
+  '/usr/local/sbin', '/usr/local/bin', '/usr/sbin', '/usr/bin', '/sbin', '/bin',
+]
+
+/**
+ * The `Environment=PATH=` value for a unit, from the PATH of the shell installing it.
+ *
+ * Returns `null` when there is nothing to add — the caller then writes NO `Environment=` line at
+ * all, rather than one restating the default. A unit that says nothing is easier to read than one
+ * that says the obvious, and this is a file people open when something is wrong.
+ */
+export function servicePath(callerPath: string | undefined): string | null {
+  const seen = new Set<string>()
+  const out: string[] = []
+  const add = (dir: string) => {
+    // Absolute only. A relative entry in a service is either dead or a way for the starting
+    // directory to decide which binary runs.
+    if (!dir.startsWith('/')) return
+    const clean = dir.length > 1 && dir.endsWith('/') ? dir.slice(0, -1) : dir
+    if (seen.has(clean)) return
+    seen.add(clean)
+    out.push(clean)
+  }
+  for (const dir of (callerPath ?? '').split(':')) add(dir)
+  const userDirs = out.length
+  for (const dir of SYSTEM_PATH) add(dir)
+  // Nothing the service would not already have had.
+  if (userDirs === 0) return null
+  const onlySystem = out.every(d => SYSTEM_PATH.includes(d))
+  return onlySystem ? null : out.join(':')
+}

--- a/packages/web/src/lib/echoMatch.test.ts
+++ b/packages/web/src/lib/echoMatch.test.ts
@@ -37,3 +37,38 @@ test('whitespace and CR differences never keep an echo standing', () => {
 test('an empty echo is not a message', () => {
   expect(pendingEchoes(['   '], [])).toEqual([])
 })
+
+test('an echo whose PATHS the harness rewrote into markers is retired', () => {
+  // The measured pair: the composer types one path per line, the harness stores `[Image #N]`.
+  const echo = '/home/u/.agentistics/attachments/ab-image.png\n'
+    + '/home/u/.agentistics/attachments/cd-image.png\n'
+    + 'vou te passar mais algumas pendencias e voce abre uma nova sessao'
+  const stored = '[Image #26] [Image #27]vou te passar mais algumas pendencias e voce abre uma nova sessao'
+  expect(pendingEchoes([echo], [stored])).toEqual([])
+})
+
+test('a files-only message is retired by the MARKER COUNT, and only then', () => {
+  const echo = '/home/u/.agentistics/attachments/ab-image.png\n/home/u/.agentistics/attachments/cd-image.png'
+  expect(pendingEchoes([echo], ['[Image #1] [Image #2]'])).toEqual([])
+  // A different number of files is a different message.
+  expect(pendingEchoes([echo], ['[Image #1]'])).toEqual([echo])
+  // A turn that HAS words is never matched by the count rule.
+  expect(pendingEchoes([echo], ['[Image #1] [Image #2] olha isso'])).toEqual([echo])
+})
+
+test('the prose rule does not retire a message that never landed', () => {
+  const echo = '/home/u/.agentistics/attachments/ab-image.png\nsobe o binário do dev pra mim'
+  expect(pendingEchoes([echo], ['[Image #9]outra coisa qualquer'])).toEqual([echo])
+})
+
+test('a windows path counts as an attachment line', () => {
+  const echo = 'C:\\Users\\u\\shot.png\nolha esse print aqui e me diz'
+  expect(pendingEchoes([echo], ['[Image #3]olha esse print aqui e me diz'])).toEqual([])
+})
+
+test('a SHORT prose still needs an exact match', () => {
+  // "ok" as prose must not be retired by appearing inside an unrelated turn.
+  const echo = '/home/u/x.png\nok'
+  expect(pendingEchoes([echo], ['[Image #1]tudo okay por aqui'])).toEqual([echo])
+  expect(pendingEchoes([echo], ['[Image #1]ok'])).toEqual([])
+})

--- a/packages/web/src/lib/echoMatch.ts
+++ b/packages/web/src/lib/echoMatch.ts
@@ -19,6 +19,22 @@
  * unrelated turns by coincidence, and retiring it there would hide a message that really was still
  * waiting. Below `SAFE_CONTAINS_LEN` the old equality rule stands: a false "still waiting" on a
  * two-letter message costs a glance, a false "delivered" costs the message.
+ *
+ * THE SECOND SHAPE, AND IT LOOKED LIKE A DUPLICATE MESSAGE. A message with attachments is sent as
+ * one path per line followed by the prose — that is what the composer types into the pane — and the
+ * harness stores it with the paths REPLACED by its own markers. Measured on this machine:
+ *
+ *   echo    '/home/u/.agentistics/attachments/ab-image.png\n…/cd-image.png\nvou te passar…'
+ *   stored  '[Image #26] [Image #27]vou te passar…'
+ *
+ * Neither equal nor contained, so the echo stood forever BESIDE the transcript's own copy of the
+ * same message — two bubbles, one message. Reported as exactly that: "aparentemente o prompt que eu
+ * mandei por aqui tbm foi enviado via terminal e dai duplicou". Nothing was sent twice.
+ *
+ * So an echo is also compared by its PROSE — itself minus the attachment lines it added. And when
+ * there is no prose (a message that was only files), by the COUNT: a stored turn that is nothing
+ * but markers, as many as the echo carried paths. That second rule is narrow on purpose — it never
+ * fires on a turn that has words in it.
  */
 
 /** Whitespace is collapsed on both sides: the harness re-wraps what it stores, and adds `\r`. */
@@ -35,16 +51,61 @@ export function collapseEcho(text: string): string {
 export const SAFE_CONTAINS_LEN = 12
 
 /** The echoes that are still waiting, given what the transcript's user turns now say. */
+/** A line that is nothing but a path — what the composer adds for each attachment. */
+function isPathLine(line: string): boolean {
+  const t = line.trim()
+  return t !== '' && !/\s/.test(t) && (t.startsWith('/') || /^[A-Za-z]:[\\/]/.test(t))
+}
+
+/** The echo without the attachment lines it carries, and how many those were. */
+export function echoProse(text: string): { prose: string; paths: number } {
+  const lines = text.split('\n')
+  const kept = lines.filter(l => !isPathLine(l))
+  return { prose: collapseEcho(kept.join('\n')), paths: lines.length - kept.length }
+}
+
+const MARKER = /\[Image #\d+\]/g
+
+/** How many markers a stored turn is made of, when it is made of nothing else. */
+function markerOnlyCount(turn: string): number {
+  const t = turn.trim()
+  const markers = t.match(MARKER)
+  if (!markers) return 0
+  return t.replace(MARKER, '').trim() === '' ? markers.length : 0
+}
+
+/**
+ * A stored turn with its LEADING markers removed — what is left is the prose the person typed.
+ *
+ * Only leading ones, and only for comparison: the harness puts them where the composer put the
+ * paths, which is the top. A marker in the middle of a sentence is something the person wrote.
+ */
+function withoutLeadingMarkers(turn: string): string {
+  return collapseEcho(turn.trim().replace(/^(?:\[Image #\d+\]\s*)+/, ''))
+}
+
 export function pendingEchoes(
   echoes: readonly string[],
   userTurns: readonly string[],
 ): string[] {
   const seen = userTurns.map(collapseEcho).filter(t => t !== '')
+  const landed = (c: string): boolean =>
+    seen.includes(c) || (c.length >= SAFE_CONTAINS_LEN && seen.some(t => t.includes(c)))
   return echoes.filter(text => {
     const c = collapseEcho(text)
     if (c === '') return false
-    if (seen.includes(c)) return false
-    if (c.length < SAFE_CONTAINS_LEN) return true
-    return !seen.some(t => t.includes(c))
+    if (landed(c)) return false
+    const { prose, paths } = echoProse(text)
+    if (paths === 0) return true
+    // The prose against the stored turn with its leading markers removed. EXACT equality is enough
+    // here and is what makes it safe for a two-word message: the markers stand exactly where the
+    // paths stood, so what remains on both sides is the same typed sentence — no coincidence to
+    // guard against, and none of the length rule's caution is needed.
+    const stripped = userTurns.map(withoutLeadingMarkers).filter(t => t !== '')
+    if (prose !== '' && (stripped.includes(prose)
+      || (prose.length >= SAFE_CONTAINS_LEN && stripped.some(t => t.includes(prose))))) return false
+    // Only files and no words: match a turn that is only markers, as many as there were paths.
+    if (prose === '' && userTurns.some(t => markerOnlyCount(t) === paths)) return false
+    return true
   })
 }

--- a/packages/web/src/lib/fleet.ts
+++ b/packages/web/src/lib/fleet.ts
@@ -20,6 +20,7 @@ import { cacheIsUsable, stripVolatile } from './fleetCache'
 import { getCentralMachine } from './centralMachinePick'
 import { relayedToSessions, type RelayedRow } from './relayedSessions'
 import { notifyFleetTransitions, type SessionActivity } from './sessionNotifications'
+import { parseActResult } from './fleetAct'
 
 /** Mirrors `SessionAction` in `@agentistics/tui/control/sessions`, minus the verbs a page cannot do. */
 export type FleetActionId =
@@ -331,12 +332,11 @@ export function useFleet(lang: 'pt' | 'en', enabled = true): FleetState {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(req),
       })
-      const json = await res.json().catch(() => null) as { ok?: boolean; message?: string } | null
-      const out = {
-        ok: Boolean(json?.ok),
-        message: json?.message
-          ?? (lang === 'pt' ? 'A ação não pôde ser executada.' : 'The action could not be run.'),
-      }
+      // Read through `parseActResult`, which is where "every field the answer carries is carried
+      // on" is written down and tested. This was an object literal building `{ ok, message }` while
+      // the declared return type promised `id?: string` — so a reopen spawned its session and the
+      // UI stood still on the dead row, because the id it needed to follow had been dropped.
+      const out = parseActResult(await res.json().catch(() => null), lang)
       // Re-read immediately: the verb changed the machine, and waiting up to five seconds to show
       // it is how a control that worked looks like one that did nothing.
       await pollOnce()

--- a/packages/web/src/lib/fleetAct.test.ts
+++ b/packages/web/src/lib/fleetAct.test.ts
@@ -1,0 +1,34 @@
+import { expect, test } from 'bun:test'
+import { actFallbackMessage, parseActResult } from './fleetAct'
+
+test('the created session id is CARRIED, which is the whole bug this replaces', () => {
+  // The exact body measured from a reopen that appeared to do nothing.
+  const body = { ok: true, message: 'started ACESSIBILIDADE VINI in the background.', id: 'aeb12129c4' }
+  expect(parseActResult(body, 'en')).toEqual({
+    ok: true, message: 'started ACESSIBILIDADE VINI in the background.', id: 'aeb12129c4',
+  })
+})
+
+test('a verb that created nothing carries no id', () => {
+  expect(parseActResult({ ok: true, message: 'stopped x.' }, 'en').id).toBeUndefined()
+})
+
+test('an id that is not a usable string is not one', () => {
+  // It would otherwise become a route this app navigates to.
+  expect(parseActResult({ ok: true, message: 'm', id: null }, 'en').id).toBeUndefined()
+  expect(parseActResult({ ok: true, message: 'm', id: 0 }, 'en').id).toBeUndefined()
+  expect(parseActResult({ ok: true, message: 'm', id: '  ' }, 'en').id).toBeUndefined()
+})
+
+test('ok is TRUE only when the machine said so', () => {
+  expect(parseActResult({ ok: 'yes', message: 'm' }, 'en').ok).toBe(false)
+  expect(parseActResult({ message: 'm' }, 'en').ok).toBe(false)
+})
+
+test('an unreadable body still yields a sentence', () => {
+  expect(parseActResult(null, 'pt')).toEqual({ ok: false, message: actFallbackMessage('pt') })
+  expect(parseActResult('nonsense', 'en').message).toBe(actFallbackMessage('en'))
+  // An EMPTY message is not a message — the machine's own wording is what this shows, and a blank
+  // line under a failed verb says nothing at all.
+  expect(parseActResult({ ok: false, message: '' }, 'en').message).toBe(actFallbackMessage('en'))
+})

--- a/packages/web/src/lib/fleetAct.ts
+++ b/packages/web/src/lib/fleetAct.ts
@@ -1,0 +1,49 @@
+/**
+ * fleetAct.ts — PURE: what a verb's answer means to the browser.
+ *
+ * `POST /api/fleet/act` answers `{ ok, message }` and, for a verb that CREATED something, the new
+ * session's `id`. That id is not decoration: a reopen mints a new row and retires the one it was
+ * asked about, so a caller that does not follow it leaves the reader on a dead session with a
+ * success message over it.
+ *
+ * That is what happened. `FleetState['act']` DECLARED `id?: string` in its return and the
+ * implementation built `{ ok, message }` — the id was dropped on the floor. TypeScript cannot catch
+ * it: the property is optional, and an object that simply lacks an optional property is assignable.
+ * The reopen worked every time, spawned the session, and the UI stood still — reported as "nao ta
+ * sendo possivel reabrir pela ui sessoes que estao off". Measured: the server answered
+ * `{"ok":true,"message":"started ACESSIBILIDADE VINI in the background.","id":"aeb12129c4"}` and the
+ * URL never moved.
+ *
+ * So the parse is a FUNCTION with a test rather than an object literal inside a callback. The rule
+ * it exists to hold: **every field the answer carries is carried on**, and a field is dropped only
+ * where dropping it is written down.
+ */
+
+export interface FleetActResult {
+  ok: boolean
+  /** Already localized by the machine that ran the verb. Never composed here. */
+  message: string
+  /** The session a verb CREATED, when it created one. */
+  id?: string
+}
+
+/** The sentence for an answer that carried none — a network error, or a body that is not ours. */
+export function actFallbackMessage(lang: 'pt' | 'en'): string {
+  return lang === 'pt' ? 'A ação não pôde ser executada.' : 'The action could not be run.'
+}
+
+/**
+ * Read one `/api/fleet/act` answer.
+ *
+ * `json` is whatever came back, including `null` for a body that could not be parsed. The id is
+ * kept only when it is a non-empty string: an `id` of `null` or `0` from some future version must
+ * not become a route this app navigates to.
+ */
+export function parseActResult(json: unknown, lang: 'pt' | 'en'): FleetActResult {
+  const o = (typeof json === 'object' && json !== null ? json : {}) as Record<string, unknown>
+  const message = typeof o.message === 'string' && o.message !== ''
+    ? o.message
+    : actFallbackMessage(lang)
+  const id = typeof o.id === 'string' && o.id.trim() !== '' ? o.id : undefined
+  return { ok: o.ok === true, message, ...(id ? { id } : {}) }
+}


### PR DESCRIPTION
## Summary

Reopening a session from the UI did nothing. Two separate causes, and the second breaks **every**
session spawn on any machine running agentop as a service.

- **The created session's id was dropped.** `FleetState['act']` declared `id?: string` in its return
  type while the implementation built `{ ok, message }` — TypeScript cannot catch an object that
  merely lacks an optional property. So the reopen minted a new session and the UI stayed on the
  dead row. The parse is now a tested function.
- **The pane died the instant it opened.** A systemd user service inherits systemd's minimal PATH,
  and every coding assistant lives outside it (`~/.local/bin`, `~/.bun/bin`, `~/.volta/bin`,
  `~/.kimi-code/bin`). The server could not spawn a single harness: `ok` plus a new id, and a tmux
  pane dead at once with `claude: No such file or directory`. The unit now carries
  `Environment=PATH=`, derived from the PATH of the shell that installs it — the only thing that
  knows where the harnesses are.

## Test plan

- `bun test` — 5.735 passing, 0 failing.
- Reproduced by hand: the spawn argv under a shell PATH opens Claude Code; under the service's PATH
  it exits 127.
- Verified on the running machine: with the PATH in place, a reopen through the API comes up as a
  live pane instead of a dead one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169AqN9y1YGiog3T4qTLVfA
