### PR TITLE
sessions: creating one is fast, the aside stops reloading, and every panel says what it cannot know

### DIFF
--- a/packages/server/server/cli-i18n.ts
+++ b/packages/server/server/cli-i18n.ts
@@ -109,6 +109,12 @@ export interface CliStrings {
     external: string
     closed: string
   }
+  /**
+   * The mark a row wears when the MAIN agent has finished its turn while something it started is
+   * still running — a background subagent. Appended to the state word, never instead of it: the
+   * session needs a person, and the mark only says why the harness still looks busy.
+   */
+  sessBackground: string
   /** Said on a session whose harness has no probed approval markers. */
   sessApprovalBlind: (harness: string) => string
   /**
@@ -490,6 +496,7 @@ const EN: CliStrings = {
     closed: 'off',
     external: 'external',
   },
+  sessBackground: 'subagent',
   sessApprovalBlind: (harness: string) =>
     `agentop has no verified screen markers for ${harness}, so a blocking question here shows as "needs you" like any other pause.`,
   sessDirGone: 'this directory no longer exists — a removed worktree, most likely. Reopening will not work until it is back.',
@@ -773,6 +780,7 @@ const PT: CliStrings = {
     closed: 'fechada',
     external: 'externa',
   },
+  sessBackground: 'subagente',
   sessApprovalBlind: (harness: string) =>
     `o agentop não tem marcadores de tela verificados para ${harness}, então uma pergunta bloqueante aqui aparece como "precisa de você", como qualquer outra pausa.`,
   sessDirGone: 'este diretório não existe mais — provavelmente uma worktree removida. Reabrir não vai funcionar enquanto ele não voltar.',

--- a/packages/server/server/index.ts
+++ b/packages/server/server/index.ts
@@ -1185,6 +1185,22 @@ async function handleRequestInner(req: Request, server: Server<WSData>): Promise
 
     // The repository's pull requests, read through `gh` in the SESSION's directory. A READ: no
     // route here opens, merges or comments on anything.
+    // What only the conversation's own transcript can answer — today, how many times it has been
+    // compacted. Guarded by the `/api/fleet` PREFIX already registered in `capability-guard.ts`.
+    if (url.pathname === '/api/fleet/conversation' && req.method === 'GET') {
+      const id = url.searchParams.get('id')
+      if (!id) {
+        return new Response(JSON.stringify({ unavailable: 'bad_request' }), {
+          status: 400, headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
+        })
+      }
+      const { readConversationFacts, fleetLang } = await import('./sessions/fleet-web')
+      const out = await readConversationFacts(fleetLang(url.searchParams.get('lang')), id)
+      return new Response(JSON.stringify(out), {
+        headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
+      })
+    }
+
     if (url.pathname === '/api/fleet/prs' && req.method === 'GET') {
       const id = url.searchParams.get('id')
       if (!id) {

--- a/packages/server/server/sessions/attention-rules.ts
+++ b/packages/server/server/sessions/attention-rules.ts
@@ -87,6 +87,10 @@ export const ATTENTION_RULES: Record<HarnessId, AttentionRules | null> = {
     ],
     // The footer while a turn runs. `? for shortcuts` takes its place when the turn ends.
     working: [/esc to interrupt/],
+    // The MAIN agent producing — see `AttentionRules.mainWorking`. Captured from a live session on
+    // 2026-09-05 (claude 2.1.261): `· Jitterbugging… (37s · ↓ 1.7k tokens · thought for 17s)`. The
+    // verb is whimsical and changes every frame; the elapsed time and the token counter do not.
+    mainWorking: [/\(\d+[hms][^)]*·\s*↓/],
   },
   codex: {
     probed: 'codex 0.113.0, 2026-08-13',

--- a/packages/server/server/sessions/attention.test.ts
+++ b/packages/server/server/sessions/attention.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'bun:test'
-import { QUIET_MS, approvalTail, attentionOf, digestFrame, frameTail } from './attention'
+import { QUIET_MS, approvalTail, attentionOf, digestFrame, frameTail, backgroundWork } from './attention'
 import type { AttentionRules } from './types'
 
 const NOW = 1_786_600_000_000
@@ -304,5 +304,44 @@ describe('a footer is the BOTTOM of the screen, not any line on it', () => {
       '   2. No',
       ' Esc to cancel · Tab to amend',
     ])).toBe('waiting-approval')
+  })
+})
+
+describe('background work', () => {
+  const rules = { approval: [], working: [/esc to interrupt/], mainWorking: [/\(\d+[hms][^)]*·\s*↓/], probed: 'test' }
+
+  it('a session that ANSWERED and has subagents running needs a person', () => {
+    // Measured on a live claude: `esc to interrupt` is printed whenever anything is interruptible,
+    // background subagents included. Reading that as `working` told a person nothing was needed
+    // from them when something was.
+    const frame = ['❯ ', '  ⏵⏵ auto mode on · esc to interrupt · ← 6 agents']
+    // Quiet for longer than `QUIET_MS`: a session that JUST moved reads as working whatever the
+    // markers say, which is a separate and correct rule.
+    expect(attentionOf({
+      alive: true, lastActivityMs: 0, nowMs: QUIET_MS + 1000, frame,
+      frameDigest: 'd', prevDigest: 'd', rules,
+    })).toBe('waiting')
+    expect(backgroundWork({ frame, rules })).toBe(true)
+  })
+
+  it('the main agent producing is WORKING, and is not background', () => {
+    const frame = ['· Jitterbugging… (37s · ↓ 1.7k tokens)', '  ⏵⏵ esc to interrupt']
+    expect(attentionOf({
+      alive: true, lastActivityMs: 0, nowMs: 1000, frame,
+      frameDigest: 'd', prevDigest: 'd', rules,
+    })).toBe('working')
+    expect(backgroundWork({ frame, rules })).toBe(false)
+  })
+
+  it('a harness with no main marker is not given a guess', () => {
+    // Without a way to tell the main turn apart, every interruptible frame would be reported as
+    // background work — a confident claim made out of an absence.
+    const bare = { approval: [], working: [/esc to interrupt/], probed: 'test' }
+    const frame = ['❯ ', 'esc to interrupt']
+    expect(backgroundWork({ frame, rules: bare })).toBe(false)
+    expect(attentionOf({
+      alive: true, lastActivityMs: 0, nowMs: 1000, frame,
+      frameDigest: 'd', prevDigest: 'd', rules: bare,
+    })).toBe('working')
   })
 })

--- a/packages/server/server/sessions/attention.ts
+++ b/packages/server/server/sessions/attention.ts
@@ -109,8 +109,20 @@ export function attentionOf(o: {
 
   // The marker is PROOF of work only while the screen has been moving at all recently. A footer
   // that lingers is not evidence, and silence eventually outweighs it — see `MARKER_STALE_MS`.
+  //
+  // AND IT MUST BE THE MAIN AGENT. `esc to interrupt` is printed whenever anything is
+  // interruptible, background subagents included, so a session that had already answered and was
+  // waiting for a person read as `working` — telling them nothing was needed when something was.
+  // Where the harness draws a distinct marker for its own turn (`mainWorking`), that is what
+  // counts; the interruptible marker alone means work is happening SOMEWHERE, which
+  // `backgroundWork` below reports separately. A harness with no `mainWorking` keeps the old
+  // behaviour exactly.
   const silentFor = o.nowMs - o.lastActivityMs
-  if (silentFor <= MARKER_STALE_MS && working(text)) {
+  const mainMarker = o.rules?.mainWorking
+  const producing = mainMarker
+    ? mainMarker.some(re => re.test(text))
+    : working(text)
+  if (silentFor <= MARKER_STALE_MS && producing) {
     return 'working'
   }
 
@@ -186,4 +198,27 @@ export function frameTail(frame: readonly string[], max = 4): string[] {
     out.push(line)
   }
   return out.reverse()
+}
+
+
+/**
+ * Is something running that is NOT the main agent's turn — PURE.
+ *
+ * True when the harness says something is interruptible while its own turn marker is absent: a
+ * background subagent, a watcher, a build being followed. The session still NEEDS A PERSON, and
+ * that is what the state says; this is the mark beside it, so "needs you" does not read as "and
+ * nothing is happening".
+ *
+ * Answers `false` for a harness with no `mainWorking`: without a way to tell the main turn apart,
+ * every interruptible frame would be reported as background work, which is a confident claim made
+ * out of an absence.
+ */
+export function backgroundWork(o: {
+  frame: readonly string[]
+  rules?: AttentionRules
+}): boolean {
+  if (!o.rules?.mainWorking?.length || !o.rules.working?.length) return false
+  const text = o.frame.join('\n')
+  if (o.rules.mainWorking.some(re => re.test(text))) return false
+  return o.rules.working.some(re => re.test(text))
 }

--- a/packages/server/server/sessions/backend-tmux.ts
+++ b/packages/server/server/sessions/backend-tmux.ts
@@ -228,8 +228,24 @@ export const tmuxBackend: SessionBackend = {
     if (req.initialPrompt) {
       // Deliver the prompt only once the harness is READY — polled, not a fixed sleep — so a slow
       // start does not lose it and a startup dialog is never submitted into. See `deliverInitialPrompt`.
-      await deliverInitialPrompt(req.id, req.initialPrompt)
+      //
+      // NOT AWAITED. The session EXISTS the moment tmux has it, which is what `spawn` promises and
+      // what the caller acts on; the prompt is a follow-up to a session that is already there.
+      // Awaiting it held every caller for as long as the harness took to draw its input box — up to
+      // `DELIVER_DEADLINE_MS`, which is fifteen seconds — so "create session" in the browser spun
+      // for the whole of claude's startup with a session that had been running since millisecond
+      // seven. Reported as creating a session taking VERY long. Nothing downstream needs the
+      // delivery to have happened: the pane is watched live, a `batch` starts its sessions in
+      // parallel instead of one startup after another, and delivery was already best-effort with
+      // its own fallback and deadline.
+      //
+      // The promise is returned so a caller that genuinely must wait can, and is caught here so a
+      // caller that does not never sees an unhandled rejection.
+      const delivery = deliverInitialPrompt(req.id, req.initialPrompt)
+        .catch(e => { console.error(`[session] ${req.id} initial prompt not delivered:`, e) })
+      return { delivery }
     }
+    return {}
   },
 
   sendText: sendTextTo,

