### PR TITLE
feat(sessions): the aside's bar keeps what fits, and a grid holds every tab

### DIFF
--- a/packages/server/server/sessions/github-prs.test.ts
+++ b/packages/server/server/sessions/github-prs.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { describe, expect, it, test } from 'bun:test'
-import { classifyPrFailure, parsePrList } from './github-prs'
+import { classifyPrFailure, parsePrList, prRank, sortPullRequests, type PullRequest } from './github-prs'
 
 test('a real `gh pr list --json` payload parses', () => {
   const text = JSON.stringify([{
@@ -77,5 +77,45 @@ describe('every field of PrList reaches the wire', () => {
   it('names every one of them', () => {
     expect(fields.length).toBeGreaterThan(1)
     for (const f of fields) expect(reply).toContain(`${f}:`)
+  })
+})
+
+describe('sortPullRequests — what is still moving comes first', () => {
+  const pr = (number: number, state: string, draft = false): PullRequest =>
+    ({ number, title: `PR ${number}`, url: `u${number}`, state, draft, branch: 'b' })
+
+  it('orders by STATUS: open, draft, merged, closed', () => {
+    // `gh` returns them by recency, which mixes a PR merged last week into the middle of the ones
+    // still open.
+    const out = sortPullRequests([
+      pr(1, 'MERGED'), pr(2, 'CLOSED'), pr(3, 'OPEN', true), pr(4, 'OPEN'),
+    ])
+    expect(out.map(p => p.number)).toEqual([4, 3, 1, 2])
+  })
+
+  it('keeps a DRAFT below the open PRs that are actually asking for something', () => {
+    const out = sortPullRequests([pr(9, 'OPEN', true), pr(1, 'OPEN')])
+    expect(out.map(p => p.number)).toEqual([1, 9])
+  })
+
+  it('leads with the newest number inside one status', () => {
+    const out = sortPullRequests([pr(3, 'OPEN'), pr(11, 'OPEN'), pr(7, 'OPEN')])
+    expect(out.map(p => p.number)).toEqual([11, 7, 3])
+  })
+
+  it('files a state it has no rank for with MERGED, never first or last', () => {
+    // Somebody else's vocabulary: an unknown word is not evidence that the PR is urgent OR
+    // abandoned.
+    expect(prRank({ state: 'SOMETHING_NEW', draft: false })).toBe(prRank({ state: 'MERGED', draft: false }))
+  })
+
+  it('reads the state case-insensitively — it is GitHub that decides the casing', () => {
+    expect(prRank({ state: 'open', draft: false })).toBe(0)
+  })
+
+  it('does not mutate what it was given', () => {
+    const input = [pr(1, 'MERGED'), pr(2, 'OPEN')]
+    sortPullRequests(input)
+    expect(input.map(p => p.number)).toEqual([1, 2])
   })
 })

--- a/packages/server/server/sessions/github-prs.ts
+++ b/packages/server/server/sessions/github-prs.ts
@@ -108,7 +108,39 @@ export function parsePrList(text: string): PullRequest[] {
       ...(typeof r.updatedAt === 'string' ? { updatedAt: r.updatedAt } : {}),
     })
   }
-  return out
+  return sortPullRequests(out)
+}
+
+/**
+ * The order the list is read in — PURE, and by STATUS before anything else.
+ *
+ * `gh` returns them by recency, which mixes a PR merged last week into the middle of the ones still
+ * open. The panel is a view of work in flight, so what is still moving comes first and what is
+ * settled sinks: OPEN, then DRAFT, then MERGED, then CLOSED.
+ *
+ * DRAFT is its own rank rather than part of OPEN. It is open in GitHub's data and it is not asking
+ * anybody for anything yet, which is the distinction the reader cares about — a draft sitting above
+ * a PR waiting on review would put the one nobody is blocked on first.
+ *
+ * The review decision is deliberately NOT a second sort key. It is on the row as a badge, and a
+ * list ordered by two things at once is a list whose order nobody can predict; the reader asked for
+ * status. Within a rank the newest number leads, which is what `gh` already implies and what a
+ * person means by "the latest one".
+ *
+ * A state this reader has no rank for sorts with MERGED rather than first or last: it is somebody
+ * else's vocabulary, and an unknown word is not evidence that the PR is urgent OR abandoned.
+ */
+const PR_RANK: Record<string, number> = { OPEN: 0, MERGED: 2, CLOSED: 3 }
+const PR_RANK_UNKNOWN = 2
+
+export function prRank(pr: Pick<PullRequest, 'state' | 'draft'>): number {
+  const state = pr.state.toUpperCase()
+  if (state === 'OPEN') return pr.draft ? 1 : 0
+  return PR_RANK[state] ?? PR_RANK_UNKNOWN
+}
+
+export function sortPullRequests(pulls: readonly PullRequest[]): PullRequest[] {
+  return [...pulls].sort((a, b) => prRank(a) - prRank(b) || b.number - a.number)
 }
 
 /**

--- a/packages/web/src/components/sessions/ArtifactsAside.tsx
+++ b/packages/web/src/components/sessions/ArtifactsAside.tsx
@@ -28,7 +28,7 @@ import { asideCache, asideKey } from '../../lib/asideCache'
 import {
   FileEdit, FilePlus2, PanelRightClose, Loader, FileText, Activity, Files,
   BookOpen, Terminal, Brain, Send, Eye, Image, Sparkles, ChevronLeft, ChevronDown, ChevronRight,
-  ExternalLink, Bot, Plug, Plus, Trash2, Pencil, GitPullRequest,
+  ExternalLink, Bot, Plug, Plus, Trash2, Pencil, GitPullRequest, LayoutGrid, X,
 } from 'lucide-react'
 import type { Artifact } from '../../lib/sessionArtifacts'
 import {
@@ -54,6 +54,7 @@ import {
   cannotWriteText, offerableScopes, runText, runningMcpCount, scopeText,
   type McpEntry, type McpListPayload, type McpScope,
 } from '../../lib/mcpPanel'
+import { splitAsideTabs } from '../../lib/asideTabs'
 import { fmt, fmtCost } from '@agentistics/core'
 import {
   galleryFileCount, galleryGroups, parseGalleryScope, parseGalleryView, producedGroups,
@@ -126,6 +127,126 @@ export interface ArtifactsAsideProps {
    * asked not to give.
    */
   facts?: ReadonlyMap<string, { bytes: number; scope: 'project' | 'temp' }>
+}
+
+/** The gap between two tabs. Shared by the bar and the ruler, or the measurement is of a different
+ *  row from the one it is measuring for. */
+const TAB_GAP = 2
+
+/** Something is RUNNING behind this tab — the reason to look now. Drawn identically wherever a tab
+ *  is, so the bar and the grid can never disagree about which ones are live. */
+function RunningDot() {
+  return (
+    <span
+      aria-hidden
+      style={{ width: 6, height: 6, borderRadius: '50%', background: '#22c55e', flexShrink: 0 }}
+    />
+  )
+}
+
+/**
+ * EVERY TAB, as a grid of labelled tiles.
+ *
+ * Every tab and not only the ones that did not fit: a grid whose contents change as the panel
+ * resizes puts the same tab in a different place each time somebody looks for it. The current one
+ * is marked, so this reads as a launcher rather than a leftovers menu.
+ *
+ * It is a POPOVER, not permanent chrome. That is the whole reason this design was chosen over a
+ * vertical icon rail: a rail costs 46px in the one dimension this panel is poor in (440px on
+ * desktop, ~343px on a phone), while this costs nothing while it is closed.
+ */
+function TabGrid({ tabs, active, pt, isMobile, onPick, onClose }: {
+  tabs: readonly { id: TabId; label: string; icon: React.ReactNode; count: number | null }[]
+  active: TabId
+  pt: boolean
+  isMobile: boolean
+  onPick: (id: TabId) => void
+  onClose: () => void
+}) {
+  const ref = useRef<HTMLDivElement | null>(null)
+
+  // `esc` closes and the focus goes back to the control that opened it — the same rule the
+  // restriction table's maximized view keeps.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') { e.stopPropagation(); onClose() } }
+    const onDown = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) onClose()
+    }
+    document.addEventListener('keydown', onKey)
+    // `mousedown` and not `click`: the control that opened this would otherwise reopen it on the
+    // same gesture that closed it.
+    document.addEventListener('mousedown', onDown)
+    return () => { document.removeEventListener('keydown', onKey); document.removeEventListener('mousedown', onDown) }
+  }, [onClose])
+
+  return (
+    <div
+      ref={ref}
+      role="dialog"
+      aria-label={pt ? 'Todas as abas' : 'All tabs'}
+      style={{
+        position: 'absolute', top: 'calc(100% - 1px)', left: 6, right: 6, zIndex: 40,
+        padding: 10, borderRadius: 11, background: 'var(--bg-surface)',
+        border: '1px solid var(--anthropic-orange)',
+        boxShadow: '0 12px 30px -10px rgba(0,0,0,0.45)',
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', marginBottom: 8 }}>
+        <span style={{
+          fontSize: 10, fontWeight: 700, letterSpacing: 0.5, textTransform: 'uppercase',
+          color: 'var(--text-tertiary)',
+        }}>{pt ? 'Todas as abas' : 'All tabs'}</span>
+        <button
+          onClick={onClose}
+          aria-label={pt ? 'Fechar' : 'Close'}
+          style={{
+            marginLeft: 'auto', display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+            width: isMobile ? 44 : 22, height: isMobile ? 44 : 22, borderRadius: 6, padding: 0,
+            border: 'none', background: 'transparent', color: 'var(--text-tertiary)', cursor: 'pointer',
+          }}
+        ><X size={13} /></button>
+      </div>
+      <div style={{
+        display: 'grid', gap: 6,
+        // Four across on a desktop aside, three on the narrower one a phone gets — a tile below
+        // ~74px cannot hold a word, and a truncated label is the ambiguity this design avoids.
+        gridTemplateColumns: `repeat(${isMobile ? 3 : 4}, minmax(0, 1fr))`,
+      }}>
+        {tabs.map(t => {
+          const on = t.id === active
+          return (
+            <button
+              key={t.id}
+              onClick={() => onPick(t.id)}
+              aria-current={on}
+              style={{
+                display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 4,
+                padding: isMobile ? '10px 3px' : '9px 3px 8px',
+                minHeight: isMobile ? 66 : undefined,
+                borderRadius: 9, cursor: 'pointer', fontFamily: 'inherit',
+                border: `1px solid ${on ? 'var(--anthropic-orange)' : 'var(--border-subtle)'}`,
+                background: on ? 'rgba(232,105,11,0.10)' : 'var(--bg-card)',
+                color: on ? 'var(--text-primary)' : 'var(--text-secondary)',
+              }}
+            >
+              <span style={{ display: 'inline-flex', position: 'relative' }}>
+                {t.icon}
+              </span>
+              <span style={{
+                fontSize: 10, fontWeight: on ? 700 : 500, lineHeight: 1.25, maxWidth: '100%',
+                overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+              }}>{t.label}</span>
+              {/* The count travels to the grid too — a tile that dropped it would say less than the
+                  bar cell it replaces. `—` where a count would be a claim (see `subagentCount`). */}
+              <span style={{
+                fontSize: 9, color: 'var(--text-tertiary)', fontVariantNumeric: 'tabular-nums',
+              }}>{t.count === null ? '—' : t.count}</span>
+            </button>
+          )
+        })}
+      </div>
+    </div>
+  )
 }
 
 /** `new` and `edited` read at a glance from the glyph; the word is beside it for everyone else. */
@@ -401,55 +522,160 @@ export function ArtifactsAside({
     { id: 'prs', label: 'PRs', icon: <GitPullRequest size={12} />, count: prs?.pulls.length ?? 0 },
   ]
 
+  /**
+   * THE BAR KEEPS WHAT FITS; the grid holds the rest — and every other tab with it.
+   *
+   * Eight tabs do not fit 440px, and less of them fit the `min(440px, 88%)` the aside gets on a
+   * phone. The bar used to scroll sideways, which put the tabs past the fold out of sight with
+   * nothing on screen saying they existed. The split is the pure `asideTabs.ts`; what lives here is
+   * the MEASURING, because the labels are words in two languages and a width estimated from
+   * character counts is wrong in one of them.
+   *
+   * The ruler below is how they are measured: an aria-hidden row holding every tab at its real
+   * size, laid out but never painted. Measuring the visible bar instead would only ever report the
+   * tabs that already fit, which is the answer this is trying to compute.
+   */
+  const barRef = useRef<HTMLDivElement | null>(null)
+  const rulerRef = useRef<HTMLDivElement | null>(null)
+  const [tabWidths, setTabWidths] = useState<Record<string, number>>({})
+  const [barWidth, setBarWidth] = useState(0)
+  const [overflowWidth, setOverflowWidth] = useState(0)
+  const [gridOpen, setGridOpen] = useState(false)
+  const gridBtnRef = useRef<HTMLButtonElement | null>(null)
+
+  // Re-measured when the LABELS can change (language) or the set does — not on every render.
+  const tabSig = tabs.map(t => `${t.id}:${t.label}:${t.count ?? ''}`).join('|')
+  useEffect(() => {
+    const measure = () => {
+      const ruler = rulerRef.current
+      if (ruler) {
+        const next: Record<string, number> = {}
+        let ctrl = 0
+        for (const el of Array.from(ruler.children)) {
+          const id = (el as HTMLElement).dataset.tabId
+          const w = el.getBoundingClientRect().width
+          if (id) next[id] = w
+          else ctrl = w
+        }
+        setTabWidths(next)
+        setOverflowWidth(ctrl)
+      }
+      const bar = barRef.current
+      // `clientWidth` minus the padding the bar draws its tabs inside of.
+      if (bar) setBarWidth(Math.max(0, bar.clientWidth - 16))
+    }
+    measure()
+    const ro = new ResizeObserver(measure)
+    if (barRef.current) ro.observe(barRef.current)
+    return () => ro.disconnect()
+  }, [tabSig, isMobile])
+
+  const split = splitAsideTabs(
+    tabs.map(t => ({ id: t.id, width: tabWidths[t.id] ?? 0 })),
+    tab,
+    { container: barWidth, overflowWidth, gap: TAB_GAP },
+  )
+  const onBar = tabs.filter(t => split.bar.includes(t.id))
+
+  /** A tab's own cell. One renderer for the bar and the ruler, so they can never measure apart. */
+  const tabCell = (t: (typeof tabs)[number], forRuler: boolean) => {
+    const on = !forRuler && tab === t.id
+    return (
+      <button
+        key={t.id}
+        {...(forRuler ? { 'data-tab-id': t.id, tabIndex: -1 } : { role: 'tab', 'aria-selected': on })}
+        onClick={forRuler ? undefined : () => { setTab(t.id); setGridOpen(false) }}
+        style={{
+          display: 'flex', alignItems: 'center', gap: 5, padding: '4px 9px',
+          borderRadius: 7, border: 'none', cursor: forRuler ? 'default' : 'pointer',
+          fontFamily: 'inherit', fontSize: 11.5, fontWeight: on ? 700 : 500,
+          background: on ? 'var(--bg-elevated)' : 'transparent',
+          color: on ? 'var(--text-primary)' : 'var(--text-tertiary)',
+          // 44px is the MOBILE number; applying it on desktop turns the bar into a row of buttons.
+          minHeight: isMobile ? 44 : undefined, flexShrink: 0, whiteSpace: 'nowrap',
+        }}
+      >
+        {t.icon}
+        {t.label}
+        {/* THE COUNTS STAY ON THE BAR. `Subagentes 64` is what says what is behind a tab without
+            opening it, and it is the whole reason this design was chosen over a vertical rail. */}
+        {t.count !== null && t.count > 0 && (
+          <span style={{ fontSize: 10, opacity: 0.7, fontVariantNumeric: 'tabular-nums' }}>{t.count}</span>
+        )}
+        {/* One dot per tab that has something RUNNING behind it — the reason to look now. */}
+        {t.id === 'mcps' && runningMcpCount(mcp?.servers ?? null) > 0 && <RunningDot />}
+        {t.id === 'agents' && runningCount(agentsState) > 0 && <RunningDot />}
+      </button>
+    )
+  }
+
   const tabBar = (
-    // SEVEN tabs do not fit a 390px phone, and the panel body must never make the PAGE scroll
-    // sideways. So the bar scrolls inside itself — the same rule this codebase applies to a wide
-    // table — and each cell keeps a 44px touch target on mobile.
-    <div role="tablist" style={{
-      display: 'flex', gap: 2, padding: '6px 8px', flexShrink: 0,
-      borderBottom: '1px solid var(--border)',
-      overflowX: 'auto', overflowY: 'hidden', scrollbarWidth: 'thin',
-    }}>
-      {tabs.map(t => {
-        const on = tab === t.id
-        return (
+    <div style={{ position: 'relative', flexShrink: 0 }}>
+      <div ref={barRef} role="tablist" style={{
+        display: 'flex', gap: TAB_GAP, padding: '6px 8px', alignItems: 'center',
+        borderBottom: '1px solid var(--border)',
+        // NO horizontal scroll any more: what does not fit is in the grid, where it can be SEEN.
+        // `hidden` stays as the backstop for the one frame before the first measurement lands.
+        overflow: 'hidden',
+      }}>
+        {onBar.map(t => tabCell(t, false))}
+        {split.overflow && (
           <button
-            key={t.id}
-            role="tab"
-            aria-selected={on}
-            onClick={() => setTab(t.id)}
+            ref={gridBtnRef}
+            onClick={() => setGridOpen(v => !v)}
+            aria-expanded={gridOpen}
+            aria-haspopup="true"
+            title={pt ? 'Todas as abas' : 'All tabs'}
             style={{
-              display: 'flex', alignItems: 'center', gap: 5, padding: '4px 9px',
-              borderRadius: 7, border: 'none', cursor: 'pointer', fontFamily: 'inherit',
-              fontSize: 11.5, fontWeight: on ? 700 : 500,
-              background: on ? 'var(--bg-elevated)' : 'transparent',
-              color: on ? 'var(--text-primary)' : 'var(--text-tertiary)',
-              // 44px is the MOBILE number; applying it on desktop turns the bar into a row of
-              // buttons. A tab must also not shrink, or the scroll it lives in cannot work.
-              minHeight: isMobile ? 44 : undefined, flexShrink: 0, whiteSpace: 'nowrap',
+              display: 'inline-flex', alignItems: 'center', gap: 5, marginLeft: 'auto',
+              padding: '4px 9px', borderRadius: 7, cursor: 'pointer', fontFamily: 'inherit',
+              fontSize: 11.5, fontWeight: 700, flexShrink: 0, whiteSpace: 'nowrap',
+              minHeight: isMobile ? 44 : undefined,
+              border: gridOpen ? '1px solid var(--anthropic-orange)' : '1px dashed var(--border)',
+              background: 'transparent',
+              color: gridOpen ? 'var(--anthropic-orange)' : 'var(--text-secondary)',
             }}
           >
-            {t.icon}
-            {t.label}
-            {t.count !== null && t.count > 0 && (
-              <span style={{ fontSize: 10, opacity: 0.7, fontVariantNumeric: 'tabular-nums' }}>{t.count}</span>
-            )}
-            {/* One dot per tab that has something RUNNING behind it — the reason to look now. */}
-            {t.id === 'mcps' && runningMcpCount(mcp?.servers ?? null) > 0 && (
-              <span
-                aria-hidden
-                style={{ width: 6, height: 6, borderRadius: '50%', background: '#22c55e', flexShrink: 0 }}
-              />
-            )}
-            {t.id === 'agents' && runningCount(agentsState) > 0 && (
-              <span
-                aria-hidden
-                style={{ width: 6, height: 6, borderRadius: '50%', background: '#22c55e', flexShrink: 0 }}
-              />
+            <LayoutGrid size={12} />
+            <span>{pt ? 'Todas' : 'All'}</span>
+            {split.hidden.length > 0 && (
+              <span style={{ fontSize: 10, opacity: 0.7, fontVariantNumeric: 'tabular-nums' }}>
+                {split.hidden.length}
+              </span>
             )}
           </button>
-        )
-      })}
+        )}
+      </div>
+
+      {/* THE RULER — every tab at its real size, laid out and never painted. `visibility: hidden`
+          rather than `display: none`, which measures nothing at all. */}
+      <div
+        ref={rulerRef}
+        aria-hidden
+        style={{
+          position: 'absolute', top: 0, left: 0, display: 'flex', gap: TAB_GAP,
+          visibility: 'hidden', pointerEvents: 'none', height: 0, overflow: 'hidden',
+        }}
+      >
+        {tabs.map(t => tabCell(t, true))}
+        <span style={{
+          display: 'inline-flex', alignItems: 'center', gap: 5, padding: '4px 9px',
+          fontSize: 11.5, fontWeight: 700, whiteSpace: 'nowrap', flexShrink: 0,
+        }}>
+          <LayoutGrid size={12} />{pt ? 'Todas' : 'All'}<span style={{ fontSize: 10 }}>88</span>
+        </span>
+      </div>
+
+      {gridOpen && (
+        <TabGrid
+          tabs={tabs}
+          active={tab}
+          pt={pt}
+          isMobile={isMobile}
+          onPick={id => { setTab(id); setGridOpen(false); gridBtnRef.current?.focus() }}
+          onClose={() => { setGridOpen(false); gridBtnRef.current?.focus() }}
+        />
+      )}
     </div>
   )
 

--- a/packages/web/src/components/sessions/ArtifactsAside.tsx
+++ b/packages/web/src/components/sessions/ArtifactsAside.tsx
@@ -237,10 +237,15 @@ function TabGrid({ tabs, active, pt, isMobile, onPick, onClose }: {
                 overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
               }}>{t.label}</span>
               {/* The count travels to the grid too — a tile that dropped it would say less than the
-                  bar cell it replaces. `—` where a count would be a claim (see `subagentCount`). */}
-              <span style={{
-                fontSize: 9, color: 'var(--text-tertiary)', fontVariantNumeric: 'tabular-nums',
-              }}>{t.count === null ? '—' : t.count}</span>
+                  bar cell it replaces. A tab NOBODY HAS OPENED has no count, and says so with a
+                  dash and a reason on hover: "not asked yet" and "there are none" are different
+                  facts, and a `0` would claim the second one. */}
+              <span
+                title={t.count === null
+                  ? (pt ? 'Ainda não lido — abra a aba para contar.' : 'Not read yet — open the tab to count.')
+                  : undefined}
+                style={{ fontSize: 9, color: 'var(--text-tertiary)', fontVariantNumeric: 'tabular-nums' }}
+              >{t.count === null ? '—' : t.count}</span>
             </button>
           )
         })}
