### PR TITLE
fix(sessions): the PR caption's cap reaches the browser, and a weak echo match stops clearing the queue

### DIFF
--- a/packages/server/server/sessions/fleet-web.ts
+++ b/packages/server/server/sessions/fleet-web.ts
@@ -471,7 +471,7 @@ export async function readConversationFacts(
 
 export async function readFleetPullRequests(
   lang: CliLang, id: string,
-): Promise<{ pulls: unknown[]; unavailable?: string; detail?: string }> {
+): Promise<{ pulls: unknown[]; limit?: number; unavailable?: string; detail?: string }> {
   const pt = lang === 'pt'
   const host = await hostFor(lang)
   if (!host.sessions) return { pulls: [], unavailable: 'no-repo' }
@@ -490,6 +490,12 @@ export async function readFleetPullRequests(
   const out = await readPullRequests(row.cwd)
   return {
     pulls: out.pulls,
+    // The cap the read actually used. This reply is built FIELD BY FIELD rather than spread, which
+    // is right — it is the boundary between a module's shape and the wire — but it means a new
+    // field is on the wire only once it is named HERE. `limit` was added to `PrList` and to the
+    // browser's type and forgotten in this object, so the caption could never claim the window and
+    // said the same sentence for four pull requests and for thirty.
+    ...(out.limit !== undefined ? { limit: out.limit } : {}),
     ...(out.unavailable ? { unavailable: out.unavailable } : {}),
     ...(out.detail ? { detail: out.detail } : {}),
   }

--- a/packages/server/server/sessions/github-prs.test.ts
+++ b/packages/server/server/sessions/github-prs.test.ts
@@ -1,4 +1,6 @@
-import { expect, test } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it, test } from 'bun:test'
 import { classifyPrFailure, parsePrList } from './github-prs'
 
 test('a real `gh pr list --json` payload parses', () => {
@@ -48,4 +50,32 @@ test('each absence is told apart, and an unknown one keeps its output', () => {
   expect(classifyPrFailure(1, 'fatal: not a git repository')).toBe('no-repo')
   // Not guessed at — the caller passes the output through, which beats a wrong label.
   expect(classifyPrFailure(1, 'HTTP 503 upstream is unavailable')).toBe('failed')
+})
+
+describe('every field of PrList reaches the wire', () => {
+  /**
+   * `readFleetPullRequests` builds its reply FIELD BY FIELD rather than spreading `PrList`. That is
+   * right — it is the boundary between a module's shape and what a browser is handed — but it means
+   * a new field is on the wire only once it is named there, and nothing else notices when it is not.
+   *
+   * That happened: `limit` was added to `PrList`, added to the browser's own type and to the
+   * caption, and forgotten in that one object. The caption then said the same sentence for four
+   * pull requests and for thirty — the exact claim it exists to make, never made.
+   *
+   * A grep, in the shape `tokens.lint.test.ts` uses over the product source, because the honest
+   * alternative would be an integration test that shells out to `gh` against a live repository.
+   */
+  const prs = readFileSync(join(import.meta.dir, 'github-prs.ts'), 'utf-8')
+  const web = readFileSync(join(import.meta.dir, 'fleet-web.ts'), 'utf-8')
+  const reply = web.slice(web.indexOf('export async function readFleetPullRequests'))
+    .slice(0, web.slice(web.indexOf('export async function readFleetPullRequests')).indexOf('\n}\n') + 3)
+
+  const fields = [...prs.slice(prs.indexOf('export interface PrList'))
+    .slice(0, prs.slice(prs.indexOf('export interface PrList')).indexOf('\n}'))
+    .matchAll(/^\s{2}(\w+)\??:/gm)].map(m => m[1]!)
+
+  it('names every one of them', () => {
+    expect(fields.length).toBeGreaterThan(1)
+    for (const f of fields) expect(reply).toContain(`${f}:`)
+  })
 })

--- a/packages/web/src/lib/echoMatch.test.ts
+++ b/packages/web/src/lib/echoMatch.test.ts
@@ -94,3 +94,13 @@ test('the ordering rule never reaches past the last landing', () => {
 test('with nothing landed, a short echo still waits', () => {
   expect(pendingEchoes(['btw'], ['outra coisa qualquer'])).toEqual(['btw'])
 })
+
+test('a SHORT coincidental match never retires the messages before it', () => {
+  // "ok" equals an "ok" the person typed an hour ago. That is the coincidence SAFE_CONTAINS_LEN
+  // guards against; it may drop its own echo and nothing else, or one stale word silently clears
+  // a queue of real messages.
+  expect(pendingEchoes(
+    ['uma mensagem de verdade que ainda espera', 'ok'],
+    ['ok'],
+  )).toEqual(['uma mensagem de verdade que ainda espera'])
+})

--- a/packages/web/src/lib/echoMatch.ts
+++ b/packages/web/src/lib/echoMatch.ts
@@ -99,44 +99,61 @@ function withoutLeadingMarkers(turn: string): string {
   return collapseEcho(turn.trim().replace(/^(?:\[Image #\d+\]\s*)+/, ''))
 }
 
+/**
+ * How the transcript accounts for one echo.
+ *
+ *   `no`      nothing in the transcript looks like it — still waiting.
+ *   `weak`    matched, but only by EQUALITY on a string under `SAFE_CONTAINS_LEN`. Good enough to
+ *             retire that one echo, and NOT good enough to speak for the ones before it.
+ *   `anchor`  matched by a comparison a coincidence cannot fake.
+ */
+type EchoMatch = 'no' | 'weak' | 'anchor'
+
 export function pendingEchoes(
   echoes: readonly string[],
   userTurns: readonly string[],
 ): string[] {
   const seen = userTurns.map(collapseEcho).filter(t => t !== '')
   const stripped = userTurns.map(withoutLeadingMarkers).filter(t => t !== '')
-  const inTranscript = echoes.map(text => carriedByTranscript(text, userTurns, seen, stripped))
-  // The LAST echo the comparisons recognised. Delivery is FIFO, so everything before it went into
-  // the same pane earlier and was read no later — see the header's third shape.
-  const lastLanded = inTranscript.lastIndexOf(true)
-  return echoes.filter((_text, i) => i > lastLanded && !inTranscript[i])
+  const match = echoes.map(text => matchEcho(text, userTurns, seen, stripped))
+  // The last echo matched by something a coincidence cannot fake. Delivery is FIFO, so everything
+  // before it went into the same pane earlier and was read no later — the header's third shape.
+  //
+  // ONLY an `anchor` may speak for the messages before it. A `weak` match is the very coincidence
+  // `SAFE_CONTAINS_LEN` exists to guard against — a person types "ok" and the transcript has an
+  // "ok" from an hour ago — and letting one of those anchor the rule turns a mistake that cost ONE
+  // spurious retirement into one that silently clears the whole queue behind it. A message the
+  // person can no longer see is the failure this file exists to prevent.
+  const lastAnchor = match.lastIndexOf('anchor')
+  return echoes.filter((_text, i) => i > lastAnchor && match[i] === 'no')
 }
 
 /**
- * Whether the transcript carries this one echo, judged on TEXT alone.
+ * How the transcript accounts for this one echo, judged on TEXT alone.
  *
  * Split out because `pendingEchoes` now needs the answer for every echo, not just the one it is
  * deciding: the ordering rule above reads the whole vector.
  */
-function carriedByTranscript(
+function matchEcho(
   text: string,
   userTurns: readonly string[],
   seen: readonly string[],
   stripped: readonly string[],
-): boolean {
+): EchoMatch {
   const c = collapseEcho(text)
-  // An empty echo is nothing to wait for; treated as carried so it is dropped either way.
-  if (c === '') return true
-  if (seen.includes(c) || (c.length >= SAFE_CONTAINS_LEN && seen.some(t => t.includes(c)))) return true
+  // An empty echo is nothing to wait for. It anchors nothing — there is no evidence in it.
+  if (c === '') return 'weak'
+  if (seen.includes(c)) return c.length >= SAFE_CONTAINS_LEN ? 'anchor' : 'weak'
+  if (c.length >= SAFE_CONTAINS_LEN && seen.some(t => t.includes(c))) return 'anchor'
   const { prose, paths } = echoProse(text)
-  if (paths === 0) return false
+  if (paths === 0) return 'no'
   // The prose against the stored turn with its leading markers removed. EXACT equality is enough
   // here and is what makes it safe for a two-word message: the markers stand exactly where the
   // paths stood, so what remains on both sides is the same typed sentence — no coincidence to
   // guard against, and none of the length rule's caution is needed.
   if (prose !== '' && (stripped.includes(prose)
-    || (prose.length >= SAFE_CONTAINS_LEN && stripped.some(t => t.includes(prose))))) return true
+    || (prose.length >= SAFE_CONTAINS_LEN && stripped.some(t => t.includes(prose))))) return 'anchor'
   // Only files and no words: match a turn that is only markers, as many as there were paths.
-  if (prose === '' && userTurns.some(t => markerOnlyCount(t) === paths)) return true
-  return false
+  if (prose === '' && userTurns.some(t => markerOnlyCount(t) === paths)) return 'anchor'
+  return 'no'
 }


### PR DESCRIPTION
Two fixes, both found by looking at the running product and re-reading what had just shipped.

### A weak echo match could clear the whole queue — shipped in v2.14.1

The FIFO deduction added in v2.14.1 let ANY recognised echo anchor the rule, including one
recognised by equality on a string under `SAFE_CONTAINS_LEN` — precisely the coincidence that guard
exists to prevent. You type `ok`, the transcript holds an `ok` from an hour ago, and instead of one
echo being retired by mistake the whole queue behind it went with it. An error costing one wrong
line became one that erases messages from the screen.

A match is now `no` / `weak` / `anchor`, and **only an `anchor` speaks for its predecessors**. A
weak match still retires its own echo and nothing else; an empty echo anchors nothing. Verified
directly — a long queued message survives a later short echo that coincidentally equals an old turn.

### The PR caption's cap never reached the browser

`limit` was added to `PrList`, to the browser's type and to `prCaption`, and forgotten in the one
object that builds the wire reply. Measured on a repository with 30 pull requests:
`pulls: 30, limit: undefined` — so the caption said the same sentence for four and for thirty,
which is the exact claim it exists to make.

`readFleetPullRequests` composes its reply field by field rather than spreading, and that is right:
it is the boundary between a module's shape and what a browser is handed. The cost is that a new
field is on the wire only once it is named there. The guard is a grep over the product source, in
the shape `tokens.lint.test.ts` uses — verified by removing the fix (test fails) and restoring it.

`bun tsc --noEmit` clean; 5817 pass / 1 skip / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169AqN9y1YGiog3T4qTLVfA