--- a/packages/server/server/sessions/chat-tail.test.ts
+++ b/packages/server/server/sessions/chat-tail.test.ts
@@ -3,7 +3,8 @@ import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { mkdtemp, mkdir, rm, writeFile, utimes } from 'node:fs/promises'
 import {
-  forgetChatTailContent, forgetChatTailPaths, readRecentChatTurns, resolveChatTranscriptPath,
+  forgetChatTailContent, forgetChatTailPaths, readChatWindow, readRecentChatTurns,
+  resolveChatTranscriptPath,
 } from './chat-tail'
 
 const SESSION_ID = 'a1b2c3d4-e5f6-4789-a0b1-c2d3e4f56789'
@@ -366,5 +367,42 @@ describe('a queued_command carries envelopes too', () => {
     const turns = await readRecentChatTurns(file)
     expect(turns.some(t => t.role === 'user' && (t.text ?? '').includes('/login'))).toBe(true)
     expect(turns.some(t => (t.text ?? '').includes('<command-name>'))).toBe(false)
+  })
+})
+
+describe('readChatWindow — the cap is a fact about the READ, and it says so', () => {
+  let root: string
+  beforeEach(async () => { root = await mkdtemp(join(tmpdir(), 'chat-window-')) })
+  afterEach(async () => { await rm(root, { recursive: true, force: true }) })
+
+  const userLine = (text: string): string =>
+    JSON.stringify({ type: 'user', message: { role: 'user', content: text } })
+
+  test('a conversation SHORTER than the cap reports nothing older', async () => {
+    const path = join(root, 'short.jsonl')
+    await writeFile(path, `${[userLine('one'), userLine('two')].join('\n')}\n`)
+    const out = await readChatWindow(path, 10)
+    expect(out.turns.length).toBe(2)
+    expect(out.older).toBe(false)
+  })
+
+  test('a walk that stops ON the cap with transcript above it reports older', async () => {
+    // The reported bug: a long session's gallery emptied itself and nothing on screen said why.
+    // The gallery lists the files of the turns it was given, so the cap has to be visible here or
+    // it is invisible everywhere.
+    const path = join(root, 'long.jsonl')
+    const lines = Array.from({ length: 20 }, (_, i) => userLine(`m${i}`))
+    await writeFile(path, `${lines.join('\n')}\n`)
+    const out = await readChatWindow(path, 5)
+    expect(out.turns.length).toBe(5)
+    expect(out.older).toBe(true)
+    // The window is the END of the conversation, not its start.
+    expect(out.turns[out.turns.length - 1]!.text).toContain('m19')
+  })
+
+  test('the trailing newline every transcript ends with is not "there is more"', async () => {
+    const path = join(root, 'exact.jsonl')
+    await writeFile(path, `${[userLine('a'), userLine('b')].join('\n')}\n`)
+    expect((await readChatWindow(path, 2)).older).toBe(false)
   })
 })

