### PR TITLE
fix(sessions): voltar para um chat mostra a conversa de agora, não a de quando você saiu

### DIFF
--- a/docs/sessions-web.md
+++ b/docs/sessions-web.md
@@ -33,6 +33,28 @@ impossible. One control per selection: the excerpt menu and the message menu use
 browser, so returning to a session that had answered showed the last message you sent for several
 seconds before catching up. `visibilitychange` now forces a read.
 
+**Coming back to the CHAT is a different thing, and it has its own answer** (`lib/chatFeed.ts`). The
+poll used to live inside the view, so the cached conversation was only ever written while that view
+was mounted — and mounting is what returning to a session IS. The first frame was therefore exactly
+as old as the time spent elsewhere: leave mid-turn, come back two minutes later, see your own last
+message, and then watch every reply since arrive in one jump. Not a slow fetch — the read answers in
+66-143 ms on every session on this machine — but a first frame that was two minutes old.
+
+The read is now a shared feed that **keeps reading the conversation you just left**, and every half
+of that is bounded, because a background poll nobody asked for is how a machine quietly gets slower:
+only the two most recently left conversations, only while the document is visible, only for five
+minutes, at a tenth of the foreground cadence, and never for a session that has ENDED — its
+transcript is final. When the frame IS stale anyway (the tab was hidden, or you were away longer
+than that), the view SAYS it is updating rather than presenting old content as current, and waits
+400 ms first so the label is not itself a flicker.
+
+**Nothing in that feed may pin a conversation the cache has released.** `sessionScratch` caps itself
+at ten parsed conversations precisely because a conversation is hundreds of turns; a reference held
+in the feed would defeat that cap from outside. So the feed keeps the last answer's BYTES (to tell a
+changed read from an unchanged one, and hand back the same instance when nothing moved — React then
+renders nothing) and reads the object back from the cache, never holding one. Entries exist only for
+what is actually polled; what outlives them is a read STAMP, a number, in its own capped map.
+
 ---
 
 ## Answering a dialog

--- a/packages/web/src/components/sessions/SessionChat.tsx
+++ b/packages/web/src/components/sessions/SessionChat.tsx
@@ -40,7 +40,8 @@ import { isImagePath } from '../../lib/attachmentPreview'
 import { splitImageAttachments } from '../../lib/attachmentPreview'
 import { attachmentUrl } from '../../lib/attachmentUrl'
 import { liveTurnText, stripAnsi } from '../../lib/liveTurn'
-import { scratchKey, sessionScratch, type CachedChat } from '../../lib/sessionScratch'
+import { scratchKey, sessionScratch } from '../../lib/sessionScratch'
+import { chatReadAt, firstFrameStale, refreshChat, subscribeChat } from '../../lib/chatFeed'
 import { composerMaxHeight } from '../../lib/composerHeight'
 import { artifactsFromTurns, hasUnlistedWrites, type Artifact } from '../../lib/sessionArtifacts'
 import type { LiveTurn } from '../../lib/artifactTabs'
@@ -107,8 +108,11 @@ export interface SessionChatProps {
   }) => void
 }
 
-/** Matches the fleet poll. The transcript only changes when a turn lands, so faster buys nothing. */
-const CHAT_POLL_MS = 3000
+// How often the conversation is re-read — and for how long it keeps being read after you leave —
+// belongs to `chatFeed.ts`, which is the one place that decides it for every surface.
+
+/** How long a stale first frame goes unannounced before the "updating" line appears. */
+const REFRESH_NOTICE_MS = 400
 
 // How tall the composer's field may grow is `composerHeight.ts` — a share of the viewport rather
 // than a constant, because a fixed number is most of a phone and a sliver of a desktop.
