### PR TITLE
fix(sessions): the composer keeps focus when the edge strip comes and goes

### DIFF
--- a/packages/web/src/pages/SessionsPage.tsx
+++ b/packages/web/src/pages/SessionsPage.tsx
@@ -836,7 +836,20 @@ export default function SessionsPage() {
     if ((artLayout.layout === 'closed' && !asideAlive) || !artifactsPane) {
       // The panel is shut. The marker rides the right edge of the session, which is where the panel
       // it opens will appear — so the control and its result are in the same place.
-      return edgeMarker === null ? panel : (
+      // THE WRAPPER IS UNCONDITIONAL, and that is a focus bug rather than a style.
+      //
+      // It used to be `edgeMarker === null ? panel : <div>{edgeMarker}{panel}</div>`. React
+      // reconciles by POSITION: swapping the root between `panel` and a div CONTAINING it changes
+      // the shape of the tree, so the whole panel is unmounted and a new one mounted — every DOM
+      // node recreated, the composer's textarea among them. Typing while a session worked lost the
+      // caret the moment the strip appeared, and lost it AGAIN when it went away, which is exactly
+      // how it was reported: "quando essa barra aparece ele desfoca e quando ela some o input
+      // tambem desfoca".
+      //
+      // Rendering the wrapper always keeps `panel` at the same position under the same parent, so it
+      // survives the strip coming and going. `{null}` occupies the slot without drawing anything,
+      // which is what makes the two cases the same SHAPE.
+      return (
         <div style={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0 }}>
           {edgeMarker}
           {panel}

--- a/packages/web/src/pages/sessionsPage.lint.test.ts
+++ b/packages/web/src/pages/sessionsPage.lint.test.ts
@@ -1,0 +1,48 @@
+/**
+ * sessionsPage.lint.test.ts — the centre's root may not change SHAPE with the edge strip.
+ *
+ * `SessionsPage` returned `edgeMarker === null ? panel : <div>{edgeMarker}{panel}</div>`. React
+ * reconciles by POSITION, so swapping the root between `panel` and a div CONTAINING it unmounts the
+ * whole panel and mounts a new one — every DOM node recreated, the composer's textarea among them.
+ * Typing while a session worked lost the caret the moment the strip appeared, and lost it AGAIN
+ * when it went away.
+ *
+ * A unit test cannot see this without mounting the page against a fleet host, which nothing in
+ * `packages/web` is set up to do. The shape is what went wrong, so the shape is what is asserted —
+ * the same approach `tokens.lint.test.ts` and `backup-route-body.lint.test.ts` take to invariants
+ * that live in source rather than in a value.
+ */
+import { test, expect } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const RAW = readFileSync(join(import.meta.dir, 'SessionsPage.tsx'), 'utf-8')
+
+/**
+ * CODE ONLY — comments are stripped before anything is asserted.
+ *
+ * The file explains the bug it forbids, quoting the old expression verbatim, so a grep over the raw
+ * text matches the explanation and fails on a file that is correct. Same trap `attention-rules.ts`
+ * records for footer markers: a source that discusses a pattern contains that pattern.
+ */
+const SRC = RAW.split('\n').filter(l => !l.trim().startsWith('//')).join('\n')
+
+test('the centre is not swapped between `panel` and a wrapper around it', () => {
+  // Any ternary whose branches are "the panel" and "something containing the panel" is this bug.
+  expect(SRC).not.toMatch(/\?\s*panel\s*:/)
+  expect(SRC).not.toMatch(/:\s*panel\s*\}/)
+})
+
+test('the edge strip is rendered INSIDE the wrapper, not as an alternative to it', () => {
+  // The wrapper holds both, in this order, unconditionally — `{null}` keeps the slot when the strip
+  // is absent, which is what makes both cases the same shape.
+  const wrapper = /return \(\s*<div style=\{\{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0 \}\}>\s*\{edgeMarker\}\s*\{panel\}/
+  expect(SRC).toMatch(wrapper)
+})
+
+// Without this the greps above could pass on a file that no longer has either name, which would be
+// a test that checks nothing while staying green.
+test('the names this pins still exist in the file', () => {
+  expect(SRC).toContain('const edgeMarker')
+  expect(SRC).toContain('const panel =')
+})


### PR DESCRIPTION
Typing into a session while it worked **lost the caret, twice**: once when the strip announcing the
current action appeared, and again when it went away.

> "quando essa barra aparece ele desfoca e quando ela some o input também desfoca, e daí fico
> precisando clicar novamente"

## It was not a blur

`SessionsPage` returned:

```tsx
edgeMarker === null ? panel : <div>{edgeMarker}{panel}</div>
```

React reconciles by **position**. Swapping the root between `panel` and a div *containing* it
changes the shape of the tree, so the whole panel is unmounted and a new one mounted — **every DOM
node recreated**, the composer's textarea among them. The element holding the caret stopped
existing.

Both directions, because both are shape changes. That is why it happened when the strip appeared
*and* when it left.

## The fix

The wrapper is unconditional; `{null}` occupies the slot when there is no strip. `panel` then stays
at the same position under the same parent and survives.

Nothing is traded: the two cases were already visually identical — the strip appears without the
layout jumping — so the wrapped layout was always the one on screen half the time.

## Pinned by a source lint

Seeing this needs the page mounted against a fleet host, which nothing in `packages/web` is set up
to do. The **shape** is what went wrong, so the shape is what is asserted — the approach
`tokens.lint.test.ts` and `backup-route-body.lint.test.ts` already take.

**Proven to catch it**: restoring the ternary turns two of its three cases red.

The lint strips comments first. The file now explains the bug it forbids, quoting the old expression
verbatim, so a grep over the raw text matches the *explanation* and fails on a file that is correct
— the same trap `attention-rules.ts` records for footer markers.

`bun test` — **6923 pass, 0 fail**; `bun tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0161UEvuEphUuJEJFygVyaKy