--- a/packages/server/server/sessions/chat-tail.ts
+++ b/packages/server/server/sessions/chat-tail.ts
@@ -567,8 +567,25 @@ async function readTurnsFromTail(
  * in memory.
  */
 export async function readChatTurns(path: string, max = 400): Promise<ChatTurn[]> {
+  return (await readChatWindow(path, max)).turns
+}
+
+/**
+ * The same read, plus whether the window CUT the conversation short.
+ *
+ * The cap is a fact about the READ, not about the conversation, and every surface built on top of
+ * these turns inherits it silently: the gallery lists the files of the turns it was given, so on a
+ * long transcript it emptied itself with nothing on screen saying why — reported exactly that way,
+ * as "everything in the gallery disappeared and there is no warning about it". A window that hides
+ * things has to say it is a window. `older` is true only when the walk stopped ON the cap with
+ * substantive lines still above it; a conversation shorter than `max` reports nothing.
+ */
+export async function readChatWindow(
+  path: string,
+  max = 400,
+): Promise<{ turns: ChatTurn[]; older: boolean }> {
   let content: string
-  try { content = await readFile(path, 'utf-8') } catch { return [] }
+  try { content = await readFile(path, 'utf-8') } catch { return { turns: [], older: false } }
 
   const lines = content.split('\n')
   const turns: ChatTurn[] = []
@@ -577,7 +594,9 @@ export async function readChatTurns(path: string, max = 400): Promise<ChatTurn[]
   /** Ids whose `<task-notification>` has already arrived. */
   const finishedTasks = new Set<string>()
   let newest = true
-  for (let i = lines.length - 1; i >= 0 && turns.length < max; i--) {
+  // Hoisted so the walk can report WHERE it stopped — see `older` at the return.
+  let i = lines.length - 1
+  for (; i >= 0 && turns.length < max; i--) {
     const line = (lines[i] ?? '').trim()
     if (!line) continue
     let e: Record<string, unknown>
@@ -639,5 +658,10 @@ export async function readChatTurns(path: string, max = 400): Promise<ChatTurn[]
   }
 
   turns.reverse()
-  return turns
+  // The walk stopped on the cap with content still above it: this is a WINDOW onto a longer
+  // conversation, and every surface reading these turns has to be able to say so. A blank tail is
+  // not content — a transcript ends with one, and reporting that as "there is more" would put the
+  // notice on every conversation.
+  const older = i >= 0 && lines.slice(0, i + 1).some(l => l.trim() !== '')
+  return { turns, older }
 }

--- a/packages/server/server/sessions/chat-tail.ts
+++ b/packages/server/server/sessions/chat-tail.ts
@@ -566,6 +566,28 @@ async function readTurnsFromTail(
  * on mtime would be a cache that misses every time by construction while holding whole transcripts
  * in memory.
  */
+/**
+ * How many times this conversation has been COMPACTED.
+ *
+ * The harness DECLARES it (`isCompactSummary: true` on the entry it writes), so this is a count of
+ * something stated rather than a heuristic — the same field `classifyUserEntry` uses to keep a
+ * compaction summary out of the chat as a message nobody sent.
+ *
+ * Over the WHOLE file, never the chat window: it answers "how much of this conversation has already
+ * been thrown away", and counting only the part still on screen would answer it with the one number
+ * that is always too low. Measured on a real 39 MB transcript: 70 ms.
+ *
+ * A file that cannot be read yields `null`, never `0` — "no compactions" and "we could not look"
+ * are different facts, and a confident zero here would read as a fresh conversation.
+ */
+export async function countCompactions(path: string): Promise<number | null> {
+  let content: string
+  try { content = await readFile(path, 'utf-8') } catch { return null }
+  let n = 0
+  for (const line of content.split('\n')) if (line.includes('"isCompactSummary":true')) n++
+  return n
+}
+
 export async function readChatTurns(path: string, max = 400): Promise<ChatTurn[]> {
   return (await readChatWindow(path, max)).turns
 }

--- a/packages/server/server/sessions/chat-web.ts
+++ b/packages/server/server/sessions/chat-web.ts
@@ -17,7 +17,7 @@
 import type { StartHost } from '../cli-start'
 import type { CliLang } from '../cli-lang'
 import { controlStrings } from '@agentistics/tui/control/i18n'
-import { readChatTurns, resolveChatTranscriptPath, type ChatTurn } from './chat-tail'
+import { readChatWindow, resolveChatTranscriptPath, type ChatTurn } from './chat-tail'
 
 export interface ChatPayload {
   /** The turns, oldest first. Empty with no `unavailable` means a conversation with nothing in it. */
@@ -31,6 +31,15 @@ export interface ChatPayload {
   unavailable?: string
   /** True while the session is running, so the view knows whether to expect more. */
   live: boolean
+  /**
+   * Already-localized: these turns are the END of a longer conversation.
+   *
+   * Present ONLY when the read stopped on its cap with transcript still above it. Everything built
+   * on these turns inherits the window — the gallery lists the files of the turns it was given —
+   * so a panel that empties because of the cap must be able to say that is why, instead of showing
+   * nothing and letting it read as "there was never anything here".
+   */
+  older?: string
 }
 
 /** The most turns one read returns. A conversation of thousands must not arrive as one response. */
@@ -96,6 +105,17 @@ export async function readSessionChat(
     }
   }
 
-  const turns = await readChatTurns(path, MAX_TURNS).catch(() => [] as ChatTurn[])
-  return { turns, live }
+  const read = await readChatWindow(path, MAX_TURNS)
+    .catch(() => ({ turns: [] as ChatTurn[], older: false }))
+  return {
+    turns: read.turns,
+    live,
+    ...(read.older
+      ? {
+          older: lang === 'pt'
+            ? `Esta é a parte final da conversa — as últimas ${MAX_TURNS} interações. O que veio antes está na transcrição, mas fora desta janela.`
+            : `This is the end of a longer conversation — its last ${MAX_TURNS} turns. What came before is still in the transcript, outside this window.`,
+        }
+      : {}),
+  }
 }

--- a/packages/server/server/sessions/control-session.ts
+++ b/packages/server/server/sessions/control-session.ts
@@ -100,6 +100,7 @@ export function toControlSession(
     cwd: v.cwd,
     project,
     ...(v.model ? { model: v.model } : {}),
+    ...(v.effort ? { effort: v.effort } : {}),
     ...(v.note ? { note: v.note } : {}),
     state,
     // The mark rides ON the state word rather than in a cell of its own, so it reaches every

--- a/packages/server/server/sessions/control-session.ts
+++ b/packages/server/server/sessions/control-session.ts
@@ -102,7 +102,14 @@ export function toControlSession(
     ...(v.model ? { model: v.model } : {}),
     ...(v.note ? { note: v.note } : {}),
     state,
-    stateLabel: stateLabel(state, s),
+    // The mark rides ON the state word rather than in a cell of its own, so it reaches every
+    // surface that draws a row — the cockpit, `session ls`, the workspace, the extension, the
+    // relayed fleet — from the one place the word is decided. A cell of its own would have to be
+    // added to each of them, and the first one missed would say `needs you` about a session that
+    // still has work running, which is the reading this mark exists to correct.
+    stateLabel: v.background ? `${stateLabel(state, s)} · ${s.sessBackground}` : stateLabel(state, s),
+    // The machine-readable half, for a surface that wants to style it rather than read it.
+    ...(v.background ? { background: true } : {}),
     actionable: v.status !== 'external' && v.status !== 'closed',
     // Stated only where it is TRUE and only for a session we actually HOST. A row that is closed or
     // running outside agentop has no screen to read at all, so "approval detection is unavailable

--- a/packages/server/server/sessions/fleet-row.ts
+++ b/packages/server/server/sessions/fleet-row.ts
@@ -119,6 +119,8 @@ export interface FleetRow {
   task?: string
   note?: string
   model?: string
+  /** The reasoning effort this session was started with — see `ControlSession.effort`. */
+  effort?: string
   conversationId?: string
   /** The dialog this session is blocked on, verbatim, and the options read off it. */
   approvalLines?: string[]
@@ -194,6 +196,7 @@ export function fleetRow(row: ControlSession, s: ControlStrings): FleetRow {
     ...(row.task ? { task: row.task } : {}),
     ...(row.note ? { note: row.note } : {}),
     ...(row.model ? { model: row.model } : {}),
+    ...(row.effort ? { effort: row.effort } : {}),
     ...(row.conversationId ? { conversationId: row.conversationId } : {}),
     ...(row.approvalLines?.length ? { approvalLines: row.approvalLines } : {}),
     ...(row.dialogOptions?.length ? { dialogOptions: [...row.dialogOptions] } : {}),

--- a/packages/server/server/sessions/fleet-web.ts
+++ b/packages/server/server/sessions/fleet-web.ts
@@ -16,6 +16,7 @@
  * host per request would fire one per poll.
  */
 
+import type { HarnessId } from '@agentistics/core'
 import type { StartHost } from '../cli-start'
 import type { CliLang } from '../cli-lang'
 import { controlStrings } from '@agentistics/tui/control/i18n'
@@ -424,6 +425,50 @@ export async function readFleetSkillBody(
  * Resolved against the SESSION's directory, never the server's: a machine running agentop for
  * something else would otherwise be asked about agentop.
  */
+/**
+ * Facts about the CONVERSATION behind a row that only its transcript can answer.
+ *
+ * Today: how many times it has been compacted. Asked for on the session's stats card, beside the
+ * context gauge, because they answer the same question from two sides — the gauge says how full
+ * this window is, the count says how many windows came before it.
+ *
+ * `compactions` is ABSENT rather than zero whenever it could not be established: a row with no
+ * linked conversation, a transcript not on this machine, a file that would not read. The card says
+ * which; a confident `0` would read as a conversation that has never been compacted.
+ */
+export async function readConversationFacts(
+  lang: CliLang, id: string,
+): Promise<{ compactions?: number; unavailable?: string }> {
+  const pt = lang === 'pt'
+  const host = await hostFor(lang)
+  if (!host.sessions) return { unavailable: controlStrings(lang).sessionsNoHost }
+  const fleet = await host.sessions()
+  const row = fleet.sessions.find(r => r.id === id || r.conversationId === id)
+  if (!row?.conversationId) {
+    return {
+      unavailable: row?.conversationBlind ?? (pt
+        ? 'Esta sessão ainda não tem uma conversa vinculada.'
+        : 'This session has no linked conversation yet.'),
+    }
+  }
+  const { countCompactions, resolveChatTranscriptPath } = await import('./chat-tail')
+  const path = await resolveChatTranscriptPath(row.cwd, row.conversationId).catch(() => null)
+  if (!path) {
+    return {
+      unavailable: pt
+        ? 'A transcrição desta conversa não foi encontrada nesta máquina.'
+        : 'This conversation’s transcript was not found on this machine.',
+    }
+  }
+  const n = await countCompactions(path)
+  if (n === null) {
+    return {
+      unavailable: pt ? 'Não foi possível ler a transcrição.' : 'The transcript could not be read.',
+    }
+  }
+  return { compactions: n }
+}
+
 export async function readFleetPullRequests(
   lang: CliLang, id: string,
 ): Promise<{ pulls: unknown[]; unavailable?: string; detail?: string }> {
@@ -505,22 +550,39 @@ export async function readNewOptions(lang: CliLang, query: string): Promise<Flee
     if (!host.startableHarnesses || !host.spawnSession) {
       return { harnesses: [], projects: [], tasks: [], unavailable: s.sessionsNoHost }
     }
+    const { readHarnessDefaults } = await import('./harness-defaults')
+    type Defaults = Awaited<ReturnType<typeof readHarnessDefaults>>
     const [harnesses, projects, tasks] = await Promise.all([
       host.startableHarnesses(),
       host.searchProjects ? host.searchProjects(query).catch(() => []) : Promise.resolve([]),
       host.sessionTasks ? host.sessionTasks().catch(() => []) : Promise.resolve([]),
     ])
+    // What each CLI will actually do here with no flags, read from THIS MACHINE's own settings
+    // files. `spawn-spec.ts` publishes none — no CLI prints its default in `--help` — but the
+    // picker offering "Default" without naming it is naming a thing without naming it, which is
+    // what was reported. Never a guess: an unreadable file or a missing key yields nothing and the
+    // picker keeps its plain "Default". See `harness-defaults.ts`.
+    const configured = new Map(await Promise.all(harnesses.map(async h =>
+      [h.id, await readHarnessDefaults(h.id as HarnessId).catch(() => ({} as Defaults))] as const,
+    )))
     return {
-      harnesses: harnesses.map(h => ({
-        id: h.id,
-        label: h.label,
-        modelSuggestions: [...h.modelSuggestions],
-        models: modelsFor(h.id),
-        ...(h.defaultModel ? { defaultModel: h.defaultModel } : {}),
-        supportsModel: h.supportsModel,
-        efforts: [...h.efforts],
-        ...(h.defaultEffort ? { defaultEffort: h.defaultEffort } : {}),
-      })),
+      harnesses: harnesses.map(h => {
+        const here = configured.get(h.id) ?? {}
+        // The tool's own published default outranks the machine's, on the rare day one publishes
+        // one: it is a fact about every machine, where this is a fact about ours.
+        const defaultModel = h.defaultModel ?? here.model
+        const defaultEffort = h.defaultEffort ?? here.effort
+        return {
+          id: h.id,
+          label: h.label,
+          modelSuggestions: [...h.modelSuggestions],
+          models: modelsFor(h.id),
+          ...(defaultModel ? { defaultModel } : {}),
+          supportsModel: h.supportsModel,
+          efforts: [...h.efforts],
+          ...(defaultEffort ? { defaultEffort } : {}),
+        }
+      }),
       projects: projects.map(p => ({
         path: p.path,
         label: p.label,

--- a/packages/server/server/sessions/harness-defaults.test.ts
+++ b/packages/server/server/sessions/harness-defaults.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { jsonStringKey, readHarnessDefaults, tomlTopKey } from './harness-defaults'
+
+describe('jsonStringKey', () => {
+  it('reads the key it was asked for', () => {
+    expect(jsonStringKey('{"model":"opus[1m]"}', 'model')).toBe('opus[1m]')
+  })
+
+  it('a document that will not parse yields nothing, never a throw', () => {
+    // A default is a convenience. It may never be the reason the new-session wizard fails.
+    expect(jsonStringKey('{ not json', 'model')).toBeUndefined()
+    expect(jsonStringKey('', 'model')).toBeUndefined()
+    expect(jsonStringKey('[1,2]', 'model')).toBeUndefined()
+    expect(jsonStringKey('"a string"', 'model')).toBeUndefined()
+  })
+
+  it('a non-string or empty value is not a default', () => {
+    expect(jsonStringKey('{"model":3}', 'model')).toBeUndefined()
+    expect(jsonStringKey('{"model":null}', 'model')).toBeUndefined()
+    expect(jsonStringKey('{"model":"  "}', 'model')).toBeUndefined()
+  })
+})
+
+describe('tomlTopKey', () => {
+  it('reads a top-level quoted value', () => {
+    const doc = 'model = "gpt-5.4-mini"\nmodel_reasoning_effort = "low"\n'
+    expect(tomlTopKey(doc, 'model')).toBe('gpt-5.4-mini')
+    expect(tomlTopKey(doc, 'model_reasoning_effort')).toBe('low')
+  })
+
+  it('STOPS at the first section — a key inside one is not in force at the top level', () => {
+    // Measured on a real `~/.kimi-code/config.toml`: `default_model` at the top, then several
+    // provider sections each carrying their OWN `model`. Reading past the header would report one
+    // provider's model as the machine's default.
+    const doc = 'default_model = "a/b"\n\n[providers.ollama]\nmodel = "qwen2.5:3b"\n'
+    expect(tomlTopKey(doc, 'default_model')).toBe('a/b')
+    expect(tomlTopKey(doc, 'model')).toBeUndefined()
+  })
+
+  it('ignores comments and trailing comments', () => {
+    expect(tomlTopKey('# model = "wrong"\nmodel = "right" # why\n', 'model')).toBe('right')
+  })
+
+  it('a bare (unquoted) value is left alone rather than half-understood', () => {
+    expect(tomlTopKey('model = true\n', 'model')).toBeUndefined()
+    expect(tomlTopKey('model = \n', 'model')).toBeUndefined()
+  })
+
+  it('a key that is merely a prefix of another is not matched', () => {
+    expect(tomlTopKey('model_reasoning_effort = "high"\n', 'model')).toBeUndefined()
+  })
+})
+
+describe('readHarnessDefaults', () => {
+  it('answers for every harness without throwing, whatever this machine holds', async () => {
+    for (const h of ['claude', 'codex', 'gemini', 'copilot', 'kimi', 'antigravity'] as const) {
+      const out = await readHarnessDefaults(h)
+      expect(typeof out).toBe('object')
+      if (out.model !== undefined) expect(out.model.length).toBeGreaterThan(0)
+      if (out.effort !== undefined) expect(out.effort.length).toBeGreaterThan(0)
+    }
+  })
+
+  it('a harness whose settings file names no model reports nothing', async () => {
+    // gemini and copilot, measured 2026-09-05. Absent IS the answer, and the picker keeps its plain
+    // "Default" rather than naming something nobody configured.
+    expect(await readHarnessDefaults('gemini')).toEqual({})
+    expect(await readHarnessDefaults('copilot')).toEqual({})
+  })
+})
+
+describe('the module names ONE key per file and nothing else', () => {
+  // Same guard, and the same reason, as `billing-detect.test.ts`. The files this reads also hold
+  // credentials — `~/.copilot/config.json` holds a live GitHub token — so the defence is that the
+  // module cannot so much as MENTION another field, checked over its own source.
+  // The CODE, with every comment stripped: the header has to be able to NAME the hazard it is
+  // defending against — a guard that forbids the module from explaining itself would be deleted.
+  const source = readFileSync(join(import.meta.dir, 'harness-defaults.ts'), 'utf-8')
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/\/\/.*$/gm, '')
+
+  it('never names a credential-bearing field', () => {
+    for (const forbidden of [
+      'copilotTokens', 'loggedInUsers', 'lastLoggedInUser', 'access_token', 'refresh_token',
+      'apiKey', 'api_key', 'OAuth', 'oauth', 'password', 'secret', 'credential',
+    ]) {
+      expect(source).not.toContain(forbidden)
+    }
+  })
+
+  it('never reads copilot\'s managed config file, which is where its token lives', () => {
+    expect(source).not.toContain("'config.json'")
+  })
+
+  it('resolves paths from HOME_DIR, never a harness data-dir constant', () => {
+    // A container mounting somebody else's `~/.claude` read-only would otherwise report that
+    // person's configured default as this machine's.
+    expect(source).toContain('HOME_DIR')
+    expect(source).not.toContain('CLAUDE_DIR')
+  })
+})

--- a/packages/server/server/sessions/harness-defaults.ts
+++ b/packages/server/server/sessions/harness-defaults.ts
@@ -1,0 +1,129 @@
+/**
+ * harness-defaults.ts — the model and effort each CLI will use HERE when none is passed.
+ *
+ * `spawn-spec.ts` holds what the TOOL publishes and, for defaults, holds nothing: measured on all
+ * six CLIs, none prints one in its own `--help`, and that module is a pure static table which a
+ * per-machine answer could not honestly live in. Its note ends by saying so about kimi — "it is
+ * THIS MACHINE's configuration rather than the CLI's".
+ *
+ * That is a reason not to put the answer in a static table, not a reason to withhold it. This
+ * machine's configuration is exactly what the session about to be started will obey, and a picker
+ * offering "Default" without saying what the default IS names a thing without naming it — reported
+ * as "you are not showing the default values for model and effort". So the answer is read HERE,
+ * impurely, at the moment the wizard asks, from the file each CLI documents as its own.
+ *
+ * EVERY ENTRY NAMES ITS FILE AND KEY, and was verified by reading a real one on 2026-09-05:
+ *
+ * - claude    `~/.claude/settings.json` → `model`  (e.g. `opus[1m]`). No effort key exists.
+ * - codex     `~/.codex/config.toml`    → `model`, `model_reasoning_effort`.
+ * - kimi      `~/.kimi-code/config.toml`→ `default_model`, which `kimi --help` names by KEY.
+ * - antigravity `~/.gemini/antigravity-cli/settings.json` → `model` (a DISPLAY name, e.g.
+ *   `Gemini 3.6 Flash (Medium)`) — shown as read, never mapped onto a `--model` value it may not be.
+ * - gemini    `~/.gemini/settings.json` carries no model key. ABSENT, and absent is the answer.
+ * - copilot   its user settings file carries no model key. ABSENT.
+ *
+ * IT NAMES NOTHING ELSE IN THOSE FILES. They also hold credentials — `~/.copilot/config.json`
+ * holds a live GitHub token, and the antigravity settings hold a GCP project and a permission
+ * allowlist — so this module reads ONE named key per file and `harness-defaults.test.ts` greps its
+ * own source and fails if it so much as mentions another. Same guard, and the same reason, as
+ * `billing-detect.ts`.
+ *
+ * A DEFAULT IS A READING, NEVER A CLAIM. An unreadable file, a missing key, a value of the wrong
+ * shape and a harness with no such file are all the same answer here: nothing. The picker then says
+ * "Default", exactly as it did before, rather than "Default (something we guessed)".
+ */
+
+import { readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import type { HarnessId } from '@agentistics/core'
+import { HOME_DIR } from '../config'
+
+/** What one harness will do with no flags, as far as this machine can be read. */
+export interface HarnessDefaults {
+  model?: string
+  effort?: string
+}
+
+/**
+ * One key out of a JSON document, as a non-empty string.
+ *
+ * Total: a document that will not parse, is not an object, or holds the key as anything but a
+ * string yields nothing. A default is a convenience; it may never be a reason a wizard fails.
+ */
+export function jsonStringKey(text: string, key: string): string | undefined {
+  let doc: unknown
+  try { doc = JSON.parse(text) } catch { return undefined }
+  if (typeof doc !== 'object' || doc === null || Array.isArray(doc)) return undefined
+  const v = (doc as Record<string, unknown>)[key]
+  return typeof v === 'string' && v.trim() !== '' ? v.trim() : undefined
+}
+
+/**
+ * One TOP-LEVEL key out of a TOML document, as a string.
+ *
+ * Deliberately not a TOML parser: the two files read here state their model at the top level, and
+ * a dependency-free reader that stops at the first `[section]` header cannot be tricked by a
+ * same-named key deeper in the document into reporting a default that is not in force. Quotes are
+ * required, because every value this reads is a string in both files; a bare value is left alone
+ * rather than half-understood.
+ */
+export function tomlTopKey(text: string, key: string): string | undefined {
+  for (const raw of text.split('\n')) {
+    const line = raw.trim()
+    if (line.startsWith('#') || line === '') continue
+    // A section header ends the top level. Everything after it belongs to something.
+    if (line.startsWith('[')) return undefined
+    const eq = line.indexOf('=')
+    if (eq < 0) continue
+    if (line.slice(0, eq).trim() !== key) continue
+    const value = line.slice(eq + 1).trim().replace(/\s*#.*$/, '').trim()
+    const m = /^"([^"]*)"$|^'([^']*)'$/.exec(value)
+    const out = (m?.[1] ?? m?.[2] ?? '').trim()
+    return out === '' ? undefined : out
+  }
+  return undefined
+}
+
+/** Read a file, or nothing. A default never throws — see the header. */
+async function text(path: string): Promise<string | null> {
+  try { return await readFile(path, 'utf-8') } catch { return null }
+}
+
+/**
+ * What this machine has configured for one harness.
+ *
+ * `HOME_DIR`, never a harness data-dir constant: these are the USER's own settings files, and a
+ * container mounting somebody else's `~/.claude` read-only would otherwise report that person's
+ * default as this machine's. Same distinction `cli-hooks.ts` and `mcp-list.ts` make.
+ */
+export async function readHarnessDefaults(harness: HarnessId): Promise<HarnessDefaults> {
+  switch (harness) {
+    case 'claude': {
+      const t = await text(join(HOME_DIR, '.claude', 'settings.json'))
+      const model = t ? jsonStringKey(t, 'model') : undefined
+      return model ? { model } : {}
+    }
+    case 'codex': {
+      const t = await text(join(HOME_DIR, '.codex', 'config.toml'))
+      if (!t) return {}
+      const model = tomlTopKey(t, 'model')
+      const effort = tomlTopKey(t, 'model_reasoning_effort')
+      return { ...(model ? { model } : {}), ...(effort ? { effort } : {}) }
+    }
+    case 'kimi': {
+      const t = await text(join(HOME_DIR, '.kimi-code', 'config.toml'))
+      const model = t ? tomlTopKey(t, 'default_model') : undefined
+      return model ? { model } : {}
+    }
+    case 'antigravity': {
+      const t = await text(join(HOME_DIR, '.gemini', 'antigravity-cli', 'settings.json'))
+      const model = t ? jsonStringKey(t, 'model') : undefined
+      return model ? { model } : {}
+    }
+    // Their settings files carry no model key at all — see the header. Absent is the answer, and
+    // it is listed rather than defaulted so a harness added later cannot fall through silently.
+    case 'gemini':
+    case 'copilot':
+      return {}
+  }
+}

--- a/packages/server/server/sessions/session-view.ts
+++ b/packages/server/server/sessions/session-view.ts
@@ -59,6 +59,14 @@ export interface SessionView {
   /** ABSENT for an external session — not capturable, so not knowable. */
   activity?: SessionActivity
   /**
+   * Work is running that is NOT this session's own turn — a background subagent.
+   *
+   * The session still needs a person, and `activity` says so. This exists so "needs you" does not
+   * read as "and nothing is happening". Absent on a `working` row, which has nothing to add, and on
+   * a harness that cannot tell its own turn apart — see `backgroundWork`.
+   */
+  background?: boolean
+  /**
    * The last few meaningful lines of this session's screen — what it is saying right now.
    *
    * Only ever present for a session agentop hosts: it comes from the frame that was captured to
@@ -367,6 +375,13 @@ export const DEFAULT_CLOSED_LIMIT = 300
 export function buildSessionViews(o: {
   reconciled: readonly ReconciledSession[]
   activity: ReadonlyMap<string, SessionActivity>
+  /**
+   * Rows with work running that is NOT their own turn — a background subagent, a watcher.
+   *
+   * The STATE still says the session needs a person, because it does. This is the mark beside it,
+   * so "needs you" does not read as "and nothing is happening". See `backgroundWork`.
+   */
+  background?: ReadonlySet<string>
   /** The tail of each hosted session's screen, keyed by session id. */
   tails?: ReadonlyMap<string, string[]>
   /** Role-tagged chat turns, keyed by session id — see `SessionView.chatTurns`. */
@@ -503,6 +518,9 @@ export function buildSessionViews(o: {
       cwd: r.managed?.cwd ?? '',
       status: finished ? ('exited' as const) : r.status,
       ...(activity ? { activity } : {}),
+      // Only where it ADDS something: a row that is already `working` has nothing to mark, and a
+      // finished one has nothing running.
+      ...(!finished && activity !== 'working' && o.background?.has(r.id) ? { background: true } : {}),
       ...((o.tails?.get(r.id)?.length ?? 0) > 0 ? { lastLines: o.tails!.get(r.id)! } : {}),
       ...((o.chatTails?.get(r.id)?.length ?? 0) > 0 ? { chatTurns: o.chatTails!.get(r.id)! } : {}),
       // Only while it is genuinely asking. A dialog frame carried on a row that has moved on would

--- a/packages/server/server/sessions/sessions-host.test.ts
+++ b/packages/server/server/sessions/sessions-host.test.ts
@@ -76,7 +76,7 @@ describe('createSessionsPoller', () => {
     // work. It reproduces at the poller: a session working (its probed footer moving), then ONE poll
     // where the frame is momentarily quiet — a repaint settling, a sub-turn finishing — reads `waiting`
     // raw. Before this fix the counter jumped to 1 on that single frame and a person was summoned.
-    const frames: Record<string, string[]> = { a: ['working hard · esc to interrupt'] }
+    const frames: Record<string, string[]> = { a: ['· Working… (12s · ↓ 1.7k tokens)'] }
     const p = poller({
       backend: fakeBackend({ sessions: [backendSession('a')], frames }),
       registry: [managed('a')],
@@ -107,7 +107,24 @@ describe('createSessionsPoller', () => {
     expect((await p.poll()).attention).toBe(0) // fell on the very next sample
   })
 
-  it('reports a session working from its probed footer', async () => {
+  it('reports a session working from its probed MAIN-agent marker', async () => {
+    const p = poller({
+      backend: fakeBackend({
+        sessions: [backendSession('a')],
+        frames: { a: ['  ⏸ manual mode on · Jitterbugging… (37s · ↓ 1.7k tokens) · ← 6 agents'] },
+      }),
+      registry: [managed('a')],
+    })
+    expect((await p.poll()).sessions[0]!.activity).toBe('working')
+    expect((await p.poll()).attention).toBe(0)
+  })
+
+  it('a session whose ONLY marker is the interruptible one needs a person, and says a subagent runs', async () => {
+    // claude prints `esc to interrupt` whenever ANYTHING is interruptible — a background subagent
+    // included — so a session that has finished its own turn and is waiting for the person to type
+    // still carried it. Reported exactly that way: the fleet said `working` about sessions that were
+    // waiting. The main agent's own spinner is what says it is producing; the bare interruptible
+    // marker says only that something else is.
     const p = poller({
       backend: fakeBackend({
         sessions: [backendSession('a')],
@@ -115,8 +132,11 @@ describe('createSessionsPoller', () => {
       }),
       registry: [managed('a')],
     })
-    expect((await p.poll()).sessions[0]!.activity).toBe('working')
-    expect((await p.poll()).attention).toBe(0)
+    await p.poll()
+    const snap = await p.poll()
+    expect(snap.sessions[0]!.activity).toBe('waiting')
+    expect(snap.sessions[0]!.background).toBe(true)
+    expect(snap.attention).toBe(1)
   })
 
   it('a SINGLE frame change never reaches the row — that is what a repaint looks like', async () => {
@@ -194,7 +214,7 @@ describe('createSessionsPoller', () => {
   })
 
   it('rings once on the transition into waiting, not on every poll', async () => {
-    const frames: Record<string, string[]> = { a: ['esc to interrupt'] }
+    const frames: Record<string, string[]> = { a: ['· Working… (3s · ↓ 12 tokens)'] }
     const p = poller({
       backend: fakeBackend({ sessions: [backendSession('a')], frames }),
       registry: [managed('a')],

--- a/packages/server/server/sessions/sessions-host.ts
+++ b/packages/server/server/sessions/sessions-host.ts
@@ -33,6 +33,7 @@ import type { ManagedSession, SessionActivity, SessionBackend } from './types'
 import { calculateProcCpu, type ProcStatSample } from '../hardware-pure'
 import { readProcRss, readProcStat } from '../hardware-probe'
 import { procAvailable } from './proc-liveness'
+import { backgroundWork } from './attention'
 
 /** How often the cockpit refreshes. Five seconds is the interval the feature was specified at. */
 export const SESSION_POLL_MS = Number(process.env.AGENTISTICS_SESSION_POLL_MS) > 0
@@ -244,6 +245,8 @@ export function createSessionsPoller(o: {
       const activity = new Map<string, SessionActivity>()
       /** Rows whose reading is backed by more than movement — see `confirmActivities`. */
       const corroborated = new Set<string>()
+      /** Rows with work running that is not their own turn — see `backgroundWork`. */
+      const background = new Set<string>()
       const tails = new Map<string, string[]>()
       const approvals = new Map<string, string[]>()
       const dialogOptions = new Map<string, DialogOption[]>()
@@ -285,6 +288,7 @@ export function createSessionsPoller(o: {
           corroborated.add(r.id)
         }
         const before = prevDigest.get(r.id)
+        if (backgroundWork({ frame, ...(rules ? { rules } : {}) })) background.add(r.id)
         const state = attentionOf({
           alive: true,
           lastActivityMs: b.lastActivityMs,
@@ -399,6 +403,7 @@ export function createSessionsPoller(o: {
       const sessions = buildSessionViews({
         reconciled,
         activity: confirmedActivity,
+        background,
         tails,
         chatTails,
         approvals,

--- a/packages/server/server/sessions/types.ts
+++ b/packages/server/server/sessions/types.ts
@@ -363,7 +363,15 @@ export interface SessionBackend {
   readonly id: 'tmux' | 'pty'
   /** Why this backend cannot run here, already localized. Absent when it can. */
   unavailable(): Promise<string | undefined>
-  spawn(req: BackendSpawn): Promise<void>
+  /**
+   * Start the session. Resolves once the session EXISTS — not once its first prompt has landed.
+   *
+   * An `initialPrompt` is delivered as a FOLLOW-UP: the harness has to draw its input box before a
+   * prompt can be typed into it, and waiting for that held every caller for the whole of the CLI's
+   * startup. `delivery` is that follow-up, for the rare caller that must wait; ignoring it is the
+   * normal case and never leaves an unhandled rejection.
+   */
+  spawn(req: BackendSpawn): Promise<{ delivery?: Promise<void> } | void>
   list(): Promise<BackendSession[]>
   /** Newest-last lines of the last rendered frame, trailing blanks removed. */
   capture(id: string, lines: number): Promise<string[]>

--- a/packages/server/server/sessions/types.ts
+++ b/packages/server/server/sessions/types.ts
@@ -337,6 +337,24 @@ export interface AttentionRules {
    * is the only working signal there is, and claiming otherwise would be a guess.
    */
   working?: RegExp[]
+  /**
+   * The MAIN agent is producing, right now.
+   *
+   * Distinct from `working`, and the distinction is the whole point: claude prints `esc to
+   * interrupt` whenever ANYTHING is interruptible — a background subagent included — so a session
+   * that has already answered you and is waiting still carries it. Reading that as `working` told
+   * a person nothing was needed from them when something was. Measured on a live session:
+   *
+   *   waiting, subagents running   `⏵⏵ auto mode on · esc to interrupt · ← 6 agents`
+   *   the agent actually producing `· Jitterbugging… (37s · ↓ 1.7k tokens · thought for 17s)`
+   *
+   * The whimsical verb changes every frame; what does not is the elapsed time and the token
+   * counter, so that is what is matched.
+   *
+   * Optional, like `working`: a harness that does not draw one is not given a guess. Where it is
+   * absent the old behaviour stands exactly.
+   */
+  mainWorking?: RegExp[]
   /** Provenance — the exact CLI version the frames came from, and the date. */
   probed: string
 }

--- a/packages/tui/src/control/types.ts
+++ b/packages/tui/src/control/types.ts
@@ -673,6 +673,14 @@ export interface ControlSession {
    */
   background?: boolean
   /**
+   * The reasoning effort this session was STARTED with, when one was asked for.
+   *
+   * Recorded at spawn, like `model` beside it — it is what agentop passed, not something read back
+   * off the running CLI, and absent means no flag was passed and the harness's own default is in
+   * force. A blank would read as "none", which is a different claim.
+   */
+  effort?: string
+  /**
    * Whether this row can be acted on at all.
    *
    * False for an external session, which is listed because "the fleet in one place" is the point,

--- a/packages/tui/src/control/types.ts
+++ b/packages/tui/src/control/types.ts
@@ -663,6 +663,16 @@ export interface ControlSession {
   /** Already-localized state word, e.g. "needs approval". */
   stateLabel: string
   /**
+   * Something this session STARTED is still running, while the session itself needs a person.
+   *
+   * claude prints `esc to interrupt` whenever anything is interruptible — a background subagent
+   * included — so a session that had finished its own turn and was waiting for you to type still
+   * carried the marker and read as `working`. The state is now decided by the MAIN agent's own
+   * spinner; this says why the screen still looks busy. Absent on an ordinary row: its presence is
+   * the statement.
+   */
+  background?: boolean
+  /**
    * Whether this row can be acted on at all.
    *
    * False for an external session, which is listed because "the fleet in one place" is the point,

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -2893,6 +2893,8 @@ export default function AppLayout() {
           lang={lang === 'pt' ? 'pt' : 'en'}
           currency={currency}
           brlRate={brlRate}
+          {...(selectedFleetSession.model ? { startedModel: selectedFleetSession.model } : {})}
+          {...(selectedFleetSession.effort ? { startedEffort: selectedFleetSession.effort } : {})}
         />
       )}
 

--- a/packages/web/src/components/sessions/ArtifactsAside.tsx
+++ b/packages/web/src/components/sessions/ArtifactsAside.tsx
@@ -24,6 +24,7 @@
  */
 
 import { useEffect, useMemo, useRef, useState } from 'react'
+import { asideCache, asideKey } from '../../lib/asideCache'
 import {
   FileEdit, FilePlus2, PanelRightClose, Loader, FileText, Activity, Files,
   BookOpen, Terminal, Brain, Send, Eye, Image, Sparkles, ChevronLeft, GitPullRequest,
@@ -185,8 +186,15 @@ export function ArtifactsAside({
    * `null` is "not read yet" and `[]` is "none", which are different sentences on screen — the same
    * distinction the rest of this panel keeps.
    */
-  const [skills, setSkills] = useState<SkillEntry[] | null>(null)
-  const [skillsNote, setSkillsNote] = useState<string | null>(null)
+  // Seeded from the cache so a panel reopened on this session DRAWS its list immediately. `null`
+  // still means "not read yet" and is the only thing that makes a tab wait — see `asideCache.ts`.
+  type SkillsAnswer = { skills: SkillEntry[]; note: string | null }
+  const [skills, setSkills] = useState<SkillEntry[] | null>(
+    () => asideCache.read<SkillsAnswer>(asideKey(sessionId, 'skills')).value?.skills ?? null,
+  )
+  const [skillsNote, setSkillsNote] = useState<string | null>(
+    () => asideCache.read<SkillsAnswer>(asideKey(sessionId, 'skills')).value?.note ?? null,
+  )
   const [skillQuery, setSkillQuery] = useState('')
   /** The skill being READ, and its file. `null` is the list; a name is the detail view. */
   const [openSkill, setOpenSkill] = useState<string | null>(null)
@@ -204,14 +212,21 @@ export function ArtifactsAside({
   useEffect(() => {
     if (openSkill === null) { setSkillBody(null); return }
     let alive = true
-    setSkillBody(null)
+    // A skill's own file does not change while the panel is open, and reopening the same one used
+    // to re-read it from disk every time. Keyed by the skill NAME as well as the session.
+    const key = asideKey(sessionId, 'skill', openSkill)
+    const hit = asideCache.read<typeof skillBody>(key)
+    setSkillBody(hit.value ?? null)
+    if (hit.value && !hit.stale) return
     fetch(`/api/fleet/skill?id=${encodeURIComponent(sessionId)}&name=${encodeURIComponent(openSkill)}&lang=${pt ? 'pt' : 'en'}`)
       .then(r => r.json())
       .then((d: { ok?: boolean; text?: string; truncated?: boolean; message?: string }) => {
+        const answer = d?.ok
+          ? { ok: true as const, text: d.text ?? '', truncated: d.truncated === true }
+          : { ok: false as const, message: d?.message ?? (pt ? 'Não foi possível ler.' : 'Could not read it.') }
+        asideCache.write(key, answer)
         if (!alive) return
-        setSkillBody(d?.ok
-          ? { ok: true, text: d.text ?? '', truncated: d.truncated === true }
-          : { ok: false, message: d?.message ?? (pt ? 'Não foi possível ler.' : 'Could not read it.') })
+        setSkillBody(answer)
       })
       .catch(() => {
         if (alive) setSkillBody({ ok: false, message: pt ? 'Não foi possível ler.' : 'Could not read it.' })
@@ -223,32 +238,47 @@ export function ArtifactsAside({
     [skills, skillQuery, pt],
   )
   useEffect(() => {
-    if (tab !== 'skills' || skills !== null) return
+    if (tab !== 'skills') return
+    // The cached list is already on screen; this refreshes BEHIND it and only when it has aged out.
+    // A fetch on every mount is the reload being fixed; never fetching would pin the list forever.
+    const key = asideKey(sessionId, 'skills')
+    const hit = asideCache.read<SkillsAnswer>(key)
+    if (hit.value && !hit.stale) return
     let alive = true
     fetch(`/api/fleet/skills?id=${encodeURIComponent(sessionId)}&lang=${pt ? 'pt' : 'en'}`)
       .then(r => (r.ok ? r.json() : null))
       .then((d: { skills?: SkillEntry[]; reason?: string } | null) => {
+        const answer: SkillsAnswer = { skills: d?.skills ?? [], note: d?.reason ?? null }
+        asideCache.write(key, answer)
         if (!alive) return
-        setSkills(d?.skills ?? [])
-        setSkillsNote(d?.reason ?? null)
+        setSkills(answer.skills)
+        setSkillsNote(answer.note)
       })
-      .catch(() => { if (alive) setSkills([]) })
+      .catch(() => { if (alive) setSkills(s => s ?? []) })
     return () => { alive = false }
   }, [tab, skills, sessionId, pt])
 
-  /** The repository's pull requests, read once when the tab is opened. See `github-prs.ts`. */
+  /** The repository's pull requests. Read when the tab opens, then cached — see `github-prs.ts`. */
+  type PrAnswer = {
+    pulls: { number: number; title: string; url: string; state: string; draft: boolean; review?: string; branch: string }[]
+    unavailable?: string
+    detail?: string
+  }
   const [prs, setPrs] = useState<{
     pulls: { number: number; title: string; url: string; state: string; draft: boolean; review?: string; branch: string }[]
     unavailable?: string
     detail?: string
-  } | null>(null)
+  } | null>(() => asideCache.read<PrAnswer>(asideKey(sessionId, 'prs')).value ?? null)
   useEffect(() => {
-    if (tab !== 'prs' || prs !== null) return
+    if (tab !== 'prs') return
+    const key = asideKey(sessionId, 'prs')
+    const hit = asideCache.read<PrAnswer>(key)
+    if (hit.value && !hit.stale) return
     let alive = true
     fetch(`/api/fleet/prs?id=${encodeURIComponent(sessionId)}&lang=${pt ? 'pt' : 'en'}`)
       .then(r => r.json())
-      .then(d => { if (alive) setPrs(d) })
-      .catch(() => { if (alive) setPrs({ pulls: [], unavailable: 'failed' }) })
+      .then((d: PrAnswer) => { asideCache.write(key, d); if (alive) setPrs(d) })
+      .catch(() => { if (alive) setPrs(p => p ?? { pulls: [], unavailable: 'failed' }) })
     return () => { alive = false }
   }, [tab, prs, sessionId, pt])
 

--- a/packages/web/src/components/sessions/ArtifactsAside.tsx
+++ b/packages/web/src/components/sessions/ArtifactsAside.tsx
@@ -73,6 +73,8 @@ export interface ArtifactsAsideProps {
    * the server; shown verbatim so this panel and the chat give one answer.
    */
   unavailable?: string
+  /** Already-localized: the conversation behind these lists is a WINDOW onto a longer one. */
+  older?: string
   onClose: () => void
   /**
    * The session wrote through commands whose paths cannot be read off the command line.
@@ -109,7 +111,7 @@ function KindIcon({ kind }: { kind: Artifact['kind'] }) {
 }
 
 export function ArtifactsAside({
-  sessionId, lang, artifacts, loading, unavailable, unlistedWrites, turns, facts, onClose,
+  sessionId, lang, artifacts, loading, unavailable, older, unlistedWrites, turns, facts, onClose,
   tabRequest,
 }: ArtifactsAsideProps) {
   const pt = lang === 'pt'
@@ -745,6 +747,7 @@ export function ArtifactsAside({
         onViewChange={chooseGalleryView}
         scope={galleryScope}
         onScopeChange={chooseGalleryScope}
+        {...(older ? { older } : {})}
       />
     )
   }

--- a/packages/web/src/components/sessions/GalleryTab.tsx
+++ b/packages/web/src/components/sessions/GalleryTab.tsx
@@ -61,13 +61,21 @@ export interface GalleryTabProps {
   /** Which side is shown — see `GalleryScope`. */
   scope: GalleryScope
   onScopeChange: (scope: GalleryScope) => void
+  /**
+   * Already-localized: the conversation these groups came from is a WINDOW onto a longer one.
+   *
+   * The gallery lists the files of the turns it was given, and that list is capped at the end of
+   * the transcript — so on a long conversation it empties itself, which reads as "everything
+   * disappeared" unless the panel says what actually happened. Reported exactly that way.
+   */
+  older?: string
 }
 
 /** How long a touch has to hold to mean "right-click". The same 500ms the session rows use. */
 const LONG_PRESS_MS = 500
 
 export function GalleryTab({
-  sessionId, groups: allGroups, lang, view, onViewChange, scope, onScopeChange,
+  sessionId, groups: allGroups, lang, view, onViewChange, scope, onScopeChange, older,
 }: GalleryTabProps) {
   const pt = lang === 'pt'
   const isMobile = useIsMobile()
@@ -148,10 +156,16 @@ export function GalleryTab({
   }, [pt])
 
   if (allGroups.length === 0) {
+    // The window outranks the "nothing yet" sentence, which would be FALSE on a long conversation:
+    // files were sent, they are simply older than the turns this view holds.
     return (
-      <Empty text={pt
-        ? 'Nada enviado nesta conversa ainda. Imagens e arquivos que você anexar a uma mensagem aparecem aqui, agrupados pela mensagem que os levou.'
-        : 'Nothing sent in this conversation yet. Images and files you attach to a message appear here, grouped by the message that carried them.'} />
+      <Empty text={older
+        ? `${older} ${pt
+          ? 'Arquivos enviados antes disso não estão nesta lista.'
+          : 'Files sent before that are not in this list.'}`
+        : pt
+          ? 'Nada enviado nesta conversa ainda. Imagens e arquivos que você anexar a uma mensagem aparecem aqui, agrupados pela mensagem que os levou.'
+          : 'Nothing sent in this conversation yet. Images and files you attach to a message appear here, grouped by the message that carried them.'} />
     )
   }
 
@@ -207,6 +221,16 @@ export function GalleryTab({
           onClick={() => onViewChange('grid')}
         />
       </div>
+
+      {/* The window, stated ONCE at the top of a NON-empty gallery too: a list showing four files
+          out of forty is a wrong answer nobody can see is wrong, which is worse than an empty one. */}
+      {older && (
+        <p style={{
+          margin: 0, padding: '6px 10px', flexShrink: 0,
+          fontSize: 10.5, lineHeight: 1.5, color: 'var(--text-tertiary)',
+          borderBottom: '1px solid var(--border-subtle)',
+        }}>{older}</p>
+      )}
 
       {notice && (
         <p role="status" style={{

--- a/packages/web/src/components/sessions/SessionChat.tsx
+++ b/packages/web/src/components/sessions/SessionChat.tsx
@@ -67,6 +67,8 @@ interface ChatPayload {
   turns: ChatTurn[]
   unavailable?: string
   live: boolean
+  /** Already-localized: these turns are the END of a longer conversation. See `chat-web.ts`. */
+  older?: string
 }
 
 export interface SessionChatProps {
@@ -87,6 +89,14 @@ export interface SessionChatProps {
     artifacts: Artifact[]
     loading: boolean
     unavailable?: string
+    /**
+     * Already-localized: the conversation is a WINDOW onto a longer one.
+     *
+     * Handed over for the same reason the turns are: every list the panel builds is built from
+     * these turns and inherits their cap, so the panel has to be able to say so instead of showing
+     * an empty gallery that reads as "there was never anything here".
+     */
+    older?: string
     /** Writes this reader cannot name — see `hasUnlistedWrites`. */
     unlisted: boolean
     /** The turns themselves, for the panel's LIVE tab. Handed over rather than re-fetched. */
@@ -740,8 +750,9 @@ export function SessionChat({ session, row, lang, act, onArtifacts }: SessionCha
       unlisted: hasUnlistedWrites(turns),
       turns,
       ...(payload?.unavailable ? { unavailable: payload.unavailable } : {}),
+      ...(payload?.older ? { older: payload.older } : {}),
     })
-  }, [artifacts, loading, turns, payload?.unavailable, onArtifacts])
+  }, [artifacts, loading, turns, payload?.unavailable, payload?.older, onArtifacts])
 
   const canPrompt = !loading && session.actionable && !blocked && payload.live !== false
   /**
@@ -933,6 +944,16 @@ export function SessionChat({ session, row, lang, act, onArtifacts }: SessionCha
           ) : turns.length === 0 && live === null && echo.length === 0 ? (
             <Muted text={pt ? 'Esta conversa ainda não tem mensagens.' : 'This conversation has no messages yet.'} />
           ) : null}
+
+          {/* Where the window BEGINS, said at the top of the scroll — the one place a reader looks
+              when they wonder where the rest went. Everything derived from these turns (the
+              gallery, Files, Live) inherits the same cap and says so in its own panel. */}
+          {!loading && payload?.older && (
+            <p style={{
+              margin: 0, textAlign: 'center', fontSize: 11, lineHeight: 1.5,
+              color: 'var(--text-tertiary)',
+            }}>{payload.older}</p>
+          )}
 
           {turns.map((t, i) => (
             <ChatBubble

--- a/packages/web/src/components/sessions/SessionStatsMenu.tsx
+++ b/packages/web/src/components/sessions/SessionStatsMenu.tsx
@@ -15,6 +15,7 @@
  */
 
 import { useEffect, useRef, useState } from 'react'
+import { asideCache, asideKey } from '../../lib/asideCache'
 import { BarChart3, X } from 'lucide-react'
 import { fmt, fmtCost, type HarnessId, type SessionMeta } from '@agentistics/core'
 import { HARNESS_LABELS } from '../../lib/harness'
@@ -28,13 +29,47 @@ export interface SessionStatsMenuProps {
   lang: 'pt' | 'en'
   currency: 'USD' | 'BRL'
   brlRate: number
+  /**
+   * The model and effort this session was STARTED with, off the fleet row.
+   *
+   * Deliberately separate from `SessionStats.model`, which is what the STORE observed the
+   * conversation using. They usually agree and are not the same claim: one is what agentop asked
+   * for, the other what the transcript recorded. Absent means no flag was passed and the harness's
+   * own default is in force, which the card says in words.
+   */
+  startedModel?: string
+  startedEffort?: string
 }
 
 export function SessionStatsMenu({
-  harness, sessionId, meta, lang, currency, brlRate,
+  harness, sessionId, meta, lang, currency, brlRate, startedModel, startedEffort,
 }: SessionStatsMenuProps) {
   const pt = lang === 'pt'
   const [open, setOpen] = useState(false)
+
+  /**
+   * How many times this conversation has been COMPACTED — read only when the card is opened, and
+   * cached, because it is a scan of the whole transcript (70 ms on a real 39 MB one).
+   *
+   * It belongs beside the context gauge: the gauge says how full THIS window is, the count says how
+   * many windows came before it. Absent, never zero, whenever it could not be established.
+   */
+  type Facts = { compactions?: number; unavailable?: string }
+  const factsKey = asideKey(sessionId, 'conversation')
+  const [facts, setFacts] = useState<Facts | null>(
+    () => asideCache.read<Facts>(factsKey).value ?? null,
+  )
+  useEffect(() => {
+    if (!open) return
+    const hit = asideCache.read<Facts>(factsKey)
+    if (hit.value && !hit.stale) { setFacts(hit.value); return }
+    let alive = true
+    fetch(`/api/fleet/conversation?id=${encodeURIComponent(sessionId)}&lang=${pt ? 'pt' : 'en'}`)
+      .then(r => r.json())
+      .then((d: Facts) => { asideCache.write(factsKey, d); if (alive) setFacts(d) })
+      .catch(() => { if (alive) setFacts(f => f ?? { unavailable: pt ? 'Não foi possível ler.' : 'Could not read it.' }) })
+    return () => { alive = false }
+  }, [open, factsKey, sessionId, pt])
   const boxRef = useRef<HTMLDivElement | null>(null)
 
   useEffect(() => {
@@ -107,6 +142,31 @@ export function SessionStatsMenu({
               }}
             ><X size={13} /></button>
           </div>
+
+          {/* HOW THIS SESSION IS RUNNING — before the numbers, because it is what the numbers are
+              OF. `model` has two sources and they are not the same claim: what agentop was asked to
+              start (the row) and what the transcript recorded (the store). The row wins when it has
+              one, and an absent flag is said in words — a blank cell would read as "none". */}
+          <Block title={pt ? 'Como está rodando' : 'How it is running'}>
+            <Line
+              k={pt ? 'Modelo' : 'Model'}
+              v={startedModel ?? s.model ?? (pt ? 'padrão do harness' : 'the harness default')}
+            />
+            <Line
+              k={pt ? 'Esforço' : 'Effort'}
+              v={startedEffort ?? (pt ? 'padrão do harness' : 'the harness default')}
+            />
+            {/* A count of what has already been thrown away, beside the gauge of what is left. */}
+            <Line
+              k={pt ? 'Compactações' : 'Compactions'}
+              v={facts?.compactions !== undefined
+                ? fmt(facts.compactions)
+                : facts === null ? '…' : '—'}
+            />
+            {facts?.compactions === undefined && facts?.unavailable && (
+              <Absent text={facts.unavailable} />
+            )}
+          </Block>
 
           {/* CONTEXT — a bar, and the bar SATURATES while the label keeps counting. A session can
               genuinely exceed the documented window, and a clamped label would hide exactly that. */}

--- a/packages/web/src/lib/asideCache.test.ts
+++ b/packages/web/src/lib/asideCache.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'bun:test'
+import { asideKey, createAsideCache, keyOfSession } from './asideCache'
+
+describe('asideCache', () => {
+  it('hands back what was written, and says it is fresh', () => {
+    const c = createAsideCache(4, 1000)
+    c.write('s1 prs', [1, 2, 3], 0)
+    expect(c.read<number[]>('s1 prs', 500)).toEqual({ value: [1, 2, 3], stale: false })
+  })
+
+  it('nothing cached is not the same as a stale value', () => {
+    // The panel branches on `value`, not on `stale`: with a value it draws and refreshes behind it,
+    // without one it must actually wait for the read. Collapsing the two would put a spinner over
+    // an answer already in hand, which is the reload being fixed.
+    const c = createAsideCache(4, 1000)
+    expect(c.read('s1 prs')).toEqual({ stale: true })
+    expect(c.read<number[]>('s1 prs').value).toBeUndefined()
+  })
+
+  it('a value past the TTL is STALE and still returned', () => {
+    const c = createAsideCache(4, 1000)
+    c.write('s1 skills', ['a'], 0)
+    const out = c.read<string[]>('s1 skills', 5000)
+    expect(out.stale).toBe(true)
+    expect(out.value).toEqual(['a'])
+  })
+
+  it('evicts the least recently READ session whole, never one of its tabs', () => {
+    // Dropping one topic of a session that is still open would make that tab reload while its
+    // siblings did not — the same surprise in miniature.
+    const c = createAsideCache(2, 10_000)
+    c.write('a prs', 1, 0)
+    c.write('a skills', 2, 0)
+    c.write('b prs', 3, 1)
+    c.read('a prs', 5) // `a` is now the most recently used
+    c.write('c prs', 4, 6) // over the cap: `b` is the oldest use
+
+    expect(c.read('a prs', 7).value).toBe(1)
+    expect(c.read('a skills', 7).value).toBe(2)
+    expect(c.read('c prs', 7).value).toBe(4)
+    expect(c.read('b prs', 7).value).toBeUndefined()
+  })
+
+  it('forgetSession removes every topic of that session and nothing else', () => {
+    const c = createAsideCache(4, 10_000)
+    c.write('s1 prs', 1, 0)
+    c.write('s1 skill body', 2, 0)
+    c.write('s2 prs', 3, 0)
+    c.forgetSession('s1')
+    expect(c.read('s1 prs').value).toBeUndefined()
+    expect(c.read('s1 skill body').value).toBeUndefined()
+    expect(c.read('s2 prs').value).toBe(3)
+  })
+
+  it('a session id is matched WHOLE — `abc` never claims `abcd`', () => {
+    expect(keyOfSession(asideKey('abcd', 'prs'), 'abc')).toBe(false)
+    expect(keyOfSession(asideKey('abc', 'prs'), 'abc')).toBe(true)
+    const c = createAsideCache(4, 10_000)
+    c.write(asideKey('abcd', 'prs'), 1, 0)
+    c.forgetSession('abc')
+    expect(c.read(asideKey('abcd', 'prs')).value).toBe(1)
+  })
+
+  it('a detail keys separately, so one skill body never answers for another', () => {
+    const c = createAsideCache(4, 10_000)
+    c.write(asideKey('s1', 'skill', 'deploy'), 'A', 0)
+    c.write(asideKey('s1', 'skill', 'review'), 'B', 0)
+    expect(c.read(asideKey('s1', 'skill', 'deploy')).value).toBe('A')
+    expect(c.read(asideKey('s1', 'skill', 'review')).value).toBe('B')
+  })
+})

--- a/packages/web/src/lib/asideCache.ts
+++ b/packages/web/src/lib/asideCache.ts
@@ -1,0 +1,106 @@
+/**
+ * asideCache.ts — what the artifacts panel already read, kept across an open/close.
+ *
+ * The panel's tabs held their answers in component state, so CLOSING the aside destroyed them and
+ * opening it again re-read every one from zero — the skills list, the repository's pull requests,
+ * a skill's own body. Reported exactly that way: "if I close the aside and come back it reloads
+ * everything from scratch, and it is slow as hell". Nothing about those answers is per-mount; they
+ * are facts about a SESSION, and the panel is a view of them.
+ *
+ * IT IS A CACHE, NOT A STORE. Every entry carries when it was read, and `read` says whether what it
+ * hands back is STALE. The panel renders the cached answer at once and refreshes behind it, so the
+ * list is instant and still current — a cache that could only ever be fresh would have to block,
+ * which is the behaviour being fixed, and one that never refreshed would show yesterday's pull
+ * requests forever.
+ *
+ * BOUNDED, and by SESSION. A fleet is dozens of conversations and a browser tab lives for days, so
+ * the map is capped and the least-recently-read SESSION goes first — dropping one topic of a
+ * session that is still open would make that one tab reload while its siblings did not, which is
+ * the same surprise in miniature.
+ *
+ * It holds only what the server already returned to this browser, and nothing is persisted: a page
+ * reload is a new question, and an answer surviving into a session that may have been renamed,
+ * reopened or killed in the meantime is a stale claim with nothing left to correct it.
+ */
+
+/** How long an answer is believed without a re-read. Long enough to survive an open/close cycle. */
+export const ASIDE_TTL_MS = 60_000
+
+/** How many sessions' answers are kept at once. */
+export const MAX_ASIDE_SESSIONS = 12
+
+interface Entry<T> {
+  value: T
+  /** When it was read, by the caller's clock. */
+  atMs: number
+  /** Last time it was HANDED BACK — what eviction orders on. */
+  usedMs: number
+}
+
+/** What one lookup answers. `value` absent means nothing is cached and the caller must read. */
+export interface AsideRead<T> {
+  value?: T
+  /**
+   * The cached value is older than the TTL.
+   *
+   * True WITH a `value` means "draw this now, and refresh behind it" — never "discard it". A stale
+   * answer on screen while a fresh one is on its way is the whole point; a spinner over an answer
+   * we already have is the reload this module exists to remove.
+   */
+  stale: boolean
+}
+
+export interface AsideCache {
+  read<T>(key: string, nowMs?: number): AsideRead<T>
+  write<T>(key: string, value: T, nowMs?: number): void
+  /** Forget everything about one session — after a kill, or when the row is gone. */
+  forgetSession(sessionId: string): void
+  clear(): void
+}
+
+/** The key one answer is filed under. A session AND a topic, never a topic alone. */
+export function asideKey(sessionId: string, topic: string, detail = ''): string {
+  return detail ? `${sessionId} ${topic} ${detail}` : `${sessionId} ${topic}`
+}
+
+/** Does this key belong to that session? Exact on the id — a prefix would match `abc` from `abcd`. */
+export function keyOfSession(key: string, sessionId: string): boolean {
+  return key.startsWith(`${sessionId} `)
+}
+
+export function createAsideCache(max = MAX_ASIDE_SESSIONS, ttlMs = ASIDE_TTL_MS): AsideCache {
+  const entries = new Map<string, Entry<unknown>>()
+
+  const evict = (): void => {
+    const seen = new Map<string, number>()
+    for (const [k, e] of entries) {
+      const id = k.split(' ')[0] ?? ''
+      seen.set(id, Math.max(seen.get(id) ?? 0, e.usedMs))
+    }
+    if (seen.size <= max) return
+    const order = [...seen.entries()].sort((a, b) => a[1] - b[1])
+    for (const [id] of order.slice(0, seen.size - max)) {
+      for (const k of [...entries.keys()]) if (keyOfSession(k, id)) entries.delete(k)
+    }
+  }
+
+  return {
+    read<T>(key: string, nowMs = Date.now()): AsideRead<T> {
+      const hit = entries.get(key)
+      if (!hit) return { stale: true }
+      hit.usedMs = nowMs
+      return { value: hit.value as T, stale: nowMs - hit.atMs >= ttlMs }
+    },
+    write<T>(key: string, value: T, nowMs = Date.now()): void {
+      entries.set(key, { value, atMs: nowMs, usedMs: nowMs })
+      evict()
+    },
+    forgetSession(sessionId: string): void {
+      for (const k of [...entries.keys()]) if (keyOfSession(k, sessionId)) entries.delete(k)
+    },
+    clear(): void { entries.clear() },
+  }
+}
+
+/** The one cache the panel uses. Module-level, so it outlives every mount of the aside. */
+export const asideCache = createAsideCache()

--- a/packages/web/src/lib/fleet.ts
+++ b/packages/web/src/lib/fleet.ts
@@ -60,6 +60,8 @@ export interface FleetRow {
   task?: string
   note?: string
   model?: string
+  /** The reasoning effort this session was started with. Absent = the harness's own default. */
+  effort?: string
   conversationId?: string
   approvalLines?: string[]
   dialogOptions?: { number: number; label: string; selected?: boolean }[]

--- a/packages/web/src/pages/SessionsPage.tsx
+++ b/packages/web/src/pages/SessionsPage.tsx
@@ -121,6 +121,8 @@ export default function SessionsPage() {
   const [artifacts, setArtifacts] = useState<readonly Artifact[]>([])
   const [artifactsLoading, setArtifactsLoading] = useState(true)
   const [artifactsUnavailable, setArtifactsUnavailable] = useState<string | undefined>(undefined)
+  /** The conversation behind these lists is the END of a longer one — see `chat-web.ts`'s `older`. */
+  const [artifactsOlder, setArtifactsOlder] = useState<string | undefined>(undefined)
   const [artifactsUnlisted, setArtifactsUnlisted] = useState(false)
   /** The conversation's turns, for the LIVE tab — the same ones the chat renders. */
   const [artifactTurns, setArtifactTurns] = useState<readonly LiveTurn[]>([])
@@ -186,12 +188,13 @@ export default function SessionsPage() {
     return () => { window.removeEventListener('mousemove', move); window.removeEventListener('mouseup', up) }
   }, [artWidth])
   const art = useArtifacts()
-  const onArtifacts = useCallback((a: { artifacts: Artifact[]; loading: boolean; unavailable?: string; unlisted: boolean; turns: readonly LiveTurn[] }) => {
+  const onArtifacts = useCallback((a: { artifacts: Artifact[]; loading: boolean; unavailable?: string; older?: string; unlisted: boolean; turns: readonly LiveTurn[] }) => {
     setArtifacts(a.artifacts)
     setArtifactsUnlisted(a.unlisted)
     setArtifactTurns(a.turns)
     setArtifactsLoading(a.loading)
     setArtifactsUnavailable(a.unavailable)
+    setArtifactsOlder(a.older)
     if (selected) setArtifactCount(selected.id, a.artifacts.length)
   }, [selected])
 
@@ -356,6 +359,7 @@ export default function SessionsPage() {
       facts={onDisk}
       loading={artifactsLoading}
       {...(artifactsUnavailable ? { unavailable: artifactsUnavailable } : {})}
+      {...(artifactsOlder ? { older: artifactsOlder } : {})}
       unlistedWrites={artifactsUnlisted}
       turns={artifactTurns}
       tabRequest={art.tabRequest}


### PR DESCRIPTION
Six reported problems, each root-caused by measurement rather than inference.

### 1. Creating a session took VERY long

Phase by phase: `tmux new-session` **7ms**, `startableHarnesses` 1ms, repo facts 23ms cold,
registry read 1ms — then `spawn` **awaited** `deliverInitialPrompt`, which polls the pane until the
harness draws its input box, up to a fifteen-second deadline. The browser spun for the whole of
claude's startup over a session running since millisecond seven.

The session exists the moment tmux has it. The prompt is now a follow-up: the promise is returned
for a caller that must wait and caught so the normal one never sees an unhandled rejection. A
`batch` now starts its sessions in parallel instead of one startup after another.

### 2. The aside reloaded every tab on reopen

The tabs held their answers in component state, so unmounting destroyed the skills list, the
repository's pull requests and any skill body already read. `asideCache.ts` is a bounded,
session-keyed cache with a TTL: a cached answer is drawn immediately and refreshed behind it only
once it has aged out. Eviction drops a whole session, never one of its tabs. Nothing is persisted.

### 3. The wizard did not name the default model or effort

No CLI publishes a default in its `--help`, so `spawn-spec.ts` (pure, static) carries none — but
this machine's own settings files do, and that is exactly what the session will obey.
`harness-defaults.ts` reads one named key per file, each verified against a real one:
claude → `model`, codex → `model` + `model_reasoning_effort`, kimi → `default_model`,
antigravity → `model`. gemini and copilot name none and stay absent.

Those files also hold credentials, so the module reads one key per file and its test greps its own
source and fails if it names another — the `billing-detect.ts` guard.

### 4. A session waiting for you read as `working`

claude prints `esc to interrupt` whenever anything is interruptible, a background subagent
included. The MAIN agent's own spinner is what says it is producing (`AttentionRules.mainWorking`,
captured live). The bare marker is said rather than dropped: the row reads **`needs you ·
subagent`**, riding on `stateLabel` so the cockpit, `session ls`, the workspace, the extension and
the relayed fleet all inherit it from one place.

### 5. The gallery emptied itself with no warning

Measured on the transcript that produced it — 38 MB, 11.834 lines, three compaction summaries, all
in one file. Compaction was the coincidence; the cause is the chat read's 400-turn cap. The window
is now stated at the top of the chat, at the top of a non-empty gallery, and instead of the
"nothing sent yet" empty state, which was false.

### 6. The session card now says how it is running

Model and effort off the row (what agentop was asked to start — a different claim from what the
store observed), plus how many times the conversation has been **compacted**, counted over the
whole transcript from the field the harness itself declares. Absent, never zero, when it cannot be
established.

`bun tsc --noEmit` clean; 5809 pass / 1 skip / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169AqN9y1YGiog3T4qTLVfA