### PR TITLE
fix(sessions): the registry stops losing records, and three bugs found by using it

### DIFF
--- a/packages/server/server/sessions/file-lock.test.ts
+++ b/packages/server/server/sessions/file-lock.test.ts
@@ -1,0 +1,66 @@
+import { expect, test } from 'bun:test'
+import { mkdir, mkdtemp, rm, stat } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { lockFile, STALE_MS, withFileLock } from './file-lock'
+
+async function tmp(): Promise<string> {
+  return join(await mkdtemp(join(tmpdir(), 'agentop-lock-')), 'file.json')
+}
+
+test('a lock is held, and released', async () => {
+  const f = await tmp()
+  const held = await lockFile(f)
+  expect(held.contended).toBe(false)
+  await expect(stat(`${f}.lock`)).resolves.toBeDefined()
+  await held.release()
+  await expect(stat(`${f}.lock`)).rejects.toBeDefined()
+})
+
+test('an ABANDONED lock is cleared rather than waited on forever', async () => {
+  // A process killed between acquire and release leaves the directory. Without expiry the next
+  // start of agentop would hang on a lock nobody holds.
+  const f = await tmp()
+  await mkdir(`${f}.lock`)
+  const old = Date.now() + STALE_MS + 1000
+  const held = await lockFile(f, () => old)
+  expect(held.contended).toBe(false)
+  await held.release()
+})
+
+test('a contended lock PROCEEDS and says so, rather than failing the caller', async () => {
+  // Refusing here would mean not recording a session that has already been spawned — a lost label
+  // is a smaller harm than a live session with no record at all.
+  const f = await tmp()
+  const first = await lockFile(f)
+  let t = Date.now()
+  const second = await lockFile(f, () => (t += 3000))
+  expect(second.contended).toBe(true)
+  await first.release()
+  await second.release()
+})
+
+test('the lock is released even when the work throws', async () => {
+  const f = await tmp()
+  await expect(withFileLock(f, async () => { throw new Error('boom') })).rejects.toThrow('boom')
+  await expect(stat(`${f}.lock`)).rejects.toBeDefined()
+})
+
+test('two callers in one process still run one at a time', async () => {
+  const f = await tmp()
+  const order: string[] = []
+  await Promise.all([
+    withFileLock(f, async () => { order.push('a-in'); await Bun.sleep(30); order.push('a-out') }),
+    withFileLock(f, async () => { order.push('b-in'); await Bun.sleep(1); order.push('b-out') }),
+  ])
+  // Whoever went first finished before the other started.
+  expect(order[0]!.endsWith('-in')).toBe(true)
+  expect(order[1]).toBe(`${order[0]!.slice(0, 1)}-out`)
+})
+
+test('the lock directory does not survive a release, so it cannot become stale garbage', async () => {
+  const f = await tmp()
+  await withFileLock(f, async () => undefined)
+  await expect(stat(`${f}.lock`)).rejects.toBeDefined()
+  await rm(f, { force: true })
+})

--- a/packages/server/server/sessions/file-lock.ts
+++ b/packages/server/server/sessions/file-lock.ts
@@ -1,0 +1,102 @@
+/**
+ * file-lock.ts — a lock ACROSS PROCESSES, for a file several agentop processes read-modify-write.
+ *
+ * `registry.ts` serialises its mutations with a promise chain, which is correct and is only half
+ * the problem: agentop runs as SEVERAL processes — the systemd server, the cockpit, and every
+ * one-shot `agentop session …` — and a promise chain is per process. Two of them reading the same
+ * `managed-sessions.json`, each adding its own record, each writing the whole list back, is a lost
+ * write every time they overlap.
+ *
+ * MEASURED, not theorised. Two sessions started minutes apart came back with the same `createdAt`
+ * to the millisecond and no `label` at all — the signature of records that were erased and then
+ * re-created by adoption, which cannot know a name. That is why "sessoes criadas por aqui nao sao
+ * renomeadas com o nome do titulo que coloquei" and "renomear sessoes nao esta renomeando de
+ * verdade" are ONE bug: both write a label into a file that another process overwrites.
+ *
+ * `mkdir` IS THE LOCK. It is the one filesystem operation that is atomic and fails when the target
+ * exists, on every platform this runs on, with no dependency and no daemon — `open(O_EXCL)` is
+ * equally atomic but leaves a file that looks like data, and a directory beside a JSON file reads
+ * as what it is. `proper-lockfile` does exactly this and is not worth a dependency here.
+ *
+ * A LOCK MUST NEVER BE ABLE TO WEDGE THE PRODUCT. Every rule below exists for that:
+ *
+ * - It is STALE after `STALE_MS`. A process killed between acquire and release leaves the directory
+ *   behind, and without expiry the next start of agentop would hang forever on a lock nobody holds.
+ * - The wait is BOUNDED. Past `WAIT_MS` the caller runs anyway — because the alternative is
+ *   refusing to record a session that has already been spawned, and a lost label is a smaller harm
+ *   than a live session with no record at all. It says so through `contended`, so a caller can log
+ *   it rather than pretend it held the lock.
+ * - Release NEVER throws. A failed cleanup becomes a stale lock, which the next acquirer clears.
+ */
+
+import { mkdir, rm, stat, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+/** A lock older than this is assumed abandoned. Longer than any write; far shorter than a coffee. */
+export const STALE_MS = 15_000
+
+/** How long to wait for someone else's lock before going ahead without it. */
+export const WAIT_MS = 5_000
+
+const RETRY_MS = 25
+
+export interface LockHandle {
+  /** True when the lock could NOT be taken and the work is proceeding anyway. */
+  contended: boolean
+  release(): Promise<void>
+}
+
+const sleep = (ms: number) => new Promise(r => setTimeout(r, ms))
+
+/** Is this lock directory old enough to be treated as abandoned? */
+async function isStale(dir: string, nowMs: number): Promise<boolean> {
+  try {
+    const st = await stat(dir)
+    return nowMs - st.mtimeMs > STALE_MS
+  } catch {
+    // Gone between the failed mkdir and this stat — whoever held it released it.
+    return true
+  }
+}
+
+/**
+ * Take the lock for `file`, or give up waiting and say so.
+ *
+ * The lock is `<file>.lock`, a directory. The pid is written inside it purely so a person looking
+ * at a stuck machine can see who to blame; nothing reads it.
+ */
+export async function lockFile(file: string, nowMs = () => Date.now()): Promise<LockHandle> {
+  const dir = `${file}.lock`
+  const deadline = nowMs() + WAIT_MS
+  for (;;) {
+    try {
+      await mkdir(dir)
+      // Best effort, and deliberately not awaited for correctness: the lock is the DIRECTORY.
+      void writeFile(join(dir, 'pid'), String(process.pid), 'utf-8').catch(() => undefined)
+      return { contended: false, release: () => rm(dir, { recursive: true, force: true }).catch(() => undefined) }
+    } catch {
+      if (await isStale(dir, nowMs())) {
+        await rm(dir, { recursive: true, force: true }).catch(() => undefined)
+        continue
+      }
+      if (nowMs() >= deadline) {
+        // Proceed WITHOUT the lock rather than fail the caller. See the header.
+        return { contended: true, release: async () => undefined }
+      }
+      await sleep(RETRY_MS)
+    }
+  }
+}
+
+/** Run `fn` while holding the lock. The handle is released whatever `fn` does. */
+export async function withFileLock<T>(
+  file: string,
+  fn: (held: { contended: boolean }) => Promise<T>,
+): Promise<T> {
+  const lock = await lockFile(file)
+  try {
+    return await fn({ contended: lock.contended })
+  } finally {
+    await lock.release()
+  }
+}

--- a/packages/server/server/sessions/registry-concurrency.test.ts
+++ b/packages/server/server/sessions/registry-concurrency.test.ts
@@ -1,0 +1,54 @@
+import { expect, test } from 'bun:test'
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+/**
+ * The registry, written by SEVERAL PROCESSES at once.
+ *
+ * This is the test that did not exist, and its absence is why the bug shipped: every existing
+ * registry test runs in ONE process, where the promise chain already serialised everything. agentop
+ * is not one process — it is the systemd server, the cockpit, and every one-shot `agentop session
+ * …` — and a promise chain does not reach across them.
+ *
+ * So this spawns real processes. It is slower than the rest of the suite and it is the only shape
+ * that can fail when the lock is removed.
+ */
+
+const WRITER = `
+const { createSessionRegistry } = await import(process.argv[2])
+const file = process.argv[3]
+const id = process.argv[4]
+const reg = createSessionRegistry(file)
+await reg.add({
+  id, harness: 'claude', cwd: '/tmp/x',
+  createdAt: new Date().toISOString(),
+  label: 'label-' + id,
+})
+`
+
+async function runWriters(file: string, ids: string[]): Promise<void> {
+  const regPath = join(import.meta.dir, 'registry.ts')
+  const script = join(await mkdtemp(join(tmpdir(), 'agentop-writer-')), 'w.ts')
+  await Bun.write(script, WRITER)
+  await Promise.all(ids.map(async id => {
+    const p = Bun.spawn(['bun', script, regPath, file, id], { stdout: 'pipe', stderr: 'pipe' })
+    await p.exited
+  }))
+}
+
+test('a record written by one process is not erased by another', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'agentop-registry-'))
+  const file = join(dir, 'managed-sessions.json')
+  try {
+    const ids = ['aaa1', 'bbb2', 'ccc3', 'ddd4', 'eee5', 'fff6']
+    await runWriters(file, ids)
+    const list = JSON.parse(await readFile(file, 'utf-8')) as { id: string; label?: string }[]
+    // EVERY id, and every label. Before the cross-process lock this lost records whenever two
+    // writers overlapped — which is exactly what a spawn racing the server's heartbeat does.
+    expect(list.map(r => r.id).sort()).toEqual([...ids].sort())
+    expect(list.every(r => r.label === `label-${r.id}`)).toBe(true)
+  } finally {
+    await rm(dir, { recursive: true, force: true })
+  }
+}, 30_000)