@@ -496,30 +501,41 @@ export function ArtifactsAside({
   )
 
   /** The three tabs. A count rides each one, so the panel says what is behind a tab unopened. */
+  /**
+   * EVERY COUNT IS `null` UNTIL SOMEBODY HAS ASKED. It is never a `0`.
+   *
+   * On the BAR a zero was invisible — `count > 0` hid it — so the lie sat in the data for as long
+   * as the bar was the only reader. The grid shows every tile's number, including a zero, and the
+   * moment it did, `Skills 0` and `Subagents 0` appeared on tabs nobody had opened. Reported
+   * exactly that way: "mostra os itens zerados, mas quando eu entro dai ele mostra o numero real".
+   *
+   * The comment that used to sit on the Skills line called `?? 0` "honest rather than lazy" and
+   * then, one clause later, stated the rule it was breaking — a number the panel has not measured
+   * is the thing this codebase refuses to print everywhere else. A control that has not asked and
+   * a thing that is empty are different facts, and only the second one is about the session.
+   *
+   * `loading` is the conversation's own signal, so the four counts derived from its turns wait on
+   * it; the three tabs that fetch for themselves wait on their own answer.
+   */
   const tabs: { id: TabId; label: string; icon: React.ReactNode; count: number | null }[] = [
-    { id: 'files', label: pt ? 'Arquivos' : 'Files', icon: <Files size={12} />, count: artifacts.length },
-    { id: 'docs', label: pt ? 'Docs' : 'Docs', icon: <BookOpen size={12} />, count: docs.length },
-    { id: 'live', label: 'Live', icon: <Activity size={12} />, count: feed.length },
+    { id: 'files', label: pt ? 'Arquivos' : 'Files', icon: <Files size={12} />, count: loading ? null : artifacts.length },
+    { id: 'docs', label: pt ? 'Docs' : 'Docs', icon: <BookOpen size={12} />, count: loading ? null : docs.length },
+    { id: 'live', label: 'Live', icon: <Activity size={12} />, count: loading ? null : feed.length },
     {
       id: 'gallery',
       label: pt ? 'Galeria' : 'Gallery',
       icon: <Image size={12} />,
-      count: galleryFiles,
+      count: loading ? null : galleryFiles,
     },
-    // The count is 0 until the tab is opened, and that is honest rather than lazy: the panel has
-    // not asked the host yet, and a number it has not measured is the thing this codebase refuses
-    // to print everywhere else.
-    { id: 'skills', label: 'Skills', icon: <Sparkles size={12} />, count: skills?.length ?? 0 },
-    // `null`, not 0, wherever a count would be a claim: only Claude Code records subagents at all,
-    // and until the tab is opened this panel has not asked. See `subagentCount`.
+    { id: 'skills', label: 'Skills', icon: <Sparkles size={12} />, count: skills === null ? null : skills.length },
     {
       id: 'agents',
       label: pt ? 'Subagentes' : 'Subagents',
       icon: <Bot size={12} />,
       count: subagentCount(agentsState),
     },
-    { id: 'mcps', label: 'MCPs', icon: <Plug size={12} />, count: mcp?.servers.length ?? null },
-    { id: 'prs', label: 'PRs', icon: <GitPullRequest size={12} />, count: prs?.pulls.length ?? 0 },
+    { id: 'mcps', label: 'MCPs', icon: <Plug size={12} />, count: mcp === null ? null : mcp.servers.length },
+    { id: 'prs', label: 'PRs', icon: <GitPullRequest size={12} />, count: prs === null ? null : prs.pulls.length },
   ]
 
   /**
@@ -631,16 +647,22 @@ export function ArtifactsAside({
               padding: '4px 9px', borderRadius: 7, cursor: 'pointer', fontFamily: 'inherit',
               fontSize: 11.5, fontWeight: 700, flexShrink: 0, whiteSpace: 'nowrap',
               minHeight: isMobile ? 44 : undefined,
-              border: gridOpen ? '1px solid var(--anthropic-orange)' : '1px dashed var(--border)',
-              background: 'transparent',
-              color: gridOpen ? 'var(--anthropic-orange)' : 'var(--text-secondary)',
+              // A real control, not a placeholder. It was a dashed outline in the tertiary colour
+              // and read as the disabled remains of something — the same thing that made the MCP
+              // tab's add button disappear into the cards under it.
+              border: '1px solid var(--anthropic-orange)',
+              background: gridOpen ? 'var(--anthropic-orange)' : 'rgba(232,105,11,0.10)',
+              color: gridOpen ? '#fff' : 'var(--anthropic-orange)',
             }}
           >
             <LayoutGrid size={12} />
             <span>{pt ? 'Todas' : 'All'}</span>
+            {/* `+5`, never `5`. A bare number here sits beside tiles and tabs whose numbers count
+                ITEMS — `MCPs 5` and `All 5` on one row meant two different things. The `+` says
+                "five more of these", which is what it is. */}
             {split.hidden.length > 0 && (
-              <span style={{ fontSize: 10, opacity: 0.7, fontVariantNumeric: 'tabular-nums' }}>
-                {split.hidden.length}
+              <span style={{ fontSize: 10, opacity: 0.85, fontVariantNumeric: 'tabular-nums' }}>
+                +{split.hidden.length}
               </span>
             )}
           </button>
