### PR TITLE
feat(sessions): five harnesses have their conversation readable, and the sixth's absence is a finding

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -359,8 +359,46 @@ packages/server/server/          — server-side modules (never bundled by Vite)
   │                          conversation, and its error paragraph runs 206–633 characters across all
   │                          77 measured) — the same rule `chat-envelope.ts` applies to Claude's
   │                          injected entries. `transcript-window.ts` is the shared byte-tail reader
-  │                          both harnesses poll through: a poll that reads whole transcripts is what
-  │                          made `/api/fleet` answer in 36 s cold. See docs/session-manager.md
+  │                          every harness polls through: a poll that reads whole transcripts is what
+  │                          made `/api/fleet` answer in 36 s cold.
+  │                          **FIVE READERS, and the sixth null is a FINDING.** `codex-chat.ts`,
+  │                          `copilot-chat.ts` and `kimi-chat.ts` joined `antigravity-chat.ts`, all
+  │                          pure, each written against a fresh measurement of that harness's own
+  │                          files. Three rules recur and every one of them was a real defect first:
+  │                          **(1) THE SAME TURN IS WRITTEN TWICE**, in a different pair of places
+  │                          each time — codex writes `event_msg/{user,agent}_message` beside
+  │                          `response_item/message`, kimi writes `turn.prompt` beside
+  │                          `context.append_message`, agy writes the tool REQUEST beside its
+  │                          EXECUTION, and kimi's metrics parser records the same trap for its usage
+  │                          records. In each case ONE family is chosen and the other is ignored
+  │                          outright, and the chosen one is the SUPERSET, measured: codex's
+  │                          `event_msg` covers 21 of 42 user messages, kimi's `turn.prompt` 15 of 22.
+  │                          **(2) WHAT NOBODY SAID IS NEVER DRAWN AS A MESSAGE**, and each harness
+  │                          declares it differently — kimi stamps `message.origin.kind`
+  │                          (`user` against `injection`, its own `isMeta`), copilot separates
+  │                          `data.content` from `data.transformedContent` (the second is the same
+  │                          text wrapped in `<current_datetime>`/`<system_reminder>` and is NEVER
+  │                          read), codex has a `developer` ROLE plus `<…>` envelopes, and codex ALSO
+  │                          has entries with no marker at all: measured over its 40 largest
+  │                          rollouts, 11 of 32 untagged user messages were the harness loading a
+  │                          file (`# AGENTS.md instructions for …`), so `INJECTED` is
+  │                          `chat-envelope.ts`'s `META_KINDS` applied there. Everywhere, an
+  │                          unrecognised entry stays the PERSON's — hiding a real message is the
+  │                          expensive direction. **(3) A SHELL DETAIL GOES THROUGH
+  │                          `commandSummary`**, never a first-line truncation: on a real codex
+  │                          rollout five consecutive chips read `cd /home/…/embark`, saying where
+  │                          the work happened and never what it was.
+  │                          **GEMINI HAS NO READER AND MAY NOT GET ONE**, and that is a LINK fact,
+  │                          not a format one. A reader is only ever offered a `conversationId`, and
+  │                          only a harness with `assignId` or an id-taking `resume` can ever have
+  │                          one — claude and copilot have `assignId`; codex, kimi and agy have
+  │                          `resume`; **gemini has neither** (`-r, --resume` takes "latest" or an
+  │                          index, and `--session-id` is excluded because gemini's id here is
+  │                          synthetic). So an entry for it would be unreachable code plus a claim
+  │                          the product cannot honour; `conversationBlind` already says so on the
+  │                          row and `SessionsPage` hides the chat tab. Its format WAS measured and
+  │                          the finding is recorded in `harness-transcript.ts` so nobody spends it
+  │                          twice: a patch log, not one message per line. See docs/session-manager.md
   ├── cli-start.ts         → the control center's HOST (`ControlHost`): service detection, start/stop/restart, connect/disconnect, boot service, archive consent, language — every action returns an already-localized `ActionResult` instead of printing
   ├── cli-stream.ts        → the control center's OUTPUT CHANNEL: subscribers + `streamCommand` (both pipes captured, never `inherit`) → lines via the pure `@agentistics/tui/control/stream`
   ├── cli-ui.ts            → dependency-free arrow-key select/confirm/input/pause + clearScreen (bundles clean into the binary; no node_modules to resolve)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -325,7 +325,42 @@ packages/server/server/          — server-side modules (never bundled by Vite)
   │                          guessed directory, and a `derived` name is never adopted as a label. The
   │                          takeover additionally READS ITS WRITE BACK and retries once, saying so
   │                          when the record still cannot be kept — the loss is otherwise invisible
