### PR TITLE
fix(sessions): honest subagent count, a PR tab that says whose PRs, and no eternally queued message

### DIFF
--- a/packages/server/server/sessions/github-prs.ts
+++ b/packages/server/server/sessions/github-prs.ts
@@ -45,7 +45,20 @@ export interface PrList {
   unavailable?: PrUnavailable
   /** The message `gh` itself printed, for `failed`. Never composed here. */
   detail?: string
+  /**
+   * How many the read asked for — `PR_LIMIT`, travelling so the UI can SAY it.
+   *
+   * The list is newest-first and capped, so a repository with more than this many pull requests
+   * shows a WINDOW; a panel that does not say so reads as the whole set, which is how a reader
+   * concludes a PR was deleted. The number is on the wire rather than restated in the browser
+   * because `packages/web` cannot import this module, and a second copy of a cap is a second
+   * number to change.
+   */
+  limit?: number
 }
+
+/** How many pull requests one read asks for. A tab, not an archive. */
+export const PR_LIMIT = 30
 
 /** The exact JSON fields asked of `gh`. Kept beside the parser so the two cannot drift. */
 export const PR_FIELDS = 'number,title,url,state,isDraft,reviewDecision,headRefName,author,updatedAt'
@@ -120,7 +133,8 @@ export function classifyPrFailure(code: number, stderr: string): PrUnavailable {
  * Run `gh` in a session's directory and read back its pull requests.
  *
  * The IMPURE half, deliberately thin: everything it decides is one of the two pure functions above.
- * `--limit 30` because this is a tab, not an archive, and the list is newest-first.
+ * `PR_LIMIT` because this is a tab, not an archive, and the list is newest-first — the cap travels
+ * back on `PrList.limit` so the panel can say which window it is showing.
  *
  * The cwd is the SESSION'S, so the repository is whichever one that session is working in — asking
  * from the server's own directory would answer about agentop on a machine using it for something
@@ -130,7 +144,7 @@ export async function readPullRequests(cwd: string): Promise<PrList> {
   if (!cwd) return { pulls: [], unavailable: 'no-repo' }
   try {
     const proc = Bun.spawn(
-      ['gh', 'pr', 'list', '--limit', '30', '--state', 'all', '--json', PR_FIELDS],
+      ['gh', 'pr', 'list', '--limit', String(PR_LIMIT), '--state', 'all', '--json', PR_FIELDS],
       { cwd, stdout: 'pipe', stderr: 'pipe' },
     )
     const [out, err] = await Promise.all([
@@ -146,7 +160,7 @@ export async function readPullRequests(cwd: string): Promise<PrList> {
         ...(kind === 'failed' && err.trim() ? { detail: err.trim().split('\n').slice(0, 2).join(' ') } : {}),
       }
     }
-    return { pulls: parsePrList(out) }
+    return { pulls: parsePrList(out), limit: PR_LIMIT }
   } catch (e) {
     // `gh` missing entirely lands here on some platforms rather than as an exit code.
     return { pulls: [], unavailable: classifyPrFailure(127, e instanceof Error ? e.message : '') }

--- a/packages/web/src/components/sessions/ArtifactsAside.tsx
+++ b/packages/web/src/components/sessions/ArtifactsAside.tsx
@@ -44,6 +44,7 @@ import {
   galleryFileCount, galleryGroups, parseGalleryScope, parseGalleryView, producedGroups,
   type GalleryScope, type GalleryTurn, type GalleryView,
 } from '../../lib/gallery'
+import { prCaption } from '../../lib/prCaption'
 import { ArtifactDoc } from './ArtifactDoc'
 import { GalleryTab } from './GalleryTab'
 
@@ -263,12 +264,10 @@ export function ArtifactsAside({
     pulls: { number: number; title: string; url: string; state: string; draft: boolean; review?: string; branch: string }[]
     unavailable?: string
     detail?: string
+    /** The cap the server read with — see `github-prs.ts`'s `PR_LIMIT`. Never restated here. */
+    limit?: number
   }
-  const [prs, setPrs] = useState<{
-    pulls: { number: number; title: string; url: string; state: string; draft: boolean; review?: string; branch: string }[]
-    unavailable?: string
-    detail?: string
-  } | null>(() => asideCache.read<PrAnswer>(asideKey(sessionId, 'prs')).value ?? null)
+  const [prs, setPrs] = useState<PrAnswer | null>(() => asideCache.read<PrAnswer>(asideKey(sessionId, 'prs')).value ?? null)
   useEffect(() => {
     if (tab !== 'prs') return
     const key = asideKey(sessionId, 'prs')
@@ -718,7 +717,11 @@ export function ArtifactsAside({
       ) : prs.pulls.length === 0 ? (
         <Note text={pt ? 'Nenhum pull request neste repositório.' : 'No pull requests in this repository.'} />
       ) : (
-        prs.pulls.map(pr => (
+        <>
+          <p style={{
+            margin: '0 0 8px', fontSize: 10.5, lineHeight: 1.45, color: 'var(--text-tertiary)',
+          }}>{prCaption({ shown: prs.pulls.length, limit: prs.limit, lang: pt ? 'pt' : 'en' })}</p>
+          {prs.pulls.map(pr => (
           <a
             key={pr.number}
             href={pr.url}
@@ -749,7 +752,8 @@ export function ArtifactsAside({
               }}>{pr.branch}</span>
             )}
           </a>
-        ))
+          ))}
+        </>
       )}
     </div>
   )

--- a/packages/web/src/lib/echoMatch.test.ts
+++ b/packages/web/src/lib/echoMatch.test.ts
@@ -72,3 +72,25 @@ test('a SHORT prose still needs an exact match', () => {
   expect(pendingEchoes([echo], ['[Image #1]tudo okay por aqui'])).toEqual([echo])
   expect(pendingEchoes([echo], ['[Image #1]ok'])).toEqual([])
 })
+
+test('a short echo the comparisons cannot recognise is retired by a LATER one that landed', () => {
+  // The reported shape: `btw` is under SAFE_CONTAINS_LEN, so only equality is allowed, and the
+  // harness stored it joined to the next message. Delivery is FIFO, so the second landing proves
+  // the first was read.
+  expect(pendingEchoes(
+    ['btw', 'faz o merge e sobe o binário'],
+    ['btw\r\nfaz o merge e sobe o binário'],
+  )).toEqual([])
+})
+
+test('the ordering rule never reaches past the last landing', () => {
+  // The third was delivered AFTER the one that landed and is genuinely still waiting.
+  expect(pendingEchoes(
+    ['ok', 'uma frase longa o bastante para casar', 'sim'],
+    ['uma frase longa o bastante para casar'],
+  )).toEqual(['sim'])
+})
+
+test('with nothing landed, a short echo still waits', () => {
+  expect(pendingEchoes(['btw'], ['outra coisa qualquer'])).toEqual(['btw'])
+})

--- a/packages/web/src/lib/echoMatch.ts
+++ b/packages/web/src/lib/echoMatch.ts
@@ -35,6 +35,21 @@
  * there is no prose (a message that was only files), by the COUNT: a stored turn that is nothing
  * but markers, as many as the echo carried paths. That second rule is narrow on purpose — it never
  * fires on a turn that has words in it.
+ *
+ * THE THIRD SHAPE — A SHORT MESSAGE WITH NO WAY OUT, and this one had no expiry at all. Every rule
+ * above is a comparison, so a message the comparisons cannot recognise waits FOREVER. Under
+ * `SAFE_CONTAINS_LEN` only equality is allowed — deliberately, a two-letter echo appears inside
+ * unrelated turns by coincidence — and the queue-joining shape above is exactly what makes equality
+ * fail. Reported with a three-letter message: "executei o btw no claude e n apareceu nada na
+ * sessão, na real tá enfileirado eternamente." It had been read and answered.
+ *
+ * The way out is not a timeout — a session really can sit on its queue for an hour, and a timer
+ * that retires an unread message is the one error worse than this one. It is ORDER. Delivery is
+ * FIFO: the write channel is FIFO by construction, `editEcho` APPENDS, and a harness commits its
+ * input queue in the order it arrived. So a LATER echo appearing in the transcript is proof that
+ * every earlier one was read — it could not have been overtaken. `landedIndex` is that rule, and it
+ * costs nothing in confidence: the later echo was recognised by the very comparisons above, and the
+ * earlier ones are then a deduction from ordering rather than a guess about their text.
  */
 
 /** Whitespace is collapsed on both sides: the harness re-wraps what it stores, and adds `\r`. */
@@ -89,23 +104,39 @@ export function pendingEchoes(
   userTurns: readonly string[],
 ): string[] {
   const seen = userTurns.map(collapseEcho).filter(t => t !== '')
-  const landed = (c: string): boolean =>
-    seen.includes(c) || (c.length >= SAFE_CONTAINS_LEN && seen.some(t => t.includes(c)))
-  return echoes.filter(text => {
-    const c = collapseEcho(text)
-    if (c === '') return false
-    if (landed(c)) return false
-    const { prose, paths } = echoProse(text)
-    if (paths === 0) return true
-    // The prose against the stored turn with its leading markers removed. EXACT equality is enough
-    // here and is what makes it safe for a two-word message: the markers stand exactly where the
-    // paths stood, so what remains on both sides is the same typed sentence — no coincidence to
-    // guard against, and none of the length rule's caution is needed.
-    const stripped = userTurns.map(withoutLeadingMarkers).filter(t => t !== '')
-    if (prose !== '' && (stripped.includes(prose)
-      || (prose.length >= SAFE_CONTAINS_LEN && stripped.some(t => t.includes(prose))))) return false
-    // Only files and no words: match a turn that is only markers, as many as there were paths.
-    if (prose === '' && userTurns.some(t => markerOnlyCount(t) === paths)) return false
-    return true
-  })
+  const stripped = userTurns.map(withoutLeadingMarkers).filter(t => t !== '')
+  const inTranscript = echoes.map(text => carriedByTranscript(text, userTurns, seen, stripped))
+  // The LAST echo the comparisons recognised. Delivery is FIFO, so everything before it went into
+  // the same pane earlier and was read no later — see the header's third shape.
+  const lastLanded = inTranscript.lastIndexOf(true)
+  return echoes.filter((_text, i) => i > lastLanded && !inTranscript[i])
+}
+
+/**
+ * Whether the transcript carries this one echo, judged on TEXT alone.
+ *
+ * Split out because `pendingEchoes` now needs the answer for every echo, not just the one it is
+ * deciding: the ordering rule above reads the whole vector.
+ */
+function carriedByTranscript(
+  text: string,
+  userTurns: readonly string[],
+  seen: readonly string[],
+  stripped: readonly string[],
+): boolean {
+  const c = collapseEcho(text)
+  // An empty echo is nothing to wait for; treated as carried so it is dropped either way.
+  if (c === '') return true
+  if (seen.includes(c) || (c.length >= SAFE_CONTAINS_LEN && seen.some(t => t.includes(c)))) return true
+  const { prose, paths } = echoProse(text)
+  if (paths === 0) return false
+  // The prose against the stored turn with its leading markers removed. EXACT equality is enough
+  // here and is what makes it safe for a two-word message: the markers stand exactly where the
+  // paths stood, so what remains on both sides is the same typed sentence — no coincidence to
+  // guard against, and none of the length rule's caution is needed.
+  if (prose !== '' && (stripped.includes(prose)
+    || (prose.length >= SAFE_CONTAINS_LEN && stripped.some(t => t.includes(prose))))) return true
+  // Only files and no words: match a turn that is only markers, as many as there were paths.
+  if (prose === '' && userTurns.some(t => markerOnlyCount(t) === paths)) return true
+  return false
 }

--- a/packages/web/src/lib/prCaption.test.ts
+++ b/packages/web/src/lib/prCaption.test.ts
@@ -1,0 +1,26 @@
+import { expect, test } from 'bun:test'
+import { prCaption } from './prCaption'
+
+test('names the window only when the list is actually capped', () => {
+  expect(prCaption({ shown: 30, limit: 30, lang: 'pt' })).toContain('30 pull requests mais recentes')
+  expect(prCaption({ shown: 4, limit: 30, lang: 'pt' })).not.toContain('30')
+  expect(prCaption({ shown: 30, limit: 30, lang: 'en' })).toContain('30 most recent')
+  expect(prCaption({ shown: 4, limit: 30, lang: 'en' })).not.toContain('30')
+})
+
+test('says the list is the repository\'s in every shape', () => {
+  for (const lang of ['pt', 'en'] as const) {
+    for (const limit of [undefined, 30]) {
+      for (const shown of [1, 30]) {
+        const s = prCaption({ shown, limit, lang })
+        expect(lang === 'pt' ? s.includes('repositório') : s.includes('repository')).toBe(true)
+        expect(lang === 'pt' ? s.includes('não só desta') : s.includes('not only this one')).toBe(true)
+      }
+    }
+  }
+})
+
+test('an absent limit never claims a window — an older server sends none', () => {
+  expect(prCaption({ shown: 30, limit: undefined, lang: 'pt' })).not.toContain('mais recentes')
+  expect(prCaption({ shown: 30, limit: 0, lang: 'en' })).not.toContain('most recent')
+})

--- a/packages/web/src/lib/prCaption.ts
+++ b/packages/web/src/lib/prCaption.ts
@@ -1,0 +1,31 @@
+/**
+ * prCaption.ts — the one sentence over the PRs list, PURE.
+ *
+ * The list is the REPOSITORY'S pull requests, read by running `gh` in the session's directory —
+ * so a session sees the PRs its siblings opened, and there is no filter by branch, author or
+ * session. Read inside a panel titled with a session's name, that is genuinely surprising: it was
+ * reported as "there are PRs here from other sessions of the repo".
+ *
+ * It is also a WINDOW. `github-prs.ts` reads `PR_LIMIT` newest-first, so on a busy repository the
+ * older ones are simply not in the answer — and a list that does not say so reads as the whole
+ * set, which is how somebody concludes a pull request was deleted.
+ *
+ * Two facts, and the second only when it is TRUE: below the cap the list IS complete, and calling
+ * it "the 30 most recent" there would invent a window that is not there. `shown < limit` is the
+ * only thing that settles it, because `gh` reports no total.
+ */
+
+export function prCaption(
+  args: { shown: number; limit?: number; lang: 'pt' | 'en' },
+): string {
+  const { shown, limit, lang } = args
+  const capped = typeof limit === 'number' && limit > 0 && shown >= limit
+  if (lang === 'pt') {
+    return capped
+      ? `Os ${limit} pull requests mais recentes deste repositório — de todas as sessões, não só desta.`
+      : 'Os pull requests deste repositório — de todas as sessões, não só desta.'
+  }
+  return capped
+    ? `The ${limit} most recent pull requests in this repository — from every session, not only this one.`
+    : 'The pull requests in this repository — from every session, not only this one.'
+}

--- a/packages/web/src/lib/sessionStats.ts
+++ b/packages/web/src/lib/sessionStats.ts
@@ -94,8 +94,23 @@ export function sessionStats(
   const used = num((meta as { context_tokens?: number }).context_tokens)
   const fraction = caps?.contextWindow ? contextFraction(used, window) : null
 
-  const invocations = meta.agentMetrics?.invocations ?? []
-  const subagents = caps?.agents
+  /**
+   * ABSENT `agentMetrics` IS NOT AN EMPTY LIST, and reading it as one is rule 2 of this file broken
+   * in the one place it was written down.
+   *
+   * `?? []` made a record with no `agentMetrics` at all report `None ran` — a confident zero about
+   * something the reader could not see. Measured on a live 39 MB transcript that dispatched several
+   * subagents: NO `Agent` tool_use is written into the parent at all (tool names present: Bash,
+   * Read, Write, Edit, AskUserQuestion, Skill, ToolSearch, one MCP call), and no
+   * `toolUseResult.agentType` either — a background agent leaves the parent transcript no record,
+   * so `extractAgentMetrics` has nothing to find and the field is never written. "None ran" was
+   * therefore false on exactly the conversations that ran the most of them.
+   *
+   * An EMPTY array is still a real zero: the parser looked and found none. The distinction is the
+   * whole point — one is an answer, the other is the absence of one.
+   */
+  const invocations = meta.agentMetrics?.invocations
+  const subagents = caps?.agents && invocations !== undefined
     ? {
       count: invocations.length,
       tokens: invocations.reduce((n, i) => n + num(i.totalTokens), 0),


### PR DESCRIPTION
Three fixes that landed just after the v2.14.0 cut.

### `SUBAGENTS — None ran`, on a conversation that ran several

`meta.agentMetrics?.invocations ?? []` read an ABSENT record as an empty one. Measured on the live
39 MB transcript that produced the screenshot: **no `Agent` tool_use is written into the parent at
all** (tool names present: Bash, Read, Write, Edit, AskUserQuestion, Skill, ToolSearch, one MCP
call) and no `toolUseResult.agentType` either — a background agent leaves the parent transcript no
record, so `extractAgentMetrics` has nothing to find. "None ran" was false on exactly the
conversations that ran the most of them.

An empty array stays a real zero: the parser looked and found none. Absent is now `null`.

### The PR tab said nothing about whose PRs it lists

They are the **repository's** — `gh pr list --limit 30 --state all` in the session's `cwd`, no
filter by session, branch or author. The cap travels on the wire as `PrList.limit` rather than
being restated in the browser, and the pure `prCaption` claims the window only when there IS one:
below the cap the list is complete, and calling it "the 30 most recent" would invent a slice.

### A short message queued forever

Every rule in `pendingEchoes` is a comparison, so a message the comparisons cannot recognise waits
forever. Under `SAFE_CONTAINS_LEN` only equality is allowed — deliberately — and the harness commits
its input queue as ONE turn, joining a short message to the next, which is what makes equality fail.
Reported with a three-letter message that had been read and answered and kept its "queued" label.

The way out is not a timeout — a session can legitimately sit on its queue for an hour, and
retiring an unread message is the one error worse than this. It is ORDER: delivery is FIFO, so a
LATER echo appearing in the transcript proves every earlier one was read.

`bun tsc --noEmit` clean; 5815 pass / 1 skip / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169AqN9y1YGiog3T4qTLVfA