@@ -662,7 +684,7 @@ export function ArtifactsAside({
           display: 'inline-flex', alignItems: 'center', gap: 5, padding: '4px 9px',
           fontSize: 11.5, fontWeight: 700, whiteSpace: 'nowrap', flexShrink: 0,
         }}>
-          <LayoutGrid size={12} />{pt ? 'Todas' : 'All'}<span style={{ fontSize: 10 }}>88</span>
+          <LayoutGrid size={12} />{pt ? 'Todas' : 'All'}<span style={{ fontSize: 10 }}>+88</span>
         </span>
       </div>
 

--- a/packages/web/src/components/sessions/ArtifactsAside.tsx
+++ b/packages/web/src/components/sessions/ArtifactsAside.tsx
@@ -419,21 +419,25 @@ export function ArtifactsAside({
   )
   const [gridOpen, setGridOpen] = useState(false)
   /**
-   * OPENING THE GRID IS ASKING WHAT IS IN THESE TABS.
+   * OPENING THE ASIDE ASKS EVERY TAB FOR ITS NUMBER.
    *
-   * Skills, PRs, Subagents and MCPs each fetch for themselves, so before anybody opened them the
-   * grid could only draw a dash — honest, and not what somebody who just opened a list of every tab
-   * wants to read. Reported as exactly that: the numbers appeared only after entering each card.
+   * Skills, PRs, Subagents and MCPs each fetch for themselves, and each used to wait for its own
+   * tab to be opened — so the bar and the grid could only draw a dash until somebody had walked
+   * into all four, one at a time. Asked for directly: "abrir a sessao ja deve disparar a busca".
    *
-   * They are NOT fetched on mount, which is what the laziness is for: the subagents list costs a
-   * full read of the parent transcript and MCPs scans `/proc`. They are fetched on the GESTURE —
-   * the one moment somebody has said "show me what is behind all of these" — and each one still
-   * loads at most once, through `asideCache`.
+   * THE MOUNT IS THE RIGHT MOMENT, and it is the aside's OWN open rather than the session's: this
+   * component is unmounted while the panel is shut (`SessionsPage` drops it once the closing
+   * animation ends), so mounting IS the panel appearing. With it shut there is no bar and no grid,
+   * so a count nobody can see would be a multi-MB transcript read, a `/proc` scan and a GitHub call
+   * spent on every session somebody clicks past.
+   *
+   * What stays lazy is the RE-READ, not the first one. A finished tab's answer cannot change, and
+   * `asideCache` serves the second open of the same session for free — so this costs one request
+   * per tab per session, once. Only the tab actually on screen keeps polling; see the subagents
+   * effect, where the poll is scheduled against `tab` and not against this.
    */
-  const wantsCounts = (id: TabId) => tab === id || gridOpen
 
   useEffect(() => {
-    if (!wantsCounts('skills')) return
     // The cached list is already on screen; this refreshes BEHIND it and only when it has aged out.
     // A fetch on every mount is the reload being fixed; never fetching would pin the list forever.
     const key = asideKey(sessionId, 'skills')
@@ -451,7 +455,7 @@ export function ArtifactsAside({
       })
       .catch(() => { if (alive) setSkills(s => s ?? []) })
     return () => { alive = false }
-  }, [tab, gridOpen, skills, sessionId, pt])
+  }, [skills, sessionId, pt])
 
   /** The repository's pull requests. Read when the tab opens, then cached — see `github-prs.ts`. */
   type PrAnswer = {
@@ -463,7 +467,6 @@ export function ArtifactsAside({
   }
   const [prs, setPrs] = useState<PrAnswer | null>(() => asideCache.read<PrAnswer>(asideKey(sessionId, 'prs')).value ?? null)
   useEffect(() => {
-    if (!wantsCounts('prs')) return
     const key = asideKey(sessionId, 'prs')
     const hit = asideCache.read<PrAnswer>(key)
     if (hit.value && !hit.stale) return
@@ -473,7 +476,7 @@ export function ArtifactsAside({
       .then((d: PrAnswer) => { asideCache.write(key, d); if (alive) setPrs(d) })
       .catch(() => { if (alive) setPrs(p => p ?? { pulls: [], unavailable: 'failed' }) })
     return () => { alive = false }
-  }, [tab, gridOpen, prs, sessionId, pt])
+  }, [prs, sessionId, pt])
 
   const feedRef = useRef<HTMLDivElement>(null)
   /** A clock, so "3m ago" ages while the panel is open rather than freezing at its first render. */
@@ -736,7 +739,6 @@ export function ArtifactsAside({
    */
   useEffect(() => {
     // The tab is what asks. Nothing is fetched for a panel nobody opened onto it.
-    if (!wantsCounts('agents')) return
     const key = asideKey(sessionId, 'subagents')
     const hit = asideCache.read<SubagentsState>(key)
     // The POLL re-reads the first page only: it is the newest by last activity, so it is where a
@@ -767,7 +769,10 @@ export function ArtifactsAside({
         asideCache.write(key, next)
         if (!alive) return
         setAgentsState(next)
-        const wait = subagentsPollMs(next)
+        // POLLED ONLY WHILE THE TAB IS ON SCREEN. The list costs a full read of the parent
+        // transcript, and re-reading it every five seconds for a count in a corner of a bar is the
+        // disk-burner `chat-tail.ts` documents, moved one panel over.
+        const wait = tab === 'agents' ? subagentsPollMs(next) : null
         if (wait !== null) timer = setTimeout(read, wait)
       } catch {
         if (alive) setAgentsState(prev => prev ?? { phase: 'failed', message: pt ? 'Não foi possível ler os subagentes.' : 'The subagents could not be read.' })
@@ -775,7 +780,7 @@ export function ArtifactsAside({
     }
     void read()
     return () => { alive = false; if (timer) clearTimeout(timer) }
-  }, [tab, gridOpen, sessionId, pt])
+  }, [tab, sessionId, pt])
 
   /**
    * A different session is a different fleet of subagents — but it may be one this panel already
@@ -877,7 +882,6 @@ export function ArtifactsAside({
    * harness's own command produced, not the one this panel guessed it would produce.
    */
   useEffect(() => {
-    if (!wantsCounts('mcps')) return
     // The DIRECTORY is part of the key: the `local` and `project` scopes are read against it, so
     // two sessions in different repositories have genuinely different answers.
     const key = asideKey(sessionId, 'mcps', cwd ?? '')
@@ -910,7 +914,7 @@ export function ArtifactsAside({
     }
     void read()
     return () => { alive = false }
-  }, [tab, gridOpen, sessionId, cwd, pt, mcpNonce])
+  }, [sessionId, cwd, pt, mcpNonce])
 
   const mcpBody = (): React.ReactNode => (
     <McpTab

--- a/packages/web/src/components/sessions/ArtifactsAside.tsx
+++ b/packages/web/src/components/sessions/ArtifactsAside.tsx
@@ -155,11 +155,20 @@ function RunningDot() {
  * vertical icon rail: a rail costs 46px in the one dimension this panel is poor in (440px on
  * desktop, ~343px on a phone), while this costs nothing while it is closed.
  */
-function TabGrid({ tabs, active, pt, isMobile, onPick, onClose }: {
+function TabGrid({ tabs, active, pt, isMobile, anchor, onPick, onClose }: {
   tabs: readonly { id: TabId; label: string; icon: React.ReactNode; count: number | null }[]
   active: TabId
   pt: boolean
   isMobile: boolean
+  /**
+   * The control that opened this.
+   *
+   * It has to be excluded from the outside-click, and NOT because of tidiness: a `mousedown` on it
+   * is outside this element, so the dismiss fired, and then the same gesture's `click` toggled the
+   * grid straight back open. Pressing the button to close it made it BLINK and stay — reported as
+   * exactly that. A popover has to know what opened it.
+   */
+  anchor: React.RefObject<HTMLButtonElement | null>
   onPick: (id: TabId) => void
   onClose: () => void
 }) {
@@ -170,14 +179,16 @@ function TabGrid({ tabs, active, pt, isMobile, onPick, onClose }: {
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') { e.stopPropagation(); onClose() } }
     const onDown = (e: MouseEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node)) onClose()
+      const t = e.target as Node
+      if (anchor.current?.contains(t)) return   // the toggle answers for itself
+      if (ref.current && !ref.current.contains(t)) onClose()
     }
     document.addEventListener('keydown', onKey)
     // `mousedown` and not `click`: the control that opened this would otherwise reopen it on the
     // same gesture that closed it.
     document.addEventListener('mousedown', onDown)
     return () => { document.removeEventListener('keydown', onKey); document.removeEventListener('mousedown', onDown) }
-  }, [onClose])
+  }, [onClose, anchor])
 
   return (
     <div
@@ -406,8 +417,23 @@ export function ArtifactsAside({
     () => groupSkills(skills ?? [], skillQuery, pt ? 'pt' : 'en'),
     [skills, skillQuery, pt],
   )
+  const [gridOpen, setGridOpen] = useState(false)
+  /**
+   * OPENING THE GRID IS ASKING WHAT IS IN THESE TABS.
+   *
+   * Skills, PRs, Subagents and MCPs each fetch for themselves, so before anybody opened them the
+   * grid could only draw a dash — honest, and not what somebody who just opened a list of every tab
+   * wants to read. Reported as exactly that: the numbers appeared only after entering each card.
+   *
+   * They are NOT fetched on mount, which is what the laziness is for: the subagents list costs a
+   * full read of the parent transcript and MCPs scans `/proc`. They are fetched on the GESTURE —
+   * the one moment somebody has said "show me what is behind all of these" — and each one still
+   * loads at most once, through `asideCache`.
+   */
+  const wantsCounts = (id: TabId) => tab === id || gridOpen
+
   useEffect(() => {
-    if (tab !== 'skills') return
+    if (!wantsCounts('skills')) return
     // The cached list is already on screen; this refreshes BEHIND it and only when it has aged out.
     // A fetch on every mount is the reload being fixed; never fetching would pin the list forever.
     const key = asideKey(sessionId, 'skills')
@@ -425,7 +451,7 @@ export function ArtifactsAside({
       })
       .catch(() => { if (alive) setSkills(s => s ?? []) })
     return () => { alive = false }
-  }, [tab, skills, sessionId, pt])
+  }, [tab, gridOpen, skills, sessionId, pt])
 
   /** The repository's pull requests. Read when the tab opens, then cached — see `github-prs.ts`. */
   type PrAnswer = {
@@ -437,7 +463,7 @@ export function ArtifactsAside({
   }
   const [prs, setPrs] = useState<PrAnswer | null>(() => asideCache.read<PrAnswer>(asideKey(sessionId, 'prs')).value ?? null)
   useEffect(() => {
-    if (tab !== 'prs') return
+    if (!wantsCounts('prs')) return
     const key = asideKey(sessionId, 'prs')
     const hit = asideCache.read<PrAnswer>(key)
     if (hit.value && !hit.stale) return
@@ -447,7 +473,7 @@ export function ArtifactsAside({
       .then((d: PrAnswer) => { asideCache.write(key, d); if (alive) setPrs(d) })
       .catch(() => { if (alive) setPrs(p => p ?? { pulls: [], unavailable: 'failed' }) })
     return () => { alive = false }
-  }, [tab, prs, sessionId, pt])
+  }, [tab, gridOpen, prs, sessionId, pt])
 
   const feedRef = useRef<HTMLDivElement>(null)
   /** A clock, so "3m ago" ages while the panel is open rather than freezing at its first render. */
@@ -556,7 +582,6 @@ export function ArtifactsAside({
   const [tabWidths, setTabWidths] = useState<Record<string, number>>({})
   const [barWidth, setBarWidth] = useState(0)
   const [overflowWidth, setOverflowWidth] = useState(0)
-  const [gridOpen, setGridOpen] = useState(false)
   const gridBtnRef = useRef<HTMLButtonElement | null>(null)
 
   // Re-measured when the LABELS can change (language) or the set does — not on every render.
@@ -694,6 +719,7 @@ export function ArtifactsAside({
           active={tab}
           pt={pt}
           isMobile={isMobile}
+          anchor={gridBtnRef}
           onPick={id => { setTab(id); setGridOpen(false); gridBtnRef.current?.focus() }}
           onClose={() => { setGridOpen(false); gridBtnRef.current?.focus() }}
         />
@@ -710,7 +736,7 @@ export function ArtifactsAside({
    */
   useEffect(() => {
     // The tab is what asks. Nothing is fetched for a panel nobody opened onto it.
-    if (tab !== 'agents') return
+    if (!wantsCounts('agents')) return
     const key = asideKey(sessionId, 'subagents')
     const hit = asideCache.read<SubagentsState>(key)
     // The POLL re-reads the first page only: it is the newest by last activity, so it is where a
@@ -749,7 +775,7 @@ export function ArtifactsAside({
     }
     void read()
     return () => { alive = false; if (timer) clearTimeout(timer) }
-  }, [tab, sessionId, pt])
+  }, [tab, gridOpen, sessionId, pt])
 
   /**
    * A different session is a different fleet of subagents — but it may be one this panel already
@@ -851,7 +877,7 @@ export function ArtifactsAside({
    * harness's own command produced, not the one this panel guessed it would produce.
    */
   useEffect(() => {
-    if (tab !== 'mcps') return
+    if (!wantsCounts('mcps')) return
     // The DIRECTORY is part of the key: the `local` and `project` scopes are read against it, so
     // two sessions in different repositories have genuinely different answers.
     const key = asideKey(sessionId, 'mcps', cwd ?? '')
@@ -884,7 +910,7 @@ export function ArtifactsAside({
     }
     void read()
     return () => { alive = false }
-  }, [tab, sessionId, cwd, pt, mcpNonce])
+  }, [tab, gridOpen, sessionId, cwd, pt, mcpNonce])
 
   const mcpBody = (): React.ReactNode => (
     <McpTab

--- a/packages/web/src/lib/asideTabs.test.ts
+++ b/packages/web/src/lib/asideTabs.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'bun:test'
+import { MIN_BAR_TABS, splitAsideTabs, type AsideTabFit } from './asideTabs'
+
+/** Eight tabs at plausible rendered widths — the panel's real set, measured shapes. */
+const TABS: AsideTabFit[] = [
+  { id: 'files', width: 76 },
+  { id: 'docs', width: 58 },
+  { id: 'live', width: 66 },
+  { id: 'gallery', width: 72 },
+  { id: 'skills', width: 60 },
+  { id: 'agents', width: 96 },
+  { id: 'mcps', width: 62 },
+  { id: 'prs', width: 52 },
+]
+const M = { container: 424, overflowWidth: 62, gap: 2 }
+
+describe('splitAsideTabs — what the bar keeps', () => {
+  it('puts everything on the bar when everything fits, and draws no control', () => {
+    // Rule 2: reserving room for the control while nothing overflows would push a tab out in order
+    // to advertise that nothing was pushed out.
+    const s = splitAsideTabs(TABS, 'files', { ...M, container: 2000 })
+    expect(s.bar).toHaveLength(8)
+    expect(s.hidden).toEqual([])
+    expect(s.overflow).toBe(false)
+  })
+
+  it('reserves the control only once something genuinely overflows', () => {
+    const s = splitAsideTabs(TABS, 'files', M)
+    expect(s.overflow).toBe(true)
+    expect(s.bar.length).toBeLessThan(8)
+    expect(s.bar.length + s.hidden.length).toBe(8)
+  })
+
+  it('keeps the tabs in their own order — the bar is not re-sorted by what fits', () => {
+    const s = splitAsideTabs(TABS, 'files', M)
+    const order = TABS.map(t => t.id)
+    expect(s.bar).toEqual(order.filter(id => s.bar.includes(id)))
+  })
+})
+
+describe('the ACTIVE tab is always on the bar', () => {
+  it('brings a tab that would have fallen past the fold onto the bar', () => {
+    // The bug the horizontal scroll already had: the bar shows tabs while the content comes from
+    // one you cannot see.
+    const s = splitAsideTabs(TABS, 'prs', M)
+    expect(s.bar).toContain('prs')
+    expect(s.hidden).not.toContain('prs')
+  })
+
+  it('displaces the LAST tab that fitted, never one further left', () => {
+    const wide = splitAsideTabs(TABS, 'files', M)
+    const displaced = wide.bar[wide.bar.length - 1]!
+    const s = splitAsideTabs(TABS, 'prs', M)
+    expect(s.bar.slice(0, -1)).toEqual(wide.bar.slice(0, -1))
+    expect(s.hidden).toContain(displaced)
+  })
+
+  it('leaves the bar alone when the active tab already fits', () => {
+    const s = splitAsideTabs(TABS, 'files', M)
+    expect(s.bar[0]).toBe('files')
+  })
+
+  it('ignores an active id that is not in the list at all', () => {
+    const s = splitAsideTabs(TABS, 'nope', M)
+    expect(s.bar.length + s.hidden.length).toBe(8)
+    expect(s.bar).not.toContain('nope')
+  })
+})
+
+describe('the floor, and the unmeasured first paint', () => {
+  it('never reduces the bar below two tabs, however narrow', () => {
+    // A bar reduced to its overflow button is a menu wearing a bar's clothes, and the tabs are then
+    // strictly harder to reach than they were.
+    const s = splitAsideTabs(TABS, 'files', { ...M, container: 40 })
+    expect(s.bar).toHaveLength(MIN_BAR_TABS)
+    expect(s.overflow).toBe(true)
+  })
+
+  it('draws every tab while the width is not known yet', () => {
+    // A first paint has no width; guessing "nothing fits" would collapse the bar for one frame on
+    // every mount, which reads as a fault. The component clips for that frame instead.
+    for (const container of [0, -10, Number.NaN]) {
+      const s = splitAsideTabs(TABS, 'files', { ...M, container })
+      expect(s.bar).toHaveLength(8)
+      expect(s.overflow).toBe(false)
+    }
+  })
+
+  it('answers an empty list without inventing a control', () => {
+    expect(splitAsideTabs([], 'files', M)).toEqual({ bar: [], hidden: [], overflow: false })
+  })
+})
+
+describe('a phone, where the aside is ~343px', () => {
+  it('still keeps the active tab and still offers every other one', () => {
+    const s = splitAsideTabs(TABS, 'agents', { ...M, container: 327 })
+    expect(s.bar).toContain('agents')
+    expect(s.overflow).toBe(true)
+    expect([...s.bar, ...s.hidden].sort()).toEqual(TABS.map(t => t.id).sort())
+  })
+})

--- a/packages/web/src/lib/asideTabs.ts
+++ b/packages/web/src/lib/asideTabs.ts
@@ -1,0 +1,116 @@
+/**
+ * asideTabs.ts — PURE: which tabs fit on the aside's bar, and which the grid holds.
+ *
+ * The artifacts aside carries eight tabs in a column that is 440px on desktop and `min(440px, 88%)`
+ * on mobile — about 343px on a 390px phone. They do not fit, and the stopgap was `overflow-x: auto`:
+ * the tabs past the fold were invisible, nothing on screen said they existed, and reaching one was
+ * a sideways drag inside a narrow column. Every round of work on this panel has added a tab.
+ *
+ * So the bar keeps what fits and a trailing control opens a GRID with every tab in it. This module
+ * decides the split, and only the split — the measuring is the component's (see `widths`), because
+ * labels are words in two languages and a width estimated from character counts is wrong in one of
+ * them.
+ *
+ * FOUR RULES, and each is the difference between this and a junk drawer.
+ *
+ * 1. **THE ACTIVE TAB IS ALWAYS ON THE BAR.** If it would fall past the fold it takes the last
+ *    visible slot and the tab that was there moves to the grid. A bar showing tabs while the
+ *    content comes from one you cannot see is the "where am I" bug the scroll already had.
+ * 2. **THE OVERFLOW CONTROL IS BUDGETED ONLY WHEN IT WILL EXIST.** Reserving room for it while
+ *    everything fits pushes out a tab in order to advertise that nothing was pushed out. So the fit
+ *    is computed WITHOUT it first, and only recomputed WITH it once something genuinely overflows.
+ * 3. **A MINIMUM STAYS ON THE BAR.** A bar reduced to its overflow button is a menu wearing a
+ *    bar's clothes, and at that point the tabs are strictly harder to reach than before. Below the
+ *    minimum the bar keeps drawing them and gives up the fit instead — the component clips there,
+ *    which is visible, rather than hiding them, which is not.
+ * 4. **THE GRID HOLDS EVERY TAB, NOT THE LEFTOVERS.** Returned as `all`, with the active one
+ *    marked by the caller. A grid of only what did not fit changes contents as the panel resizes,
+ *    so the same tab is in a different place each time you look for it.
+ */
+
+/** One tab, as much of it as this module reads. Kept structural so it never imports the panel. */
+export interface AsideTabFit {
+  id: string
+  /** The tab's rendered width in px, measured by the caller. */
+  width: number
+}
+
+export interface TabSplit {
+  /** The ids the bar draws, in the tabs' own order. */
+  bar: string[]
+  /** The ids the bar does NOT draw — what the overflow control's badge counts. */
+  hidden: string[]
+  /** Whether the overflow control is drawn at all. False only when everything fits. */
+  overflow: boolean
+}
+
+/**
+ * How few tabs the bar may be reduced to before it stops giving ground.
+ *
+ * Two, not one: with one visible tab plus a button there is nothing left for the bar to be, and the
+ * grid is a strictly better version of that. Two is where a bar is still a bar.
+ */
+export const MIN_BAR_TABS = 2
+
+/** Gap between tabs, and the bar's own horizontal padding — the component's own metrics. */
+export interface BarMetrics {
+  /** Usable width of the bar, measured. */
+  container: number
+  /** Width of the overflow control, measured. */
+  overflowWidth: number
+  /** Space between two tabs. */
+  gap: number
+}
+
+function packed(tabs: readonly AsideTabFit[], room: number, gap: number): number {
+  let used = 0
+  let n = 0
+  for (const t of tabs) {
+    const next = used + (n === 0 ? 0 : gap) + t.width
+    if (next > room) break
+    used = next
+    n++
+  }
+  return n
+}
+
+/**
+ * Split the tabs between the bar and the grid.
+ *
+ * A container that has not been measured yet (0, negative, non-finite) puts EVERYTHING on the bar
+ * and draws no overflow control: a first paint has no width, and guessing "nothing fits" would
+ * collapse the bar to a button for one frame on every mount, which reads as a fault. The component
+ * clips for that frame instead, and the measurement corrects it.
+ */
+export function splitAsideTabs(
+  tabs: readonly AsideTabFit[],
+  active: string,
+  m: BarMetrics,
+): TabSplit {
+  const all = tabs.map(t => t.id)
+  if (!Number.isFinite(m.container) || m.container <= 0 || tabs.length === 0) {
+    return { bar: all, hidden: [], overflow: false }
+  }
+
+  // Rule 2: ask whether everything fits with NO control reserved.
+  if (packed(tabs, m.container, m.gap) === tabs.length) {
+    return { bar: all, hidden: [], overflow: false }
+  }
+
+  // Something overflows, so the control exists and takes its room.
+  const room = m.container - m.overflowWidth - m.gap
+  const count = Math.max(MIN_BAR_TABS, packed(tabs, room, m.gap))
+  const shown = tabs.slice(0, Math.min(count, tabs.length))
+
+  // Rule 1: the active tab is on the bar, even if it had to displace the last one that fitted.
+  const barIds = shown.map(t => t.id)
+  if (!barIds.includes(active) && all.includes(active)) {
+    barIds[barIds.length - 1] = active
+  }
+
+  return {
+    bar: barIds,
+    hidden: all.filter(id => !barIds.includes(id)),
+    overflow: true,
+  }
+}


### PR DESCRIPTION
## Summary

- The aside's tab bar stopped scrolling sideways. It keeps the tabs that **fit** and a trailing
  control opens **a grid of labelled tiles with every tab in it**.
- `asideTabs.ts` is the pure split; the panel owns only the measuring. Eleven tests pin the four
  rules that separate this from a junk drawer.
- The counts stay on the bar — `Subagentes 64` is what says what is behind a tab without opening it.

## Motivation

Closes #377.

Eight tabs in a column that is 440px on desktop and `min(440px, 88%)` on a phone (~343px). They do
not fit. The stopgap when the seventh and eighth landed was `overflow-x: auto`, so the tabs past
the fold were **out of sight with nothing on screen saying they existed**, and reaching one was a
sideways drag inside a narrow column. Every round of work on this panel has added a tab; this does
not get better by itself.

## Changes

**`packages/web/src/lib/asideTabs.ts`** (new, pure, tested) — `splitAsideTabs(tabs, active, metrics)`
returns what the bar draws, what it hides and whether the control exists. Four rules live here:

- **The ACTIVE tab is always on the bar.** If it would fall past the fold it takes the last visible
  slot and the tab that was there moves to the grid. A bar showing tabs while the content comes
  from one you cannot see is the "where am I" bug the scroll already had.
- **The control is budgeted only when it will exist.** Reserving room for it while everything fits
  pushes a tab out in order to advertise that nothing was pushed out — so the fit is computed
  WITHOUT it first, and recomputed WITH it only once something genuinely overflows.
- **A minimum of two stays on the bar.** Reduced to its own button a bar is a menu wearing a bar's
  clothes, and the tabs are then strictly harder to reach than they were.
- **The grid holds EVERY tab**, with the current one marked — not the leftovers. A grid whose
  contents change as the panel resizes puts the same tab in a different place each time somebody
  looks for it.

An unmeasured first paint (0 / negative / NaN width) draws every tab and no control: guessing
"nothing fits" would collapse the bar to a button for one frame on every mount, which reads as a
fault. The component clips for that frame instead, and the measurement corrects it.

**`ArtifactsAside.tsx`** — the measuring, and the grid.

The **ruler** is an `aria-hidden` row holding every tab at its real size, laid out and never
painted (`visibility: hidden`, not `display: none`, which measures nothing). Measuring the visible
bar would only ever report the tabs that already fit, which is the answer being computed. One
`tabCell` renderer serves both the bar and the ruler, so they cannot measure apart. It re-measures
when the LABELS can change (language, counts) or the width does — not on every render.

`TabGrid` is a popover: `esc` closes it, focus returns to the control that opened it, and an
outside `mousedown` (not `click`, or the opener would reopen it on the same gesture) closes it too.

## Test plan

- [x] `bun test` — 6.107 pass, 0 fail. `bun tsc --noEmit` clean, `vite build` clean.
- [x] **11 tests on the pure split**, including the two that are easy to get wrong: the active tab
      displaces the LAST tab that fitted and never one further left, and an unmeasured container
      draws everything rather than nothing.
- [ ] **In the browser**, on the Sessions workspace with the aside open:
  - the bar no longer scrolls sideways; what does not fit is behind **Todas N**;
  - the grid lists **all eight**, the current one outlined, counts on every tile;
  - picking a tab from the grid closes it and selects that tab;
  - `esc` closes it and the focus lands back on **Todas**;
  - narrow the window: tabs move into the grid one at a time and the **selected one never leaves
    the bar**;
  - at 390px: three tiles across, 44px targets, and the page still does not scroll sideways.

## Alternative considered and rejected

A **vertical icon rail** (VS Code's activity bar). It scales better — sixteen tabs stay visible —
and it was built as a working prototype and compared side by side against this one before choosing.
It loses on the dimension that matters here: **46px permanently in the one direction this panel is
poor in** (440 → 394 on desktop, 343 → 297 on a phone), the counts reduced to an 8px badge, and
three of the eight icons all reading as "a document" (Arquivos, Docs, Galeria) with no hover on
touch to give the names back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0161UEvuEphUuJEJFygVyaKy