--- a/packages/server/server/sessions/registry.ts
+++ b/packages/server/server/sessions/registry.ts
@@ -27,6 +27,7 @@ import { dirname } from 'node:path'
 import { randomUUID } from 'node:crypto'
 import { MANAGED_SESSIONS_FILE } from '../config'
 import type { ManagedSession } from './types'
+import { withFileLock } from './file-lock'
 
 /**
  * A short, lowercase id that is safe as a tmux session name.
@@ -212,8 +213,16 @@ export function createSessionRegistry(file: string): SessionRegistry {
   // Chains `fn` behind whatever is already queued, so its read and write run as one atomic step
   // relative to every other call made through this same function. Kept alive across a rejection —
   // otherwise one failed mutation would wedge every mutation queued after it.
+  //
+  // AND ACROSS PROCESSES. The chain is per process, and agentop runs as several: the systemd
+  // server, the cockpit, and every one-shot `agentop session …`. Two of them read the same list,
+  // each adds its own record, each writes the whole thing back — and one record is gone. Measured:
+  // two sessions started minutes apart came back with an identical `createdAt` and no label,
+  // because both records had been erased and re-created by adoption, which cannot know a name.
+  // That is the one bug behind "the title I typed was ignored" and "rename does not rename".
+  // See `file-lock.ts` for why the lock can never wedge the product.
   function enqueue<T>(fn: () => Promise<T>): Promise<T> {
-    const next = queue.then(fn)
+    const next = queue.then(() => withFileLock(file, fn))
     queue = next.catch(() => undefined)
     return next
   }

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -97,6 +97,7 @@ import { CentralSessions } from './components/sessions/CentralSessions'
 // filter row in the strip and the body under it have to move together at every width.
 import { PAGE_INSET, PAGE_MAX_WIDTH } from './components/sessions/FleetOverview'
 import { setFleetSourceCentral } from './lib/fleet'
+import { sessionPath } from './lib/sessionRoute'
 
 /**
  * What the SESSIONS filter bar may filter by — narrower than the dashboard's on purpose: a fleet
@@ -2913,7 +2914,7 @@ export default function AppLayout() {
           act={headerFleetAct}
           onGone={() => navigate('/sessions')}
           // A reopen mints a NEW session; going to it is what makes the verb visibly do something.
-          onOpened={id => navigate(`/sessions/${id}`)}
+          onOpened={id => navigate(sessionPath(id))}
         />
       )}
     </div>

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -98,6 +98,7 @@ import { CentralSessions } from './components/sessions/CentralSessions'
 import { PAGE_INSET, PAGE_MAX_WIDTH } from './components/sessions/FleetOverview'
 import { setFleetSourceCentral } from './lib/fleet'
 import { sessionPath } from './lib/sessionRoute'
+import { SessionStatsMenu } from './components/sessions/SessionStatsMenu'
 
 /**
  * What the SESSIONS filter bar may filter by — narrower than the dashboard's on purpose: a fleet
@@ -2878,6 +2879,23 @@ export default function AppLayout() {
           conversation, and the conversation does not leave the machine. A control that cannot work
           is not rendered inert — the same rule the fleet's verbs keep. The sentence is on the row
           in the panel's place, so the absence is explained where the button would have been. */}
