### PR TITLE
fix(web): the date windows read narrow to wide, with Today after All

### DIFF
--- a/packages/web/src/components/FiltersBar.tsx
+++ b/packages/web/src/components/FiltersBar.tsx
@@ -141,14 +141,17 @@ interface Props {
 }
 
 const DATE_RANGES: { key: DateRange; labelPt: string; labelEn: string }[] = [
-  // TODAY leads, because it is the one people reach for most and the one the custom range could
-  // never express: the calendar's "Today" fills an END and leaves the start where it was, which is
-  // "up to today" — a different question from "only today".
-  { key: 'today', labelPt: 'Hoje',   labelEn: 'Today'   },
+  // The windows run from narrow to wide, and TODAY sits after ALL rather than before 7d. It is not
+  // a step in that progression — the others ask "the last N days", it asks "only today" — and the
+  // custom range cannot express it either: the calendar's "Today" fills an END and leaves the start
+  // where it was, which is "up to today", a different question. Sitting at the end keeps the
+  // sequence one thing you read left to right, and leaves the odd one out where it is found rather
+  // than crossed over.
   { key: '7d',  labelPt: '7d',       labelEn: '7d'      },
   { key: '30d', labelPt: '30d',      labelEn: '30d'     },
   { key: '90d', labelPt: '90d',      labelEn: '90d'     },
   { key: 'all', labelPt: 'Tudo',     labelEn: 'All'     },
+  { key: 'today', labelPt: 'Hoje',   labelEn: 'Today'   },
 ]
 
 /**


### PR DESCRIPTION
`Today` led the date row:

```
[ Hoje ] [ 7d ] [ 30d ] [ 90d ] [ Tudo ]
```

It is not a step in that progression — the other four ask *"the last N days"* and it asks *"only
today"* — so it interrupted a sequence that otherwise reads left to right. Now:

```
[ 7d ] [ 30d ] [ 90d ] [ Tudo ] [ Hoje ]
```

The comment that justified the old position is **replaced**, not left contradicting the code. What
it still records is why `Today` exists as its own preset at all: the custom range cannot express
it, because the calendar's "Today" fills an **end** and leaves the start where it was — that is
"up to today", a different question.

`bun test` — **6801 pass, 0 fail**; `bun tsc --noEmit` clean. Nothing else reads `DATE_RANGES`, so
no ordering assumption travels with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0161UEvuEphUuJEJFygVyaKy
