### PR TITLE
feat(sessions): the edge strip opens the action it names

### DIFF
--- a/packages/web/src/components/sessions/ArtifactsAside.tsx
+++ b/packages/web/src/components/sessions/ArtifactsAside.tsx
@@ -126,7 +126,7 @@ export interface ArtifactsAsideProps {
    * whole sentence is "the harness is running something", and pressing it to land on the file list
    * answers a question nobody asked. See `artifactsStore.ts`.
    */
-  tabRequest?: { tab: string; at: number } | null
+  tabRequest?: { tab: string; at: number; ref?: string } | null
   sessionId: string
   lang: 'pt' | 'en'
   /** Every file this session touched, newest first. */
@@ -362,11 +362,31 @@ export function ArtifactsAside({
    * An unknown tab is IGNORED rather than defaulted: whoever wrote it meant something this panel
    * does not have, and dropping them on Files would look like the request was honoured.
    */
+  /**
+   * The step the edge strip asked for, until the reader moves on.
+   *
+   * It does two things and they are deliberately the same state: the row opens itself, and it is
+   * highlighted so the eye finds it in a feed that may be long. The highlight FADES — it exists to
+   * answer "where", and a marker that stays becomes part of the row.
+   */
+  const [focusStep, setFocusStep] = useState<string | undefined>(undefined)
+  useEffect(() => {
+    if (focusStep === undefined) return
+    // Long enough to be found, short enough not to become furniture.
+    const t = setTimeout(() => setFocusStep(undefined), 4000)
+    return () => clearTimeout(t)
+  }, [focusStep])
+
   const askedAt = tabRequest?.at
   useEffect(() => {
     const t = tabRequest?.tab
     if (t === 'files' || t === 'docs' || t === 'live' || t === 'gallery' || t === 'skills'
       || t === 'agents' || t === 'forks' || t === 'workflows' || t === 'mcps' || t === 'prs') setTab(t)
+    // A requested STEP comes with the tab: the edge strip names an action, so pressing it
+    // lands on that row rather than on the top of a feed to be searched. Set unconditionally,
+    // including to undefined, so a later request with no step clears the previous one — a
+    // highlight left over from an earlier press would point at the wrong line.
+    setFocusStep(tabRequest?.ref)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [askedAt])
 
@@ -1713,15 +1733,31 @@ function StepBlock({ label, text, tone }: { label: string; text: string; tone?: 
   )
 }
 
-function EventRow({ e, pt, now, onOpen, status, sessionId, agentId }: {
+function EventRow({ e, pt, now, onOpen, status, sessionId, agentId, focused }: {
   e: LiveEvent; pt: boolean; now: number; onOpen?: () => void; status?: WriteStatus
   sessionId: string
   /** Set inside a SUBAGENT's activity: its refs live in its own transcript, not the parent's. */
   agentId?: string
+  /** The edge strip pointed at THIS row: it opens itself and wears a marker until it fades. */
+  focused?: boolean
 }) {
   const isMobile = useIsMobile()
-  const [open, setOpen] = useState(false)
+  const [open, setOpen] = useState(focused === true)
   const openable = stepOpenable(e)
+  // It may become the pointed-at row after it was drawn — the strip is pressed while the feed is
+  // already on screen. Opening then is the same gesture one render later; it never CLOSES anything,
+  // so a row the reader shut stays shut.
+  const wasFocused = useRef(focused === true)
+  useEffect(() => {
+    if (focused === true && !wasFocused.current) setOpen(true)
+    wasFocused.current = focused === true
+  }, [focused])
+  /** Brings the pointed-at row into view — `nearest`, never `smooth`: the feed follows its own tail
+   *  and a smooth scroll racing that leaves the box drifting. */
+  const rowRef = useRef<HTMLDivElement | null>(null)
+  useEffect(() => {
+    if (focused === true) rowRef.current?.scrollIntoView({ block: 'nearest' })
+  }, [focused])
   const detail = useStepDetail(sessionId, e, open, pt, agentId)
   const notice = detail ? stepNotice(detail, pt) : null
   const meta: Record<LiveEvent['kind'], { icon: React.ReactNode; color: string; label: string }> = {
@@ -1744,7 +1780,14 @@ function EventRow({ e, pt, now, onOpen, status, sessionId, agentId }: {
    */
   const Tag = openable ? 'button' : 'div'
   return (
-    <div style={{ borderRadius: 7, background: open ? 'var(--bg-elevated)' : 'transparent' }}>
+    <div
+      ref={rowRef}
+      style={{
+        borderRadius: 7,
+        background: open ? 'var(--bg-elevated)' : 'transparent',
+        ...(focused === true ? { animation: 'ag-row-flash 1.6s ease-in-out 2' } : {}),
+      }}
+    >
     <div style={{ display: 'flex', alignItems: 'flex-start' }}>
     <Tag
       {...(openable ? {
@@ -2313,6 +2356,16 @@ function SubagentCard({ row, pt, now, onOpen }: {
         )}
       </div>
       <style>{`@keyframes ag-agent-pulse { 0%,100% { opacity: 1 } 50% { opacity: 0.3 } }
+        /* "It is here." A marker that ENDS: three beats and gone. A highlight that stays becomes
+           part of the row, and then it is pointing at nothing. Background and a ring, never a
+           colour on the text — the row still has to be readable while it is being pointed at. */
+        @keyframes ag-row-flash {
+          0%, 100% { background: transparent; box-shadow: 0 0 0 0 transparent }
+          15%, 55% {
+            background: color-mix(in srgb, var(--anthropic-orange) 20%, transparent);
+            box-shadow: 0 0 0 1px color-mix(in srgb, var(--anthropic-orange) 55%, transparent)
+          }
+        }
         /* The line being executed. A BACKGROUND pulse, not an opacity one: the text must stay
            readable through the whole cycle — a command you cannot read while it runs is the one
            moment you most want to read it. Soft on purpose; it sits under a monospace block. */

--- a/packages/web/src/lib/artifactLayout.test.ts
+++ b/packages/web/src/lib/artifactLayout.test.ts
@@ -61,3 +61,36 @@ describe('edgeHint', () => {
     expect(edgeHint({ open: false, events: [], isMobile: false })).toBeNull()
   })
 })
+
+describe('the edge hint carries the step it names', () => {
+  // The strip NAMES what is happening; pressing it should land on that row, opened. So the step
+  // travels with it — see `EdgeHint.ref`.
+  it('carries the step of the action it names', () => {
+    expect(edgeHint({
+      open: false, isMobile: false,
+      events: [
+        { kind: 'read', text: 'a.ts', live: false, ref: 'old' },
+        { kind: 'ran', text: 'bun test', live: true, ref: 'toolu_9' },
+      ],
+    })).toEqual({ kind: 'ran', text: 'bun test', ref: 'toolu_9' })
+  })
+
+  // `undefined` means "open the feed"; `''` would name a step that is not there, and the two must
+  // not read the same downstream.
+  it('omits the ref entirely when the event has none', () => {
+    const h = edgeHint({
+      open: false, isMobile: false,
+      events: [{ kind: 'thought', text: 'weighing two options', live: true }],
+    })
+    expect(h).toEqual({ kind: 'thought', text: 'weighing two options' })
+    expect(h && 'ref' in h).toBe(false)
+  })
+
+  it('does not carry an empty ref either', () => {
+    const h = edgeHint({
+      open: false, isMobile: false,
+      events: [{ kind: 'ran', text: 'ls', live: true, ref: '' }],
+    })
+    expect(h && 'ref' in h).toBe(false)
+  })
+})

--- a/packages/web/src/lib/artifactLayout.ts
+++ b/packages/web/src/lib/artifactLayout.ts
@@ -94,12 +94,21 @@ export interface EdgeHint {
   kind: 'wrote' | 'read' | 'ran' | 'thought' | 'delegated'
   /** The path or command it names. */
   text: string
+  /**
+   * The step this action IS, when the feed can resolve one.
+   *
+   * The strip names what is happening; pressing it should land on THAT row, opened, rather than on
+   * the top of a feed the reader then has to search. Optional because not every event has a step
+   * behind it — reasoning carries its whole text and no `ref` — and a strip without one still opens
+   * the feed, which is what it did before.
+   */
+  ref?: string
 }
 
 export function edgeHint(
   { open, events, isMobile }: {
     open: boolean
-    events: readonly { kind: EdgeHint['kind']; text: string; live?: boolean }[]
+    events: readonly { kind: EdgeHint['kind']; text: string; live?: boolean; ref?: string }[]
     isMobile: boolean
   },
 ): EdgeHint | null {
@@ -108,7 +117,10 @@ export function edgeHint(
   if (open || isMobile) return null
   for (let i = events.length - 1; i >= 0; i--) {
     const e = events[i]!
-    if (e.live) return { kind: e.kind, text: e.text }
+    // The `ref` travels with it so the press can open that exact row. Omitted rather than
+    // empty when the event has none: `undefined` is "open the feed", `''` would be a step
+    // that is not there, and the two must not read the same downstream.
+    if (e.live) return { kind: e.kind, text: e.text, ...(e.ref ? { ref: e.ref } : {}) }
   }
   return null
 }

--- a/packages/web/src/lib/artifactsStore.ts
+++ b/packages/web/src/lib/artifactsStore.ts
@@ -46,7 +46,7 @@ export interface ArtifactsState {
    * next render puts them back. Asking twice for the same tab is two requests, so the stamp changes
    * even when the tab does not.
    */
-  tabRequest: { tab: string; at: number } | null
+  tabRequest: { tab: string; at: number; ref?: string } | null
 }
 
 const EMPTY: ArtifactsState = {
@@ -89,10 +89,12 @@ export function setArtifactCount(sessionId: string, count: number): void {
     : { sessionId, count, open: false, dismissed: false, tabRequest: null })
 }
 
-export function openArtifacts(tab?: string): void {
+export function openArtifacts(tab?: string, ref?: string): void {
   emit({
     ...state, open: true,
-    ...(tab === undefined ? {} : { tabRequest: { tab, at: Date.now() } }),
+    // `ref` names a STEP to open once the tab is there — the edge strip names an action, and
+    // pressing it should land on that row rather than on the top of a feed to be searched.
+    ...(tab === undefined ? {} : { tabRequest: { tab, at: Date.now(), ...(ref ? { ref } : {}) } }),
   })
 }
 

--- a/packages/web/src/pages/SessionsPage.tsx
+++ b/packages/web/src/pages/SessionsPage.tsx
@@ -335,7 +335,12 @@ export default function SessionsPage() {
     <button
       // LIVE, not wherever the panel was last left: this control says the harness is running
       // something, so the answer to pressing it is the feed of what it is doing.
-      onClick={() => openArtifacts('live')}
+      // LIVE, and ON THE ACTION IT NAMES. Landing on the top of the feed made the strip a
+      // navigation control rather than an answer: it says "running bun test", and the row saying
+      // so is somewhere in a list the reader then has to search. `hint.ref` is absent for an event
+      // with no step behind it (reasoning carries its own text), and then this opens the feed
+      // exactly as it did before.
+      onClick={() => openArtifacts('live', hint.ref)}
       title={`${HINT_VERB[hint.kind]} · ${hint.text}`}
       style={{
         // THIRD PLACE, and the first two were both wrong for the same reason: it FLOATED.


### PR DESCRIPTION
The strip at the top of the conversation names what the harness is doing right now — *"running bun
test"* — and pressing it opened the Live tab **at the top of the feed**.

That made it a navigation control rather than an answer: it had just said *which* action, and the
row saying so was somewhere in a list the reader then had to search.

It now lands on that row, **opened**, with a marker on it.

## The step was already there to carry

Every event a tool call produces carries **that call's id** (`LiveEvent.ref`) — it is what the step
reader resolves. So `EdgeHint` carries it, `openArtifacts(tab, ref)` takes it beside the tab, and
the aside hands it to the one row whose ref matches.

`ref` is **omitted, never empty**, when the event has no step behind it — reasoning carries its
whole text and has none. `undefined` means "open the feed", which is exactly what this did before;
an empty string would name a step that is not there, and the two must not read the same downstream.

## The marker ends

Three beats and gone (`ag-row-flash`; the focus itself clears after 4 s). It exists to answer
**where**, and a highlight that stays becomes part of the row — at which point it is pointing at
nothing.

Background and a ring, never a colour on the text: the row still has to be readable while it is
being pointed at.

## Two behaviours worth stating

- The row opens itself if it becomes the pointed-at one **after** being drawn — the strip is pressed
  while the feed is already on screen. It never **closes** anything, so a row the reader shut stays
  shut.
- Scrolled into view with `block: 'nearest'` and never `smooth`: the feed follows its own tail, and
  a smooth scroll racing that leaves the box drifting.

`bun test` — **6913 pass, 0 fail**; `bun tsc --noEmit` clean. 3 new cases on `edgeHint`, two of them
asserting it does **not** carry a ref rather than carrying a wrong one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0161UEvuEphUuJEJFygVyaKy
