### PR TITLE
fix(security): o servidor para de negar o microfone à própria página

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -142,7 +142,7 @@ test asserting exactly that (`auth-principal.test.ts`, `stepup.test.ts`).
 | **Step-up** (`stepup.ts`) | requires fresh proof for destructive operations | protect non-destructive reads; a stolen cookie can still read everything in scope |
 | **CSRF** (`csrf.ts`) | rejects unsafe methods that carry a cookie without same-origin provenance | apply to Bearer clients, which carry no cookie and are exempt by definition |
 | **CORS** (`cors.ts`) | exact-match allowlist; no ACAO at all for an unknown origin | matter to non-browser clients, which ignore CORS entirely |
-| **CSP / headers** (`security-headers.ts`) | no inline script, `frame-ancestors 'none'`, HSTS under TLS, `no-store` on `/api` | prevent an XSS — it reduces what one can do |
+| **CSP / headers** (`security-headers.ts`) | no inline script, `frame-ancestors 'none'`, HSTS under TLS, `no-store` on `/api`, every capability denied but `microphone=(self)` | prevent an XSS — it reduces what one can do |
 | **Team scoping** (`team-scope.ts`) | filters sessions, projects, caches and presence to the principal's teams plus machines they own | apply to routes that do not go through it; new data routes must opt in |
 | **Audit log** (`audit.ts`) | append-only, 180-day TTL, secret-shaped fields redacted before write | prevent anything — it is how you find out |
 | **Resource limits** (`limits.ts`) | byte-counted bodies abandoned mid-stream, SSE cap, outbound timeouts | bound memory used by a legitimate large aggregation |

--- a/docs/sessions-web.md
+++ b/docs/sessions-web.md
@@ -93,6 +93,18 @@ advertise the cycle key.
 
 - **Dictation shows what it is hearing.** `interimResults` is on, the interim text is previewed, and
   the mic pulses while it is live — a control that records silently is one you cannot tell is broken.
+- **The SERVER may not deny the microphone to its own page.** The baseline security header said
+  `Permissions-Policy: microphone=()`, which denies the document itself and not merely a third
+  party, so dictation was dead on `localhost` too — where the secure context it needs is satisfied.
+  Measured on `http://localhost:47292`: `isSecureContext` true, `allowsFeature('microphone')`
+  FALSE, `SpeechRecognition.start()` answering `onerror: not-allowed`, which `dictationError` then
+  reported as the browser having refused a permission the user was never asked for. It is
+  `microphone=(self)`: same-origin only, and the browser's own prompt is still the consent gate.
+  `dictationSupport` has a `blocked` state for it, because a reverse proxy in front of a central can
+  send the same header and the button must name what is actually refusing.
+- **A stale service worker carries stale HEADERS.** The PWA precache serves the whole document, and
+  a cached response brings its `Permissions-Policy` with it — so the fix above appears not to work
+  until the shell is replaced. `Ctrl+Shift+R`, or unregister the worker.
 - **It does not lose focus mid-sentence.** The poll re-rendered the view under the field.
 - **`Enter` sends on a hardware keyboard and BREAKS THE LINE on a phone.** `shift+enter` needs a
   shift key a software keyboard does not have, so on a touch layout the return key is the only way

--- a/packages/server/server/security-headers.test.ts
+++ b/packages/server/server/security-headers.test.ts
@@ -71,6 +71,12 @@ describe('securityHeaders', () => {
     expect(h['Cross-Origin-Opener-Policy']).toBe('same-origin')
     expect(h['Cross-Origin-Resource-Policy']).toBe('same-origin')
     expect(h['Permissions-Policy']).toContain('camera=()')
+    // The composer's dictation is a first-party feature of this page, and `microphone=()` denies
+    // the page itself — that is why the microphone was dead on `localhost`, where the secure
+    // context dictation requires is satisfied. `(self)` is same-origin only; the browser's own
+    // prompt is still what grants it.
+    expect(h['Permissions-Policy']).toContain('microphone=(self)')
+    expect(h['Permissions-Policy']).not.toContain('microphone=()')
     expect(h['Content-Security-Policy']).toContain("default-src 'self'")
   })
 