@@ -152,6 +156,16 @@ export function SessionChat({ session, row, lang, act, onArtifacts }: SessionCha
   const scratchId = scratchKey(session)
 
   const [payload, setPayload] = useState<ChatPayload | null>(() => sessionScratch.readChat(scratchId) as ChatPayload | null)
+  /**
+   * The frame on screen is one this session cached a while ago, and a fresh read is on its way.
+   *
+   * Only ever true for a first frame that is genuinely BEHIND (`firstFrameStale`) — the tab was
+   * hidden, or the warm window closed while you were away. Saying nothing there is what makes the
+   * conversation appear to change on its own; saying it on every mount would be a label that
+   * flashes for 150 ms and means nothing, which is why the marker itself also waits (see
+   * `showRefreshing`).
+   */
+  const [refreshing, setRefreshing] = useState(() => firstFrameStale(chatReadAt(scratchId), Date.now()))
   const [draft, setDraft] = useState(() => sessionScratch.readDraft(scratchId))
 
   /**
@@ -203,6 +217,7 @@ export function SessionChat({ session, row, lang, act, onArtifacts }: SessionCha
     landedRef.current = false
     setAtTail(true)
     setPayload(sessionScratch.readChat(scratchId) as ChatPayload | null)
+    setRefreshing(firstFrameStale(chatReadAt(scratchId), Date.now()))
     setDraft(sessionScratch.readDraft(scratchId))
     setReplyTo(sessionScratch.readReply(scratchId))
     setEcho(sessionScratch.readEchoes(scratchId))
@@ -604,42 +619,54 @@ export function SessionChat({ session, row, lang, act, onArtifacts }: SessionCha
    */
   const nudgeChat = useRef<() => void>(() => {})
 
+  /*
+   * THE CONVERSATION IS READ BY `chatFeed`, NOT BY THIS COMPONENT.
+   *
+   * The poll used to live here, which meant it existed only while this view was mounted — and
+   * mounting is what returning to a session IS. So the cached first frame was exactly as old as
+   * the time spent elsewhere: leave mid-turn, come back two minutes later, and the conversation
+   * on screen was the one you left, ending at your own last message, with every reply since
+   * arriving in one jump a moment later. Reported as "por um instante fica meu último prompt ali
+   * e, do nada, carrega todas as novas mensagens".
+   *
+   * The feed keeps reading it for a few minutes after the last watcher leaves, so the frame this
+   * mount paints from the cache is current. Everything else is unchanged: it still asks on mount,
+   * still polls at the same cadence while watched, and a failed read still keeps the conversation
+   * on screen rather than blanking it.
+   *
+   * A BACKGROUND TAB still does not poll — Chrome throttles a hidden tab's timers to roughly once
+   * a minute, and the warm read stands down there too — so coming back into view asks immediately,
+   * which is the exact moment somebody wants what they missed.
+   */
   useEffect(() => {
-    let alive = true
-    const poll = async () => {
-      try {
-        const res = await fetch(`/api/fleet/chat?id=${encodeURIComponent(session.id)}&lang=${lang}`)
-        if (!res.ok || !alive) return
-        const next = await res.json() as ChatPayload
-        setPayload(next)
-        // Write through, so the NEXT visit starts where this one ended.
-        sessionScratch.writeChat(scratchId, next as unknown as CachedChat)
-      } catch { /* transient — keep the last conversation rather than blanking it */ }
-    }
-    nudgeChat.current = () => { void poll() }
-    void poll()
-    const t = setInterval(poll, CHAT_POLL_MS)
-    /*
-     * A BACKGROUND TAB DOES NOT POLL, and nothing here noticed it coming back.
-     *
-     * Chrome throttles `setInterval` in a hidden tab to roughly once a minute, so leaving the
-     * session to do something else and returning meant the conversation on screen was as old as the
-     * last tick — the cached turns ending at your own last message — until the throttled interval
-     * happened to fire. Reported as "fica um tempo na minha última mensagem e depois de uns 5
-     * segundos aparece as mensagens". Measured against the server, which is not the slow part: the
-     * chat read answers in 100-220ms on every session on this machine.
-     *
-     * Coming back into view is the exact moment somebody wants what they missed, so it asks then.
-     */
-    const onVisible = () => { if (document.visibilityState === 'visible') void poll() }
+    const stop = subscribeChat({ id: session.id, key: scratchId, lang }, next => {
+      setPayload(next as unknown as ChatPayload)
+      setRefreshing(false)
+    })
+    nudgeChat.current = () => { refreshChat(session.id) }
+    const onVisible = () => { if (document.visibilityState === 'visible') refreshChat(session.id) }
     document.addEventListener('visibilitychange', onVisible)
     return () => {
-      alive = false
       nudgeChat.current = () => {}
-      clearInterval(t)
       document.removeEventListener('visibilitychange', onVisible)
+      stop()
     }
-  }, [session.id, lang])
+  }, [session.id, lang, scratchId])
+
+  /**
+   * THE MARKER WAITS, and that is what keeps it from being noise.
+   *
+   * The read answers in 66-143 ms on this machine, so a label rendered the instant a mount starts
+   * would appear and vanish inside a blink on almost every visit — a flicker announcing a flicker.
+   * It is shown only once the wait is long enough to be felt, which on a phone reaching a member
+   * machine over the LAN with a long transcript is where it actually earns its place.
+   */
+  const [showRefreshing, setShowRefreshing] = useState(false)
+  useEffect(() => {
+    if (!refreshing) { setShowRefreshing(false); return }
+    const t = setTimeout(() => setShowRefreshing(true), REFRESH_NOTICE_MS)
+    return () => clearTimeout(t)
+  }, [refreshing])
 
   /**
    * IS THE LIVE SCREEN WORTH WATCHING RIGHT NOW?
@@ -1211,6 +1238,16 @@ export function SessionChat({ session, row, lang, act, onArtifacts }: SessionCha
               wrong PLACE for whatever chrome slipped through. `live` still drives the follow-the-
               tail effect below (new screen content is a sign to keep scrolling), and `WorkingNote`
               is the one and only "the session is busy" indicator now — small, grey, no raw text. */}
