### PR TITLE
feat(sessions): a running workflow opens by itself, on the line it is executing

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -342,6 +342,10 @@ export interface WorkflowAgent {
   labelSource?: 'record' | 'matched' | 'none'
   /** Every tool call the agent made. Optional for the same backward-compatibility reason. */
   toolCalls?: number
+  /** Its transcript ends on a tool call nobody answered — the agent is waiting on something. A
+   *  fact about the FILE: only a caller that knows the RUN is live may read it as "running", since
+   *  a killed run leaves the same dangling ask behind. */
+  pending?: boolean
   model: string
   status: 'completed' | 'failed' | 'skipped'
   tokensIn: number

--- a/packages/server/server/sessions/workflows-web.ts
+++ b/packages/server/server/sessions/workflows-web.ts
@@ -36,6 +36,8 @@ export interface WorkflowAgentRow {
   phase: string
   /** How many tool calls it made. `null` when nothing could count them. */
   toolCalls: number | null
+  /** Its transcript ends on an unanswered tool call. Only meaningful while the RUN is live. */
+  pending?: boolean
   model: string
   /** The four counters. `null` when the agent has produced none — never a zeroed breakdown. */
   tokens: TokenBreakdown | null
@@ -145,6 +147,7 @@ export async function readSessionWorkflows(
           ...(a.labelSource ? { labelSource: a.labelSource } : {}),
           phase: a.phase, model: a.model,
           toolCalls: typeof a.toolCalls === 'number' ? a.toolCalls : null,
+          ...(a.pending ? { pending: true } : {}),
           tokens: at,
           totalTokens: at ? workflowTokens(a) : null,
           costUSD: a.costUSD > 0 ? a.costUSD : null,
@@ -174,6 +177,9 @@ export type WorkflowAgentDetail =
       commands: string[]
       /** The list was cut at the cap — said, so it never implies the agent stopped there. */
       commandsClipped: boolean
+      /** Index, among ALL calls, of the one asked and not yet answered — the live edge. Null when
+       *  every call came back. A fact about the file; the view decides whether to call it running. */
+      pendingIndex: number | null
     }
   | { ok: false; message: string }
 
@@ -231,5 +237,6 @@ export async function readWorkflowAgent(
     tools: agg.tools,
     commands: agg.commands,
     commandsClipped: agg.commandsClipped,
+    pendingIndex: agg.pendingToolIndex,
   }
 }

--- a/packages/server/server/workflow-agent.test.ts
+++ b/packages/server/server/workflow-agent.test.ts
@@ -21,7 +21,7 @@ test('empty input yields zeros', () => {
   const r = aggregateWorkflowAgent([])
   expect(r).toEqual({
     model: '', tokensIn: 0, tokensOut: 0, cacheRead: 0, cacheWrite: 0, costUSD: 0, prompt: '', startedAt: '',
-    toolCalls: 0, tools: {}, commands: [], commandsClipped: false,
+    toolCalls: 0, tools: {}, commands: [], commandsClipped: false, pendingToolIndex: null,
   })
 })
 
@@ -99,4 +99,56 @@ test('the list is clipped and SAYS so, while the count stays exact', () => {
   expect(r.toolCalls).toBe(MAX_COMMANDS + 5)
   expect(r.commands.length).toBe(MAX_COMMANDS)
   expect(r.commandsClipped).toBe(true)
+})
+
+// --- which call is happening RIGHT NOW --------------------------------------
+//
+// A transcript records a `tool_use` when the agent asks and a `tool_result` when the answer comes
+// back. An ask with no answer is the one thing in the file that is still happening. Verified on a
+// real finished agent: 58 asks, 58 answers, none pending.
+
+const asked = (id: string, cmd: string) => JSON.stringify({
+  type: 'assistant',
+  message: { model: 'claude-opus-5', usage: {}, content: [{ type: 'tool_use', id, name: 'Bash', input: { command: cmd } }] },
+})
+const answered = (id: string) => JSON.stringify({
+  type: 'user', message: { content: [{ type: 'tool_result', tool_use_id: id, content: 'ok' }] },
+})
+
+test('an agent whose every call was answered has nothing in flight', () => {
+  const r = aggregateWorkflowAgent([asked('t1', 'a'), answered('t1'), asked('t2', 'b'), answered('t2')])
+  expect(r.toolCalls).toBe(2)
+  expect(r.pendingToolIndex).toBe(null)
+})
+
+test('the unanswered call is the one in flight, by its index among all calls', () => {
+  const r = aggregateWorkflowAgent([asked('t1', 'a'), answered('t1'), asked('t2', 'b')], { withCommands: true })
+  expect(r.pendingToolIndex).toBe(1)
+  expect(r.commands[r.pendingToolIndex!]).toBe('b')
+})
+
+// An earlier dangling ask is a result that was never written; the NEWEST is what it waits on now.
+test('with several dangling asks the newest one is the live edge', () => {
+  const r = aggregateWorkflowAgent([asked('t1', 'a'), asked('t2', 'b'), answered('t2'), asked('t3', 'c')])
+  expect(r.pendingToolIndex).toBe(2)
+})
+
+test('a call the transcript gave no id is never reported as in flight', () => {
+  const noId = JSON.stringify({
+    type: 'assistant',
+    message: { model: 'x', usage: {}, content: [{ type: 'tool_use', name: 'Bash', input: { command: 'a' } }] },
+  })
+  expect(aggregateWorkflowAgent([noId]).pendingToolIndex).toBe(null)
+})
+
+// The index counts ALL calls, so it stays meaningful when the command list itself was clipped.
+test('the index counts every call, not only the ones the list kept', () => {
+  const lines = [
+    JSON.stringify({ type: 'assistant', message: { model: 'x', usage: {}, content:
+      Array.from({ length: MAX_COMMANDS + 3 }, (_, i) => ({ type: 'tool_use', id: `t${i}`, name: 'Bash', input: { command: `c${i}` } })),
+    } }),
+  ]
+  const r = aggregateWorkflowAgent(lines, { withCommands: true })
+  expect(r.commands.length).toBe(MAX_COMMANDS)
+  expect(r.pendingToolIndex).toBe(MAX_COMMANDS + 2)
 })

--- a/packages/server/server/workflow-agent.ts
+++ b/packages/server/server/workflow-agent.ts
@@ -45,6 +45,19 @@ export function aggregateWorkflowAgent(lines: string[], opts: { withCommands?: b
   /** True when `commands` was cut at `MAX_COMMANDS`, so the view can say so instead of implying
    *  the agent stopped there. */
   commandsClipped: boolean
+  /**
+   * The index — among ALL tool calls, not among the possibly-clipped `commands` — of the one that
+   * was asked for and has no result yet. That is the call IN FLIGHT.
+   *
+   * A transcript records a `tool_use` when the agent asks and a `tool_result` when the answer comes
+   * back, so an unanswered ask is the one thing here that is happening RIGHT NOW rather than having
+   * happened. Verified on a finished agent: 58 asks, 58 results, none pending.
+   *
+   * `null` when every call was answered. It is a fact about the FILE, not a claim that the agent is
+   * alive: a transcript left dangling by a killed run also ends on an unanswered ask, which is why
+   * only a caller that knows the run is live may render it as "running".
+   */
+  pendingToolIndex: number | null
 } {
   let model = ''
   let prompt = '', startedAt = ''
@@ -53,6 +66,9 @@ export function aggregateWorkflowAgent(lines: string[], opts: { withCommands?: b
   const tools: Record<string, number> = {}
   const commands: string[] = []
   let commandsClipped = false
+  // Asked, in order; answered, as a set. What is asked and never answered is in flight.
+  const asked: string[] = []
+  const answered = new Set<string>()
   for (const raw of lines) {
     const line = raw.trim()
     if (!line) continue
@@ -61,6 +77,16 @@ export function aggregateWorkflowAgent(lines: string[], opts: { withCommands?: b
     if (!prompt && e.type === 'user') {
       const text = userText(e)
       if (text) { prompt = text; startedAt = typeof e.timestamp === 'string' ? e.timestamp : '' }
+    }
+    // A tool's ANSWER comes back in a user envelope, so the result scan happens before the
+    // assistant-only gate below.
+    const anyMsg = e.message as Record<string, unknown> | undefined
+    const anyContent = anyMsg?.content
+    if (Array.isArray(anyContent)) {
+      for (const part of anyContent) {
+        const c = part as Record<string, unknown>
+        if (c?.type === 'tool_result' && typeof c.tool_use_id === 'string') answered.add(c.tool_use_id)
+      }
     }
     if (e.type !== 'assistant') continue
     const msg = e.message as Record<string, unknown> | undefined
@@ -75,6 +101,7 @@ export function aggregateWorkflowAgent(lines: string[], opts: { withCommands?: b
         if (c?.type !== 'tool_use' || typeof c.name !== 'string') continue
         toolCalls += 1
         tools[c.name] = (tools[c.name] ?? 0) + 1
+        asked.push(typeof c.id === 'string' ? c.id : '')
         if (!opts.withCommands) continue
         if (commands.length >= MAX_COMMANDS) { commandsClipped = true; continue }
         commands.push(commandLine(c.name, c.input))
@@ -90,9 +117,16 @@ export function aggregateWorkflowAgent(lines: string[], opts: { withCommands?: b
     { inputTokens: tokensIn, outputTokens: tokensOut, cacheReadInputTokens: cacheRead, cacheCreationInputTokens: cacheWrite, webSearchRequests: 0, costUSD: 0 },
     model,
   )
+  // The LAST unanswered ask, not the first: an earlier one left dangling is a call whose result
+  // was never written, while the newest is the one the agent is waiting on now.
+  let pendingToolIndex: number | null = null
+  for (let i = asked.length - 1; i >= 0; i -= 1) {
+    const id = asked[i]!
+    if (id !== '' && !answered.has(id)) { pendingToolIndex = i; break }
+  }
   return {
     model, tokensIn, tokensOut, cacheRead, cacheWrite, costUSD, prompt, startedAt,
-    toolCalls, tools, commands, commandsClipped,
+    toolCalls, tools, commands, commandsClipped, pendingToolIndex,
   }
 }
 

--- a/packages/server/server/workflow-metrics.ts
+++ b/packages/server/server/workflow-metrics.ts
@@ -217,6 +217,7 @@ export async function assembleWorkflowRuns(
         ...(agentId ? { agentId } : {}),
         labelSource,
         toolCalls: agg.toolCalls,
+        pending: agg.pendingToolIndex !== null,
         model: agg.model || (meta?.model ?? ''),
         // NOTE: per-agent status is a best-effort 'completed'. The available data
         // (journal.jsonl + the task-notification <usage> counts) reports how many

--- a/packages/web/src/components/sessions/ArtifactsAside.tsx
+++ b/packages/web/src/components/sessions/ArtifactsAside.tsx
@@ -56,7 +56,8 @@ import {
   type SubagentRow, type SubagentsPayload, type SubagentsState,
 } from '../../lib/subagents'
 import {
-  agentDetailStateOf, agentDetailUrl, agentOpenable, groupAgentsByPhase, labelCaveat,
+  agentDetailStateOf, agentDetailUrl, agentIsRunning, agentOpenable, agentOpensByDefault,
+  groupAgentsByPhase, labelCaveat, runOpensByDefault, runningCommandIndex,
   liveRunCount, runDurationText, runStatusNote, runStatusText, unmeasuredRunText,
   unplacedPhaseText, workflowCount, workflowsPollMs, workflowsStateOf,
   type AgentDetailState, type WorkflowAgentDetail, type WorkflowAgentRow,
@@ -304,6 +305,9 @@ export function ArtifactsAside({
     () => asideCache.read<WorkflowsState>(asideKey(sessionId, 'workflows')).value ?? null,
   )
   const [openRun, setOpenRun] = useState<string | null>(null)
+  /** Runs already opened for the user once. Closing one must STAY closed — the poll runs every
+   *  five seconds, and re-opening it on each would take the panel away from them repeatedly. */
+  const autoOpened = useRef<Set<string>>(new Set())
   const [agentsState, setAgentsState] = useState<SubagentsState | null>(
     () => asideCache.read<SubagentsState>(asideKey(sessionId, 'subagents')).value ?? null,
   )
@@ -881,6 +885,15 @@ export function ArtifactsAside({
     finally { setAgentsMore(false) }
   }
 
+
+  /** A run somebody is WATCHING opens by itself — that is what the tab polls for. Once. */
+  useEffect(() => {
+    if (wfState?.phase !== 'ready') return
+    const live = wfState.rows.find(r => runOpensByDefault(r) && !autoOpened.current.has(r.runId))
+    if (!live) return
+    autoOpened.current.add(live.runId)
+    setOpenRun(prev => prev ?? live.runId)
+  }, [wfState])
 
   const workflowsBody = (): React.ReactNode => {
     const st = wfState
@@ -1824,11 +1837,34 @@ function EventRow({ e, pt, now, onOpen, status, sessionId, agentId }: {
  * agent of every run on each poll, and one 72-agent run is megabytes of shell. Same split, and the
  * same reason, as the subagents tab's list versus its activity.
  */
-function WorkflowAgentLine({ sessionId, runId, agent, pt }: {
-  sessionId: string; runId: string; agent: WorkflowAgentRow; pt: boolean
+
+/** Keeps the executing line in view. Its own component so the effect runs AFTER the line it
+ *  watches has been drawn, without the parent having to re-render to schedule it. */
+function FollowLine({ target }: { target: React.RefObject<HTMLDivElement | null> }) {
+  useEffect(() => {
+    target.current?.scrollIntoView({ block: 'nearest' })
+  })
+  return null
+}
+
+function WorkflowAgentLine({ sessionId, runId, agent, pt, runLive }: {
+  sessionId: string; runId: string; agent: WorkflowAgentRow; pt: boolean; runLive: boolean
 }) {
   const isMobile = useIsMobile()
-  const [open, setOpen] = useState(false)
+  const working = agentIsRunning(agent, runLive)
+  // The agent actually doing something opens by itself — following it is the point.
+  const [open, setOpen] = useState(() => agentOpensByDefault(agent, runLive))
+  // It may only START working after the row was drawn. Opening then is the same gesture, one poll
+  // later; it never CLOSES anything, so a row the user shut stays shut.
+  const wasWorking = useRef(working)
+  useEffect(() => {
+    if (working && !wasWorking.current && agentOpensByDefault(agent, runLive)) setOpen(true)
+    wasWorking.current = working
+  }, [working, agent, runLive])
+  /** The line being executed, so following it means the box scrolls to it rather than the user
+   *  hunting for the pulse. `nearest` and never `smooth`: this fires on every poll while a run
+   *  works, and a smooth scroll every five seconds is a box that will not sit still. */
+  const followRef = useRef<HTMLDivElement | null>(null)
   const [detail, setDetail] = useState<AgentDetailState | null>(null)
   const openable = agentOpenable(agent)
   const caveat = labelCaveat(agent, pt)
@@ -1863,9 +1899,16 @@ function WorkflowAgentLine({ sessionId, runId, agent, pt }: {
           {open ? <ChevronDown size={10} /> : <ChevronRight size={10} />}
         </span>
       )}
+      {/* Working is said by a dot AND by the label's colour — never by colour alone. */}
+      {working && (
+        <span aria-hidden style={{
+          flexShrink: 0, width: 5, height: 5, borderRadius: '50%',
+          background: 'var(--anthropic-orange)', animation: 'ag-agent-pulse 1.6s ease-in-out infinite',
+        }} />
+      )}
       <span style={{
         minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
-        color: 'var(--text-secondary)',
+        color: working ? 'var(--anthropic-orange)' : 'var(--text-secondary)',
         // A label nothing recorded IS the file name; saying it in the same weight as a real one
         // would present a hash as a name somebody chose.
         fontStyle: agent.labelSource === 'none' ? 'italic' : undefined,
@@ -1913,6 +1956,7 @@ function WorkflowAgentLine({ sessionId, runId, agent, pt }: {
             <p style={{ margin: 0, fontSize: 10, color: 'var(--text-tertiary)', fontStyle: 'italic' }}>{detail.message}</p>
           ) : (
             <>
+              <FollowLine target={followRef} />
               {detail.detail.prompt !== '' && (
                 <p style={{
                   margin: '0 0 4px', fontSize: 10, lineHeight: 1.5, color: 'var(--text-tertiary)',
@@ -1933,12 +1977,24 @@ function WorkflowAgentLine({ sessionId, runId, agent, pt }: {
                     border: '1px solid var(--border-subtle)', borderRadius: 6, padding: '4px 6px',
                     background: 'var(--bg-elevated)',
                   }}>
-                    {detail.detail.commands.map((c, i) => (
-                      <div key={i} style={{
-                        fontFamily: 'var(--font-mono, ui-monospace, monospace)', fontSize: 10, lineHeight: 1.6,
-                        color: 'var(--text-secondary)', whiteSpace: 'pre', minWidth: 0,
-                      }}>{c}</div>
-                    ))}
+                    {detail.detail.commands.map((c, i) => {
+                      const now = runningCommandIndex(detail.detail.pendingIndex, detail.detail.commands.length, runLive) === i
+                      return (
+                        <div
+                          key={i}
+                          ref={now ? followRef : undefined}
+                          style={{
+                            fontFamily: 'var(--font-mono, ui-monospace, monospace)', fontSize: 10, lineHeight: 1.6,
+                            color: now ? 'var(--text-primary)' : 'var(--text-secondary)',
+                            whiteSpace: 'pre', minWidth: 0,
+                            ...(now ? {
+                              animation: 'ag-line-pulse 1.8s ease-in-out infinite',
+                              borderRadius: 4, margin: '0 -3px', padding: '0 3px', fontWeight: 600,
+                            } : {}),
+                          }}
+                        >{c}</div>
+                      )
+                    })}
                   </div>
                   {/* The COUNT stays exact even when the list is cut, so the two never disagree. */}
                   {detail.detail.commandsClipped && (
@@ -2064,7 +2120,7 @@ function WorkflowCard({ sessionId, row, pt, now, open, onToggle }: {
               {g.agents.map((a, i) => (
                 <WorkflowAgentLine
                   key={a.agentId ?? `${a.label}-${i}`}
-                  sessionId={sessionId} runId={row.runId} agent={a} pt={pt}
+                  sessionId={sessionId} runId={row.runId} agent={a} pt={pt} runLive={row.live}
                 />
               ))}
             </div>
@@ -2169,7 +2225,14 @@ function SubagentCard({ row, pt, now, onOpen }: {
           <span>{pt ? `nível ${row.spawnDepth}` : `depth ${row.spawnDepth}`}</span>
         )}
       </div>
-      <style>{`@keyframes ag-agent-pulse { 0%,100% { opacity: 1 } 50% { opacity: 0.3 } }`}</style>
+      <style>{`@keyframes ag-agent-pulse { 0%,100% { opacity: 1 } 50% { opacity: 0.3 } }
+        /* The line being executed. A BACKGROUND pulse, not an opacity one: the text must stay
+           readable through the whole cycle — a command you cannot read while it runs is the one
+           moment you most want to read it. Soft on purpose; it sits under a monospace block. */
+        @keyframes ag-line-pulse {
+          0%,100% { background: color-mix(in srgb, var(--anthropic-orange) 10%, transparent) }
+          50%     { background: color-mix(in srgb, var(--anthropic-orange) 26%, transparent) }
+        }`}</style>
     </button>
   )
 }

--- a/packages/web/src/components/sessions/ArtifactsAside.tsx
+++ b/packages/web/src/components/sessions/ArtifactsAside.tsx
@@ -57,7 +57,8 @@ import {
 } from '../../lib/subagents'
 import {
   agentDetailStateOf, agentDetailUrl, agentIsRunning, agentOpenable, agentOpensByDefault,
-  groupAgentsByPhase, labelCaveat, runOpensByDefault, runningCommandIndex,
+  declaredPhases, groupAgentsByPhase, labelCaveat, placementKnown, runOpensByDefault,
+  runningCommandIndex,
   liveRunCount, runDurationText, runStatusNote, runStatusText, unmeasuredRunText,
   unplacedPhaseText, workflowCount, workflowsPollMs, workflowsStateOf,
   type AgentDetailState, type WorkflowAgentDetail, type WorkflowAgentRow,
@@ -2097,6 +2098,30 @@ function WorkflowCard({ sessionId, row, pt, now, open, onToggle }: {
                 ? (pt ? 'Nenhum agente escreveu ainda.' : 'No agent has written yet.')
                 : (pt ? 'Nenhuma transcrição de agente ficou no disco.' : 'No agent transcript was left on disk.')}
             </p>
+          ) : !placementKnown(row) ? (
+            /* Nothing could be placed yet — the exact mapping is written when the run ENDS. Drawing
+               phase headings here would render every declared phase as "nothing ran" beside agents
+               that are plainly running: three false impressions from two true facts. So the plan is
+               STATED and the agents listed under it. */
+            <>
+              {declaredPhases(row).length > 0 && (
+                <p style={{ margin: '0 0 5px', fontSize: 10, lineHeight: 1.5, color: 'var(--text-tertiary)' }}>
+                  {pt ? 'Fases previstas: ' : 'Planned phases: '}
+                  <span style={{ color: 'var(--text-secondary)' }}>{declaredPhases(row).join(' → ')}</span>
+                  {row.live
+                    ? (pt ? ' — em qual delas cada agente está só fica registrado quando a run termina.'
+                          : ' — which one each agent is in is only recorded once the run ends.')
+                    : (pt ? ' — esta run não registrou em qual delas cada agente rodou.'
+                          : ' — this run did not record which one each agent ran in.')}
+                </p>
+              )}
+              {row.agents.map((a, i) => (
+                <WorkflowAgentLine
+                  key={a.agentId ?? `${a.label}-${i}`}
+                  sessionId={sessionId} runId={row.runId} agent={a} pt={pt} runLive={row.live}
+                />
+              ))}
+            </>
           ) : groupAgentsByPhase(row).map((g, gi) => (
             <div key={`${g.title}-${gi}`} style={{ marginBottom: 5 }}>
               {/* THE PHASE IS THE PLAN. A flat list of agents is the run's shape flattened away —

--- a/packages/web/src/lib/workflows.test.ts
+++ b/packages/web/src/lib/workflows.test.ts
@@ -4,6 +4,7 @@ import {
   runStatusNote, runDurationText, unmeasuredRunText, WORKFLOW_POLL_MS,
   groupAgentsByPhase, labelCaveat, agentOpenable, agentDetailUrl, agentDetailStateOf,
   agentIsRunning, runningCommandIndex, runOpensByDefault, agentOpensByDefault,
+  placementKnown, declaredPhases,
   type WorkflowRunRow, type WorkflowsPayload, type WorkflowAgentRow,
 } from './workflows'
 
@@ -184,4 +185,19 @@ test('inside a live run, the working agent is the one that opens', () => {
   expect(agentOpensByDefault(ag({ pending: false }), true)).toBe(false)
   // Nothing to open when there is no transcript to ask for.
   expect(agentOpensByDefault(ag({ pending: true, agentId: undefined }), true)).toBe(false)
+})
+
+test('placement is unknown while a run is going, and the plan is still nameable', () => {
+  const live = run({
+    live: true, status: 'running',
+    phases: [{ title: 'Recon', agentCount: 0 }, { title: 'Build', agentCount: 0 }],
+    agents: [ag({ phase: '', labelSource: 'none' }), ag({ agentId: 'a2', phase: '', labelSource: 'none' })],
+  })
+  expect(placementKnown(live)).toBe(false)
+  expect(declaredPhases(live)).toEqual(['Recon', 'Build'])
+})
+
+test('placement is known as soon as one agent carries a phase', () => {
+  expect(placementKnown(run({ agents: [ag({ phase: 'A' }), ag({ agentId: 'a2', phase: '' })] }))).toBe(true)
+  expect(placementKnown(run({ agents: [] }))).toBe(false)
 })

--- a/packages/web/src/lib/workflows.test.ts
+++ b/packages/web/src/lib/workflows.test.ts
@@ -3,6 +3,7 @@ import {
   workflowsStateOf, workflowCount, liveRunCount, workflowsPollMs, runStatusText,
   runStatusNote, runDurationText, unmeasuredRunText, WORKFLOW_POLL_MS,
   groupAgentsByPhase, labelCaveat, agentOpenable, agentDetailUrl, agentDetailStateOf,
+  agentIsRunning, runningCommandIndex, runOpensByDefault, agentOpensByDefault,
   type WorkflowRunRow, type WorkflowsPayload, type WorkflowAgentRow,
 } from './workflows'
 
@@ -150,4 +151,37 @@ test('the detail url carries the run AND the agent, both escaped', () => {
 
 test('a refused detail keeps its sentence', () => {
   expect(agentDetailStateOf({ ok: false, message: 'gone' })).toEqual({ phase: 'failed', message: 'gone' })
+})
+
+// --- following a run while it happens ---------------------------------------
+
+test('a pending agent counts as running only while the run itself is live', () => {
+  const a = ag({ pending: true })
+  expect(agentIsRunning(a, true)).toBe(true)
+  // A killed run leaves the same dangling call behind; nothing in it is happening now.
+  expect(agentIsRunning(a, false)).toBe(false)
+  expect(agentIsRunning(ag({ pending: false }), true)).toBe(false)
+  expect(agentIsRunning(ag({ pending: undefined }), true)).toBe(false)
+})
+
+test('the highlighted line is the pending one, and nothing when it would be a guess', () => {
+  expect(runningCommandIndex(2, 5, true)).toBe(2)
+  expect(runningCommandIndex(2, 5, false)).toBe(null)   // the run is over
+  expect(runningCommandIndex(null, 5, true)).toBe(null) // nothing pending
+  // Past the end of a clipped list: the line exists but is not on screen, and highlighting the
+  // last visible one instead would point at the wrong command.
+  expect(runningCommandIndex(7, 5, true)).toBe(null)
+  expect(runningCommandIndex(-1, 5, true)).toBe(null)
+})
+
+test('a live run opens by itself; a finished one does not', () => {
+  expect(runOpensByDefault(run({ live: true, status: 'running' }))).toBe(true)
+  expect(runOpensByDefault(run({ live: false }))).toBe(false)
+})
+
+test('inside a live run, the working agent is the one that opens', () => {
+  expect(agentOpensByDefault(ag({ pending: true }), true)).toBe(true)
+  expect(agentOpensByDefault(ag({ pending: false }), true)).toBe(false)
+  // Nothing to open when there is no transcript to ask for.
+  expect(agentOpensByDefault(ag({ pending: true, agentId: undefined }), true)).toBe(false)
 })

--- a/packages/web/src/lib/workflows.ts
+++ b/packages/web/src/lib/workflows.ts
@@ -284,3 +284,26 @@ export function runOpensByDefault(row: WorkflowRunRow): boolean {
 export function agentOpensByDefault(agent: WorkflowAgentRow, runLive: boolean): boolean {
   return agentIsRunning(agent, runLive) && agentOpenable(agent)
 }
+
+
+/**
+ * Could ANY agent be placed in a phase?
+ *
+ * False is the live case. A run's exact placement is written when it ENDS, and while it is going
+ * the only fallback is `workflow-match.ts` pairing transcripts to `agent()` calls by prompt, which
+ * is deliberately conservative and often matches nothing.
+ *
+ * It matters for the drawing. Grouping under phase headings when nothing is placed renders every
+ * declared phase as "nothing ran" beside a pile of agents that plainly ARE running — three false
+ * impressions from two true facts. When this is false the view should state the declared phases as
+ * the PLAN and list the agents under it, which says both facts and implies neither.
+ */
+export function placementKnown(run: WorkflowRunRow): boolean {
+  return run.agents.some(a => a.phase !== '')
+}
+
+/** The declared phases, as one line — what the run set out to do, when where each agent landed is
+ *  not yet knowable. Empty when the script declared none. */
+export function declaredPhases(run: WorkflowRunRow): string[] {
+  return run.phases.map(p => p.title).filter(t => t !== '')
+}

--- a/packages/web/src/lib/workflows.ts
+++ b/packages/web/src/lib/workflows.ts
@@ -30,6 +30,8 @@ export interface WorkflowAgentRow {
   labelSource?: 'record' | 'matched' | 'none'
   phase: string
   toolCalls: number | null
+  /** Its transcript ends on an unanswered tool call. Only meaningful while the RUN is live. */
+  pending?: boolean
   model: string
   tokens: { input: number; output: number; cacheRead: number; cacheWrite: number } | null
   totalTokens: number | null
@@ -216,6 +218,7 @@ export type WorkflowAgentDetail =
   | {
       ok: true; agentId: string; label: string; phase: string; model: string; prompt: string
       toolCalls: number; tools: Record<string, number>; commands: string[]; commandsClipped: boolean
+      pendingIndex: number | null
     }
   | { ok: false; message: string }
 
@@ -235,4 +238,49 @@ export function agentDetailUrl(sessionId: string, runId: string, agentId: string
 /** An agent whose transcript is gone cannot be opened; the row must not offer it. */
 export function agentOpenable(a: WorkflowAgentRow): boolean {
   return typeof a.agentId === 'string' && a.agentId !== ''
+}
+
+
+// --- following a run while it happens ---------------------------------------
+
+/**
+ * Is this agent the one doing something RIGHT NOW?
+ *
+ * `pending` says its transcript ends on a tool call nobody answered — true of an agent that is
+ * working AND of one whose run was killed mid-call, which leaves exactly the same file behind. So
+ * the run's own liveness is required as well: a finished run has no live edge, whatever its
+ * transcripts look like, and pulsing a line inside it would announce work that stopped hours ago.
+ */
+export function agentIsRunning(agent: WorkflowAgentRow, runLive: boolean): boolean {
+  return runLive && agent.pending === true
+}
+
+/**
+ * Which command line to highlight, or null for none.
+ *
+ * Null whenever the answer would be a guess: the run is not live, nothing is pending, or the live
+ * edge is past the end of a clipped list — in that last case the line exists but is not on screen,
+ * and highlighting the last visible one instead would point at the wrong command.
+ */
+export function runningCommandIndex(
+  pendingIndex: number | null, commandCount: number, runLive: boolean,
+): number | null {
+  if (!runLive || pendingIndex === null) return null
+  return pendingIndex >= 0 && pendingIndex < commandCount ? pendingIndex : null
+}
+
+/**
+ * Does this run open by itself?
+ *
+ * A live run is one somebody is WATCHING — the whole reason the tab polls — so it opens without a
+ * click. A finished one does not: the list would then be several expanded runs deep and the newest
+ * would be off screen.
+ */
+export function runOpensByDefault(row: WorkflowRunRow): boolean {
+  return row.live
+}
+
+/** The agent that opens by itself inside an open live run: the one actually working. */
+export function agentOpensByDefault(agent: WorkflowAgentRow, runLive: boolean): boolean {
+  return agentIsRunning(agent, runLive) && agentOpenable(agent)
 }


### PR DESCRIPTION
Following a run meant three gestures: click the run, click the agent, then find the live edge by
eye. It now opens on it.

## Which line is running is not a guess

A transcript records a `tool_use` when the agent asks and a `tool_result` when the answer comes
back, so **an ask with no answer is the only thing in the file that is still happening**.

- Verified on a real finished agent: **58 asks, 58 answers, none pending**.
- Verified on a synthesised live one: the index lands on exactly the unanswered call.

```
[0] git status --short
[1] bun test packages/server
[2] bun run build          <- pendingToolIndex = 2

highlighted (run live)     -> 2
highlighted (run finished) -> null
```

It is a fact about the **file**, not a claim that anything is alive — a killed run leaves the same
dangling ask behind. So `agentIsRunning` requires the run's own liveness too, and
`runningCommandIndex` returns `null` whenever the answer would be a guess: the run is over, nothing
is pending, or the live edge is past the end of a **clipped** list. In that last case the line
exists and is not on screen, and highlighting the last visible one would point at the wrong
command.

## Opening by itself, without taking the panel over

- A run opens by itself only while it is **live**, and only **once**. The poll runs every five
  seconds; re-opening a card the user closed would take the panel away from them repeatedly.
- Inside it, the agent actually working is the one that opens. An agent that **starts** working
  later opens on the poll that notices — it never closes anything, so a row somebody shut stays
  shut.

## The highlight

A **background** pulse, not an opacity one: the text has to stay readable through the whole cycle,
and a command you cannot read while it runs is the one you most want to read. The executing line is
scrolled into view with `block: 'nearest'` and never `smooth` — this fires on every poll, and a
smooth scroll every five seconds is a box that will not sit still.

Working is said by a dot **and** by the label's colour, never by colour alone.

## Verification

`bun test` — **6751 pass, 0 fail**; `bun tsc --noEmit` clean. 8 new tests cover the in-flight
detection and the four cases where the highlight must be withheld.

Refs #349.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0161UEvuEphUuJEJFygVyaKy
