### PR TITLE
feat(web): the notifications row names WHERE this dashboard is already served over https

### DIFF
--- a/packages/server/server/capability-guard.ts
+++ b/packages/server/server/capability-guard.ts
@@ -16,6 +16,9 @@ import { CAPS, type Capabilities } from './exposure'
 /** Exact path → capability. Detail sub-paths are handled by the prefix table below. */
 const EXACT: ReadonlyMap<string, keyof Capabilities> = new Map<string, keyof Capabilities>([
   ['/api/exec', 'localShell'],
+  // It SPAWNS `tailscale` to read what this machine is already serving — a process, so it is host
+  // power and belongs here. It configures nothing; see `secure-origin.ts`.
+  ['/api/secure-origin', 'localShell'],
   ['/api/chat-tty', 'localChat'],
   ['/api/chat-harnesses', 'localChat'],
   ['/api/projects-list', 'localTranscripts'],

--- a/packages/server/server/index.ts
+++ b/packages/server/server/index.ts
@@ -786,6 +786,27 @@ async function handleRequestInner(req: Request, server: Server<WSData>): Promise
       }
     }
 
+    /**
+     * WHERE THIS DASHBOARD IS ALREADY REACHABLE OVER HTTPS, if anywhere.
+     *
+     * Notifications, service workers and installability all need a secure origin, and a machine's
+     * dashboard is plain http — so on a phone the settings screen could only name `tailscale serve`
+     * as a rule. It could not say WHERE, because the page cannot learn the machine's name on the
+     * tailnet. This can: `secure-origin.ts` reads a configuration that ALREADY EXISTS and reports
+     * the origin only when it provably serves this very port.
+     *
+     * It configures nothing. Publishing a dashboard to a tailnet is the user's decision, exactly as
+     * `autostart.ts` only ever SUGGESTS the line it would add. Guarded as `localShell` in
+     * `capability-guard.ts` because it spawns a process, and authenticated like every other route.
+     */
+    if (url.pathname === '/api/secure-origin' && req.method === 'GET') {
+      const { readSecureOrigin } = await import('./secure-origin')
+      const origin = await readSecureOrigin(WEB_PORT)
+      return new Response(JSON.stringify({ ...(origin ? { origin } : {}) }), {
+        headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
+      })
+    }
+
     if (url.pathname === '/api/preferences' && req.method === 'GET') {
       try {
         // Secrets never leave the process: the UI adds a connection by POSTing a token and every

--- a/packages/server/server/secure-origin.test.ts
+++ b/packages/server/server/secure-origin.test.ts
@@ -1,0 +1,60 @@
+import { test, expect } from 'bun:test'
+import { secureOriginFor } from './secure-origin'
+
+/** The real shape, read off this machine while both rules were configured. */
+const REAL = {
+  Web: {
+    'alien-wsl.seahorse-cobia.ts.net:443': { Handlers: { '/': { Proxy: 'http://127.0.0.1:4900' } } },
+    'alien-wsl.seahorse-cobia.ts.net:8443': { Handlers: { '/': { Proxy: 'http://127.0.0.1:47292' } } },
+  },
+}
+
+test('finds the https origin that proxies to OUR web port, and no other', () => {
+  expect(secureOriginFor(REAL, 47292)).toBe('https://alien-wsl.seahorse-cobia.ts.net:8443')
+})
+
+/**
+ * The rule that keeps this from being a confident wrong answer: an https origin pointing at some
+ * OTHER service on the same machine is not this dashboard, and sending somebody there is worse
+ * than sending them nowhere.
+ */
+test('never claims an origin that serves something else', () => {
+  expect(secureOriginFor(REAL, 4900)).toBe('https://alien-wsl.seahorse-cobia.ts.net')
+  expect(secureOriginFor(REAL, 9999)).toBe(null)
+})
+
+test('drops an explicit :443 — an origin says nothing about its default port', () => {
+  const s = { Web: { 'h.ts.net:443': { Handlers: { '/': { Proxy: 'http://127.0.0.1:47292' } } } } }
+  expect(secureOriginFor(s, 47292)).toBe('https://h.ts.net')
+})
+
+/**
+ * A sub-path proxy would serve the app from a base the bundle was not built for — the service
+ * worker's scope, the manifest's `start_url` and every absolute asset are root-relative. A link to
+ * a broken page is worse than no link.
+ */
+test('ignores a handler that is not the ROOT', () => {
+  const s = { Web: { 'h.ts.net:8443': { Handlers: { '/agentistics': { Proxy: 'http://127.0.0.1:47292' } } } } }
+  expect(secureOriginFor(s, 47292)).toBe(null)
+})
+
+test('a proxy to another MACHINE is not this dashboard', () => {
+  const s = { Web: { 'h.ts.net:8443': { Handlers: { '/': { Proxy: 'http://10.0.0.5:47292' } } } } }
+  expect(secureOriginFor(s, 47292)).toBe(null)
+})
+
+test('accepts the other ways loopback is written', () => {
+  for (const host of ['localhost', '[::1]']) {
+    const s = { Web: { 'h.ts.net:8443': { Handlers: { '/': { Proxy: `http://${host}:47292` } } } } }
+    expect(secureOriginFor(s, 47292)).toBe('https://h.ts.net:8443')
+  }
+})
+
+test('says null for everything it cannot read, rather than guessing', () => {
+  expect(secureOriginFor(null, 47292)).toBe(null)
+  expect(secureOriginFor({}, 47292)).toBe(null)
+  expect(secureOriginFor({ Web: {} }, 47292)).toBe(null)
+  expect(secureOriginFor({ Web: { 'h:8443': {} } }, 47292)).toBe(null)
+  expect(secureOriginFor({ Web: { 'h:8443': { Handlers: { '/': { Proxy: 42 } } } } }, 47292)).toBe(null)
+  expect(secureOriginFor({ Web: { 'h:8443': { Handlers: { '/': { Proxy: 'not a url' } } } } }, 47292)).toBe(null)
+})

--- a/packages/server/server/secure-origin.ts
+++ b/packages/server/server/secure-origin.ts
@@ -1,0 +1,103 @@
+/**
+ * secure-origin.ts — PURE: is this dashboard already reachable over https, and where?
+ *
+ * ## Why the browser cannot answer this
+ *
+ * Notifications, service workers and installability all require a SECURE ORIGIN. A machine's
+ * dashboard is reached at `http://100.109.247.39:47292` — a plain-http address — so on a phone the
+ * settings screen can only say "this is not a secure origin" and name `tailscale serve` as the
+ * remedy in the abstract. It cannot say WHERE, because the page has no way to learn the machine's
+ * name on the tailnet: from inside the browser one IP looks like any other.
+ *
+ * The SERVER can. `tailscale serve status --json` says exactly which https origins proxy to which
+ * local ports, so if one of them already points at this dashboard's web port, that is the address
+ * the person should be using — and the row stops being a rule and becomes a link.
+ *
+ * ## What this refuses to do
+ *
+ * It NEVER configures anything. Publishing a dashboard to a tailnet is an exposure decision and
+ * belongs to the user, exactly as `autostart.ts` only ever SUGGESTS the line it would add to a
+ * shell profile. This reads a configuration that already exists and reports it.
+ *
+ * And it only claims an origin that provably serves THIS dashboard: the handler's proxy target has
+ * to be our own web port on a loopback address. An https origin pointing somewhere else is another
+ * service on the same machine, and sending someone there would be a confident wrong answer of the
+ * kind this codebase spends most of its comments avoiding.
+ */
+
+/** The shape `tailscale serve status --json` prints. Someone else's format: every field checked. */
+export interface ServeStatusish {
+  Web?: Record<string, { Handlers?: Record<string, { Proxy?: unknown }> } | undefined> | undefined
+}
+
+/** Loopback, in the forms a proxy target is actually written in. */
+const LOOPBACK = new Set(['127.0.0.1', 'localhost', '[::1]', '::1'])
+
+/**
+ * The https origin that proxies to `webPort` on this machine, or `null`.
+ *
+ * `null` is the honest answer for every case that is not a proven match — no config, a config for
+ * some other service, a shape this cannot read. The caller renders nothing rather than a guess.
+ *
+ * Only the ROOT handler counts. A sub-path proxy (`/agentistics` → us) would serve the app from a
+ * base path the bundle was not built for: the service worker's scope, the manifest's `start_url`
+ * and every absolute asset path are all root-relative, so the link would open a broken page. That
+ * is a worse answer than no link.
+ */
+export function secureOriginFor(status: ServeStatusish | null, webPort: number): string | null {
+  const web = status?.Web
+  if (!web || typeof web !== 'object') return null
+  for (const [hostPort, entry] of Object.entries(web)) {
+    const proxy = entry?.Handlers?.['/']?.Proxy
+    if (typeof proxy !== 'string') continue
+    if (!proxiesToPort(proxy, webPort)) continue
+    // `Web` is keyed by `host:port`, and 443 is written explicitly. An origin says nothing about
+    // its default port, so `:443` is dropped and anything else is kept.
+    const origin = hostPort.endsWith(':443') ? hostPort.slice(0, -4) : hostPort
+    return `https://${origin}`
+  }
+  return null
+}
+
+/** Does this proxy target name OUR web port, on this machine? */
+function proxiesToPort(proxy: string, webPort: number): boolean {
+  let url: URL
+  try { url = new URL(proxy) } catch { return false }
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') return false
+  if (!LOOPBACK.has(url.hostname)) return false
+  return url.port === String(webPort)
+}
+
+/**
+ * Ask Tailscale what it is serving, if it is installed at all.
+ *
+ * `null` for every failure — not installed, not running, a version whose `--json` differs, a
+ * timeout. This is a HINT on a settings row; it must never be a reason a screen fails to load.
+ *
+ * Memoized for a minute: it spawns a process, and the row that reads it is repainted on every
+ * render of a settings screen.
+ */
+let memo: { at: number; origin: string | null } | null = null
+const TTL_MS = 60_000
+
+export async function readSecureOrigin(webPort: number, now = Date.now()): Promise<string | null> {
+  if (memo && now - memo.at < TTL_MS) return memo.origin
+  let origin: string | null = null
+  try {
+    const proc = Bun.spawn(['tailscale', 'serve', 'status', '--json'], {
+      stdout: 'pipe', stderr: 'ignore',
+    })
+    const out = await Promise.race([
+      new Response(proc.stdout).text(),
+      new Promise<string>(r => setTimeout(() => r(''), 2_000)),
+    ])
+    origin = out ? secureOriginFor(JSON.parse(out) as ServeStatusish, webPort) : null
+  } catch {
+    origin = null
+  }
+  memo = { at: now, origin }
+  return origin
+}
+
+/** Tests only. */
+export function forgetSecureOrigin(): void { memo = null }

--- a/packages/web/src/pages/settings/NotificationsSettings.tsx
+++ b/packages/web/src/pages/settings/NotificationsSettings.tsx
@@ -29,6 +29,28 @@ export default function NotificationsSettings() {
   // simply absent, so the button below could never do anything and the screen had no way to say
   // why. Read once, in an effect, so a server render never touches `navigator`.
   const [support, setSupport] = useState<NotificationSupport>('ok')
+  /**
+   * WHERE THIS DASHBOARD IS ALREADY SERVED OVER HTTPS, when it is.
+   *
+   * The page cannot work this out: from inside a browser one IP address looks like any other, and
+   * the machine's name on a tailnet is not something the document knows. The SERVER reads a
+   * `tailscale serve` configuration that already exists and reports the origin only when it
+   * provably proxies to this very dashboard — so the row stops being a rule and becomes a link.
+   *
+   * Asked for ONLY when the origin is insecure: that is the one state where the answer changes
+   * anything, and it spawns a process on the machine.
+   */
+  const [secureOrigin, setSecureOrigin] = useState<string | null>(null)
+  useEffect(() => {
+    if (support !== 'insecure') return
+    let alive = true
+    void fetch('/api/secure-origin')
+      .then(r => (r.ok ? r.json() : null))
+      .then((j: { origin?: string } | null) => { if (alive && j?.origin) setSecureOrigin(j.origin) })
+      // A hint that cannot be fetched is simply not shown — the sentence above still stands alone.
+      .catch(() => {})
+    return () => { alive = false }
+  }, [support])
 
   useEffect(() => {
     setPermission(getBrowserNotificationPermission())
@@ -177,9 +199,13 @@ export default function NotificationsSettings() {
                   <ShieldAlert size={12} style={{ color: 'var(--anthropic-orange)' }} />
                   <span>
                     {support === 'insecure'
-                      ? (pt
-                          ? 'Esta página está em http://, e notificações (assim como o service worker e a instalação) só existem em uma origem segura. Se você acessa por Tailscale, use `tailscale serve` para servir em https:// pelo nome da máquina — é o que destrava tudo isto.'
-                          : 'This page is on http://, and notifications — like the service worker and installability — exist only on a secure origin. If you reach it over Tailscale, use `tailscale serve` to serve it over https:// on the machine name; that is what unlocks all of this.')
+                      ? (secureOrigin
+                          ? (pt
+                              ? 'Esta página está em http://, e notificações (assim como o service worker e a instalação) só existem em uma origem segura. Esta máquina JÁ é servida em https — abra o painel pelo endereço abaixo e adicione-o à tela de início a partir dele.'
+                              : 'This page is on http://, and notifications — like the service worker and installability — exist only on a secure origin. This machine is ALREADY served over https — open the dashboard at the address below and add it to your Home Screen from there.')
+                          : (pt
+                              ? 'Esta página está em http://, e notificações (assim como o service worker e a instalação) só existem em uma origem segura. Se você acessa por Tailscale, use `tailscale serve` para servir em https:// pelo nome da máquina — é o que destrava tudo isto.'
+                              : 'This page is on http://, and notifications — like the service worker and installability — exist only on a secure origin. If you reach it over Tailscale, use `tailscale serve` to serve it over https:// on the machine name; that is what unlocks all of this.'))
                       : support === 'needs-safari'
                         ? (pt
                             ? 'Este app foi adicionado à tela de início pelo Chrome, e no iPhone só um app adicionado pelo Safari roda de verdade em modo standalone — que é o único que recebe notificações. Remova este ícone e adicione de novo pelo Safari.'
@@ -191,6 +217,23 @@ export default function NotificationsSettings() {
                           : (pt
                               ? 'Este navegador não oferece notificações. Os alertas sonoros continuam funcionando.'
                               : 'This browser offers no notifications. The sound alerts still work.')}
+                    {/* THE ADDRESS, not the rule. The sentence above can only ever name
+                        `tailscale serve`; this is where this machine is actually served, read from
+                        a configuration that already exists — so the row becomes something to press
+                        rather than something to go and do. Absent unless the server could prove an
+                        https origin proxies to THIS dashboard. */}
+                    {support === 'insecure' && secureOrigin && (
+                      <a
+                        href={secureOrigin}
+                        style={{
+                          display: 'block', marginTop: 8, fontSize: 12, lineHeight: 1.5,
+                          color: 'var(--anthropic-orange)', overflowWrap: 'anywhere',
+                          textDecoration: 'none', fontWeight: 600,
+                        }}
+                      >
+                        {pt ? `Abrir em ${secureOrigin}` : `Open at ${secureOrigin}`}
+                      </a>
+                    )}
                   </span>
                 </>
               ) : permission === 'granted' ? (


### PR DESCRIPTION
Reported as notifications working on the central and not on a phone. They are not broken:
notifications, service workers and installability all require a **secure origin**, a machine's
dashboard is `http://<tailnet-ip>:47292`, and the central works because it is deployed behind
https. The browser is refusing correctly.

The settings row already said so, and already named `tailscale serve` as the remedy. What it could
not say is **where** — from inside a browser one IP address looks like any other, and the machine's
name on a tailnet is not something the document knows. So the row was a rule, and a rule is
something you have to go and act on.

The server can answer it. `tailscale serve status --json` says which https origins proxy to which
local ports; if one already points at this dashboard's web port, that is the address the person
should be using, and the row becomes a link.

## What `secureOriginFor` refuses to claim

- **The proxy target must be our web port, on a loopback address.** An https origin pointing
  elsewhere is another service on the same machine, and sending somebody there is a confident wrong
  answer of the kind this codebase spends most of its comments avoiding.
- **Only the root handler counts.** A sub-path proxy would serve the app from a base the bundle was
  not built for — the service worker's scope, the manifest's `start_url` and every absolute asset
  are root-relative — so that link opens a broken page, which is worse than no link.
- `null` for a missing config, an unreadable shape, a bad URL, a timeout. The sentence still stands
  alone without it.

## It configures nothing

Publishing a dashboard to a tailnet is an exposure decision and belongs to the user, exactly as
`autostart.ts` only ever SUGGESTS the line it would add to a shell profile. This reads a
configuration that already exists.

The route spawns a process, so it is registered in `capability-guard.ts` under `localShell` —
unreachable on a `lan` or `public` profile — and is authenticated like every other `/api` route.
Memoized for a minute, because a settings row repaints often and this costs a process; the browser
asks only while the origin is insecure, which is the one state where the answer changes anything.

## Verified

`bun tsc --noEmit` exit 0, `bun test` 6912 pass / 0 fail, Vite and binary builds. 7 new tests over
the real `serve status` shape read off a live machine. End to end on that machine: the route answers
`{"origin":"https://alien-wsl.…:8443"}` over both http and its own https endpoint, which serves the
dashboard with a valid certificate (`ssl_verify_result=0`), `sw.js`, the manifest and the icons all
200.

Not verified: how the row LOOKS. There is no usable browser on the machine this was written on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AMEMsUBxH7gqdN2SNGaRww