--- a/packages/server/server/security-headers.ts
+++ b/packages/server/server/security-headers.ts
@@ -75,7 +75,24 @@ export function securityHeaders(opts: {
     // where this applies, the server is bound to 127.0.0.1 anyway. Every other profile keeps
     // `same-origin`.
     'Cross-Origin-Resource-Policy': opts.embed ? 'cross-origin' : 'same-origin',
-    'Permissions-Policy': 'camera=(), microphone=(), geolocation=(), payment=(), usb=()',
+    /*
+     * MICROPHONE IS `self`, and every other capability stays denied.
+     *
+     * The composer takes DICTATION (`dictation.ts`), which is a first-party feature of this very
+     * page — and `microphone=()` denies the page ITSELF, not merely third parties. So the mic was
+     * off everywhere, `localhost` included, where the secure-context rule the whole dictation
+     * module is written around is satisfied. Measured on this dashboard at http://localhost:47292:
+     * `isSecureContext` true, `document.featurePolicy.allowsFeature('microphone')` FALSE, and
+     * `SpeechRecognition.start()` answering `onerror: not-allowed` — which `dictationError` then
+     * reported as "the browser denied this page permission", sending the user to fix a browser
+     * setting that was never the problem. Reported as "o microfone não funciona no localhost".
+     *
+     * `(self)` is the narrow grant: same-origin documents only, no third-party frame, and the
+     * browser's own permission prompt is still the consent gate — nothing here grants a microphone,
+     * it only stops the server from refusing one on the user's behalf. Camera, geolocation, payment
+     * and usb have no feature in this product and stay denied.
+     */
+    'Permissions-Policy': 'camera=(), microphone=(self), geolocation=(), payment=(), usb=()',
   }
   if (opts.tls) h['Strict-Transport-Security'] = 'max-age=31536000; includeSubDomains'
   // API responses carry account-scoped data; a shared cache must never hold them.

--- a/packages/web/src/lib/dictation.test.ts
+++ b/packages/web/src/lib/dictation.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'bun:test'
-import { dictationSupport, dictationLocale, dictationError, insecureAlternative, dictatedText, appendDictation } from './dictation'
+import { dictationSupport, dictationLocale, dictationError, insecureAlternative, dictatedText, appendDictation, micDenied } from './dictation'
 
 describe('dictationSupport', () => {
   it('is ready when the API exists in a secure context', () => {
@@ -31,6 +31,39 @@ describe('dictationSupport', () => {
 
   it('survives having no window at all', () => {
     expect(dictationSupport(undefined, 'en').state).toBe('no-api')
+  })
+
+  it('names the PERMISSIONS POLICY when the page itself is denied the microphone', () => {
+    // The bug this covers: agentop's own baseline sent `Permissions-Policy: microphone=()`, which
+    // denies the PAGE, not merely third parties. Measured on http://localhost:47292 —
+    // `isSecureContext` true, `allowsFeature('microphone')` false, `SpeechRecognition.start()`
+    // answering `not-allowed` — so the user was told the browser had refused a permission they
+    // had never been asked for. A reverse proxy can send the same header, so the check stays.
+    const win = {
+      SpeechRecognition: class {},
+      isSecureContext: true,
+      document: { featurePolicy: { allowsFeature: (f: string) => f !== 'microphone' } },
+    }
+    const s = dictationSupport(win, 'pt')
+    expect(s.state).toBe('blocked')
+    expect(s.reason).toMatch(/Permissions-Policy/)
+    expect(dictationSupport(win, 'en').reason).toMatch(/Permissions-Policy/)
+  })
+
+  it('is READY when the policy allows the microphone', () => {
+    expect(dictationSupport({
+      SpeechRecognition: class {},
+      isSecureContext: true,
+      document: { featurePolicy: { allowsFeature: () => true } },
+    }, 'en').state).toBe('ready')
+  })
+
+  it('reports HTTP before the policy — the protocol is the fixable half', () => {
+    expect(dictationSupport({
+      SpeechRecognition: class {},
+      isSecureContext: false,
+      document: { featurePolicy: { allowsFeature: () => false } },
+    }, 'en').state).toBe('insecure')
   })
 
   it('every refusal has real text in both languages', () => {
@@ -145,5 +178,21 @@ describe('insecureAlternative on a phone', () => {
 
   it('defaults to the old behaviour, so no caller loses it by omission', () => {
     expect(insecureAlternative('http://10.0.0.4:47292/')).toBe('http://localhost:47292/')
+  })
+})
+
+describe('micDenied', () => {
+  it('counts only a definite false — an absent API is not a denial', () => {
+    // Reporting a refusal in front of a microphone that works is the opposite of this module's job.
+    expect(micDenied(undefined)).toBe(false)
+    expect(micDenied({})).toBe(false)
+    expect(micDenied({ document: {} })).toBe(false)
+    expect(micDenied({ document: { featurePolicy: {} } })).toBe(false)
+    expect(micDenied({ document: { featurePolicy: { allowsFeature: () => true } } })).toBe(false)
+    expect(micDenied({ document: { featurePolicy: { allowsFeature: () => false } } })).toBe(true)
+  })
+
+  it('a throwing implementation is not an answer either', () => {
+    expect(micDenied({ document: { featurePolicy: { allowsFeature: () => { throw new Error('nope') } } } })).toBe(false)
   })
 })

--- a/packages/web/src/lib/dictation.ts
+++ b/packages/web/src/lib/dictation.ts
@@ -15,7 +15,7 @@
  * to send — the same text they could have typed.
  */
 
-export type DictationState = 'ready' | 'no-api' | 'insecure'
+export type DictationState = 'ready' | 'no-api' | 'insecure' | 'blocked'
 
 export interface DictationSupport {
   state: DictationState
@@ -29,7 +29,13 @@ export interface DictationSupport {
  * nothing checks.
  */
 export function dictationSupport(
-  win: { SpeechRecognition?: unknown; webkitSpeechRecognition?: unknown; isSecureContext?: boolean } | undefined,
+  win: {
+    SpeechRecognition?: unknown
+    webkitSpeechRecognition?: unknown
+    isSecureContext?: boolean
+    /** Reached through the window so the caller keeps passing ONE object — see `micDenied`. */
+    document?: { featurePolicy?: { allowsFeature?: (feature: string) => boolean } }
+  } | undefined,
   lang: 'en' | 'pt',
 ): DictationSupport {
   const pt = lang === 'pt'
@@ -52,7 +58,42 @@ export function dictationSupport(
         : 'The microphone needs HTTPS or localhost. This page is on plain HTTP.',
     }
   }
+  // Checked THIRD, and it is the one a person cannot fix from their side: the PAGE may be denied
+  // the microphone by the `Permissions-Policy` header the server sent, and the browser then answers
+  // `not-allowed` — indistinguishable, from inside the recogniser, from someone clicking "Block".
+  // That is exactly what shipped: agentop's own baseline said `microphone=()`, which denies the
+  // page itself, so dictation was dead on `localhost` too and the message blamed the browser.
+  // A reverse proxy in front of a central can do the same thing, so the check stays whatever the
+  // baseline says.
+  if (micDenied(win)) {
+    return {
+      state: 'blocked',
+      reason: pt
+        ? 'Esta página está proibida de usar o microfone pelo cabeçalho Permissions-Policy do servidor (ou do proxy na frente dele). Não é uma permissão do navegador.'
+        : 'This page is denied the microphone by the server’s Permissions-Policy header (or a proxy in front of it). This is not a browser permission.',
+    }
+  }
   return { state: 'ready', reason: null }
+}
+
+/**
+ * PURE: does the permissions policy of THIS document deny the microphone?
+ *
+ * Only a definite `false` counts. `document.featurePolicy` is non-standard-ish and absent in some
+ * browsers, and an absent answer is not a denial — reporting one would put a refusal in front of a
+ * microphone that works, which is the opposite of the rule this module exists for.
+ */
+export function micDenied(win: {
+  document?: { featurePolicy?: { allowsFeature?: (feature: string) => boolean } }
+} | undefined): boolean {
+  const fp = win?.document?.featurePolicy
+  if (!fp || typeof fp.allowsFeature !== 'function') return false
+  try {
+    return fp.allowsFeature('microphone') === false
+  } catch {
+    // A throw is not an answer either.
+    return false
+  }
 }
 
 /** The BCP-47 tag the recogniser listens in — the UI language, because that is what the user types


### PR DESCRIPTION
## Summary

- `Permissions-Policy` passa de `microphone=()` para `microphone=(self)` — o valor antigo negava a capacidade ao **próprio documento**, não só a terceiros, então o ditado do compositor estava morto em toda origem, `localhost` inclusive.
- `dictationSupport` ganha o estado `blocked`, para quando um proxy reverso reintroduzir o mesmo header.
- Documenta as duas metades do sintoma em `docs/sessions-web.md` — incluindo o service worker do PWA, que serve headers cacheados junto com o shell e faz a correção parecer não ter funcionado.

## Motivation

Reportado como "o microfone não funciona no localhost" — o estado `listening` acendia por um instante e apagava, sem prompt de permissão nenhum, e aba anônima não mudava nada.

Medido em `http://localhost:47292`, que é contexto seguro e portanto deveria funcionar:

```
isSecureContext                                : true
document.featurePolicy.allowsFeature('microphone') : false
SpeechRecognition.start()                      : onerror -> not-allowed
```

O `not-allowed` era então traduzido por `dictationError` como "o navegador negou a permissão para esta página", mandando a pessoa consertar uma configuração de navegador que nunca foi o problema. `dictationSupport` também não tinha como dizer o contrário: checa API e contexto seguro, os dois passam, e o botão é oferecido como se funcionasse.

`(self)` é a concessão estreita — mesma origem, nenhum frame de terceiro — e o prompt do próprio navegador segue sendo o portão de consentimento. Nada aqui **concede** microfone; apenas para de recusá-lo em nome do usuário. Câmera, geolocalização, pagamento e USB continuam negados.

Fora de escopo, e dito na Issue: microfone em `http://` de LAN (celular) continua impossível. Nenhum navegador libera isso fora de HTTPS/localhost, e nenhum header resolve.

Closes #401

## Changes

- `packages/server/server/security-headers.ts` — `microphone=(self)`, com o registro do que foi medido e por que a concessão é estreita.
- `packages/server/server/security-headers.test.ts` — fixa `microphone=(self)` e a ausência de `microphone=()`.
- `packages/web/src/lib/dictation.ts` — novo estado `blocked` + `micDenied`, puro. Checado **depois** de API e contexto seguro (o protocolo é a metade consertável) e só com um `false` definitivo: uma API ausente ou que lança não é uma negativa, e anunciar recusa na frente de um microfone que funciona é o inverso do que o módulo existe para fazer.
- `packages/web/src/lib/dictation.test.ts` — 5 casos novos, incluindo a ordem HTTP-antes-da-política.
- `docs/security.md`, `docs/sessions-web.md`.

## Test plan

- [x] `bunx tsc --noEmit` limpo; `bun test` 6816 passando / 0 falhando.
- [x] Header servido conferido com o código novo: `camera=(), microphone=(self), geolocation=(), payment=(), usb=()`.
- [x] No Chrome, contra esse header: `allowsFeature('microphone')` **true**, `permissions.query('microphone')` em **`prompt`** — a decisão volta a ser do usuário. Antes: `false` e `not-allowed` imediato, sem prompt.
- [x] Binário compilado, instalado e serviço reiniciado nesta máquina; no dashboard real o reconhecedor **arranca e para limpo** (`started-and-stopped-ok`).
- [ ] Reviewer: com o binário novo, um `Ctrl+Shift+R` é necessário — o service worker antigo serve o documento cacheado **com os headers antigos junto**, e sem isso a correção parece não ter funcionado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GRbrwycvprKKy9uhEVQ8ke