### PR TITLE
fix(server): an agent is not the tool that launched it, so background agents stop being invisible

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,7 +80,12 @@ packages/server/server/          — server-side modules (never bundled by Vite)
   ├── archive.ts           → mirrorFile, fullSync, snapshotStatsCache ('full' mode: raw transcript mirror → ~/.agentistics/archive)
   ├── consolidate.ts       → writeConsolidated, loadConsolidated ('consolidate' mode: per-session metrics → ~/.agentistics/sessions/<harness>/<id>.json; legacy flat files load as claude)
   ├── data.ts              → loadSessionMetas, scanProjects, buildApiResponse (main orchestrator)
-  ├── agent-metrics.ts     → extractAgentMetrics (parses Agent tool_use from JSONL)
+  ├── agent-metrics.ts     → extractAgentMetrics (every agent launch the parent records — an `Agent`
+  │                          tool_use, a result that NAMES an agent whatever tool produced it, and a
+  │                          launch the parent never answered)
+  ├── subagent-join.ts     → **pure**: which transcript belongs to which invocation. The `subagents/`
+  │                          DIRECTORY is authoritative for which agents existed; the parent only for
+  │                          how each was launched — and it does not always say even that
   ├── otel-watcher.ts      → chokidar file watcher + OTLP metrics export daemon
   ├── preferences.ts       → ~/.agentistics prefs incl. team config (mode/endpoint/token/user)
   ├── version.ts           → getVersionInfo (current vs latest); drives update banners/notifications
@@ -1284,6 +1289,35 @@ The numbers moved to `~/.claude/projects/<project>/<session-id>/subagents/agent-
   entirely. Cycle-safe by a visited set.
 - **The DURATION is the root's own span** — a nested agent runs inside its parent, and adding the two
   counts the same wall time twice.
+- **THE LIST OF INVOCATIONS IS THE DIRECTORY'S, NOT THE PARENT'S.** Keying on `Agent` tool_use +
+  matching `tool_result` was a statement about the TOOL that launched an agent, not about whether one
+  ran. Measured 2026-09-06 (408 conversations, 541 subagent transcripts) — three shapes fell through:
+  a call the user INTERRUPTED (`toolUseResult` is the STRING `"Error: [Request interrupted by user
+  for tool use]"`, so no `agentId`: the row existed and was permanently unmeasured); a **background
+  agent** (the `Agent` tool_use is there and NO `tool_result` ever arrives — the launch sat in the
+  pending map to the end of the file and was dropped); and a **background forked skill** (`/code-
+  review` is a **`Skill`** tool_use whose result is `{status:'forked', background:true, agentId}` —
+  the parent names the agent perfectly well, only the tool differs). Four top-level transcripts,
+  1,6 MB, including a 24-million-token agent at US$ 15,76. `subagent-join.ts` pairs by the EXACT
+  `agentId` first and only then by the meta's own `toolUseId` — a single pass would let the fallback
+  consume a transcript some other invocation names outright — one transcript to at most one
+  invocation, and a `toolUseId` naming TWO transcripts is ambiguous and pairs NEITHER (a half-read
+  link is published as a measurement; an absence is rendered N/A). A NESTED transcript is excluded
+  from the candidate pool OUTRIGHT rather than by relying on no invocation happening to match it: its
+  meta carries a `toolUseId` too, and a second row would report the same tokens twice. A top-level
+  transcript nobody claims adds NO row and is REPORTED (`AgentJoinPlan.unclaimed`) — today those are
+  conversation FORKS (5 transcripts, 11,4 MB here), which belong to no `tool_use` anywhere.
+- **The gate must not be `toolCounts['Agent']` either.** A conversation whose only agent was a
+  background forked skill has no `Agent` in `toolCounts` at all, so `jsonl.ts` never called the
+  reader and `uses_task_agent` was false. Both now also accept "some `toolUseResult` named an agent"
+  (`sawAgentLaunch`).
+- **`cachedEnrich` enriches OUTSIDE its memo.** That path serves the meta-sourced sessions — MOST
+  Claude sessions — and was written before #373; it called `extractAgentMetrics` and never
+  `enrichFromSubagentTranscripts`, so every invocation it published stayed unmeasured. Caching the
+  enriched result would be the smaller diff and the wrong one: that memo is keyed on the PARENT's
+  stamp and a subagent's file goes on changing while the conversation sits idle, so the numbers would
+  freeze at the first read. `subagent-metrics.ts` keeps its own memo on each subagent file's own
+  mtime and size, which is the only stamp that answers this question.
 - **An invocation whose transcript is gone is `unmeasured: true`, never a zero.** Read that flag
   BEFORE any figure on the record: it carries zeros only because the type has no other value to
   carry. `SessionAgentMetrics` totals exclude them and `unmeasuredInvocations` counts them, so a
@@ -1294,7 +1328,7 @@ The numbers moved to `~/.claude/projects/<project>/<session-id>/subagents/agent-
 |---|---|
 | `agentType` | `toolUseResult.agentType`, else the `tool_use` input's `subagent_type` |
 | `description` | `tool_use.input.description` |
-| `agentId` | `toolUseResult.agentId` — names the subagent transcript |
+| `agentId` | `toolUseResult.agentId` — names the subagent transcript; absent when the call was interrupted or never answered, and then the join recovers it from `agent-<id>.meta.json`'s `toolUseId` |
 | `totalTokens` (all four counters) / `inputTokens` / `outputTokens` / `cacheReadTokens` / `cacheWriteTokens` | the subagent transcript's `message.usage`, per model; legacy: `toolUseResult.usage.*` |
 | `totalDurationMs` | the subagent transcript's first→last timestamp; legacy: `toolUseResult.totalDurationMs` |
 | `totalToolUseCount` / `toolStats` | the subagent transcript's `tool_use` items and `structuredPatch` hunks; legacy: `toolUseResult.toolStats` |

--- a/docs/data-sources.md
+++ b/docs/data-sources.md
@@ -20,7 +20,8 @@ agentistics reads data exclusively from local files written by Claude Code. No d
   └── projects/**/*.jsonl
          ↓
     server/data.ts  (buildApiResponse — main orchestrator)
-    server/agent-metrics.ts  (extractAgentMetrics — parses Agent tool_use)
+    server/agent-metrics.ts  (extractAgentMetrics — every agent launch the parent records)
+    server/subagent-join.ts  (pure — which transcript belongs to which invocation)
          ↓
     /api/data  →  useData()  →  useDerivedStats()  →  React components
 ```
@@ -134,7 +135,9 @@ The numbers moved into the subagent's **own transcript**, at
 `~/.claude/projects/<project>/<session-id>/subagents/agent-<agentId>.jsonl`, with an
 `agent-<agentId>.meta.json` beside it carrying `agentType`, `description` and the parent's
 `toolUseId`. `server/subagent-parse.ts` (pure) sums one such transcript and
-`server/subagent-metrics.ts` finds it, follows nested subagents and memoizes the result.
+`server/subagent-metrics.ts` finds it, follows nested subagents and memoizes the result — keyed on
+each subagent file's OWN mtime and size, never the parent's, because those files go on changing while
+the conversation sits idle.
 
 Three rules that fall out of the new shape:
 
@@ -147,6 +150,40 @@ Three rules that fall out of the new shape:
 - **A nested subagent counts inside the invocation that spawned it.** Only a top-level `Agent`
   `tool_use` becomes an `AgentInvocation`, so a subtree left out here is left out of the session's
   agent totals entirely. The walk is cycle-safe.
