### PR TITLE
release: a conversation fork is labelled as one

### DIFF
--- a/packages/web/src/components/sessions/ArtifactsAside.tsx
+++ b/packages/web/src/components/sessions/ArtifactsAside.tsx
@@ -1931,6 +1931,20 @@ function SubagentCard({ row, pt, now, onOpen }: {
   const unmeasured = unmeasuredText(row, pt)
   const unpriced = unpricedText(row, pt)
   const title = row.description ?? row.agentType ?? row.agentId
+  /**
+   * A FORK IS NOT A SUBAGENT, AND THE ROW HAS TO SAY SO.
+   *
+   * Reported as the two halves of one screen contradicting each other: this panel showed
+   * "Subagents 1" while the session's own metrics card said none had run. The card was RIGHT. What
+   * is listed here is a conversation FORK — `agentType: 'fork'`, no `toolUseId`, claimed by no
+   * `tool_use` anywhere — and `agent-metrics.ts` deliberately files those outside the invocation
+   * list for exactly that reason: nothing dispatched it, so counting it as an agent this session
+   * ran would make the totals wrong in the direction that reads as work you did not do.
+   *
+   * It is still SHOWN, because it is real work with real tokens against this conversation and
+   * finding it any other way means a file manager. It is shown as what it is.
+   */
+  const isFork = row.agentType === 'fork'
   return (
     <button
       onClick={onOpen}
@@ -1956,6 +1970,16 @@ function SubagentCard({ row, pt, now, onOpen }: {
           )}
           {st.text}
         </span>
+        {/* Named, not merely styled: "fork" beside a status a reader already knows how to read is
+            the shortest way to say this row is a different KIND of thing from the ones around it. */}
+        {isFork && (
+          <span style={{
+            fontSize: 9, fontWeight: 700, letterSpacing: 0.4, textTransform: 'uppercase',
+            flexShrink: 0, padding: '1px 5px', borderRadius: 5,
+            color: 'var(--text-secondary)', background: 'var(--bg-elevated)',
+            border: '1px solid var(--border-subtle)',
+          }}>{pt ? 'fork' : 'fork'}</span>
+        )}
         <span style={{
           fontSize: 12, fontWeight: 600, color: 'var(--text-primary)', minWidth: 0,
           overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',


### PR DESCRIPTION
## Summary

One commit, on top of release #390.

**A conversation fork is labelled as one, not shown as a subagent.** Reported as two halves of one
screen contradicting each other: the aside said "Subagents 1" while the session's own metrics card
said none had run. The card was right — `GET /api/fleet/subagents` returns that row as
`agentType: 'fork'`, `toolUseId: null`, claimed by no `tool_use` anywhere, and `agent-metrics.ts`
files forks outside the invocation list on purpose: nothing dispatched it, so counting it as an
agent this session ran makes the totals wrong in the direction that reads as work you did not do.

The row is still shown — it is real work with real tokens against the conversation — but it now
says what it is.

Named rather than hidden: the tab's badge still counts forks, because that number is the route's
`total` and rows are paged, so the client cannot recompute it without the server separating the
two. The row's own label is what explains the mismatch today; the count is a follow-up.

## Test plan

- `bun tsc --noEmit` clean.
- `bun test`: 6721 pass / 0 fail across 428 files.
- Measured against the running server: the row in question comes back `agentType: "fork"` with a
  null `toolUseId`, which is what settled which of the two surfaces was wrong.

## Notes for the merge

**Merge commit, never squash** (AGENTS.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169AqN9y1YGiog3T4qTLVfA