+
+          {/* The conversation on screen is one this tab cached before you left, and the current one
+              is on its way. AT THE TAIL rather than the top: the view lands at the end, which is
+              where the reader is looking and where the messages that changed will appear. */}
+          {showRefreshing && (
+            <p role="status" style={{
+              margin: 0, textAlign: 'center', fontSize: 11, lineHeight: 1.5,
+              color: 'var(--text-tertiary)',
+            }}>{pt ? 'Atualizando a conversa…' : 'Updating this conversation…'}</p>
+          )}
 
           {/* The quiet line saying the session is busy. AFTER the messages, deliberately not styled
               as one — it is the only place the reasoning and the tool calls surface, and rendering

--- a/packages/web/src/lib/chatFeed.test.ts
+++ b/packages/web/src/lib/chatFeed.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect } from 'bun:test'
+import {
+  feedDue,
+  feedExpired,
+  firstFrameStale,
+  newEntry,
+  warmToDrop,
+  stampsToDrop,
+  MAX_STAMPS,
+  FOREGROUND_POLL_MS,
+  WARM_POLL_MS,
+  WARM_TTL_MS,
+  STALE_FRAME_MS,
+  type FeedEntry,
+} from './chatFeed'
+
+const NOW = 1_000_000
+
+function entry(over: Partial<FeedEntry> = {}): FeedEntry {
+  return { ...newEntry(), ...over }
+}
+
+describe('feedDue — a watched conversation', () => {
+  it('is read at once when it has never been read', () => {
+    expect(feedDue(entry({ watchers: 1 }), NOW, true)).toBe(true)
+  })
+
+  it('keeps the cadence the view has always had', () => {
+    const e = entry({ watchers: 1, triedAt: NOW - FOREGROUND_POLL_MS + 1 })
+    expect(feedDue(e, NOW, true)).toBe(false)
+    expect(feedDue({ ...e, triedAt: NOW - FOREGROUND_POLL_MS }, NOW, true)).toBe(true)
+  })
+
+  it('is read even in a hidden tab — the browser throttles that timer by itself', () => {
+    // Suppressing it here would add a second rule on top of the browser's, and the visibility
+    // handler that asks the moment the tab comes back is what actually closes the gap.
+    expect(feedDue(entry({ watchers: 1, triedAt: NOW - FOREGROUND_POLL_MS }), NOW, false)).toBe(true)
+  })
+})
+
+describe('feedDue — a conversation nobody has open', () => {
+  it('is read at a slower cadence than a watched one', () => {
+    const left = entry({ watchers: 0, leftAt: NOW - 1000, triedAt: NOW - FOREGROUND_POLL_MS })
+    expect(feedDue(left, NOW, true)).toBe(false)
+    expect(feedDue({ ...left, triedAt: NOW - WARM_POLL_MS }, NOW, true)).toBe(true)
+  })
+
+  it('is NOT read while the document is hidden', () => {
+    // A hidden tab has no reader to be surprised by a stale first frame, and a background poll
+    // nobody asked for is exactly the kind of thing that quietly costs a machine.
+    const e = entry({ watchers: 0, leftAt: NOW - 1000, triedAt: NOW - WARM_POLL_MS })
+    expect(feedDue(e, NOW, false)).toBe(false)
+  })
+
+  it('is NOT read once the warm window has closed', () => {
+    const e = entry({ watchers: 0, leftAt: NOW - WARM_TTL_MS, triedAt: NOW - WARM_POLL_MS })
+    expect(feedDue(e, NOW, true)).toBe(false)
+  })
+
+  it('is NOT read when the session has ended — its transcript is final', () => {
+    const e = entry({ watchers: 0, leftAt: NOW - 1000, triedAt: NOW - WARM_POLL_MS, ended: true })
+    expect(feedDue(e, NOW, true)).toBe(false)
+  })
+
+  it('IS still read while watched, even after it ended — the view asked for it', () => {
+    const e = entry({ watchers: 1, leftAt: null, triedAt: NOW - FOREGROUND_POLL_MS, ended: true })
+    expect(feedDue(e, NOW, true)).toBe(true)
+  })
+})
+
+describe('feedExpired', () => {
+  it('never expires something on screen', () => {
+    expect(feedExpired(entry({ watchers: 1, leftAt: NOW - WARM_TTL_MS * 10, ended: true }), NOW)).toBe(false)
+  })
+
+  it('drops an ended conversation AT ONCE — an entry nothing reads is pure memory', () => {
+    // It holds the last answer's bytes (90-106 KB on the largest sessions here) and nothing would
+    // ever re-read it. What a reopened conversation needs is the read STAMP, and that outlives the
+    // entry in its own map.
+    expect(feedExpired(entry({ watchers: 0, leftAt: NOW, ended: true }), NOW)).toBe(true)
+  })
+
+  it('expires exactly at the warm TTL', () => {
+    expect(feedExpired(entry({ watchers: 0, leftAt: NOW - WARM_TTL_MS + 1 }), NOW)).toBe(false)
+    expect(feedExpired(entry({ watchers: 0, leftAt: NOW - WARM_TTL_MS }), NOW)).toBe(true)
+  })
+})
+
+describe('warmToDrop', () => {
+  it('keeps the most recently left and drops the rest', () => {
+    const list = [
+      ['a', entry({ watchers: 0, leftAt: 100 })],
+      ['b', entry({ watchers: 0, leftAt: 300 })],
+      ['c', entry({ watchers: 0, leftAt: 200 })],
+    ] as const
+    expect(warmToDrop(list, 2)).toEqual(['a'])
+  })
+
+  it('never drops a conversation something is showing, however long ago it was left', () => {
+    const list = [
+      ['open', entry({ watchers: 1, leftAt: 1 })],
+      ['x', entry({ watchers: 0, leftAt: 300 })],
+      ['y', entry({ watchers: 0, leftAt: 200 })],
+    ] as const
+    expect(warmToDrop(list, 1)).toEqual(['y'])
+  })
+
+  it('drops nothing while it is within the budget', () => {
+    expect(warmToDrop([['a', entry({ watchers: 0, leftAt: 1 })]], 2)).toEqual([])
+  })
+})
+
+describe('firstFrameStale', () => {
+  it('an UNKNOWN age is stale', () => {
+    // A frame this session never saw read is a frame of unknown age, and presenting one as current
+    // is the whole defect: the reader is shown their own last message and then, with nothing said,
+    // every reply that landed while they were away.
+    expect(firstFrameStale(null, NOW)).toBe(true)
+    expect(firstFrameStale(undefined, NOW)).toBe(true)
+  })
+
+  it('a frame from between two polls is not announced as stale', () => {
+    expect(firstFrameStale(NOW - STALE_FRAME_MS + 1, NOW)).toBe(false)
+    expect(firstFrameStale(NOW - STALE_FRAME_MS, NOW)).toBe(true)
+  })
+})
+
+describe('stampsToDrop', () => {
+  it('forgets nothing while the map is within budget', () => {
+    expect(stampsToDrop([['a', 1], ['b', 2]], 2)).toEqual([])
+  })
+
+  it('forgets the LEAST recently read first', () => {
+    // A map that only ever grows is a leak whether its rows are small or not — the same reason
+    // `sessionScratch` caps the cached conversations it holds.
+    expect(stampsToDrop([['old', 10], ['new', 30], ['mid', 20]], 1)).toEqual(['old', 'mid'])
+  })
+
+  it('keeps far more stamps than there are cached conversations', () => {
+    // A stamp is a number; the frame it describes is hundreds of KB. They do not deserve the same
+    // budget, and a stamp for a conversation the cache has released is still the right answer.
+    expect(MAX_STAMPS).toBeGreaterThan(10)
+  })
+})

--- a/packages/web/src/lib/chatFeed.ts
+++ b/packages/web/src/lib/chatFeed.ts
@@ -1,0 +1,327 @@
+/**
+ * chatFeed.ts — ONE read of a conversation, shared by whoever is watching it, and kept WARM for a
+ * while after they leave.
+ *
+ * THE BUG THIS EXISTS FOR: "se eu saio de um chat e volto, por um instante fica meu último prompt
+ * ali e, do nada, carrega todas as novas mensagens".
+ *
+ * `sessionScratch` caches the conversation so returning paints instantly instead of showing an
+ * empty column, and the view re-fetches on mount so the cache is never the answer, only the first
+ * frame. That is right, and it has one consequence nobody wrote down: THE CACHE IS ONLY WRITTEN
+ * WHILE THE VIEW IS MOUNTED, so its age is exactly how long you have been away. Leave a session
+ * mid-turn, spend two minutes elsewhere, come back — the first frame is the conversation as it was
+ * when you left, ending at your own last message, and every reply that landed in between arrives
+ * in one jump a few hundred milliseconds later. The jump is not a slow fetch (the read answers in
+ * 66-143 ms on every session on this machine); it is a first frame that was two minutes old.
+ *
+ * So the fix is not a faster fetch, it is a first frame that is not stale: the conversation you
+ * just left KEEPS BEING READ for a few minutes, at a relaxed cadence, and returning to it paints
+ * something current. Both halves are bounded, because a background poll nobody asked for is the
+ * kind of thing that quietly costs a machine:
+ *
+ *   - only the `MAX_WARM` most recently left conversations, never every cached one;
+ *   - only while the document is VISIBLE — a hidden tab has no reader to be surprised;
+ *   - only for `WARM_TTL_MS`, after which the conversation is on its own again;
+ *   - never for a conversation whose session has ENDED, whose transcript cannot change.
+ *
+ * What it deliberately does NOT do is claim the cached frame is current. When the first frame IS
+ * stale — the tab was hidden, or you were away longer than the warm window — the view says it is
+ * updating, because content that changes under the reader with nothing said is the complaint this
+ * whole module is answering.
+ */
+
+import { sessionScratch, type CachedChat } from './sessionScratch'
+
+/** Matches the fleet poll. The transcript only changes when a turn lands, so faster buys nothing. */
+export const FOREGROUND_POLL_MS = 3000
+
+/**
+ * How often a conversation NOBODY IS LOOKING AT is re-read.
+ *
+ * Deliberately much slower than the foreground: the only thing this cadence buys is the age of the
+ * FIRST FRAME on return, and the view's own read on mount closes whatever gap is left. Ten seconds
+ * means that first frame is at most one turn behind — usually identical — for a tenth of the
+ * requests a foreground poll would spend on a conversation nobody has open.
+ */
+export const WARM_POLL_MS = 10000
+
+/**
+ * How long a conversation stays warm after its last watcher leaves.
+ *
+ * Long enough to cover going somewhere else and coming back, short enough that a session opened
+ * once and abandoned stops costing anything. Past it the cached frame is stale and SAID to be.
+ */
+export const WARM_TTL_MS = 5 * 60_000
+
+/** How many left-behind conversations stay warm at once. The most recently left win. */
+export const MAX_WARM = 2
+
+/**
+ * How old a cached first frame may be before the view says it is updating.
+ *
+ * A second and a half is comfortably more than one foreground poll plus its round trip, so a frame
+ * that is merely between ticks is never announced as stale — only one that is actually behind.
+ */
+export const STALE_FRAME_MS = 1500
+
+/** What this module knows about one conversation. Pure data, so every decision below is testable. */
+export interface FeedEntry {
+  /** How many mounted surfaces are watching it right now. */
+  watchers: number
+  /** When the last watcher left, or null while one is still there. */
+  leftAt: number | null
+  /** When a read was last ATTEMPTED — the cadence is measured on attempts, so a failing read
+   *  waits its turn like any other instead of being retried on every tick. */
+  triedAt: number | null
+  /** The last answer said the session is not running, so its transcript is final. */
+  ended: boolean
+}
+
+export function newEntry(): FeedEntry {
+  return { watchers: 0, leftAt: null, triedAt: null, ended: false }
+}
+
+/** Is this conversation due for a read right now? */
+export function feedDue(e: FeedEntry, now: number, visible: boolean): boolean {
+  const since = e.triedAt === null ? Infinity : now - e.triedAt
+  // WATCHED: the cadence the view has always had. A hidden tab still counts as watched — the
+  // browser throttles its timers to about once a minute by itself, and coming back into view asks
+  // immediately (`refreshChat`), which is what covers the gap.
+  if (e.watchers > 0) return since >= FOREGROUND_POLL_MS
+  // WARM: a conversation nobody has open, being kept current for a possible return.
+  if (!visible) return false
+  if (e.ended) return false
+  if (feedExpired(e, now)) return false
+  return since >= WARM_POLL_MS
+}
+
+/**
+ * Has the warm window closed? A watched conversation never expires.
+ *
+ * An ENDED one goes AT ONCE: its transcript is final, so nothing would re-read it, and an entry
+ * that is never read is pure memory — it holds the last answer's bytes. What a reopened
+ * conversation needs is only the STAMP, and that outlives the entry in `readStamps`.
+ */
+export function feedExpired(e: FeedEntry, now: number): boolean {
+  if (e.watchers > 0) return false
+  if (e.ended) return true
+  if (e.leftAt === null) return false
+  return now - e.leftAt >= WARM_TTL_MS
+}
+
+/**
+ * Which warm conversations to let go of, keeping the `max` most recently left.
+ *
+ * Watched ones are never dropped, whatever they cost — something is on screen showing them.
+ */
+export function warmToDrop(entries: readonly (readonly [string, FeedEntry])[], max = MAX_WARM): string[] {
+  const warm = entries.filter(([, e]) => e.watchers === 0)
+  const ordered = [...warm].sort((a, b) => (b[1].leftAt ?? 0) - (a[1].leftAt ?? 0))
+  return ordered.slice(max).map(([k]) => k)
+}
+
+/**
+ * Is the frame this view is about to paint from the cache old enough to be worth saying so?
+ *
+ * An UNKNOWN age counts as stale: the payload was cached by a version of this app, or a mount, that
+ * this module never saw read it, and presenting a frame of unknown age as current is the exact
+ * thing being fixed. `null` here means "no cached frame at all", which is the loading state and not
+ * this question — the caller only asks once it has something to paint.
+ */
+export function firstFrameStale(at: number | null | undefined, now: number): boolean {
+  if (at === null || at === undefined) return true
+  return now - at >= STALE_FRAME_MS
+}
+
+// ---------------------------------------------------------------------------------------------
+// The live half: one entry per session id, one timer for all of them.
+// ---------------------------------------------------------------------------------------------
+
+interface LiveEntry extends FeedEntry {
+  /** The session id the route takes. */
+  id: string
+  /** The scratch key the CACHE is filed under — the conversation, not the row. Kept up to date by
+   *  every subscribe, because a live row learns its `conversationId` mid-use. */
+  key: string
+  lang: string
+  listeners: Set<(payload: CachedChat) => void>
+  inFlight: boolean
+  /**
+   * The last answer's raw bytes — and NOT the object parsed from them.
+   *
+   * A transcript changes when a turn lands and not otherwise, so most reads answer exactly what the
+   * last one did, and handing the view a NEW object each time re-rendered the whole conversation
+   * every three seconds for nothing. Comparing the bytes is what lets the unchanged case hand back
+   * the SAME instance, which React's own `Object.is` bail-out turns into no render at all.
+   *
+   * The instance it hands back is READ FROM `sessionScratch`, never held here. That cache caps
+   * itself at `MAX_CACHED_CHATS` precisely because a conversation is hundreds of turns and an
+   * unbounded map grows with how much of the product you use — and a reference kept in this module
+   * would pin exactly the payloads that cap exists to release, defeating it from outside. When the
+   * cache has moved on, the bytes are parsed again: one render, no leak.
+   *
+   * `raw` itself is bounded by the entry, and entries are bounded to what is being POLLED — the
+   * one conversation on screen plus `MAX_WARM`. Measured over the 14 sessions on this machine, the
+   * largest chat read is 132 KB and the median far below it, so the ceiling here is a few hundred
+   * KB held only while those conversations are in use — against a `sessionScratch` that already
+   * holds ten parsed conversations by design.
+   */
+  raw: string | null
+}
+
+const entries = new Map<string, LiveEntry>()
+
+/**
+ * WHEN each conversation's cached frame was last read — the one thing that must outlive the entry.
+ *
+ * Two numbers per conversation is nothing, and it is what lets everything else be dropped
+ * aggressively: an entry can go the moment nobody is reading it, because the answer to "is the
+ * frame I am about to paint behind?" no longer lives on it.
+ *
+ * Capped and evicted oldest-first for the same reason `MAX_CACHED_CHATS` is: a map that only ever
+ * grows is a leak whether its rows are small or not. An evicted stamp reads as an unknown age,
+ * which `firstFrameStale` already treats as stale — the safe direction.
+ */
+const readStamps = new Map<string, number>()
+
+/** How many conversations keep a read stamp. Well past `MAX_CACHED_CHATS`, because a stamp costs
+ *  a number and the cached frame it describes costs hundreds of KB. */
+export const MAX_STAMPS = 50
+
+/** PURE: the stamps to forget, oldest read first, once the map is over budget. */
+export function stampsToDrop(stamps: readonly (readonly [string, number])[], max = MAX_STAMPS): string[] {
+  if (stamps.length <= max) return []
+  return [...stamps].sort((a, b) => a[1] - b[1]).slice(0, stamps.length - max).map(([k]) => k)
+}
+
+function stampRead(key: string, at: number): void {
+  readStamps.set(key, at)
+  for (const k of stampsToDrop([...readStamps])) readStamps.delete(k)
+}
+
+let ticker: ReturnType<typeof setInterval> | null = null
+
+/** The ticker asks every second and the per-entry cadence decides — one timer, any number of
+ *  conversations, and a cadence that can change (watched -> warm) without rescheduling anything. */
+const TICK_MS = 1000
+
+function visible(): boolean {
+  return typeof document === 'undefined' || document.visibilityState === 'visible'
+}
+
+function startTicker(): void {
+  if (ticker !== null || typeof setInterval === 'undefined') return
+  ticker = setInterval(tick, TICK_MS)
+}
+
+function stopTicker(): void {
+  if (ticker === null) return
+  clearInterval(ticker)
+  ticker = null
+}
+
+function tick(): void {
+  const now = Date.now()
+  const vis = visible()
+  for (const [key, e] of [...entries]) {
+    if (feedExpired(e, now)) { entries.delete(key); continue }
+  }
+  for (const key of warmToDrop([...entries].map(([k, e]) => [k, e] as const))) entries.delete(key)
+  if (entries.size === 0) { stopTicker(); return }
+  for (const e of [...entries.values()]) if (feedDue(e, now, vis)) void read(e)
+}
+
+async function read(e: LiveEntry): Promise<void> {
+  if (e.inFlight) return
+  e.inFlight = true
+  e.triedAt = Date.now()
+  try {
+    const res = await fetch(`/api/fleet/chat?id=${encodeURIComponent(e.id)}&lang=${e.lang}`)
+    if (!res.ok) return
+    const text = await res.text()
+    // The frame is CURRENT as of now whether or not it changed — freshness is when the answer was
+    // last confirmed, not when it last differed.
+    stampRead(e.key, Date.now())
+    const held = e.raw === text ? sessionScratch.readChat(e.key) : null
+    if (held !== null) {
+      // Same instance, deliberately: the watchers still hear that a read landed (which is what
+      // clears "updating"), and React renders nothing. Read back rather than kept, so this module
+      // pins no conversation the cache has already let go of.
+      for (const cb of [...e.listeners]) cb(held)
+      return
+    }
+    const next = JSON.parse(text) as CachedChat
+    e.raw = text
+    e.ended = next.live === false
+    // Write through, so the NEXT visit starts where this one ended.
+    sessionScratch.writeChat(e.key, next)
+    for (const cb of [...e.listeners]) cb(next)
+  } catch {
+    /* transient — keep the last conversation rather than blanking it */
+  } finally {
+    e.inFlight = false
+  }
+}
+
+/**
+ * Watch one conversation. Returns the unsubscribe, which leaves it WARM rather than stopping it.
+ *
+ * `key` is the scratch key (the conversation), `id` the session id the route takes — the two are
+ * different things and `scratchKey` explains why.
+ */
+export function subscribeChat(
+  opts: { id: string; key: string; lang: string },
+  onPayload: (payload: CachedChat) => void,
+): () => void {
+  let e = entries.get(opts.id)
+  if (!e) {
+    e = {
+      ...newEntry(),
+      id: opts.id, key: opts.key, lang: opts.lang,
+      listeners: new Set(), inFlight: false, raw: null,
+    }
+    entries.set(opts.id, e)
+  }
+  const entry = e
+  // A row that has just learned its `conversationId` files its cache under a new name; the feed
+  // keeps reading the same session and starts writing to the new slot.
+  entry.key = opts.key
+  // A language change is a DIFFERENT answer from the same route (the harness labels are localized),
+  // so the bytes it last saw no longer describe what it would get back.
+  if (entry.lang !== opts.lang) { entry.lang = opts.lang; entry.raw = null }
+  entry.watchers += 1
+  entry.leftAt = null
+  entry.listeners.add(onPayload)
+  startTicker()
+  // The mount's own read. Whatever the cache holds, the view asks once for itself — that has always
+  // been the rule here, and it is what makes the cache "the first frame, never the answer".
+  void read(entry)
+  return () => {
+    entry.listeners.delete(onPayload)
+    entry.watchers = Math.max(0, entry.watchers - 1)
+    if (entry.watchers === 0) entry.leftAt = Date.now()
+  }
+}
+
+/**
+ * Ask for this conversation NOW, outside the cadence.
+ *
+ * The two moments a reader is actually waiting are not on the interval: the instant a message is
+ * sent, and the instant a turn ends.
+ */
+export function refreshChat(id: string): void {
+  const e = entries.get(id)
+  if (e) void read(e)
+}
+
+/** When the cached frame for this conversation was read, or null if this session never read it. */
+export function chatReadAt(key: string): number | null {
+  return readStamps.get(key) ?? null
+}
+
+/** Testing seam: forget everything, including the timer. */
+export function resetChatFeed(): void {
+  entries.clear()
+  readStamps.clear()
+  stopTicker()
+}


### PR DESCRIPTION
## Summary

- A leitura da conversa sai de dentro de `SessionChat` e vira o feed compartilhado `lib/chatFeed.ts`, que **continua lendo a conversa que você acabou de deixar** — então o primeiro frame ao voltar é atual, em vez de ter a idade do tempo que você passou fora.
- Quando o frame ainda assim estiver atrasado, a tela **diz** que está atualizando, em vez de apresentar conteúdo velho como se fosse o atual.
- Leitura sem mudança devolve a **mesma instância**, então a conversa inteira parou de re-renderizar a cada 3 s à toa.

## Motivation

Reportado como "por um instante fica meu último prompt ali e, do nada, carrega todas as novas mensagens".

O poll morava dentro do componente, e o cache (`sessionScratch`) só era escrito enquanto aquela view estava montada — mas montar é exatamente o que voltar para uma sessão **é**. A idade do primeiro frame era, precisamente, o tempo passado fora. Não é fetch lento: medido nas 14 sessões desta máquina, `GET /api/fleet/chat` responde em **66-143 ms**. É um primeiro frame de dois minutos atrás.

O caso da ABA em segundo plano já tinha resposta (`visibilitychange` força uma leitura). Navegar dentro do app não dispara `visibilitychange` nenhum — e é o caso mais comum.

Cada metade do "continua lendo" é limitada, porque um poll em segundo plano que ninguém pediu é como uma máquina fica lenta em silêncio: só as **2** conversas deixadas mais recentemente, só com o documento **visível**, só por **5 min**, a **um décimo** da cadência de primeiro plano, e **nunca** para uma sessão encerrada — o transcript dela é final.

Closes #402

## Changes

- `packages/web/src/lib/chatFeed.ts` (novo) — o feed. Metade pura e testada (`feedDue` / `feedExpired` / `warmToDrop` / `stampsToDrop` / `firstFrameStale`), metade viva: um mapa de entradas e **um** timer para todas, que para sozinho quando o mapa esvazia.
- `packages/web/src/lib/chatFeed.test.ts` (novo) — 19 casos sobre as decisões puras.
- `packages/web/src/components/sessions/SessionChat.tsx` — assina o feed em vez de manter o próprio intervalo; `nudgeChat` vira `refreshChat`; o aviso de "atualizando" espera 400 ms para não ser ele próprio um piscar, e é desenhado **na cauda**, onde a view aterrissa e onde as mensagens novas vão aparecer.
- `docs/sessions-web.md`.

**A memória decidiu o desenho interno, e vale a leitura no review.** `sessionScratch` limita-se a dez conversas parseadas justamente porque uma conversa são centenas de turnos — uma referência guardada no feed anularia esse teto **por fora**. Então o feed guarda os **bytes** da última resposta (para distinguir leitura mudada de inalterada, e devolver a mesma instância quando nada mudou) e lê o objeto de volta do cache, sem nunca segurar um. Entradas existem só para o que é realmente lido — uma conversa encerrada é descartada na hora, porque uma entrada que ninguém lê é só memória. O que sobrevive a elas é um **carimbo** de leitura, um número, em mapa próprio com teto de 50. Maior leitura medida aqui: **132 KB**, então o teto em uso é de algumas centenas de KB.

## Test plan

- [x] `bunx tsc --noEmit` limpo; `bun test` 6830 passando / 0 falhando.
- [x] Latência do endpoint medida nas 14 sessões desta máquina (66-143 ms) e tamanho das respostas (maior: 132 KB) — os números que aparecem nos comentários.
- [ ] Reviewer, à mão: abrir uma sessão que está trabalhando, sair para outra página, esperar ~30 s, voltar. Deve abrir já na conversa atual, sem mostrar o último prompt e depois pular.
- [ ] Reviewer, no DevTools → Network, filtro `fleet/chat`: depois de sair do chat a leitura daquela conversa continua a cada ~10 s; minimizar a aba a interrompe; uma sessão encerrada não é relida.
- [ ] **Não observado no app rodando por esta sessão** — subir um segundo servidor contra o registry vivo é a corrida que `registry.ts` documenta, então a verificação aqui foi por teste e por leitura de código.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GRbrwycvprKKy9uhEVQ8ke