+
+### Which agents exist is the DIRECTORY's answer, not the parent's
+
+`extractAgentMetrics` used to build the invocation list from one shape only — an `Agent` `tool_use`
+paired with the `tool_result` that answers it. The `subagents/` directory is the authoritative record
+of which agents actually ran; the parent is authoritative for how each was launched. Measured on one
+machine on 2026-09-06 — 408 conversations, 541 subagent transcripts — three shapes fell through:
+
+| shape | what the parent holds | what happened |
+|---|---|---|
+| the user interrupted the call | `toolUseResult` is the STRING `"Error: [Request interrupted by user for tool use]"` — no `agentId` | the row existed and was permanently `unmeasured` |
+| a **background agent** | the `Agent` `tool_use`, and **no `tool_result` at all** | no row: the launch sat in the pending map to the end of the file and was dropped |
+| a **background forked skill** | a **`Skill`** `tool_use` whose result is `{"status":"forked","background":true,"agentId":"…"}` | no row: nothing keyed on `Agent` could see it |
+
+Four top-level transcripts (1,6 MB) on that machine, including a 24-million-token agent worth
+US$ 15,76 and two `/code-review` runs worth US$ 6,24 together. `server/subagent-join.ts` (pure) is the
+join: an invocation is paired with a transcript by the exact `agentId` first, then by the meta's own
+`toolUseId`, one transcript to at most one invocation. A `toolUseId` naming two transcripts is
+ambiguous and pairs neither — a half-read link gets published as a measurement, which is worse than
+an absence rendered N/A.
+
+Two rules the join exists to keep:
+
+- **A nested transcript never becomes its own row.** It is already counted inside the invocation
+  that spawned it, so a second row would report the same tokens twice. Nested entries are excluded
+  from the candidate pool outright rather than relying on no invocation happening to match them.
+- **A top-level transcript nobody claims adds no row, and is reported rather than swallowed.** Those
+  are conversation forks today (5 transcripts, 11,4 MB on the same machine): they belong to no
+  `tool_use` anywhere, and whether they are invocations of the conversation they are filed under is a
+  separate question.
+
+The gates that decide whether the reader runs at all follow the same rule: a conversation whose only
+agent was a background forked skill has no `Agent` in `toolCounts`, so both `uses_task_agent` and the
+`agentMetrics` call now also accept "some tool result named an agent".
 
 ### An invocation whose transcript is gone reports N/A, never zero
 

--- a/packages/server/server/agent-metrics.test.ts
+++ b/packages/server/server/agent-metrics.test.ts
@@ -87,3 +87,88 @@ test('the legacy shape is read exactly as it always was', () => {
   expect(inv.costUSD).toBeGreaterThan(0)
   expect(m.unmeasuredInvocations).toBe(0)
 })
+
+/** A skill launched in the BACKGROUND. The tool is `Skill`, and the result names the agent. */
+function skillCall(id: string, name: string) {
+  return JSON.stringify({
+    type: 'assistant',
+    message: { content: [{ type: 'tool_use', id, name: 'Skill', input: { skill: name } }] },
+  })
+}
+function forkedSkillResult(id: string, agentId: string, commandName: string) {
+  return JSON.stringify({
+    type: 'user',
+    toolUseResult: {
+      success: true, commandName, status: 'forked', background: true, agentId,
+      result: `Running in the background as @${commandName}`,
+    },
+    message: { content: [{ type: 'tool_result', tool_use_id: id, content: 'launched' }] },
+  })
+}
+
+test('a BACKGROUND forked skill is an agent — the launching tool is not what makes it one', () => {
+  // Measured 2026-09-06: `/code-review` run in the background produces a `Skill` tool_use whose
+  // result carries `{status:'forked', background:true, agentId}`. The parent names the agent; only
+  // the tool differs, and keying on `Agent` alone made the whole run vanish from the dashboard.
+  const m = extractAgentMetrics([
+    skillCall('toolu_1', 'code-review'),
+    forkedSkillResult('toolu_1', 'af78d79cddebfe710', 'code-review'),
+  ], 'claude-opus-5')
+
+  expect(m.invocations).toHaveLength(1)
+  const inv = m.invocations[0]!
+  expect(inv.toolUseId).toBe('toolu_1')
+  expect(inv.agentId).toBe('af78d79cddebfe710')
+  expect(inv.unmeasured).toBe(true)
+  expect(m.unmeasuredInvocations).toBe(1)
+})
+
+test('an Agent launched and never resolved is still an invocation', () => {
+  // The plain background agent: the parent gets no `tool_result` at all, so the launch used to sit
+  // in the pending map to the end of the file and be dropped. It ran; it has a transcript.
+  const m = extractAgentMetrics([agentCall('toolu_1', 'P2 Task 8: attach from the TUI')], 'claude-opus-5')
+
+  expect(m.invocations).toHaveLength(1)
+  const inv = m.invocations[0]!
+  expect(inv.toolUseId).toBe('toolu_1')
+  expect(inv.unmeasured).toBe(true)
+  expect(inv.description).toBe('P2 Task 8: attach from the TUI')
+  expect(inv.agentType).toBe('general-purpose')
+  expect(inv.agentId).toBeUndefined()
+})
+
+test('an unresolved launch is appended AFTER the ones the parent answered', () => {
+  const m = extractAgentMetrics([
+    agentCall('toolu_1', 'launched'),
+    agentCall('toolu_2', 'answered'), legacyResult('toolu_2'),
+  ], 'claude-opus-5')
+
+  expect(m.invocations.map(i => i.toolUseId)).toEqual(['toolu_2', 'toolu_1'])
+})
+
+test('a result that names an agent already recorded never opens a SECOND row', () => {
+  const m = extractAgentMetrics([
+    agentCall('toolu_1', 'one'), asyncResult('toolu_1', 'aOne', 'one'),
+    // A later tool reporting on the same agent — a status read, an output fetch — is not a launch.
+    JSON.stringify({
+      type: 'user',
+      toolUseResult: { agentId: 'aOne', status: 'completed' },
+      message: { content: [{ type: 'tool_result', tool_use_id: 'toolu_99' }] },
+    }),
+  ], 'claude-opus-5')
+
+  expect(m.invocations).toHaveLength(1)
+  expect(m.invocations[0]!.toolUseId).toBe('toolu_1')
+})
+
+test('a tool_result carrying no agentId and answering no Agent call is not an invocation', () => {
+  const m = extractAgentMetrics([
+    JSON.stringify({
+      type: 'user',
+      toolUseResult: { stdout: 'ok' },
+      message: { content: [{ type: 'tool_result', tool_use_id: 'toolu_7' }] },
+    }),
+  ], 'claude-opus-5')
+
+  expect(m.invocations).toEqual([])
+})