+      {/* WHAT THIS CONVERSATION HAS SPENT. The context percentage rides the button, because it is
+          the one figure that changes what you do next: a session near its window is one to finish
+          rather than extend. The record comes from the store by CONVERSATION id — a session the
+          store has not seen yet reads as "not recorded yet", never as zero. */}
+      {selectedFleetSession && (
+        <SessionStatsMenu
+          harness={selectedFleetSession.harness}
+          sessionId={selectedFleetSession.conversationId ?? selectedFleetSession.id}
+          meta={selectedFleetSession.conversationId
+            ? data?.sessions?.find(x => x.session_id === selectedFleetSession.conversationId)
+            : undefined}
+          lang={lang === 'pt' ? 'pt' : 'en'}
+          currency={currency}
+          brlRate={brlRate}
+        />
+      )}
+
       {selectedFleetSession && !isCentral && (
         <button
           onClick={toggleArtifacts}

--- a/packages/web/src/components/nav/SessionsAside.tsx
+++ b/packages/web/src/components/nav/SessionsAside.tsx
@@ -27,6 +27,7 @@ import { NewSessionModal } from '../sessions/NewSessionModal'
 import { rowMenuEntries, type RowVerb } from '../../lib/rowMenu'
 import { SessionRowMenu } from '../sessions/SessionRowMenu'
 import { SessionFacts } from '../sessions/SessionFacts'
+import { sessionPath } from '../../lib/sessionRoute'
 import {
   MAX_PINNED, getPinnedIds, movePinnedSession, pinnedServerSnapshot, resolvePinnedRows,
   subscribePinnedSessions, togglePinnedSession,
@@ -286,7 +287,7 @@ export function SessionsAside({
             setCreating(false)
             // Straight into it. The row will arrive on the next poll; navigating now means the
             // panel is already open on it when it does.
-            if (id) navigate(`/sessions/${id}`)
+            if (id) navigate(sessionPath(id))
           }}
         />
       )}
@@ -415,7 +416,7 @@ export function SessionsAside({
                     pinned
                     {...(tap ? { tap } : {})}
                     onPin={() => flip(s)}
-                    onOpen={() => (onOpenRow ? onOpenRow(s) : navigate(`/sessions/${s.id}`))}
+                    onOpen={() => (onOpenRow ? onOpenRow(s) : navigate(sessionPath(s.id)))}
                     onMoveBy={d => movePinnedSession(i, i + d)}
                     {...(rowsById?.get(s.id) ? { verbs: rowsById.get(s.id)!.verbs } : {})}
                     onOpenMenu={(x, y, verbs) => openMenu(s, x, y, verbs)}
@@ -441,7 +442,7 @@ export function SessionsAside({
                 key={`${i}-${b.label}`}
                 label={b.label} rows={b.rows} pinned={pinned}
                 sessionId={sessionId} tap={tap} onPin={flip}
-                onOpen={s => (onOpenRow ? onOpenRow(s) : navigate(`/sessions/${s.id}`))}
+                onOpen={s => (onOpenRow ? onOpenRow(s) : navigate(sessionPath(s.id)))}
                 {...(rowsById ? { rowsById } : {})}
                 onOpenMenu={openMenu}
               />

--- a/packages/web/src/components/nav/SessionsRail.tsx
+++ b/packages/web/src/components/nav/SessionsRail.tsx
@@ -21,6 +21,7 @@ import { useNavigate } from 'react-router-dom'
 import type { ControlSession } from '@agentistics/tui/control/session-fleet'
 import { HarnessMark } from '../sessions/HarnessMark'
 import { SessionFacts } from '../sessions/SessionFacts'
+import { sessionPath } from '../../lib/sessionRoute'
 
 /**
  * The dot a state earns, or null for one that earns none.
@@ -55,7 +56,7 @@ export function SessionsRail({ rows, selectedId }: {
       {shown.map(s => (
         <button
           key={s.id}
-          onClick={() => navigate(`/sessions/${s.id}`)}
+          onClick={() => navigate(sessionPath(s.id))}
           aria-label={s.title}
           onMouseEnter={e => {
             const r = e.currentTarget.getBoundingClientRect()

--- a/packages/web/src/components/sessions/SessionPanel.tsx
+++ b/packages/web/src/components/sessions/SessionPanel.tsx
@@ -137,8 +137,21 @@ export function SessionPanel({ session, row, lang, theme, act, authorName, onGon
       )}
 
       <div style={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
+        {/* KEYED BY THE SESSION, and this is a correctness fix rather than a hint to React.
+            Without it the same instance is reused when `session` changes, so every piece of state
+            that is READ ONCE AT MOUNT belongs to whichever session was open first: the draft
+            (`useState(() => readDraft(session.id))`), the attachments, and the in-flight `sending`
+            / `stopping` flags.
+            Reported, and it is the worst shape this could take: a message typed for one session
+            was sent into ANOTHER after switching rows mid-request, with every button in the new
+            session's composer stuck on a spinner that belonged to the old one. Per-session state
+            must not outlive the session, and a `key` is how React is told that. */}
         {active === 'chat' ? (
-          <SessionChat session={session} {...(row ? { row } : {})} lang={lang} act={act} {...(onArtifacts ? { onArtifacts } : {})} />
+          <SessionChat
+            key={session.id}
+            session={session} {...(row ? { row } : {})} lang={lang} act={act}
+            {...(onArtifacts ? { onArtifacts } : {})}
+          />
         ) : (
           <div style={{ flex: 1, minHeight: 0, padding: 16, display: 'flex', flexDirection: 'column' }}>
             {/* The very component the sessions list uses. Assembling a second one from the stream

--- a/packages/web/src/components/sessions/SessionStatsMenu.tsx
+++ b/packages/web/src/components/sessions/SessionStatsMenu.tsx
@@ -1,0 +1,216 @@
+/**
+ * SessionStatsMenu — what THIS conversation has spent, in a dropdown beside the session's controls.
+ *
+ * The dashboard has a strip of figures for the whole machine; this is the same question asked of
+ * the session you have open. Asked for directly, and the first line of it is the one that decides
+ * when to start a new conversation: how full the context window is.
+ *
+ * Every rule about what the numbers MEAN lives in `sessionStats.ts`. This file draws them, and its
+ * only judgement is how to say "not available" — twice, differently:
+ *
+ *   `harness`    this assistant cannot produce it at all (`HARNESS_CAPABILITIES`)
+ *   `unrecorded` the conversation is not in the local store yet
+ *
+ * They send a reader to two different places, so they are two sentences and never one dash.
+ */
+
+import { useEffect, useRef, useState } from 'react'
+import { BarChart3, X } from 'lucide-react'
+import { fmt, fmtCost, type HarnessId, type SessionMeta } from '@agentistics/core'
+import { HARNESS_LABELS } from '../../lib/harness'
+import { sessionStats, statReason } from '../../lib/sessionStats'
+
+export interface SessionStatsMenuProps {
+  harness: string
+  sessionId: string
+  /** The store's record for this conversation, or `undefined` when it has none yet. */
+  meta: SessionMeta | undefined
+  lang: 'pt' | 'en'
+  currency: 'USD' | 'BRL'
+  brlRate: number
+}
+
+export function SessionStatsMenu({
+  harness, sessionId, meta, lang, currency, brlRate,
+}: SessionStatsMenuProps) {
+  const pt = lang === 'pt'
+  const [open, setOpen] = useState(false)
+  const boxRef = useRef<HTMLDivElement | null>(null)
+
+  useEffect(() => {
+    if (!open) return
+    const away = (e: MouseEvent) => {
+      if (!boxRef.current?.contains(e.target as Node)) setOpen(false)
+    }
+    const esc = (e: KeyboardEvent) => { if (e.key === 'Escape') setOpen(false) }
+    document.addEventListener('mousedown', away)
+    document.addEventListener('keydown', esc)
+    return () => {
+      document.removeEventListener('mousedown', away)
+      document.removeEventListener('keydown', esc)
+    }
+  }, [open])
+
+  const h = harness as HarnessId
+  const s = sessionStats(h, sessionId, meta)
+  const money = (usd: number) => fmtCost(usd, currency, brlRate)
+  const label = (HARNESS_LABELS as Record<string, string>)[harness] ?? harness
+
+  /** The sentence for an absent figure — see the header. */
+  const na = (metric: Parameters<typeof statReason>[1]) =>
+    statReason(h, metric) === 'harness'
+      ? (pt ? `${label} não reporta isso` : `${label} does not report this`)
+      : (pt ? 'ainda não registrado' : 'not recorded yet')
+
+  return (
+    <div ref={boxRef} style={{ position: 'relative', flexShrink: 0 }}>
+      <button
+        onClick={() => setOpen(v => !v)}
+        aria-expanded={open}
+        aria-label={pt ? 'Métricas desta sessão' : 'This session’s metrics'}
+        title={pt ? 'Métricas desta sessão' : 'This session’s metrics'}
+        style={{
+          display: 'flex', alignItems: 'center', gap: 6, height: 30, padding: '0 10px',
+          borderRadius: 9, cursor: 'pointer', flexShrink: 0,
+          border: '1px solid ' + (open ? 'var(--anthropic-orange)' : 'var(--border-subtle)'),
+          background: open ? 'var(--anthropic-orange-dim)' : 'var(--bg-elevated)',
+          color: open ? 'var(--anthropic-orange)' : 'var(--text-secondary)',
+          fontFamily: 'inherit', fontSize: 12,
+        }}
+      >
+        <BarChart3 size={14} />
+        {/* The context percentage rides the BUTTON, because it is the one figure that changes what
+            you do next — a conversation near its window is one to finish rather than extend. It is
+            absent, not zero, when it cannot be known. */}
+        {s.context && <span style={{ fontWeight: 650 }}>{Math.floor(s.context.fraction * 100)}%</span>}
+      </button>
+
+      {open && (
+        <div style={{
+          position: 'absolute', top: 36, right: 0, zIndex: 60,
+          width: 300, padding: 12, borderRadius: 12,
+          background: 'var(--bg-elevated)', border: '1px solid var(--border)',
+          boxShadow: '0 12px 32px rgba(0,0,0,0.4)',
+        }}>
+          <div style={{ display: 'flex', alignItems: 'center', marginBottom: 10 }}>
+            <span style={{
+              fontSize: 11, fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.06em',
+              color: 'var(--text-tertiary)',
+            }}>{pt ? 'Esta sessão' : 'This session'}</span>
+            <button
+              onClick={() => setOpen(false)}
+              aria-label={pt ? 'Fechar' : 'Close'}
+              style={{
+                marginLeft: 'auto', display: 'flex', width: 22, height: 22, borderRadius: 6,
+                alignItems: 'center', justifyContent: 'center', border: 'none',
+                background: 'transparent', color: 'var(--text-tertiary)', cursor: 'pointer',
+              }}
+            ><X size={13} /></button>
+          </div>
+
+          {/* CONTEXT — a bar, and the bar SATURATES while the label keeps counting. A session can
+              genuinely exceed the documented window, and a clamped label would hide exactly that. */}
+          <Block title={pt ? 'Contexto' : 'Context'}>
+            {s.context ? (
+              <>
+                <div style={{
+                  height: 6, borderRadius: 3, background: 'var(--bg-base)', overflow: 'hidden',
+                  marginBottom: 5,
+                }}>
+                  <div style={{
+                    height: '100%', width: `${Math.min(100, s.context.fraction * 100)}%`,
+                    background: s.context.fraction >= 0.85 ? 'var(--accent-red)' : 'var(--anthropic-orange)',
+                    transition: 'width 0.3s',
+                  }} />
+                </div>
+                <Line
+                  k={`${Math.floor(s.context.fraction * 100)}%`}
+                  v={`${fmt(s.context.used)} / ${fmt(s.context.window)}`}
+                />
+              </>
+            ) : <Absent text={na('contextWindow')} />}
+          </Block>
+
+          <Block title="Tokens">
+            {s.tokens && s.conversation ? (
+              <>
+                <Line k={pt ? 'Total (com cache)' : 'Total (with cache)'}
+                  v={fmt(s.tokens.input + s.tokens.output + s.tokens.cacheRead + s.tokens.cacheWrite)} />
+                <Line k={pt ? 'Sem cache (i/o)' : 'Without cache (i/o)'}
+                  v={`${fmt(s.conversation.input)} / ${fmt(s.conversation.output)}`} />
+                <Line k={pt ? 'Cache lido / escrito' : 'Cache read / write'}
+                  v={`${fmt(s.tokens.cacheRead)} / ${fmt(s.tokens.cacheWrite)}`} />
+              </>
+            ) : <Absent text={na('tokens')} />}
+          </Block>
+
+          <Block title={pt ? 'Custo' : 'Cost'}>
+            {s.costUSD === null
+              ? <Absent text={na('cost')} />
+              : <Line k={pt ? 'Estimado (API)' : 'Estimated (API)'} v={money(s.costUSD)} />}
+          </Block>
+
+          <Block title={pt ? 'Mensagens' : 'Messages'}>
+            {s.messages ? (
+              <Line k={pt ? 'Suas / do agente' : 'Yours / the agent’s'}
+                v={`${fmt(s.messages.user)} / ${fmt(s.messages.assistant)}`} />
+            ) : <Absent text={pt ? 'ainda não registrado' : 'not recorded yet'} />}
+          </Block>
+
+          <Block title="Subagents">
+            {s.subagents ? (
+              s.subagents.count === 0
+                ? <Line k={pt ? 'Nenhum rodou' : 'None ran'} v="—" />
+                : (
+                  <>
+                    <Line k={pt ? 'Rodaram' : 'Ran'} v={fmt(s.subagents.count)} />
+                    <Line k="Tokens" v={fmt(s.subagents.tokens)} />
+                    <Line k={pt ? 'Custo' : 'Cost'} v={money(s.subagents.costUSD)} />
+                  </>
+                )
+            ) : <Absent text={na('agents')} />}
+          </Block>
+
+          <Block title={pt ? 'No repositório' : 'In the repository'} last>
+            {s.git ? (
+              <>
+                <Line k="Commits" v={fmt(s.git.commits)} />
+                <Line k={pt ? 'Linhas' : 'Lines'} v={`+${fmt(s.git.added)} / −${fmt(s.git.removed)}`} />
+                <Line k={pt ? 'Arquivos' : 'Files'} v={fmt(s.git.files)} />
+              </>
+            ) : <Absent text={na('gitLines')} />}
+          </Block>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function Block({ title, children, last }: { title: string; children: React.ReactNode; last?: boolean }) {
+  return (
+    <div style={{
+      paddingBottom: last ? 0 : 8, marginBottom: last ? 0 : 8,
+      borderBottom: last ? 'none' : '1px solid var(--border-subtle)',
+    }}>
+      <p style={{
+        margin: '0 0 5px', fontSize: 10, fontWeight: 700, textTransform: 'uppercase',
+        letterSpacing: '0.05em', color: 'var(--text-tertiary)',
+      }}>{title}</p>
+      {children}
+    </div>
+  )
+}
+
+function Line({ k, v }: { k: string; v: string }) {
+  return (
+    <div style={{ display: 'flex', alignItems: 'baseline', gap: 8, fontSize: 11.5, lineHeight: 1.7 }}>
+      <span style={{ color: 'var(--text-tertiary)', minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{k}</span>
+      <span style={{ marginLeft: 'auto', color: 'var(--text-primary)', fontWeight: 600, whiteSpace: 'nowrap' }}>{v}</span>
+    </div>
+  )
+}
+
+/** N/A with its REASON. Never a dash on its own — that is the confident zero in another costume. */
+function Absent({ text }: { text: string }) {
+  return <p style={{ margin: 0, fontSize: 11, lineHeight: 1.5, color: 'var(--text-tertiary)' }}>{text}</p>
+}

--- a/packages/web/src/lib/sessionNotifications.test.ts
+++ b/packages/web/src/lib/sessionNotifications.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
 import type { SessionMeta } from '@agentistics/core'
 import {
   DEFAULT_NOTIFICATION_SETTINGS, handleSessionStateTransitions, notifyFleetTransitions,
-  type SessionActivity,
+  resetNotificationMemory, type SessionActivity,
 } from './sessionNotifications'
 
 /**
@@ -52,7 +52,7 @@ const session = (id: string): SessionMeta => ({
 
 let captured: Array<{ title: string; body: string }>
 
-beforeEach(() => { captured = installBrowser().notifications })
+beforeEach(() => { captured = installBrowser().notifications; resetNotificationMemory() })
 afterEach(() => {
   const g = globalThis as Record<string, unknown>
   delete g.Notification
@@ -111,13 +111,31 @@ describe('the caller that was missing — the live fleet', () => {
     expect(captured).toHaveLength(0)
   })
 
-  it('rings on a transition and stays quiet on the level', () => {
+  it('rings on a CONFIRMED transition and stays quiet on the level', () => {
     const first = notifyFleetTransitions(null, [{ id: 'a', state: 'working' }], 'en')
     expect(captured).toHaveLength(0)
+    // First sighting of `waiting` — held back until it is seen again.
     const second = notifyFleetTransitions(first, [{ id: 'a', state: 'waiting' }], 'en')
+    expect(captured).toHaveLength(0)
+    const third = notifyFleetTransitions(second, [{ id: 'a', state: 'waiting' }], 'en')
     expect(captured).toHaveLength(1)
-    notifyFleetTransitions(second, [{ id: 'a', state: 'waiting' }], 'en')
+    notifyFleetTransitions(third, [{ id: 'a', state: 'waiting' }], 'en')
     expect(captured).toHaveLength(1)
+  })
+
+  it('a state that FLICKERS for one poll is never announced', () => {
+    // The reported storm: a pane repaints, the row reads `working` for a single poll and goes back.
+    let snap = notifyFleetTransitions(null, [{ id: 'a', state: 'waiting' }], 'en')
+    for (let i = 0; i < 6; i++) {
+      snap = notifyFleetTransitions(snap, [{ id: 'a', state: i % 2 === 0 ? 'working' : 'waiting' }], 'en')
+    }
+    expect(captured).toHaveLength(0)
+  })
+
+  it('a row that leaves the fleet is forgotten, so its return is news again', () => {
+    let snap = notifyFleetTransitions(null, [{ id: 'a', state: 'working' }], 'en')
+    snap = notifyFleetTransitions(snap, [], 'en')
+    expect(snap).toEqual({})
   })
 
   it('has no words for what a row IS, so those are not events', () => {
@@ -128,12 +146,12 @@ describe('the caller that was missing — the live fleet', () => {
   })
 
   it('names the session from the fleet ROW — it is not a transcript', () => {
-    const first = notifyFleetTransitions(null, [
-      { id: 'a', state: 'working', title: 'the migration one', cwd: '/home/padawan/agentistics', harness: 'claude' },
-    ], 'en')
-    notifyFleetTransitions(first, [
-      { id: 'a', state: 'waiting', title: 'the migration one', cwd: '/home/padawan/agentistics', harness: 'claude' },
-    ], 'en')
+    const row = (state: string) =>
+      [{ id: 'a', state, title: 'the migration one', cwd: '/home/padawan/agentistics', harness: 'claude' }]
+    let snap = notifyFleetTransitions(null, row('working'), 'en')
+    // Two polls, because a state is only announced once it has been confirmed.
+    snap = notifyFleetTransitions(snap, row('waiting'), 'en')
+    notifyFleetTransitions(snap, row('waiting'), 'en')
     expect(captured[0]?.title).toContain('the migration one')
     expect(captured[0]?.body).toContain('agentistics')
   })

--- a/packages/web/src/lib/sessionNotifications.ts
+++ b/packages/web/src/lib/sessionNotifications.ts
@@ -375,15 +375,54 @@ export function fleetActivityStates(
   return out
 }
 
+/**
+ * The states seen on the PREVIOUS poll but not yet announced — see `notifyFleetTransitions`.
+ *
+ * Module-level and not a parameter, because the caller already threads one snapshot and adding a
+ * second would let the two drift apart. It is reset by a `null` snapshot, which is what a fresh
+ * page is.
+ */
+let unconfirmed: Record<string, SessionActivity> = {}
+
 export function notifyFleetTransitions(
   prev: Record<string, SessionActivity> | null,
   rows: readonly { id: string; state: string; title?: string; cwd?: string; harness?: string }[],
   lang: 'pt' | 'en',
 ): Record<string, SessionActivity> {
-  const next = fleetActivityStates(rows)
+  const seen = fleetActivityStates(rows)
   // `null` is the first snapshot — see the rule above. It is deliberately distinct from `{}`, which
   // is a machine that genuinely had no sessions a moment ago and now has one.
-  if (prev === null) return next
+  if (prev === null) { unconfirmed = seen; return seen }
+
+  /*
+   * A STATE COUNTS ONLY ONCE IT HAS BEEN SEEN TWICE IN A ROW.
+   *
+   * `attention.ts` decides `working` from whether the pane MOVED, and a pane moves for reasons that
+   * are not a turn: a repaint, an advisory line, a plugin notice. One of those flips a session to
+   * `working` for a single poll and back, and every flip was an announcement — reported as "tem
+   * sessao que fica alternando o status de needs you pra working e fica disparando notificacao
+   * adoidado".
+   *
+   * This is not a new idea in this codebase: `event-plan.ts` holds the same rule, for the same
+   * signal, and says a time window does NOT work — the next flicker lands outside it. The web
+   * notifier simply never applied it.
+   *
+   * The cost is stated: a state that lasts less than one poll interval is never announced. That is
+   * the right trade for a channel whose whole job is to interrupt a person.
+   */
+  const next: Record<string, SessionActivity> = { ...prev }
+  const announce: Record<string, SessionActivity> = {}
+  for (const [id, state] of Object.entries(seen)) {
+    if (prev[id] === state) continue          // already announced, nothing new
+    if (unconfirmed[id] !== state) continue   // first sighting — wait for the next poll
+    next[id] = state
+    announce[id] = state
+  }
+  // A row that vanished from the fleet stops being tracked, or its last state would be re-announced
+  // if it came back to the same one.
+  for (const id of Object.keys(next)) if (!(id in seen)) delete next[id]
+  unconfirmed = seen
+  if (Object.keys(announce).length === 0) return next
   const map = new Map<string, NotifiableSession>()
   for (const r of rows) {
     map.set(r.id, {
@@ -392,6 +431,13 @@ export function notifyFleetTransitions(
       ...(r.harness ? { harness: r.harness } : {}),
     })
   }
-  handleSessionStateTransitions(prev, next, map, lang)
+  // Only what was CONFIRMED this poll — `prev` is passed as the baseline so the handler's own
+  // "has it changed" check still holds for each of them.
+  handleSessionStateTransitions(prev, announce, map, lang)
   return next
+}
+
+/** Test seam: the confirmation memory is module state, and a test must be able to clear it. */
+export function resetNotificationMemory(): void {
+  unconfirmed = {}
 }

--- a/packages/web/src/lib/sessionRoute.test.ts
+++ b/packages/web/src/lib/sessionRoute.test.ts
@@ -1,0 +1,24 @@
+import { expect, test } from 'bun:test'
+import { sessionPath } from './sessionRoute'
+
+test('an external id keeps its directory inside ONE path segment', () => {
+  // Raw interpolation made this three segments and matched no route — a blank page.
+  const id = 'external:antigravity:/home/mithrandir/agentistics:1788625485620'
+  const path = sessionPath(id)
+  expect(path.slice('/sessions/'.length)).not.toContain('/')
+  expect(decodeURIComponent(path.slice('/sessions/'.length))).toBe(id)
+})
+
+test('a closed id round-trips too', () => {
+  const id = 'closed:731e8d13-db8a-465b-81fc-3c520aba76d4'
+  expect(decodeURIComponent(sessionPath(id).slice('/sessions/'.length))).toBe(id)
+})
+
+test('a plain managed id is unchanged in practice', () => {
+  expect(sessionPath('a61d428316')).toBe('/sessions/a61d428316')
+})
+
+test('a windows-shaped cwd survives as well', () => {
+  const id = 'external:claude:C:\\Users\\u\\proj:12'
+  expect(decodeURIComponent(sessionPath(id).slice('/sessions/'.length))).toBe(id)
+})

--- a/packages/web/src/lib/sessionRoute.ts
+++ b/packages/web/src/lib/sessionRoute.ts
@@ -1,0 +1,26 @@
+/**
+ * sessionRoute.ts — PURE: the URL of one session.
+ *
+ * A row's id is not always a token. `external:<harness>:<cwd>:<startedMs>` carries a DIRECTORY, and
+ * a directory has slashes:
+ *
+ *     external:antigravity:/home/mithrandir/agentistics:1788625485620
+ *
+ * Interpolated raw into `/sessions/${id}`, those slashes become PATH SEPARATORS. The route is
+ * `/sessions/:id`, which matches one segment, so nothing matched and the page rendered blank —
+ * "tem uma external que se eu clicar nela ela crasha a aplicacao". Navigating to the same row with
+ * the id encoded works, which is why it was invisible to anything that built the URL by hand.
+ *
+ * So the encoding happens HERE, in one function every caller goes through, rather than at five
+ * `navigate()` sites where the sixth will forget. `useParams` decodes on the way back in, so
+ * nothing downstream changes.
+ *
+ * The id is NOT reshaped to avoid the problem: `externalId()` composes it from the facts that
+ * identify an external process, and a row's identity is not the place to make a routing concern
+ * disappear.
+ */
+
+/** The path for one session row. `id` is used verbatim; only the URL encoding is added. */
+export function sessionPath(id: string): string {
+  return `/sessions/${encodeURIComponent(id)}`
+}

--- a/packages/web/src/lib/sessionStats.test.ts
+++ b/packages/web/src/lib/sessionStats.test.ts
@@ -1,0 +1,77 @@
+import { expect, test } from 'bun:test'
+import type { SessionMeta } from '@agentistics/core'
+import { sessionStats, statReason } from './sessionStats'
+
+const meta = (over: Partial<SessionMeta> = {}): SessionMeta => ({
+  session_id: 's1', harness: 'claude', model: 'claude-opus-5',
+  input_tokens: 100, output_tokens: 200,
+  cache_read_input_tokens: 5_000, cache_creation_input_tokens: 300,
+  user_message_count: 4, assistant_message_count: 9,
+  git_commits: 2, lines_added: 30, lines_removed: 5, files_modified: 3,
+  active_minutes: 12,
+  ...over,
+} as SessionMeta)
+
+test('a conversation the store has not seen is NULL everywhere, never zero', () => {
+  // Zero would be true only by accident, and wrong a minute later.
+  const s = sessionStats('claude', 's1', undefined)
+  expect(s.tokens).toBeNull()
+  expect(s.costUSD).toBeNull()
+  expect(s.context).toBeNull()
+  expect(s.messages).toBeNull()
+  expect(s.git).toBeNull()
+})
+
+test('tokens are all FOUR counters, and the pair is reported separately', () => {
+  const s = sessionStats('claude', 's1', meta())
+  expect(s.tokens).toEqual({ input: 100, output: 200, cacheRead: 5_000, cacheWrite: 300 })
+  // "sem cache" on screen is the conversational pair — never the label for the total.
+  expect(s.conversation).toEqual({ input: 100, output: 200 })
+})
+
+test('cost is priced WITH the cache counters', () => {
+  const withCache = sessionStats('claude', 's1', meta())!.costUSD!
+  const withoutCache = sessionStats('claude', 's1', meta({
+    cache_read_input_tokens: 0, cache_creation_input_tokens: 0,
+  }))!.costUSD!
+  // Zeroing the cache prices the cheap few per cent of the volume — the two must differ.
+  expect(withCache).toBeGreaterThan(withoutCache)
+})
+
+test('a harness that cannot produce a metric gets NULL, and the reason says which', () => {
+  // Codex reports no agent metrics; the panel must say so rather than print "0 subagents".
+  const s = sessionStats('codex', 's1', meta({ harness: 'codex' }))
+  expect(s.subagents).toBeNull()
+  expect(statReason('codex', 'agents')).toBe('harness')
+  // Claude CAN, so an absent figure there means the store has not caught up.
+  expect(statReason('claude', 'agents')).toBe('unrecorded')
+})
+
+test('the context fraction is UNCLAMPED — a session really can exceed its window', () => {
+  const s = sessionStats('claude', 's1', meta({
+    context_tokens: 250_000, context_window: 200_000,
+  } as Partial<SessionMeta>))
+  expect(s.context?.fraction).toBeGreaterThan(1)
+})
+
+test('a window the harness DECLARED outranks the table', () => {
+  // It knows the deployment and any per-session cap; a model id cannot express either.
+  const s = sessionStats('claude', 's1', meta({
+    context_tokens: 100_000, context_window: 128_000,
+  } as Partial<SessionMeta>))
+  expect(s.context?.window).toBe(128_000)
+})
+
+test('no window anywhere means NO bar, not a 0%', () => {
+  const s = sessionStats('claude', 's1', meta({ model: 'a-model-nobody-has-priced' }))
+  expect(s.context).toBeNull()
+})
+
+test('subagents are counted and summed when the harness has them', () => {
+  const s = sessionStats('claude', 's1', meta({
+    agentMetrics: { invocations: [
+      { totalTokens: 10, costUSD: 1 }, { totalTokens: 5, costUSD: 0.5 },
+    ] },
+  } as unknown as Partial<SessionMeta>))
+  expect(s.subagents).toEqual({ count: 2, tokens: 15, costUSD: 1.5 })
+})

--- a/packages/web/src/lib/sessionStats.ts
+++ b/packages/web/src/lib/sessionStats.ts
@@ -1,0 +1,154 @@
+/**
+ * sessionStats.ts — PURE: the numbers behind ONE session, and which of them this harness can
+ * actually produce.
+ *
+ * The dashboard has a stats strip for the whole machine; this is the same idea for the conversation
+ * you have open — how full its context is, what it has spent, how much of the talking was yours,
+ * how many subagents it ran, what it changed in the repository.
+ *
+ * TWO RULES CARRY THE WHOLE FILE, and both come from `HARNESS_CAPABILITIES`:
+ *
+ * 1. A METRIC THIS HARNESS CANNOT PRODUCE IS `null`, NEVER 0. Gemini reports no tokens; Codex
+ *    reports no agents. A confident `0` beside real figures is read as "it did nothing", which is a
+ *    different and false statement from "this cannot be measured here". The panel renders `null` as
+ *    N/A with the harness's own reason.
+ * 2. A CONVERSATION THE STORE HAS NOT SEEN YET IS `null` TOO — not zero. A session started ten
+ *    seconds ago has no record; saying it has spent nothing would be true only by accident, and
+ *    wrong a minute later.
+ *
+ * The context gauge is `contextFraction` from `@agentistics/core` and inherits its rule unchanged:
+ * a fraction exists only when BOTH the measurement and the window are known, the window is never
+ * guessed from a model id that is not in the table, and the value is NOT clamped — a session really
+ * can exceed the documented window, so the bar saturates while the label keeps saying 106%.
+ */
+
+import {
+  HARNESS_CAPABILITIES, calcCost, contextFraction, resolveContextWindow, sessionTokens,
+  type HarnessId, type SessionMeta, type TokenBreakdown,
+} from '@agentistics/core'
+
+export interface SessionStats {
+  /** The conversation these numbers are FOR, so a stale panel can be spotted. */
+  sessionId: string
+  harness: HarnessId
+  /** All four counters. `null` when the harness reports none. */
+  tokens: TokenBreakdown | null
+  /** The conversational pair alone — what "sem cache" means on screen. */
+  conversation: { input: number; output: number } | null
+  /** USD. Converted for display by the caller, which is where the rate lives. */
+  costUSD: number | null
+  /** 0..n, unclamped — see the header. `null` when either half is unknown. */
+  context: { fraction: number; used: number; window: number } | null
+  messages: { user: number; assistant: number } | null
+  /** How many subagent invocations ran, and what they cost. `null` when the harness has no agents. */
+  subagents: { count: number; tokens: number; costUSD: number } | null
+  git: { commits: number; added: number; removed: number; files: number } | null
+  activeMinutes: number | null
+  model: string | null
+}
+
+/** Why a metric is absent, in the words the panel prints. Absent when the metric IS available. */
+export type StatReason = 'harness' | 'unrecorded'
+
+const num = (v: unknown): number => (typeof v === 'number' && Number.isFinite(v) ? v : 0)
+
+/**
+ * The panel's numbers for one session.
+ *
+ * `meta` is the store's record, or `undefined` when the conversation is not in it yet — a live
+ * session the poller has not caught up with, or one whose harness writes no transcript this
+ * product can read. That case is NOT an error and NOT zero: every field comes back `null`, and the
+ * caller says which of the two it is.
+ */
+export function sessionStats(
+  harness: HarnessId,
+  sessionId: string,
+  meta: SessionMeta | undefined,
+): SessionStats {
+  const caps = HARNESS_CAPABILITIES[harness]
+  const base: SessionStats = {
+    sessionId,
+    harness,
+    tokens: null,
+    conversation: null,
+    costUSD: null,
+    context: null,
+    messages: null,
+    subagents: null,
+    git: null,
+    activeMinutes: null,
+    model: null,
+  }
+  if (!meta) return base
+
+  const tokens = caps?.tokens ? sessionTokens(meta) : null
+  const model = typeof meta.model === 'string' && meta.model !== '' ? meta.model : null
+
+  // The window the HARNESS declared outranks the table — it knows the deployment and any per-session
+  // cap, which a model id cannot express. Same order `SessionMeta.context_window` is given
+  // everywhere else.
+  const declared = num((meta as { context_window?: number }).context_window)
+  const window = declared > 0
+    ? declared
+    : (model ? resolveContextWindow(model)?.tokens ?? 0 : 0)
+  const used = num((meta as { context_tokens?: number }).context_tokens)
+  const fraction = caps?.contextWindow ? contextFraction(used, window) : null
+
+  const invocations = meta.agentMetrics?.invocations ?? []
+  const subagents = caps?.agents
+    ? {
+      count: invocations.length,
+      tokens: invocations.reduce((n, i) => n + num(i.totalTokens), 0),
+      costUSD: invocations.reduce((n, i) => n + num(i.costUSD), 0),
+    }
+    : null
+
+  return {
+    sessionId,
+    harness,
+    tokens,
+    conversation: caps?.tokens ? { input: num(meta.input_tokens), output: num(meta.output_tokens) } : null,
+    // Priced through `calcCost` with the REAL cache counters — pricing cache as fresh input is
+    // roughly tenfold too high, and zeroing it prices the cheap 4% of the volume.
+    costUSD: caps?.cost && tokens
+      ? calcCost({
+        inputTokens: tokens.input,
+        outputTokens: tokens.output,
+        cacheReadInputTokens: tokens.cacheRead,
+        cacheCreationInputTokens: tokens.cacheWrite,
+        webSearchRequests: 0,
+        costUSD: 0,
+      }, model ?? '')
+      : null,
+    context: fraction === null ? null : { fraction, used, window },
+    messages: {
+      user: num(meta.user_message_count),
+      assistant: num(meta.assistant_message_count),
+    },
+    subagents,
+    git: caps?.gitLines
+      ? {
+        commits: num(meta.git_commits),
+        added: num(meta.lines_added),
+        removed: num(meta.lines_removed),
+        files: num(meta.files_modified),
+      }
+      : null,
+    activeMinutes: caps?.activeTime ? num(meta.active_minutes) : null,
+    model,
+  }
+}
+
+/**
+ * Why a figure is missing — the sentence's INPUT, not the sentence.
+ *
+ * `harness` means this assistant cannot produce it at all; `unrecorded` means the conversation is
+ * not in the store yet. They send a reader to two different places, so they must not collapse into
+ * one "—".
+ */
+export function statReason(
+  harness: HarnessId,
+  metric: keyof (typeof HARNESS_CAPABILITIES)[HarnessId],
+): StatReason {
+  return HARNESS_CAPABILITIES[harness]?.[metric] ? 'unrecorded' : 'harness'
+}

--- a/packages/web/src/pages/SessionsPage.tsx
+++ b/packages/web/src/pages/SessionsPage.tsx
@@ -38,6 +38,7 @@ import { SessionsAside } from '../components/nav/SessionsAside'
 import { SessionActions } from '../components/sessions/SessionActions'
 import { filterFleet } from '../lib/fleetFilter'
 import { FiltersSheet } from '../components/sessions/FiltersSheet'
+import { sessionPath } from '../lib/sessionRoute'
 
 /** The dimensions a live fleet row can be narrowed by — the same set on both layouts. */
 const FLEET_FILTER_DIMS: Array<'harnesses' | 'repos' | 'projects' | 'models'> =
@@ -557,7 +558,7 @@ export default function SessionsPage() {
                 lang={pt ? 'pt' : 'en'}
                 act={act}
                 onGone={() => navigate('/sessions')}
-                onOpened={id => navigate(`/sessions/${id}`)}
+                onOpened={id => navigate(sessionPath(id))}
               />
             )}
           </div>


### PR DESCRIPTION
## Summary

Four fixes to the sessions workspace, three of them found by using it, plus the session metrics
panel.

- **The registry stops losing records to another process.** `registry.ts` serialised its mutations
  with a promise chain — correct, and half the problem: agentop runs as several processes (the
  systemd server, the cockpit, every one-shot `agentop session …`) and a chain is per process. Two
  of them read the same list, each adds its record, each writes it back, and one is gone; the poller
  then adopts the orphaned session, and adoption cannot know a name. That is the one bug behind
  "the title I typed was ignored" AND "rename does not rename". Measured: two sessions started
  minutes apart carried an identical `createdAt` to the millisecond and no label.
- **Clicking an external session no longer blanks the page.** Its id carries a cwd, so the slashes
  became path separators and `/sessions/:id` matched nothing.
- **State that belongs to one session stops leaking into another.** `<SessionChat>` had no `key`, so
  switching rows mid-request carried the draft, the attachments and the in-flight flags across —
  and sent a message into the wrong session.
- **The notification storm stops.** A state now counts only once seen on two consecutive polls, the
  rule `event-plan.ts` already holds for the same signal.
- **Session metrics panel**: context percentage on the button, tokens with and without cache, cost
  in the selected currency, messages, subagents, commits and lines — every figure `null` rather than
  a confident 0 when the harness cannot produce it or the store has not seen the conversation.

## Test plan

- `bun test` — **5.761 passing**, 0 failing, across 362 files.
- `registry-concurrency.test.ts` spawns real processes and was verified BOTH ways: it fails with the
  lock removed and passes with it. Every existing registry test ran in one process, which is why
  this shipped.
- The external-row fix was verified by clicking the row in a real browser, not by navigating to a
  URL built by hand — which is exactly how the bug hid from the earlier probe.
- The metrics panel measured against the live app: 70% of a 1.0M window, 1.5B tokens, USD 886.41.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169AqN9y1YGiog3T4qTLVfA