-  │                          at the moment it happens. See docs/session-manager.md
+  │                          at the moment it happens.
+  │                          **WHOSE CONVERSATION CAN BE READ** is `harness-transcript.ts`, a
+  │                          `Record<HarnessId, HarnessTranscript | null>` behind the workspace's
+  │                          chat view and the fleet poll's six-row tail. There are TWO limits and
+  │                          they were one thing for as long as Claude was the only readable
+  │                          harness: the LINK (is this row's `conversationId` exact?) and the
+  │                          FORMAT (has anybody written a reader?). Collapsing them cost the
+  │                          feature its honesty — measured 2026-09-05 on a live antigravity session
+  │                          whose `/proc/<pid>/cmdline` was `agy --conversation 01d0814f-…` for the
+  │                          very id the registry held, `GET /api/fleet/chat` ran into the
+  │                          CLAUDE-only path resolver, found nothing, took the live branch and
+  │                          answered `{turns: [], live: true}`: a blank pane with no sentence on
+  │                          it, because `SessionChat.tsx` draws "no messages yet" only when
+  │                          `live === null`. A `null` reader is now REFUSED IN WORDS and NAMES the
+  │                          harness. The link rule is untouched: only `ManagedSession.conversationId`
+  │                          reaches a reader, never the harness-and-directory guess, or some other
+  │                          conversation from the same folder appears under this session's name.
+  │                          `antigravity-chat.ts` is the first non-Claude reader and is PURE. agy
+  │                          writes the REQUEST and the EXECUTION as two steps — a `PLANNER_RESPONSE`
+  │                          carrying prose, `thinking` and `tool_calls`, then a `RUN_COMMAND` /
+  │                          `VIEW_FILE` / … step whose `content` is the result (1094 against 909 on
+  │                          the measured file; the executions carry no `tool_calls` at all). The
+  │                          chat keeps the REQUESTS and drops the executions, which is the INVERSE
+  │                          of `harness-activity.ts`'s choice for the same transcript and for the
+  │                          same reason — counting both is counting twice; a count wants the thing
+  │                          that happened, a bubble wants the one with the command in it. Tool names
+  │                          go through `canonicalTool`, so `sessionArtifacts.ts` — which selects by
+  │                          Claude's names — works on an agy session without knowing agy exists.
+  │                          `CONVERSATION_HISTORY` is a replay and is skipped; `SYSTEM_MESSAGE`,
+  │                          `CHECKPOINT` and `ERROR_MESSAGE` become unattributed notes that NAME the
+  │                          kind and never carry the body (agy's checkpoint is the whole truncated
+  │                          conversation, and its error paragraph runs 206–633 characters across all
+  │                          77 measured) — the same rule `chat-envelope.ts` applies to Claude's
+  │                          injected entries. `transcript-window.ts` is the shared byte-tail reader
+  │                          both harnesses poll through: a poll that reads whole transcripts is what
+  │                          made `/api/fleet` answer in 36 s cold. See docs/session-manager.md
   ├── cli-start.ts         → the control center's HOST (`ControlHost`): service detection, start/stop/restart, connect/disconnect, boot service, archive consent, language — every action returns an already-localized `ActionResult` instead of printing
   ├── cli-stream.ts        → the control center's OUTPUT CHANNEL: subscribers + `streamCommand` (both pipes captured, never `inherit`) → lines via the pure `@agentistics/tui/control/stream`
   ├── cli-ui.ts            → dependency-free arrow-key select/confirm/input/pause + clearScreen (bundles clean into the binary; no node_modules to resolve)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1185,19 +1185,48 @@ Only active when `SERVE_STATIC=1` (set by `cli.ts` for the `server` subcommand).
 
 Agent metrics are extracted from raw JSONL files by `server/agent-metrics.ts`. They are available in the `agentMetrics` field of each `SessionMeta`.
 
-### Data available per Agent invocation
+### The numbers are in the SUBAGENT'S OWN transcript, not in the parent's result
+
+**Claude Code made the `Agent` tool asynchronous on 2026-08-14 and the parent's `toolUseResult`
+stopped carrying any numbers.** It is now `{ agentId, description, isAsync, outputFile,
+resolvedModel, status: 'async_launched' }` — no `usage`, no `totalTokens`, no `toolStats`, no
+duration. Every `?? 0` in the old reader fired at once and each invocation was published **priced at
+nothing**: measured on one machine, 391 of 391 invocations from 08-14 onward reported 0 tokens while
+the panel kept drawing rows for all of them. That is the whole failure mode worth remembering — a
+PARTIALLY working reader. `agentType` and `description` come from the parent's `tool_use` input, so
+the rows kept their names and only the values were gone, and it went unnoticed for three weeks.
+
+The numbers moved to `~/.claude/projects/<project>/<session-id>/subagents/agent-<agentId>.jsonl`
+(+ an `agent-<agentId>.meta.json` naming the parent's `toolUseId`). `subagent-parse.ts` is **pure**
+— it sums one such transcript — and `subagent-metrics.ts` does the I/O: find, recurse, memoize.
+
+- **`outputFile` is NOT the file to read.** It is the agent's text answer in the run's `/tmp` scratch
+  directory, cleared on reboot and already gone for every invocation measured here. The durable one
+  is under `subagents/`.
+- **Price each model at ITS OWN rate.** A subagent commonly runs `haiku` under an `opus` parent (four
+  distinct models across 440 transcripts here), so one `modelId` for the whole invocation bills a
+  cheap agent as an expensive one — which is exactly what the old reader did with the parent's model.
+- **A nested subagent counts inside the invocation that spawned it.** Only a top-level `Agent`
+  `tool_use` becomes an `AgentInvocation`, so a subtree left out is left out of the session's totals
+  entirely. Cycle-safe by a visited set.
+- **The DURATION is the root's own span** — a nested agent runs inside its parent, and adding the two
+  counts the same wall time twice.
+- **An invocation whose transcript is gone is `unmeasured: true`, never a zero.** Read that flag
+  BEFORE any figure on the record: it carries zeros only because the type has no other value to
+  carry. `SessionAgentMetrics` totals exclude them and `unmeasuredInvocations` counts them, so a
+  surface can say the totals cover fewer rows than it is showing (`web/src/lib/agentMeasured.ts`).
+  Same rule as `HARNESS_CAPABILITIES`, applied to one row instead of a whole harness.
 
 | Field | Source |
 |---|---|
-| `agentType` | `toolUseResult.agentType` in the JSONL message envelope |
+| `agentType` | `toolUseResult.agentType`, else the `tool_use` input's `subagent_type` |
 | `description` | `tool_use.input.description` |
-| `totalTokens` | `toolUseResult.totalTokens` |
-| `totalDurationMs` | `toolUseResult.totalDurationMs` |
-| `totalToolUseCount` | `toolUseResult.totalToolUseCount` |
-| `inputTokens / outputTokens / cacheReadTokens / cacheWriteTokens` | `toolUseResult.usage.*` |
-| `toolStats` (reads, searches, bash, edits, lines changed) | `toolUseResult.toolStats` |
-| `costUSD` | Calculated via `calcCost()` |
-| `status` | `toolUseResult.status` (`completed` / `failed`) |
+| `agentId` | `toolUseResult.agentId` — names the subagent transcript |
+| `totalTokens` (all four counters) / `inputTokens` / `outputTokens` / `cacheReadTokens` / `cacheWriteTokens` | the subagent transcript's `message.usage`, per model; legacy: `toolUseResult.usage.*` |
+| `totalDurationMs` | the subagent transcript's first→last timestamp; legacy: `toolUseResult.totalDurationMs` |
+| `totalToolUseCount` / `toolStats` | the subagent transcript's `tool_use` items and `structuredPatch` hunks; legacy: `toolUseResult.toolStats` |
+| `costUSD` | `calcCost()` per model of the subagent's own turns |
+| `status` | `toolUseResult.status` (`failed` → `failed`, anything else → `completed`) |
 
 ### What is NOT available for Skills and Tasks
 

--- a/docs/data-sources.md
+++ b/docs/data-sources.md
@@ -103,7 +103,12 @@ interface SessionMeta {
 
 Agent metrics are extracted from raw JSONL by `server/agent-metrics.ts`. They are only available for sessions whose JSONL files are accessible (`_source: 'meta'`-only sessions may have incomplete agent data if the underlying JSONL was removed).
 
-### Available per Agent invocation
+### Two transcript shapes, and only one of them holds the numbers
+
+Claude Code made the `Agent` tool **asynchronous on 2026-08-14**, and the shape of the result it
+writes into the parent transcript changed with it. Both are read.
+
+**Legacy (until 2026-08-13)** — the numbers were inline, and the reader took them from there:
 
 | Field | Source in JSONL |
 |---|---|
@@ -116,6 +121,43 @@ Agent metrics are extracted from raw JSONL by `server/agent-metrics.ts`. They ar
 | `toolStats` | `toolUseResult.toolStats` |
 | `costUSD` | Calculated via `calcCost()` |
 | `status` | `toolUseResult.status` |
+
+**Current (2026-08-14 onward)** — the parent's result carries no numbers at all, only a name:
+
+```json
+{ "agentId": "a23c974fb8aab9fbf", "description": "Task 1: backup-plan.ts", "isAsync": true,
+  "status": "async_launched", "resolvedModel": "claude-haiku-4-5-20251001",
+  "outputFile": "/tmp/.../tasks/a23c974fb8aab9fbf.output", "canReadOutputFile": true }
+```
+
+The numbers moved into the subagent's **own transcript**, at
+`~/.claude/projects/<project>/<session-id>/subagents/agent-<agentId>.jsonl`, with an
+`agent-<agentId>.meta.json` beside it carrying `agentType`, `description` and the parent's
+`toolUseId`. `server/subagent-parse.ts` (pure) sums one such transcript and
+`server/subagent-metrics.ts` finds it, follows nested subagents and memoizes the result.
+
+Three rules that fall out of the new shape:
+
+- **`outputFile` is not used.** It points into the run's scratch directory under `/tmp`, holds the
+  agent's text answer rather than its accounting, and is routinely already gone. The durable file is
+  the one under `subagents/`.
+- **Each model is priced at its own rate.** A subagent commonly runs `haiku` under an `opus` parent
+  (four distinct models were measured across 440 subagent transcripts on one machine), so pricing an
+  invocation with the parent's model id bills a cheap agent as an expensive one.
+- **A nested subagent counts inside the invocation that spawned it.** Only a top-level `Agent`
+  `tool_use` becomes an `AgentInvocation`, so a subtree left out here is left out of the session's
+  agent totals entirely. The walk is cycle-safe.
+
+### An invocation whose transcript is gone reports N/A, never zero
+
+Claude Code deletes transcripts after `cleanupPeriodDays`. When a subagent's transcript cannot be
+read, the invocation is still listed — the parent recorded that it happened — and is marked
+`AgentInvocation.unmeasured: true`. Consumers **must read that flag before any figure on the
+record**: an unmeasured invocation carries zeros because the type has no other value to carry.
+`SessionAgentMetrics.totalTokens` / `totalDurationMs` / `totalCostUSD` exclude them and
+`unmeasuredInvocations` counts them, so a surface can say the totals cover fewer invocations than it
+is showing. This is the same rule `HARNESS_CAPABILITIES` applies to a metric a harness cannot
+produce, applied to one row.
 
 ### What is NOT tracked for Skills and Tasks
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -243,9 +243,27 @@ export interface SessionMeta {
 
 export interface AgentInvocation {
   toolUseId: string
+  /**
+   * The subagent's own transcript id, when the harness names one.
+   *
+   * Present since Claude Code made the `Agent` tool asynchronous (2026-08-14): the parent's result
+   * carries no numbers any more, only this id, and the numbers live in
+   * `<project>/<session-id>/subagents/agent-<agentId>.jsonl`. Absent on every record written before
+   * that, and on any harness that names no such file.
+   */
+  agentId?: string
   agentType: string
   description: string
   status: 'completed' | 'failed'
+  /**
+   * `true` when the numbers below could NOT be established for this invocation.
+   *
+   * Read it BEFORE reading any figure here: an unmeasured invocation carries zeros because the type
+   * has no other value to carry, and a zero rendered as a fact is the confident-0 this repository
+   * forbids everywhere else. A surface must render N/A for these, exactly as it does for a metric a
+   * harness cannot produce (`HARNESS_CAPABILITIES`). Absent means measured.
+   */
+  unmeasured?: true
   totalTokens: number
   totalDurationMs: number
   totalToolUseCount: number
@@ -268,6 +286,13 @@ export interface AgentInvocation {
 export interface SessionAgentMetrics {
   invocations: AgentInvocation[]
   totalInvocations: number
+  /**
+   * How many of them carry no established numbers — so a surface can say that the totals beside it
+   * cover fewer invocations than it is showing, instead of implying the rest cost nothing.
+   *
+   * Optional because a record stored before this existed has no such count; absent is not zero.
+   */
+  unmeasuredInvocations?: number
   totalTokens: number
   totalDurationMs: number
   totalCostUSD: number

--- a/packages/server/server/agent-metrics.test.ts
+++ b/packages/server/server/agent-metrics.test.ts
@@ -1,0 +1,89 @@
+import { test, expect } from 'bun:test'
+import { extractAgentMetrics } from './agent-metrics'
+
+/** The `Agent` tool_use as the session transcript records it. */
+function agentCall(id: string, description: string, subagentType = 'general-purpose') {
+  return JSON.stringify({
+    type: 'assistant',
+    message: { content: [{ type: 'tool_use', id, name: 'Agent', input: { description, subagent_type: subagentType } }] },
+  })
+}
+
+/** The result Claude Code writes TODAY: the agent is launched async and carries no numbers. */
+function asyncResult(id: string, agentId: string, description: string) {
+  return JSON.stringify({
+    type: 'user',
+    toolUseResult: {
+      agentId, description, isAsync: true, status: 'async_launched',
+      resolvedModel: 'claude-haiku-4-5-20251001',
+      outputFile: `/tmp/tasks/${agentId}.output`, canReadOutputFile: true,
+    },
+    message: { content: [{ type: 'tool_result', tool_use_id: id }] },
+  })
+}
+
+/** The result Claude Code wrote until 2026-08-13, with the numbers inline. */
+function legacyResult(id: string) {
+  return JSON.stringify({
+    type: 'user',
+    toolUseResult: {
+      status: 'completed', agentType: 'explorer',
+      totalTokens: 900, totalDurationMs: 4200, totalToolUseCount: 6,
+      usage: { input_tokens: 100, output_tokens: 200, cache_read_input_tokens: 5000, cache_creation_input_tokens: 30 },
+      toolStats: { readCount: 2, searchCount: 1, bashCount: 3, editFileCount: 0, linesAdded: 9, linesRemoved: 1, otherToolCount: 0 },
+    },
+    message: { content: [{ type: 'tool_result', tool_use_id: id }] },
+  })
+}
+
+test('the async shape is recorded as UNMEASURED and NAMES its transcript, never priced at zero', () => {
+  const m = extractAgentMetrics([
+    agentCall('toolu_1', 'Task 1: backup-plan.ts'),
+    asyncResult('toolu_1', 'a23c974fb8aab9fbf', 'Task 1: backup-plan.ts'),
+  ], 'claude-opus-5')
+
+  expect(m.invocations).toHaveLength(1)
+  const inv = m.invocations[0]!
+  expect(inv.unmeasured).toBe(true)
+  expect(inv.agentId).toBe('a23c974fb8aab9fbf')
+  expect(inv.description).toBe('Task 1: backup-plan.ts')
+  expect(inv.agentType).toBe('general-purpose')
+})
+
+test('an unmeasured invocation is counted, and counted SEPARATELY', () => {
+  const m = extractAgentMetrics([
+    agentCall('toolu_1', 'one'), asyncResult('toolu_1', 'aOne', 'one'),
+    agentCall('toolu_2', 'two'), legacyResult('toolu_2'),
+  ], 'claude-opus-5')
+
+  expect(m.totalInvocations).toBe(2)
+  expect(m.unmeasuredInvocations).toBe(1)
+})
+
+test('an unmeasured invocation adds nothing to the totals — it is not a zero, it is an absence', () => {
+  const m = extractAgentMetrics([
+    agentCall('toolu_1', 'one'), asyncResult('toolu_1', 'aOne', 'one'),
+  ], 'claude-opus-5')
+
+  expect(m.totalTokens).toBe(0)
+  expect(m.totalCostUSD).toBe(0)
+  expect(m.unmeasuredInvocations).toBe(1)
+})
+
+test('the legacy shape is read exactly as it always was', () => {
+  const m = extractAgentMetrics([
+    agentCall('toolu_2', 'legacy one'), legacyResult('toolu_2'),
+  ], 'claude-opus-5')
+
+  const inv = m.invocations[0]!
+  expect(inv.unmeasured).toBeUndefined()
+  expect(inv.agentType).toBe('explorer')
+  expect(inv.totalTokens).toBe(900)
+  expect(inv.totalDurationMs).toBe(4200)
+  expect(inv.totalToolUseCount).toBe(6)
+  expect(inv.inputTokens).toBe(100)
+  expect(inv.cacheReadTokens).toBe(5000)
+  expect(inv.toolStats.bashCount).toBe(3)
+  expect(inv.costUSD).toBeGreaterThan(0)
+  expect(m.unmeasuredInvocations).toBe(0)
+})

--- a/packages/server/server/agent-metrics.ts
+++ b/packages/server/server/agent-metrics.ts
@@ -1,5 +1,8 @@
 import { readFile } from 'fs/promises'
+import { basename } from 'path'
 import { calcCost } from '@agentistics/core'
+import { totalsOf } from './subagent-parse'
+import { enrichFromSubagentTranscripts } from './subagent-metrics'
 import type { AgentInvocation, SessionAgentMetrics } from '@agentistics/core'
 
 interface ToolUseRecord {
@@ -100,6 +103,27 @@ export function extractAgentMetrics(lines: Iterable<string>, modelId: string): S
         // We have a match — build the AgentInvocation
         pendingAgents.delete(toolUseId)
 
+        /**
+         * Did this result carry NUMBERS at all?
+         *
+         * Since Claude Code made the `Agent` tool asynchronous (measured: the shape changed on
+         * 2026-08-14) the result is only `{ agentId, description, isAsync, outputFile,
+         * resolvedModel, status: 'async_launched' }` — no `usage`, no totals, no `toolStats`. Every
+         * `?? 0` below then fired at once and the invocation was published priced at nothing, which
+         * is exactly the confident zero this repository forbids: the panel kept rendering rows and
+         * only the values were gone, which is why it went unnoticed for three weeks.
+         *
+         * So a result with no numbers is marked UNMEASURED here and enriched from the subagent's own
+         * transcript by `subagent-metrics.ts`. What cannot be found there stays unmeasured, and the
+         * surface renders N/A.
+         */
+        const measured =
+          toolUseResult.usage !== undefined ||
+          toolUseResult.totalTokens !== undefined ||
+          toolUseResult.totalDurationMs !== undefined ||
+          toolUseResult.totalToolUseCount !== undefined ||
+          toolUseResult.toolStats !== undefined
+
         const usage = toolUseResult.usage ?? {}
         const toolStats = toolUseResult.toolStats ?? {}
 
@@ -122,6 +146,8 @@ export function extractAgentMetrics(lines: Iterable<string>, modelId: string): S
 
         invocations.push({
           toolUseId,
+          ...(toolUseResult.agentId ? { agentId: toolUseResult.agentId } : {}),
+          ...(measured ? {} : { unmeasured: true as const }),
           agentType: toolUseResult.agentType ?? pending.input.subagent_type ?? 'unknown',
           description: pending.input.description ?? '',
           status: (toolUseResult.status === 'failed') ? 'failed' : 'completed',
@@ -147,18 +173,7 @@ export function extractAgentMetrics(lines: Iterable<string>, modelId: string): S
     }
   }
 
-  const totalInvocations = invocations.length
-  const totalTokens = invocations.reduce((s, i) => s + i.totalTokens, 0)
-  const totalDurationMs = invocations.reduce((s, i) => s + i.totalDurationMs, 0)
-  const totalCostUSD = invocations.reduce((s, i) => s + i.costUSD, 0)
-
-  return {
-    invocations,
-    totalInvocations,
-    totalTokens,
-    totalDurationMs,
-    totalCostUSD,
-  }
+  return totalsOf(invocations)
 }
 
 /**
@@ -166,7 +181,7 @@ export function extractAgentMetrics(lines: Iterable<string>, modelId: string): S
  * Used for meta-sourced sessions that have agent tool usage.
  */
 export async function extractAgentMetricsFromFile(filePath: string): Promise<SessionAgentMetrics> {
-  const empty: SessionAgentMetrics = { invocations: [], totalInvocations: 0, totalTokens: 0, totalDurationMs: 0, totalCostUSD: 0 }
+  const empty: SessionAgentMetrics = { invocations: [], totalInvocations: 0, unmeasuredInvocations: 0, totalTokens: 0, totalDurationMs: 0, totalCostUSD: 0 }
   let content: string
   try {
     content = await readFile(filePath, 'utf-8')
@@ -190,5 +205,8 @@ export async function extractAgentMetricsFromFile(filePath: string): Promise<Ses
     } catch { continue }
   }
 
-  return extractAgentMetrics(lines, modelId)
+  // The session id is the file's own name — which is exactly what names the `subagents/` directory
+  // holding each subagent's transcript.
+  const sessionId = basename(filePath).replace(/\.jsonl$/, '')
+  return enrichFromSubagentTranscripts(extractAgentMetrics(lines, modelId), filePath, sessionId)
 }

--- a/packages/server/server/index.ts
+++ b/packages/server/server/index.ts
@@ -1401,8 +1401,9 @@ async function handleRequestInner(req: Request, server: Server<WSData>): Promise
       }
     }
 
-    // One hosted session's conversation, for the workspace's chat view. Claude only in practice —
-    // the module refuses in words wherever the live-session -> conversation link is not exact.
+    // One hosted session's conversation, for the workspace's chat view. Which harnesses can be read
+    // is `harness-transcript.ts`; the module refuses IN WORDS wherever the conversation link is not
+    // exact or nothing here parses that harness's transcript format.
     if (url.pathname === '/api/fleet/chat' && req.method === 'GET') {
       const id = url.searchParams.get('id')
       if (!id) {

--- a/packages/server/server/jsonl.ts
+++ b/packages/server/server/jsonl.ts
@@ -4,6 +4,7 @@ import { activeMinutesOf } from '@agentistics/core'
 import { getGitFileStats } from './git'
 import { countGitCommands } from './harness-activity'
 import { extractAgentMetrics } from './agent-metrics'
+import { enrichFromSubagentTranscripts } from './subagent-metrics'
 import { addDelta, editDelta, type EditDelta } from './edit-lines'
 
 // File extension → language name (used when session-meta is absent)
@@ -448,9 +449,14 @@ export async function parseSessionJsonl(
   // Use whichever count is higher: git-tracked files changed or files Claude directly edited
   const filesModifiedCount = Math.max(gitFileStats.filesModified, claudeFilesModified.size)
 
-  // Extract agent metrics if this session used the Agent tool
+  // Extract agent metrics if this session used the Agent tool.
+  //
+  // The parse alone can no longer produce the NUMBERS: since Claude Code made the Agent tool
+  // asynchronous the parent transcript names the subagent and nothing else, so the invocations come
+  // back marked `unmeasured` and are filled in from each subagent's own transcript, which sits
+  // beside this file. See `subagent-metrics.ts`.
   const agentMetrics = toolCounts['Agent']
-    ? extractAgentMetrics(iterLines(content), modelId)
+    ? await enrichFromSubagentTranscripts(extractAgentMetrics(iterLines(content), modelId), filePath, sessionId)
     : undefined
 
   return {

--- a/packages/server/server/sessions/antigravity-chat.test.ts
+++ b/packages/server/server/sessions/antigravity-chat.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it } from 'bun:test'
+import { parseAntigravityChat, userRequestText } from './antigravity-chat'
+
+/**
+ * Every fixture below is the SHAPE measured on the live conversation
+ * `01d0814f-ef39-4838-8461-c50e540e552a` (agy 1.1.22, 2026-09-05), trimmed to the fields that
+ * decide the answer. Where a rule exists because of a number, the number is in the test's name.
+ */
+
+const line = (o: Record<string, unknown>): string => JSON.stringify(o)
+
+const userInput = (idx: number, text: string): string => line({
+  step_index: idx,
+  source: 'USER_EXPLICIT',
+  type: 'USER_INPUT',
+  status: 'DONE',
+  created_at: '2026-09-05T17:22:28Z',
+  content: `<USER_REQUEST>\n${text}\n</USER_REQUEST>\n<ADDITIONAL_METADATA>\nThe current local time is: 2026-09-05T14:22:28-03:00.\n</ADDITIONAL_METADATA>`,
+})
+
+const planner = (idx: number, o: Record<string, unknown> = {}): string => line({
+  step_index: idx,
+  source: 'MODEL',
+  type: 'PLANNER_RESPONSE',
+  status: 'DONE',
+  created_at: '2026-09-05T17:22:30Z',
+  ...o,
+})
+
+describe('userRequestText', () => {
+  it('keeps the request and drops the metadata block the harness appends', () => {
+    const raw = '<USER_REQUEST>\nacabamos?\n</USER_REQUEST>\n<ADDITIONAL_METADATA>\nThe current local time is: 2026-09-05T14:22:28-03:00.\n</ADDITIONAL_METADATA>'
+    expect(userRequestText(raw)).toBe('acabamos?')
+  })
+
+  it('an unwrapped input still yields its text — a turn that happened is never erased', () => {
+    expect(userRequestText('só isso\n<ADDITIONAL_METADATA>\nx\n</ADDITIONAL_METADATA>')).toBe('só isso')
+  })
+})
+
+describe('parseAntigravityChat', () => {
+  it('reads a person turn and a model turn, oldest first', () => {
+    const turns = parseAntigravityChat([
+      userInput(0, 'acabamos?'),
+      planner(1, { content: 'Sim, finalizamos.' }),
+    ])
+    expect(turns).toEqual([
+      { role: 'user', text: 'acabamos?', at: '2026-09-05T17:22:28Z' },
+      { role: 'assistant', text: 'Sim, finalizamos.', at: '2026-09-05T17:22:30Z' },
+    ])
+  })
+
+  it('carries thinking apart from the answer', () => {
+    const [turn] = parseAntigravityChat([planner(0, { content: 'ok', thinking: 'Executing Session Kill' })])
+    expect(turn).toMatchObject({ role: 'assistant', text: 'ok', thinking: 'Executing Session Kill' })
+  })
+
+  it('maps a tool call onto the shared vocabulary and shows its argument, not its label', () => {
+    const [turn] = parseAntigravityChat([planner(0, {
+      tool_calls: [{
+        name: 'run_command',
+        args: {
+          CommandLine: 'agentop session kill 29bce',
+          Cwd: '/home/mithrandir/agentistics',
+          toolSummary: 'End session via agentop cli',
+        },
+      }],
+    })])
+    // `run_command` → `Bash`, so `sessionArtifacts.ts` and `ChatBubble` — both written against
+    // Claude's names — read an agy session with no knowledge that agy exists.
+    expect(turn!.tools).toEqual([{ name: 'Bash', detail: 'agentop session kill 29bce' }])
+  })
+
+  it('names a write by its file, never by the file contents it carries', () => {
+    const [turn] = parseAntigravityChat([planner(0, {
+      tool_calls: [{
+        name: 'write_to_file',
+        args: { TargetFile: '/repo/src/a.ts', CodeContent: 'x'.repeat(5000), toolSummary: 'Create a file' },
+      }],
+    })])
+    expect(turn!.tools).toEqual([{ name: 'Write', detail: '/repo/src/a.ts' }])
+  })
+
+  it('truncates a detail longer than 200 characters rather than shipping it whole', () => {
+    const [turn] = parseAntigravityChat([planner(0, {
+      tool_calls: [{ name: 'run_command', args: { CommandLine: 'x'.repeat(400) } }],
+    })])
+    expect(turn!.tools![0]!.detail!.length).toBe(201)
+    expect(turn!.tools![0]!.detail!.endsWith('…')).toBe(true)
+  })
+
+  it('an unmapped tool name passes through as itself', () => {
+    const [turn] = parseAntigravityChat([planner(0, {
+      tool_calls: [{ name: 'manage_task', args: { Action: 'complete', TaskId: 't-1' } }],
+    })])
+    expect(turn!.tools![0]!.name).toBe('manage_task')
+  })
+
+  it('drops the EXECUTION steps — the request above them already said what ran', () => {
+    // 1094 planner steps against 909 executions on the measured file: keeping both draws every
+    // action twice, and the execution's `content` is the whole stdout.
+    const turns = parseAntigravityChat([
+      planner(0, { tool_calls: [{ name: 'run_command', args: { CommandLine: 'ls' } }] }),
+      line({ step_index: 1, source: 'MODEL', type: 'RUN_COMMAND', status: 'DONE', exit_code: 0, content: 'a\nb\nc' }),
+      line({ step_index: 2, source: 'MODEL', type: 'VIEW_FILE', status: 'DONE', content: '…5000 lines…' }),
+      line({ step_index: 3, source: 'MODEL', type: 'CODE_ACTION', status: 'DONE', content: '[diff_block_start]…' }),
+    ])
+    expect(turns).toHaveLength(1)
+    expect(turns[0]!.tools).toEqual([{ name: 'Bash', detail: 'ls' }])
+  })
+
+  it('skips CONVERSATION_HISTORY — it is a replay of turns already in the file', () => {
+    const turns = parseAntigravityChat([
+      userInput(0, 'oi'),
+      line({ step_index: 1, source: 'SYSTEM', type: 'CONVERSATION_HISTORY', status: 'DONE', content: 'oi' }),
+    ])
+    expect(turns).toEqual([{ role: 'user', text: 'oi', at: '2026-09-05T17:22:28Z' }])
+  })
+
+  it('a system step is an unattributed note that NAMES the kind and never carries the body', () => {
+    // agy's checkpoint is the whole truncated conversation and its error paragraph runs 206–633
+    // characters across all 77 measured — neither is a line in a chat.
+    const turns = parseAntigravityChat([
+      line({ step_index: 0, source: 'SYSTEM', type: 'SYSTEM_MESSAGE', status: 'DONE', content: 'x'.repeat(900) }),
+      line({ step_index: 1, source: 'SYSTEM', type: 'CHECKPOINT', status: 'DONE', content: '{{ CHECKPOINT 33 }}…' }),
+      line({ step_index: 2, source: 'SYSTEM', type: 'ERROR_MESSAGE', status: 'DONE', error: 'y'.repeat(600) }),
+    ])
+    expect(turns.map(t => t.system)).toEqual([
+      'a system message', 'the conversation was truncated', 'the harness reported an error',
+    ])
+    for (const t of turns) expect(t.text).toBe(t.system!)
+  })
+
+  it('a step type nobody has mapped is named by its own type, never silently dropped', () => {
+    const [turn] = parseAntigravityChat([
+      line({ step_index: 0, source: 'SYSTEM', type: 'BRAND_NEW_THING', status: 'DONE', content: 'x' }),
+    ])
+    expect(turn!.system).toBe('a brand new thing step')
+  })
+
+  it('USER_INPUT that did not come from the person is a note, never the reader’s bubble', () => {
+    const [turn] = parseAntigravityChat([line({
+      step_index: 0, source: 'SYSTEM', type: 'USER_INPUT', status: 'DONE',
+      content: '<USER_REQUEST>\ncontinue\n</USER_REQUEST>',
+    })])
+    expect(turn).toMatchObject({ system: 'input from the harness' })
+  })
+
+  it('only the NEWEST tool call with no text after it is pending', () => {
+    const turns = parseAntigravityChat([
+      planner(0, { tool_calls: [{ name: 'run_command', args: { CommandLine: 'a' } }] }),
+      planner(1, { content: 'done' }),
+      planner(2, { tool_calls: [{ name: 'run_command', args: { CommandLine: 'b' } }] }),
+    ])
+    expect(turns.map(t => t.pending)).toEqual([undefined, undefined, true])
+  })
+
+  it('dedupes by step_index, keeping the LATER write', () => {
+    const turns = parseAntigravityChat([
+      planner(7, { content: 'half' }),
+      planner(7, { content: 'whole' }),
+    ])
+    expect(turns).toHaveLength(1)
+    expect(turns[0]!.text).toBe('whole')
+  })
+
+  it('a half line the tail window cut through is skipped, not parsed', () => {
+    const turns = parseAntigravityChat(['dex":9,"type":"PLAN', userInput(10, 'oi')])
+    expect(turns).toHaveLength(1)
+  })
+
+  it('caps at max, keeping the END of the conversation', () => {
+    const lines = Array.from({ length: 20 }, (_, i) => planner(i, { content: `m${i}` }))
+    const turns = parseAntigravityChat(lines, 'antigravity', 3)
+    expect(turns.map(t => t.text)).toEqual(['m17', 'm18', 'm19'])
+  })
+
+  it('a planner step with nothing in it is not a turn', () => {
+    expect(parseAntigravityChat([planner(0, {}), planner(1, { content: '   ' })])).toEqual([])
+  })
+
+  it('a turn with no recorded time gets none rather than an invented now', () => {
+    const [turn] = parseAntigravityChat([line({
+      step_index: 0, source: 'MODEL', type: 'PLANNER_RESPONSE', content: 'oi',
+    })])
+    expect(turn!.at).toBeUndefined()
+  })
+})

--- a/packages/server/server/sessions/antigravity-chat.test.ts
+++ b/packages/server/server/sessions/antigravity-chat.test.ts
@@ -55,7 +55,7 @@ describe('parseAntigravityChat', () => {
     expect(turn).toMatchObject({ role: 'assistant', text: 'ok', thinking: 'Executing Session Kill' })
   })
 
-  it('maps a tool call onto the shared vocabulary and shows its argument, not its label', () => {
+  it('keeps AGY\'s own tool name for display, with the shared one carried beside it', () => {
     const [turn] = parseAntigravityChat([planner(0, {
       tool_calls: [{
         name: 'run_command',
@@ -66,9 +66,12 @@ describe('parseAntigravityChat', () => {
         },
       }],
     })])
-    // `run_command` → `Bash`, so `sessionArtifacts.ts` and `ChatBubble` — both written against
-    // Claude's names — read an agy session with no knowledge that agy exists.
-    expect(turn!.tools).toEqual([{ name: 'Bash', detail: 'agentop session kill 29bce' }])
+    // The first version emitted `name: 'Bash'` and nothing else, so an Antigravity conversation
+    // rendered Claude Code's tool names for actions agy never took. `name` is what agy called it;
+    // `canonical` is what `sessionArtifacts.ts` selects on.
+    expect(turn!.tools).toEqual([{
+      name: 'run_command', canonical: 'Bash', detail: 'agentop session kill 29bce',
+    }])
   })
 
   it('names a write by its file, never by the file contents it carries', () => {
@@ -78,7 +81,25 @@ describe('parseAntigravityChat', () => {
         args: { TargetFile: '/repo/src/a.ts', CodeContent: 'x'.repeat(5000), toolSummary: 'Create a file' },
       }],
     })])
-    expect(turn!.tools).toEqual([{ name: 'Write', detail: '/repo/src/a.ts' }])
+    expect(turn!.tools).toEqual([{
+      name: 'write_to_file', canonical: 'Write', detail: '/repo/src/a.ts',
+    }])
+  })
+
+  it('NO tool is renamed on the way to the screen — the whole list speaks one vocabulary', () => {
+    // The tell that exposed the bug: five mapped names rendered as Claude's beside `manage_task`
+    // and `schedule`, which nothing maps, so one list spoke two vocabularies at once.
+    const [turn] = parseAntigravityChat([planner(0, {
+      tool_calls: [
+        { name: 'run_command', args: { CommandLine: 'ls' } },
+        { name: 'view_file', args: { AbsolutePath: '/a' } },
+        { name: 'grep_search', args: { Query: 'x' } },
+        { name: 'manage_task', args: { Action: 'complete' } },
+        { name: 'schedule', args: { Prompt: 'later' } },
+      ],
+    })])
+    expect(turn!.tools!.map(t => t.name))
+      .toEqual(['run_command', 'view_file', 'grep_search', 'manage_task', 'schedule'])
   })
 
   it('truncates a detail longer than 200 characters rather than shipping it whole', () => {
@@ -89,11 +110,12 @@ describe('parseAntigravityChat', () => {
     expect(turn!.tools![0]!.detail!.endsWith('…')).toBe(true)
   })
 
-  it('an unmapped tool name passes through as itself', () => {
+  it('an unmapped tool carries NO canonical field — there is no second reading to state', () => {
     const [turn] = parseAntigravityChat([planner(0, {
       tool_calls: [{ name: 'manage_task', args: { Action: 'complete', TaskId: 't-1' } }],
     })])
     expect(turn!.tools![0]!.name).toBe('manage_task')
+    expect(turn!.tools![0]!.canonical).toBeUndefined()
   })
 
   it('drops the EXECUTION steps — the request above them already said what ran', () => {
@@ -106,7 +128,7 @@ describe('parseAntigravityChat', () => {
       line({ step_index: 3, source: 'MODEL', type: 'CODE_ACTION', status: 'DONE', content: '[diff_block_start]…' }),
     ])
     expect(turns).toHaveLength(1)
-    expect(turns[0]!.tools).toEqual([{ name: 'Bash', detail: 'ls' }])
+    expect(turns[0]!.tools).toEqual([{ name: 'run_command', canonical: 'Bash', detail: 'ls' }])
   })
 
   it('skips CONVERSATION_HISTORY — it is a replay of turns already in the file', () => {

--- a/packages/server/server/sessions/antigravity-chat.ts
+++ b/packages/server/server/sessions/antigravity-chat.ts
@@ -1,0 +1,236 @@
+/**
+ * antigravity-chat.ts — PURE: an Antigravity (agy) transcript's lines → `ChatTurn[]`.
+ *
+ * No fs, no side effects. `harness-transcript.ts` finds the file and hands the lines over.
+ *
+ * ON-DISK SHAPE, re-measured 2026-09-05 against the live conversation
+ * `01d0814f-ef39-4838-8461-c50e540e552a` (agy 1.1.22, 2290 lines, appended to while it was read).
+ * `antigravity-parse.ts` — the METRICS parser — already documents the envelope; what follows is the
+ * part a CONVERSATION needs, which that parser never had to answer.
+ *
+ *   step_index  monotonic, unique in every file measured (0 duplicates in 2290)
+ *   source      USER_EXPLICIT | MODEL | SYSTEM   — the honest role, and the only one
+ *   type        USER_INPUT | PLANNER_RESPONSE | VIEW_FILE | RUN_COMMAND | GREP_SEARCH |
+ *               CODE_ACTION | LIST_DIRECTORY | ERROR_MESSAGE | SYSTEM_MESSAGE | CHECKPOINT |
+ *               CONVERSATION_HISTORY | GENERIC | …
+ *   created_at  ISO with `Z`
+ *   content     a STRING (never an object), absent on 1079 of the 2290 lines
+ *   thinking    the model's reasoning, on a PLANNER_RESPONSE
+ *   tool_calls  [{name, args}] — the REQUEST, and ONLY ever on a PLANNER_RESPONSE
+ *   error / error_code / exit_code
+ *
+ * THE REQUEST AND THE EXECUTION ARE TWO STEPS, and this is the whole of the mapping.
+ * A `PLANNER_RESPONSE` carries the model's prose, its thinking and the `tool_calls` it is asking
+ * for — `{name: 'run_command', args: {CommandLine: 'agentop session kill 29bce', …}}`. The
+ * execution then arrives as its OWN step (`RUN_COMMAND`, `VIEW_FILE`, …) whose `content` is the
+ * result: for a command, the entire stdout. Measured: 1094 planner steps against 909 execution
+ * steps, and the executions carry no `tool_calls` at all.
+ *
+ * So the conversation is built from the REQUESTS and the executions are dropped. This is the
+ * inverse of the choice `harness-activity.ts` records for the same transcript ("Agy counts the
+ * EXECUTION, never the request") and for the same reason — counting both is counting twice. A
+ * COUNT wants the execution because that is the thing that happened; a CHAT BUBBLE wants the
+ * request because that is the thing with the command in it, and the execution is pages of output
+ * that `ChatTurn` has nowhere to put and a reader has no room for.
+ *
+ * WHAT NOBODY SAID IS NEVER DRAWN AS A MESSAGE. `USER_INPUT` is wrapped in `<USER_REQUEST>` with
+ * an `<ADDITIONAL_METADATA>` block the harness appends (the local time); only the request is the
+ * person's. `SYSTEM_MESSAGE`, `CHECKPOINT` and `ERROR_MESSAGE` are the harness talking and become
+ * unattributed notes, exactly as `chat-envelope.ts` does for Claude's injected entries — and, like
+ * those, a note NAMES the kind and never carries the body: agy's checkpoint summary is the whole
+ * truncated conversation, and its error paragraph runs 206–633 characters (measured over all 77).
+ *
+ * `CONVERSATION_HISTORY` is a REPLAY of earlier turns and is skipped, the same rule
+ * `antigravity-parse.ts` applies for the same reason: the turns it repeats are already in the file
+ * as themselves, and reading both shows every one of them twice.
+ */
+
+import type { HarnessId } from '@agentistics/core'
+import { canonicalTool } from '../harness-activity'
+import type { ChatTurn } from './chat-turn'
+
+/** One line of `transcript_full.jsonl`, as far as a conversation is concerned. */
+interface AgyStep {
+  step_index?: unknown
+  source?: unknown
+  type?: unknown
+  created_at?: unknown
+  content?: unknown
+  thinking?: unknown
+  error?: unknown
+  tool_calls?: unknown
+}
+
+/**
+ * Steps that are the RESULT of a `tool_calls` entry already carried by the planner step above them.
+ *
+ * Listed rather than inferred from "has no tool_calls", because that is also true of a step type
+ * nobody here has seen: an unknown type falls through to a named note (see `noteFor`) so it shows
+ * up as itself and gets looked at, which is the same rule `canonicalTool` follows for a tool name
+ * nobody has mapped.
+ */
+const EXECUTION_TYPES = new Set([
+  'VIEW_FILE', 'RUN_COMMAND', 'GREP_SEARCH', 'CODE_ACTION', 'LIST_DIRECTORY',
+  'SEARCH_WEB', 'READ_URL_CONTENT', 'BROWSER_ACTION', 'MEMORY', 'GENERIC',
+  'INVOKE_SUBAGENT', 'MANAGE_TASK', 'SCHEDULE',
+])
+
+/**
+ * The note an unattributed step becomes. English, like every note `chat-envelope.ts` produces —
+ * `ChatBubble` holds the Portuguese, because a note is chrome rather than a machine's answer.
+ */
+const NOTES: Record<string, string> = {
+  SYSTEM_MESSAGE: 'a system message',
+  CHECKPOINT: 'the conversation was truncated',
+  ERROR_MESSAGE: 'the harness reported an error',
+}
+
+/**
+ * The one line worth showing for a tool call — agy's field names, Claude's rule.
+ *
+ * Named fields in priority order rather than a dump of the args, exactly as `chat-tail.ts`'s
+ * `toolDetail` does: a `write_to_file` carries the whole new file in `CodeContent` and a
+ * `replace_file_content` carries both sides of the edit, and neither belongs in a chat bubble.
+ * `toolSummary` is agy's OWN one-line label and is the last resort rather than the first: it says
+ * "Edit a file", where `TargetFile` says which.
+ */
+const DETAIL_KEYS = [
+  'CommandLine', 'AbsolutePath', 'TargetFile', 'DirectoryPath', 'Query', 'SearchPath',
+  'Prompt', 'Instruction', 'Description', 'toolSummary', 'toolAction',
+]
+
+function toolDetail(args: unknown): string | null {
+  if (typeof args !== 'object' || args === null) return null
+  const o = args as Record<string, unknown>
+  for (const key of DETAIL_KEYS) {
+    const v = o[key]
+    if (typeof v === 'string' && v.trim() !== '') {
+      const line = v.trim().split('\n')[0]!
+      return line.length > 200 ? `${line.slice(0, 200)}…` : line
+    }
+  }
+  return null
+}
+
+/**
+ * The tools one planner step asked for, under the SHARED vocabulary.
+ *
+ * `canonicalTool` maps agy's names onto Claude's (`write_to_file` → `Write`, `run_command` →
+ * `Bash`), which is what makes the artifacts panel work for an agy session without knowing agy
+ * exists: `sessionArtifacts.ts` selects by tool NAME, and its set is Claude's names. An unmapped
+ * name passes through as itself.
+ */
+function toolsOf(step: AgyStep, harness: HarnessId): ChatTurn['tools'] {
+  if (!Array.isArray(step.tool_calls)) return undefined
+  const out: NonNullable<ChatTurn['tools']> = []
+  for (const raw of step.tool_calls as unknown[]) {
+    if (typeof raw !== 'object' || raw === null) continue
+    const call = raw as Record<string, unknown>
+    if (typeof call.name !== 'string' || call.name === '') continue
+    const detail = toolDetail(call.args)
+    out.push({ name: canonicalTool(harness, call.name), ...(detail ? { detail } : {}) })
+  }
+  return out.length > 0 ? out : undefined
+}
+
+/** `<USER_REQUEST>` is the person; `<ADDITIONAL_METADATA>` is the harness stamping the local time. */
+export function userRequestText(content: string): string {
+  const m = /<USER_REQUEST>([\s\S]*?)<\/USER_REQUEST>/.exec(content)
+  if (m) return m[1]!.trim()
+  // No envelope at all: strip the metadata block the harness appends and keep what is left. An
+  // unwrapped USER_INPUT has not been seen, and dropping it would erase a turn that happened.
+  return content.replace(/<ADDITIONAL_METADATA>[\s\S]*?<\/ADDITIONAL_METADATA>/g, '').trim()
+}
+
+function str(v: unknown): string {
+  return typeof v === 'string' ? v.trim() : ''
+}
+
+/**
+ * The turn one step becomes, or `null` when it is not a turn at all.
+ *
+ * `isNewest` is the last substantive step in the file, and the ONLY place "a tool call with no text
+ * after it" means "busy right now" — the same shape earlier in the transcript is an ordinary call
+ * whose result already exists further down. Identical rule, and identical reason, to `chat-tail.ts`.
+ */
+function turnOf(step: AgyStep, harness: HarnessId, isNewest: boolean): ChatTurn | null {
+  const type = str(step.type)
+  const at = typeof step.created_at === 'string' ? step.created_at : undefined
+  const stamp = (t: ChatTurn): ChatTurn => (at ? { ...t, at } : t)
+
+  if (type === 'CONVERSATION_HISTORY') return null
+  if (EXECUTION_TYPES.has(type)) return null
+
+  if (type === 'USER_INPUT') {
+    const text = userRequestText(str(step.content))
+    if (text === '') return null
+    // Only `USER_EXPLICIT` is the person. Every USER_INPUT measured carried it, and a step arriving
+    // under this type from SYSTEM would be the harness feeding itself input — which may never be
+    // drawn over the reader's avatar, the same rule `chat-envelope.ts` exists to enforce.
+    if (str(step.source) !== 'USER_EXPLICIT') {
+      return stamp({ role: 'user', text: 'input from the harness', system: 'input from the harness' })
+    }
+    return stamp({ role: 'user', text })
+  }
+
+  if (type === 'PLANNER_RESPONSE') {
+    const text = str(step.content)
+    const thinking = str(step.thinking)
+    const tools = toolsOf(step, harness)
+    if (text === '' && thinking === '' && !tools) return null
+    return stamp({
+      role: 'assistant',
+      text,
+      ...(tools ? { tools } : {}),
+      ...(thinking ? { thinking } : {}),
+      ...(isNewest && text === '' && tools ? { pending: true } : {}),
+    })
+  }
+
+  // Everything else is the harness, not either party. A note names the kind; a type nobody has
+  // mapped is named by its own type rather than dropped, so a new one is visible instead of silent.
+  const note = NOTES[type] ?? (type === '' ? '' : `a ${type.toLowerCase().replace(/_/g, ' ')} step`)
+  if (note === '') return null
+  return stamp({ role: 'user', text: note, system: note })
+}
+
+/**
+ * The conversation these lines hold, oldest first, capped at `max` turns from the END.
+ *
+ * Walked BACKWARD so a tail window can stop as soon as it has enough, and so the `isNewest` rule
+ * has a cheap answer. `atStart` tells the caller whether the window reached the beginning of the
+ * file; the caller widens and asks again when it came back short.
+ */
+export function parseAntigravityChat(
+  lines: string[],
+  harness: HarnessId = 'antigravity',
+  max = 400,
+): ChatTurn[] {
+  const turns: ChatTurn[] = []
+  /**
+   * `step_index` already emitted. The metrics parser dedupes on it and this one must too: a step
+   * rewritten as it completes appears twice, and walking backward means the LATER write is the one
+   * seen first — which is the one to keep.
+   */
+  const seen = new Set<number>()
+  let newest = true
+  for (let i = lines.length - 1; i >= 0 && turns.length < max; i--) {
+    const line = (lines[i] ?? '').trim()
+    if (line === '') continue
+    let step: AgyStep
+    try { step = JSON.parse(line) as AgyStep } catch { continue }
+
+    const idx = typeof step.step_index === 'number' ? step.step_index : null
+    if (idx !== null) {
+      if (seen.has(idx)) continue
+      seen.add(idx)
+    }
+
+    const isNewest = newest
+    newest = false
+    const turn = turnOf(step, harness, isNewest)
+    if (turn) turns.push(turn)
+  }
+  turns.reverse()
+  return turns
+}

--- a/packages/server/server/sessions/antigravity-chat.ts
+++ b/packages/server/server/sessions/antigravity-chat.ts
@@ -113,12 +113,17 @@ function toolDetail(args: unknown): string | null {
 }
 
 /**
- * The tools one planner step asked for, under the SHARED vocabulary.
+ * The tools one planner step asked for — under AGY'S OWN NAMES, with the shared one beside them.
  *
- * `canonicalTool` maps agy's names onto Claude's (`write_to_file` → `Write`, `run_command` →
- * `Bash`), which is what makes the artifacts panel work for an agy session without knowing agy
- * exists: `sessionArtifacts.ts` selects by tool NAME, and its set is Claude's names. An unmapped
- * name passes through as itself.
+ * The first version of this reader emitted only `canonicalTool`'s answer, so an Antigravity
+ * conversation rendered its actions as `Bash`, `Read`, `Grep`, `Edit` and `Write` — Claude Code's
+ * tool names, in a session that ran none of them. It was reported the moment it reached the screen,
+ * and the result gave itself away: those five stood beside `manage_task` and `schedule`, which are
+ * agy's own and which nothing maps, so the same list spoke two vocabularies at once.
+ *
+ * `name` is therefore what agy called it and `canonical` is the shared reading, carried separately
+ * and only when the two differ — `sessionArtifacts.ts` still finds the writes (its set is Claude's
+ * names) without the bubble claiming agy ran a tool it does not have. See `ChatTurn.tools`.
  */
 function toolsOf(step: AgyStep, harness: HarnessId): ChatTurn['tools'] {
   if (!Array.isArray(step.tool_calls)) return undefined
@@ -128,7 +133,12 @@ function toolsOf(step: AgyStep, harness: HarnessId): ChatTurn['tools'] {
     const call = raw as Record<string, unknown>
     if (typeof call.name !== 'string' || call.name === '') continue
     const detail = toolDetail(call.args)
-    out.push({ name: canonicalTool(harness, call.name), ...(detail ? { detail } : {}) })
+    const canonical = canonicalTool(harness, call.name)
+    out.push({
+      name: call.name,
+      ...(canonical !== call.name ? { canonical } : {}),
+      ...(detail ? { detail } : {}),
+    })
   }
   return out.length > 0 ? out : undefined
 }

--- a/packages/server/server/sessions/chat-tail.ts
+++ b/packages/server/server/sessions/chat-tail.ts
@@ -17,90 +17,22 @@
  * is never re-scanned on a later poll.
  */
 
-// `open` is the TAIL reader's (readRecentChatTurns, the 5s poll); `readFile` is the CHAT view's,
-// which deliberately reads the whole transcript — see readChatTurns' own note on why a cache there
-// would miss by construction. Two readers, two budgets, one import line.
-import { open, readFile, readdir, stat } from 'node:fs/promises'
+// The TAIL reader (readRecentChatTurns, the 5s poll) reads through `transcript-window.ts`;
+// `readFile` is the CHAT view's, which deliberately reads the whole transcript — see readChatTurns'
+// own note on why a cache there would miss by construction. Two readers, two budgets.
+import { readFile, readdir, stat } from 'node:fs/promises'
 import { join } from 'node:path'
 import { PROJECTS_DIR } from '../config'
 import { UUID_RE } from '../git'
 import { isHumanUserEntry } from '../jsonl'
 import { commandSummary, hasUnreadableWrite, shellWrites } from './shell-writes'
 import { classifyUserEntry, type UserEntry } from './chat-envelope'
+import type { ChatTurn } from './chat-turn'
+import { MAX_TAIL_BYTES, TAIL_BYTES, readTailBytes, windowLines } from './transcript-window'
 
-export interface ChatTurn {
-  /**
-   * When the transcript recorded this turn, ISO.
-   *
-   * Optional because an older transcript may not carry one, and a turn with no time is shown
-   * without one rather than given a made-up "now" — a feed whose ordering is the whole point cannot
-   * afford an invented timestamp.
-   */
-  at?: string
-  role: 'user' | 'assistant'
-  text: string
-  /**
-   * The tools this turn INVOKED, with the first line of each call's own input.
-   *
-   * The chat view renders these as the actions the assistant took, the way the terminal shows
-   * `Running 1 shell command…` with the command under it. Without them a conversation reads as
-   * the assistant talking to itself between long silences, when what happened in the silence is
-   * most of the work.
-   */
-  tools?: Array<{
-    name: string
-    detail?: string
-    /**
-     * For a SHELL call, the paths that command writes — read by the pure `shell-writes.ts`.
-     *
-     * `detail` is only the command's first LINE, which is where the artifacts panel went blind: a
-     * session that writes through heredocs showed 263 shell calls and no files. The paths are
-     * computed here rather than by shipping whole multi-line commands to the browser, which is a
-     * chat bubble's worth of shell script per turn.
-     */
-    writes?: string[]
-    /**
-     * The command wrote through something that cannot be read off the command line — an interpreter
-     * fed a program on stdin. The panel says so rather than claiming nothing was written.
-     */
-    opaqueWrite?: boolean
-  }>
-  /**
-   * The assistant's extended thinking, when the transcript carries it.
-   *
-   * Kept apart from `text` rather than concatenated: it is reasoning, not an answer, and the UI
-   * shows it collapsed. Merging the two would put paragraphs of deliberation above every reply
-   * with nothing marking where one ends.
-   */
-  thinking?: string
-  /**
-   * This is not something the assistant SAID — it is a synthesized note that a tool call has been
-   * written to the transcript and no text has followed it yet, which is exactly the window where a
-   * session is visibly busy and the pane would otherwise show nothing (or a stale turn from before
-   * the tool call). Rendered dim, like every other status line in this pane, never in the role
-   * colours — it is not a message either side wrote.
-   */
-  pending?: boolean
-  /**
-   * A background TASK this turn started, by the label the assistant gave it.
-   *
-   * Rendered as a status line and never as a message: nobody said it. `running` is true while no
-   * `<task-notification>` has come back for it yet — which is what makes a watcher visible WHILE
-   * it is the thing you are waiting on, rather than only once it is over.
-   */
-  task?: { label: string; running: boolean }
-  /**
-   * This entry sat under the `user` role and NO PERSON WROTE IT — a background task reporting
-   * back, an injected reminder, a `!` command's stdout. The value is a short phrase naming which,
-   * never the body: a `<system-reminder>` can be the whole of CLAUDE.md.
-   *
-   * It is a turn rather than a drop so the conversation stays legible — an assistant reply with
-   * nothing above it reads as the assistant talking to itself — and it is rendered unattributed,
-   * like `pending`, because the one thing it may never do is appear over the user's avatar. See
-   * `chat-envelope.ts` for the measured list and why two of those envelopes are the person's.
-   */
-  system?: string
-}
+// The turn shape now lives in `chat-turn.ts` — every harness reader produces it, and this module
+// is only one of them. Re-exported so nothing that already imports it from here has to move.
+export type { ChatTurn } from './chat-turn'
 
 /** Resolved paths and one-time-scan misses, keyed by conversation id. Never re-scanned once known. */
 const pathCache = new Map<string, string | null>()
@@ -400,52 +332,9 @@ function toolActivityLabel(tools: string[]): string {
   return `Running ${tools.join(', ')}`
 }
 
-/**
- * How much of the END of a transcript is read to find the last few turns, and how far that window
- * is allowed to grow before the whole file is being read anyway.
- *
- * This used to read the WHOLE file. Parsing was already careful — from the end, stopping at `max` —
- * but the read and the `split('\n')` were not, and they ran on every poll of every live session:
- * the cache is keyed on mtime, and a session that is working changes its mtime every few seconds.
- * Measured on one machine: nine active transcripts totalling 31 MB, re-read and re-split every five
- * seconds, which is what made `/api/fleet` answer in 5-8 s warm and 36 s cold — long enough that the
- * VS Code extension's fetch gave up and reported the server as unreachable while it was answering
- * everything else instantly. It is the same disk-burner `searchTranscripts` is documented as
- * avoiding, in the one place that runs on a timer.
- *
- * The window GROWS rather than truncating the answer: a window that happened to cut through the
- * middle of the last six turns would silently show fewer of them, and a detail pane quietly missing
- * the newest message is worse than a slow one. Growth is bounded, and a file smaller than the window
- * is simply read whole — this is the same result as before, reached by reading far less.
- */
-const TAIL_BYTES = 256 * 1024
-const MAX_TAIL_BYTES = 16 * 1024 * 1024
+// The tail window — its size, its growth and the byte read — is `transcript-window.ts`, shared
+// with every other harness reader. Its header carries the measurement that made it necessary.
 
-/**
- * The last `bytes` of a file, as text, plus whether that reached the file's start.
- *
- * A window that starts mid-file almost always starts mid-LINE, and can also start mid-CHARACTER for
- * any multi-byte codepoint. Both are handled by the same rule: the caller drops everything before
- * the first newline, so the partial line — and any broken byte sequence inside it — never reaches
- * `JSON.parse`.
- */
-async function readTailBytes(path: string, bytes: number): Promise<{ text: string; atStart: boolean } | null> {
-  let fh
-  try { fh = await open(path, 'r') } catch { return null }
-  try {
-    const size = (await fh.stat()).size
-    const start = Math.max(0, size - bytes)
-    const length = size - start
-    if (length === 0) return { text: '', atStart: true }
-    const buf = Buffer.alloc(length)
-    await fh.read(buf, 0, length, start)
-    return { text: buf.toString('utf-8'), atStart: start === 0 }
-  } catch {
-    return null
-  } finally {
-    await fh.close().catch(() => {})
-  }
-}
 
 /**
  * The most recent chat turns in a Claude transcript, oldest first.
@@ -484,12 +373,7 @@ async function readTurnsFromTail(
   const tail = await readTailBytes(path, windowBytes)
   if (!tail) return null
 
-  // Everything before the first newline belongs to a line this window cut in half — it is already
-  // present, whole, further up the file, and parsing the fragment would at best fail and at worst
-  // succeed on a truncated object.
-  const content = tail.atStart ? tail.text : tail.text.slice(tail.text.indexOf('\n') + 1)
-
-  const lines = content.split('\n')
+  const lines = windowLines(tail)
   const turns: ChatTurn[] = []
   /** Tasks started in this file, and the `tool-use-id` each completion will name. */
   const taskTurns: Array<{ id: string; turn: ChatTurn }> = []

--- a/packages/server/server/sessions/chat-turn.ts
+++ b/packages/server/server/sessions/chat-turn.ts
@@ -1,0 +1,86 @@
+/**
+ * chat-turn.ts — what ONE turn of a conversation is, whatever harness wrote it.
+ *
+ * It lived inside `chat-tail.ts`, the CLAUDE transcript reader, for as long as Claude was the only
+ * harness whose conversation could be read at all. It is now the shape every reader in
+ * `harness-transcript.ts` produces, and a second harness importing the first one's module to learn
+ * what a turn is would make Claude's reader the thing the others are defined against rather than
+ * one of them.
+ *
+ * Nothing here is Claude-specific. Where a field only ever applies to one harness that is said on
+ * the field, not enforced by which module owns it.
+ */
+
+export interface ChatTurn {
+  /**
+   * When the transcript recorded this turn, ISO.
+   *
+   * Optional because an older transcript may not carry one, and a turn with no time is shown
+   * without one rather than given a made-up "now" — a feed whose ordering is the whole point cannot
+   * afford an invented timestamp.
+   */
+  at?: string
+  role: 'user' | 'assistant'
+  text: string
+  /**
+   * The tools this turn INVOKED, with the first line of each call's own input.
+   *
+   * The chat view renders these as the actions the assistant took, the way the terminal shows
+   * `Running 1 shell command…` with the command under it. Without them a conversation reads as
+   * the assistant talking to itself between long silences, when what happened in the silence is
+   * most of the work.
+   */
+  tools?: Array<{
+    name: string
+    detail?: string
+    /**
+     * For a SHELL call, the paths that command writes — read by the pure `shell-writes.ts`.
+     *
+     * `detail` is only the command's first LINE, which is where the artifacts panel went blind: a
+     * session that writes through heredocs showed 263 shell calls and no files. The paths are
+     * computed here rather than by shipping whole multi-line commands to the browser, which is a
+     * chat bubble's worth of shell script per turn.
+     */
+    writes?: string[]
+    /**
+     * The command wrote through something that cannot be read off the command line — an interpreter
+     * fed a program on stdin. The panel says so rather than claiming nothing was written.
+     */
+    opaqueWrite?: boolean
+  }>
+  /**
+   * The assistant's extended thinking, when the transcript carries it.
+   *
+   * Kept apart from `text` rather than concatenated: it is reasoning, not an answer, and the UI
+   * shows it collapsed. Merging the two would put paragraphs of deliberation above every reply
+   * with nothing marking where one ends.
+   */
+  thinking?: string
+  /**
+   * This is not something the assistant SAID — it is a synthesized note that a tool call has been
+   * written to the transcript and no text has followed it yet, which is exactly the window where a
+   * session is visibly busy and the pane would otherwise show nothing (or a stale turn from before
+   * the tool call). Rendered dim, like every other status line in this pane, never in the role
+   * colours — it is not a message either side wrote.
+   */
+  pending?: boolean
+  /**
+   * A background TASK this turn started, by the label the assistant gave it.
+   *
+   * Rendered as a status line and never as a message: nobody said it. `running` is true while no
+   * `<task-notification>` has come back for it yet — which is what makes a watcher visible WHILE
+   * it is the thing you are waiting on, rather than only once it is over.
+   */
+  task?: { label: string; running: boolean }
+  /**
+   * This entry sat under the `user` role and NO PERSON WROTE IT — a background task reporting
+   * back, an injected reminder, a `!` command's stdout. The value is a short phrase naming which,
+   * never the body: a `<system-reminder>` can be the whole of CLAUDE.md.
+   *
+   * It is a turn rather than a drop so the conversation stays legible — an assistant reply with
+   * nothing above it reads as the assistant talking to itself — and it is rendered unattributed,
+   * like `pending`, because the one thing it may never do is appear over the user's avatar. See
+   * `chat-envelope.ts` for the measured list and why two of those envelopes are the person's.
+   */
+  system?: string
+}

--- a/packages/server/server/sessions/chat-turn.ts
+++ b/packages/server/server/sessions/chat-turn.ts
@@ -31,7 +31,31 @@ export interface ChatTurn {
    * most of the work.
    */
   tools?: Array<{
+    /**
+     * The tool's name AS THE HARNESS CALLED IT — `run_command`, not `Bash`.
+     *
+     * A conversation is a record of what happened, and agy did not run a tool called `Bash`.
+     * Rendering the shared vocabulary here put Claude Code's tool names in an Antigravity session's
+     * bubbles, which is a false statement about what that session did — reported exactly that way,
+     * and visible in the result itself: `Bash`, `Read` and `Grep` stood next to `manage_task` and
+     * `schedule`, agy's own names, which nothing maps. Half a translation reads as a bug even when
+     * the reader does not know which half is wrong.
+     */
     name: string
+    /**
+     * The same tool under the SHARED vocabulary (`canonicalTool`), present only where it differs.
+     *
+     * `harness-activity.ts` maps every harness's names onto Claude's because that is what every
+     * chart and filter is written against — a METRIC has to compare harnesses, so it cannot have
+     * one of them calling it `Bash` and another `run_command`. Selection is that same question:
+     * `sessionArtifacts.ts` picks the file-writing tools out of a turn, and its set is Claude's
+     * names.
+     *
+     * So the two readings are carried apart rather than one being made to serve both. DISPLAY reads
+     * `name`; anything SELECTING or COUNTING reads `canonical ?? name`. Absent on every Claude turn,
+     * where the harness's own name already is the shared one.
+     */
+    canonical?: string
     detail?: string
     /**
      * For a SHELL call, the paths that command writes — read by the pure `shell-writes.ts`.

--- a/packages/server/server/sessions/chat-web.test.ts
+++ b/packages/server/server/sessions/chat-web.test.ts
@@ -60,16 +60,18 @@ test('an unknown id still reports that the session left this machine, never an e
  * pane with no sentence on it. The link was never the problem; there was no reader.
  */
 test('a harness nobody has written a reader for is refused in words, and NAMED', async () => {
-  const out = await readSessionChat(hostWith('waiting', 'kimi'), 'en', 'sess1')
+  // Gemini is the only one, and permanently: it can never carry a conversation id (no `assignId`,
+  // and its `--resume` takes "latest" or an index) — see `harness-transcript.ts`.
+  const out = await readSessionChat(hostWith('waiting', 'gemini'), 'en', 'sess1')
   expect(out.turns).toEqual([])
-  expect(out.unavailable).toContain('kimi')
+  expect(out.unavailable).toContain('gemini')
 })
 
 test('a harness that HAS a reader falls through to the transcript rules, not to that refusal', async () => {
   // Each of these resolves against its own store, where this id does not exist — so it must land
   // on the live/not-yet branch, exactly as claude does, and NOT on "no reader". This test is what
   // failed when codex gained a reader, which is the point: adding one is visible here.
-  for (const harness of ['antigravity', 'codex'] as const) {
+  for (const harness of ['antigravity', 'codex', 'copilot', 'kimi'] as const) {
     const out = await readSessionChat(hostWith('waiting', harness), 'en', 'sess1')
     expect(out.unavailable).toBeUndefined()
     expect(out.live).toBe(true)

--- a/packages/server/server/sessions/chat-web.test.ts
+++ b/packages/server/server/sessions/chat-web.test.ts
@@ -14,9 +14,10 @@ import { readSessionChat } from './chat-web'
 /** A cwd that is not a project on any machine, so no transcript can ever resolve for it. */
 const NO_PROJECT = '/nonexistent/agentistics-chat-web-test'
 
-function hostWith(state: string) {
+function hostWith(state: string, harness = 'claude') {
   const row = {
     id: 'sess1',
+    harness,
     cwd: NO_PROJECT,
     conversationId: '00000000-0000-4000-8000-000000000000',
     state,
@@ -47,4 +48,32 @@ test('a session that is NOT running keeps the refusal — there the transcript i
 test('an unknown id still reports that the session left this machine, never an empty chat', async () => {
   const out = await readSessionChat(hostWith('waiting'), 'en', 'other')
   expect(out.unavailable).toBeTruthy()
+})
+
+/**
+ * The SECOND limit — the transcript FORMAT, which used to be tangled up with the first one.
+ *
+ * Measured 2026-09-05 on a live antigravity session carrying a perfectly exact conversation link
+ * (`/proc/<pid>/cmdline` was `agy --conversation 01d0814f-…`): the request ran into the Claude-only
+ * path resolver, found nothing, took the live branch above and answered `{turns: [], live: true}`.
+ * `SessionChat.tsx` draws "no messages yet" only when `live === null`, so the result was a blank
+ * pane with no sentence on it. The link was never the problem; there was no reader.
+ */
+test('a harness nobody has written a reader for is refused in words, and NAMED', async () => {
+  const out = await readSessionChat(hostWith('waiting', 'codex'), 'en', 'sess1')
+  expect(out.turns).toEqual([])
+  expect(out.unavailable).toContain('codex')
+})
+
+test('a harness that HAS a reader falls through to the transcript rules, not to that refusal', async () => {
+  // antigravity resolves against `brain/<conversation-id>/…`, which does not exist for this id —
+  // so it must land on the live/not-yet branch, exactly as claude does, and NOT on "no reader".
+  const out = await readSessionChat(hostWith('waiting', 'antigravity'), 'en', 'sess1')
+  expect(out.unavailable).toBeUndefined()
+  expect(out.live).toBe(true)
+})
+
+test('a row whose harness the registry has forgotten says THAT, not "we cannot read \'\'"', async () => {
+  const out = await readSessionChat(hostWith('waiting', ''), 'en', 'sess1')
+  expect(out.unavailable).toContain('which assistant')
 })

--- a/packages/server/server/sessions/chat-web.test.ts
+++ b/packages/server/server/sessions/chat-web.test.ts
@@ -60,17 +60,20 @@ test('an unknown id still reports that the session left this machine, never an e
  * pane with no sentence on it. The link was never the problem; there was no reader.
  */
 test('a harness nobody has written a reader for is refused in words, and NAMED', async () => {
-  const out = await readSessionChat(hostWith('waiting', 'codex'), 'en', 'sess1')
+  const out = await readSessionChat(hostWith('waiting', 'kimi'), 'en', 'sess1')
   expect(out.turns).toEqual([])
-  expect(out.unavailable).toContain('codex')
+  expect(out.unavailable).toContain('kimi')
 })
 
 test('a harness that HAS a reader falls through to the transcript rules, not to that refusal', async () => {
-  // antigravity resolves against `brain/<conversation-id>/…`, which does not exist for this id —
-  // so it must land on the live/not-yet branch, exactly as claude does, and NOT on "no reader".
-  const out = await readSessionChat(hostWith('waiting', 'antigravity'), 'en', 'sess1')
-  expect(out.unavailable).toBeUndefined()
-  expect(out.live).toBe(true)
+  // Each of these resolves against its own store, where this id does not exist — so it must land
+  // on the live/not-yet branch, exactly as claude does, and NOT on "no reader". This test is what
+  // failed when codex gained a reader, which is the point: adding one is visible here.
+  for (const harness of ['antigravity', 'codex'] as const) {
+    const out = await readSessionChat(hostWith('waiting', harness), 'en', 'sess1')
+    expect(out.unavailable).toBeUndefined()
+    expect(out.live).toBe(true)
+  }
 })
 
 test('a row whose harness the registry has forgotten says THAT, not "we cannot read \'\'"', async () => {

--- a/packages/server/server/sessions/chat-web.ts
+++ b/packages/server/server/sessions/chat-web.ts
@@ -6,18 +6,29 @@
  * already seen — so this reads the transcript with an explicit turn budget and reports how many
  * turns exist, letting the browser hold what it already has.
  *
- * THE HARNESS LIMIT IS THE POINT. A live session can only be tied to its transcript where the link
- * is EXACT — Claude Code's own `~/.claude/sessions/<pid>.json` naming our tmux session. Everywhere
- * else the honest answer is that this view cannot exist, and the caller says so in words. Guessing
- * by harness-and-directory would put SOME OTHER conversation from the same folder on screen under
- * this session's name, which is worse than showing nothing: it is a confident wrong answer, and the
- * reader has no way to tell.
+ * THE HARNESS LIMIT IS THE POINT, and it is TWO limits that were one thing for as long as Claude
+ * was the only readable harness.
+ *
+ * The first is the LINK: a session can only be tied to its transcript where the id is EXACT — the
+ * one agentop handed the CLI, or Claude Code's own `~/.claude/sessions/<pid>.json` naming our tmux
+ * session. Guessing by harness-and-directory would put SOME OTHER conversation from the same folder
+ * on screen under this session's name, which is worse than showing nothing: a confident wrong
+ * answer the reader has no way to tell. `SessionView.conversationId` already enforces this, and
+ * nothing here relaxes it.
+ *
+ * The second is the FORMAT: whether anybody has written a reader for it (`harness-transcript.ts`).
+ * Collapsing the two cost the feature its honesty. Measured 2026-09-05 on a live antigravity
+ * session holding a perfectly exact link — `/proc/<pid>/cmdline` was `agy --conversation
+ * 01d0814f-…`, the very id the registry held — the request ran into the CLAUDE path resolver, came
+ * back with no file, and answered `{turns: [], live: true}`: a completely blank pane with nothing
+ * on it saying why. The link was never the problem; there was no reader.
  */
 
 import type { StartHost } from '../cli-start'
 import type { CliLang } from '../cli-lang'
 import { controlStrings } from '@agentistics/tui/control/i18n'
-import { readChatTurns, resolveChatTranscriptPath, type ChatTurn } from './chat-tail'
+import type { ChatTurn } from './chat-turn'
+import { transcriptReaderFor } from './harness-transcript'
 
 export interface ChatPayload {
   /** The turns, oldest first. Empty with no `unavailable` means a conversation with nothing in it. */
@@ -71,7 +82,36 @@ export async function readSessionChat(
     }
   }
 
-  const path = await resolveChatTranscriptPath(row.cwd, row.conversationId).catch(() => null)
+  // No reader for this harness's transcript FORMAT — see `harness-transcript.ts`. It is said in
+  // words and it NAMES the harness, because "nothing here parses this yet" and "this conversation
+  // has said nothing yet" are different facts, and only the second one changes on its own.
+  // A row whose harness the registry has forgotten (`ControlSession.harness` is `''`) cannot be
+  // routed to any reader, and saying "we cannot read ''" would be worse than saying nothing.
+  if (!row.harness) {
+    return {
+      turns: [],
+      unavailable: lang === 'pt'
+        ? 'O registro não guarda mais qual assistente escreveu esta sessão, então não há como saber que transcrição ler.'
+        : 'The registry no longer records which assistant wrote this session, so there is no way to know which transcript to read.',
+      live,
+    }
+  }
+
+  const reader = transcriptReaderFor(row.harness)
+  if (!reader) {
+    const name = row.harness
+    return {
+      turns: [],
+      unavailable: lang === 'pt'
+        ? `Ainda não sabemos ler a transcrição do ${name}. A conversa desta sessão está gravada no disco desta máquina — o que falta é um leitor para o formato dela.`
+        : `We cannot read ${name}'s transcript format yet. This session's conversation is recorded on this machine — what is missing is a reader for it.`,
+      live,
+    }
+  }
+
+  const path = await reader
+    .resolve({ conversationId: row.conversationId, ...(row.cwd ? { cwd: row.cwd } : {}) })
+    .catch(() => null)
   if (!path) {
     // A LIVE session whose transcript is not on disk YET is an EMPTY conversation, not a missing
     // one — and the difference is the whole usability of a new session. A harness writes its
@@ -96,6 +136,6 @@ export async function readSessionChat(
     }
   }
 
-  const turns = await readChatTurns(path, MAX_TURNS).catch(() => [] as ChatTurn[])
+  const turns = await reader.read(path, MAX_TURNS).catch(() => [] as ChatTurn[])
   return { turns, live }
 }

--- a/packages/server/server/sessions/codex-chat.test.ts
+++ b/packages/server/server/sessions/codex-chat.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, it } from 'bun:test'
+import { parseCodexChat, reasoningText, shellCommandOf, toolDetailOf } from './codex-chat'
+
+/**
+ * Every fixture is the SHAPE measured 2026-09-05 over the 14 largest rollouts on this machine,
+ * trimmed to the fields that decide the answer. Where a rule exists because of a number, the number
+ * is in the test's name.
+ */
+
+const AT = '2026-07-07T22:04:06.000Z'
+const line = (payload: Record<string, unknown>, type = 'response_item'): string =>
+  JSON.stringify({ timestamp: AT, type, payload })
+
+const msg = (role: string, text: string): string =>
+  line({ type: 'message', role, content: [{ type: 'input_text', text }] })
+
+const call = (name: string, args: Record<string, unknown>): string =>
+  line({ type: 'function_call', name, arguments: JSON.stringify(args) })
+
+describe('the pieces', () => {
+  it('a shell envelope yields the COMMAND, never the stdout it also carries', () => {
+    const raw = '<user_shell_command>\n<command>\nls -la\n</command>\n<result>\nExit code: 0\nOutput:\na\nb\n</result>\n</user_shell_command>'
+    expect(shellCommandOf(raw)).toBe('ls -la')
+  })
+
+  it('reasoning reads the summary and NEVER the encrypted field', () => {
+    expect(reasoningText({
+      summary: [{ type: 'summary_text', text: '**Crafting a Dockerfile**' }],
+      encrypted_content: 'gAAAAABqTXfW6j_9rnbI',
+    })).toBe('**Crafting a Dockerfile**')
+    // 12 of the 17 measured carry only the encrypted half. An absent thought is absent.
+    expect(reasoningText({ summary: [], encrypted_content: 'gAAAA' })).toBe('')
+  })
+
+  it('`arguments` is a JSON STRING, and the detail is the command inside it', () => {
+    expect(toolDetailOf(JSON.stringify({ cmd: 'pwd', workdir: '/x', max_output_tokens: 12000 })))
+      .toBe('pwd')
+    expect(toolDetailOf('not json')).toBeNull()
+    expect(toolDetailOf(undefined)).toBeNull()
+  })
+
+  it('a shell command is SUMMARISED past its `cd`, never truncated at the first segment', () => {
+    // Measured on a real rollout: five consecutive calls all opened `cd /home/…/embark`, so the
+    // chips were a column of identical `cd` rows. `commandSummary` shows the segment that acts.
+    expect(toolDetailOf(JSON.stringify({ cmd: 'cd /home/me/embark && cat package.json' })))
+      .toBe('cat package.json')
+  })
+})
+
+describe('parseCodexChat', () => {
+  it('reads the person and the assistant, oldest first', () => {
+    expect(parseCodexChat([msg('user', 'Salve'), msg('assistant', 'Salve.')])).toEqual([
+      { role: 'user', text: 'Salve', at: AT },
+      { role: 'assistant', text: 'Salve.', at: AT },
+    ])
+  })
+
+  it('IGNORES the event_msg copy — every message is written twice', () => {
+    // Measured: the user's `response_item` precedes its `event_msg` and the assistant's follows it,
+    // so reading both draws each turn twice AND in an inconsistent order.
+    const turns = parseCodexChat([
+      msg('user', 'Salve'),
+      line({ type: 'user_message', message: 'Salve' }, 'event_msg'),
+      line({ type: 'agent_message', message: 'Salve.' }, 'event_msg'),
+      msg('assistant', 'Salve.'),
+    ])
+    expect(turns.map(t => t.text)).toEqual(['Salve', 'Salve.'])
+  })
+
+  it('gathers the tool calls onto the assistant message they belong to', () => {
+    // One turn is several lines here: reasoning → message → function_call, function_call.
+    const turns = parseCodexChat([
+      msg('assistant', 'Vou checar o estado local do plugin.'),
+      call('exec_command', { cmd: 'rg --files .', workdir: '/repo' }),
+      call('exec_command', { cmd: 'find /repo -maxdepth 4', workdir: '/repo' }),
+    ])
+    expect(turns).toHaveLength(1)
+    expect(turns[0]!.text).toBe('Vou checar o estado local do plugin.')
+    // In FILE order, both on the one turn.
+    expect(turns[0]!.tools).toEqual([
+      { name: 'exec_command', canonical: 'Bash', detail: 'rg --files .' },
+      { name: 'exec_command', canonical: 'Bash', detail: 'find /repo -maxdepth 4' },
+    ])
+  })
+
+  it("keeps CODEX's own tool name for display, with the shared one beside it", () => {
+    const [turn] = parseCodexChat([msg('assistant', 'x'), call('exec_command', { cmd: 'ls' })])
+    expect(turn!.tools![0]).toEqual({ name: 'exec_command', canonical: 'Bash', detail: 'ls' })
+  })
+
+  it('attaches the reasoning to the assistant turn below it, not to a turn of its own', () => {
+    const turns = parseCodexChat([
+      line({ type: 'reasoning', summary: [{ type: 'summary_text', text: 'thinking hard' }] }),
+      msg('assistant', 'the answer'),
+    ])
+    expect(turns).toEqual([
+      { role: 'assistant', text: 'the answer', at: AT, thinking: 'thinking hard' },
+    ])
+  })
+
+  it('a reasoning with nothing to attach to still becomes a turn carrying the thought', () => {
+    const turns = parseCodexChat([
+      msg('user', 'oi'),
+      line({ type: 'reasoning', summary: [{ type: 'summary_text', text: 'hmm' }] }),
+    ])
+    expect(turns).toHaveLength(2)
+    expect(turns[1]).toMatchObject({ role: 'assistant', text: '', thinking: 'hmm' })
+  })
+
+  it('a reasoning carrying only the ENCRYPTED half contributes nothing', () => {
+    const turns = parseCodexChat([
+      msg('assistant', 'a'),
+      line({ type: 'reasoning', summary: [], encrypted_content: 'gAAAA' }),
+    ])
+    expect(turns).toEqual([{ role: 'assistant', text: 'a', at: AT }])
+  })
+
+  it('the `developer` role is ALWAYS the harness — 19 of 19 measured', () => {
+    const turns = parseCodexChat([
+      msg('developer', '<permissions instructions>\nFilesystem sandboxing…'),
+      msg('developer', '<collaboration_mode>\n…'),
+      msg('developer', '<model_switch>\nThe user was previously…'),
+      msg('developer', 'something nobody has tagged'),
+    ])
+    expect(turns.map(t => t.system)).toEqual([
+      'the harness stated its permissions',
+      'the collaboration mode changed',
+      'the model was switched',
+      'instructions from the harness',
+    ])
+  })
+
+  it('a `user` envelope the harness wrote is a note, never the reader’s bubble', () => {
+    const turns = parseCodexChat([
+      msg('user', '<environment_context>\n  <cwd>/repo</cwd>\n'),
+      msg('user', '<turn_aborted>\n'),
+    ])
+    expect(turns.map(t => t.system)).toEqual([
+      'the environment was described to the assistant', 'the turn was aborted',
+    ])
+  })
+
+  it('a `<user_shell_command>` IS the person and is unwrapped to what they ran', () => {
+    const [turn] = parseCodexChat([
+      msg('user', '<user_shell_command>\n<command>\nls -la\n</command>\n<result>\nExit code: 0\n</result>\n</user_shell_command>'),
+    ])
+    // Same call `chat-envelope.ts` makes for Claude's `<bash-input>`: dropping it would erase a
+    // turn that happened.
+    expect(turn).toEqual({ role: 'user', text: 'ls -la', at: AT })
+  })
+
+  it('the harness loading a FILE into the user role is a note, though nothing tags it', () => {
+    // Codex has no `isMeta`; the payload is indistinguishable in shape from a typed message, so
+    // the opening line is the only signal. 11 of the 32 untagged user messages measured were these.
+    const turns = parseCodexChat([
+      msg('user', '# AGENTS.md instructions for /home/me/embark\n\n<INSTRUCTIONS>\n…a whole file…'),
+      msg('user', '# Context from my IDE setup:\n…'),
+    ])
+    expect(turns.map(t => t.system))
+      .toEqual(['project instructions were loaded', 'context from the editor'])
+    // Never the body: an AGENTS.md dump is a whole file.
+    expect(turns[0]!.text).toBe('project instructions were loaded')
+  })
+
+  it('a message merely STARTING with # is the person’s — the table is not a prefix guess', () => {
+    const [turn] = parseCodexChat([msg('user', '# why does this heading break the build?')])
+    expect(turn).toEqual({ role: 'user', text: '# why does this heading break the build?', at: AT })
+  })
+
+  it('an UNRECOGNISED tag stays the person’s — the safe direction', () => {
+    const [turn] = parseCodexChat([msg('user', '<Foo /> renders twice, why?')])
+    expect(turn).toEqual({ role: 'user', text: '<Foo /> renders twice, why?', at: AT })
+    expect(turn!.system).toBeUndefined()
+  })
+
+  it('drops the function_call_output — the request above already said what ran', () => {
+    const turns = parseCodexChat([
+      msg('assistant', 'running it'),
+      call('exec_command', { cmd: 'ls' }),
+      line({ type: 'function_call_output', call_id: 'c1', output: 'a\nb\nc'.repeat(500) }),
+      line({ type: 'ghost_snapshot' }),
+    ])
+    expect(turns).toHaveLength(1)
+    expect(turns[0]!.tools).toHaveLength(1)
+  })
+
+  it('only the NEWEST batch of calls with no text after it is pending', () => {
+    const turns = parseCodexChat([
+      call('exec_command', { cmd: 'first' }),
+      msg('user', 'go on'),
+      call('exec_command', { cmd: 'last' }),
+    ])
+    expect(turns.map(t => t.pending)).toEqual([undefined, undefined, true])
+  })
+
+  it('caps at max, keeping the END of the conversation', () => {
+    const lines = Array.from({ length: 20 }, (_, i) => msg('assistant', `m${i}`))
+    expect(parseCodexChat(lines, 'codex', 3).map(t => t.text)).toEqual(['m17', 'm18', 'm19'])
+  })
+
+  it('a half line the tail window cut through is skipped, not parsed', () => {
+    expect(parseCodexChat(['tamp":"x","type":"resp', msg('user', 'oi')])).toHaveLength(1)
+  })
+
+  it('a turn with no recorded time gets none rather than an invented now', () => {
+    const [turn] = parseCodexChat([JSON.stringify({
+      type: 'response_item', payload: { type: 'message', role: 'user', content: [{ text: 'oi' }] },
+    })])
+    expect(turn!.at).toBeUndefined()
+  })
+})

--- a/packages/server/server/sessions/codex-chat.ts
+++ b/packages/server/server/sessions/codex-chat.ts
@@ -1,0 +1,337 @@
+/**
+ * codex-chat.ts — PURE: a Codex CLI rollout's lines → `ChatTurn[]`.
+ *
+ * No fs, no side effects. `harness-transcript.ts` finds the file and hands the lines over.
+ *
+ * ON-DISK SHAPE, measured 2026-09-05 over the 14 largest rollouts on this machine
+ * (`~/.codex/sessions/YYYY/MM/DD/rollout-<time>-<conversation-id>.jsonl`). `codex-parse.ts` — the
+ * METRICS parser — documents the envelope; what follows is the part a CONVERSATION needs.
+ *
+ * Every line is `{timestamp, type, payload}` and the semantic type is at `payload.type`
+ * (`codex-parse.ts` says the same). Counts over those 14 files:
+ *
+ *   response_item / message            81   (user 42, developer 19, assistant 20)
+ *   response_item / function_call      23   the tool REQUEST — `{name, arguments}` (a JSON STRING)
+ *   response_item / function_call_output 23 the result
+ *   response_item / reasoning          17   `summary` + `encrypted_content`
+ *   response_item / ghost_snapshot      3
+ *   event_msg / user_message           21
+ *   event_msg / agent_message          20
+ *
+ * EVERY MESSAGE IS WRITTEN TWICE, and picking the wrong copy loses half the conversation.
+ * `event_msg/{user_message,agent_message}` and `response_item/message` carry the same text, adjacent
+ * in the file and in an order that is not even consistent (the user's `response_item` precedes its
+ * `event_msg`; the assistant's follows it). Reading both draws every turn twice, which is the trap
+ * `kimi-parse.ts` records for its duplicated usage records and `harness-activity.ts` for agy's
+ * request/execution pair.
+ *
+ * `response_item` is the copy that is read, for three reasons and not merely because it is bigger:
+ *   1. The `event_msg` family is a strict SUBSET — 21 user events against 42 user messages. Eleven
+ *      turns exist only as `response_item`, so that family cannot be the source at all.
+ *   2. `function_call` and `reasoning` are already `response_item`s. Taking messages from the other
+ *      family would mean reconciling two orderings to rebuild one conversation.
+ *   3. It is the only copy that carries the harness's own injected material, which has to be
+ *      CLASSIFIED rather than silently dropped — see below.
+ *
+ * WHAT NOBODY SAID IS NEVER DRAWN AS A MESSAGE. Same rule, same reason, as `chat-envelope.ts`'s for
+ * Claude. Two things decide it here, and the ROLE is the stronger one:
+ *   - `developer` is ALWAYS the harness. All 19 measured were tagged (`permissions` 12,
+ *     `collaboration_mode` 4, `model_switch` 3) and none of them is a person speaking.
+ *   - `user` is the person UNLESS an envelope says otherwise: `<environment_context>` (7) and
+ *     `<turn_aborted>` (1) are the harness, while `<user_shell_command>` (2) IS the person — they
+ *     ran a command — and is UNWRAPPED to what they ran, exactly as `chat-envelope.ts` unwraps
+ *     Claude's `<bash-input>`. 32 of the 42 carried no tag at all and are simply theirs.
+ *   - An UNRECOGNISED tag is left as the person's. That is the safe direction and the one
+ *     `chat-envelope.ts` argues for: a message that merely starts with `<` (a diff, a snippet) is
+ *     real, and hiding it is the expensive mistake.
+ *
+ * THINKING EXISTS, SOMETIMES, AND IS NEVER THE ENCRYPTED FIELD. A `reasoning` item carries
+ * `encrypted_content` (17 of 17) and a `summary` that is readable on only 5 of them. The summary is
+ * used when it is there and the item contributes nothing when it is not — an absent thought is
+ * absent, and `encrypted_content` is not one this or any reader can show.
+ */
+
+import type { HarnessId } from '@agentistics/core'
+import { canonicalTool } from '../harness-activity'
+import type { ChatTurn } from './chat-turn'
+import { commandSummary } from './shell-writes'
+
+interface CodexLine {
+  timestamp?: unknown
+  type?: unknown
+  payload?: unknown
+}
+
+/**
+ * The `user`-role envelopes, and what each one is.
+ *
+ * `unwrap` marks the one the person really performed. The table is a matched pair with the
+ * measurement in the header and nothing more — an envelope nobody has seen is not in it, and an
+ * unrecognised tag stays the person's.
+ */
+const USER_ENVELOPES: Record<string, { unwrap: boolean; note: string }> = {
+  environment_context: { unwrap: false, note: 'the environment was described to the assistant' },
+  turn_aborted: { unwrap: false, note: 'the turn was aborted' },
+  user_shell_command: { unwrap: true, note: 'shell command' },
+}
+
+/** The `developer`-role envelopes. Every one of them is the harness; the tag only names which. */
+const DEVELOPER_NOTES: Record<string, string> = {
+  permissions: 'the harness stated its permissions',
+  collaboration_mode: 'the collaboration mode changed',
+  model_switch: 'the model was switched',
+}
+
+/**
+ * UNTAGGED `user` messages that no person wrote, named by their opening line.
+ *
+ * Codex has no `isMeta` flag — the payload of one of these is literally `{type, role, content}`,
+ * indistinguishable in SHAPE from a message somebody typed — so the text is the only signal there
+ * is. This is `chat-envelope.ts`'s `META_KINDS` applied to a different harness, and it is a matched
+ * pair with a measurement: over the 40 largest rollouts, 32 user messages carried no envelope tag
+ * and **11 of them were these two** (`# AGENTS.md instructions for <path>` nine times, `# Context
+ * from my IDE setup:` twice) — a third of the reader's own bubble was the harness loading a file.
+ *
+ * The NOTE never carries the body, for the reason `chat-envelope.ts` gives: an AGENTS.md dump is a
+ * whole file. And a line nobody has measured stays the PERSON's — a heuristic that guesses wider
+ * hides real messages, which is the expensive direction.
+ */
+const INJECTED: Array<{ test: RegExp; note: string }> = [
+  { test: /^# AGENTS\.md instructions for /, note: 'project instructions were loaded' },
+  { test: /^# Context from my IDE setup:/, note: 'context from the editor' },
+]
+
+/** The leading `<tag` of a message, lowercased, or `null` when it does not open with one. */
+function leadingTag(text: string): string | null {
+  const m = /^<([a-zA-Z][\w-]*)/.exec(text)
+  return m ? m[1]!.toLowerCase() : null
+}
+
+/** The text of a `message` payload — its content parts joined. */
+function messageText(payload: Record<string, unknown>): string {
+  const c = payload.content
+  if (typeof c === 'string') return c.trim()
+  if (!Array.isArray(c)) return ''
+  return (c as Record<string, unknown>[])
+    .map(part => (typeof part.text === 'string' ? part.text : ''))
+    .join('')
+    .trim()
+}
+
+/**
+ * What the person actually ran, out of a `<user_shell_command>` envelope.
+ *
+ * The envelope carries the command AND its whole stdout in a `<result>` block. Only the command is
+ * the person's act; the output is the machine answering, and a chat bubble is not a terminal — the
+ * same reason `chat-tail.ts`'s `toolDetail` keeps one line of a tool input.
+ */
+export function shellCommandOf(text: string): string {
+  const m = /<command>([\s\S]*?)<\/command>/.exec(text)
+  const cmd = (m ? m[1]! : '').trim()
+  if (cmd === '') return ''
+  const line = cmd.split('\n')[0]!
+  return line.length > 200 ? `${line.slice(0, 200)}…` : line
+}
+
+/** The readable half of a `reasoning` item. Never `encrypted_content`. */
+export function reasoningText(payload: Record<string, unknown>): string {
+  const s = payload.summary
+  if (!Array.isArray(s)) return ''
+  return (s as Record<string, unknown>[])
+    .map(part => (typeof part.text === 'string' ? part.text : ''))
+    .filter(t => t.trim() !== '')
+    .join('\n\n')
+    .trim()
+}
+
+/**
+ * The one line worth showing for a tool call.
+ *
+ * `arguments` is a JSON STRING, not an object. Only `exec_command` was measured (23 of 23) and its
+ * argument is `cmd`; the other keys are budget and sandbox settings that say nothing about what
+ * ran. A name nobody has mapped still shows, keyed on the first string-valued field it does carry,
+ * so a new tool appears as itself rather than as a bare chip.
+ */
+const DETAIL_KEYS = ['cmd', 'command', 'path', 'file_path', 'pattern', 'query', 'url']
+
+export function toolDetailOf(rawArguments: unknown): string | null {
+  if (typeof rawArguments !== 'string' || rawArguments.trim() === '') return null
+  let args: unknown
+  try { args = JSON.parse(rawArguments) } catch { return null }
+  if (typeof args !== 'object' || args === null) return null
+  const o = args as Record<string, unknown>
+  for (const key of DETAIL_KEYS) {
+    const v = o[key]
+    if (typeof v === 'string' && v.trim() !== '') {
+      // A SHELL command is SUMMARISED, not truncated to its first line — the same call
+      // `chat-tail.ts`'s `toolDetail` makes, and measured here for the same reason: on a real
+      // rollout every one of five consecutive calls opened with `cd /home/…/embark`, so the chips
+      // read as a column of identical `cd` rows saying where the work happened and never what it
+      // was. `commandSummary` skips the `cd`/`set`/`export` segments and shows the one that acts.
+      if (key === 'cmd' || key === 'command') return commandSummary(v)
+      const line = v.trim().split('\n')[0]!
+      return line.length > 200 ? `${line.slice(0, 200)}…` : line
+    }
+  }
+  return null
+}
+
+type Tool = NonNullable<ChatTurn['tools']>[number]
+
+function toolOf(payload: Record<string, unknown>, harness: HarnessId): Tool | null {
+  const name = typeof payload.name === 'string' ? payload.name : ''
+  if (name === '') return null
+  const detail = toolDetailOf(payload.arguments)
+  const canonical = canonicalTool(harness, name)
+  return {
+    // The harness's OWN name is what a conversation shows; `canonical` is the shared vocabulary
+    // anything selecting or counting reads. See `ChatTurn.tools`.
+    name,
+    ...(canonical !== name ? { canonical } : {}),
+    ...(detail ? { detail } : {}),
+  }
+}
+
+/**
+ * The conversation these lines hold, oldest first, capped at `max` turns from the END.
+ *
+ * Walked BACKWARD so a tail window can stop as soon as it has enough. Two items are gathered onto
+ * the assistant turn they belong to rather than becoming turns of their own, because in this
+ * format one turn is several lines:
+ *
+ *   reasoning → message(assistant) → function_call, function_call, …
+ *
+ * so the tool calls are FLUSHED onto the assistant message above them and the reasoning is attached
+ * to the turn below it. That reproduces the single assistant turn Claude's reader emits, where text,
+ * thinking and tool calls arrive in one event. A batch of calls with no assistant text is still a
+ * turn — it is what the session did — and a `reasoning` with nowhere to attach becomes a turn
+ * carrying only the thought.
+ */
+export function parseCodexChat(
+  lines: string[],
+  harness: HarnessId = 'codex',
+  max = 400,
+): ChatTurn[] {
+  const turns: ChatTurn[] = []
+  /** Tool calls seen since the assistant message they belong to, in FILE order. */
+  let pending: Tool[] = []
+  let pendingAt: string | undefined
+  /** Whether the batch currently accumulating is the LAST thing in the file. */
+  let newestBatch = false
+  let newest = true
+
+  /** The tool calls become a turn of their own when no assistant message claims them. */
+  const flushTools = (): void => {
+    if (pending.length === 0) return
+    turns.push({
+      role: 'assistant',
+      text: '',
+      tools: pending,
+      ...(pendingAt ? { at: pendingAt } : {}),
+      // "no text has followed these calls yet" is a statement about RIGHT NOW, so only the newest
+      // batch in the file can be pending. Identical rule, and reason, to `chat-tail.ts`.
+      ...(newestBatch ? { pending: true } : {}),
+    })
+    pending = []
+    pendingAt = undefined
+    newestBatch = false
+  }
+
+  for (let i = lines.length - 1; i >= 0 && turns.length < max; i--) {
+    const line = (lines[i] ?? '').trim()
+    if (line === '') continue
+    let e: CodexLine
+    try { e = JSON.parse(line) as CodexLine } catch { continue }
+    if (e.type !== 'response_item') continue
+    const payload = (typeof e.payload === 'object' && e.payload !== null)
+      ? e.payload as Record<string, unknown>
+      : null
+    if (!payload) continue
+    const at = typeof e.timestamp === 'string' ? e.timestamp : undefined
+    const kind = typeof payload.type === 'string' ? payload.type : ''
+
+    if (kind === 'function_call') {
+      const tool = toolOf(payload, harness)
+      if (tool) {
+        if (pending.length === 0) { pendingAt = at; newestBatch = newest }
+        // Backward walk, file order kept: the earliest call of the batch ends up first.
+        pending.unshift(tool)
+        newest = false
+      }
+      continue
+    }
+
+    if (kind === 'message') {
+      const role = typeof payload.role === 'string' ? payload.role : ''
+      const text = messageText(payload)
+      if (role === 'assistant') {
+        newest = false
+        if (text === '' && pending.length === 0) continue
+        turns.push({
+          role: 'assistant',
+          text,
+          ...(pending.length > 0 ? { tools: pending } : {}),
+          ...(at ? { at } : {}),
+          ...(text === '' && pending.length > 0 && newestBatch ? { pending: true } : {}),
+        })
+        pending = []
+        pendingAt = undefined
+        newestBatch = false
+        continue
+      }
+      flushTools()
+      newest = false
+      if (text === '') continue
+      const turn = userTurn(role, text)
+      if (turn) turns.push(at ? { ...turn, at } : turn)
+      continue
+    }
+
+    if (kind === 'reasoning') {
+      flushTools()
+      newest = false
+      const thinking = reasoningText(payload)
+      if (thinking === '') continue
+      // The reasoning precedes its assistant message in the file, so walking backward the message
+      // has already been pushed — attach to it rather than drawing the thought as a second turn.
+      const last = turns[turns.length - 1]
+      if (last && last.role === 'assistant' && last.thinking === undefined) last.thinking = thinking
+      else turns.push({ role: 'assistant', text: '', thinking, ...(at ? { at } : {}) })
+      continue
+    }
+
+    // `function_call_output` (the result, whose body is the whole stdout) and `ghost_snapshot` are
+    // not turns. The request above already said what ran — the same choice `antigravity-chat.ts`
+    // makes, and for the same reason.
+    flushTools()
+    newest = false
+  }
+
+  flushTools()
+  turns.reverse()
+  return turns
+}
+
+/** One `message` that is not the assistant's, classified. `null` when there is nothing to draw. */
+function userTurn(role: string, text: string): ChatTurn | null {
+  if (role === 'developer') {
+    const tag = leadingTag(text)
+    const note = (tag && DEVELOPER_NOTES[tag]) ?? 'instructions from the harness'
+    return { role: 'user', text: note, system: note }
+  }
+  const tag = leadingTag(text)
+  const env = tag ? USER_ENVELOPES[tag] : undefined
+  if (!env) {
+    // No envelope. It is still not certainly the person: see `INJECTED`.
+    const injected = INJECTED.find(k => k.test.test(text))
+    if (injected) return { role: 'user', text: injected.note, system: injected.note }
+    // Otherwise the person's, verbatim. The safe direction — a real message wrongly hidden is
+    // gone, while an unknown envelope wrongly shown is what already shipped.
+    return { role: 'user', text }
+  }
+  if (!env.unwrap) return { role: 'user', text: env.note, system: env.note }
+  const cmd = shellCommandOf(text)
+  return cmd === ''
+    ? { role: 'user', text: env.note, system: env.note }
+    : { role: 'user', text: cmd }
+}

--- a/packages/server/server/sessions/copilot-chat.test.ts
+++ b/packages/server/server/sessions/copilot-chat.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from 'bun:test'
+import { parseCopilotChat, toolDetailOf } from './copilot-chat'
+
+/**
+ * Fixtures are the SHAPE measured 2026-09-05 over the 11 largest sessions on this machine, trimmed
+ * to the fields that decide the answer. Where a rule exists because of a number, it is in the name.
+ */
+
+const AT = '2026-06-30T14:53:11.560Z'
+const line = (type: string, data: Record<string, unknown>): string =>
+  JSON.stringify({ type, data, id: 'x', timestamp: AT })
+
+describe('toolDetailOf', () => {
+  it('a shell command is summarised past its `cd`', () => {
+    expect(toolDetailOf({ command: 'cd /repo && bun test', description: 'run tests' }))
+      .toBe('bun test')
+  })
+
+  it('a read is named by its path', () => {
+    expect(toolDetailOf({ path: '/repo/packages' })).toBe('/repo/packages')
+  })
+})
+
+describe('parseCopilotChat', () => {
+  it('reads the person and the assistant, oldest first', () => {
+    const turns = parseCopilotChat([
+      line('user.message', { content: 'salve mano' }),
+      line('assistant.message', { content: 'Salve, meu mano! 👊', toolRequests: [] }),
+    ])
+    expect(turns).toEqual([
+      { role: 'user', text: 'salve mano', at: AT },
+      { role: 'assistant', text: 'Salve, meu mano! 👊', at: AT },
+    ])
+  })
+
+  it('reads `content` and NEVER `transformedContent`', () => {
+    // `transformedContent` is the same message wrapped by the harness in `<current_datetime>` and
+    // `<system_reminder>` blocks. It is longer and looks more complete, and putting it on screen
+    // is the defect `chat-envelope.ts` exists to prevent: the harness's reminders inside the
+    // reader's own bubble.
+    const [turn] = parseCopilotChat([line('user.message', {
+      content: 'salve mano',
+      transformedContent: '<current_datetime>2026-06-30T11:53:11.488-03:00</current_datetime>\n\nsalve mano\n\n<system_reminder>\n<sql_tables>Available tables: todos</sql_tables>\n</system_reminder>',
+    })])
+    expect(turn!.text).toBe('salve mano')
+  })
+
+  it('one assistant turn is ONE line — text, tools and thinking together', () => {
+    // Unlike codex, kimi and agy, copilot puts the requests on the message itself, so nothing has
+    // to be gathered across lines.
+    const [turn] = parseCopilotChat([line('assistant.message', {
+      content: 'vou procurar o diretório',
+      reasoningText: 'The user wants the package location.',
+      toolRequests: [
+        { toolCallId: 't1', name: 'view', arguments: { path: '/repo/packages' }, type: 'function' },
+        { toolCallId: 't2', name: 'bash', arguments: { command: 'find /repo -type d', description: 'Localizar' }, type: 'function' },
+      ],
+    })])
+    expect(turn).toEqual({
+      role: 'assistant',
+      text: 'vou procurar o diretório',
+      tools: [
+        { name: 'view', canonical: 'Read', detail: '/repo/packages' },
+        { name: 'bash', canonical: 'Bash', detail: 'find /repo -type d' },
+      ],
+      thinking: 'The user wants the package location.',
+      at: AT,
+    })
+  })
+
+  it("keeps COPILOT's own tool name for display, with the shared one beside it", () => {
+    const [turn] = parseCopilotChat([line('assistant.message', {
+      content: '', toolRequests: [{ name: 'view', arguments: { path: '/a' } }],
+    })])
+    expect(turn!.tools![0]).toEqual({ name: 'view', canonical: 'Read', detail: '/a' })
+  })
+
+  it('an unmapped tool carries no second reading', () => {
+    const [turn] = parseCopilotChat([line('assistant.message', {
+      content: '', toolRequests: [{ name: 'report_intent', arguments: { intent: 'Explorando docs' } }],
+    })])
+    expect(turn!.tools![0]).toEqual({ name: 'report_intent', detail: 'Explorando docs' })
+  })
+
+  it('only `reasoningText` is a thought — the opaque and encrypted halves are not', () => {
+    const [turn] = parseCopilotChat([line('assistant.message', {
+      content: 'ok', toolRequests: [],
+      reasoningOpaque: '6sGm+sK0rp4ZxWx34c3hwmYpIY',
+      encryptedContent: 'gAAAA',
+    })])
+    expect(turn!.thinking).toBeUndefined()
+  })
+
+  it('the system prompt is a note that names it, never its body', () => {
+    // The measured one opens "You are the GitHub Copilot CLI…" and runs for pages.
+    const [turn] = parseCopilotChat([line('system.message', {
+      role: 'system', content: 'You are the GitHub Copilot CLI, a terminal assistant…'.repeat(80),
+    })])
+    expect(turn).toEqual({ role: 'user', text: 'the system prompt was set', system: 'the system prompt was set', at: AT })
+  })
+
+  it('the session events worth a line get one, and the bracketing does NOT', () => {
+    const turns = parseCopilotChat([
+      line('session.start', { sessionId: 'a', context: { cwd: '/repo' } }),
+      line('assistant.turn_start', { turnId: '0' }),
+      line('tool.execution_start', { toolCallId: 't1' }),
+      line('tool.execution_complete', { toolCallId: 't1', output: 'x'.repeat(9000) }),
+      line('assistant.turn_end', { turnId: '0' }),
+      line('session.usage_checkpoint', {}),
+      line('session.model_change', { model: 'gpt-5.3-codex' }),
+      line('abort', {}),
+      line('session.error', { message: 'boom' }),
+    ])
+    expect(turns.map(t => t.system)).toEqual([
+      'the model was changed', 'the turn was aborted', 'the session reported an error',
+    ])
+  })
+
+  it('only the NEWEST message with calls and no text is pending', () => {
+    const turns = parseCopilotChat([
+      line('assistant.message', { content: '', toolRequests: [{ name: 'bash', arguments: { command: 'first' } }] }),
+      line('user.message', { content: 'go on' }),
+      line('assistant.message', { content: '', toolRequests: [{ name: 'bash', arguments: { command: 'last' } }] }),
+    ])
+    expect(turns.map(t => t.pending)).toEqual([undefined, undefined, true])
+  })
+
+  it('caps at max, keeping the END of the conversation', () => {
+    const lines = Array.from({ length: 20 }, (_, i) =>
+      line('assistant.message', { content: `m${i}`, toolRequests: [] }))
+    expect(parseCopilotChat(lines, 'copilot', 3).map(t => t.text)).toEqual(['m17', 'm18', 'm19'])
+  })
+
+  it('a half line the tail window cut through is skipped, not parsed', () => {
+    expect(parseCopilotChat(['ype":"user.mess', line('user.message', { content: 'oi' })])).toHaveLength(1)
+  })
+
+  it('a turn with no recorded time gets none rather than an invented now', () => {
+    const [turn] = parseCopilotChat([JSON.stringify({
+      type: 'user.message', data: { content: 'oi' },
+    })])
+    expect(turn!.at).toBeUndefined()
+  })
+})

--- a/packages/server/server/sessions/copilot-chat.ts
+++ b/packages/server/server/sessions/copilot-chat.ts
@@ -1,0 +1,171 @@
+/**
+ * copilot-chat.ts — PURE: a Copilot CLI session's `events.jsonl` lines → `ChatTurn[]`.
+ *
+ * No fs, no side effects. `harness-transcript.ts` finds the file and hands the lines over.
+ *
+ * ON-DISK SHAPE, measured 2026-09-05 over the 11 largest sessions on this machine
+ * (`~/.copilot/session-state/<session-id>/events.jsonl`). `copilot-parse.ts` — the METRICS parser
+ * — documents the envelope; what follows is the part a CONVERSATION needs. Counts:
+ *
+ *   assistant.turn_start 26   tool.execution_start 26   assistant.turn_end 24
+ *   tool.execution_complete 24   assistant.message 22   session.start 11   user.message 11
+ *   session.model_change 9   session.shutdown 7   system.message 4   session.error 4
+ *   session.auto_mode_resolved 3   session.usage_checkpoint 2   abort 2
+ *
+ * Every line is `{type, data, id, timestamp, parentId}` — a real ISO `timestamp`, unlike kimi's
+ * epoch milliseconds.
+ *
+ * THE TRAP HERE IS INSIDE ONE FIELD, not across two families. `user.message` carries BOTH
+ * `data.content` — what the person typed — and `data.transformedContent`, the same text wrapped by
+ * the harness in `<current_datetime>` and `<system_reminder>` blocks. `transformedContent` is the
+ * longer, more "complete"-looking field and is exactly the wrong one: it puts the harness's
+ * injected reminders inside the reader's own bubble, which is the defect `chat-envelope.ts` exists
+ * to prevent for Claude. `content` is read; `transformedContent` never is.
+ *
+ * THE TOOL REQUESTS RIDE ON THE MESSAGE. `assistant.message.data.toolRequests` is
+ * `[{toolCallId, name, arguments}]` with `arguments` a real OBJECT (codex's is a JSON string), so
+ * one assistant turn is one line — no gathering, unlike codex, kimi and agy. The separate
+ * `tool.execution_start` / `tool.execution_complete` events are the EXECUTION and are dropped: the
+ * request already said what ran, and the completion carries the whole output.
+ *
+ * THINKING EXISTS, SOMETIMES, AND IS NEVER THE OPAQUE FIELD. `assistant.message.data` carries
+ * `reasoningText` on 4 of the 22 measured, `reasoningOpaque` on 6 and `encryptedContent` on 2. Only
+ * `reasoningText` can be shown; the other two are not thoughts this or any reader can read.
+ *
+ * `system.message` is the whole system prompt under `data.role: 'system'`. It becomes a note that
+ * names the kind and never carries the body — the measured one opens "You are the GitHub Copilot
+ * CLI…" and runs for pages.
+ */
+
+import type { HarnessId } from '@agentistics/core'
+import { canonicalTool } from '../harness-activity'
+import type { ChatTurn } from './chat-turn'
+import { commandSummary } from './shell-writes'
+
+interface CopilotLine {
+  type?: unknown
+  timestamp?: unknown
+  data?: unknown
+}
+
+/**
+ * The session-level events that are worth a note, and what each says.
+ *
+ * Everything not listed is not a turn: `assistant.turn_start`/`turn_end` bracket a turn the
+ * `assistant.message` inside it already represents, `tool.execution_*` is the execution, and
+ * `session.usage_checkpoint` / `session.auto_mode_resolved` / `session.start` are bookkeeping the
+ * reader has no use for. A note for every one of those would be a status log, not a conversation.
+ */
+const EVENT_NOTES: Record<string, string> = {
+  'system.message': 'the system prompt was set',
+  'session.model_change': 'the model was changed',
+  'session.error': 'the session reported an error',
+  'abort': 'the turn was aborted',
+  'session.shutdown': 'the session ended',
+}
+
+const DETAIL_KEYS = ['command', 'path', 'file_path', 'filePath', 'pattern', 'query', 'url', 'intent', 'description']
+
+export function toolDetailOf(args: unknown): string | null {
+  if (typeof args !== 'object' || args === null) return null
+  const o = args as Record<string, unknown>
+  for (const key of DETAIL_KEYS) {
+    const v = o[key]
+    if (typeof v === 'string' && v.trim() !== '') {
+      // Summarised past its `cd`, the same call every other reader here makes.
+      if (key === 'command') return commandSummary(v)
+      const line = v.trim().split('\n')[0]!
+      return line.length > 200 ? `${line.slice(0, 200)}…` : line
+    }
+  }
+  return null
+}
+
+function toolsOf(data: Record<string, unknown>, harness: HarnessId): ChatTurn['tools'] {
+  const reqs = data.toolRequests
+  if (!Array.isArray(reqs)) return undefined
+  const out: NonNullable<ChatTurn['tools']> = []
+  for (const raw of reqs as unknown[]) {
+    if (typeof raw !== 'object' || raw === null) continue
+    const r = raw as Record<string, unknown>
+    const name = typeof r.name === 'string' ? r.name : ''
+    if (name === '') continue
+    const detail = toolDetailOf(r.arguments)
+    const canonical = canonicalTool(harness, name)
+    out.push({
+      // Copilot's own name for display; the shared one beside it. See `ChatTurn.tools`.
+      name,
+      ...(canonical !== name ? { canonical } : {}),
+      ...(detail ? { detail } : {}),
+    })
+  }
+  return out.length > 0 ? out : undefined
+}
+
+/**
+ * The conversation these lines hold, oldest first, capped at `max` turns from the END.
+ *
+ * Walked BACKWARD so a tail window can stop as soon as it has enough. No gathering is needed: an
+ * assistant turn is exactly one `assistant.message`, text and tools and thinking together.
+ */
+export function parseCopilotChat(
+  lines: string[],
+  harness: HarnessId = 'copilot',
+  max = 400,
+): ChatTurn[] {
+  const turns: ChatTurn[] = []
+  let newest = true
+
+  for (let i = lines.length - 1; i >= 0 && turns.length < max; i--) {
+    const line = (lines[i] ?? '').trim()
+    if (line === '') continue
+    let e: CopilotLine
+    try { e = JSON.parse(line) as CopilotLine } catch { continue }
+    const type = typeof e.type === 'string' ? e.type : ''
+    const data = (typeof e.data === 'object' && e.data !== null)
+      ? e.data as Record<string, unknown>
+      : {}
+    const at = typeof e.timestamp === 'string' ? e.timestamp : undefined
+    const stamp = (t: ChatTurn): ChatTurn => (at ? { ...t, at } : t)
+
+    if (type === 'user.message') {
+      newest = false
+      // `content`, NEVER `transformedContent` — see the header.
+      const text = typeof data.content === 'string' ? data.content.trim() : ''
+      if (text === '') continue
+      turns.push(stamp({ role: 'user', text }))
+      continue
+    }
+
+    if (type === 'assistant.message') {
+      const isNewest = newest
+      newest = false
+      const text = typeof data.content === 'string' ? data.content.trim() : ''
+      const tools = toolsOf(data, harness)
+      // Only `reasoningText` is readable. `reasoningOpaque` and `encryptedContent` are not thoughts
+      // anything here can show, and an absent thought is absent.
+      const thinking = typeof data.reasoningText === 'string' ? data.reasoningText.trim() : ''
+      if (text === '' && !tools && thinking === '') continue
+      turns.push(stamp({
+        role: 'assistant',
+        text,
+        ...(tools ? { tools } : {}),
+        ...(thinking ? { thinking } : {}),
+        // "no text has followed these calls yet" is a statement about right now, so only the
+        // NEWEST message in the file can be pending.
+        ...(isNewest && text === '' && tools ? { pending: true } : {}),
+      }))
+      continue
+    }
+
+    const note = EVENT_NOTES[type]
+    if (note) {
+      newest = false
+      turns.push(stamp({ role: 'user', text: note, system: note }))
+    }
+    // Everything else is bracketing or bookkeeping — see `EVENT_NOTES`.
+  }
+
+  turns.reverse()
+  return turns
+}

--- a/packages/server/server/sessions/harness-transcript.test.ts
+++ b/packages/server/server/sessions/harness-transcript.test.ts
@@ -3,8 +3,9 @@ import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import {
-  HARNESS_TRANSCRIPTS, forgetCodexTranscriptPaths, resolveAntigravityTranscript,
-  resolveCodexTranscript, transcriptReaderFor,
+  HARNESS_TRANSCRIPTS, forgetCodexTranscriptPaths, forgetKimiTranscriptPaths,
+  resolveAntigravityTranscript, resolveCodexTranscript, resolveCopilotTranscript,
+  resolveKimiTranscript, transcriptReaderFor,
 } from './harness-transcript'
 
 const CONV = '01d0814f-ef39-4838-8461-c50e540e552a'
@@ -20,10 +21,19 @@ describe('the reader registry', () => {
       .toEqual(['antigravity', 'claude', 'codex', 'copilot', 'gemini', 'kimi'])
   })
 
-  it('a harness with no reader is ABSENT — the caller turns that into a sentence', () => {
-    expect(transcriptReaderFor('kimi')).toBeNull()
-    expect(transcriptReaderFor('copilot')).toBeNull()
+  it('GEMINI is the one null, and it is a LINK fact rather than a missing reader', () => {
+    // A reader is only ever offered a conversationId, and gemini has neither `assignId` nor a
+    // `resume` that takes one — so a gemini row can never carry one and an entry here would be
+    // unreachable code. `conversationBlind` already says so on the row.
     expect(transcriptReaderFor('gemini')).toBeNull()
+  })
+
+  it('every harness that CAN carry an exact conversation id has a reader', () => {
+    // The five with `assignId` or `resume` in `spawn-spec.ts`. If one of these goes null, a row
+    // that knows exactly which conversation it is in stops being readable.
+    for (const h of ['claude', 'codex', 'copilot', 'kimi', 'antigravity'] as const) {
+      expect(transcriptReaderFor(h)).not.toBeNull()
+    }
   })
 
   it("a row whose harness the registry forgot ('') resolves to nothing rather than throwing", () => {
@@ -153,5 +163,78 @@ describe('the codex reader', () => {
       { role: 'user', text: 'Salve', at: '2026-07-07T22:02:40Z' },
     ])
     expect(await HARNESS_TRANSCRIPTS.codex!.readRecent(path, 6)).toEqual(turns)
+  })
+})
+
+describe('the copilot reader', () => {
+  const ID = 'dbd94500-8d79-4c7c-8c69-a2cd0c044201'
+  let root: string
+
+  beforeAll(async () => {
+    root = await mkdtemp(join(tmpdir(), 'copilot-state-'))
+    await mkdir(join(root, ID), { recursive: true })
+    await writeFile(join(root, ID, 'events.jsonl'), [
+      JSON.stringify({ type: 'session.start', data: { sessionId: ID }, timestamp: '2026-06-30T14:53:06Z' }),
+      JSON.stringify({
+        type: 'user.message', timestamp: '2026-06-30T14:53:11Z',
+        data: { content: 'salve mano', transformedContent: '<current_datetime>x</current_datetime>\n\nsalve mano' },
+      }),
+    ].join('\n'))
+  })
+  afterAll(async () => { await rm(root, { recursive: true, force: true }) })
+
+  it('the session DIRECTORY is named with the conversation id, so no scan is needed', async () => {
+    expect(await resolveCopilotTranscript({ conversationId: ID }, root))
+      .toBe(join(root, ID, 'events.jsonl'))
+  })
+
+  it('an id that is not a UUID resolves to nothing and reaches no filesystem', async () => {
+    expect(await resolveCopilotTranscript({ conversationId: '../../etc' }, root)).toBeNull()
+  })
+
+  it('reads the person’s own text, not the transformed copy', async () => {
+    const path = join(root, ID, 'events.jsonl')
+    const turns = await HARNESS_TRANSCRIPTS.copilot!.read(path, 400)
+    expect(turns).toEqual([{ role: 'user', text: 'salve mano', at: '2026-06-30T14:53:11Z' }])
+    expect(await HARNESS_TRANSCRIPTS.copilot!.readRecent(path, 6)).toEqual(turns)
+  })
+})
+
+describe('the kimi reader', () => {
+  const ID = 'f8f1e9b0-235e-44c3-8d66-7a5cd6b54009'
+  let root: string
+  let wire: string
+
+  beforeAll(async () => {
+    forgetKimiTranscriptPaths()
+    root = await mkdtemp(join(tmpdir(), 'kimi-sessions-'))
+    wire = join(root, 'wd_scratchpad_a2dd52466aab', `session_${ID}`, 'agents', 'main', 'wire.jsonl')
+    await mkdir(join(root, 'wd_scratchpad_a2dd52466aab', `session_${ID}`, 'agents', 'main'), { recursive: true })
+    await writeFile(wire, [
+      JSON.stringify({
+        type: 'context.append_message', time: 1785943919760,
+        message: { role: 'user', content: [{ type: 'text', text: 'salve' }], origin: { kind: 'user' } },
+      }),
+      // The duplicate copy, which must not be read.
+      JSON.stringify({ type: 'turn.prompt', time: 1785943919757, input: [{ type: 'text', text: 'salve' }] }),
+    ].join('\n'))
+  })
+  afterAll(async () => { await rm(root, { recursive: true, force: true }) })
+
+  it('finds the MAIN agent’s wire under whichever workspace holds the session', async () => {
+    expect(await resolveKimiTranscript({ conversationId: ID }, root)).toBe(wire)
+  })
+
+  it('an unknown conversation resolves to nothing — and the MISS is memoized', async () => {
+    const other = '11111111-2222-4333-8444-555555555555'
+    expect(await resolveKimiTranscript({ conversationId: other }, root)).toBeNull()
+    expect(await resolveKimiTranscript({ conversationId: other }, root)).toBeNull()
+  })
+
+  it('reads the conversation, taking exactly one copy of the duplicated prompt', async () => {
+    const turns = await HARNESS_TRANSCRIPTS.kimi!.read(wire, 400)
+    expect(turns).toHaveLength(1)
+    expect(turns[0]).toMatchObject({ role: 'user', text: 'salve' })
+    expect(await HARNESS_TRANSCRIPTS.kimi!.readRecent(wire, 6)).toEqual(turns)
   })
 })

--- a/packages/server/server/sessions/harness-transcript.test.ts
+++ b/packages/server/server/sessions/harness-transcript.test.ts
@@ -1,0 +1,101 @@
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import {
+  HARNESS_TRANSCRIPTS, resolveAntigravityTranscript, transcriptReaderFor,
+} from './harness-transcript'
+
+const CONV = '01d0814f-ef39-4838-8461-c50e540e552a'
+
+/** One agy step, in the shape measured on the live transcript. */
+const step = (idx: number, o: Record<string, unknown>): string => JSON.stringify({
+  step_index: idx, status: 'DONE', created_at: '2026-09-05T17:22:28Z', ...o,
+})
+
+describe('the reader registry', () => {
+  it('names every harness, so adding one is a decision here rather than a lookup miss', () => {
+    expect(Object.keys(HARNESS_TRANSCRIPTS).sort())
+      .toEqual(['antigravity', 'claude', 'codex', 'copilot', 'gemini', 'kimi'])
+  })
+
+  it('a harness with no reader is ABSENT — the caller turns that into a sentence', () => {
+    expect(transcriptReaderFor('codex')).toBeNull()
+  })
+
+  it("a row whose harness the registry forgot ('') resolves to nothing rather than throwing", () => {
+    expect(transcriptReaderFor('')).toBeNull()
+    expect(transcriptReaderFor(undefined)).toBeNull()
+    expect(transcriptReaderFor('a-harness-from-a-newer-build')).toBeNull()
+  })
+})
+
+describe('the antigravity reader', () => {
+  let brain: string
+  let logs: string
+
+  beforeAll(async () => {
+    brain = await mkdtemp(join(tmpdir(), 'agy-brain-'))
+    logs = join(brain, CONV, '.system_generated', 'logs')
+    await mkdir(logs, { recursive: true })
+  })
+  afterAll(async () => { await rm(brain, { recursive: true, force: true }) })
+
+  it('prefers transcript_full.jsonl — transcript.jsonl is the truncated copy of it', async () => {
+    await writeFile(join(logs, 'transcript.jsonl'), '')
+    expect(await resolveAntigravityTranscript({ conversationId: CONV }, brain))
+      .toBe(join(logs, 'transcript.jsonl'))
+    await writeFile(join(logs, 'transcript_full.jsonl'), '')
+    expect(await resolveAntigravityTranscript({ conversationId: CONV }, brain))
+      .toBe(join(logs, 'transcript_full.jsonl'))
+  })
+
+  it('a conversation id that is not a UUID resolves to nothing, and reaches no filesystem', async () => {
+    expect(await resolveAntigravityTranscript({ conversationId: '../../etc' }, brain)).toBeNull()
+  })
+
+  it('an unknown conversation resolves to nothing rather than to a path that does not exist', async () => {
+    const other = '11111111-2222-4333-8444-555555555555'
+    expect(await resolveAntigravityTranscript({ conversationId: other }, brain)).toBeNull()
+  })
+
+  it('reads the whole conversation, and the TAIL reads only its end', async () => {
+    const lines: string[] = []
+    for (let i = 0; i < 300; i++) {
+      lines.push(step(i, { source: 'MODEL', type: 'PLANNER_RESPONSE', content: `m${i}` }))
+    }
+    const path = join(logs, 'transcript_full.jsonl')
+    await writeFile(path, `${lines.join('\n')}\n`)
+
+    const reader = HARNESS_TRANSCRIPTS.antigravity!
+    const all = await reader.read(path, 400)
+    expect(all).toHaveLength(300)
+    expect(all[0]!.text).toBe('m0')
+    expect(all[299]!.text).toBe('m299')
+
+    // The 5s poll's budget: the last few turns, off the end of the file.
+    const tail = await reader.readRecent(path, 6)
+    expect(tail.map(t => t.text)).toEqual(['m294', 'm295', 'm296', 'm297', 'm298', 'm299'])
+  })
+
+  it('the tail WIDENS its window rather than returning fewer turns than asked for', async () => {
+    // One turn, then padding far larger than the 256 KB first window, so a fixed window would
+    // reach the end of the file and find nothing — the answer would be silently short.
+    const pad = Array.from({ length: 4000 }, (_, i) =>
+      step(i + 1, { source: 'MODEL', type: 'VIEW_FILE', content: 'x'.repeat(200) }))
+    const path = join(logs, 'wide.jsonl')
+    await writeFile(path, [
+      step(0, { source: 'USER_EXPLICIT', type: 'USER_INPUT', content: '<USER_REQUEST>\noi\n</USER_REQUEST>' }),
+      ...pad,
+    ].join('\n'))
+
+    const tail = await HARNESS_TRANSCRIPTS.antigravity!.readRecent(path, 1)
+    expect(tail).toEqual([{ role: 'user', text: 'oi', at: '2026-09-05T17:22:28Z' }])
+  })
+
+  it('an unreadable file is an empty conversation, never a throw', async () => {
+    const reader = HARNESS_TRANSCRIPTS.antigravity!
+    expect(await reader.read(join(logs, 'nope.jsonl'), 10)).toEqual([])
+    expect(await reader.readRecent(join(logs, 'nope.jsonl'), 10)).toEqual([])
+  })
+})

--- a/packages/server/server/sessions/harness-transcript.test.ts
+++ b/packages/server/server/sessions/harness-transcript.test.ts
@@ -3,7 +3,8 @@ import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import {
-  HARNESS_TRANSCRIPTS, resolveAntigravityTranscript, transcriptReaderFor,
+  HARNESS_TRANSCRIPTS, forgetCodexTranscriptPaths, resolveAntigravityTranscript,
+  resolveCodexTranscript, transcriptReaderFor,
 } from './harness-transcript'
 
 const CONV = '01d0814f-ef39-4838-8461-c50e540e552a'
@@ -20,7 +21,9 @@ describe('the reader registry', () => {
   })
 
   it('a harness with no reader is ABSENT — the caller turns that into a sentence', () => {
-    expect(transcriptReaderFor('codex')).toBeNull()
+    expect(transcriptReaderFor('kimi')).toBeNull()
+    expect(transcriptReaderFor('copilot')).toBeNull()
+    expect(transcriptReaderFor('gemini')).toBeNull()
   })
 
   it("a row whose harness the registry forgot ('') resolves to nothing rather than throwing", () => {
@@ -97,5 +100,58 @@ describe('the antigravity reader', () => {
     const reader = HARNESS_TRANSCRIPTS.antigravity!
     expect(await reader.read(join(logs, 'nope.jsonl'), 10)).toEqual([])
     expect(await reader.readRecent(join(logs, 'nope.jsonl'), 10)).toEqual([])
+  })
+})
+
+describe('the codex reader', () => {
+  const ID = '019f3e9a-43b1-7391-b8a2-19fcdfeb88b0'
+  let root: string
+
+  beforeAll(async () => {
+    forgetCodexTranscriptPaths()
+    root = await mkdtemp(join(tmpdir(), 'codex-sessions-'))
+    await mkdir(join(root, '2026', '07', '07'), { recursive: true })
+    await writeFile(
+      join(root, '2026', '07', '07', `rollout-2026-07-07T19-02-05-${ID}.jsonl`),
+      [
+        JSON.stringify({ timestamp: '2026-07-07T22:02:11Z', type: 'session_meta', payload: { id: ID } }),
+        JSON.stringify({
+          timestamp: '2026-07-07T22:02:40Z',
+          type: 'response_item',
+          payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'Salve' }] },
+        }),
+        // The duplicate copy, which must not be read.
+        JSON.stringify({
+          timestamp: '2026-07-07T22:02:40Z', type: 'event_msg',
+          payload: { type: 'user_message', message: 'Salve' },
+        }),
+      ].join('\n'),
+    )
+  })
+  afterAll(async () => { await rm(root, { recursive: true, force: true }) })
+
+  it('finds the rollout by the conversation id in its FILENAME, across the day tree', async () => {
+    expect(await resolveCodexTranscript({ conversationId: ID }, root))
+      .toBe(join(root, '2026', '07', '07', `rollout-2026-07-07T19-02-05-${ID}.jsonl`))
+  })
+
+  it('an id that is not a UUID resolves to nothing and reaches no filesystem', async () => {
+    expect(await resolveCodexTranscript({ conversationId: '../../etc/passwd' }, root)).toBeNull()
+  })
+
+  it('an unknown conversation resolves to nothing — and the MISS is memoized', async () => {
+    const other = '11111111-2222-4333-8444-555555555555'
+    expect(await resolveCodexTranscript({ conversationId: other }, root)).toBeNull()
+    // A machine keeps a directory per day forever; a miss must cost one scan, not one per poll.
+    expect(await resolveCodexTranscript({ conversationId: other }, root)).toBeNull()
+  })
+
+  it('reads the conversation, taking exactly one copy of the duplicated message', async () => {
+    const path = join(root, '2026', '07', '07', `rollout-2026-07-07T19-02-05-${ID}.jsonl`)
+    const turns = await HARNESS_TRANSCRIPTS.codex!.read(path, 400)
+    expect(turns).toEqual([
+      { role: 'user', text: 'Salve', at: '2026-07-07T22:02:40Z' },
+    ])
+    expect(await HARNESS_TRANSCRIPTS.codex!.readRecent(path, 6)).toEqual(turns)
   })
 })

--- a/packages/server/server/sessions/harness-transcript.ts
+++ b/packages/server/server/sessions/harness-transcript.ts
@@ -25,10 +25,12 @@
 import { readFile, readdir, stat } from 'node:fs/promises'
 import { join } from 'node:path'
 import type { HarnessId } from '@agentistics/core'
-import { ANTIGRAVITY_BRAIN_DIR, CODEX_SESSIONS_DIR } from '../config'
+import { ANTIGRAVITY_BRAIN_DIR, CODEX_SESSIONS_DIR, COPILOT_DIR, KIMI_DIR } from '../config'
 import { UUID_RE } from '../git'
 import { parseAntigravityChat } from './antigravity-chat'
 import { parseCodexChat } from './codex-chat'
+import { parseCopilotChat } from './copilot-chat'
+import { parseKimiChat } from './kimi-chat'
 import type { ChatTurn } from './chat-turn'
 import { readChatTurns, readRecentChatTurns, resolveChatTranscriptPath } from './chat-tail'
 import { readTailWindow } from './transcript-window'
@@ -162,6 +164,92 @@ const CODEX: HarnessTranscript = {
   },
 }
 
+
+/**
+ * Copilot names the session's DIRECTORY with its own id — verified: the folder
+ * `dbd94500-8d79-4c7c-8c69-a2cd0c044201` holds an `events.jsonl` whose `session.start` carries
+ * exactly that `sessionId`. It is also the id `copilot --session-id <uuid>` assigns, which
+ * `spawn-spec.ts` records as VERIFIED, so a copilot session agentop STARTED is linked from its
+ * first turn rather than only after a reopen. No scan is needed.
+ */
+export async function resolveCopilotTranscript(
+  ref: TranscriptRef,
+  stateDir: string = join(COPILOT_DIR, 'session-state'),
+): Promise<string | null> {
+  if (!UUID_RE.test(ref.conversationId)) return null
+  const p = join(stateDir, ref.conversationId, 'events.jsonl')
+  return (await exists(p)) ? p : null
+}
+
+const COPILOT: HarnessTranscript = {
+  resolve: ref => resolveCopilotTranscript(ref),
+  async read(path, max) {
+    let content: string
+    try { content = await readFile(path, 'utf-8') } catch { return [] }
+    return parseCopilotChat(content.split('\n'), 'copilot', max)
+  },
+  async readRecent(path, max) {
+    return readTailWindow(path, max, lines => parseCopilotChat(lines, 'copilot', max))
+  },
+}
+
+/**
+ * Kimi files a session under its WORKSPACE — `sessions/<workspaceId>/session_<uuid>/` — so the
+ * conversation id alone does not name a path and the workspace directories have to be listed. One
+ * shallow `readdir` plus a `stat` per workspace, memoized like codex's for the same reason.
+ *
+ * ONLY THE `main` AGENT IS READ. A kimi session can hold several agents and `kimi-parse.ts` folds
+ * every one of them into its metrics, which is right for a COUNT — the work happened. A CHAT is a
+ * different question: `main` is the conversation the person had, and a subagent's wire is the
+ * assistant's own working notes, so splicing them together would interleave two dialogues under one
+ * heading. Measured: every one of the 14 sessions on this machine has exactly one agent, `main`. The
+ * fallback to the first agent directory costs nothing and covers a session that somehow has none.
+ */
+const kimiPathCache = new Map<string, string | null>()
+
+/** Reset the memo. Tests only. */
+export function forgetKimiTranscriptPaths(): void {
+  kimiPathCache.clear()
+}
+
+async function findKimiWire(id: string, root: string): Promise<string | null> {
+  for (const ws of await subdirs(root)) {
+    const agents = join(root, ws, `session_${id}`, 'agents')
+    const main = join(agents, 'main', 'wire.jsonl')
+    if (await exists(main)) return main
+    const others = await subdirs(agents)
+    for (const a of others) {
+      const p = join(agents, a, 'wire.jsonl')
+      if (await exists(p)) return p
+    }
+  }
+  return null
+}
+
+export async function resolveKimiTranscript(
+  ref: TranscriptRef,
+  sessionsDir: string = join(KIMI_DIR, 'sessions'),
+): Promise<string | null> {
+  if (!UUID_RE.test(ref.conversationId)) return null
+  const cached = kimiPathCache.get(ref.conversationId)
+  if (cached !== undefined) return cached
+  const found = await findKimiWire(ref.conversationId, sessionsDir)
+  kimiPathCache.set(ref.conversationId, found)
+  return found
+}
+
+const KIMI: HarnessTranscript = {
+  resolve: ref => resolveKimiTranscript(ref),
+  async read(path, max) {
+    let content: string
+    try { content = await readFile(path, 'utf-8') } catch { return [] }
+    return parseKimiChat(content.split('\n'), 'kimi', max)
+  },
+  async readRecent(path, max) {
+    return readTailWindow(path, max, lines => parseKimiChat(lines, 'kimi', max))
+  },
+}
+
 const CLAUDE: HarnessTranscript = {
   resolve: ref => (ref.cwd === undefined
     ? Promise.resolve(null)
@@ -171,20 +259,34 @@ const CLAUDE: HarnessTranscript = {
 }
 
 /**
- * The reader for each harness, or `null` where nobody has written one.
+ * The reader for each harness, and the one `null` that is not a gap.
  *
- * `null` is a statement about THIS PRODUCT, not about the harness — kimi, copilot and gemini all
- * keep a readable transcript on disk (`adapters/*-parse.ts` already read every one of them for
- * metrics) and each is a reader waiting to be written. It is spelled out here rather than left to
- * a lookup miss so that adding one is a line in this table, and so the caller has something to say.
+ * GEMINI CAN NEVER BE READ HERE, and that is a fact about the LINK rather than about the format.
+ * A reader is only ever offered a `conversationId`, and `ManagedSession.conversationId` exists only
+ * where agentop handed the id to the CLI. Measured against `spawn-spec.ts`: claude and copilot have
+ * `assignId`, and codex, kimi and antigravity have `resume` — so every one of those five can carry
+ * an exact id. **Gemini has neither** (`-r, --resume` takes "latest" or an index, not an id, and
+ * `--session-id` is deliberately excluded because gemini's id in this product is synthetic —
+ * `${dir}/${file}` — so a recorded UUID would resolve to nothing while LOOKING exact). A gemini row
+ * therefore never has a conversation id at all, `conversationBlind` already says so in words, and
+ * `SessionsPage` hides the chat tab on such a row.
+ *
+ * So a gemini entry here would be code nothing can reach, plus a claim the product cannot honour.
+ * Its chat file WAS read and understood — it is a patch log, not one message per line: a header,
+ * then `{"$set":{messages:[…]}}` seeding the list once (measured: 1 seed, always at line 1, in 4 of
+ * 12 files) and bare message objects appended after it, with types `user` / `gemini` / `info` /
+ * `error` and a `<session_context>` bootstrap block the harness writes under the user role. That
+ * note is here so the next reader of this file does not spend the measurement again, and so the
+ * absence reads as a finding rather than as a to-do. It becomes writable the day gemini accepts an
+ * id agentop can hand it — not before.
  */
 export const HARNESS_TRANSCRIPTS: Record<HarnessId, HarnessTranscript | null> = {
   claude: CLAUDE,
   antigravity: ANTIGRAVITY,
   codex: CODEX,
+  copilot: COPILOT,
+  kimi: KIMI,
   gemini: null,
-  copilot: null,
-  kimi: null,
 }
 
 /**

--- a/packages/server/server/sessions/harness-transcript.ts
+++ b/packages/server/server/sessions/harness-transcript.ts
@@ -1,0 +1,129 @@
+/**
+ * harness-transcript.ts — WHICH harnesses can have their conversation read, and how.
+ *
+ * `Record<HarnessId, HarnessTranscript | null>`, so the compiler asks about a new harness on the
+ * day it is added and a reader that does not exist is ABSENT rather than a call that fails. The
+ * caller turns a `null` into a sentence; it never turns it into an empty conversation, which is the
+ * defect this module was written to remove. Measured 2026-09-05 on a live antigravity session:
+ * `GET /api/fleet/chat` answered `{"turns":[],"live":true}` and `SessionChat.tsx` drew a completely
+ * blank pane with nothing on it explaining why — no reader, no refusal, no words.
+ *
+ * A READER IS ONLY EVER OFFERED A CONVERSATION ID THAT IS EXACT. `SessionView.conversationId` is
+ * filled solely from `ManagedSession.conversationId`, which exists only because agentop handed that
+ * id to the CLI (`SpawnSpec.assignId`, or `resume`) — verified on the live agy session, whose
+ * `/proc/<pid>/cmdline` reads `agy --conversation 01d0814f-…` for exactly the id the registry
+ * holds. The harness-and-directory INFERENCE behind `resume` never reaches here: it is good enough
+ * to offer a reopen a person confirms by title, and putting SOME OTHER conversation from the same
+ * folder on screen under this session's name is a confident wrong answer the reader cannot detect.
+ *
+ * Two budgets, deliberately. `read` is the CHAT VIEW's and reads the conversation; `readRecent` is
+ * the 5 s fleet poll's and reads only the end of the file through `transcript-window.ts`. A poll
+ * that reads whole transcripts is what made `/api/fleet` answer in 36 s cold — see that module's
+ * header for the measurement.
+ */
+
+import { readFile, stat } from 'node:fs/promises'
+import { join } from 'node:path'
+import type { HarnessId } from '@agentistics/core'
+import { ANTIGRAVITY_BRAIN_DIR } from '../config'
+import { UUID_RE } from '../git'
+import { parseAntigravityChat } from './antigravity-chat'
+import type { ChatTurn } from './chat-turn'
+import { readChatTurns, readRecentChatTurns, resolveChatTranscriptPath } from './chat-tail'
+import { readTailWindow } from './transcript-window'
+
+/** Everything a reader is told about the session whose conversation is wanted. */
+export interface TranscriptRef {
+  /** The harness's own conversation id, known EXACTLY — never inferred. See the header. */
+  conversationId: string
+  /** The session's working directory. Some harnesses key their store on it; agy does not. */
+  cwd?: string
+}
+
+export interface HarnessTranscript {
+  /** The absolute path to this conversation's transcript here, or `null` when there is none. */
+  resolve(ref: TranscriptRef): Promise<string | null>
+  /** The conversation, oldest first, capped at `max` turns from the end. */
+  read(path: string, max: number): Promise<ChatTurn[]>
+  /** The last `max` turns only, read from the END of the file. The fleet poll's budget. */
+  readRecent(path: string, max: number): Promise<ChatTurn[]>
+}
+
+async function exists(path: string): Promise<boolean> {
+  try { await stat(path); return true } catch { return false }
+}
+
+/**
+ * agy writes one directory per conversation under `brain/`, and the transcript inside it.
+ *
+ * `transcript_full.jsonl` is the whole thing and `transcript.jsonl` is a truncated copy of it —
+ * the same pair, and the same preference, `antigravity-parse.ts` records. Measured on the live
+ * conversation: 5.598.537 bytes against 3.669.964, both being appended to as it ran.
+ */
+export async function resolveAntigravityTranscript(
+  ref: TranscriptRef,
+  // Overridable only so a test can point at a fixture tree without a subprocess — `config.ts`'s
+  // constants are fixed at import time and shared across a whole `bun test` run. Same escape hatch,
+  // for the same reason, as `resolveChatTranscriptPath`'s `projectsDir`.
+  brainDir: string = ANTIGRAVITY_BRAIN_DIR,
+): Promise<string | null> {
+  if (!UUID_RE.test(ref.conversationId)) return null
+  const dir = join(brainDir, ref.conversationId, '.system_generated', 'logs')
+  for (const name of ['transcript_full.jsonl', 'transcript.jsonl']) {
+    const p = join(dir, name)
+    if (await exists(p)) return p
+  }
+  return null
+}
+
+const ANTIGRAVITY: HarnessTranscript = {
+  resolve: resolveAntigravityTranscript,
+  async read(path, max) {
+    // No cache and no window: a chat view re-reads a file that is being appended to, and a cache
+    // keyed on mtime would miss every time by construction while holding whole transcripts in
+    // memory. Same call `chat-tail.ts`'s `readChatTurns` makes, for the same reason.
+    let content: string
+    try { content = await readFile(path, 'utf-8') } catch { return [] }
+    return parseAntigravityChat(content.split('\n'), 'antigravity', max)
+  },
+  async readRecent(path, max) {
+    return readTailWindow(path, max, lines => parseAntigravityChat(lines, 'antigravity', max))
+  },
+}
+
+const CLAUDE: HarnessTranscript = {
+  resolve: ref => (ref.cwd === undefined
+    ? Promise.resolve(null)
+    : resolveChatTranscriptPath(ref.cwd, ref.conversationId)),
+  read: (path, max) => readChatTurns(path, max),
+  readRecent: (path, max) => readRecentChatTurns(path, max),
+}
+
+/**
+ * The reader for each harness, or `null` where nobody has written one.
+ *
+ * `null` is a statement about THIS PRODUCT, not about the harness — codex, kimi, copilot and gemini
+ * all keep a readable transcript on disk (`adapters/*-parse.ts` already read every one of them for
+ * metrics) and each is a reader waiting to be written. It is spelled out here rather than left to
+ * a lookup miss so that adding one is a line in this table, and so the caller has something to say.
+ */
+export const HARNESS_TRANSCRIPTS: Record<HarnessId, HarnessTranscript | null> = {
+  claude: CLAUDE,
+  antigravity: ANTIGRAVITY,
+  codex: null,
+  gemini: null,
+  copilot: null,
+  kimi: null,
+}
+
+/**
+ * The reader for a harness named as a plain string.
+ *
+ * `ControlSession.harness` is a `string` — a `HarnessId`, or `''` when the registry has forgotten
+ * which harness a row is. Both of those, and an id from a newer build, resolve to `null` here
+ * rather than to a throw: a row nobody can name is a row whose conversation nobody can read.
+ */
+export function transcriptReaderFor(harness: string | undefined): HarnessTranscript | null {
+  if (!harness) return null
+  return HARNESS_TRANSCRIPTS[harness as HarnessId] ?? null
+}

--- a/packages/server/server/sessions/harness-transcript.ts
+++ b/packages/server/server/sessions/harness-transcript.ts
@@ -22,12 +22,13 @@
  * header for the measurement.
  */
 
-import { readFile, stat } from 'node:fs/promises'
+import { readFile, readdir, stat } from 'node:fs/promises'
 import { join } from 'node:path'
 import type { HarnessId } from '@agentistics/core'
-import { ANTIGRAVITY_BRAIN_DIR } from '../config'
+import { ANTIGRAVITY_BRAIN_DIR, CODEX_SESSIONS_DIR } from '../config'
 import { UUID_RE } from '../git'
 import { parseAntigravityChat } from './antigravity-chat'
+import { parseCodexChat } from './codex-chat'
 import type { ChatTurn } from './chat-turn'
 import { readChatTurns, readRecentChatTurns, resolveChatTranscriptPath } from './chat-tail'
 import { readTailWindow } from './transcript-window'
@@ -91,6 +92,76 @@ const ANTIGRAVITY: HarnessTranscript = {
   },
 }
 
+
+/**
+ * Codex files its rollouts by DAY — `sessions/YYYY/MM/DD/rollout-<time>-<conversation-id>.jsonl` —
+ * and the conversation id is both the filename suffix and `session_meta.id` inside (verified: the
+ * file `rollout-2026-07-07T19-02-05-019f3e9a-…` carries `id: 019f3e9a-…`). It is the id
+ * `codex-parse.ts` keys a session by, so it is the id the registry recorded and the one
+ * `codex resume <id>` takes.
+ *
+ * The scan is three shallow `readdir`s rather than one deep walk, and both the hit and the MISS are
+ * memoized — a machine keeps a directory per day forever, so an unresolvable id must cost one scan
+ * and not one per poll. Same rule, same reason, as `resolveChatTranscriptPath`'s own cache.
+ */
+const codexPathCache = new Map<string, string | null>()
+
+/** Reset the memo. Tests only. */
+export function forgetCodexTranscriptPaths(): void {
+  codexPathCache.clear()
+}
+
+async function subdirs(dir: string): Promise<string[]> {
+  try {
+    return (await readdir(dir, { withFileTypes: true }))
+      .filter(d => d.isDirectory())
+      .map(d => d.name)
+  } catch { return [] }
+}
+
+async function scanCodexRollout(id: string, root: string): Promise<string | null> {
+  const suffix = `-${id}.jsonl`
+  for (const year of await subdirs(root)) {
+    for (const month of await subdirs(join(root, year))) {
+      for (const day of await subdirs(join(root, year, month))) {
+        const dir = join(root, year, month, day)
+        let names: string[]
+        try { names = await readdir(dir) } catch { continue }
+        const hit = names.find(n => n.startsWith('rollout-') && n.endsWith(suffix))
+        if (hit) return join(dir, hit)
+      }
+    }
+  }
+  return null
+}
+
+export async function resolveCodexTranscript(
+  ref: TranscriptRef,
+  // Overridable for tests only — see `resolveAntigravityTranscript`'s note.
+  sessionsDir: string = CODEX_SESSIONS_DIR,
+): Promise<string | null> {
+  // Codex's ids are UUIDv7; `UUID_RE` is version-agnostic, so this rejects a path fragment without
+  // rejecting the real thing.
+  if (!UUID_RE.test(ref.conversationId)) return null
+  const cached = codexPathCache.get(ref.conversationId)
+  if (cached !== undefined) return cached
+  const found = await scanCodexRollout(ref.conversationId, sessionsDir)
+  codexPathCache.set(ref.conversationId, found)
+  return found
+}
+
+const CODEX: HarnessTranscript = {
+  resolve: ref => resolveCodexTranscript(ref),
+  async read(path, max) {
+    let content: string
+    try { content = await readFile(path, 'utf-8') } catch { return [] }
+    return parseCodexChat(content.split('\n'), 'codex', max)
+  },
+  async readRecent(path, max) {
+    return readTailWindow(path, max, lines => parseCodexChat(lines, 'codex', max))
+  },
+}
+
 const CLAUDE: HarnessTranscript = {
   resolve: ref => (ref.cwd === undefined
     ? Promise.resolve(null)
@@ -102,15 +173,15 @@ const CLAUDE: HarnessTranscript = {
 /**
  * The reader for each harness, or `null` where nobody has written one.
  *
- * `null` is a statement about THIS PRODUCT, not about the harness — codex, kimi, copilot and gemini
- * all keep a readable transcript on disk (`adapters/*-parse.ts` already read every one of them for
+ * `null` is a statement about THIS PRODUCT, not about the harness — kimi, copilot and gemini all
+ * keep a readable transcript on disk (`adapters/*-parse.ts` already read every one of them for
  * metrics) and each is a reader waiting to be written. It is spelled out here rather than left to
  * a lookup miss so that adding one is a line in this table, and so the caller has something to say.
  */
 export const HARNESS_TRANSCRIPTS: Record<HarnessId, HarnessTranscript | null> = {
   claude: CLAUDE,
   antigravity: ANTIGRAVITY,
-  codex: null,
+  codex: CODEX,
   gemini: null,
   copilot: null,
   kimi: null,

--- a/packages/server/server/sessions/kimi-chat.test.ts
+++ b/packages/server/server/sessions/kimi-chat.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from 'bun:test'
+import { isoOf, parseKimiChat, toolDetailOf } from './kimi-chat'
+
+/**
+ * Fixtures are the SHAPE measured 2026-09-05 over the 10 largest wires on this machine, trimmed to
+ * the fields that decide the answer. Where a rule exists because of a number, it is in the name.
+ */
+
+const T = 1785943919760
+const AT = new Date(T).toISOString()
+
+const line = (o: Record<string, unknown>): string => JSON.stringify({ time: T, ...o })
+
+const userMsg = (text: string): string => line({
+  type: 'context.append_message',
+  message: { role: 'user', content: [{ type: 'text', text }], toolCalls: [], origin: { kind: 'user' } },
+})
+
+const injected = (variant: string, body: string): string => line({
+  type: 'context.append_message',
+  message: {
+    role: 'user', content: [{ type: 'text', text: body }], toolCalls: [],
+    origin: { kind: 'injection', variant },
+  },
+})
+
+const loop = (event: Record<string, unknown>): string =>
+  line({ type: 'context.append_loop_event', event })
+
+const say = (text: string): string =>
+  loop({ type: 'content.part', turnId: '0', step: 1, part: { type: 'text', text } })
+
+describe('the pieces', () => {
+  it('kimi stamps epoch MILLISECONDS; every other reader emits ISO', () => {
+    expect(isoOf(1785943919760)).toBe(new Date(1785943919760).toISOString())
+    expect(isoOf(1785943919760)).toMatch(/^\d{4}-\d{2}-\d{2}T/)
+    expect(isoOf(0)).toBeUndefined()
+    expect(isoOf('nope')).toBeUndefined()
+  })
+
+  it('a shell command is summarised past its `cd`', () => {
+    expect(toolDetailOf({ command: 'cd /repo && bun test' })).toBe('bun test')
+  })
+
+  it('a write is named by its path, never by the file it carries', () => {
+    expect(toolDetailOf({ path: 'frase.txt', content: 'x'.repeat(5000) })).toBe('frase.txt')
+  })
+})
+
+describe('parseKimiChat', () => {
+  it('reads the person and the assistant, oldest first', () => {
+    expect(parseKimiChat([userMsg('salve'), say('Salve! Como posso ajudar você hoje?')])).toEqual([
+      { role: 'user', text: 'salve', at: AT },
+      { role: 'assistant', text: 'Salve! Como posso ajudar você hoje?', at: AT },
+    ])
+  })
+
+  it('IGNORES turn.prompt — the same text, and a strict subset (15 against 22)', () => {
+    const turns = parseKimiChat([
+      line({ type: 'turn.prompt', input: [{ type: 'text', text: 'salve' }], origin: { kind: 'user' } }),
+      userMsg('salve'),
+    ])
+    expect(turns).toHaveLength(1)
+  })
+
+  it('an entry KIMI ITSELF marks as injected is a note that names the variant, never the body', () => {
+    // `origin.kind` is kimi's own declaration — the field codex has no equivalent for. Measured:
+    // 15 `user`, 3 `todo_list_reminder`, 4 `permission_mode`.
+    const turns = parseKimiChat([
+      injected('todo_list_reminder', '<system-reminder>\nThe TodoList tool has not been updated…'),
+      injected('permission_mode', '<system-reminder>\nAuto permission mode is active…'),
+      injected('something_new', '<system-reminder>\n…'),
+    ])
+    expect(turns.map(t => t.system)).toEqual([
+      'a reminder about the task list',
+      'the permission mode was announced',
+      'an injected something new',
+    ])
+    for (const t of turns) expect(t.text).toBe(t.system!)
+  })
+
+  it('an injected entry with no variant still says it was not the person', () => {
+    const [turn] = parseKimiChat([line({
+      type: 'context.append_message',
+      message: { role: 'user', content: [{ type: 'text', text: 'x' }], origin: { kind: 'injection' } },
+    })])
+    expect(turn!.system).toBe('injected by the harness')
+  })
+
+  it('gathers tool.call onto the content.part above it', () => {
+    const turns = parseKimiChat([
+      say('vou escrever o arquivo'),
+      loop({ type: 'tool.call', toolCallId: 'c1', name: 'Write', args: { path: 'frase.txt', content: 'oi' } }),
+      loop({ type: 'tool.call', toolCallId: 'c2', name: 'Bash', args: { command: 'cat frase.txt' } }),
+    ])
+    expect(turns).toHaveLength(1)
+    expect(turns[0]!.tools).toEqual([
+      { name: 'Write', detail: 'frase.txt' },
+      { name: 'Bash', detail: 'cat frase.txt' },
+    ])
+  })
+
+  it("kimi's tool names are ALREADY the shared ones, so no second reading is carried", () => {
+    const [turn] = parseKimiChat([loop({ type: 'tool.call', name: 'Write', args: { path: 'a.ts' } })])
+    expect(turn!.tools![0]!.canonical).toBeUndefined()
+  })
+
+  it('drops tool.result and the step brackets — the request already said what ran', () => {
+    const turns = parseKimiChat([
+      say('a'),
+      loop({ type: 'step.begin', step: 1 }),
+      loop({ type: 'tool.call', name: 'Write', args: { path: 'a.ts' } }),
+      loop({ type: 'tool.result', toolCallId: 'c1', result: { output: 'Wrote 475 bytes to frase.txt' } }),
+      loop({ type: 'step.end', finishReason: 'end_turn', usage: { output: 12 } }),
+    ])
+    expect(turns).toHaveLength(1)
+    expect(turns[0]!.tools).toHaveLength(1)
+  })
+
+  it('only the NEWEST batch of calls with no text after it is pending', () => {
+    const turns = parseKimiChat([
+      loop({ type: 'tool.call', name: 'Bash', args: { command: 'first' } }),
+      userMsg('go on'),
+      loop({ type: 'tool.call', name: 'Bash', args: { command: 'last' } }),
+    ])
+    expect(turns.map(t => t.pending)).toEqual([undefined, undefined, true])
+  })
+
+  it('caps at max, keeping the END of the conversation', () => {
+    const lines = Array.from({ length: 20 }, (_, i) => say(`m${i}`))
+    expect(parseKimiChat(lines, 'kimi', 3).map(t => t.text)).toEqual(['m17', 'm18', 'm19'])
+  })
+
+  it('a half line the tail window cut through is skipped, not parsed', () => {
+    expect(parseKimiChat(['pe":"context.append_me', userMsg('oi')])).toHaveLength(1)
+  })
+
+  it('a turn with no recorded time gets none rather than an invented now', () => {
+    const [turn] = parseKimiChat([JSON.stringify({
+      type: 'context.append_message',
+      message: { role: 'user', content: [{ type: 'text', text: 'oi' }], origin: { kind: 'user' } },
+    })])
+    expect(turn!.at).toBeUndefined()
+  })
+})

--- a/packages/server/server/sessions/kimi-chat.ts
+++ b/packages/server/server/sessions/kimi-chat.ts
@@ -1,0 +1,237 @@
+/**
+ * kimi-chat.ts — PURE: a Kimi Code agent's `wire.jsonl` lines → `ChatTurn[]`.
+ *
+ * No fs, no side effects. `harness-transcript.ts` finds the file and hands the lines over.
+ *
+ * ON-DISK SHAPE, measured 2026-09-05 over the 10 largest wires on this machine
+ * (`~/.kimi-code/sessions/<workspaceId>/session_<uuid>/agents/<agentId>/wire.jsonl`).
+ * `kimi-parse.ts` — the METRICS parser — documents the envelope; what follows is the part a
+ * CONVERSATION needs. Counts over those 10 files:
+ *
+ *   context.append_loop_event  214   the assistant's work, one `event` per line
+ *   llm.request                 95   the call being made — not a turn
+ *   usage.record                41   tokens
+ *   context.append_message      22   the messages the context holds
+ *   turn.prompt                 15   the prompt that opened a turn
+ *   turn.ended / metadata / profile.bind / permission.* / llm.tools_snapshot / interaction.*
+ *
+ * Inside `context.append_loop_event`, `event.type` is:
+ *   step.begin  95   step.end  41   tool.call  34   tool.result  34   content.part  10
+ *
+ * THE PERSON IS `context.append_message`, AND KIMI SAYS SO ITSELF. `turn.prompt` carries the same
+ * text and would be the obvious source, but it is a strict SUBSET: 15 prompts against 22 messages,
+ * and reading both draws the person's turn twice — the same duplication trap `codex-chat.ts` and
+ * `kimi-parse.ts` each document for their own file. The seven extra messages are the difference
+ * that matters: kimi stamps every one with `message.origin`, and it came out
+ * `{kind:'user'}` 15, `{kind:'injection', variant:'todo_list_reminder'}` 3 and
+ * `{kind:'injection', variant:'permission_mode'}` 4. So the harness DECLARES which entries under
+ * the user role nobody typed — the same thing Claude's `isMeta` does and the thing codex has no
+ * field for at all. Anything that is not `origin.kind === 'user'` is a note, and the note names the
+ * VARIANT rather than carrying the body, which is a `<system-reminder>`.
+ *
+ * THE ASSISTANT IS `content.part`, and its tools are `tool.call`. `context.append_message` holds
+ * NO assistant rows at all (22 of 22 were `user`), so a reader that looked only there would show a
+ * conversation of questions and no answers. `tool.result` is the result and is dropped, exactly as
+ * agy's execution steps and codex's `function_call_output` are: the request above already said what
+ * ran, and the result is the whole output.
+ *
+ * Kimi's tool names are ALREADY Claude's (`Write` verbatim in the measured wire), so `canonicalTool`
+ * usually returns the name unchanged and `ChatTurn.tools.canonical` is simply absent. That is the
+ * mapping doing nothing because there is nothing to do, not the mapping being skipped.
+ */
+
+import type { HarnessId } from '@agentistics/core'
+import { canonicalTool } from '../harness-activity'
+import type { ChatTurn } from './chat-turn'
+import { commandSummary } from './shell-writes'
+
+interface KimiLine {
+  type?: unknown
+  time?: unknown
+  message?: unknown
+  event?: unknown
+}
+
+/**
+ * What each `origin.variant` is, for an entry the harness injected under the user role.
+ *
+ * A matched pair with the measurement above; a variant nobody has seen still becomes a note (the
+ * `origin.kind` already said it is not the person) and simply says less — the same shape
+ * `chat-envelope.ts`'s `META_KINDS` takes, and the reason a new one cannot regress anything.
+ */
+const INJECTION_NOTES: Record<string, string> = {
+  todo_list_reminder: 'a reminder about the task list',
+  permission_mode: 'the permission mode was announced',
+}
+
+/** The `text` parts of a content array, joined. */
+function partsText(content: unknown): string {
+  if (typeof content === 'string') return content.trim()
+  if (!Array.isArray(content)) return ''
+  return (content as Record<string, unknown>[])
+    .map(p => (p && p.type === 'text' && typeof p.text === 'string' ? p.text : ''))
+    .join('')
+    .trim()
+}
+
+/**
+ * The one line worth showing for a tool call.
+ *
+ * `args` is a real object here. `command` is summarised rather than truncated — the same
+ * `commandSummary` `chat-tail.ts` and `codex-chat.ts` use, so a session that opens every call with
+ * `cd <dir>` does not draw a column of identical rows.
+ */
+const DETAIL_KEYS = ['command', 'cmd', 'path', 'file_path', 'filePath', 'pattern', 'query', 'url', 'description']
+
+export function toolDetailOf(args: unknown): string | null {
+  if (typeof args !== 'object' || args === null) return null
+  const o = args as Record<string, unknown>
+  for (const key of DETAIL_KEYS) {
+    const v = o[key]
+    if (typeof v === 'string' && v.trim() !== '') {
+      if (key === 'command' || key === 'cmd') return commandSummary(v)
+      const line = v.trim().split('\n')[0]!
+      return line.length > 200 ? `${line.slice(0, 200)}…` : line
+    }
+  }
+  return null
+}
+
+/** Kimi stamps epoch MILLISECONDS; every other reader here emits ISO. */
+export function isoOf(time: unknown): string | undefined {
+  if (typeof time !== 'number' || !Number.isFinite(time) || time <= 0) return undefined
+  const d = new Date(time)
+  return Number.isNaN(d.getTime()) ? undefined : d.toISOString()
+}
+
+type Tool = NonNullable<ChatTurn['tools']>[number]
+
+function toolOf(event: Record<string, unknown>, harness: HarnessId): Tool | null {
+  const name = typeof event.name === 'string' ? event.name : ''
+  if (name === '') return null
+  const detail = toolDetailOf(event.args)
+  const canonical = canonicalTool(harness, name)
+  return {
+    name,
+    ...(canonical !== name ? { canonical } : {}),
+    ...(detail ? { detail } : {}),
+  }
+}
+
+/**
+ * The conversation these lines hold, oldest first, capped at `max` turns from the END.
+ *
+ * Walked BACKWARD so a tail window can stop as soon as it has enough. `tool.call`s are gathered
+ * onto the `content.part` above them, reproducing the single assistant turn Claude's reader emits;
+ * a batch with no text of its own is still a turn, because it is what the session did.
+ */
+export function parseKimiChat(
+  lines: string[],
+  harness: HarnessId = 'kimi',
+  max = 400,
+): ChatTurn[] {
+  const turns: ChatTurn[] = []
+  /** Tool calls seen since the assistant text they belong to, in FILE order. */
+  let pending: Tool[] = []
+  let pendingAt: string | undefined
+  /** Whether the batch currently accumulating is the LAST thing in the file. */
+  let newestBatch = false
+  let newest = true
+
+  const flushTools = (): void => {
+    if (pending.length === 0) return
+    turns.push({
+      role: 'assistant',
+      text: '',
+      tools: pending,
+      ...(pendingAt ? { at: pendingAt } : {}),
+      ...(newestBatch ? { pending: true } : {}),
+    })
+    pending = []
+    pendingAt = undefined
+    newestBatch = false
+  }
+
+  for (let i = lines.length - 1; i >= 0 && turns.length < max; i--) {
+    const line = (lines[i] ?? '').trim()
+    if (line === '') continue
+    let e: KimiLine
+    try { e = JSON.parse(line) as KimiLine } catch { continue }
+    const at = isoOf(e.time)
+
+    if (e.type === 'context.append_loop_event') {
+      const event = (typeof e.event === 'object' && e.event !== null)
+        ? e.event as Record<string, unknown>
+        : null
+      if (!event) continue
+      if (event.type === 'tool.call') {
+        const tool = toolOf(event, harness)
+        if (tool) {
+          if (pending.length === 0) { pendingAt = at; newestBatch = newest }
+          pending.unshift(tool)
+          newest = false
+        }
+        continue
+      }
+      if (event.type === 'content.part') {
+        const part = (typeof event.part === 'object' && event.part !== null)
+          ? event.part as Record<string, unknown>
+          : null
+        const text = part && typeof part.text === 'string' ? part.text.trim() : ''
+        newest = false
+        if (text === '' && pending.length === 0) continue
+        turns.push({
+          role: 'assistant',
+          text,
+          ...(pending.length > 0 ? { tools: pending } : {}),
+          ...(at ? { at } : {}),
+          ...(text === '' && pending.length > 0 && newestBatch ? { pending: true } : {}),
+        })
+        pending = []
+        pendingAt = undefined
+        newestBatch = false
+        continue
+      }
+      // `step.begin` / `step.end` bracket a step and `tool.result` is the result — the request
+      // above already said what ran, and the result is the whole output.
+      continue
+    }
+
+    if (e.type === 'context.append_message') {
+      const m = (typeof e.message === 'object' && e.message !== null)
+        ? e.message as Record<string, unknown>
+        : null
+      if (!m) continue
+      flushTools()
+      newest = false
+      const text = partsText(m.content)
+      if (text === '') continue
+      const turn = messageTurn(m, text)
+      if (turn) turns.push(at ? { ...turn, at } : turn)
+      continue
+    }
+
+    // `turn.prompt` is deliberately ignored — it is the same text as the `context.append_message`
+    // above and a strict subset of it (15 against 22). See the header.
+  }
+
+  flushTools()
+  turns.reverse()
+  return turns
+}
+
+/** One `context.append_message`, classified by the origin KIMI ITSELF stamped on it. */
+function messageTurn(message: Record<string, unknown>, text: string): ChatTurn | null {
+  const origin = (typeof message.origin === 'object' && message.origin !== null)
+    ? message.origin as Record<string, unknown>
+    : null
+  const kind = origin && typeof origin.kind === 'string' ? origin.kind : ''
+  if (kind === 'user') return { role: 'user', text }
+
+  // Not the person, and kimi said so. The note names the VARIANT and never the body — the injected
+  // entries measured here are `<system-reminder>` blocks.
+  const variant = origin && typeof origin.variant === 'string' ? origin.variant : ''
+  const note = INJECTION_NOTES[variant]
+    ?? (variant !== '' ? `an injected ${variant.replace(/_/g, ' ')}` : 'injected by the harness')
+  return { role: 'user', text: note, system: note }
+}

--- a/packages/server/server/sessions/sessions-host.ts
+++ b/packages/server/server/sessions/sessions-host.ts
@@ -16,7 +16,8 @@ import type { HarnessProcess } from '../live-sessions'
 import { rulesFor } from './attention-rules'
 import { approvalTail, attentionOf, digestFrame, frameTail } from './attention'
 import { EMPTY_CONFIRM_MEMORY, confirmActivities, type ConfirmMemory } from './attention-confirm'
-import { readRecentChatTurns, resolveChatTranscriptPath, type ChatTurn } from './chat-tail'
+import type { ChatTurn } from './chat-turn'
+import { transcriptReaderFor } from './harness-transcript'
 import { markFleetPhase } from './fleet-profile'
 import { parseDialogOptions, type DialogOption } from './dialog-choice'
 // Taking a running session back when its registry record is gone. See `session-adopt.ts`.
@@ -50,7 +51,7 @@ const CAPTURE_CONCURRENCY = 4
  *  with; the pane cuts from the bottom to whatever it can actually draw. */
 const TAIL_LINES = 8
 
-/** How many role-tagged chat turns to carry for a Claude session — see `chat-tail.ts`. */
+/** How many role-tagged chat turns to carry for a readable session — see `harness-transcript.ts`. */
 const TAIL_CHAT_TURNS = 6
 
 /**
@@ -260,15 +261,26 @@ export function createSessionsPoller(o: {
 
         const harness = harnessOf.get(r.id)
 
-        // Claude only: the one harness with an EXACT live-session -> conversation-id link
-        // (`harness-sessions.ts`), which is what makes reading its own transcript safe rather than
-        // a guess. Every other harness keeps the raw screen tail above as its only detail content.
+        // Read the harness's own transcript instead of the screen, wherever BOTH halves hold: the
+        // conversation id is EXACT and somebody has written a reader for that harness's format
+        // (`harness-transcript.ts`). Either missing and the raw screen tail above stays the row's
+        // only detail content — never a conversation guessed from harness-and-directory.
+        //
+        // TWO exact sources, and they are not interchangeable. Claude's own
+        // `~/.claude/sessions/<pid>.json` names our tmux session, which is the link for a session
+        // we did not start; `ManagedSession.conversationId` is the id agentop handed the CLI
+        // itself, which is the only one the other harnesses can ever have. Claude's own record is
+        // preferred where both exist — it is the LIVE one, while the registry's was recorded once.
         const cwd = r.managed?.cwd
         const conversationId = harnessSessions.byManagedId.get(r.id)?.sessionId
-        if (harness === 'claude' && cwd && conversationId) {
-          const path = await resolveChatTranscriptPath(cwd, conversationId).catch(() => null)
+          ?? r.managed?.conversationId
+        const transcript = transcriptReaderFor(harness)
+        if (transcript && conversationId) {
+          const path = await transcript
+            .resolve({ conversationId, ...(cwd ? { cwd } : {}) })
+            .catch(() => null)
           if (path) {
-            const turns = await readRecentChatTurns(path, TAIL_CHAT_TURNS).catch(() => [] as ChatTurn[])
+            const turns = await transcript.readRecent(path, TAIL_CHAT_TURNS).catch(() => [] as ChatTurn[])
             if (turns.length > 0) chatTails.set(r.id, turns)
           }
         }

--- a/packages/server/server/sessions/transcript-window.ts
+++ b/packages/server/server/sessions/transcript-window.ts
@@ -1,0 +1,83 @@
+/**
+ * transcript-window.ts — reading the END of a growing JSONL transcript, for every harness.
+ *
+ * A live transcript is appended to for as long as its session runs and is read on every poll of
+ * every session. `chat-tail.ts` documents what reading the WHOLE file costs, measured: nine active
+ * Claude transcripts totalling 31 MB, re-read and re-split every five seconds, which is what made
+ * `/api/fleet` answer in 5–8 s warm and 36 s cold. Antigravity's are the same order — 5.6 MB on the
+ * one live conversation measured here — so the second harness to be read must not re-learn this.
+ *
+ * The window GROWS rather than truncating the answer. A window that happened to cut through the
+ * middle of the last few turns would silently show fewer of them, and a detail pane quietly missing
+ * the newest message is worse than a slow one. Growth is bounded, and a file smaller than the
+ * window is simply read whole.
+ */
+
+import { open } from 'node:fs/promises'
+
+/** The first window tried, and the point past which the whole file is being read anyway. */
+export const TAIL_BYTES = 256 * 1024
+export const MAX_TAIL_BYTES = 16 * 1024 * 1024
+
+/**
+ * The last `bytes` of a file, as text, plus whether that reached the file's start.
+ *
+ * A window that starts mid-file almost always starts mid-LINE, and can also start mid-CHARACTER for
+ * any multi-byte codepoint. Both are handled by the same rule: `windowLines` below drops everything
+ * before the first newline, so the partial line — and any broken byte sequence inside it — never
+ * reaches `JSON.parse`.
+ */
+export async function readTailBytes(
+  path: string,
+  bytes: number,
+): Promise<{ text: string; atStart: boolean } | null> {
+  let fh
+  try { fh = await open(path, 'r') } catch { return null }
+  try {
+    const size = (await fh.stat()).size
+    const start = Math.max(0, size - bytes)
+    const length = size - start
+    if (length === 0) return { text: '', atStart: true }
+    const buf = Buffer.alloc(length)
+    await fh.read(buf, 0, length, start)
+    return { text: buf.toString('utf-8'), atStart: start === 0 }
+  } catch {
+    return null
+  } finally {
+    await fh.close().catch(() => {})
+  }
+}
+
+/** The whole lines inside one window — the half-line the window cut through is dropped. */
+export function windowLines(tail: { text: string; atStart: boolean }): string[] {
+  // Everything before the first newline belongs to a line this window cut in half — it is already
+  // present, whole, further up the file, and parsing the fragment would at best fail and at worst
+  // succeed on a truncated object.
+  const content = tail.atStart ? tail.text : tail.text.slice(tail.text.indexOf('\n') + 1)
+  return content.split('\n')
+}
+
+/**
+ * Read the end of `path` until `parse` has produced `want` items, widening the window as needed.
+ *
+ * `parse` is given the whole lines of one window and returns what it found there; it is called
+ * again on a wider window whenever it came back short AND the window had not yet reached the start
+ * of the file. Fewer than `want` with the window at the start means the file really is that short.
+ */
+export async function readTailWindow<T>(
+  path: string,
+  want: number,
+  parse: (lines: string[], atStart: boolean) => T[],
+  first: number = TAIL_BYTES,
+  max: number = MAX_TAIL_BYTES,
+): Promise<T[]> {
+  let window = first
+  let out: T[] = []
+  for (;;) {
+    const tail = await readTailBytes(path, window)
+    if (!tail) return out
+    out = parse(windowLines(tail), tail.atStart)
+    if (out.length >= want || tail.atStart || window >= max) return out
+    window = Math.min(window * 4, max)
+  }
+}

--- a/packages/server/server/subagent-metrics.test.ts
+++ b/packages/server/server/subagent-metrics.test.ts
@@ -1,0 +1,96 @@
+import { test, expect } from 'bun:test'
+import { mkdtemp, mkdir, writeFile } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import type { SessionAgentMetrics } from '@agentistics/core'
+import { enrichFromSubagentTranscripts } from './subagent-metrics'
+
+/** A real directory tree, because the thing under test is the file layout itself. */
+async function machine(sessionId: string, files: Record<string, string[]>) {
+  const root = await mkdtemp(join(tmpdir(), 'agentistics-subagents-'))
+  const dir = join(root, sessionId, 'subagents')
+  await mkdir(dir, { recursive: true })
+  for (const [agentId, lines] of Object.entries(files)) {
+    await writeFile(join(dir, `agent-${agentId}.jsonl`), lines.join('\n'))
+  }
+  return { transcriptPath: join(root, `${sessionId}.jsonl`) }
+}
+
+function turn(model: string, out: number, at = '2026-09-01T10:00:00.000Z', content: unknown[] = []) {
+  return JSON.stringify({ type: 'assistant', timestamp: at, message: { model, usage: { output_tokens: out }, content } })
+}
+
+function unmeasured(toolUseId: string, agentId: string): SessionAgentMetrics['invocations'][number] {
+  return {
+    toolUseId, agentId, unmeasured: true, agentType: 'general-purpose', description: 'd',
+    status: 'completed', totalTokens: 0, totalDurationMs: 0, totalToolUseCount: 0,
+    inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0,
+    toolStats: { readCount: 0, searchCount: 0, bashCount: 0, editFileCount: 0, linesAdded: 0, linesRemoved: 0, otherToolCount: 0 },
+    costUSD: 0,
+  }
+}
+
+function metrics(...invocations: SessionAgentMetrics['invocations']): SessionAgentMetrics {
+  return { invocations, totalInvocations: invocations.length, unmeasuredInvocations: invocations.length, totalTokens: 0, totalDurationMs: 0, totalCostUSD: 0 }
+}
+
+test('an unmeasured invocation is filled in from the subagent’s own transcript', async () => {
+  const { transcriptPath } = await machine('s1', {
+    aOne: [turn('claude-sonnet-5', 500, '2026-09-01T10:00:00.000Z'), turn('claude-sonnet-5', 300, '2026-09-01T10:00:30.000Z')],
+  })
+
+  const out = await enrichFromSubagentTranscripts(metrics(unmeasured('toolu_1', 'aOne')), transcriptPath, 's1')
+
+  const inv = out.invocations[0]!
+  expect(inv.unmeasured).toBeUndefined()
+  expect(inv.outputTokens).toBe(800)
+  expect(inv.totalTokens).toBe(800)
+  expect(inv.totalDurationMs).toBe(30_000)
+  expect(inv.costUSD).toBeGreaterThan(0)
+  expect(out.unmeasuredInvocations).toBe(0)
+  expect(out.totalTokens).toBe(800)
+})
+
+test('a missing subagent transcript leaves the invocation unmeasured — never a zero', async () => {
+  const { transcriptPath } = await machine('s2', {})
+
+  const out = await enrichFromSubagentTranscripts(metrics(unmeasured('toolu_1', 'aGone')), transcriptPath, 's2')
+
+  expect(out.invocations[0]!.unmeasured).toBe(true)
+  expect(out.unmeasuredInvocations).toBe(1)
+})
+
+test('a nested subagent counts inside the invocation that spawned it', async () => {
+  const { transcriptPath } = await machine('s3', {
+    aParent: [
+      turn('claude-sonnet-5', 100),
+      JSON.stringify({ type: 'user', timestamp: '2026-09-01T10:00:05.000Z', toolUseResult: { agentId: 'aChild', isAsync: true } }),
+    ],
+    aChild: [turn('claude-sonnet-5', 900)],
+  })
+
+  const out = await enrichFromSubagentTranscripts(metrics(unmeasured('toolu_1', 'aParent')), transcriptPath, 's3')
+
+  expect(out.invocations[0]!.outputTokens).toBe(1000)
+})
+
+test('subagents that name each other cannot loop forever', async () => {
+  const { transcriptPath } = await machine('s4', {
+    aA: [turn('claude-sonnet-5', 10), JSON.stringify({ type: 'user', toolUseResult: { agentId: 'aB' } })],
+    aB: [turn('claude-sonnet-5', 20), JSON.stringify({ type: 'user', toolUseResult: { agentId: 'aA' } })],
+  })
+
+  const out = await enrichFromSubagentTranscripts(metrics(unmeasured('toolu_1', 'aA')), transcriptPath, 's4')
+
+  expect(out.invocations[0]!.outputTokens).toBe(30)
+})
+
+test('an invocation that already has numbers is left exactly as it is', async () => {
+  const { transcriptPath } = await machine('s5', { aOne: [turn('claude-sonnet-5', 9999)] })
+  const legacy = { ...unmeasured('toolu_1', 'aOne'), unmeasured: undefined, outputTokens: 42, totalTokens: 42 }
+  delete (legacy as Record<string, unknown>).unmeasured
+
+  const out = await enrichFromSubagentTranscripts(metrics(legacy), transcriptPath, 's5')
+
+  expect(out.invocations[0]!.outputTokens).toBe(42)
+})

--- a/packages/server/server/subagent-metrics.ts
+++ b/packages/server/server/subagent-metrics.ts
@@ -1,0 +1,103 @@
+/**
+ * subagent-metrics.ts — the I/O half: find each subagent's own transcript and read it.
+ *
+ * Claude Code made the `Agent` tool asynchronous on 2026-08-14. The parent's `toolUseResult` stopped
+ * carrying the agent's numbers and now names it instead — `agentId` — while the numbers moved into
+ * `<project>/<session-id>/subagents/agent-<agentId>.jsonl`. `agent-metrics.ts` marks those
+ * invocations UNMEASURED; this module is what makes almost all of them measured again (on the
+ * machine this was written against: 440 of 442 async invocations had their transcript on disk).
+ *
+ * **The `outputFile` the result also names is deliberately NOT used.** It points into the run's
+ * scratch directory under `/tmp`, which is cleared on reboot and by the OS — it is the agent's text
+ * answer, not its accounting, and it was already gone for every invocation measured here. The
+ * durable file is the one this module opens.
+ *
+ * What cannot be found stays unmeasured. A transcript deleted by Claude's own 30-day cleanup is a
+ * fact nobody can recover, and reporting it as zero would be the very defect this fixes.
+ */
+
+import { readFile, stat } from 'fs/promises'
+import { dirname, join } from 'path'
+import type { AgentInvocation, SessionAgentMetrics } from '@agentistics/core'
+import { agentNumbers, summarizeSubagentTranscript, totalsOf, type SubagentSummary } from './subagent-parse'
+
+/**
+ * Parsed subagent transcripts, keyed by path + mtime + size.
+ *
+ * A finished subagent's transcript never changes, and the data walk runs on a 30s cache over a
+ * machine that can hold hundreds of them — re-parsing half a megabyte per invocation per build is
+ * the storm `git.ts` had to be rescued from. The key carries mtime and size so a transcript still
+ * being written is re-read rather than frozen at its first reading.
+ */
+const CACHE = new Map<string, SubagentSummary>()
+
+async function summaryFor(file: string): Promise<SubagentSummary | null> {
+  let key: string
+  try {
+    const st = await stat(file)
+    key = `${file}\0${st.mtimeMs}\0${st.size}`
+  } catch {
+    return null
+  }
+  const hit = CACHE.get(key)
+  if (hit) return hit
+
+  let content: string
+  try { content = await readFile(file, 'utf-8') } catch { return null }
+
+  const summary = summarizeSubagentTranscript(content.split('\n'))
+  CACHE.set(key, summary)
+  return summary
+}
+
+/** Every summary under one agent, the agent itself excluded. Cycle-safe by construction. */
+async function descendantsOf(
+  dir: string,
+  root: SubagentSummary,
+  seen: Set<string>,
+): Promise<SubagentSummary[]> {
+  const out: SubagentSummary[] = []
+  const queue = [...root.childAgentIds]
+  while (queue.length > 0) {
+    const id = queue.shift()!
+    if (seen.has(id)) continue
+    seen.add(id)
+    const summary = await summaryFor(join(dir, `agent-${id}.jsonl`))
+    if (!summary) continue
+    out.push(summary)
+    queue.push(...summary.childAgentIds)
+  }
+  return out
+}
+
+/**
+ * Fill in every UNMEASURED invocation that names a transcript this machine still has.
+ *
+ * Total: a session with no `subagents/` directory, an unreadable file or an invocation with no
+ * `agentId` comes back exactly as it went in.
+ */
+export async function enrichFromSubagentTranscripts(
+  metrics: SessionAgentMetrics,
+  transcriptPath: string,
+  sessionId: string,
+): Promise<SessionAgentMetrics> {
+  if (!metrics.invocations.some(i => i.unmeasured && i.agentId)) return metrics
+
+  const dir = join(dirname(transcriptPath), sessionId, 'subagents')
+  const invocations: AgentInvocation[] = []
+  let changed = false
+
+  for (const inv of metrics.invocations) {
+    if (!inv.unmeasured || !inv.agentId) { invocations.push(inv); continue }
+
+    const root = await summaryFor(join(dir, `agent-${inv.agentId}.jsonl`))
+    if (!root) { invocations.push(inv); continue }
+
+    const descendants = await descendantsOf(dir, root, new Set([inv.agentId]))
+    const { unmeasured: _dropped, ...rest } = inv
+    invocations.push({ ...rest, ...agentNumbers(root, descendants) })
+    changed = true
+  }
+
+  return changed ? totalsOf(invocations) : metrics
+}

--- a/packages/server/server/subagent-parse.test.ts
+++ b/packages/server/server/subagent-parse.test.ts
@@ -1,0 +1,163 @@
+import { test, expect } from 'bun:test'
+import { summarizeSubagentTranscript } from './subagent-parse'
+
+/** One assistant turn of a subagent transcript, as Claude Code writes it. */
+function assistant(model: string, usage: Record<string, number>, extra: Record<string, unknown> = {}) {
+  return JSON.stringify({
+    type: 'assistant',
+    timestamp: extra.timestamp ?? '2026-09-01T10:00:00.000Z',
+    message: { model, usage, content: extra.content ?? [] },
+  })
+}
+
+test('usage is summed PER MODEL — a subagent may run a cheaper model than its parent', () => {
+  const s = summarizeSubagentTranscript([
+    assistant('claude-haiku-4-5-20251001', { input_tokens: 8, output_tokens: 100, cache_read_input_tokens: 90, cache_creation_input_tokens: 2 }),
+    assistant('claude-haiku-4-5-20251001', { input_tokens: 2, output_tokens: 50, cache_read_input_tokens: 10, cache_creation_input_tokens: 0 }),
+    assistant('claude-sonnet-5', { input_tokens: 1, output_tokens: 7, cache_read_input_tokens: 0, cache_creation_input_tokens: 3 }),
+  ])
+
+  expect(s.usage).toEqual([
+    { model: 'claude-haiku-4-5-20251001', inputTokens: 10, outputTokens: 150, cacheReadTokens: 100, cacheWriteTokens: 2 },
+    { model: 'claude-sonnet-5', inputTokens: 1, outputTokens: 7, cacheReadTokens: 0, cacheWriteTokens: 3 },
+  ])
+})
+
+test('the span is the first and last timestamp of the transcript', () => {
+  const s = summarizeSubagentTranscript([
+    assistant('m', { output_tokens: 1 }, { timestamp: '2026-09-01T10:00:00.000Z' }),
+    assistant('m', { output_tokens: 1 }, { timestamp: '2026-09-01T10:02:30.000Z' }),
+  ])
+  expect(s.firstMs).toBe(Date.parse('2026-09-01T10:00:00.000Z'))
+  expect(s.lastMs).toBe(Date.parse('2026-09-01T10:02:30.000Z'))
+})
+
+test('a transcript with no timestamp reports no span, never a zero duration', () => {
+  const s = summarizeSubagentTranscript([
+    JSON.stringify({ type: 'assistant', message: { model: 'm', usage: { output_tokens: 1 }, content: [] } }),
+  ])
+  expect(s.firstMs).toBeNull()
+  expect(s.lastMs).toBeNull()
+})
+
+test('junk lines and blank lines are skipped without throwing', () => {
+  const s = summarizeSubagentTranscript(['', '   ', 'not json at all', assistant('m', { output_tokens: 4 })])
+  expect(s.usage).toEqual([{ model: 'm', inputTokens: 0, outputTokens: 4, cacheReadTokens: 0, cacheWriteTokens: 0 }])
+})
+
+/** A tool_use item inside an assistant turn. */
+function toolUse(name: string) {
+  return JSON.stringify({
+    type: 'assistant',
+    timestamp: '2026-09-01T10:00:00.000Z',
+    message: { model: 'm', content: [{ type: 'tool_use', id: 't1', name, input: {} }] },
+  })
+}
+
+test('tool uses are counted and bucketed the way the panel reads them', () => {
+  const s = summarizeSubagentTranscript([
+    toolUse('Read'), toolUse('Grep'), toolUse('Glob'), toolUse('Bash'), toolUse('Bash'),
+    toolUse('Edit'), toolUse('Write'), toolUse('MultiEdit'), toolUse('WebFetch'),
+  ])
+  expect(s.toolUseCount).toBe(9)
+  expect(s.toolStats.readCount).toBe(1)
+  expect(s.toolStats.searchCount).toBe(2)
+  expect(s.toolStats.bashCount).toBe(2)
+  expect(s.toolStats.editFileCount).toBe(3)
+  expect(s.toolStats.otherToolCount).toBe(1)
+})
+
+test('lines changed come from the edit patch the transcript already carries', () => {
+  const s = summarizeSubagentTranscript([
+    JSON.stringify({
+      type: 'user',
+      timestamp: '2026-09-01T10:00:01.000Z',
+      toolUseResult: {
+        structuredPatch: [
+          { lines: [' kept', '-gone', '+new', '+also new'] },
+          { lines: ['-gone too'] },
+        ],
+      },
+    }),
+  ])
+  expect(s.toolStats.linesAdded).toBe(2)
+  expect(s.toolStats.linesRemoved).toBe(2)
+})
+
+test('a nested subagent is NAMED so its own transcript can be found', () => {
+  const s = summarizeSubagentTranscript([
+    JSON.stringify({ type: 'user', toolUseResult: { agentId: 'aNested1', isAsync: true } }),
+    JSON.stringify({ type: 'user', toolUseResult: { agentId: 'aNested2', isAsync: true } }),
+    JSON.stringify({ type: 'user', toolUseResult: { stdout: 'no agent here' } }),
+  ])
+  expect(s.childAgentIds).toEqual(['aNested1', 'aNested2'])
+})
+
+test('the same nested subagent named twice is one child, never two', () => {
+  const s = summarizeSubagentTranscript([
+    JSON.stringify({ type: 'user', toolUseResult: { agentId: 'aNested1' } }),
+    JSON.stringify({ type: 'user', toolUseResult: { agentId: 'aNested1' } }),
+  ])
+  expect(s.childAgentIds).toEqual(['aNested1'])
+})
+
+// --- the numbers one invocation reports, from its own transcript and everything it spawned ---
+
+import { agentNumbers } from './subagent-parse'
+import { calcCost } from '@agentistics/core'
+
+const emptyStats = { readCount: 0, searchCount: 0, bashCount: 0, editFileCount: 0, linesAdded: 0, linesRemoved: 0, otherToolCount: 0 }
+function summary(over: Partial<Parameters<typeof agentNumbers>[0]> = {}) {
+  return { usage: [], firstMs: null, lastMs: null, toolUseCount: 0, toolStats: { ...emptyStats }, childAgentIds: [], ...over }
+}
+
+test('cost prices each model at ITS OWN rate — a haiku child under an opus parent is not opus money', () => {
+  const usage = { inputTokens: 1000, outputTokens: 2000, cacheReadTokens: 30000, cacheWriteTokens: 400 }
+  const n = agentNumbers(summary({ usage: [{ model: 'claude-haiku-4-5-20251001', ...usage }] }), [])
+
+  const asHaiku = calcCost(
+    { inputTokens: 1000, outputTokens: 2000, cacheReadInputTokens: 30000, cacheCreationInputTokens: 400, webSearchRequests: 0, costUSD: 0 },
+    'claude-haiku-4-5-20251001',
+  )
+  expect(n.costUSD).toBeCloseTo(asHaiku, 10)
+
+  const asOpus = calcCost(
+    { inputTokens: 1000, outputTokens: 2000, cacheReadInputTokens: 30000, cacheCreationInputTokens: 400, webSearchRequests: 0, costUSD: 0 },
+    'claude-opus-5',
+  )
+  expect(n.costUSD).toBeLessThan(asOpus)
+})
+
+test('tokens is ALL FOUR counters — a subagent read of the cache is most of its volume', () => {
+  const n = agentNumbers(summary({
+    usage: [{ model: 'claude-sonnet-5', inputTokens: 8, outputTokens: 100, cacheReadTokens: 97781, cacheWriteTokens: 261 }],
+  }), [])
+  expect(n.totalTokens).toBe(8 + 100 + 97781 + 261)
+})
+
+test('a nested subagent counts inside the invocation that spawned it', () => {
+  const root = summary({
+    usage: [{ model: 'claude-sonnet-5', inputTokens: 10, outputTokens: 20, cacheReadTokens: 0, cacheWriteTokens: 0 }],
+    toolUseCount: 3,
+    toolStats: { ...emptyStats, bashCount: 3 },
+  })
+  const nested = summary({
+    usage: [{ model: 'claude-sonnet-5', inputTokens: 5, outputTokens: 7, cacheReadTokens: 0, cacheWriteTokens: 0 }],
+    toolUseCount: 2,
+    toolStats: { ...emptyStats, readCount: 2, linesAdded: 4 },
+  })
+
+  const n = agentNumbers(root, [nested])
+  expect(n.inputTokens).toBe(15)
+  expect(n.outputTokens).toBe(27)
+  expect(n.totalToolUseCount).toBe(5)
+  expect(n.toolStats.bashCount).toBe(3)
+  expect(n.toolStats.readCount).toBe(2)
+  expect(n.toolStats.linesAdded).toBe(4)
+})
+
+test('duration is the ROOT agent’s own span — a nested agent runs inside it, not after it', () => {
+  const root = summary({ firstMs: 1000, lastMs: 61000 })
+  const nested = summary({ firstMs: 5000, lastMs: 9000 })
+  expect(agentNumbers(root, [nested]).totalDurationMs).toBe(60000)
+})

--- a/packages/server/server/subagent-parse.ts
+++ b/packages/server/server/subagent-parse.ts
@@ -1,0 +1,258 @@
+/**
+ * subagent-parse.ts — PURE: what one subagent's own transcript says it spent.
+ *
+ * Claude Code stopped putting a subagent's numbers in the parent's `toolUseResult`. Since the Agent
+ * tool went ASYNCHRONOUS (measured here: the shape changed on 2026-08-14) the parent records only
+ * `{ agentId, description, isAsync, outputFile, resolvedModel, status: 'async_launched' }` — no
+ * usage, no tool stats, no duration. The numbers did not disappear: the subagent writes its own
+ * transcript at `<project>/<session-id>/subagents/agent-<agentId>.jsonl`, and this module reads it.
+ *
+ * It is the parse half only. The file reading, the recursion into nested subagents and the memo
+ * live in `subagent-metrics.ts`, so everything here stays a pure function of lines — the same split
+ * every harness adapter makes.
+ */
+
+import { calcCost, totalTokens } from '@agentistics/core'
+import type { AgentInvocation, SessionAgentMetrics } from '@agentistics/core'
+
+/** What one MODEL cost inside a subagent. Per model, because a subagent may run a cheaper one. */
+export interface SubagentUsage {
+  model: string
+  inputTokens: number
+  outputTokens: number
+  cacheReadTokens: number
+  cacheWriteTokens: number
+}
+
+/** Exactly the numeric half of `AgentInvocation` — what `agentNumbers` establishes. */
+export interface AgentNumbers {
+  totalTokens: number
+  inputTokens: number
+  outputTokens: number
+  cacheReadTokens: number
+  cacheWriteTokens: number
+  totalDurationMs: number
+  totalToolUseCount: number
+  toolStats: SubagentToolStats
+  costUSD: number
+}
+
+/** The same buckets `AgentInvocation.toolStats` has always carried. */
+export interface SubagentToolStats {
+  readCount: number
+  searchCount: number
+  bashCount: number
+  editFileCount: number
+  linesAdded: number
+  linesRemoved: number
+  otherToolCount: number
+}
+
+export interface SubagentSummary {
+  /**
+   * One entry per model the subagent used, in first-seen order.
+   *
+   * NEVER collapsed into a single figure here: a subagent commonly runs `haiku` under an `opus`
+   * parent, and pricing its tokens at the parent's rate is how a cheap agent is billed as an
+   * expensive one. The caller prices each entry with its own model id.
+   */
+  usage: SubagentUsage[]
+  /** First and last timestamp seen, or `null` — an absent span is not a zero duration. */
+  firstMs: number | null
+  lastMs: number | null
+  toolUseCount: number
+  toolStats: SubagentToolStats
+  /**
+   * The subagents THIS subagent spawned, by `agentId`, deduped and in first-seen order.
+   *
+   * A nested agent's work appears in no other place the parent session can reach: only a top-level
+   * `Agent` tool_use in the session transcript becomes an `AgentInvocation`, so without this the
+   * whole subtree's tokens are missing from the session's agent totals. The caller resolves each id
+   * to its own transcript in the same `subagents/` directory.
+   */
+  childAgentIds: string[]
+}
+
+interface UsageRecord {
+  input_tokens?: number
+  output_tokens?: number
+  cache_read_input_tokens?: number
+  cache_creation_input_tokens?: number
+}
+
+/**
+ * Which bucket a tool name falls in.
+ *
+ * A MAPPING, never a filter: a name nobody listed here is still counted, in `otherToolCount`, so a
+ * tool added upstream shows up as work done rather than as work that never happened.
+ */
+const SEARCH_TOOLS = new Set(['Grep', 'Glob'])
+const EDIT_TOOLS = new Set(['Edit', 'Write', 'MultiEdit', 'NotebookEdit'])
+
+const num = (v: unknown): number => (typeof v === 'number' && Number.isFinite(v) ? v : 0)
+
+/** Sum one subagent transcript. Total: malformed input yields an empty summary, never a throw. */
+export function summarizeSubagentTranscript(lines: Iterable<string>): SubagentSummary {
+  const byModel = new Map<string, SubagentUsage>()
+  let firstMs: number | null = null
+  let lastMs: number | null = null
+  let toolUseCount = 0
+  const toolStats: SubagentToolStats = {
+    readCount: 0, searchCount: 0, bashCount: 0, editFileCount: 0,
+    linesAdded: 0, linesRemoved: 0, otherToolCount: 0,
+  }
+  const childAgentIds: string[] = []
+  const seenChild = new Set<string>()
+
+  for (const raw of lines) {
+    const line = raw.trim()
+    if (!line) continue
+
+    let e: Record<string, unknown>
+    try { e = JSON.parse(line) as Record<string, unknown> } catch { continue }
+
+    const ts = typeof e.timestamp === 'string' ? Date.parse(e.timestamp) : NaN
+    if (Number.isFinite(ts)) {
+      if (firstMs === null || ts < firstMs) firstMs = ts
+      if (lastMs === null || ts > lastMs) lastMs = ts
+    }
+
+    const result = e.toolUseResult as Record<string, unknown> | undefined
+    if (result && typeof result === 'object') {
+      const childId = result.agentId
+      if (typeof childId === 'string' && childId && !seenChild.has(childId)) {
+        seenChild.add(childId)
+        childAgentIds.push(childId)
+      }
+      // The edit patch the transcript already carries. `git diff` is not available here and would
+      // answer about the working tree anyway, not about what this agent changed.
+      const patch = result.structuredPatch
+      if (Array.isArray(patch)) {
+        for (const hunk of patch as Record<string, unknown>[]) {
+          const hunkLines = hunk?.lines
+          if (!Array.isArray(hunkLines)) continue
+          for (const l of hunkLines as unknown[]) {
+            if (typeof l !== 'string') continue
+            if (l.startsWith('+')) toolStats.linesAdded++
+            else if (l.startsWith('-')) toolStats.linesRemoved++
+          }
+        }
+      }
+    }
+
+    if (e.type !== 'assistant') continue
+    const msg = e.message as Record<string, unknown> | undefined
+
+    if (Array.isArray(msg?.content)) {
+      for (const item of msg!.content as Record<string, unknown>[]) {
+        if (item?.type !== 'tool_use') continue
+        toolUseCount++
+        const name = typeof item.name === 'string' ? item.name : ''
+        if (name === 'Read') toolStats.readCount++
+        else if (SEARCH_TOOLS.has(name)) toolStats.searchCount++
+        else if (name === 'Bash') toolStats.bashCount++
+        else if (EDIT_TOOLS.has(name)) toolStats.editFileCount++
+        else toolStats.otherToolCount++
+      }
+    }
+
+    const usage = msg?.usage as UsageRecord | undefined
+    if (!usage) continue
+
+    const model = typeof msg?.model === 'string' ? msg.model : ''
+    let entry = byModel.get(model)
+    if (!entry) {
+      entry = { model, inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0 }
+      byModel.set(model, entry)
+    }
+    entry.inputTokens += num(usage.input_tokens)
+    entry.outputTokens += num(usage.output_tokens)
+    entry.cacheReadTokens += num(usage.cache_read_input_tokens)
+    entry.cacheWriteTokens += num(usage.cache_creation_input_tokens)
+  }
+
+  return { usage: [...byModel.values()], firstMs, lastMs, toolUseCount, toolStats, childAgentIds }
+}
+
+/**
+ * The numbers ONE invocation reports: its own transcript plus everything it spawned.
+ *
+ * Two rules the old reader could not follow, because the parent's `toolUseResult` gave it neither:
+ *
+ * - **Each model is priced at ITS OWN rate.** A subagent commonly runs `haiku` under an `opus`
+ *   parent (measured on this machine: four different models across 440 subagent transcripts), so
+ *   pricing the whole invocation with the parent's model id bills a cheap agent as an expensive one.
+ * - **A nested subagent counts inside the invocation that spawned it.** Only a top-level `Agent`
+ *   tool_use in the session transcript becomes an `AgentInvocation`, so a subtree left out here is
+ *   left out of the session's agent totals entirely.
+ *
+ * The DURATION is the root's own span: a nested agent runs inside its parent, so adding the two
+ * would count the same wall time twice.
+ */
+export function agentNumbers(root: SubagentSummary, descendants: readonly SubagentSummary[]): AgentNumbers {
+  const toolStats: SubagentToolStats = {
+    readCount: 0, searchCount: 0, bashCount: 0, editFileCount: 0,
+    linesAdded: 0, linesRemoved: 0, otherToolCount: 0,
+  }
+  let inputTokens = 0, outputTokens = 0, cacheReadTokens = 0, cacheWriteTokens = 0
+  let totalToolUseCount = 0
+  let costUSD = 0
+
+  for (const s of [root, ...descendants]) {
+    for (const u of s.usage) {
+      inputTokens += u.inputTokens
+      outputTokens += u.outputTokens
+      cacheReadTokens += u.cacheReadTokens
+      cacheWriteTokens += u.cacheWriteTokens
+      costUSD += calcCost(
+        {
+          inputTokens: u.inputTokens,
+          outputTokens: u.outputTokens,
+          cacheReadInputTokens: u.cacheReadTokens,
+          cacheCreationInputTokens: u.cacheWriteTokens,
+          webSearchRequests: 0,
+          costUSD: 0,
+        },
+        u.model,
+      )
+    }
+    totalToolUseCount += s.toolUseCount
+    toolStats.readCount += s.toolStats.readCount
+    toolStats.searchCount += s.toolStats.searchCount
+    toolStats.bashCount += s.toolStats.bashCount
+    toolStats.editFileCount += s.toolStats.editFileCount
+    toolStats.linesAdded += s.toolStats.linesAdded
+    toolStats.linesRemoved += s.toolStats.linesRemoved
+    toolStats.otherToolCount += s.toolStats.otherToolCount
+  }
+
+  return {
+    totalTokens: totalTokens({ input: inputTokens, output: outputTokens, cacheRead: cacheReadTokens, cacheWrite: cacheWriteTokens }),
+    inputTokens,
+    outputTokens,
+    cacheReadTokens,
+    cacheWriteTokens,
+    totalDurationMs: root.firstMs !== null && root.lastMs !== null ? root.lastMs - root.firstMs : 0,
+    totalToolUseCount,
+    toolStats,
+    costUSD,
+  }
+}
+
+/**
+ * The session-level totals, over the invocations that HAVE numbers.
+ *
+ * An unmeasured invocation contributes nothing — it is an absence, not a zero — and is counted
+ * separately so a surface can say how much of what it is showing the totals actually cover.
+ */
+export function totalsOf(invocations: AgentInvocation[]): SessionAgentMetrics {
+  const measured = invocations.filter(i => !i.unmeasured)
+  return {
+    invocations,
+    totalInvocations: invocations.length,
+    unmeasuredInvocations: invocations.length - measured.length,
+    totalTokens: measured.reduce((s, i) => s + i.totalTokens, 0),
+    totalDurationMs: measured.reduce((s, i) => s + i.totalDurationMs, 0),
+    totalCostUSD: measured.reduce((s, i) => s + i.costUSD, 0),
+  }
+}

--- a/packages/web/src/components/AgentMetricsPanel.tsx
+++ b/packages/web/src/components/AgentMetricsPanel.tsx
@@ -7,6 +7,7 @@ import { MetricNote } from './MetricNote'
 import { useIsMobile } from '../hooks/useIsMobile'
 import { capable } from '../lib/harness'
 import { NAtag } from './NAtag'
+import { unmeasuredNote } from '../lib/agentMeasured'
 
 interface AgentMetricsPanelProps {
   invocations: AgentInvocation[]
@@ -26,6 +27,11 @@ interface AgentMetricsPanelProps {
 }
 
 
+
+/** No figure, and never a zero — see `agentMeasured.ts`. */
+function Absent() {
+  return <span style={{ color: 'var(--text-tertiary)' }}>—</span>
+}
 
 function fmtDuration(ms: number): string {
   if (ms === 0) return '—'
@@ -125,6 +131,10 @@ export function AgentMetricsPanel({
   const maxCount = sortedTypes[0]?.[1].count ?? 1
 
   const displayInvocations = showAll ? invocations : invocations.slice(0, 10)
+  // Derived from the rows ON SCREEN rather than taken as a prop, so the sentence always describes
+  // the list the reader is looking at.
+  const unmeasuredShown = displayInvocations.filter(i => i.unmeasured).length
+  const note = unmeasuredNote(unmeasuredShown, displayInvocations.length, lang)
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 20 }}>
@@ -212,6 +222,11 @@ export function AgentMetricsPanel({
             ({pt ? `exibindo ${displayInvocations.length} de ${totalInvocations}` : `showing ${displayInvocations.length} of ${totalInvocations}`})
           </span>
         </div>
+        {note && (
+          <div style={{ fontSize: 11, lineHeight: 1.5, color: 'var(--text-tertiary)', marginBottom: 8 }}>
+            {note}
+          </div>
+        )}
         <div style={{ border: '1px solid var(--border)', borderRadius: 8, overflow: isMobile ? 'auto' : 'hidden', width: '100%' }}>
           <div style={{ minWidth: isMobile ? 480 : undefined }}>
           {/* Table header */}
@@ -265,17 +280,21 @@ export function AgentMetricsPanel({
                   {inv.description || <em style={{ color: 'var(--text-tertiary)' }}>—</em>}
                 </span>
               </div>
+              {/* An invocation whose subagent transcript is gone carries zeros because the type has
+                  no other value to carry. Rendering them would price real work at nothing — the
+                  confident 0 this product refuses everywhere else — so the cell says nothing
+                  instead, and the note under the heading says why. */}
               <span style={{ fontSize: 11, color: 'var(--text-primary)', textAlign: 'right' }}>
-                {fmt(inv.totalTokens)}
+                {inv.unmeasured ? <Absent /> : fmt(inv.totalTokens)}
               </span>
               <span style={{ fontSize: 11, color: 'var(--text-secondary)', textAlign: 'right' }}>
-                {inv.totalToolUseCount}
+                {inv.unmeasured ? <Absent /> : inv.totalToolUseCount}
               </span>
               <span style={{ fontSize: 11, color: 'var(--text-secondary)', textAlign: 'right' }}>
-                {fmtDuration(inv.totalDurationMs)}
+                {inv.unmeasured ? <Absent /> : fmtDuration(inv.totalDurationMs)}
               </span>
               <span style={{ fontSize: 11, color: 'var(--anthropic-orange)', textAlign: 'right' }}>
-                {fmtCost(inv.costUSD, currency, brlRate)}
+                {inv.unmeasured ? <Absent /> : fmtCost(inv.costUSD, currency, brlRate)}
               </span>
             </div>
           ))}

--- a/packages/web/src/components/sessions/ChatBubble.tsx
+++ b/packages/web/src/components/sessions/ChatBubble.tsx
@@ -129,6 +129,29 @@ const SYSTEM_NOTE_PT: Record<string, string> = {
   'command output': 'saída de comando',
   'slash command': 'comando de barra',
   'shell command': 'comando de shell',
+  // The notes the FIVE non-claude readers produce (`antigravity-chat.ts`, `codex-chat.ts`,
+  // `copilot-chat.ts`, `kimi-chat.ts`). They arrived with their readers and this table did not grow
+  // with them, so a conversation in any of those harnesses printed English chrome in the middle of
+  // a Portuguese screen. The fall-through above is what kept that a cosmetic gap rather than a
+  // missing line, which is why it survived unnoticed — it is still the right fall-through.
+  'a system message': 'uma mensagem do sistema',
+  'the conversation was truncated': 'a conversa foi truncada',
+  'the harness reported an error': 'o assistente reportou um erro',
+  'instructions from the harness': 'instruções do assistente',
+  'project instructions were loaded': 'instruções do projeto foram carregadas',
+  'the environment was described to the assistant': 'o ambiente foi descrito ao assistente',
+  'the system prompt was set': 'o prompt de sistema foi definido',
+  'the model was changed': 'o modelo foi trocado',
+  'the model was switched': 'o modelo foi trocado',
+  'the session ended': 'a sessão terminou',
+  'the session reported an error': 'a sessão reportou um erro',
+  'the turn was aborted': 'o turno foi interrompido',
+  'context from the editor': 'contexto vindo do editor',
+  'the collaboration mode changed': 'o modo de colaboração mudou',
+  'a reminder about the task list': 'um lembrete sobre a lista de tarefas',
+  'the harness stated its permissions': 'o assistente informou suas permissões',
+  'the permission mode was announced': 'o modo de permissão foi anunciado',
+
   // The untagged `isMeta` entries — see `chat-envelope.ts`'s second measurement.
   'a skill was loaded': 'uma skill foi carregada',
   'a skill was re-invoked': 'uma skill foi reinvocada',

--- a/packages/web/src/lib/agentMeasured.test.ts
+++ b/packages/web/src/lib/agentMeasured.test.ts
@@ -1,0 +1,21 @@
+import { test, expect } from 'bun:test'
+import { unmeasuredNote } from './agentMeasured'
+
+test('nothing is said when every invocation carries its numbers', () => {
+  expect(unmeasuredNote(0, 12, 'en')).toBeNull()
+})
+
+test('the note names how many of the shown invocations the totals do NOT cover', () => {
+  expect(unmeasuredNote(3, 12, 'en')).toContain('3 of 12')
+  expect(unmeasuredNote(3, 12, 'pt')).toContain('3 de 12')
+})
+
+test('the note says WHY, so an absent number does not read as a fault in the panel', () => {
+  expect(unmeasuredNote(1, 2, 'en')?.toLowerCase()).toContain('transcript')
+  expect(unmeasuredNote(1, 2, 'pt')?.toLowerCase()).toContain('transcri')
+})
+
+test('one is singular in both languages', () => {
+  expect(unmeasuredNote(1, 4, 'en')).toContain('1 of 4')
+  expect(unmeasuredNote(1, 4, 'pt')).toContain('1 de 4')
+})

--- a/packages/web/src/lib/agentMeasured.ts
+++ b/packages/web/src/lib/agentMeasured.ts
@@ -1,0 +1,21 @@
+/**
+ * agentMeasured.ts — the sentence an absent agent metric needs.
+ *
+ * A subagent's numbers live in its own transcript (`subagents/agent-<id>.jsonl`), and Claude Code
+ * deletes transcripts after `cleanupPeriodDays`. When one is gone the invocation is still real and
+ * still listed — the parent recorded that it happened — but nothing on this machine can say what it
+ * spent. The row renders no figure, and this is the line that stops the reader taking that dash for
+ * a broken panel: same rule as `HARNESS_CAPABILITIES`, applied to one row instead of a whole
+ * harness. A zero would be the confident claim; a dash with no explanation is a bug report waiting
+ * to be filed.
+ */
+
+import type { Lang } from '@agentistics/core'
+
+/** `null` when every invocation on screen carries its numbers — there is then nothing to say. */
+export function unmeasuredNote(unmeasured: number, shown: number, lang: Lang): string | null {
+  if (unmeasured <= 0) return null
+  return lang === 'pt'
+    ? `${unmeasured} de ${shown} sem números: o transcript do subagente já não está no disco, então os totais acima não as incluem.`
+    : `${unmeasured} of ${shown} carry no numbers: the subagent's transcript is no longer on disk, so the totals above do not include them.`
+}

--- a/packages/web/src/lib/sessionArtifacts.test.ts
+++ b/packages/web/src/lib/sessionArtifacts.test.ts
@@ -114,3 +114,31 @@ describe('files the SHELL wrote', () => {
     expect(hasUnlistedWrites([])).toBe(false)
   })
 })
+
+describe('a harness that does not speak Claude', () => {
+  it('finds an agy write through `canonical`, while the bubble keeps agy\'s own name', () => {
+    // The turn carries both readings: `name` is what agy called the tool and is what the
+    // conversation shows; `canonical` is the shared vocabulary this set is written in. Selecting on
+    // the displayed name would leave this panel blind on every harness but Claude, and rewriting
+    // the displayed name to suit this set put Claude's tool names in an Antigravity session.
+    const out = artifactsFromTurns([{
+      tools: [
+        { name: 'write_to_file', canonical: 'Write', detail: '/repo/a.ts' },
+        { name: 'replace_file_content', canonical: 'Edit', detail: '/repo/b.ts' },
+        { name: 'view_file', canonical: 'Read', detail: '/repo/c.ts' },
+      ],
+    }])
+    // The write and the edit are found; the READ is not — this panel answers what the session
+    // PRODUCED. Order is the panel's own (newest first) and is asserted by the tests above.
+    expect(out.map(a => a.path).sort()).toEqual(['/repo/a.ts', '/repo/b.ts'])
+    expect(out.find(a => a.path === '/repo/a.ts')!.kind).toBe('new')
+    expect(out.find(a => a.path === '/repo/b.ts')!.kind).toBe('edited')
+  })
+
+  it('a tool with no canonical reading is judged by its own name, as Claude\'s always were', () => {
+    expect(artifactsFromTurns([{ tools: [{ name: 'Write', detail: '/repo/x.ts' }] }]))
+      .toHaveLength(1)
+    expect(artifactsFromTurns([{ tools: [{ name: 'manage_task', detail: 'complete' }] }]))
+      .toEqual([])
+  })
+})

--- a/packages/web/src/lib/sessionArtifacts.ts
+++ b/packages/web/src/lib/sessionArtifacts.ts
@@ -12,11 +12,22 @@
  * `command`, so a `Bash` call's detail is a shell line — and "this looks like a path" would put
  * `rm -rf build/` in a list of files somebody is about to click.
  *
+ * AND IT IS THE CANONICAL NAME, NOT THE DISPLAYED ONE. A turn carries both: `name` is what the
+ * harness itself called the tool (agy's `write_to_file`), which is what the bubble shows because a
+ * conversation records what happened; `canonical` is the same tool under the shared vocabulary
+ * (`Write`), present only where the two differ. This set is written in the shared vocabulary, so it
+ * reads `canonical ?? name` — matching on the displayed name alone would make this panel blind on
+ * every harness but Claude, and rewriting the displayed name to suit this set is what put Claude's
+ * tool names in an Antigravity session's bubbles.
+ *
  * `Read` is excluded. The question this panel answers is what the session PRODUCED; an assistant
  * reading forty files to answer one question would bury the two it wrote.
  */
 
-/** The tools whose `detail` is a file path. Read from `chat-tail.ts`'s own priority list. */
+/**
+ * The tools whose `detail` is a file path, in the SHARED vocabulary — see `canonical` above.
+ * Read from `chat-tail.ts`'s own priority list.
+ */
 export const ARTIFACT_TOOLS: ReadonlySet<string> = new Set([
   'Write', 'Edit', 'MultiEdit', 'NotebookEdit',
 ])
@@ -37,7 +48,14 @@ export interface Artifact {
 }
 
 interface Turnish {
-  tools?: { name: string; detail?: string; writes?: string[]; opaqueWrite?: boolean }[]
+  tools?: {
+    name: string
+    /** The shared-vocabulary name, when it differs from the displayed one. */
+    canonical?: string
+    detail?: string
+    writes?: string[]
+    opaqueWrite?: boolean
+  }[]
   pending?: boolean
 }
 
@@ -69,7 +87,7 @@ export function artifactsFromTurns(turns: readonly Turnish[]): Artifact[] {
         if (prevW) { prevW.touches += 1; prevW.order = order++; prevW.live = t?.pending === true }
         else seen.set(w, { first: 'Write', touches: 1, order: order++, live: t?.pending === true })
       }
-      if (!ARTIFACT_TOOLS.has(call.name)) continue
+      if (!ARTIFACT_TOOLS.has(call.canonical ?? call.name)) continue
       const path = call.detail?.trim()
       if (!path) continue
       // `toolDetail` appends an ellipsis past 200 characters. A truncated path names no file, and
@@ -81,7 +99,12 @@ export function artifactsFromTurns(turns: readonly Turnish[]): Artifact[] {
         prev.order = order++
         prev.live = t.pending === true
       } else {
-        seen.set(path, { first: call.name, touches: 1, order: order++, live: t.pending === true })
+        // The CANONICAL name again: `kind` is decided by whether the first touch was a `Write`, so
+        // recording agy's own `write_to_file` here would file every file it created as `edited`.
+        // Same reading as the `ARTIFACT_TOOLS` test above, and it must not drift from it.
+        seen.set(path, {
+          first: call.canonical ?? call.name, touches: 1, order: order++, live: t.pending === true,
+        })
       }
     }
   }


### PR DESCRIPTION
The Sessions workspace could only ever show a chat for Claude Code. Every other harness opened on
the terminal alone — reported as "iniciei uma sessão com o antigravity e só tá com a view em
terminal". The work existed, finished and tested, in a worktree that was never pushed.

### Five readers

- **antigravity** — plus a fix: an agy conversation was rendering its actions under Claude Code's
  tool names (`Bash`, `Read`, `Grep`) in a session that ran none of them.
- **codex** — the hardest of the four; also fixes the `cd …` chips and the `AGENTS.md` that landed
  inside the reader's own bubble.
- **copilot** — the trap is `transformedContent`: longer than `data.content`, looks more complete,
  and is exactly the wrong one, because it wraps the person's text in the harness's own reminders.
- **kimi** — `main` agent only. `kimi-parse.ts` folds every agent into its metrics, which is right
  for a count and would be two interleaved dialogues under one heading in a chat.
- **gemini** — REFUSED, and it is a LINK fact rather than a format one. A reader is only ever
  offered a `conversationId`, which exists only where agentop handed the id to the CLI. Measured
  against `spawn-spec.ts`: claude and copilot have `assignId`, codex/kimi/antigravity have
  `resume`, gemini has NEITHER. An entry would be unreachable code plus a claim the product cannot
  honour. Its format was measured anyway and recorded in the module so nobody spends it twice.

### The merge conflict, and how it was resolved

Both sides had changed the same return in `chat-web.ts`: this branch routes the read through a
per-harness `HarnessTranscript`, and dev had just added the window notice telling a reader that
these turns are the END of a longer conversation.

The window became an OPTIONAL member of the reader contract (`readWindow`). Only claude's walk
reports where it stopped, so only claude implements it and every other reader makes NO claim.
`turns.length === max` was the available inference and would call a conversation of exactly `max`
turns a window — false in the reassuring direction.

### Two things found by running it

- Seventeen system notes from the new readers had no Portuguese, so a conversation printed English
  chrome in the middle of a Portuguese screen. Translated.
- Also included: #373, a subagent's own transcript read so agent metrics stop reporting zero.

Verified against a live antigravity conversation on a real machine: the row reopened with the exact
conversation link, 400 turns read, roles correct, 35 system notes.

`bun tsc --noEmit` clean; 5937 pass / 1 skip / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169AqN9y1YGiog3T4qTLVfA