--- a/packages/server/server/agent-metrics.ts
+++ b/packages/server/server/agent-metrics.ts
@@ -39,18 +39,35 @@ interface ToolUseResult {
 }
 
 /**
- * Parse JSONL lines from a session file and extract Agent tool invocation metrics.
+ * Parse JSONL lines from a session file and extract agent invocation metrics.
  *
  * Key JSONL structure:
  * - Assistant messages have `content` items with `type: "tool_use"` and `name: "Agent"`
  * - The input has: `{ description, subagent_type, prompt }`
  * - Correlating user messages have `toolUseResult` at the message level with usage/timing info
  * - Correlation: match by `tool_use_id` in the tool_result content array
+ *
+ * **An agent is not defined by the tool that launched it.** Three shapes reach this reader, and for
+ * a release only the first of them produced a row (measured 2026-09-06, one machine, 541 subagent
+ * transcripts on disk):
+ *
+ * 1. An `Agent` tool_use answered by a `tool_result` — 528 of them, and all this used to read.
+ * 2. A `tool_result` naming an agent with NO `Agent` call before it. A skill run in the BACKGROUND
+ *    is a `Skill` tool_use whose result is `{status:'forked', background:true, agentId}` — the
+ *    parent names the agent perfectly well, and keying on the tool name made the whole run vanish.
+ * 3. An `Agent` tool_use the parent NEVER answered — launched and left running. It used to sit in
+ *    the pending map to the end of the file and be dropped, although it had a full transcript.
+ *
+ * Shapes 2 and 3 are recorded UNMEASURED here and measured from the subagent's own transcript by
+ * `subagent-metrics.ts`, which joins the two sides through `subagent-join.ts`. An agent already
+ * recorded never opens a second row: a later tool reporting ON an agent is not another launch.
  */
 export function extractAgentMetrics(lines: Iterable<string>, modelId: string): SessionAgentMetrics {
   // Map of tool_use_id → ToolUseRecord for pending Agent invocations
   const pendingAgents = new Map<string, ToolUseRecord>()
   const invocations: AgentInvocation[] = []
+  /** Every agent already given a row, so a later report ON one cannot open a second. */
+  const recordedAgentIds = new Set<string>()
 
   for (const raw of lines) {
     const line = raw.trim()
@@ -98,10 +115,16 @@ export function extractAgentMetrics(lines: Iterable<string>, modelId: string): S
         if (!toolUseId) continue
 
         const pending = pendingAgents.get(toolUseId)
-        if (!pending) continue
+        // A result that NAMES an agent is a launch whatever tool produced it — that is the
+        // background forked skill, whose `Skill` call left nothing pending here. It is not a launch
+        // when the agent already has a row: a later tool reporting on one is a report, not a spawn.
+        const named = typeof toolUseResult.agentId === 'string' ? toolUseResult.agentId : ''
+        if (!pending && (!named || recordedAgentIds.has(named))) continue
 
         // We have a match — build the AgentInvocation
         pendingAgents.delete(toolUseId)
+        if (named) recordedAgentIds.add(named)
+        const input = pending?.input ?? {}
 
         /**
          * Did this result carry NUMBERS at all?
@@ -148,8 +171,8 @@ export function extractAgentMetrics(lines: Iterable<string>, modelId: string): S
           toolUseId,
           ...(toolUseResult.agentId ? { agentId: toolUseResult.agentId } : {}),
           ...(measured ? {} : { unmeasured: true as const }),
-          agentType: toolUseResult.agentType ?? pending.input.subagent_type ?? 'unknown',
-          description: pending.input.description ?? '',
+          agentType: toolUseResult.agentType ?? input.subagent_type ?? 'unknown',
+          description: input.description ?? '',
           status: (toolUseResult.status === 'failed') ? 'failed' : 'completed',
           totalTokens: toolUseResult.totalTokens ?? (inputTokens + outputTokens),
           totalDurationMs: toolUseResult.totalDurationMs ?? 0,
@@ -171,6 +194,35 @@ export function extractAgentMetrics(lines: Iterable<string>, modelId: string): S
         })
       }
     }
+  }
+
+  /**
+   * Every launch the parent never answered — the plain background agent.
+   *
+   * Appended after the answered ones rather than woven back into their place: the transcript gives
+   * no moment at which they finished, and any position chosen for them would be invented. They
+   * carry no numbers here; the transcript beside the session does.
+   */
+  for (const [toolUseId, pending] of pendingAgents) {
+    invocations.push({
+      toolUseId,
+      unmeasured: true as const,
+      agentType: pending.input.subagent_type ?? 'unknown',
+      description: pending.input.description ?? '',
+      status: 'completed',
+      totalTokens: 0,
+      totalDurationMs: 0,
+      totalToolUseCount: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+      toolStats: {
+        readCount: 0, searchCount: 0, bashCount: 0, editFileCount: 0,
+        linesAdded: 0, linesRemoved: 0, otherToolCount: 0,
+      },
+      costUSD: 0,
+    })
   }
 
   return totalsOf(invocations)

--- a/packages/server/server/jsonl.ts
+++ b/packages/server/server/jsonl.ts
@@ -241,6 +241,16 @@ export async function parseSessionJsonl(
   let gitCommits = 0, gitPushes = 0
   let toolErrors = 0, userInterruptions = 0
   let hasMcp = false
+  /**
+   * Did any tool result NAME an agent?
+   *
+   * The gate below used to be `toolCounts['Agent']` alone, which is a statement about the tool that
+   * launched an agent rather than about whether one ran. A skill run in the BACKGROUND is a `Skill`
+   * tool_use whose result carries `{status:'forked', background:true, agentId}` — measured
+   * 2026-09-06, two such runs on this machine, and neither reached the reader at all because this
+   * conversation had no `Agent` call in it.
+   */
+  let sawAgentLaunch = false
   const claudeFilesModified = new Set<string>()
   /** Lines this session's OWN edits changed — see `edit-lines.ts`. */
   let editLines: EditDelta = { added: 0, removed: 0 }
@@ -310,6 +320,10 @@ export async function parseSessionJsonl(
     }
 
     if (e.type === 'user') {
+      const result = e.toolUseResult as Record<string, unknown> | undefined
+      if (result && typeof result === 'object' && typeof result.agentId === 'string' && result.agentId) {
+        sawAgentLaunch = true
+      }
       const msgContent = (e.message as Record<string, unknown> | undefined)?.content
       const contentArr = Array.isArray(msgContent) ? msgContent as Record<string, unknown>[] : null
 
@@ -455,7 +469,7 @@ export async function parseSessionJsonl(
   // asynchronous the parent transcript names the subagent and nothing else, so the invocations come
   // back marked `unmeasured` and are filled in from each subagent's own transcript, which sits
   // beside this file. See `subagent-metrics.ts`.
-  const agentMetrics = toolCounts['Agent']
+  const agentMetrics = (toolCounts['Agent'] || sawAgentLaunch)
     ? await enrichFromSubagentTranscripts(extractAgentMetrics(iterLines(content), modelId), filePath, sessionId)
     : undefined
 
@@ -488,7 +502,7 @@ export async function parseSessionJsonl(
     user_response_times: userResponseTimes,
     tool_errors: toolErrors,
     tool_error_categories: toolErrorCategories,
-    uses_task_agent: 'Task' in toolCounts || 'Agent' in toolCounts,
+    uses_task_agent: 'Task' in toolCounts || 'Agent' in toolCounts || sawAgentLaunch,
     uses_mcp: hasMcp,
     uses_web_search: 'WebSearch' in toolCounts,
     uses_web_fetch: 'WebFetch' in toolCounts,

--- a/packages/server/server/parse-cache-jsonl.ts
+++ b/packages/server/server/parse-cache-jsonl.ts
@@ -2,6 +2,8 @@ import { readFile } from 'fs/promises'
 import type { SessionMeta, SessionAgentMetrics } from '@agentistics/core'
 import { parseSessionJsonl, activeMinutesFromClaudeJsonl, contextTokensFromClaudeJsonl } from './jsonl'
 import { extractAgentMetrics } from './agent-metrics'
+import { enrichFromSubagentTranscripts } from './subagent-metrics'
+import { basename } from 'path'
 import { safeStat } from './utils'
 import type { ParseCache } from './parse-cache'
 import type { FileStamp } from './parse-cache-key'
@@ -61,7 +63,7 @@ export async function cachedParseSession(
 }
 
 /** The shape of a stored `session` row. See the note in `cachedParseSession`. */
-const SESSION_SHAPE = 'v2'
+const SESSION_SHAPE = 'v3'
 
 /** Everything `scanProjectDir` needs from a transcript whose session already exists in
  *  Claude's own session-meta — which carries none of it. */
@@ -91,7 +93,7 @@ export interface EnrichResult {
  * changed in `EnrichResult`.** Costs one slow build; the alternative is a metric that
  * is silently blank and looks like missing data rather than a stale cache.
  */
-const ENRICH_SHAPE = 'v2'
+const ENRICH_SHAPE = 'v3'
 
 /** The first `claude-*` model in the transcript's opening 200 lines — the same scan
  *  `scanProjectDir` did inline, kept identical on purpose. */
@@ -137,7 +139,7 @@ export async function cachedEnrich(
 
   const variant = `${ENRICH_SHAPE}:${metaModel}`
   const hit = cache.get<EnrichResult>('enrich', stamp, variant)
-  if (hit) return hit
+  if (hit) return withSubagentNumbers(hit, filePath)
 
   const content = await readFile(filePath, 'utf-8').catch(() => '')
   if (!content) return null
@@ -152,5 +154,26 @@ export async function cachedEnrich(
     agentMetrics: metrics.totalInvocations > 0 ? metrics : null,
   }
   cache.set('enrich', stamp, result, variant)
-  return result
+  return withSubagentNumbers(result, filePath)
+}
+
+/**
+ * The subagents' numbers, read OUTSIDE the memo — and it has to be outside.
+ *
+ * This path serves the meta-sourced sessions, which is MOST Claude sessions, and it was added
+ * before #373 moved an async agent's numbers into the agent's own transcript. It never gained the
+ * enrichment, so every invocation it published stayed `unmeasured` — the row rendered N/A forever
+ * on the very path that carries the bulk of them.
+ *
+ * Caching the enriched result would have been the smaller diff and the wrong one: this memo is
+ * keyed on the PARENT transcript's stamp, and a subagent's file goes on changing while the
+ * conversation sits idle. The enriched numbers would freeze at whatever the agent had written the
+ * first time the parent was read. `subagent-metrics.ts` keeps its own memo, keyed on each
+ * subagent file's own mtime and size, which is the only stamp that answers this question.
+ */
+async function withSubagentNumbers(result: EnrichResult, filePath: string): Promise<EnrichResult> {
+  if (!result.agentMetrics) return result
+  const sessionId = basename(filePath).replace(/\.jsonl$/, '')
+  const agentMetrics = await enrichFromSubagentTranscripts(result.agentMetrics, filePath, sessionId)
+  return agentMetrics === result.agentMetrics ? result : { ...result, agentMetrics }
 }

--- a/packages/server/server/subagent-join.test.ts
+++ b/packages/server/server/subagent-join.test.ts
@@ -1,0 +1,159 @@
+import { test, expect } from 'bun:test'
+import type { AgentInvocation } from '@agentistics/core'
+import { parseAgentMeta, isNestedAgent, describedFrom, planAgentJoin } from './subagent-join'
+
+function inv(toolUseId: string, over: Partial<AgentInvocation> = {}): AgentInvocation {
+  return {
+    toolUseId, agentType: 'general-purpose', description: 'd', status: 'completed',
+    totalTokens: 0, totalDurationMs: 0, totalToolUseCount: 0,
+    inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0,
+    toolStats: { readCount: 0, searchCount: 0, bashCount: 0, editFileCount: 0, linesAdded: 0, linesRemoved: 0, otherToolCount: 0 },
+    costUSD: 0, ...over,
+  }
+}
+
+// ---------------------------------------------------------------- parseAgentMeta
+
+test('parseAgentMeta reads the fields the harness writes, and nothing else', () => {
+  const m = parseAgentMeta(JSON.stringify({
+    agentType: 'Explore', description: 'Map i18n wiring', toolUseId: 'toolu_1',
+    parentAgentId: 'aRoot', spawnDepth: 2, isFork: true, name: 'code-review', model: 'haiku',
+    somethingNew: 42,
+  }))
+  expect(m).toEqual({
+    agentType: 'Explore', description: 'Map i18n wiring', toolUseId: 'toolu_1',
+    parentAgentId: 'aRoot', spawnDepth: 2, isFork: true, name: 'code-review', model: 'haiku',
+  })
+})
+
+test('parseAgentMeta is total — junk, a non-object and an empty file all yield null', () => {
+  expect(parseAgentMeta('not json')).toBeNull()
+  expect(parseAgentMeta('[1,2]')).toBeNull()
+  expect(parseAgentMeta('"x"')).toBeNull()
+  expect(parseAgentMeta('')).toBeNull()
+})
+
+test('parseAgentMeta drops a field of the wrong type rather than carrying it', () => {
+  expect(parseAgentMeta('{"agentType":7,"spawnDepth":"2","toolUseId":null}')).toEqual({})
+})
+
+// ---------------------------------------------------------------- isNestedAgent
+
+test('a transcript with a parentAgentId or a depth past the first is NESTED', () => {
+  expect(isNestedAgent({ parentAgentId: 'aRoot', spawnDepth: 2 })).toBe(true)
+  expect(isNestedAgent({ spawnDepth: 2 })).toBe(true)
+  expect(isNestedAgent({ parentAgentId: 'aRoot' })).toBe(true)
+})
+
+test('a top-level transcript, and one whose meta could not be read, are not nested', () => {
+  expect(isNestedAgent({ spawnDepth: 1 })).toBe(false)
+  expect(isNestedAgent({})).toBe(false)
+  expect(isNestedAgent(null)).toBe(false)
+})
+
+// ---------------------------------------------------------------- describedFrom
+
+test('the meta names an invocation the parent could not', () => {
+  const out = describedFrom(inv('toolu_1', { agentType: 'unknown', description: '' }),
+    { agentType: 'general-purpose', description: '/code-review PR #276' })
+  expect(out.agentType).toBe('general-purpose')
+  expect(out.description).toBe('/code-review PR #276')
+})
+
+test('what the PARENT said is never overwritten by the meta', () => {
+  const out = describedFrom(inv('toolu_1', { agentType: 'Explore', description: 'Map i18n' }),
+    { agentType: 'general-purpose', description: 'something else' })
+  expect(out.agentType).toBe('Explore')
+  expect(out.description).toBe('Map i18n')
+})
+
+test('describedFrom returns the invocation itself when the meta adds nothing', () => {
+  const one = inv('toolu_1', { agentType: 'unknown', description: '' })
+  expect(describedFrom(one, null)).toBe(one)
+  expect(describedFrom(one, {})).toBe(one)
+})
+
+// ---------------------------------------------------------------- planAgentJoin
+
+test('an invocation is paired with the transcript its agentId names', () => {
+  const plan = planAgentJoin([inv('toolu_1', { agentId: 'aOne' })], [{ agentId: 'aOne', meta: {} }])
+  expect(plan.reads).toEqual([{ invocation: expect.objectContaining({ toolUseId: 'toolu_1' }), agentId: 'aOne' }])
+  expect(plan.unclaimed).toEqual([])
+})
+
+test('an invocation with NO agentId is paired through the meta’s own toolUseId', () => {
+  // C — the parent's result was the string "[Request interrupted by user for tool use]", so it
+  // carries no agentId at all. The meta beside the transcript is the only link left.
+  const plan = planAgentJoin([inv('toolu_1')], [{ agentId: 'aOne', meta: { toolUseId: 'toolu_1' } }])
+  expect(plan.reads[0]!.agentId).toBe('aOne')
+  expect(plan.unclaimed).toEqual([])
+})
+
+test('an agentId match is never stolen by a toolUseId match', () => {
+  const plan = planAgentJoin(
+    [inv('toolu_1', { agentId: 'aTwo' }), inv('toolu_2')],
+    [{ agentId: 'aTwo', meta: { toolUseId: 'toolu_2' } }, { agentId: 'aThree', meta: { toolUseId: 'toolu_2' } }],
+  )
+  expect(plan.reads[0]!.agentId).toBe('aTwo')
+})
+
+test('a toolUseId that names TWO transcripts pairs neither of them', () => {
+  // A half-read link is worse than none: it gets published as a measurement. The exact link
+  // (`agentId`) is unaffected — only the fallback refuses.
+  const plan = planAgentJoin(
+    [inv('toolu_1')],
+    [{ agentId: 'aOne', meta: { toolUseId: 'toolu_1' } }, { agentId: 'aTwo', meta: { toolUseId: 'toolu_1' } }],
+  )
+  expect(plan.reads[0]!.agentId).toBeNull()
+  expect(plan.unclaimed.map(e => e.agentId)).toEqual(['aOne', 'aTwo'])
+})
+
+test('a NESTED transcript is never paired and never reported unclaimed — it is counted inside its root', () => {
+  const plan = planAgentJoin(
+    [inv('toolu_1', { agentId: 'aRoot' })],
+    [{ agentId: 'aRoot', meta: { toolUseId: 'toolu_1' } },
+     { agentId: 'aChild', meta: { toolUseId: 'toolu_9', parentAgentId: 'aRoot', spawnDepth: 2 } }],
+  )
+  expect(plan.reads).toHaveLength(1)
+  expect(plan.reads[0]!.agentId).toBe('aRoot')
+  expect(plan.unclaimed).toEqual([])
+})
+
+test('a nested transcript is not paired even when its toolUseId matches an invocation', () => {
+  // It really happens: a nested agent's meta carries the toolUseId of the `Agent` call its PARENT
+  // made, which no entry in the session transcript ever matches — but nothing may rely on that.
+  const plan = planAgentJoin(
+    [inv('toolu_9')],
+    [{ agentId: 'aChild', meta: { toolUseId: 'toolu_9', spawnDepth: 2 } }],
+  )
+  expect(plan.reads[0]!.agentId).toBeNull()
+  expect(plan.unclaimed).toEqual([])
+})
+
+test('an invocation no transcript can serve reads nothing, and stays in the list', () => {
+  const plan = planAgentJoin([inv('toolu_1', { agentId: 'aGone' })], [])
+  expect(plan.reads).toEqual([{ invocation: expect.objectContaining({ toolUseId: 'toolu_1' }), agentId: null }])
+})
+
+test('a top-level transcript no invocation claims is reported, never silently dropped', () => {
+  const plan = planAgentJoin([], [{ agentId: 'aFork', meta: { isFork: true, spawnDepth: 1 } }])
+  expect(plan.reads).toEqual([])
+  expect(plan.unclaimed).toEqual([{ agentId: 'aFork', meta: { isFork: true, spawnDepth: 1 } }])
+})
+
+test('one transcript serves at most one invocation', () => {
+  const plan = planAgentJoin(
+    [inv('toolu_1', { agentId: 'aOne' }), inv('toolu_2', { agentId: 'aOne' })],
+    [{ agentId: 'aOne', meta: {} }],
+  )
+  expect(plan.reads[0]!.agentId).toBe('aOne')
+  expect(plan.reads[1]!.agentId).toBeNull()
+})
+
+test('the reads keep the parent’s order', () => {
+  const plan = planAgentJoin(
+    [inv('toolu_1', { agentId: 'aOne' }), inv('toolu_2', { agentId: 'aTwo' })],
+    [{ agentId: 'aTwo', meta: {} }, { agentId: 'aOne', meta: {} }],
+  )
+  expect(plan.reads.map(r => r.invocation.toolUseId)).toEqual(['toolu_1', 'toolu_2'])
+})

--- a/packages/server/server/subagent-join.ts
+++ b/packages/server/server/subagent-join.ts
@@ -1,0 +1,178 @@
+/**
+ * subagent-join.ts — PURE: which transcript belongs to which invocation.
+ *
+ * The parent transcript and the `subagents/` directory answer two different questions, and until
+ * now only the first was asked. The parent says how an agent was LAUNCHED and what it was asked to
+ * do; the directory is the authoritative record of which agents actually EXISTED. An agent the
+ * parent never names in the one shape the reader recognised — an `Agent` tool_use paired with the
+ * `tool_result` that answers it — therefore became no row at all.
+ *
+ * Measured on one machine, 2026-09-06: 541 subagent transcripts, of which four top-level ones
+ * (1,6 MB) were invisible or permanently unmeasured. Three shapes did it:
+ *
+ * - **The parent got a result with no `agentId`.** The user interrupted the call, so `toolUseResult`
+ *   is the STRING `"Error: [Request interrupted by user for tool use]"`. The agent had already run
+ *   and left a full transcript; the enrichment keyed only on `agentId` and skipped it. The link it
+ *   needed is `agent-<id>.meta.json`'s own `toolUseId`.
+ * - **The parent never got a result at all** — the plain background agent, launched and never
+ *   resolved in the transcript.
+ * - **The launch was not an `Agent` call.** A skill run in the background (`/code-review`) is a
+ *   `Skill` tool_use whose result carries `{ status: 'forked', background: true, agentId }`. The
+ *   parent names the agent; only the tool it came from is different.
+ *
+ * Two rules this module exists to keep:
+ *
+ * - **A NESTED transcript never becomes its own row.** It is already counted inside the invocation
+ *   that spawned it (`descendantsOf` in `subagent-metrics.ts`), so pairing it again would report
+ *   the same tokens twice. It is excluded from the candidate pool outright rather than by relying
+ *   on no invocation happening to match it.
+ * - **A top-level transcript nobody claims is REPORTED, never silently dropped.** Today those are
+ *   conversation forks (5 transcripts, 11,4 MB on the same machine), which have no `tool_use`
+ *   anywhere to key on and whose place in this product is a separate question — see issue #384. An
+ *   absence a caller can see is a fact; one this module swallowed would be a fact nobody could find.
+ */
+
+import type { AgentInvocation } from '@agentistics/core'
+
+/**
+ * What `agent-<id>.meta.json` carries beside a subagent's transcript.
+ *
+ * Every field is optional: the file's shape has already changed once (`model` and `name` appear
+ * only on the newer records) and a reader that requires a field is a reader that breaks on the next
+ * change. `toolUseId` is the one that matters — it is the link back to the parent's own tool call
+ * when the parent's result could not provide one.
+ */
+export interface AgentMeta {
+  agentType?: string
+  description?: string
+  toolUseId?: string
+  parentAgentId?: string
+  spawnDepth?: number
+  isFork?: boolean
+  name?: string
+  model?: string
+}
+
+/** One transcript found in a `subagents/` directory. */
+export interface AgentEntry {
+  agentId: string
+  meta: AgentMeta | null
+}
+
+export interface AgentJoinPlan {
+  /** Every invocation in the parent's own order, with the transcript that measures it — or `null`. */
+  reads: { invocation: AgentInvocation; agentId: string | null }[]
+  /** Top-level transcripts no invocation claims. Reported so a caller can say so; see issue #384. */
+  unclaimed: AgentEntry[]
+}
+
+const str = (v: unknown): string | undefined => (typeof v === 'string' && v ? v : undefined)
+
+/**
+ * Read one `agent-<id>.meta.json`. Total: junk, a non-object and an empty file all yield `null`,
+ * and a field of the wrong type is dropped rather than carried into the rest of the pipeline.
+ */
+export function parseAgentMeta(text: string): AgentMeta | null {
+  let raw: unknown
+  try { raw = JSON.parse(text) } catch { return null }
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null
+  const o = raw as Record<string, unknown>
+  const meta: AgentMeta = {}
+  const agentType = str(o.agentType); if (agentType) meta.agentType = agentType
+  const description = str(o.description); if (description) meta.description = description
+  const toolUseId = str(o.toolUseId); if (toolUseId) meta.toolUseId = toolUseId
+  const parentAgentId = str(o.parentAgentId); if (parentAgentId) meta.parentAgentId = parentAgentId
+  if (typeof o.spawnDepth === 'number' && Number.isFinite(o.spawnDepth)) meta.spawnDepth = o.spawnDepth
+  if (typeof o.isFork === 'boolean') meta.isFork = o.isFork
+  const name = str(o.name); if (name) meta.name = name
+  const model = str(o.model); if (model) meta.model = model
+  return meta
+}
+
+/**
+ * Is this transcript an agent spawned by another agent?
+ *
+ * Such a transcript is counted INSIDE the invocation at the root of its subtree, per the rule
+ * `agentNumbers` documents, so it must never also become a row of its own. A meta that could not be
+ * read is NOT treated as nested: excluding a transcript on a guess loses a real agent, while a
+ * missing exclusion is caught by the claim rules below.
+ */
+export function isNestedAgent(meta: AgentMeta | null): boolean {
+  if (!meta) return false
+  return meta.parentAgentId !== undefined || (meta.spawnDepth !== undefined && meta.spawnDepth > 1)
+}
+
+/**
+ * Fill in what the parent could not say, from the transcript's own meta.
+ *
+ * Only ever fills a BLANK: what the parent recorded is what the assistant actually asked for, and
+ * the meta is the harness's own restatement of it. A background forked skill is the case this
+ * exists for — its launch is a `Skill` call, so the parent names no agent type and no description,
+ * while the meta carries both.
+ */
+export function describedFrom(invocation: AgentInvocation, meta: AgentMeta | null): AgentInvocation {
+  if (!meta) return invocation
+  const needsType = !invocation.agentType || invocation.agentType === 'unknown'
+  const needsDescription = !invocation.description
+  const agentType = needsType ? meta.agentType : undefined
+  const description = needsDescription ? meta.description : undefined
+  if (!agentType && !description) return invocation
+  return {
+    ...invocation,
+    ...(agentType ? { agentType } : {}),
+    ...(description ? { description } : {}),
+  }
+}
+
+/**
+ * Pair each invocation with the transcript that measures it.
+ *
+ * Two passes, in this order and not the other: the `agentId` the parent recorded is an EXACT link,
+ * while the meta's `toolUseId` is a link back that only exists because the exact one is missing. A
+ * single pass would let a `toolUseId` match consume a transcript some other invocation names
+ * outright. One transcript serves at most one invocation, and one invocation reads at most one
+ * transcript — a second claim on either side reads `null` and stays unmeasured, which is the right
+ * answer to "these two rows describe the same agent" and is not a shape this module may invent
+ * around.
+ */
+export function planAgentJoin(
+  invocations: readonly AgentInvocation[],
+  entries: readonly AgentEntry[],
+): AgentJoinPlan {
+  const candidates = entries.filter(e => !isNestedAgent(e.meta))
+  const byAgentId = new Map(candidates.map(e => [e.agentId, e]))
+  // A `toolUseId` naming MORE THAN ONE transcript is ambiguous, and an ambiguous link pairs
+  // nothing: half-read options get published as a measurement, which is worse than an absence the
+  // surface renders as N/A. The exact `agentId` link above is unaffected.
+  const byToolUseId = new Map<string, AgentEntry | null>()
+  for (const e of candidates) {
+    const t = e.meta?.toolUseId
+    if (!t) continue
+    byToolUseId.set(t, byToolUseId.has(t) ? null : e)
+  }
+
+  const claimed = new Set<string>()
+  const paired = new Map<AgentInvocation, string>()
+
+  for (const invocation of invocations) {
+    const id = invocation.agentId
+    if (!id) continue
+    const entry = byAgentId.get(id)
+    if (!entry || claimed.has(entry.agentId)) continue
+    claimed.add(entry.agentId)
+    paired.set(invocation, entry.agentId)
+  }
+
+  for (const invocation of invocations) {
+    if (paired.has(invocation)) continue
+    const entry = byToolUseId.get(invocation.toolUseId) ?? null
+    if (!entry || claimed.has(entry.agentId)) continue
+    claimed.add(entry.agentId)
+    paired.set(invocation, entry.agentId)
+  }
+
+  return {
+    reads: invocations.map(invocation => ({ invocation, agentId: paired.get(invocation) ?? null })),
+    unclaimed: candidates.filter(e => !claimed.has(e.agentId)),
+  }
+}

--- a/packages/server/server/subagent-metrics.test.ts
+++ b/packages/server/server/subagent-metrics.test.ts
@@ -6,12 +6,19 @@ import type { SessionAgentMetrics } from '@agentistics/core'
 import { enrichFromSubagentTranscripts } from './subagent-metrics'
 
 /** A real directory tree, because the thing under test is the file layout itself. */
-async function machine(sessionId: string, files: Record<string, string[]>) {
+async function machine(
+  sessionId: string,
+  files: Record<string, string[]>,
+  metas: Record<string, unknown> = {},
+) {
   const root = await mkdtemp(join(tmpdir(), 'agentistics-subagents-'))
   const dir = join(root, sessionId, 'subagents')
   await mkdir(dir, { recursive: true })
   for (const [agentId, lines] of Object.entries(files)) {
     await writeFile(join(dir, `agent-${agentId}.jsonl`), lines.join('\n'))
+  }
+  for (const [agentId, meta] of Object.entries(metas)) {
+    await writeFile(join(dir, `agent-${agentId}.meta.json`), JSON.stringify(meta))
   }
   return { transcriptPath: join(root, `${sessionId}.jsonl`) }
 }
@@ -93,4 +100,84 @@ test('an invocation that already has numbers is left exactly as it is', async ()
   const out = await enrichFromSubagentTranscripts(metrics(legacy), transcriptPath, 's5')
 
   expect(out.invocations[0]!.outputTokens).toBe(42)
+})
+
+test('an invocation with NO agentId is measured through the meta’s own toolUseId', async () => {
+  // The user interrupted the `Agent` call, so the parent's `toolUseResult` is the STRING
+  // "Error: [Request interrupted by user for tool use]" and carries no agentId at all. The agent
+  // had already run: 60 KB of transcript on the machine this was measured on.
+  const { transcriptPath } = await machine('s6',
+    { aOne: [turn('claude-sonnet-5', 700)] },
+    { aOne: { agentType: 'general-purpose', description: 'Implement Task 5', toolUseId: 'toolu_1', spawnDepth: 1 } },
+  )
+  const inv = { ...unmeasured('toolu_1', 'aOne') }
+  delete (inv as Record<string, unknown>).agentId
+
+  const out = await enrichFromSubagentTranscripts(metrics(inv), transcriptPath, 's6')
+
+  expect(out.invocations[0]!.unmeasured).toBeUndefined()
+  expect(out.invocations[0]!.outputTokens).toBe(700)
+})
+
+test('the meta names an agent the parent could not — the background forked skill', async () => {
+  const { transcriptPath } = await machine('s7',
+    { aSkill: [turn('claude-sonnet-5', 500)] },
+    { aSkill: { agentType: 'general-purpose', description: '/code-review high origin/dev...HEAD', name: 'code-review', spawnDepth: 1 } },
+  )
+  const inv = { ...unmeasured('toolu_1', 'aSkill'), agentType: 'unknown', description: '' }
+
+  const out = await enrichFromSubagentTranscripts(metrics(inv), transcriptPath, 's7')
+
+  expect(out.invocations[0]!.agentType).toBe('general-purpose')
+  expect(out.invocations[0]!.description).toBe('/code-review high origin/dev...HEAD')
+  expect(out.invocations[0]!.outputTokens).toBe(500)
+})
+
+test('what the PARENT recorded survives the meta', async () => {
+  const { transcriptPath } = await machine('s8',
+    { aOne: [turn('claude-sonnet-5', 1)] },
+    { aOne: { agentType: 'general-purpose', description: 'the harness’s own wording' } },
+  )
+
+  const out = await enrichFromSubagentTranscripts(metrics(unmeasured('toolu_1', 'aOne')), transcriptPath, 's8')
+
+  expect(out.invocations[0]!.agentType).toBe('general-purpose')
+  expect(out.invocations[0]!.description).toBe('d')
+})
+
+test('a NESTED transcript never becomes a row of its own', async () => {
+  // It is already counted inside the invocation that spawned it. A second row would report the
+  // same tokens twice — and its meta carries a toolUseId, so nothing may rely on no match.
+  const { transcriptPath } = await machine('s9',
+    {
+      aRoot: [turn('claude-sonnet-5', 100), JSON.stringify({ type: 'user', toolUseResult: { agentId: 'aChild' } })],
+      aChild: [turn('claude-sonnet-5', 900)],
+    },
+    {
+      aRoot: { toolUseId: 'toolu_1', spawnDepth: 1 },
+      aChild: { toolUseId: 'toolu_2', parentAgentId: 'aRoot', spawnDepth: 2 },
+    },
+  )
+
+  const out = await enrichFromSubagentTranscripts(
+    metrics(unmeasured('toolu_1', 'aRoot'), { ...unmeasured('toolu_2', 'aGone') }), transcriptPath, 's9')
+
+  expect(out.invocations[0]!.outputTokens).toBe(1000)
+  expect(out.invocations[1]!.unmeasured).toBe(true)
+  expect(out.invocations).toHaveLength(2)
+})
+
+test('a top-level transcript nobody claims adds no row — the list is the parent’s', async () => {
+  // Conversation forks: 5 transcripts and 11,4 MB on the machine measured. They belong to no
+  // `tool_use` anywhere, and whether they are agent invocations at all is issue #384.
+  const { transcriptPath } = await machine('s10',
+    { aFork: [turn('claude-sonnet-5', 4242)] },
+    { aFork: { agentType: 'fork', isFork: true, description: 'the user’s own message', spawnDepth: 1 } },
+  )
+
+  const out = await enrichFromSubagentTranscripts(metrics(unmeasured('toolu_1', 'aGone')), transcriptPath, 's10')
+
+  expect(out.invocations).toHaveLength(1)
+  expect(out.invocations[0]!.unmeasured).toBe(true)
+  expect(out.totalTokens).toBe(0)
 })

--- a/packages/server/server/subagent-metrics.ts
+++ b/packages/server/server/subagent-metrics.ts
@@ -16,10 +16,11 @@
  * fact nobody can recover, and reporting it as zero would be the very defect this fixes.
  */
 
-import { readFile, stat } from 'fs/promises'
+import { readFile, readdir, stat } from 'fs/promises'
 import { dirname, join } from 'path'
 import type { AgentInvocation, SessionAgentMetrics } from '@agentistics/core'
 import { agentNumbers, summarizeSubagentTranscript, totalsOf, type SubagentSummary } from './subagent-parse'
+import { describedFrom, parseAgentMeta, planAgentJoin, type AgentEntry } from './subagent-join'
 
 /**
  * Parsed subagent transcripts, keyed by path + mtime + size.
@@ -71,31 +72,65 @@ async function descendantsOf(
 }
 
 /**
- * Fill in every UNMEASURED invocation that names a transcript this machine still has.
+ * Every transcript in one `subagents/` directory, with the meta that names it.
  *
- * Total: a session with no `subagents/` directory, an unreadable file or an invocation with no
- * `agentId` comes back exactly as it went in.
+ * The directory is the authoritative record of which agents EXISTED — the parent transcript only
+ * says how each was launched, and it does not always say even that. A meta that is missing or
+ * unreadable yields `null` rather than dropping the transcript: a file we cannot describe is still
+ * a file, and `planAgentJoin` can still pair it by `agentId`.
+ */
+async function entriesIn(dir: string): Promise<AgentEntry[]> {
+  let names: string[]
+  try { names = await readdir(dir) } catch { return [] }
+
+  const entries: AgentEntry[] = []
+  for (const name of names) {
+    const agentId = /^agent-(.+)\.jsonl$/.exec(name)?.[1]
+    if (!agentId) continue
+    const text = await readFile(join(dir, `agent-${agentId}.meta.json`), 'utf-8').catch(() => '')
+    entries.push({ agentId, meta: text ? parseAgentMeta(text) : null })
+  }
+  return entries
+}
+
+/**
+ * Fill in every UNMEASURED invocation whose transcript this machine still has.
+ *
+ * The pairing is `subagent-join.ts`'s, and it is the whole point: keying only on
+ * `toolUseResult.agentId` left an interrupted call, a launch the parent never answered and a
+ * background forked skill permanently unmeasured, although all three had a full transcript beside
+ * the session. The meta's own `toolUseId` is the link back in exactly those cases.
+ *
+ * Total: a session with no `subagents/` directory, an unreadable file or an invocation nothing on
+ * disk can serve comes back exactly as it went in — `unmeasured`, which a surface renders N/A,
+ * never a zero. A transcript the join leaves UNCLAIMED adds no row: the invocation list is the
+ * parent's, and a conversation fork is not an agent this conversation dispatched (issue #384).
  */
 export async function enrichFromSubagentTranscripts(
   metrics: SessionAgentMetrics,
   transcriptPath: string,
   sessionId: string,
 ): Promise<SessionAgentMetrics> {
-  if (!metrics.invocations.some(i => i.unmeasured && i.agentId)) return metrics
+  if (!metrics.invocations.some(i => i.unmeasured)) return metrics
 
   const dir = join(dirname(transcriptPath), sessionId, 'subagents')
+  const entries = await entriesIn(dir)
+  if (entries.length === 0) return metrics
+
+  const plan = planAgentJoin(metrics.invocations, entries)
+  const metaOf = new Map(entries.map(e => [e.agentId, e.meta]))
   const invocations: AgentInvocation[] = []
   let changed = false
 
-  for (const inv of metrics.invocations) {
-    if (!inv.unmeasured || !inv.agentId) { invocations.push(inv); continue }
+  for (const { invocation, agentId } of plan.reads) {
+    if (!invocation.unmeasured || !agentId) { invocations.push(invocation); continue }
 
-    const root = await summaryFor(join(dir, `agent-${inv.agentId}.jsonl`))
-    if (!root) { invocations.push(inv); continue }
+    const root = await summaryFor(join(dir, `agent-${agentId}.jsonl`))
+    if (!root) { invocations.push(invocation); continue }
 
-    const descendants = await descendantsOf(dir, root, new Set([inv.agentId]))
-    const { unmeasured: _dropped, ...rest } = inv
-    invocations.push({ ...rest, ...agentNumbers(root, descendants) })
+    const descendants = await descendantsOf(dir, root, new Set([agentId]))
+    const { unmeasured: _dropped, ...rest } = describedFrom(invocation, metaOf.get(agentId) ?? null)
+    invocations.push({ ...rest, agentId, ...agentNumbers(root, descendants) })
     changed = true
   }
 


### PR DESCRIPTION
## Summary

- The invocation list is built from the `subagents/` **directory** joined to the parent, not from
  `Agent` tool_uses in the parent alone — so an agent the parent never names that way stops being
  invisible.
- Three shapes that produced no row, or a permanently unmeasured one: an **interrupted** call, a
  **background agent** the parent never answered, and a **background forked skill** (`/code-review`,
  a `Skill` tool_use whose result is `{status:'forked', background:true, agentId}`).
- Two gates had the same defect and are widened; `cachedEnrich` — the path serving most Claude
  sessions — never gained #373's enrichment and now applies it, outside its memo.

## Motivation

Refs #383. `extractAgentMetrics` recognised exactly one shape: an `Agent` `tool_use` paired with the
`tool_result` that answers it. That is a statement about the TOOL that launched an agent, not about
whether one ran. The `subagents/` directory is the authoritative record of which agents existed; the
parent is authoritative for how each was launched, and it does not always say even that.

**Measured 2026-09-06, one machine** — 408 conversations, 47 with a `subagents/` directory, **541
subagent transcripts on disk**:

| | transcripts | before |
|---|---|---|
| nested (`spawnDepth > 1`) | 4 | correct — folded into their root invocation |
| `Agent` tool_use + `toolUseResult.agentId` | 528 | measured |
| `Agent` tool_use, result carries **no** `agentId` (user interrupted it) | 1 | row existed, permanently **unmeasured** |
| `Agent` tool_use, parent **never got a result** | 1 | **no row at all** |
| **background forked skill** (`Skill` tool_use) | 2 | **no row at all** |
| conversation fork, no `tool_use` anywhere | 5 | no row — out of scope, issue #384 |

## Changes

- **`packages/server/server/subagent-join.ts`** — NEW, pure. `parseAgentMeta` (total: junk yields
  `null`, a field of the wrong type is dropped), `isNestedAgent`, `describedFrom` and
  `planAgentJoin`. The join pairs by the **exact `agentId` first** and only then by the meta's own
  `toolUseId` — a single pass would let the fallback consume a transcript another invocation names
  outright. One transcript serves at most one invocation, and a `toolUseId` naming **two**
  transcripts is ambiguous and pairs **neither**: a half-read link is published as a measurement,
  while an absence is rendered N/A. A **nested** transcript is excluded from the candidate pool
  outright rather than by relying on no invocation happening to match it — its meta carries a
  `toolUseId` too, and a second row would report the same tokens twice. A top-level transcript
  nobody claims adds no row and is **reported** (`AgentJoinPlan.unclaimed`) rather than swallowed.
- **`agent-metrics.ts`** — a `tool_result` that NAMES an agent is a launch whatever tool produced it
  (the forked skill), and an `Agent` tool_use left unresolved at end of file becomes an invocation,
  appended after the answered ones because the transcript gives no moment to place it at. An agent
  already recorded never opens a second row: a later tool reporting ON one is a report, not a spawn.
- **`subagent-metrics.ts`** — reads the directory (`entriesIn`), runs the join, and fills
  `agentType` / `description` from the meta **only when the parent said nothing**. What the parent
  recorded is never overwritten.
- **`jsonl.ts`** — `sawAgentLaunch`. The reader ran only when `toolCounts['Agent']` was set, so a
  conversation whose only agent was a forked skill was never read at all; `uses_task_agent` had the
  same hole.
- **`parse-cache-jsonl.ts`** — `withSubagentNumbers` applies the enrichment **outside** the memo.
  Caching the enriched result would be the smaller diff and the wrong one: that memo is keyed on the
  PARENT's stamp, and a subagent's file goes on changing while the conversation sits idle, so the
  numbers would freeze at the first read. `SESSION_SHAPE` and `ENRICH_SHAPE` bumped to `v3`, or
  every already-cached transcript would keep answering in the old shape.
- **`docs/data-sources.md`**, **`CLAUDE.md`** — the rules above, with the measurement.

No change to `AgentInvocation` or `SessionAgentMetrics`: every row this adds carries a real
`toolUseId` from the parent, so no public-contract Discussion is needed.

## Test plan

- [x] `bun tsc --noEmit` clean; **`bun test` — 6161 pass, 0 fail** (before and after merging `dev`).
- [x] 18 new tests in `subagent-join.test.ts`, 5 in `agent-metrics.test.ts`, 5 in
      `subagent-metrics.test.ts` — including the two that must NOT regress: a nested transcript never
      becomes its own row, and an unclaimed one adds none.
- [x] **Before/after on the real machine**, same `parseSessionJsonl` over every conversation with a
      `subagents/` directory:

  | | before (`origin/dev`) | after |
  |---|---|---|
  | sessions reporting agent metrics | 33 | **35** |
  | invocations | 535 | **538** |
  | unmeasured | 6 | **5** |
  | agent cost | US$ 1.225,06 | **US$ 1.247,11** |

  Per conversation — and the delta closes exactly on `2,05 + 4,19 + 15,76 + 0,05 = 22,05`:

  | conversation | before | after |
  |---|---|---|
  | `f6820c84` `/code-review` in the background | **no metrics at all** | 1 inv · 6.791.459 tok · US$ 2,05 |
  | `1c308076` `/code-review` in the background | **no metrics at all** | 1 inv · 5.042.914 tok · US$ 4,19 |
  | `c40379e9` agent launched, never answered | 39 inv · 4.943.417 tok · US$ 5,15 | 40 inv · **29.224.641** tok · US$ 20,91 |
  | `aabe988b` interrupted call | 36 inv · 2 unmeasured · US$ 4,56 | 36 inv · **1** unmeasured · US$ 4,61 |
  | `731e8d13` (66 transcripts, 2 nested) | 65 inv · US$ 369,83 | **unchanged** |
  | `a67d7dd2` (30 transcripts, 1 nested) | 29 inv · US$ 10,59 | **unchanged** |

  The one invocation still unmeasured in `aabe988b` has no transcript on disk — the honest N/A this
  repository asks for, not a zero.
- [x] End-to-end through `GET /api/data` on a server started from this branch with an **isolated
      `AGENTISTICS_DIR`** (so the consolidate store written by the machine's running build could not
      contaminate the reading): the same six figures.
- No UI component changed; `AgentMetricsPanel` already renders `<Absent />` per unmeasured row.

Out of scope, filed separately: **conversation forks** (5 transcripts, 11,4 MB) — issue #384. They
belong to no `tool_use` anywhere, `AgentInvocation.toolUseId` is required, and whether they are
invocations of the conversation they are filed under is a product question that wants a Discussion
first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011vr7Fj45fAi9WsPrYkhp9C
