### PR TITLE
fix(server): read a subagent's own transcript, so agent metrics stop reporting zero

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1185,19 +1185,48 @@ Only active when `SERVE_STATIC=1` (set by `cli.ts` for the `server` subcommand).
 
 Agent metrics are extracted from raw JSONL files by `server/agent-metrics.ts`. They are available in the `agentMetrics` field of each `SessionMeta`.
 
-### Data available per Agent invocation
+### The numbers are in the SUBAGENT'S OWN transcript, not in the parent's result
+
+**Claude Code made the `Agent` tool asynchronous on 2026-08-14 and the parent's `toolUseResult`
+stopped carrying any numbers.** It is now `{ agentId, description, isAsync, outputFile,
+resolvedModel, status: 'async_launched' }` — no `usage`, no `totalTokens`, no `toolStats`, no
+duration. Every `?? 0` in the old reader fired at once and each invocation was published **priced at
+nothing**: measured on one machine, 391 of 391 invocations from 08-14 onward reported 0 tokens while
+the panel kept drawing rows for all of them. That is the whole failure mode worth remembering — a
+PARTIALLY working reader. `agentType` and `description` come from the parent's `tool_use` input, so
+the rows kept their names and only the values were gone, and it went unnoticed for three weeks.
+
+The numbers moved to `~/.claude/projects/<project>/<session-id>/subagents/agent-<agentId>.jsonl`
+(+ an `agent-<agentId>.meta.json` naming the parent's `toolUseId`). `subagent-parse.ts` is **pure**
+— it sums one such transcript — and `subagent-metrics.ts` does the I/O: find, recurse, memoize.
+
+- **`outputFile` is NOT the file to read.** It is the agent's text answer in the run's `/tmp` scratch
+  directory, cleared on reboot and already gone for every invocation measured here. The durable one
+  is under `subagents/`.
+- **Price each model at ITS OWN rate.** A subagent commonly runs `haiku` under an `opus` parent (four
+  distinct models across 440 transcripts here), so one `modelId` for the whole invocation bills a
+  cheap agent as an expensive one — which is exactly what the old reader did with the parent's model.
+- **A nested subagent counts inside the invocation that spawned it.** Only a top-level `Agent`
+  `tool_use` becomes an `AgentInvocation`, so a subtree left out is left out of the session's totals
+  entirely. Cycle-safe by a visited set.
+- **The DURATION is the root's own span** — a nested agent runs inside its parent, and adding the two
+  counts the same wall time twice.
+- **An invocation whose transcript is gone is `unmeasured: true`, never a zero.** Read that flag
+  BEFORE any figure on the record: it carries zeros only because the type has no other value to
+  carry. `SessionAgentMetrics` totals exclude them and `unmeasuredInvocations` counts them, so a
+  surface can say the totals cover fewer rows than it is showing (`web/src/lib/agentMeasured.ts`).
+  Same rule as `HARNESS_CAPABILITIES`, applied to one row instead of a whole harness.
 
 | Field | Source |
 |---|---|
-| `agentType` | `toolUseResult.agentType` in the JSONL message envelope |
+| `agentType` | `toolUseResult.agentType`, else the `tool_use` input's `subagent_type` |
 | `description` | `tool_use.input.description` |
-| `totalTokens` | `toolUseResult.totalTokens` |
-| `totalDurationMs` | `toolUseResult.totalDurationMs` |
-| `totalToolUseCount` | `toolUseResult.totalToolUseCount` |
-| `inputTokens / outputTokens / cacheReadTokens / cacheWriteTokens` | `toolUseResult.usage.*` |
-| `toolStats` (reads, searches, bash, edits, lines changed) | `toolUseResult.toolStats` |
-| `costUSD` | Calculated via `calcCost()` |
-| `status` | `toolUseResult.status` (`completed` / `failed`) |
+| `agentId` | `toolUseResult.agentId` — names the subagent transcript |
+| `totalTokens` (all four counters) / `inputTokens` / `outputTokens` / `cacheReadTokens` / `cacheWriteTokens` | the subagent transcript's `message.usage`, per model; legacy: `toolUseResult.usage.*` |
+| `totalDurationMs` | the subagent transcript's first→last timestamp; legacy: `toolUseResult.totalDurationMs` |
+| `totalToolUseCount` / `toolStats` | the subagent transcript's `tool_use` items and `structuredPatch` hunks; legacy: `toolUseResult.toolStats` |
+| `costUSD` | `calcCost()` per model of the subagent's own turns |
+| `status` | `toolUseResult.status` (`failed` → `failed`, anything else → `completed`) |
 
 ### What is NOT available for Skills and Tasks
 

--- a/docs/data-sources.md
+++ b/docs/data-sources.md
@@ -103,7 +103,12 @@ interface SessionMeta {
 
 Agent metrics are extracted from raw JSONL by `server/agent-metrics.ts`. They are only available for sessions whose JSONL files are accessible (`_source: 'meta'`-only sessions may have incomplete agent data if the underlying JSONL was removed).
 
-### Available per Agent invocation
+### Two transcript shapes, and only one of them holds the numbers
+
+Claude Code made the `Agent` tool **asynchronous on 2026-08-14**, and the shape of the result it
+writes into the parent transcript changed with it. Both are read.
+
+**Legacy (until 2026-08-13)** — the numbers were inline, and the reader took them from there:
 
 | Field | Source in JSONL |
 |---|---|
@@ -116,6 +121,43 @@ Agent metrics are extracted from raw JSONL by `server/agent-metrics.ts`. They ar
 | `toolStats` | `toolUseResult.toolStats` |
 | `costUSD` | Calculated via `calcCost()` |
 | `status` | `toolUseResult.status` |
+
+**Current (2026-08-14 onward)** — the parent's result carries no numbers at all, only a name:
+
+```json
+{ "agentId": "a23c974fb8aab9fbf", "description": "Task 1: backup-plan.ts", "isAsync": true,
+  "status": "async_launched", "resolvedModel": "claude-haiku-4-5-20251001",
+  "outputFile": "/tmp/.../tasks/a23c974fb8aab9fbf.output", "canReadOutputFile": true }
+```
+
+The numbers moved into the subagent's **own transcript**, at
+`~/.claude/projects/<project>/<session-id>/subagents/agent-<agentId>.jsonl`, with an
+`agent-<agentId>.meta.json` beside it carrying `agentType`, `description` and the parent's
+`toolUseId`. `server/subagent-parse.ts` (pure) sums one such transcript and
+`server/subagent-metrics.ts` finds it, follows nested subagents and memoizes the result.
+
+Three rules that fall out of the new shape:
+
+- **`outputFile` is not used.** It points into the run's scratch directory under `/tmp`, holds the
+  agent's text answer rather than its accounting, and is routinely already gone. The durable file is
+  the one under `subagents/`.
+- **Each model is priced at its own rate.** A subagent commonly runs `haiku` under an `opus` parent
+  (four distinct models were measured across 440 subagent transcripts on one machine), so pricing an
+  invocation with the parent's model id bills a cheap agent as an expensive one.
+- **A nested subagent counts inside the invocation that spawned it.** Only a top-level `Agent`
+  `tool_use` becomes an `AgentInvocation`, so a subtree left out here is left out of the session's
+  agent totals entirely. The walk is cycle-safe.
+
+### An invocation whose transcript is gone reports N/A, never zero
+
+Claude Code deletes transcripts after `cleanupPeriodDays`. When a subagent's transcript cannot be
+read, the invocation is still listed — the parent recorded that it happened — and is marked
+`AgentInvocation.unmeasured: true`. Consumers **must read that flag before any figure on the
+record**: an unmeasured invocation carries zeros because the type has no other value to carry.
+`SessionAgentMetrics.totalTokens` / `totalDurationMs` / `totalCostUSD` exclude them and
+`unmeasuredInvocations` counts them, so a surface can say the totals cover fewer invocations than it
+is showing. This is the same rule `HARNESS_CAPABILITIES` applies to a metric a harness cannot
+produce, applied to one row.
 
 ### What is NOT tracked for Skills and Tasks
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -243,9 +243,27 @@ export interface SessionMeta {
 
 export interface AgentInvocation {
   toolUseId: string
+  /**
+   * The subagent's own transcript id, when the harness names one.
+   *
+   * Present since Claude Code made the `Agent` tool asynchronous (2026-08-14): the parent's result
+   * carries no numbers any more, only this id, and the numbers live in
+   * `<project>/<session-id>/subagents/agent-<agentId>.jsonl`. Absent on every record written before
+   * that, and on any harness that names no such file.
+   */
+  agentId?: string
   agentType: string
   description: string
   status: 'completed' | 'failed'
+  /**
+   * `true` when the numbers below could NOT be established for this invocation.
+   *
+   * Read it BEFORE reading any figure here: an unmeasured invocation carries zeros because the type
+   * has no other value to carry, and a zero rendered as a fact is the confident-0 this repository
+   * forbids everywhere else. A surface must render N/A for these, exactly as it does for a metric a
+   * harness cannot produce (`HARNESS_CAPABILITIES`). Absent means measured.
+   */
+  unmeasured?: true
   totalTokens: number
   totalDurationMs: number
   totalToolUseCount: number
@@ -268,6 +286,13 @@ export interface AgentInvocation {
 export interface SessionAgentMetrics {
   invocations: AgentInvocation[]
   totalInvocations: number
+  /**
+   * How many of them carry no established numbers — so a surface can say that the totals beside it
+   * cover fewer invocations than it is showing, instead of implying the rest cost nothing.
+   *
+   * Optional because a record stored before this existed has no such count; absent is not zero.
+   */
+  unmeasuredInvocations?: number
   totalTokens: number
   totalDurationMs: number
   totalCostUSD: number

--- a/packages/server/server/agent-metrics.test.ts
+++ b/packages/server/server/agent-metrics.test.ts
@@ -1,0 +1,89 @@
+import { test, expect } from 'bun:test'
+import { extractAgentMetrics } from './agent-metrics'
+
+/** The `Agent` tool_use as the session transcript records it. */
+function agentCall(id: string, description: string, subagentType = 'general-purpose') {
+  return JSON.stringify({
+    type: 'assistant',
+    message: { content: [{ type: 'tool_use', id, name: 'Agent', input: { description, subagent_type: subagentType } }] },
+  })
+}
+
+/** The result Claude Code writes TODAY: the agent is launched async and carries no numbers. */
+function asyncResult(id: string, agentId: string, description: string) {
+  return JSON.stringify({
+    type: 'user',
+    toolUseResult: {
+      agentId, description, isAsync: true, status: 'async_launched',
+      resolvedModel: 'claude-haiku-4-5-20251001',
+      outputFile: `/tmp/tasks/${agentId}.output`, canReadOutputFile: true,
+    },
+    message: { content: [{ type: 'tool_result', tool_use_id: id }] },
+  })
+}
+
+/** The result Claude Code wrote until 2026-08-13, with the numbers inline. */
+function legacyResult(id: string) {
+  return JSON.stringify({
+    type: 'user',
+    toolUseResult: {
+      status: 'completed', agentType: 'explorer',
+      totalTokens: 900, totalDurationMs: 4200, totalToolUseCount: 6,
+      usage: { input_tokens: 100, output_tokens: 200, cache_read_input_tokens: 5000, cache_creation_input_tokens: 30 },
+      toolStats: { readCount: 2, searchCount: 1, bashCount: 3, editFileCount: 0, linesAdded: 9, linesRemoved: 1, otherToolCount: 0 },
+    },
+    message: { content: [{ type: 'tool_result', tool_use_id: id }] },
+  })
+}
+
+test('the async shape is recorded as UNMEASURED and NAMES its transcript, never priced at zero', () => {
+  const m = extractAgentMetrics([
+    agentCall('toolu_1', 'Task 1: backup-plan.ts'),
+    asyncResult('toolu_1', 'a23c974fb8aab9fbf', 'Task 1: backup-plan.ts'),
+  ], 'claude-opus-5')
+
+  expect(m.invocations).toHaveLength(1)
+  const inv = m.invocations[0]!
+  expect(inv.unmeasured).toBe(true)
+  expect(inv.agentId).toBe('a23c974fb8aab9fbf')
+  expect(inv.description).toBe('Task 1: backup-plan.ts')
+  expect(inv.agentType).toBe('general-purpose')
+})
+
+test('an unmeasured invocation is counted, and counted SEPARATELY', () => {
+  const m = extractAgentMetrics([
+    agentCall('toolu_1', 'one'), asyncResult('toolu_1', 'aOne', 'one'),
+    agentCall('toolu_2', 'two'), legacyResult('toolu_2'),
+  ], 'claude-opus-5')
+
+  expect(m.totalInvocations).toBe(2)
+  expect(m.unmeasuredInvocations).toBe(1)
+})
+
+test('an unmeasured invocation adds nothing to the totals — it is not a zero, it is an absence', () => {
+  const m = extractAgentMetrics([
+    agentCall('toolu_1', 'one'), asyncResult('toolu_1', 'aOne', 'one'),
+  ], 'claude-opus-5')
+
+  expect(m.totalTokens).toBe(0)
+  expect(m.totalCostUSD).toBe(0)
+  expect(m.unmeasuredInvocations).toBe(1)
+})
+
+test('the legacy shape is read exactly as it always was', () => {
+  const m = extractAgentMetrics([
+    agentCall('toolu_2', 'legacy one'), legacyResult('toolu_2'),
+  ], 'claude-opus-5')
+
+  const inv = m.invocations[0]!
+  expect(inv.unmeasured).toBeUndefined()
+  expect(inv.agentType).toBe('explorer')
+  expect(inv.totalTokens).toBe(900)
+  expect(inv.totalDurationMs).toBe(4200)
+  expect(inv.totalToolUseCount).toBe(6)
+  expect(inv.inputTokens).toBe(100)
+  expect(inv.cacheReadTokens).toBe(5000)
+  expect(inv.toolStats.bashCount).toBe(3)
+  expect(inv.costUSD).toBeGreaterThan(0)
+  expect(m.unmeasuredInvocations).toBe(0)
+})

--- a/packages/server/server/agent-metrics.ts
+++ b/packages/server/server/agent-metrics.ts
@@ -1,5 +1,8 @@
 import { readFile } from 'fs/promises'
+import { basename } from 'path'
 import { calcCost } from '@agentistics/core'
+import { totalsOf } from './subagent-parse'
+import { enrichFromSubagentTranscripts } from './subagent-metrics'
 import type { AgentInvocation, SessionAgentMetrics } from '@agentistics/core'
 
 interface ToolUseRecord {
@@ -100,6 +103,27 @@ export function extractAgentMetrics(lines: Iterable<string>, modelId: string): S
         // We have a match — build the AgentInvocation
         pendingAgents.delete(toolUseId)
 
+        /**
+         * Did this result carry NUMBERS at all?
+         *
+         * Since Claude Code made the `Agent` tool asynchronous (measured: the shape changed on
+         * 2026-08-14) the result is only `{ agentId, description, isAsync, outputFile,
+         * resolvedModel, status: 'async_launched' }` — no `usage`, no totals, no `toolStats`. Every
+         * `?? 0` below then fired at once and the invocation was published priced at nothing, which
+         * is exactly the confident zero this repository forbids: the panel kept rendering rows and
+         * only the values were gone, which is why it went unnoticed for three weeks.
+         *
+         * So a result with no numbers is marked UNMEASURED here and enriched from the subagent's own
+         * transcript by `subagent-metrics.ts`. What cannot be found there stays unmeasured, and the
+         * surface renders N/A.
+         */
+        const measured =
+          toolUseResult.usage !== undefined ||
+          toolUseResult.totalTokens !== undefined ||
+          toolUseResult.totalDurationMs !== undefined ||
+          toolUseResult.totalToolUseCount !== undefined ||
+          toolUseResult.toolStats !== undefined
+
         const usage = toolUseResult.usage ?? {}
         const toolStats = toolUseResult.toolStats ?? {}
 
@@ -122,6 +146,8 @@ export function extractAgentMetrics(lines: Iterable<string>, modelId: string): S
 
         invocations.push({
           toolUseId,
+          ...(toolUseResult.agentId ? { agentId: toolUseResult.agentId } : {}),
+          ...(measured ? {} : { unmeasured: true as const }),
           agentType: toolUseResult.agentType ?? pending.input.subagent_type ?? 'unknown',
           description: pending.input.description ?? '',
           status: (toolUseResult.status === 'failed') ? 'failed' : 'completed',
@@ -147,18 +173,7 @@ export function extractAgentMetrics(lines: Iterable<string>, modelId: string): S
     }
   }
 
-  const totalInvocations = invocations.length
-  const totalTokens = invocations.reduce((s, i) => s + i.totalTokens, 0)
-  const totalDurationMs = invocations.reduce((s, i) => s + i.totalDurationMs, 0)
-  const totalCostUSD = invocations.reduce((s, i) => s + i.costUSD, 0)
-
-  return {
-    invocations,
-    totalInvocations,
-    totalTokens,
-    totalDurationMs,
-    totalCostUSD,
-  }
+  return totalsOf(invocations)
 }
 
 /**
@@ -166,7 +181,7 @@ export function extractAgentMetrics(lines: Iterable<string>, modelId: string): S
  * Used for meta-sourced sessions that have agent tool usage.
  */
 export async function extractAgentMetricsFromFile(filePath: string): Promise<SessionAgentMetrics> {
-  const empty: SessionAgentMetrics = { invocations: [], totalInvocations: 0, totalTokens: 0, totalDurationMs: 0, totalCostUSD: 0 }
+  const empty: SessionAgentMetrics = { invocations: [], totalInvocations: 0, unmeasuredInvocations: 0, totalTokens: 0, totalDurationMs: 0, totalCostUSD: 0 }
   let content: string
   try {
     content = await readFile(filePath, 'utf-8')
@@ -190,5 +205,8 @@ export async function extractAgentMetricsFromFile(filePath: string): Promise<Ses
     } catch { continue }
   }
 
-  return extractAgentMetrics(lines, modelId)
+  // The session id is the file's own name — which is exactly what names the `subagents/` directory
+  // holding each subagent's transcript.
+  const sessionId = basename(filePath).replace(/\.jsonl$/, '')
+  return enrichFromSubagentTranscripts(extractAgentMetrics(lines, modelId), filePath, sessionId)
 }

--- a/packages/server/server/jsonl.ts
+++ b/packages/server/server/jsonl.ts
@@ -4,6 +4,7 @@ import { activeMinutesOf } from '@agentistics/core'
 import { getGitFileStats } from './git'
 import { countGitCommands } from './harness-activity'
 import { extractAgentMetrics } from './agent-metrics'
+import { enrichFromSubagentTranscripts } from './subagent-metrics'
 import { addDelta, editDelta, type EditDelta } from './edit-lines'
 
 // File extension → language name (used when session-meta is absent)
@@ -448,9 +449,14 @@ export async function parseSessionJsonl(
   // Use whichever count is higher: git-tracked files changed or files Claude directly edited
   const filesModifiedCount = Math.max(gitFileStats.filesModified, claudeFilesModified.size)
 
-  // Extract agent metrics if this session used the Agent tool
+  // Extract agent metrics if this session used the Agent tool.
+  //
+  // The parse alone can no longer produce the NUMBERS: since Claude Code made the Agent tool
+  // asynchronous the parent transcript names the subagent and nothing else, so the invocations come
+  // back marked `unmeasured` and are filled in from each subagent's own transcript, which sits
+  // beside this file. See `subagent-metrics.ts`.
   const agentMetrics = toolCounts['Agent']
-    ? extractAgentMetrics(iterLines(content), modelId)
+    ? await enrichFromSubagentTranscripts(extractAgentMetrics(iterLines(content), modelId), filePath, sessionId)
     : undefined
 
   return {

--- a/packages/server/server/subagent-metrics.test.ts
+++ b/packages/server/server/subagent-metrics.test.ts
@@ -1,0 +1,96 @@
+import { test, expect } from 'bun:test'
+import { mkdtemp, mkdir, writeFile } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import type { SessionAgentMetrics } from '@agentistics/core'
+import { enrichFromSubagentTranscripts } from './subagent-metrics'
+
+/** A real directory tree, because the thing under test is the file layout itself. */
+async function machine(sessionId: string, files: Record<string, string[]>) {
+  const root = await mkdtemp(join(tmpdir(), 'agentistics-subagents-'))
+  const dir = join(root, sessionId, 'subagents')
+  await mkdir(dir, { recursive: true })
+  for (const [agentId, lines] of Object.entries(files)) {
+    await writeFile(join(dir, `agent-${agentId}.jsonl`), lines.join('\n'))
+  }
+  return { transcriptPath: join(root, `${sessionId}.jsonl`) }
+}
+
+function turn(model: string, out: number, at = '2026-09-01T10:00:00.000Z', content: unknown[] = []) {
+  return JSON.stringify({ type: 'assistant', timestamp: at, message: { model, usage: { output_tokens: out }, content } })
+}
+
+function unmeasured(toolUseId: string, agentId: string): SessionAgentMetrics['invocations'][number] {
+  return {
+    toolUseId, agentId, unmeasured: true, agentType: 'general-purpose', description: 'd',
+    status: 'completed', totalTokens: 0, totalDurationMs: 0, totalToolUseCount: 0,
+    inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0,
+    toolStats: { readCount: 0, searchCount: 0, bashCount: 0, editFileCount: 0, linesAdded: 0, linesRemoved: 0, otherToolCount: 0 },
+    costUSD: 0,
+  }
+}
+
+function metrics(...invocations: SessionAgentMetrics['invocations']): SessionAgentMetrics {
+  return { invocations, totalInvocations: invocations.length, unmeasuredInvocations: invocations.length, totalTokens: 0, totalDurationMs: 0, totalCostUSD: 0 }
+}
+
+test('an unmeasured invocation is filled in from the subagent’s own transcript', async () => {
+  const { transcriptPath } = await machine('s1', {
+    aOne: [turn('claude-sonnet-5', 500, '2026-09-01T10:00:00.000Z'), turn('claude-sonnet-5', 300, '2026-09-01T10:00:30.000Z')],
+  })
+
+  const out = await enrichFromSubagentTranscripts(metrics(unmeasured('toolu_1', 'aOne')), transcriptPath, 's1')
+
+  const inv = out.invocations[0]!
+  expect(inv.unmeasured).toBeUndefined()
+  expect(inv.outputTokens).toBe(800)
+  expect(inv.totalTokens).toBe(800)
+  expect(inv.totalDurationMs).toBe(30_000)
+  expect(inv.costUSD).toBeGreaterThan(0)
+  expect(out.unmeasuredInvocations).toBe(0)
+  expect(out.totalTokens).toBe(800)
+})
+
+test('a missing subagent transcript leaves the invocation unmeasured — never a zero', async () => {
+  const { transcriptPath } = await machine('s2', {})
+
+  const out = await enrichFromSubagentTranscripts(metrics(unmeasured('toolu_1', 'aGone')), transcriptPath, 's2')
+
+  expect(out.invocations[0]!.unmeasured).toBe(true)
+  expect(out.unmeasuredInvocations).toBe(1)
+})
+
+test('a nested subagent counts inside the invocation that spawned it', async () => {
+  const { transcriptPath } = await machine('s3', {
+    aParent: [
+      turn('claude-sonnet-5', 100),
+      JSON.stringify({ type: 'user', timestamp: '2026-09-01T10:00:05.000Z', toolUseResult: { agentId: 'aChild', isAsync: true } }),
+    ],
+    aChild: [turn('claude-sonnet-5', 900)],
+  })
+
+  const out = await enrichFromSubagentTranscripts(metrics(unmeasured('toolu_1', 'aParent')), transcriptPath, 's3')
+
+  expect(out.invocations[0]!.outputTokens).toBe(1000)
+})
+
+test('subagents that name each other cannot loop forever', async () => {
+  const { transcriptPath } = await machine('s4', {
+    aA: [turn('claude-sonnet-5', 10), JSON.stringify({ type: 'user', toolUseResult: { agentId: 'aB' } })],
+    aB: [turn('claude-sonnet-5', 20), JSON.stringify({ type: 'user', toolUseResult: { agentId: 'aA' } })],
+  })
+
+  const out = await enrichFromSubagentTranscripts(metrics(unmeasured('toolu_1', 'aA')), transcriptPath, 's4')
+
+  expect(out.invocations[0]!.outputTokens).toBe(30)
+})
+
+test('an invocation that already has numbers is left exactly as it is', async () => {
+  const { transcriptPath } = await machine('s5', { aOne: [turn('claude-sonnet-5', 9999)] })
+  const legacy = { ...unmeasured('toolu_1', 'aOne'), unmeasured: undefined, outputTokens: 42, totalTokens: 42 }
+  delete (legacy as Record<string, unknown>).unmeasured
+
+  const out = await enrichFromSubagentTranscripts(metrics(legacy), transcriptPath, 's5')
+
+  expect(out.invocations[0]!.outputTokens).toBe(42)
+})

--- a/packages/server/server/subagent-metrics.ts
+++ b/packages/server/server/subagent-metrics.ts
@@ -1,0 +1,103 @@
+/**
+ * subagent-metrics.ts — the I/O half: find each subagent's own transcript and read it.
+ *
+ * Claude Code made the `Agent` tool asynchronous on 2026-08-14. The parent's `toolUseResult` stopped
+ * carrying the agent's numbers and now names it instead — `agentId` — while the numbers moved into
+ * `<project>/<session-id>/subagents/agent-<agentId>.jsonl`. `agent-metrics.ts` marks those
+ * invocations UNMEASURED; this module is what makes almost all of them measured again (on the
+ * machine this was written against: 440 of 442 async invocations had their transcript on disk).
+ *
+ * **The `outputFile` the result also names is deliberately NOT used.** It points into the run's
+ * scratch directory under `/tmp`, which is cleared on reboot and by the OS — it is the agent's text
+ * answer, not its accounting, and it was already gone for every invocation measured here. The
+ * durable file is the one this module opens.
+ *
+ * What cannot be found stays unmeasured. A transcript deleted by Claude's own 30-day cleanup is a
+ * fact nobody can recover, and reporting it as zero would be the very defect this fixes.
+ */
+
+import { readFile, stat } from 'fs/promises'
+import { dirname, join } from 'path'
+import type { AgentInvocation, SessionAgentMetrics } from '@agentistics/core'
+import { agentNumbers, summarizeSubagentTranscript, totalsOf, type SubagentSummary } from './subagent-parse'
+
+/**
+ * Parsed subagent transcripts, keyed by path + mtime + size.
+ *
+ * A finished subagent's transcript never changes, and the data walk runs on a 30s cache over a
+ * machine that can hold hundreds of them — re-parsing half a megabyte per invocation per build is
+ * the storm `git.ts` had to be rescued from. The key carries mtime and size so a transcript still
+ * being written is re-read rather than frozen at its first reading.
+ */
+const CACHE = new Map<string, SubagentSummary>()
+
+async function summaryFor(file: string): Promise<SubagentSummary | null> {
+  let key: string
+  try {
+    const st = await stat(file)
+    key = `${file}\0${st.mtimeMs}\0${st.size}`
+  } catch {
+    return null
+  }
+  const hit = CACHE.get(key)
+  if (hit) return hit
+
+  let content: string
+  try { content = await readFile(file, 'utf-8') } catch { return null }
+
+  const summary = summarizeSubagentTranscript(content.split('\n'))
+  CACHE.set(key, summary)
+  return summary
+}
+
+/** Every summary under one agent, the agent itself excluded. Cycle-safe by construction. */
+async function descendantsOf(
+  dir: string,
+  root: SubagentSummary,
+  seen: Set<string>,
+): Promise<SubagentSummary[]> {
+  const out: SubagentSummary[] = []
+  const queue = [...root.childAgentIds]
+  while (queue.length > 0) {
+    const id = queue.shift()!
+    if (seen.has(id)) continue
+    seen.add(id)
+    const summary = await summaryFor(join(dir, `agent-${id}.jsonl`))
+    if (!summary) continue
+    out.push(summary)
+    queue.push(...summary.childAgentIds)
+  }
+  return out
+}
+
+/**
+ * Fill in every UNMEASURED invocation that names a transcript this machine still has.
+ *
+ * Total: a session with no `subagents/` directory, an unreadable file or an invocation with no
+ * `agentId` comes back exactly as it went in.
+ */
+export async function enrichFromSubagentTranscripts(
+  metrics: SessionAgentMetrics,
+  transcriptPath: string,
+  sessionId: string,
+): Promise<SessionAgentMetrics> {
+  if (!metrics.invocations.some(i => i.unmeasured && i.agentId)) return metrics
+
+  const dir = join(dirname(transcriptPath), sessionId, 'subagents')
+  const invocations: AgentInvocation[] = []
+  let changed = false
+
+  for (const inv of metrics.invocations) {
+    if (!inv.unmeasured || !inv.agentId) { invocations.push(inv); continue }
+
+    const root = await summaryFor(join(dir, `agent-${inv.agentId}.jsonl`))
+    if (!root) { invocations.push(inv); continue }
+
+    const descendants = await descendantsOf(dir, root, new Set([inv.agentId]))
+    const { unmeasured: _dropped, ...rest } = inv
+    invocations.push({ ...rest, ...agentNumbers(root, descendants) })
+    changed = true
+  }
+
+  return changed ? totalsOf(invocations) : metrics
+}

--- a/packages/server/server/subagent-parse.test.ts
+++ b/packages/server/server/subagent-parse.test.ts
@@ -1,0 +1,163 @@
+import { test, expect } from 'bun:test'
+import { summarizeSubagentTranscript } from './subagent-parse'
+
+/** One assistant turn of a subagent transcript, as Claude Code writes it. */
+function assistant(model: string, usage: Record<string, number>, extra: Record<string, unknown> = {}) {
+  return JSON.stringify({
+    type: 'assistant',
+    timestamp: extra.timestamp ?? '2026-09-01T10:00:00.000Z',
+    message: { model, usage, content: extra.content ?? [] },
+  })
+}
+
+test('usage is summed PER MODEL — a subagent may run a cheaper model than its parent', () => {
+  const s = summarizeSubagentTranscript([
+    assistant('claude-haiku-4-5-20251001', { input_tokens: 8, output_tokens: 100, cache_read_input_tokens: 90, cache_creation_input_tokens: 2 }),
+    assistant('claude-haiku-4-5-20251001', { input_tokens: 2, output_tokens: 50, cache_read_input_tokens: 10, cache_creation_input_tokens: 0 }),
+    assistant('claude-sonnet-5', { input_tokens: 1, output_tokens: 7, cache_read_input_tokens: 0, cache_creation_input_tokens: 3 }),
+  ])
+
+  expect(s.usage).toEqual([
+    { model: 'claude-haiku-4-5-20251001', inputTokens: 10, outputTokens: 150, cacheReadTokens: 100, cacheWriteTokens: 2 },
+    { model: 'claude-sonnet-5', inputTokens: 1, outputTokens: 7, cacheReadTokens: 0, cacheWriteTokens: 3 },
+  ])
+})
+
+test('the span is the first and last timestamp of the transcript', () => {
+  const s = summarizeSubagentTranscript([
+    assistant('m', { output_tokens: 1 }, { timestamp: '2026-09-01T10:00:00.000Z' }),
+    assistant('m', { output_tokens: 1 }, { timestamp: '2026-09-01T10:02:30.000Z' }),
+  ])
+  expect(s.firstMs).toBe(Date.parse('2026-09-01T10:00:00.000Z'))
+  expect(s.lastMs).toBe(Date.parse('2026-09-01T10:02:30.000Z'))
+})
+
+test('a transcript with no timestamp reports no span, never a zero duration', () => {
+  const s = summarizeSubagentTranscript([
+    JSON.stringify({ type: 'assistant', message: { model: 'm', usage: { output_tokens: 1 }, content: [] } }),
+  ])
+  expect(s.firstMs).toBeNull()
+  expect(s.lastMs).toBeNull()
+})
+
+test('junk lines and blank lines are skipped without throwing', () => {
+  const s = summarizeSubagentTranscript(['', '   ', 'not json at all', assistant('m', { output_tokens: 4 })])
+  expect(s.usage).toEqual([{ model: 'm', inputTokens: 0, outputTokens: 4, cacheReadTokens: 0, cacheWriteTokens: 0 }])
+})
+
+/** A tool_use item inside an assistant turn. */
+function toolUse(name: string) {
+  return JSON.stringify({
+    type: 'assistant',
+    timestamp: '2026-09-01T10:00:00.000Z',
+    message: { model: 'm', content: [{ type: 'tool_use', id: 't1', name, input: {} }] },
+  })
+}
+
+test('tool uses are counted and bucketed the way the panel reads them', () => {
+  const s = summarizeSubagentTranscript([
+    toolUse('Read'), toolUse('Grep'), toolUse('Glob'), toolUse('Bash'), toolUse('Bash'),
+    toolUse('Edit'), toolUse('Write'), toolUse('MultiEdit'), toolUse('WebFetch'),
+  ])
+  expect(s.toolUseCount).toBe(9)
+  expect(s.toolStats.readCount).toBe(1)
+  expect(s.toolStats.searchCount).toBe(2)
+  expect(s.toolStats.bashCount).toBe(2)
+  expect(s.toolStats.editFileCount).toBe(3)
+  expect(s.toolStats.otherToolCount).toBe(1)
+})
+
+test('lines changed come from the edit patch the transcript already carries', () => {
+  const s = summarizeSubagentTranscript([
+    JSON.stringify({
+      type: 'user',
+      timestamp: '2026-09-01T10:00:01.000Z',
+      toolUseResult: {
+        structuredPatch: [
+          { lines: [' kept', '-gone', '+new', '+also new'] },
+          { lines: ['-gone too'] },
+        ],
+      },
+    }),
+  ])
+  expect(s.toolStats.linesAdded).toBe(2)
+  expect(s.toolStats.linesRemoved).toBe(2)
+})
+
+test('a nested subagent is NAMED so its own transcript can be found', () => {
+  const s = summarizeSubagentTranscript([
+    JSON.stringify({ type: 'user', toolUseResult: { agentId: 'aNested1', isAsync: true } }),
+    JSON.stringify({ type: 'user', toolUseResult: { agentId: 'aNested2', isAsync: true } }),
+    JSON.stringify({ type: 'user', toolUseResult: { stdout: 'no agent here' } }),
+  ])
+  expect(s.childAgentIds).toEqual(['aNested1', 'aNested2'])
+})
+
+test('the same nested subagent named twice is one child, never two', () => {
+  const s = summarizeSubagentTranscript([
+    JSON.stringify({ type: 'user', toolUseResult: { agentId: 'aNested1' } }),
+    JSON.stringify({ type: 'user', toolUseResult: { agentId: 'aNested1' } }),
+  ])
+  expect(s.childAgentIds).toEqual(['aNested1'])
+})
+
+// --- the numbers one invocation reports, from its own transcript and everything it spawned ---
+
+import { agentNumbers } from './subagent-parse'
+import { calcCost } from '@agentistics/core'
+
+const emptyStats = { readCount: 0, searchCount: 0, bashCount: 0, editFileCount: 0, linesAdded: 0, linesRemoved: 0, otherToolCount: 0 }
+function summary(over: Partial<Parameters<typeof agentNumbers>[0]> = {}) {
+  return { usage: [], firstMs: null, lastMs: null, toolUseCount: 0, toolStats: { ...emptyStats }, childAgentIds: [], ...over }
+}
+
+test('cost prices each model at ITS OWN rate — a haiku child under an opus parent is not opus money', () => {
+  const usage = { inputTokens: 1000, outputTokens: 2000, cacheReadTokens: 30000, cacheWriteTokens: 400 }
+  const n = agentNumbers(summary({ usage: [{ model: 'claude-haiku-4-5-20251001', ...usage }] }), [])
+
+  const asHaiku = calcCost(
+    { inputTokens: 1000, outputTokens: 2000, cacheReadInputTokens: 30000, cacheCreationInputTokens: 400, webSearchRequests: 0, costUSD: 0 },
+    'claude-haiku-4-5-20251001',
+  )
+  expect(n.costUSD).toBeCloseTo(asHaiku, 10)
+
+  const asOpus = calcCost(
+    { inputTokens: 1000, outputTokens: 2000, cacheReadInputTokens: 30000, cacheCreationInputTokens: 400, webSearchRequests: 0, costUSD: 0 },
+    'claude-opus-5',
+  )
+  expect(n.costUSD).toBeLessThan(asOpus)
+})
+
+test('tokens is ALL FOUR counters — a subagent read of the cache is most of its volume', () => {
+  const n = agentNumbers(summary({
+    usage: [{ model: 'claude-sonnet-5', inputTokens: 8, outputTokens: 100, cacheReadTokens: 97781, cacheWriteTokens: 261 }],
+  }), [])
+  expect(n.totalTokens).toBe(8 + 100 + 97781 + 261)
+})
+
+test('a nested subagent counts inside the invocation that spawned it', () => {
+  const root = summary({
+    usage: [{ model: 'claude-sonnet-5', inputTokens: 10, outputTokens: 20, cacheReadTokens: 0, cacheWriteTokens: 0 }],
+    toolUseCount: 3,
+    toolStats: { ...emptyStats, bashCount: 3 },
+  })
+  const nested = summary({
+    usage: [{ model: 'claude-sonnet-5', inputTokens: 5, outputTokens: 7, cacheReadTokens: 0, cacheWriteTokens: 0 }],
+    toolUseCount: 2,
+    toolStats: { ...emptyStats, readCount: 2, linesAdded: 4 },
+  })
+
+  const n = agentNumbers(root, [nested])
+  expect(n.inputTokens).toBe(15)
+  expect(n.outputTokens).toBe(27)
+  expect(n.totalToolUseCount).toBe(5)
+  expect(n.toolStats.bashCount).toBe(3)
+  expect(n.toolStats.readCount).toBe(2)
+  expect(n.toolStats.linesAdded).toBe(4)
+})
+
+test('duration is the ROOT agent’s own span — a nested agent runs inside it, not after it', () => {
+  const root = summary({ firstMs: 1000, lastMs: 61000 })
+  const nested = summary({ firstMs: 5000, lastMs: 9000 })
+  expect(agentNumbers(root, [nested]).totalDurationMs).toBe(60000)
+})

--- a/packages/server/server/subagent-parse.ts
+++ b/packages/server/server/subagent-parse.ts
@@ -1,0 +1,258 @@
+/**
+ * subagent-parse.ts — PURE: what one subagent's own transcript says it spent.
+ *
+ * Claude Code stopped putting a subagent's numbers in the parent's `toolUseResult`. Since the Agent
+ * tool went ASYNCHRONOUS (measured here: the shape changed on 2026-08-14) the parent records only
+ * `{ agentId, description, isAsync, outputFile, resolvedModel, status: 'async_launched' }` — no
+ * usage, no tool stats, no duration. The numbers did not disappear: the subagent writes its own
+ * transcript at `<project>/<session-id>/subagents/agent-<agentId>.jsonl`, and this module reads it.
+ *
+ * It is the parse half only. The file reading, the recursion into nested subagents and the memo
+ * live in `subagent-metrics.ts`, so everything here stays a pure function of lines — the same split
+ * every harness adapter makes.
+ */
+
+import { calcCost, totalTokens } from '@agentistics/core'
+import type { AgentInvocation, SessionAgentMetrics } from '@agentistics/core'
+
+/** What one MODEL cost inside a subagent. Per model, because a subagent may run a cheaper one. */
+export interface SubagentUsage {
+  model: string
+  inputTokens: number
+  outputTokens: number
+  cacheReadTokens: number
+  cacheWriteTokens: number
+}
+
+/** Exactly the numeric half of `AgentInvocation` — what `agentNumbers` establishes. */
+export interface AgentNumbers {
+  totalTokens: number
+  inputTokens: number
+  outputTokens: number
+  cacheReadTokens: number
+  cacheWriteTokens: number
+  totalDurationMs: number
+  totalToolUseCount: number
+  toolStats: SubagentToolStats
+  costUSD: number
+}
+
+/** The same buckets `AgentInvocation.toolStats` has always carried. */
+export interface SubagentToolStats {
+  readCount: number
+  searchCount: number
+  bashCount: number
+  editFileCount: number
+  linesAdded: number
+  linesRemoved: number
+  otherToolCount: number
+}
+
+export interface SubagentSummary {
+  /**
+   * One entry per model the subagent used, in first-seen order.
+   *
+   * NEVER collapsed into a single figure here: a subagent commonly runs `haiku` under an `opus`
+   * parent, and pricing its tokens at the parent's rate is how a cheap agent is billed as an
+   * expensive one. The caller prices each entry with its own model id.
+   */
+  usage: SubagentUsage[]
+  /** First and last timestamp seen, or `null` — an absent span is not a zero duration. */
+  firstMs: number | null
+  lastMs: number | null
+  toolUseCount: number
+  toolStats: SubagentToolStats
+  /**
+   * The subagents THIS subagent spawned, by `agentId`, deduped and in first-seen order.
+   *
+   * A nested agent's work appears in no other place the parent session can reach: only a top-level
+   * `Agent` tool_use in the session transcript becomes an `AgentInvocation`, so without this the
+   * whole subtree's tokens are missing from the session's agent totals. The caller resolves each id
+   * to its own transcript in the same `subagents/` directory.
+   */
+  childAgentIds: string[]
+}
+
+interface UsageRecord {
+  input_tokens?: number
+  output_tokens?: number
+  cache_read_input_tokens?: number
+  cache_creation_input_tokens?: number
+}
+
+/**
+ * Which bucket a tool name falls in.
+ *
+ * A MAPPING, never a filter: a name nobody listed here is still counted, in `otherToolCount`, so a
+ * tool added upstream shows up as work done rather than as work that never happened.
+ */
+const SEARCH_TOOLS = new Set(['Grep', 'Glob'])
+const EDIT_TOOLS = new Set(['Edit', 'Write', 'MultiEdit', 'NotebookEdit'])
+
+const num = (v: unknown): number => (typeof v === 'number' && Number.isFinite(v) ? v : 0)
+
+/** Sum one subagent transcript. Total: malformed input yields an empty summary, never a throw. */
+export function summarizeSubagentTranscript(lines: Iterable<string>): SubagentSummary {
+  const byModel = new Map<string, SubagentUsage>()
+  let firstMs: number | null = null
+  let lastMs: number | null = null
+  let toolUseCount = 0
+  const toolStats: SubagentToolStats = {
+    readCount: 0, searchCount: 0, bashCount: 0, editFileCount: 0,
+    linesAdded: 0, linesRemoved: 0, otherToolCount: 0,
+  }
+  const childAgentIds: string[] = []
+  const seenChild = new Set<string>()
+
+  for (const raw of lines) {
+    const line = raw.trim()
+    if (!line) continue
+
+    let e: Record<string, unknown>
+    try { e = JSON.parse(line) as Record<string, unknown> } catch { continue }
+
+    const ts = typeof e.timestamp === 'string' ? Date.parse(e.timestamp) : NaN
+    if (Number.isFinite(ts)) {
+      if (firstMs === null || ts < firstMs) firstMs = ts
+      if (lastMs === null || ts > lastMs) lastMs = ts
+    }
+
+    const result = e.toolUseResult as Record<string, unknown> | undefined
+    if (result && typeof result === 'object') {
+      const childId = result.agentId
+      if (typeof childId === 'string' && childId && !seenChild.has(childId)) {
+        seenChild.add(childId)
+        childAgentIds.push(childId)
+      }
+      // The edit patch the transcript already carries. `git diff` is not available here and would
+      // answer about the working tree anyway, not about what this agent changed.
+      const patch = result.structuredPatch
+      if (Array.isArray(patch)) {
+        for (const hunk of patch as Record<string, unknown>[]) {
+          const hunkLines = hunk?.lines
+          if (!Array.isArray(hunkLines)) continue
+          for (const l of hunkLines as unknown[]) {
+            if (typeof l !== 'string') continue
+            if (l.startsWith('+')) toolStats.linesAdded++
+            else if (l.startsWith('-')) toolStats.linesRemoved++
+          }
+        }
+      }
+    }
+
+    if (e.type !== 'assistant') continue
+    const msg = e.message as Record<string, unknown> | undefined
+
+    if (Array.isArray(msg?.content)) {
+      for (const item of msg!.content as Record<string, unknown>[]) {
+        if (item?.type !== 'tool_use') continue
+        toolUseCount++
+        const name = typeof item.name === 'string' ? item.name : ''
+        if (name === 'Read') toolStats.readCount++
+        else if (SEARCH_TOOLS.has(name)) toolStats.searchCount++
+        else if (name === 'Bash') toolStats.bashCount++
+        else if (EDIT_TOOLS.has(name)) toolStats.editFileCount++
+        else toolStats.otherToolCount++
+      }
+    }
+
+    const usage = msg?.usage as UsageRecord | undefined
+    if (!usage) continue
+
+    const model = typeof msg?.model === 'string' ? msg.model : ''
+    let entry = byModel.get(model)
+    if (!entry) {
+      entry = { model, inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0 }
+      byModel.set(model, entry)
+    }
+    entry.inputTokens += num(usage.input_tokens)
+    entry.outputTokens += num(usage.output_tokens)
+    entry.cacheReadTokens += num(usage.cache_read_input_tokens)
+    entry.cacheWriteTokens += num(usage.cache_creation_input_tokens)
+  }
+
+  return { usage: [...byModel.values()], firstMs, lastMs, toolUseCount, toolStats, childAgentIds }
+}
+
+/**
+ * The numbers ONE invocation reports: its own transcript plus everything it spawned.
+ *
+ * Two rules the old reader could not follow, because the parent's `toolUseResult` gave it neither:
+ *
+ * - **Each model is priced at ITS OWN rate.** A subagent commonly runs `haiku` under an `opus`
+ *   parent (measured on this machine: four different models across 440 subagent transcripts), so
+ *   pricing the whole invocation with the parent's model id bills a cheap agent as an expensive one.
+ * - **A nested subagent counts inside the invocation that spawned it.** Only a top-level `Agent`
+ *   tool_use in the session transcript becomes an `AgentInvocation`, so a subtree left out here is
+ *   left out of the session's agent totals entirely.
+ *
+ * The DURATION is the root's own span: a nested agent runs inside its parent, so adding the two
+ * would count the same wall time twice.
+ */
+export function agentNumbers(root: SubagentSummary, descendants: readonly SubagentSummary[]): AgentNumbers {
+  const toolStats: SubagentToolStats = {
+    readCount: 0, searchCount: 0, bashCount: 0, editFileCount: 0,
+    linesAdded: 0, linesRemoved: 0, otherToolCount: 0,
+  }
+  let inputTokens = 0, outputTokens = 0, cacheReadTokens = 0, cacheWriteTokens = 0
+  let totalToolUseCount = 0
+  let costUSD = 0
+
+  for (const s of [root, ...descendants]) {
+    for (const u of s.usage) {
+      inputTokens += u.inputTokens
+      outputTokens += u.outputTokens
+      cacheReadTokens += u.cacheReadTokens
+      cacheWriteTokens += u.cacheWriteTokens
+      costUSD += calcCost(
+        {
+          inputTokens: u.inputTokens,
+          outputTokens: u.outputTokens,
+          cacheReadInputTokens: u.cacheReadTokens,
+          cacheCreationInputTokens: u.cacheWriteTokens,
+          webSearchRequests: 0,
+          costUSD: 0,
+        },
+        u.model,
+      )
+    }
+    totalToolUseCount += s.toolUseCount
+    toolStats.readCount += s.toolStats.readCount
+    toolStats.searchCount += s.toolStats.searchCount
+    toolStats.bashCount += s.toolStats.bashCount
+    toolStats.editFileCount += s.toolStats.editFileCount
+    toolStats.linesAdded += s.toolStats.linesAdded
+    toolStats.linesRemoved += s.toolStats.linesRemoved
+    toolStats.otherToolCount += s.toolStats.otherToolCount
+  }
+
+  return {
+    totalTokens: totalTokens({ input: inputTokens, output: outputTokens, cacheRead: cacheReadTokens, cacheWrite: cacheWriteTokens }),
+    inputTokens,
+    outputTokens,
+    cacheReadTokens,
+    cacheWriteTokens,
+    totalDurationMs: root.firstMs !== null && root.lastMs !== null ? root.lastMs - root.firstMs : 0,
+    totalToolUseCount,
+    toolStats,
+    costUSD,
+  }
+}
+
+/**
+ * The session-level totals, over the invocations that HAVE numbers.
+ *
+ * An unmeasured invocation contributes nothing — it is an absence, not a zero — and is counted
+ * separately so a surface can say how much of what it is showing the totals actually cover.
+ */
+export function totalsOf(invocations: AgentInvocation[]): SessionAgentMetrics {
+  const measured = invocations.filter(i => !i.unmeasured)
+  return {
+    invocations,
+    totalInvocations: invocations.length,
+    unmeasuredInvocations: invocations.length - measured.length,
+    totalTokens: measured.reduce((s, i) => s + i.totalTokens, 0),
+    totalDurationMs: measured.reduce((s, i) => s + i.totalDurationMs, 0),
+    totalCostUSD: measured.reduce((s, i) => s + i.costUSD, 0),
+  }
+}

--- a/packages/web/src/components/AgentMetricsPanel.tsx
+++ b/packages/web/src/components/AgentMetricsPanel.tsx
@@ -7,6 +7,7 @@ import { MetricNote } from './MetricNote'
 import { useIsMobile } from '../hooks/useIsMobile'
 import { capable } from '../lib/harness'
 import { NAtag } from './NAtag'
+import { unmeasuredNote } from '../lib/agentMeasured'
 
 interface AgentMetricsPanelProps {
   invocations: AgentInvocation[]
@@ -26,6 +27,11 @@ interface AgentMetricsPanelProps {
 }
 
 
+
+/** No figure, and never a zero — see `agentMeasured.ts`. */
+function Absent() {
+  return <span style={{ color: 'var(--text-tertiary)' }}>—</span>
+}
 
 function fmtDuration(ms: number): string {
   if (ms === 0) return '—'
@@ -125,6 +131,10 @@ export function AgentMetricsPanel({
   const maxCount = sortedTypes[0]?.[1].count ?? 1
 
   const displayInvocations = showAll ? invocations : invocations.slice(0, 10)
+  // Derived from the rows ON SCREEN rather than taken as a prop, so the sentence always describes
+  // the list the reader is looking at.
+  const unmeasuredShown = displayInvocations.filter(i => i.unmeasured).length
+  const note = unmeasuredNote(unmeasuredShown, displayInvocations.length, lang)
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 20 }}>
@@ -212,6 +222,11 @@ export function AgentMetricsPanel({
             ({pt ? `exibindo ${displayInvocations.length} de ${totalInvocations}` : `showing ${displayInvocations.length} of ${totalInvocations}`})
           </span>
         </div>
+        {note && (
+          <div style={{ fontSize: 11, lineHeight: 1.5, color: 'var(--text-tertiary)', marginBottom: 8 }}>
+            {note}
+          </div>
+        )}
         <div style={{ border: '1px solid var(--border)', borderRadius: 8, overflow: isMobile ? 'auto' : 'hidden', width: '100%' }}>
           <div style={{ minWidth: isMobile ? 480 : undefined }}>
           {/* Table header */}
@@ -265,17 +280,21 @@ export function AgentMetricsPanel({
                   {inv.description || <em style={{ color: 'var(--text-tertiary)' }}>—</em>}
                 </span>
               </div>
+              {/* An invocation whose subagent transcript is gone carries zeros because the type has
+                  no other value to carry. Rendering them would price real work at nothing — the
+                  confident 0 this product refuses everywhere else — so the cell says nothing
+                  instead, and the note under the heading says why. */}
               <span style={{ fontSize: 11, color: 'var(--text-primary)', textAlign: 'right' }}>
-                {fmt(inv.totalTokens)}
+                {inv.unmeasured ? <Absent /> : fmt(inv.totalTokens)}
               </span>
               <span style={{ fontSize: 11, color: 'var(--text-secondary)', textAlign: 'right' }}>
-                {inv.totalToolUseCount}
+                {inv.unmeasured ? <Absent /> : inv.totalToolUseCount}
               </span>
               <span style={{ fontSize: 11, color: 'var(--text-secondary)', textAlign: 'right' }}>
-                {fmtDuration(inv.totalDurationMs)}
+                {inv.unmeasured ? <Absent /> : fmtDuration(inv.totalDurationMs)}
               </span>
               <span style={{ fontSize: 11, color: 'var(--anthropic-orange)', textAlign: 'right' }}>
-                {fmtCost(inv.costUSD, currency, brlRate)}
+                {inv.unmeasured ? <Absent /> : fmtCost(inv.costUSD, currency, brlRate)}
               </span>
             </div>
           ))}

--- a/packages/web/src/lib/agentMeasured.test.ts
+++ b/packages/web/src/lib/agentMeasured.test.ts
@@ -1,0 +1,21 @@
+import { test, expect } from 'bun:test'
+import { unmeasuredNote } from './agentMeasured'
+
+test('nothing is said when every invocation carries its numbers', () => {
+  expect(unmeasuredNote(0, 12, 'en')).toBeNull()
+})
+
+test('the note names how many of the shown invocations the totals do NOT cover', () => {
+  expect(unmeasuredNote(3, 12, 'en')).toContain('3 of 12')
+  expect(unmeasuredNote(3, 12, 'pt')).toContain('3 de 12')
+})
+
+test('the note says WHY, so an absent number does not read as a fault in the panel', () => {
+  expect(unmeasuredNote(1, 2, 'en')?.toLowerCase()).toContain('transcript')
+  expect(unmeasuredNote(1, 2, 'pt')?.toLowerCase()).toContain('transcri')
+})
+
+test('one is singular in both languages', () => {
+  expect(unmeasuredNote(1, 4, 'en')).toContain('1 of 4')
+  expect(unmeasuredNote(1, 4, 'pt')).toContain('1 de 4')
+})

--- a/packages/web/src/lib/agentMeasured.ts
+++ b/packages/web/src/lib/agentMeasured.ts
@@ -1,0 +1,21 @@
+/**
+ * agentMeasured.ts — the sentence an absent agent metric needs.
+ *
+ * A subagent's numbers live in its own transcript (`subagents/agent-<id>.jsonl`), and Claude Code
+ * deletes transcripts after `cleanupPeriodDays`. When one is gone the invocation is still real and
+ * still listed — the parent recorded that it happened — but nothing on this machine can say what it
+ * spent. The row renders no figure, and this is the line that stops the reader taking that dash for
+ * a broken panel: same rule as `HARNESS_CAPABILITIES`, applied to one row instead of a whole
+ * harness. A zero would be the confident claim; a dash with no explanation is a bug report waiting
+ * to be filed.
+ */
+
+import type { Lang } from '@agentistics/core'
+
+/** `null` when every invocation on screen carries its numbers — there is then nothing to say. */
+export function unmeasuredNote(unmeasured: number, shown: number, lang: Lang): string | null {
+  if (unmeasured <= 0) return null
+  return lang === 'pt'
+    ? `${unmeasured} de ${shown} sem números: o transcript do subagente já não está no disco, então os totais acima não as incluem.`
+    : `${unmeasured} of ${shown} carry no numbers: the subagent's transcript is no longer on disk, so the totals above do not include them.`
+}


### PR DESCRIPTION
## Summary

- Read a subagent's **own transcript** (`<project>/<session-id>/subagents/agent-<agentId>.jsonl`) for the numbers Claude Code stopped putting in the parent's `toolUseResult` when the `Agent` tool went asynchronous on 2026-08-14.
- Price **each model at its own rate** and count **nested subagents** inside the invocation that spawned them — neither was possible before, because the parent's result carried one model id and no subtree.
- An invocation whose transcript is gone is marked `unmeasured: true` and renders **N/A, never a zero**; the session totals exclude it and `unmeasuredInvocations` counts it.

## Motivation

Closes #348.

The reader kept **half** working, which is why this survived three weeks unnoticed: `agentType` and `description` come from the parent's own `tool_use` input, so the Agent Metrics panel went on drawing rows with names on them and only the values were gone. Measured on this machine: **391 of 391 invocations from 2026-08-14 onward reported 0 tokens**, against 30,4 million in the window before it.

Today's result shape is:

```json
{ "agentId": "a23c974fb8aab9fbf", "description": "Task 1: backup-plan.ts", "isAsync": true,
  "status": "async_launched", "resolvedModel": "claude-haiku-4-5-20251001",
  "outputFile": "/tmp/.../tasks/a23c974fb8aab9fbf.output", "canReadOutputFile": true }
```

No `usage`, no `totalTokens`, no `toolStats`, no duration — so every `?? 0` fired at once and real work was published priced at nothing. That is the confident zero this repository forbids everywhere else.

### Four decisions the new shape forces

- **`outputFile` is NOT the file to read**, contrary to what the issue proposed. It points into the run's `/tmp` scratch directory, holds the agent's *text answer* rather than its accounting, and was already gone for every invocation measured here. The durable file is the one under `subagents/`.
- **Each model is priced at its own rate.** A subagent commonly runs `haiku` under an `opus` parent — four distinct models across 440 subagent transcripts on this machine — so the old single `modelId` billed a cheap agent as an expensive one. Visible in the verification below: *Review Task 1* costs more than *Task 1* on a third of the tokens, because one ran sonnet and the other haiku.
- **A nested subagent counts inside the invocation that spawned it.** Only a top-level `Agent` `tool_use` becomes an `AgentInvocation`, so a subtree left out here is left out of the session's agent totals entirely. Cycle-safe by a visited set.
- **The duration is the root's own span.** A nested agent runs inside its parent; adding the two counts the same wall time twice.

### What is deliberately NOT here

**No migration of already-stored zeros.** A stored record with everything at zero could be the async shape *or* a legacy agent that genuinely did nothing, and a heuristic that cannot tell them apart would relabel real facts. It is also not needed yet: the store is rewritten from the transcript on every build, the async shape began on 2026-08-14, and Claude's own 30-day cleanup does not start removing those transcripts until ~2026-09-13. Every affected invocation on this machine is still measurable exactly — 8 of 533 were not, and those are pre-08-14 records.

**Overlaps with #368**, which also claims `Closes #348` inside a seven-subject, 57-file branch that is currently conflicting with `dev`. This is the one concern on its own, per the scope rule in `AGENTS.md`. Whichever lands first, the other should drop its half rather than merge two readers.

## Changes

| File | What |
|---|---|
| `packages/server/server/subagent-parse.ts` *(new, pure)* | Sum one subagent transcript: usage **per model**, tool uses bucketed, lines from `structuredPatch`, first/last span, the ids of subagents it spawned. Plus `agentNumbers` (root + descendants → the numeric half of an invocation) and `totalsOf` (session totals over the **measured** invocations only). |
| `packages/server/server/subagent-metrics.ts` *(new, I/O)* | Find `subagents/agent-<id>.jsonl`, follow nesting breadth-first with a visited set, memoize by `path + mtime + size`. What cannot be read stays unmeasured. |
| `packages/server/server/agent-metrics.ts` | Records `agentId`; marks a result carrying **no numbers at all** as `unmeasured` instead of writing zeros; enriches in `extractAgentMetricsFromFile`. |
| `packages/server/server/jsonl.ts` | The main parse path enriches too. |
| `packages/core/src/types.ts` | `AgentInvocation.agentId?` / `.unmeasured?`, `SessionAgentMetrics.unmeasuredInvocations?` — all optional, so a record stored by an older build still reads. |
| `packages/web/src/lib/agentMeasured.ts` *(new, pure)* + `AgentMetricsPanel.tsx` | Unmeasured rows render `—` in tokens/tools/duration/cost, with one sentence saying how many and why — a dash with no explanation is a bug report waiting to be filed. |
| `docs/data-sources.md`, `CLAUDE.md` | Both transcript shapes, where the numbers live now, and the four rules above. |

## Test plan

- [x] `bun test` — **5842 pass, 0 fail** (25 new across four files, each written before its implementation).
- [x] `bun tsc --noEmit` clean.
- [x] **Real data, one session** (62 agents, previously `$0.00`):
  ```
  { invocations: 62, unmeasured: 0, totalTokens: "1,183,166,616",
    totalCostUSD: "340.92", totalDurationMin: 583, parseMs: 291 }
   Task 1: backup-plan.ts           2,900,698 tok  $0.633  189s  14 tools
   Review Task 1 (spec + quality)   1,115,349 tok  $1.128  159s   4 tools
  ```
- [x] **Real data, every transcript on this machine**: `533 invocations, 8 unmeasured (1,5 %), 2,90 billion tokens, USD 1.184,06` — recovered from a build reporting `USD 0` for all of them. Cold walk: **2,8 s**; memoized afterwards.

**Reviewers should look hardest at:** (a) counting nested subagents inside the parent invocation — it is a judgement call about what "this invocation cost" means, and it changes totals; (b) `measured`'s predicate in `agent-metrics.ts` — a legacy result that happened to omit every numeric field would be marked unmeasured rather than zeroed, which is the safe direction but worth agreeing on; (c) the memo key (`path + mtime + size`) against a transcript still being written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016sAFk6uj152XoZUNV2jksq
