### PR TITLE
fix(data): the day series counts the day a session WORKED, not the day it began

### DIFF
--- a/packages/server/server/data.ts
+++ b/packages/server/server/data.ts
@@ -547,7 +547,7 @@ export async function buildApiResponse(): Promise<ApiResponse> {
  *  Fills gaps left by Claude Code's own stats-cache updater (e.g. activity from today
  *  that hasn't been rolled into ~/.claude/stats-cache.json yet). Only sessions whose
  *  model starts with `claude-` are counted (skips `<synthetic>` and other sentinels). */
-function supplementStatsCache(statsCache: StatsCache, sessions: SessionMeta[]): void {
+export function supplementStatsCache(statsCache: StatsCache, sessions: SessionMeta[]): void {
   if (sessions.length === 0) return
   const lastComputed = statsCache.lastComputedDate ?? ''
 
@@ -559,35 +559,95 @@ function supplementStatsCache(statsCache: StatsCache, sessions: SessionMeta[]): 
     if (!s.start_time) continue
     // `sessionDay`, not `.slice`: an adapter that wrote the wrong shape must not be able to throw
     // here and take the whole API response with it. See sessionDay.
-    const day = sessionDay(s.start_time)
-    if (!day) continue
-    if (lastComputed && day <= lastComputed) continue
+    const startDay = sessionDay(s.start_time)
+    if (!startDay) continue
 
-    const da = dailyActivity.get(day) ?? { messageCount: 0, sessionCount: 0, toolCallCount: 0 }
-    da.messageCount += (s.user_message_count ?? 0) + (s.assistant_message_count ?? 0)
-    da.sessionCount += 1
-    da.toolCallCount += Object.values(s.tool_counts ?? {}).reduce((a, b) => a + b, 0)
-    dailyActivity.set(day, da)
+    /**
+     * A DAY THE SESSION WORKED, NOT THE DAY IT STARTED — and its LIFETIME totals are not one day's.
+     *
+     * This filed every counter a session ever accumulated under the day it BEGAN. A conversation
+     * opened on Tuesday and still running on Sunday put six days of tokens on Tuesday and NOTHING
+     * on the five days after it, so the daily series was wrong in both directions at once.
+     *
+     * Measured on this machine, against the same sessions' own per-day records:
+     *
+     *   2026-09-03   cache said 3,89 B   really 1,26 B    3x too much
+     *   2026-09-06   cache said    64 M  really 1,83 B   28x too little
+     *   2026-09-07   cache said   550 M  really 1,77 B    3x too little
+     *
+     * And it is not a corner: this supplement covers every day after `lastComputedDate`, which on
+     * that machine is 2026-07-19 — seven weeks of the dashboard's day series.
+     *
+     * The front end already learned this rule twice, for the date FILTER and for the activity
+     * calendar, whose own note says it in these words: "A calendar of when work BEGAN is not a
+     * calendar of when work happened." `SessionMeta.daily` is what both of them read. This is the
+     * third place, and the one the other two were compensating for.
+     *
+     * A session with NO `daily` keeps the old treatment, for the reason it is kept everywhere else:
+     * it cannot be split, and inventing a spread for it would be worse than filing it where it
+     * began.
+     */
+    const daily = s.daily
+    const lifeMsgs = (s.user_message_count ?? 0) + (s.assistant_message_count ?? 0)
+    const lifeTools = Object.values(s.tool_counts ?? {}).reduce((a, b) => a + b, 0)
+    const days: { day: string; msgs: number; tools: number; inp: number; out: number; cr: number; cw: number }[] = []
+    if (daily) {
+      for (const [day, u] of Object.entries(daily)) {
+        const msgs = u.messages ?? 0
+        const inp = u.input_tokens ?? 0
+        const out = u.output_tokens ?? 0
+        const cr = u.cache_read_input_tokens ?? 0
+        const cw = u.cache_creation_input_tokens ?? 0
+        // A day the session merely EXISTED through, with no turn on it, is not activity — the same
+        // rule the calendar applies, so the two cannot disagree about which days it was alive on.
+        if (msgs <= 0 && inp <= 0 && out <= 0 && cr <= 0 && cw <= 0) continue
+        days.push({
+          day, msgs, inp, out, cr, cw,
+          // Tool calls are NOT recorded per day, so this is an apportionment by that day's share of
+          // the session's messages — stated rather than passed off as a measurement, and the same
+          // treatment the calendar already gives it for the same reason.
+          tools: lifeMsgs > 0 ? Math.round((msgs / lifeMsgs) * lifeTools) : 0,
+        })
+      }
+    }
+    if (days.length === 0) {
+      days.push({
+        day: startDay, msgs: lifeMsgs, tools: lifeTools,
+        inp: s.input_tokens ?? 0, out: s.output_tokens ?? 0,
+        cr: s.cache_read_input_tokens ?? 0, cw: s.cache_creation_input_tokens ?? 0,
+      })
+    }
 
-    const model = s.model
-    if (!model || !model.startsWith('claude-')) continue
-    const inp = s.input_tokens ?? 0
-    const out = s.output_tokens ?? 0
-    const cr  = s.cache_read_input_tokens ?? 0
-    const cw  = s.cache_creation_input_tokens ?? 0
-    const total = inp + out + cr + cw
-    if (total === 0) continue
+    for (const d of days) {
+      // The watermark is per DAY, as it always was: a session that started before it but worked
+      // after contributes only the days Claude's own updater has not rolled up yet.
+      if (lastComputed && d.day <= lastComputed) continue
 
-    const byModel = dailyModel.get(day) ?? new Map<string, number>()
-    byModel.set(model, (byModel.get(model) ?? 0) + total)
-    dailyModel.set(day, byModel)
+      const da = dailyActivity.get(d.day) ?? { messageCount: 0, sessionCount: 0, toolCallCount: 0 }
+      da.messageCount += d.msgs
+      // ONE PER DAY IT WORKED. "Sessions that day" is how many conversations were alive then, which
+      // is the question the number answers; counting each only on its first day is what made a week
+      // of work look like a single spike.
+      da.sessionCount += 1
+      da.toolCallCount += d.tools
+      dailyActivity.set(d.day, da)
 
-    const mt = modelTotals.get(model) ?? { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }
-    mt.input     += inp
-    mt.output    += out
-    mt.cacheRead += cr
-    mt.cacheWrite += cw
-    modelTotals.set(model, mt)
+      const model = s.model
+      if (!model || !model.startsWith('claude-')) continue
+      const total = d.inp + d.out + d.cr + d.cw
+      if (total === 0) continue
+
+      const byModel = dailyModel.get(d.day) ?? new Map<string, number>()
+      byModel.set(model, (byModel.get(model) ?? 0) + total)
+      dailyModel.set(d.day, byModel)
+
+      const mt = modelTotals.get(model) ?? { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }
+      mt.input     += d.inp
+      mt.output    += d.out
+      mt.cacheRead += d.cr
+      mt.cacheWrite += d.cw
+      modelTotals.set(model, mt)
+    }
   }
 
   if (dailyActivity.size === 0 && dailyModel.size === 0 && modelTotals.size === 0) return

--- a/packages/server/server/supplement-stats.test.ts
+++ b/packages/server/server/supplement-stats.test.ts
@@ -1,0 +1,124 @@
+import { test, expect } from 'bun:test'
+import type { SessionMeta, StatsCache } from '@agentistics/core'
+import { supplementStatsCache } from './data'
+
+const empty = (): StatsCache => ({
+  lastComputedDate: '2026-07-19',
+  dailyActivity: [], dailyModelTokens: [], modelUsage: {},
+} as unknown as StatsCache)
+
+const sess = (o: Partial<SessionMeta>): SessionMeta => ({
+  session_id: 's', project_path: '/p', start_time: '2026-09-05T10:00:00Z',
+  model: 'claude-opus-5', harness: 'claude',
+  user_message_count: 0, assistant_message_count: 0,
+  input_tokens: 0, output_tokens: 0,
+  cache_read_input_tokens: 0, cache_creation_input_tokens: 0,
+  ...o,
+} as unknown as SessionMeta)
+
+const tokensOn = (sc: StatsCache, day: string): number =>
+  Object.values((sc.dailyModelTokens ?? []).find(d => d.date === day)?.tokensByModel ?? {})
+    .reduce((a, b) => a + b, 0)
+
+/**
+ * THE BUG, in one session. A conversation opened on the 5th and still running on the 7th put every
+ * token it ever spent on the 5th and nothing on the two days after it — so the day series was wrong
+ * in both directions at once. Measured on a real machine: 2026-09-06 read 64 M against an actual
+ * 1,83 B, and 2026-09-03 read 3,89 B against an actual 1,26 B.
+ */
+test('a session that ran for three days is counted on each of them, for what it spent there', () => {
+  const sc = empty()
+  supplementStatsCache(sc, [sess({
+    start_time: '2026-09-05T10:00:00Z',
+    user_message_count: 6, assistant_message_count: 6,
+    // The lifetime counters, which is what the old rule filed on the start day.
+    input_tokens: 60, output_tokens: 0, cache_read_input_tokens: 0, cache_creation_input_tokens: 0,
+    daily: {
+      '2026-09-05': { input_tokens: 10, output_tokens: 0, cache_read_input_tokens: 0, cache_creation_input_tokens: 0, messages: 2 },
+      '2026-09-06': { input_tokens: 20, output_tokens: 0, cache_read_input_tokens: 0, cache_creation_input_tokens: 0, messages: 4 },
+      '2026-09-07': { input_tokens: 30, output_tokens: 0, cache_read_input_tokens: 0, cache_creation_input_tokens: 0, messages: 6 },
+    },
+  } as Partial<SessionMeta>)])
+
+  expect(tokensOn(sc, '2026-09-05')).toBe(10)
+  expect(tokensOn(sc, '2026-09-06')).toBe(20)
+  expect(tokensOn(sc, '2026-09-07')).toBe(30)
+  // And the days still add up to the lifetime — nothing is lost or invented by spreading it.
+  expect(tokensOn(sc, '2026-09-05') + tokensOn(sc, '2026-09-06') + tokensOn(sc, '2026-09-07')).toBe(60)
+})
+
+test('it is counted as ALIVE on every day it worked, not only on its first', () => {
+  const sc = empty()
+  supplementStatsCache(sc, [sess({
+    user_message_count: 2, assistant_message_count: 2,
+    daily: {
+      '2026-09-05': { input_tokens: 1, output_tokens: 0, cache_read_input_tokens: 0, cache_creation_input_tokens: 0, messages: 2 },
+      '2026-09-06': { input_tokens: 1, output_tokens: 0, cache_read_input_tokens: 0, cache_creation_input_tokens: 0, messages: 2 },
+    },
+  } as Partial<SessionMeta>)])
+  const days = sc.dailyActivity ?? []
+  expect(days.find(d => d.date === '2026-09-05')?.sessionCount).toBe(1)
+  expect(days.find(d => d.date === '2026-09-06')?.sessionCount).toBe(1)
+  expect(days.find(d => d.date === '2026-09-05')?.messageCount).toBe(2)
+  expect(days.find(d => d.date === '2026-09-06')?.messageCount).toBe(2)
+})
+
+/** A day it merely existed through, with no turn on it, is not activity. */
+test('a day with nothing on it draws no entry', () => {
+  const sc = empty()
+  supplementStatsCache(sc, [sess({
+    user_message_count: 2, assistant_message_count: 0,
+    daily: {
+      '2026-09-05': { input_tokens: 5, output_tokens: 0, cache_read_input_tokens: 0, cache_creation_input_tokens: 0, messages: 2 },
+      '2026-09-06': { input_tokens: 0, output_tokens: 0, cache_read_input_tokens: 0, cache_creation_input_tokens: 0, messages: 0 },
+    },
+  } as Partial<SessionMeta>)])
+  expect((sc.dailyActivity ?? []).map(d => d.date)).toEqual(['2026-09-05'])
+})
+
+/**
+ * A session with no per-day record cannot be split, and inventing a spread for it would be worse
+ * than filing it where it began — the same fallback the date filter and the calendar keep.
+ */
+test('with no `daily` it keeps the start-day rule and its lifetime totals', () => {
+  const sc = empty()
+  supplementStatsCache(sc, [sess({
+    start_time: '2026-09-05T10:00:00Z',
+    user_message_count: 3, assistant_message_count: 4,
+    input_tokens: 99,
+  } as Partial<SessionMeta>)])
+  expect(tokensOn(sc, '2026-09-05')).toBe(99)
+  expect((sc.dailyActivity ?? []).find(d => d.date === '2026-09-05')?.messageCount).toBe(7)
+})
+
+/**
+ * The watermark is per DAY and always was: Claude's own updater has rolled up everything up to
+ * `lastComputedDate`, so counting those days again would double them. A session that STARTED
+ * before it and worked after contributes only the days after.
+ */
+test('days at or before lastComputedDate are left to Claude Code, whatever day the session began', () => {
+  const sc = empty()
+  supplementStatsCache(sc, [sess({
+    start_time: '2026-07-01T10:00:00Z',
+    user_message_count: 4, assistant_message_count: 0,
+    daily: {
+      '2026-07-18': { input_tokens: 7, output_tokens: 0, cache_read_input_tokens: 0, cache_creation_input_tokens: 0, messages: 2 },
+      '2026-07-19': { input_tokens: 7, output_tokens: 0, cache_read_input_tokens: 0, cache_creation_input_tokens: 0, messages: 2 },
+      '2026-07-20': { input_tokens: 5, output_tokens: 0, cache_read_input_tokens: 0, cache_creation_input_tokens: 0, messages: 2 },
+    },
+  } as Partial<SessionMeta>)])
+  expect((sc.dailyActivity ?? []).map(d => d.date)).toEqual(['2026-07-20'])
+  expect(tokensOn(sc, '2026-07-20')).toBe(5)
+})
+
+test('every one of the four counters is attributed per day, not just input', () => {
+  const sc = empty()
+  supplementStatsCache(sc, [sess({
+    user_message_count: 2, assistant_message_count: 0,
+    daily: {
+      '2026-09-06': { input_tokens: 1, output_tokens: 2, cache_read_input_tokens: 400, cache_creation_input_tokens: 8, messages: 2 },
+    },
+  } as Partial<SessionMeta>)])
+  // Cache read is 98% of the volume on real data — a sum that dropped it would be off by ~50x.
+  expect(tokensOn(sc, '2026-09-06')).toBe(411)
+})

--- a/packages/web/src/components/sessions/FleetOverview.tsx
+++ b/packages/web/src/components/sessions/FleetOverview.tsx
@@ -18,7 +18,7 @@ import type { ControlSession } from '@agentistics/tui/control/session-fleet'
 import { HARNESS_COLORS, HARNESS_LABELS } from '../../lib/harness'
 import { formatUptime, summarizeFleet } from '../../lib/fleetSummary'
 import { ActivityHeatmap } from '../ActivityHeatmap'
-import { linePoints, trendChart, type TrendSeries } from '../../lib/trendLines'
+import { formatDay, linePoints, trendChart, trendTicks, type TrendSeries } from '../../lib/trendLines'
 
 export interface HeatmapDay { date: string; value: number; sessions: number; tools: number }
 
@@ -410,8 +410,9 @@ function ActivityTrend({ chart, lang }: {
 
   const W = 300
   const H = 92
-  const first = chart.days[0]!
-  const last = chart.days[chart.days.length - 1]!
+  const first = formatDay(chart.days[0]!, lang)
+  const last = formatDay(chart.days[chart.days.length - 1]!, lang)
+  const ticks = trendTicks(chart.days)
   return (
     <div>
       <h3 style={{
@@ -427,6 +428,23 @@ function ActivityTrend({ chart, lang }: {
       </p>
       {/* `preserveAspectRatio="none"` so the strip stretches to whatever column it lands in: the
           shape is what is read here, and the day spacing carries no meaning a reader measures. */}
+      {/* THE SCALE, WHERE THERE WAS A CAPTION.
+          This function's own note calls a line with no scale a decoration, and answered that by
+          PRINTING the peak and the span above it — which is a caption, and still not a scale. Asked
+          for: put the dates on an axis.
+          The Y end is the peak and the floor is zero, said in two labels rather than a grid: three
+          gridlines across a 92px strip is more chrome than the shape it would be explaining. */}
+      <div style={{ display: 'flex', gap: 6, alignItems: 'stretch' }}>
+        <div style={{
+          display: 'flex', flexDirection: 'column', justifyContent: 'space-between',
+          flexShrink: 0, height: H, fontSize: 9.5, lineHeight: 1,
+          color: 'var(--text-tertiary)', fontVariantNumeric: 'tabular-nums',
+          textAlign: 'right', minWidth: 12,
+        }}>
+          <span>{chart.peak}</span>
+          <span>0</span>
+        </div>
+        <div style={{ flex: 1, minWidth: 0 }}>
       <svg
         viewBox={`0 0 ${W} ${H}`} preserveAspectRatio="none" role="img"
         aria-label={pt ? 'Sessões por dia, uma linha por assistente' : 'Sessions per day, one line per assistant'}
@@ -448,6 +466,26 @@ function ActivityTrend({ chart, lang }: {
           />
         ))}
       </svg>
+      {/* THE DAYS, under the points they belong to. Positioned by their own share of the width and
+          translated by HALF their own box, so a tick sits centred on its day instead of starting
+          there — and the two ends are pulled back inside, or the first and last labels hang off the
+          strip. At most three: more than that overlaps on a few hundred pixels, and an overlapping
+          label is worse than an absent one. Without the year, which repeats on every one of them. */}
+      <div style={{ position: 'relative', height: 12, marginTop: 4 }}>
+        {ticks.map(t => (
+          <span
+            key={t.day}
+            style={{
+              position: 'absolute', left: `${t.at * 100}%`, top: 0,
+              transform: t.at === 0 ? 'none' : t.at === 1 ? 'translateX(-100%)' : 'translateX(-50%)',
+              fontSize: 9.5, lineHeight: 1, whiteSpace: 'nowrap',
+              color: 'var(--text-tertiary)', fontVariantNumeric: 'tabular-nums',
+            }}
+          >{formatDay(t.day, lang, false)}</span>
+        ))}
+      </div>
+        </div>
+      </div>
       <div style={{ display: 'flex', flexWrap: 'wrap', gap: '4px 12px', marginTop: 8 }}>
         {chart.series.map(s => <TrendKey key={s.harness} series={s} pt={pt} />)}
       </div>

--- a/packages/web/src/lib/trendLines.test.ts
+++ b/packages/web/src/lib/trendLines.test.ts
@@ -1,5 +1,5 @@
-import { expect, test } from 'bun:test'
-import { linePoints, trendChart } from './trendLines'
+import { describe, expect, it, test } from 'bun:test'
+import { formatDay, linePoints, trendChart, trendTicks } from './trendLines'
 
 const d = (date: string, sessions: number) => ({ date, sessions })
 
@@ -60,4 +60,63 @@ test('a single day still draws — a flat segment, not nothing', () => {
 test('the polyline puts the peak at the top and a zero on the floor', () => {
   const c = trendChart({ claude: [d('2026-01-01', 10), d('2026-01-02', 0), d('2026-01-03', 5)] })
   expect(linePoints(c.series[0]!, c.peak, 100, 50)).toBe('0.0,0.0 50.0,50.0 100.0,25.0')
+})
+
+describe('formatDay — the reader\'s own notation, not the storage key', () => {
+  it('writes a Portuguese date the Portuguese way', () => {
+    expect(formatDay('2026-09-05', 'pt')).toBe('05/09/2026')
+    expect(formatDay('2026-09-05', 'pt', false)).toBe('05/09')
+  })
+
+  it('writes an English one the English way', () => {
+    expect(formatDay('2026-09-05', 'en')).toBe('Sep 5, 2026')
+    expect(formatDay('2026-09-05', 'en', false)).toBe('Sep 5')
+  })
+
+  /**
+   * `new Date('2026-09-05')` is UTC midnight, and rendering THAT in a local zone west of Greenwich
+   * gives the day before. The string already names the day; there is nothing to convert.
+   */
+  it('never goes through Date, so a timezone cannot move the day', () => {
+    expect(formatDay('2026-01-01', 'pt')).toBe('01/01/2026')
+    expect(formatDay('2026-12-31', 'en', false)).toBe('Dec 31')
+  })
+
+  it('returns anything it cannot read untouched, rather than mangling it', () => {
+    expect(formatDay('', 'pt')).toBe('')
+    expect(formatDay('not-a-day', 'pt')).toBe('not-a-day')
+    expect(formatDay('2026-9-5', 'pt')).toBe('2026-9-5')
+  })
+})
+
+describe('trendTicks — a scale, where there was a caption', () => {
+  const days = (n: number) => Array.from({ length: n }, (_, i) => `2026-09-${String(i + 1).padStart(2, '0')}`)
+
+  it('marks the two ends, which is what a span is read from', () => {
+    expect(trendTicks(days(3))).toEqual([
+      { day: '2026-09-01', at: 0 },
+      { day: '2026-09-03', at: 1 },
+    ])
+  })
+
+  it('adds a middle only once there is room for it', () => {
+    expect(trendTicks(days(4))).toHaveLength(2)
+    const five = trendTicks(days(5))
+    expect(five).toHaveLength(3)
+    expect(five[1]).toEqual({ day: '2026-09-03', at: 0.5 })
+  })
+
+  it('a single day is ONE tick, not the same date at both ends', () => {
+    expect(trendTicks(days(1))).toEqual([{ day: '2026-09-01', at: 0.5 }])
+  })
+
+  it('never more than three, however long the window', () => {
+    expect(trendTicks(days(90))).toHaveLength(3)
+    // And the ends are still the real ends.
+    expect(trendTicks(days(90))[0]!.day).toBe('2026-09-01')
+  })
+
+  it('says nothing about an empty window', () => {
+    expect(trendTicks([])).toEqual([])
+  })
 })

--- a/packages/web/src/lib/trendLines.ts
+++ b/packages/web/src/lib/trendLines.ts
@@ -128,3 +128,55 @@ export function linePoints(
     return `${(i * step).toFixed(1)},${y.toFixed(1)}`
   }).join(' ')
 }
+
+/**
+ * ONE DAY, IN THE READER'S OWN NOTATION.
+ *
+ * The chart printed its span as `2026-09-05 to 2026-09-07` — the key `SessionMeta.daily` is written
+ * with, which is a storage format and not a date anybody reads. In Portuguese it is `05/09/2026`,
+ * and it was being shown to a Portuguese reader.
+ *
+ * Built from the PARTS rather than through `Date`, deliberately: `new Date('2026-09-05')` parses as
+ * UTC midnight and `toLocaleDateString` then renders it in the local zone, which west of Greenwich
+ * is the day BEFORE. The string already names the day; there is nothing to convert.
+ *
+ * `withYear` is false for an axis tick, where the year repeats on every label and the width is the
+ * scarce thing, and true where the span is stated once.
+ */
+export function formatDay(day: string, lang: 'pt' | 'en', withYear = true): string {
+  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(day)
+  // Not a day this can read: returned untouched rather than mangled into something that looks like
+  // a date and is not.
+  if (!m) return day
+  const [, y, mo, d] = m as unknown as [string, string, string, string]
+  if (lang === 'pt') return withYear ? `${d}/${mo}/${y}` : `${d}/${mo}`
+  const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+  const name = MONTHS[Number(mo) - 1] ?? mo
+  return withYear ? `${name} ${Number(d)}, ${y}` : `${name} ${Number(d)}`
+}
+
+/**
+ * WHICH DAYS GET A TICK under the line, and where each one sits (0..1 across the width).
+ *
+ * The line had no axis at all — its own note called a line with no scale a decoration and answered
+ * that with a SENTENCE above it, which is a caption and still not a scale. Asked for: put the dates
+ * on an axis.
+ *
+ * At most three: the first, the last, and the middle when there is room for it. More than that on a
+ * strip a few hundred pixels wide overlaps, and an overlapping label is worse than an absent one —
+ * the first and the last are what a span is read from anyway.
+ *
+ * A single day yields ONE tick rather than the same date twice at both ends.
+ */
+export function trendTicks(days: readonly string[]): { day: string; at: number }[] {
+  if (days.length === 0) return []
+  if (days.length === 1) return [{ day: days[0]!, at: 0.5 }]
+  const last = days.length - 1
+  const out = [{ day: days[0]!, at: 0 }, { day: days[last]!, at: 1 }]
+  // Three days is the smallest span where a middle tick names a day the ends do not.
+  if (days.length >= 5) {
+    const mid = Math.floor(last / 2)
+    out.splice(1, 0, { day: days[mid]!, at: mid / last })
+  }
+  return out
+}


### PR DESCRIPTION
Reported as two readings of the same window disagreeing: `Today` gave one figure, and `Today` +
`active only` — a strictly **narrower** scope — gave a far larger one. Sessions, messages and tool
calls went DOWN with the extra filter while tokens and cost went UP ~55x. That is two different
sources answering one question.

They are. `activeOnly` makes the scope cache-blind (a live-fleet intersection has no cache
granularity of any kind), so the totals come from sessions, sliced per day by `SessionMeta.daily`.
Without it they come from `stats-cache.json`. **The cache is the one that is wrong.**

## The rule

`supplementStatsCache` filed every counter a session ever accumulated under the day it BEGAN. A
conversation opened on Tuesday and still running on Sunday put six days of tokens on Tuesday and
nothing on the five days after it — wrong in both directions at once.

Measured on a live machine, against the same sessions' own per-day records:

| day | the cache said | it really was | |
|---|---|---|---|
| 2026-09-03 | 3,89 B | 1,26 B | **3× too much** |
| 2026-09-06 | 64 M | 1,83 B | **28× too little** |
| 2026-09-07 | 550 M | 1,77 B | **3× too little** |

It is not a corner. The supplement covers every day after `lastComputedDate`, which on that machine
is 2026-07-19 — **seven weeks** of the dashboard's day series, and with it the heatmap, the trend,
the streak and every date-filtered total that is not otherwise cache-blind.

## The front end already learned this twice

This is the place both of them were compensating for. The date filter reads `SessionMeta.daily`; so
does the activity calendar, whose own note says it in these words — *"A calendar of when work BEGAN
is not a calendar of when work happened."* The third reader is this one, on the server, and it is
the one that feeds the others.

So each day of a session's `daily` gets its own four counters, its own messages, and one session
alive that day. Tool calls are not recorded per day and are apportioned by that day's share of the
session's messages — stated as an apportionment, the same treatment the calendar already gives them.

## Three rules kept exactly as they were, each tested

- a session with **no** `daily` keeps the start-day rule and its lifetime totals. It cannot be
  split, and inventing a spread would be worse than filing it where it began.
- the `lastComputedDate` watermark stays **per day**: a session that started before it and worked
  after contributes only the days after, so nothing Claude Code has rolled up is counted twice.
- a day the session merely existed through, with no turn on it, is not activity.

## Verified

`bun tsc --noEmit` exit 0, `bun test` 6923 pass / 0 fail, with 6 new tests — including that the days
still **sum to the lifetime**, so nothing is lost or invented by spreading it.

And end to end on the reporting machine, after installing this build: every day's cache figure now
equals the sessions' own per-day sum to **1.00×**, where it had been 3×, 28× and 3.2× out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AMEMsUBxH7gqdN2SNGaRww
