### PR TITLE
fix(backup): a daily schedule runs once a day, at an hour you choose

### DIFF
--- a/packages/server/server/backup-routes.ts
+++ b/packages/server/server/backup-routes.ts
@@ -68,6 +68,9 @@ export interface BackupStatusJson {
     scheduleActive: boolean
     /** Hours between runs when `schedule` is `'custom'`; null when it has never been set. */
     customHours: number | null
+    /** The local hour a daily/weekly run is anchored to; null when never chosen (reads as the
+     *  default in `schedule.ts`, which is the one place that decides it). */
+    atHour: number | null
     keep: number
     /** What EVERY retained backup occupies together, already formatted. */
     retainedLabel: string
@@ -104,6 +107,8 @@ export interface BackupConfigPatch {
   schedule?: ScheduleId
   /** Hours between runs, when `schedule` is `'custom'`. */
   customHours?: number
+  /** The local hour a daily/weekly run is anchored to. */
+  atHour?: number
 }
 
 /**
@@ -157,7 +162,8 @@ export async function readBackupStatus(): Promise<BackupStatusJson> {
   const last = lastBackup(entries)
   const st = scheduleStatus({
     schedule: prefs.schedule,
-    customHours: prefs.customHours,
+    customHours: prefs.customHours, atHour: prefs.atHour,
+    tzOffsetMinutes: new Date().getTimezoneOffset(),
     lastAt: last?.at ?? null,
     nowMs: Date.now(),
     serverRunning: existsSync(join(AGENTISTICS_DATA_DIR, 'events-producer.json')),
@@ -173,6 +179,7 @@ export async function readBackupStatus(): Promise<BackupStatusJson> {
       // Sent even when the schedule is not `custom`, so switching to it in the interface shows the
       // number the user last chose rather than an empty field.
       customHours: prefs.customHours ?? null,
+      atHour: prefs.atHour ?? null,
       scheduleActive: st.kind === 'next',
       keep: prefs.keep,
       retainedLabel: formatBytes(retainedTotal(entries.filter(e => e.present))),
@@ -252,7 +259,11 @@ export async function updateBackupConfig(
       && (!Number.isFinite(patch.customHours) || patch.customHours <= 0)) {
       return { ok: false, reason: 'custom schedule takes a positive number of hours' }
     }
-    await writeBackupSchedule(patch.schedule, patch.customHours)
+    // Validated for SHAPE here and clamped by `normalizeHour` — same division as `customHours`.
+    if (patch.atHour !== undefined && !Number.isFinite(patch.atHour)) {
+      return { ok: false, reason: 'the hour of day must be a number' }
+    }
+    await writeBackupSchedule(patch.schedule, patch.customHours, patch.atHour)
   }
   return { ok: true, status: await readBackupStatus() }
 }

--- a/packages/server/server/backup/backup-store.test.ts
+++ b/packages/server/server/backup/backup-store.test.ts
@@ -3,8 +3,8 @@ import { mkdtempSync, rmSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import {
-  lastBackup, lastPerHarness, loadBackupHistory, markPresence, readBackups, readPrunedPaths,
-  recordBackup, recordPrune, toPrune, type BackupRecord,
+  lastBackup, lastBackupRun, lastPerHarness, loadBackupHistory, markPresence, readBackups,
+  readPrunedPaths, recordBackup, recordPrune, toPrune, type BackupRecord,
 } from './backup-store'
 
 const rec = (over: Partial<BackupRecord> & { at: string; path: string }): BackupRecord => ({
@@ -193,4 +193,36 @@ test('a torn or hand-edited line is skipped on both reads, never thrown on', asy
   } finally {
     cleanup()
   }
+})
+
+// --- when one last RAN, which is a different question -----------------------
+//
+// THE BUG THIS EXISTS FOR, measured on a real machine: a `daily` schedule fired every fifteen
+// minutes for hours. With `deleteLocalAfterUpload` on, every scheduled run uploaded its archive
+// and deleted the local copy, so no run it performed was ever `present`; the newest surviving file
+// stayed a day old, "more than 24 h ago" was permanently true, and every tick started another
+// 112 MB backup. The schedule was asking the restore question.
+
+test('the last RUN counts a backup whose file was uploaded and deleted', () => {
+  const entries = markPresence([
+    rec({ at: '2026-09-07T19:11:36Z', path: '/b/uploaded.tar.zst' }),
+    rec({ at: '2026-09-06T16:12:22Z', path: '/b/still-here.tar.zst' }),
+  ], NONE, p => p === '/b/still-here.tar.zst')
+  // What can I restore from? The one still on disk.
+  expect(lastBackup(entries)?.at).toBe('2026-09-06T16:12:22Z')
+  // When did one last run? The one that ran.
+  expect(lastBackupRun(entries)?.at).toBe('2026-09-07T19:11:36Z')
+})
+
+test('the last run is order-independent — it does not depend on the caller having sorted', () => {
+  const entries = markPresence([
+    rec({ at: '2026-09-01T00:00:00Z', path: '/b/a.tar.zst' }),
+    rec({ at: '2026-09-09T00:00:00Z', path: '/b/c.tar.zst' }),
+    rec({ at: '2026-09-05T00:00:00Z', path: '/b/b.tar.zst' }),
+  ], NONE, () => false)
+  expect(lastBackupRun(entries)?.at).toBe('2026-09-09T00:00:00Z')
+})
+
+test('with no records at all there is no last run', () => {
+  expect(lastBackupRun([])).toBeNull()
 })

--- a/packages/server/server/backup/backup-store.ts
+++ b/packages/server/server/backup/backup-store.ts
@@ -128,6 +128,32 @@ export function lastBackup(entries: BackupHistoryEntry[]): BackupHistoryEntry | 
 }
 
 /**
+ * When a backup last RAN — regardless of whether its file is still here.
+ *
+ * A different question from `lastBackup`, which answers "what can I restore from" and therefore
+ * requires the file to be present. Confusing the two is what made a daily schedule fire every
+ * fifteen minutes, measured on a real machine: with `deleteLocalAfterUpload` on, every scheduled
+ * run uploaded its archive and deleted the local copy, so no run it performed was ever `present`.
+ * The newest surviving file stayed a day old, "more than 24 h since the last backup" became
+ * permanently true, and every tick of the daemon started another one — 13 backups in three hours,
+ * each 112 MB, each re-downloaded to verify its hash.
+ *
+ * So the SCHEDULE reads this, and only the restore surfaces read `lastBackup`. A run that happened
+ * and was uploaded happened, whatever became of the local copy.
+ *
+ * Order-INDEPENDENT for the same reason `lastPerHarness` is: `markPresence` sorts, but a function
+ * whose answer depends on its caller having sorted silently becomes wrong the day one does not.
+ */
+export function lastBackupRun(entries: BackupHistoryEntry[]): BackupHistoryEntry | null {
+  let best: BackupHistoryEntry | null = null
+  for (const e of entries) {
+    if (!e.at) continue
+    if (best === null || e.at > best.at) best = e
+  }
+  return best
+}
+
+/**
  * When each harness was last covered by a backup that still exists.
  *
  * Deliberately order-INDEPENDENT: it keeps the maximum rather than the first hit. `markPresence`

--- a/packages/server/server/backup/daemon.ts
+++ b/packages/server/server/backup/daemon.ts
@@ -10,7 +10,7 @@
  */
 import { readPreferences } from '../preferences'
 import { performBackup, readBackupPrefs } from '../cli-backup'
-import { lastBackup, loadBackupHistory } from './backup-store'
+import { lastBackupRun, loadBackupHistory } from './backup-store'
 import { isDue } from './schedule'
 
 const CHECK_MS = 15 * 60_000
@@ -30,10 +30,14 @@ export function startScheduledBackup(log: (line: string) => void = console.log):
     try {
       const prefs = readBackupPrefs(await readPreferences())
       const entries = await loadBackupHistory()
-      const last = lastBackup(entries)
+      // `lastBackupRun`, NOT `lastBackup`: the schedule asks when one last RAN, and a run whose
+      // archive was uploaded and then deleted locally still ran. Reading the restorable-from one
+      // here made a daily schedule fire every fifteen minutes — see backup-store.ts.
+      const last = lastBackupRun(entries)
       // serverRunning is true by construction: this code only runs inside the daemon.
       const verdict = isDue({
         schedule: prefs.schedule, customHours: prefs.customHours,
+        atHour: prefs.atHour, tzOffsetMinutes: new Date().getTimezoneOffset(),
         lastAt: last?.at ?? null, nowMs: Date.now(), serverRunning: true,
       })
       if (!verdict.due) return

--- a/packages/server/server/backup/github-restore.test.ts
+++ b/packages/server/server/backup/github-restore.test.ts
@@ -14,7 +14,7 @@ import { join } from 'path'
 import { buildReleaseBody } from './backup-github'
 import type { FetchLike } from './github-api'
 import {
-  downloadBackupAsset, downloadBackupRelease, groupReleasesByMachine, listBackupReleases,
+  downloadBackupAsset, downloadBackupRelease, groupReleasesByMachine, listBackupReleases, releaseInstant,
   newestForMachine, pickBackupAsset,
   pickBackupRelease, type GithubReleaseInfo,
 } from './github-restore'
@@ -84,9 +84,9 @@ async function withDestDir(fn: (destDir: string) => Promise<void>): Promise<void
 
 describe('pickBackupRelease', () => {
   const releases = (): GithubReleaseInfo[] => [
-    { id: 1, tagName: 'backup-2026-09-01T00-00-00Z', createdAt: '2026-09-01T00:00:00Z', body: '', assets: [] },
-    { id: 2, tagName: 'backup-2026-09-03T00-00-00Z', createdAt: '2026-09-03T00:00:00Z', body: '', assets: [] },
-    { id: 3, tagName: 'v1.0.0', createdAt: '2026-09-04T00:00:00Z', body: '', assets: [] }, // hand-made, newer!
+    { id: 1, tagName: 'backup-2026-09-01T00-00-00Z', createdAt: '2026-09-01T00:00:00Z', publishedAt: '2026-09-01T00:00:00Z', body: '', assets: [] },
+    { id: 2, tagName: 'backup-2026-09-03T00-00-00Z', createdAt: '2026-09-03T00:00:00Z', publishedAt: '2026-09-03T00:00:00Z', body: '', assets: [] },
+    { id: 3, tagName: 'v1.0.0', createdAt: '2026-09-04T00:00:00Z', publishedAt: '2026-09-04T00:00:00Z', body: '', assets: [] }, // hand-made, newer!
   ]
 
   test('without --release, picks the newest release whose tag isBackupTag recognises', () => {
@@ -120,7 +120,7 @@ describe('pickBackupRelease', () => {
 
 describe('pickBackupAsset', () => {
   const release = (assets: { id: number; name: string; size: number }[]): GithubReleaseInfo => (
-    { id: 1, tagName: 'backup-x', createdAt: '2026-01-01T00:00:00Z', body: '', assets }
+    { id: 1, tagName: 'backup-x', createdAt: '2026-01-01T00:00:00Z', publishedAt: '2026-01-01T00:00:00Z', body: '', assets }
   )
 
   test('matches the single asset whose size equals the summary archiveBytes', () => {
@@ -449,4 +449,47 @@ test('the newest release OF A GIVEN MACHINE is selectable', () => {
   // Asking for a machine that has nothing here answers NOTHING — never the newest of some other
   // machine, which would restore the wrong computer onto this one without saying so.
   expect(newestForMachine(list, 'tablet')).toBe(null)
+})
+
+// --- when a release actually happened ---------------------------------------
+//
+// MEASURED on a real backup repository: four releases from four different uploads, GitHub's
+// `created_at` IDENTICAL on all four (`2026-09-06T16:24:54Z`) because every backup tag hangs off
+// the same commit, while `published_at` differed by hours. Two things broke: the restore list
+// printed one date on every card, and `pickBackupRelease` sorted on that constant — a no-op sort,
+// so "the newest backup" was whichever GitHub returned first.
+
+test('the instant comes from the tag agentop stamped, not from created_at', () => {
+  expect(releaseInstant({
+    tagName: 'backup-alienware-2026-09-07T19-11-36-983Z',
+    publishedAt: '2026-09-07T19:11:38Z',
+    createdAt: '2026-09-06T16:24:54Z',
+  })).toBe('2026-09-07T19:11:36.983Z')
+})
+
+test('a release agentop did not tag falls back to published_at, never created_at', () => {
+  expect(releaseInstant({
+    tagName: 'v1.0.0', publishedAt: '2026-09-07T10:00:00Z', createdAt: '2026-09-06T16:24:54Z',
+  })).toBe('2026-09-07T10:00:00Z')
+})
+
+test('with neither, created_at is the last resort so nothing sorts nowhere', () => {
+  expect(releaseInstant({ tagName: 'v1', publishedAt: '', createdAt: '2026-09-06T16:24:54Z' }))
+    .toBe('2026-09-06T16:24:54Z')
+  expect(releaseInstant({ tagName: 'v1', createdAt: '2026-09-06T16:24:54Z' }))
+    .toBe('2026-09-06T16:24:54Z')
+})
+
+test('the real repository: a constant created_at still orders correctly', () => {
+  const SAME = '2026-09-06T16:24:54Z'
+  const list: GithubReleaseInfo[] = [
+    { id: 1, tagName: 'backup-braiaode2-2026-09-06T16-24-49-398Z', createdAt: SAME, publishedAt: '2026-09-06T16:24:55Z', body: '', assets: [] },
+    { id: 2, tagName: 'backup-alienware-2026-09-07T19-11-36-983Z', createdAt: SAME, publishedAt: '2026-09-07T19:11:38Z', body: '', assets: [] },
+    { id: 3, tagName: 'backup-alienware-2026-09-07T18-55-54-355Z', createdAt: SAME, publishedAt: '2026-09-07T18:56:03Z', body: '', assets: [] },
+  ]
+  const picked = pickBackupRelease(list)
+  expect(picked.ok).toBe(true)
+  if (!picked.ok) return
+  // The genuinely newest upload, not whichever the API listed first.
+  expect(picked.release.tagName).toBe('backup-alienware-2026-09-07T19-11-36-983Z')
 })

--- a/packages/server/server/backup/github-restore.ts
+++ b/packages/server/server/backup/github-restore.ts
@@ -45,7 +45,11 @@ export interface GithubReleaseAsset {
 export interface GithubReleaseInfo {
   id: number
   tagName: string
+  /** GitHub's `created_at`, which is the TAG'S COMMIT date and NOT when the release was made.
+   *  Kept because it is what the API said; never used to order or display — see `releaseInstant`. */
   createdAt: string
+  /** GitHub's `published_at` — when the release actually appeared. */
+  publishedAt: string
   /** Raw markdown — `parseReleaseBody` is what turns this into something a caller can act on. */
   body: string
   assets: GithubReleaseAsset[]
@@ -55,6 +59,7 @@ interface RawGithubRelease {
   id: number
   tag_name: string
   created_at: string
+  published_at: string | null
   body: string | null
   assets: { id: number; name: string; size: number }[]
 }
@@ -74,10 +79,39 @@ export async function listGithubReleases(
     id: r.id,
     tagName: r.tag_name,
     createdAt: r.created_at,
+    publishedAt: r.published_at ?? '',
     body: r.body ?? '',
     assets: r.assets.map(a => ({ id: a.id, name: a.name, size: a.size })),
   }))
   return { ok: true, releases }
+}
+
+
+/** The timestamp agentop stamps into its own tags: `backup-<machine>-2026-09-07T19-11-36-983Z`. */
+const TAG_STAMP = /-(\d{4}-\d{2}-\d{2})T(\d{2})-(\d{2})-(\d{2})-(\d{3})Z$/
+
+/**
+ * WHEN A RELEASE ACTUALLY HAPPENED.
+ *
+ * Never `created_at`. GitHub sets that to the date of the COMMIT the tag points at, so a repository
+ * whose backup tags all hang off one commit reports the SAME instant for every release. Measured on
+ * a real backup repo: four releases, four different uploads, `created_at` identical on all four
+ * (`2026-09-06T16:24:54Z`) while `published_at` differed by hours.
+ *
+ * Two things were wrong because of it, and only one of them was visible. The restore list printed
+ * the same date on every card. And `pickBackupRelease` — which restores "the newest" when no tag is
+ * named — sorted on a field that is constant, so the sort was a no-op and the release it picked was
+ * whichever GitHub happened to return first.
+ *
+ * The order of preference is by how much each source can be trusted to be OURS: the timestamp
+ * agentop itself stamped into the tag, then GitHub's `published_at`, then `created_at` as the last
+ * resort so a release always sorts somewhere rather than vanishing.
+ */
+export function releaseInstant(r: { tagName: string; publishedAt?: string; createdAt: string }): string {
+  const m = TAG_STAMP.exec(r.tagName)
+  if (m) return `${m[1]}T${m[2]}:${m[3]}:${m[4]}.${m[5]}Z`
+  if (r.publishedAt) return r.publishedAt
+  return r.createdAt
 }
 
 export type PickReleaseResult =
@@ -99,7 +133,7 @@ export function pickBackupRelease(releases: GithubReleaseInfo[], tag?: string): 
   }
   const backups = [...releases]
     .filter(r => isBackupTag(r.tagName))
-    .sort((a, b) => b.createdAt.localeCompare(a.createdAt))
+    .sort((a, b) => releaseInstant(b).localeCompare(releaseInstant(a)))
   const newest = backups[0]
   return newest
     ? { ok: true, release: newest }
@@ -312,8 +346,8 @@ export async function listBackupReleases(
   if (!listed.ok) return { ok: false, message: listed.message }
   const releases = listed.releases
     .filter(r => isBackupTag(r.tagName))
-    .sort((a, b) => b.createdAt.localeCompare(a.createdAt))
-    .map(r => ({ tagName: r.tagName, createdAt: r.createdAt, summary: parseReleaseBody(r.body) }))
+    .sort((a, b) => releaseInstant(b).localeCompare(releaseInstant(a)))
+    .map(r => ({ tagName: r.tagName, createdAt: releaseInstant(r), summary: parseReleaseBody(r.body) }))
   return { ok: true, releases }
 }
 
@@ -352,13 +386,14 @@ export function groupReleasesByMachine(releases: ListedBackupRelease[]): Machine
   }
   const groups = [...byMachine.entries()].map(([machine, list]) => ({
     machine,
-    releases: [...list].sort((a, b) => b.createdAt.localeCompare(a.createdAt)),
+    releases: [...list].sort((a, b) => releaseInstant(b).localeCompare(releaseInstant(a))),
   }))
   return groups.sort((a, b) => {
     // The unattributable group is last whatever its dates: it is the one a person cannot act on
     // with confidence.
     if ((a.machine === null) !== (b.machine === null)) return a.machine === null ? 1 : -1
-    return (b.releases[0]?.createdAt ?? '').localeCompare(a.releases[0]?.createdAt ?? '')
+    const bi = b.releases[0], ai = a.releases[0]
+    return (bi ? releaseInstant(bi) : '').localeCompare(ai ? releaseInstant(ai) : '')
   })
 }
 

--- a/packages/server/server/backup/schedule.test.ts
+++ b/packages/server/server/backup/schedule.test.ts
@@ -1,7 +1,10 @@
 import { describe, test, expect } from 'bun:test'
 import { readFileSync } from 'fs'
 import { join } from 'path'
-import { MIN_CUSTOM_HOURS, intervalMs, isDue, scheduleStatus, SCHEDULE_IDS } from './schedule'
+import {
+  MIN_CUSTOM_HOURS, DEFAULT_HOUR, intervalMs, isDue, scheduleStatus, SCHEDULE_IDS,
+  normalizeHour, hourAnchorOnLocalDay, nextRunMs,
+} from './schedule'
 
 const DAY = 86_400_000
 const now = Date.parse('2026-09-04T12:00:00.000Z')
@@ -51,12 +54,16 @@ test('with the server stopped nothing is due and the status is `inactive`, with 
   expect(s.nextAtMs).toBeNull()
 })
 
-test('with the server running the status names the next time', () => {
+// A daily run is now ANCHORED to an hour, so the next time is that hour on the next day rather
+// than one interval after whenever the last one happened to fire.
+test('with the server running the status names the next anchored time', () => {
   const s = scheduleStatus({
-    schedule: 'daily', lastAt: new Date(now - DAY / 2).toISOString(), nowMs: now, serverRunning: true,
+    schedule: 'daily', atHour: 10, tzOffsetMinutes: 0,
+    lastAt: new Date(now - DAY / 2).toISOString(), nowMs: now, serverRunning: true,
   })
   expect(s.kind).toBe('next')
-  expect(s.nextAtMs).toBe(now + DAY / 2)
+  // last = 2026-09-04T00:00Z, so the next daily run is 2026-09-05T10:00Z.
+  expect(s.nextAtMs).toBe(Date.parse('2026-09-05T10:00:00.000Z'))
 })
 
 test('an off schedule reports off, not a missing next time', () => {
@@ -117,4 +124,74 @@ describe('custom — an interval the user picks', () => {
   test('custom is in SCHEDULE_IDS, so every surface offering the list offers it', () => {
     expect(SCHEDULE_IDS).toContain('custom')
   })
+})
+
+// --- the hour of the day ----------------------------------------------------
+
+test('an hour outside the clock is clamped, never refused — a field is an intent', () => {
+  expect(normalizeHour(undefined)).toBe(DEFAULT_HOUR)
+  expect(normalizeHour(NaN)).toBe(DEFAULT_HOUR)
+  expect(normalizeHour(-3)).toBe(0)
+  expect(normalizeHour(99)).toBe(23)
+  expect(normalizeHour(10.7)).toBe(10)
+})
+
+test('the anchor lands on the local clock, not on UTC', () => {
+  // UTC-3: 10:00 local is 13:00Z.
+  const at = hourAnchorOnLocalDay(Date.parse('2026-09-04T12:00:00Z'), 1, 10, 180)
+  expect(new Date(at).toISOString()).toBe('2026-09-05T13:00:00.000Z')
+})
+
+// THE BUG THIS EXISTS FOR: "daily" fired every 15 minutes. It must fire once.
+test('a daily run already taken today is not due again today', () => {
+  const base = { schedule: 'daily' as const, atHour: 10, tzOffsetMinutes: 0, serverRunning: true }
+  // Ran at 09:00, and it is now 11:00 — the anchor hour has passed, but the day already has a run.
+  const v = isDue({ ...base, lastAt: '2026-09-04T09:00:00.000Z', nowMs: Date.parse('2026-09-04T11:00:00Z') })
+  expect(v.due).toBe(false)
+  if (v.due) return
+  expect(v.reason).toBe('not-yet')
+})
+
+test('a daily run is due at the anchor hour the next day, and not before', () => {
+  const base = { schedule: 'daily' as const, atHour: 10, tzOffsetMinutes: 0, serverRunning: true, lastAt: '2026-09-04T09:00:00.000Z' }
+  expect(isDue({ ...base, nowMs: Date.parse('2026-09-05T09:59:00Z') }).due).toBe(false)
+  expect(isDue({ ...base, nowMs: Date.parse('2026-09-05T10:00:00Z') }).due).toBe(true)
+})
+
+// The machine that was off through its hour: it comes back OWED, runs once, then waits.
+test('a missed window is owed on start, and the run after it is the next anchor', () => {
+  const base = { schedule: 'daily' as const, atHour: 10, tzOffsetMinutes: 0, serverRunning: true }
+  const bootedLate = Date.parse('2026-09-06T14:00:00Z')
+  expect(isDue({ ...base, lastAt: '2026-09-04T10:00:00.000Z', nowMs: bootedLate }).due).toBe(true)
+  // Having run at 14:00, the next one is 10:00 the following day — not immediately, not a day late.
+  const after = nextRunMs({ ...base, lastAt: null, nowMs: bootedLate }, bootedLate)
+  expect(new Date(after!).toISOString()).toBe('2026-09-07T10:00:00.000Z')
+})
+
+test('a weekly run is anchored a week on, at the same hour', () => {
+  const after = nextRunMs(
+    { schedule: 'weekly', atHour: 8, tzOffsetMinutes: 0, lastAt: null, nowMs: now, serverRunning: true },
+    Date.parse('2026-09-04T09:00:00Z'),
+  )
+  expect(new Date(after!).toISOString()).toBe('2026-09-11T08:00:00.000Z')
+})
+
+// An interval cadence has no time of day, and forcing one on it would turn it into something else.
+test('a custom interval keeps interval semantics, unanchored', () => {
+  const last = Date.parse('2026-09-04T09:13:00Z')
+  const after = nextRunMs(
+    { schedule: 'custom', customHours: 6, atHour: 10, tzOffsetMinutes: 0, lastAt: null, nowMs: now, serverRunning: true },
+    last,
+  )
+  expect(after).toBe(last + 6 * 3_600_000)
+})
+
+test('an owed run is reported as now, never as a time already past', () => {
+  const s = scheduleStatus({
+    schedule: 'daily', atHour: 10, tzOffsetMinutes: 0,
+    lastAt: '2026-09-01T10:00:00.000Z', nowMs: now, serverRunning: true,
+  })
+  expect(s.kind).toBe('next')
+  if (s.kind !== 'next') return
+  expect(s.nextAtMs).toBe(now)
 })

--- a/packages/server/server/backup/schedule.ts
+++ b/packages/server/server/backup/schedule.ts
@@ -31,6 +31,43 @@ const HOUR_MS = 3_600_000
  */
 export const MIN_CUSTOM_HOURS = 1
 
+/**
+ * The hour of the local day a `daily` / `weekly` run is anchored to.
+ *
+ * A cadence with no time of day is a cadence anchored to whenever the machine last happened to run
+ * one, which drifts and lands in the middle of the working day. Mid-morning is the default because
+ * the machine is on by then and the run is not competing with a login.
+ */
+export const DEFAULT_HOUR = 10
+
+/** An hour outside 0–23 is not an hour. Clamped, never refused: a field is an intent. */
+export function normalizeHour(h: number | undefined): number {
+  if (h === undefined || !Number.isFinite(h)) return DEFAULT_HOUR
+  return Math.min(23, Math.max(0, Math.trunc(h)))
+}
+
+/**
+ * `hour:00:00` local, on the local day `dayOffset` days after the one holding `ms`.
+ *
+ * Anchoring to the DAY rather than to "the next time that hour comes round" is what makes `daily`
+ * mean AT MOST ONE PER DAY. The other reading fires an hour after a manual backup taken at 09:00
+ * with the anchor at 10:00 — two runs in a morning, from a setting that says "daily".
+ *
+ * The offset is passed in rather than read here so the module stays pure and testable: the caller
+ * hands it `new Date().getTimezoneOffset()`, the same local-clock convention the harness adapters
+ * use for activity hours. Sub-hour precision is deliberately dropped — a backup is not a cron job,
+ * and "10am" is the whole of what anyone asked for.
+ */
+export function hourAnchorOnLocalDay(
+  ms: number, dayOffset: number, hour: number, tzOffsetMinutes: number,
+): number {
+  const offset = tzOffsetMinutes * 60_000
+  // Shift into a frame where plain arithmetic reads the local clock.
+  const local = ms - offset
+  const dayStart = Math.floor(local / DAY_MS) * DAY_MS
+  return dayStart + dayOffset * DAY_MS + normalizeHour(hour) * HOUR_MS + offset
+}
+
 /** null = never fires. A Record so a new id cannot be added without giving it an interval.
  *  `custom` is null HERE because its interval is not a constant — see `intervalMs`. */
 export const SCHEDULE_MS: Record<ScheduleId, number | null> = {
@@ -61,6 +98,11 @@ export interface ScheduleInput {
   schedule: ScheduleId
   /** Only read when `schedule` is `'custom'`. See `intervalMs`. */
   customHours?: number
+  /** The local hour a daily/weekly run is anchored to. Absent reads as `DEFAULT_HOUR`.
+   *  Meaningless for `custom`, which is an interval and has no time of day. */
+  atHour?: number
+  /** `new Date().getTimezoneOffset()` from the caller — see `hourAnchorAfter`. */
+  tzOffsetMinutes?: number
   /** ISO of the last run, or null. Unparseable reads as never — a corrupt timestamp must not
    *  suppress backups forever, which is what treating it as "now" would do. */
   lastAt: string | null
@@ -83,13 +125,34 @@ function lastMs(lastAt: string | null): number | null {
   return Number.isFinite(t) ? t : null
 }
 
+/**
+ * When the run AFTER `last` is owed.
+ *
+ * One rule for all three schedules, which is what makes the missed-window case fall out instead of
+ * needing a branch of its own: `daily` is the anchor hour on the NEXT local day, `weekly` the
+ * anchor hour a week on, and `custom` a plain interval — an "every 6 hours" cadence has no time of
+ * day to anchor to, and forcing one on it would turn it into something else.
+ *
+ * A machine that was off through its hour comes back with the run already OWED, runs it once on
+ * start, and is then due again on the next anchored day — not immediately, and not a day late.
+ */
+export function nextRunMs(input: ScheduleInput, last: number): number | null {
+  const every = intervalMs(input.schedule, input.customHours)
+  if (every === null) return null
+  if (input.schedule === 'custom') return last + every
+  const tz = input.tzOffsetMinutes ?? 0
+  return hourAnchorOnLocalDay(last, input.schedule === 'weekly' ? 7 : 1, normalizeHour(input.atHour), tz)
+}
+
 export function isDue(input: ScheduleInput): ScheduleVerdict {
   const every = intervalMs(input.schedule, input.customHours)
   if (every === null) return { due: false, reason: 'off' }
   if (!input.serverRunning) return { due: false, reason: 'no-server' }
   const last = lastMs(input.lastAt)
   if (last === null) return { due: true }
-  return input.nowMs - last >= every ? { due: true } : { due: false, reason: 'not-yet' }
+  const next = nextRunMs(input, last)
+  if (next === null) return { due: false, reason: 'off' }
+  return input.nowMs >= next ? { due: true } : { due: false, reason: 'not-yet' }
 }
 
 export function scheduleStatus(input: ScheduleInput): ScheduleStatus {
@@ -97,5 +160,9 @@ export function scheduleStatus(input: ScheduleInput): ScheduleStatus {
   if (every === null) return { kind: 'off', nextAtMs: null }
   if (!input.serverRunning) return { kind: 'inactive-no-server', nextAtMs: null }
   const last = lastMs(input.lastAt)
-  return { kind: 'next', nextAtMs: last === null ? input.nowMs : last + every }
+  if (last === null) return { kind: 'next', nextAtMs: input.nowMs }
+  const next = nextRunMs(input, last)
+  // An owed run is reported as NOW, not as a time in the past: the schedule says when the next one
+  // happens, and "it is already owed" is answered by the next tick, seconds away.
+  return { kind: 'next', nextAtMs: next === null ? input.nowMs : Math.max(next, input.nowMs) }
 }

--- a/packages/server/server/cli-backup.ts
+++ b/packages/server/server/cli-backup.ts
@@ -50,6 +50,9 @@ export interface BackupPrefs {
   schedule: ScheduleId
   /** Hours between runs when `schedule` is `'custom'`. Undefined otherwise. */
   customHours?: number
+  /** The local hour a `daily`/`weekly` run is anchored to. Undefined reads as `DEFAULT_HOUR`
+   *  in `schedule.ts`, which is the one place that clamps and defaults it. */
+  atHour?: number
   layers: BackupLayer[]
   scheduleLayers: BackupLayer[]
   harnesses: HarnessId[]
@@ -68,6 +71,9 @@ export function readBackupPrefs(p: Preferences): BackupPrefs {
     // Carried raw. `intervalMs` is the ONE place that clamps and defaults it, so a hand-edited
     // preferences file cannot smuggle a five-minute backup past a validation that lives elsewhere.
     customHours: typeof b.customHours === 'number' ? b.customHours : undefined,
+    // Carried raw for the same reason as `customHours`: `normalizeHour` is the one place that
+    // clamps it, so a hand-edited file cannot smuggle an hour past a validation living elsewhere.
+    atHour: typeof b.atHour === 'number' ? b.atHour : undefined,
     layers,
     scheduleLayers: (b.scheduleLayers as BackupLayer[] | undefined) ?? DEFAULT_LAYERS,
     harnesses: (b.harnesses as HarnessId[] | undefined)?.filter(h => HARNESS_ORDER.includes(h)) ?? [...HARNESS_ORDER],
@@ -156,16 +162,19 @@ export async function writeBackupScheduleLayers(layers: BackupLayer[]): Promise<
   return normalized
 }
 
-export async function writeBackupSchedule(schedule: ScheduleId, customHours?: number): Promise<void> {
+export async function writeBackupSchedule(
+  schedule: ScheduleId, customHours?: number, atHour?: number,
+): Promise<void> {
   const p = await readPreferences()
-  // `customHours` is written only when it was given, so switching to `weekly` and back to `custom`
-  // returns to the number the user had chosen rather than to a default they never picked.
+  // `customHours` and `atHour` are written only when given, so switching to `weekly` and back to
+  // `custom` returns to the number the user had chosen rather than to a default they never picked.
   await writePreferences({
     ...p,
     backup: {
       ...(p.backup ?? {}),
       schedule,
       ...(customHours === undefined ? null : { customHours }),
+      ...(atHour === undefined ? null : { atHour }),
     },
   })
 }

--- a/packages/server/server/cli-start.ts
+++ b/packages/server/server/cli-start.ts
@@ -2561,6 +2561,7 @@ export function createControlHost(initialLang: CliLang, altScreen: Suspendable):
       const last = lastBackup(entries)
       const st = scheduleStatus({
         schedule: prefs.schedule, customHours: prefs.customHours,
+        atHour: prefs.atHour, tzOffsetMinutes: new Date().getTimezoneOffset(),
         lastAt: last?.at ?? null, nowMs: Date.now(),
         serverRunning: existsSync(join(AGENTISTICS_DATA_DIR, 'events-producer.json')),
       })

--- a/packages/server/server/preferences.ts
+++ b/packages/server/server/preferences.ts
@@ -131,6 +131,8 @@ export interface Preferences {
     /** Hours between runs when `schedule` is `'custom'`. Clamped and defaulted by `intervalMs`
      *  (backup/schedule.ts), never here — a preferences file is hand-editable. */
     customHours?: number
+    /** Local hour (0–23) a daily/weekly run is anchored to. */
+    atHour?: number
     /** Layers a MANUAL run writes when no `--with-*` flag is given. An explicit flag wins. */
     layers?: ('metrics' | 'repos' | 'archive' | 'raw')[]
     /** Layers a SCHEDULED run writes. Deliberately separate: `raw` is 2.4 GB a copy, so a daily

--- a/packages/web/src/pages/settings/BackupSettings.tsx
+++ b/packages/web/src/pages/settings/BackupSettings.tsx
@@ -76,6 +76,8 @@ interface BackupStatusJson {
     scheduleActive: boolean
     /** Hours between runs when `schedule` is `'custom'`; null when never set. */
     customHours: number | null
+    /** The local hour a daily/weekly run is anchored to; null when never chosen. */
+    atHour: number | null
     keep: number
     retainedLabel: string
     secretsCount: number
@@ -103,6 +105,8 @@ interface BackupConfigPatch {
   schedule?: BackupScheduleId
   /** Hours between runs, when `schedule` is `'custom'`. */
   customHours?: number
+  /** The local hour a daily/weekly run is anchored to. */
+  atHour?: number
 }
 
 type RunOutcome = { ok: true; bytesLabel: string; skipped?: number } | { ok: false; reason: string }
@@ -1187,7 +1191,8 @@ export default function BackupSettings() {
             pt={pt}
             disabled={savingConfig}
             customHours={status.config.customHours ?? null}
-            onChange={(schedule, customHours) => void patchConfig({ schedule, customHours })}
+            atHour={status.config.atHour ?? null}
+            onChange={(schedule, customHours, atHour) => void patchConfig({ schedule, customHours, atHour })}
           />
           <p style={{ fontSize: 12, fontWeight: 600, color: 'var(--text-secondary)', margin: '18px 0 4px' }}>
             {pt ? 'O que uma execução agendada grava' : 'What a scheduled run carries'}
@@ -1545,14 +1550,18 @@ function LayerPicker({ layers, sizes, archiveMode, pt, disabled, onToggle }: {
  * `active` mirrors `ControlBackupConfig.scheduleActive` — with the server stopped, a schedule other
  * than `off` reads INACTIVE rather than a "next at…" that will not arrive.
  */
-function SchedulePicker({ value, active, pt, disabled, customHours, onChange }: {
+const DEFAULT_BACKUP_HOUR = 10
+
+function SchedulePicker({ value, active, pt, disabled, customHours, atHour, onChange }: {
   value: BackupScheduleId
   active: boolean
   pt: boolean
   disabled: boolean
   /** The hours last chosen, or null when never set. */
   customHours: number | null
-  onChange: (schedule: BackupScheduleId, customHours?: number) => void
+  /** The local hour chosen, or null when never chosen — rendered as the default, not as blank. */
+  atHour: number | null
+  onChange: (schedule: BackupScheduleId, customHours?: number, atHour?: number) => void
 }) {
   const isMobile = useIsMobile()
   // Local, so typing a two-digit number does not fire a save on the first digit — `6` would be a
@@ -1588,6 +1597,39 @@ function SchedulePicker({ value, active, pt, disabled, customHours, onChange }: 
           )
         })}
       </div>
+      {/* A cadence with no time of day is anchored to whenever the machine last happened to run
+          one, which drifts across the day. `custom` is deliberately excluded: "every 6 hours" has
+          no single time of day, and forcing one on it would turn it into a different schedule. */}
+      {(value === 'daily' || value === 'weekly') && (
+        <div style={{ marginTop: 10 }}>
+          <div style={{ fontSize: 12, fontWeight: 600, color: 'var(--text-secondary)', marginBottom: 2 }}>
+            {pt ? 'A que horas' : 'At what time'}
+          </div>
+          <p style={{ fontSize: 11, color: 'var(--text-tertiary)', lineHeight: 1.45, margin: '0 0 6px' }}>
+            {pt
+              ? 'No relógio desta máquina. Se ela estiver desligada nesse horário, o backup roda assim que você ligar e o próximo volta a ser no horário marcado.'
+              : 'On this machine’s clock. If it is off at that time the backup runs as soon as you turn it on, and the next one goes back to the chosen time.'}
+          </p>
+          <select
+            value={String(atHour ?? DEFAULT_BACKUP_HOUR)}
+            disabled={disabled}
+            onChange={e => onChange(value, undefined, Number(e.target.value))}
+            style={{
+              padding: '7px 10px', minHeight: isMobile ? 44 : undefined,
+              width: isMobile ? '100%' : 140, boxSizing: 'border-box',
+              background: 'var(--bg-elevated)', border: '1px solid var(--border)', borderRadius: 7,
+              // 16px or iOS Safari zooms the viewport on focus and breaks the sticky header.
+              fontFamily: 'inherit', fontSize: isMobile ? 16 : 13,
+              color: 'var(--text-primary)', outline: 'none',
+              ...(disabled ? { opacity: 0.6, cursor: 'not-allowed' } : {}),
+            }}
+          >
+            {Array.from({ length: 24 }, (_, h) => (
+              <option key={h} value={String(h)}>{`${String(h).padStart(2, '0')}:00`}</option>
+            ))}
+          </select>
+        </div>
+      )}
       {value === 'custom' && (
         <div style={{ marginTop: 10 }}>
           <div style={{ fontSize: 12, fontWeight: 600, color: 'var(--text-secondary)', marginBottom: 2 }}>


### PR DESCRIPTION
## The measurement

A schedule set to **daily** wrote **13 backups in three hours**:

```
16:20:23  16:32:24  16:48:17  17:04:17  17:20:13  17:36:05  17:51:50
18:07:36  18:23:34  18:39:32  18:55:54  19:11:36  19:33:22
```

Every ~15 min 50 s — exactly the daemon's `CHECK_MS` (15 min) plus the backup's own duration. That
is the signature of a due-check that is **always true**. Each run is 112 MB and confirming its
upload re-downloads the whole file to hash it.

## The cause: a question asked of the wrong function

`lastBackup` answers *"what can I RESTORE from"*, so it requires the archive to still be on disk:

```ts
return entries.find(e => e.present) ?? null
```

With `deleteLocalAfterUpload` on, every scheduled run uploads its archive and **deletes the local
copy** — so no run the schedule performed was ever `present`. Measured:

| | |
|---|---|
| newest record whose file still exists | `2026-09-06T16:12` |
| newest record, full stop | `2026-09-07T19:33` |

The first runaway run is at **16:20** on a machine whose last surviving file is **16:12 the day
before** — the first tick after that crossed 24 h. From then on "more than 24 h ago" is permanently
true and every tick starts another backup.

`lastBackupRun` is the other question. The schedule reads it; the restore surfaces keep reading
`lastBackup` **unchanged**, because a timestamp pointing at a file that no longer exists is exactly
what *that* one must never report.

## The hour of the day

A cadence with no time of day is anchored to whenever the machine last happened to run one, which
drifts across the working day. `daily`/`weekly` now take an hour (`atHour`, **default 10**), and
the rule is **one per local day at that hour**.

Not *"the next time that hour comes round"* — that fires an hour after a manual 09:00 backup and
puts two runs in one morning. `custom` is deliberately excluded: "every 6 hours" has no single time
of day, and forcing one on it would make it a different schedule.

**A machine that was off through its hour** comes back with the run OWED, takes it once on start,
and is then due at the next anchor — not immediately, and not a day late. That falls out of the one
rule rather than needing a branch of its own.

## Also fixed, found while reading the same panel

GitHub's release `created_at` is the date of the **commit a tag points at**, so a backup repository
whose tags all hang off one commit reports the same instant for every release. Measured on the real
repo — four uploads hours apart:

```
created_at 2026-09-06T16:24:54Z   published_at 2026-09-06T16:24:55Z
created_at 2026-09-06T16:24:54Z   published_at 2026-09-06T16:46:24Z
created_at 2026-09-06T16:24:54Z   published_at 2026-09-07T18:56:03Z
created_at 2026-09-06T16:24:54Z   published_at 2026-09-07T19:11:38Z
```

Two things were wrong and **only one was visible**: every card in the restore list printed the same
date, and `pickBackupRelease` — which restores "the newest" when no tag is named — sorted on that
constant, so the sort was a **no-op** and the release it picked was whichever GitHub returned
first. `releaseInstant` prefers the timestamp agentop stamped into its own tag, then
`published_at`, then `created_at` as a last resort so nothing sorts nowhere.

## Verification

- `bun test` — **6757 pass, 0 fail**; `bun tsc --noEmit` clean.
- The regression tests were **proven to catch it**: restoring the old `find(e => e.present)` turns
  2 of them red.
- Against this machine's real `backups.jsonl`: **before** `due = true` (fires now, and again in 15
  minutes); **after** `due = false`, next run **08/09 10:00**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0161UEvuEphUuJEJFygVyaKy
