### PR TITLE
fix(server): the instance claim is on the data directory, not the port

### DIFF
--- a/packages/server/server/backup/backup-plan.ts
+++ b/packages/server/server/backup/backup-plan.ts
@@ -50,7 +50,7 @@ export interface ExcludeRule {
    * `prefix` — the path STARTS WITH `pattern`. A string prefix, deliberately, not a directory
    * boundary: three rules depend on it matching a filename STEM rather than a directory
    * — `.agentistics/cache.db` must catch `cache.db-wal` and `cache.db-shm`, `.agentistics/git-stats.db`
-   * the same, and `.agentistics/server-` must catch `server-47291.lock`. A boundary check would let
+   * the same, and `.agentistics/server.lock` must be caught. A boundary check would let
    * all of those through.
    *
    * The cost is that a path merely sharing a string prefix is excluded too (a hypothetical
@@ -307,8 +307,8 @@ const RUNTIME: ExcludeRule[] = [
     why: 'Names tmux sessions that will not exist on the new machine. Restoring it yields rows pointing at nothing.',
   },
   {
-    pattern: '.agentistics/server-', match: 'prefix', reason: 'runtime',
-    why: 'Port lock files held by a process on the old machine.',
+    pattern: '.agentistics/server.lock', match: 'prefix', reason: 'runtime',
+    why: 'The instance claim, held by a process on the old machine. Restoring it would make a fresh machine believe a server it does not have is already running.',
   },
   {
     pattern: '.agentistics/events-producer.json', match: 'prefix', reason: 'runtime',

--- a/packages/server/server/config.ts
+++ b/packages/server/server/config.ts
@@ -86,7 +86,22 @@ export const GIT_STATS_CACHE_FILE = process.env.AGENTISTICS_GIT_STATS_CACHE_FILE
 /** One server per PORT. Keyed on the port rather than the machine because a local server and a
  *  central are two legitimate processes on one host — what must never happen twice is two servers
  *  answering for the same address while both scan every repository on disk. */
-export const serverLockFile = (port: number): string => join(AGENTISTICS_DATA_DIR, `server-${port}.lock`)
+/**
+ * The instance claim, keyed on the DATA DIRECTORY — never on the port.
+ *
+ * It was `server-${port}.lock`, which is a claim on a port, and the port already has a claim: the
+ * bind. What two servers actually contend over is this directory — the session registry, the
+ * consolidate store, the backup history — and the repositories they each walk to fill it.
+ *
+ * Measured on one machine with the port-keyed lock installed: `agentop server` on 47291 and a
+ * second one on 48801, both with no `AGENTISTICS_DIR`, both writing `~/.agentistics` and both
+ * spawning `git log --numstat` across every worktree. Two different lock names, so both passed the
+ * guard that exists to stop exactly that.
+ *
+ * Keyed on the directory, a preview on another port still runs — it just has to say WHERE its data
+ * goes (`AGENTISTICS_DIR=…`), which is the thing that made it harmless in the first place.
+ */
+export const serverLockFile = (): string => join(AGENTISTICS_DATA_DIR, 'server.lock')
 export const PARSE_CACHE_ENABLED = process.env.AGENTISTICS_PARSE_CACHE !== '0'
 
 // ---------------------------------------------------------------------------

--- a/packages/server/server/index.ts
+++ b/packages/server/server/index.ts
@@ -150,12 +150,15 @@ const serverProcStatsMap = new Map<number, ProcStatSample>()
 {
   const { claimInstanceLock } = await import('./single-instance')
   const { serverLockFile } = await import('./config')
-  const lock = await claimInstanceLock(serverLockFile(PORT))
+  const { AGENTISTICS_DATA_DIR: LOCK_DIR } = await import('./config')
+  const lock = await claimInstanceLock(serverLockFile())
   if (!lock.ok) {
     console.error(
-      `[startup] another agentop server is already running on port ${PORT}` +
+      `[startup] another agentop server is already using ${LOCK_DIR}` +
       (lock.holder ? ` (pid ${lock.holder})` : '') +
-      ' — exiting instead of scanning every repository a second time.'
+      ' — exiting instead of scanning every repository a second time.\n' +
+      '          To run a second one anyway, give it its own data directory: ' +
+      'AGENTISTICS_DIR=/path/to/dir agentop server'
     )
     process.exit(1)
   }

--- a/packages/server/server/single-instance.test.ts
+++ b/packages/server/server/single-instance.test.ts
@@ -4,7 +4,7 @@
 import { test, expect } from 'bun:test'
 import { mkdtemp, writeFile, readFile, utimes } from 'fs/promises'
 import { tmpdir } from 'os'
-import { join } from 'path'
+import { basename, join } from 'path'
 import { claimInstanceLock } from './single-instance'
 
 async function lockPath(): Promise<string> {
@@ -98,4 +98,19 @@ test('release does not free a lock another process has already taken over', asyn
 
   // Still held by 2222 — the late release must not have opened the door to a third.
   expect((await readFile(file, 'utf-8')).trim()).toBe('2222')
+})
+
+// THE CLAIM IS ON THE DATA DIRECTORY, NOT THE PORT — see `serverLockFile`'s header.
+//
+// It used to be `server-${port}.lock`, and measured on a real machine WITH that guard installed:
+// `agentop server` on 47291 and a second one on 48801, both with no `AGENTISTICS_DIR`, both
+// writing `~/.agentistics` and both spawning `git log --numstat` across every worktree. Two lock
+// names, so both passed the guard that exists to stop exactly that. The port already has a claim
+// — the bind. What two servers contend over is the directory.
+test('the lock names the data directory and carries no port', async () => {
+  const { serverLockFile, AGENTISTICS_DATA_DIR } = await import('./config')
+  const file = serverLockFile()
+  expect(file).toBe(join(AGENTISTICS_DATA_DIR, 'server.lock'))
+  // A port in the name is what let two servers past it.
+  expect(/\d{4,5}/.test(basename(file))).toBe(false)
 })


### PR DESCRIPTION
## The guard had a hole, and this machine was standing in it

`#301` shipped `single-instance.ts` — "one server per machine, decided before any work is spent".
Its lock file was:

```ts
serverLockFile = (port) => join(AGENTISTICS_DATA_DIR, `server-${port}.lock`)
```

That is a claim on a **port**, and the port already has one: the bind. What two servers actually
contend over is the **data directory** — the session registry, the consolidate store, the backup
history, and the repositories they each walk to fill it.

**Measured with that guard installed and running:**

```
agentop server            port 47291   AGENTISTICS_DIR unset  ->  ~/.agentistics
./release/agentop server  port 48801   AGENTISTICS_DIR unset  ->  ~/.agentistics

both spawning `git log --numstat` across every worktree
load average 65 · swap 7.9 GB of 8.0 GB
```

Two different lock names, so **both passed the guard that exists to stop exactly that**.

## The change

The claim is keyed on the directory. A preview on another port still runs — it just has to say
**where its data goes**, which is the thing that made it harmless in the first place. So the
refusal names the directory it could not claim *and* the flag that gives a second instance its own:

```
[startup] another agentop server is already using /home/you/.agentistics (pid 989173)
          — exiting instead of scanning every repository a second time.
          To run a second one anyway, give it its own data directory:
          AGENTISTICS_DIR=/path/to/dir agentop server
```

A refusal that does not say how to proceed is one people work around by deleting the guard.

## Caught by an existing lint, not by me

Renaming the file made `backup-coverage.lint.test.ts` fail: *"every path agentop writes under
~/.agentistics is either backed up or excluded WITH A REASON"*. The exclusion is updated — a lock
must never be restored, or a fresh machine believes a server it does not have is already running.

## Verification

- The new test is **proven to catch the regression**: putting the port back in the name turns it
  red, taking it out turns it green.
- `bun test` — **6802 pass, 0 fail**; `bun tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0161UEvuEphUuJEJFygVyaKy
