### PR TITLE
fix(sessions): a tool call the feed has no verb for is shown, not dropped

### DIFF
--- a/packages/web/src/components/sessions/ArtifactsAside.tsx
+++ b/packages/web/src/components/sessions/ArtifactsAside.tsx
@@ -1766,6 +1766,9 @@ function EventRow({ e, pt, now, onOpen, status, sessionId, agentId, focused }: {
     ran: { icon: <Terminal size={11} />, color: 'var(--text-secondary)', label: pt ? 'rodou' : 'ran' },
     thought: { icon: <Brain size={11} />, color: '#a78bfa', label: pt ? 'pensou' : 'thought' },
     delegated: { icon: <Send size={11} />, color: '#22c55e', label: pt ? 'delegou' : 'delegated' },
+    // Anything this feed has no verb of its own for. An MCP call is the common case, and it is
+    // named rather than dropped — see `toolDisplayName`.
+    used: { icon: <Plug size={11} />, color: 'var(--text-tertiary)', label: pt ? 'usou' : 'used' },
   }
   const m = meta[e.kind]
   const mono = e.kind === 'wrote' || e.kind === 'read' || e.kind === 'ran'

--- a/packages/web/src/lib/artifactLayout.ts
+++ b/packages/web/src/lib/artifactLayout.ts
@@ -91,7 +91,7 @@ export function resolveArtifactLayout(
  */
 export interface EdgeHint {
   /** The verb, already localized by the caller's own table. */
-  kind: 'wrote' | 'read' | 'ran' | 'thought' | 'delegated'
+  kind: 'wrote' | 'read' | 'ran' | 'thought' | 'delegated' | 'used'
   /** The path or command it names. */
   text: string
   /**

--- a/packages/web/src/lib/artifactTabs.test.ts
+++ b/packages/web/src/lib/artifactTabs.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, test } from 'bun:test'
-import { agoLabel, isDoc, liveEvents, writeStatus } from './artifactTabs'
+import { agoLabel, isDoc, liveEvents, writeStatus, toolDisplayName } from './artifactTabs'
 
 test('a document is decided by extension or by a known name', () => {
   for (const p of ['docs/spec.md', 'a/b/NOTES.txt', 'README', 'CHANGELOG.md', 'x/plan.mdx']) {
@@ -99,4 +99,46 @@ describe('writeStatus', () => {
   it('anything else the server did not list is gone', () => {
     expect(writeStatus('/repo/deleted.ts', disk)).toBe('gone')
   })
+})
+
+// --- a call that matched no verb is still something that happened -----------
+//
+// MEASURED on a real subagent: 95 tool calls, every one `mcp__playwright__*`, and the panel said
+// "This subagent recorded no actions." The chain ended after Bash/write/read/delegate, so anything
+// else produced no row — and `toolDetail` on the server looks for `command`/`file_path`/`query`/…,
+// none of which an MCP call carries, so there was no text either.
+
+test('an MCP call produces a row, named by its tool', () => {
+  const evs = liveEvents([{ tools: [{ name: 'mcp__playwright__browser_click', ref: 't1' }] }] as never)
+  expect(evs).toHaveLength(1)
+  expect(evs[0]!.kind).toBe('used')
+  expect(evs[0]!.text).toBe('playwright · browser_click')
+  expect(evs[0]!.ref).toBe('t1')
+})
+
+test('the tool name keeps BOTH halves — server and tool', () => {
+  expect(toolDisplayName('mcp__playwright__browser_click')).toBe('playwright · browser_click')
+  expect(toolDisplayName('mcp__MongoDB__find')).toBe('MongoDB · find')
+  // A mapping, never a filter: a name it does not know passes through as itself.
+  expect(toolDisplayName('ToolSearch')).toBe('ToolSearch')
+  expect(toolDisplayName('Bash')).toBe('Bash')
+})
+
+test('a detail is preferred over the tool name when the call carries one', () => {
+  const evs = liveEvents([{ tools: [{ name: 'ToolSearch', detail: 'select:Read,Edit' }] }] as never)
+  expect(evs[0]!.text).toBe('select:Read,Edit')
+})
+
+// The fallback must not double up on calls the chain already spoke for.
+test('a call that already produced a row does not get a second one', () => {
+  expect(liveEvents([{ tools: [{ name: 'Bash', detail: 'ls -la' }] }] as never)).toHaveLength(1)
+  expect(liveEvents([{ tools: [{ name: 'Read', detail: '/a/b.ts' }] }] as never)).toHaveLength(1)
+  expect(liveEvents([{ tools: [{ name: 'Agent', detail: 'sweep' }] }] as never)).toHaveLength(1)
+})
+
+// A Bash call with NO detail said nothing at all before; it is still a shell command that ran.
+test('a Bash call with no detail is still a row', () => {
+  const evs = liveEvents([{ tools: [{ name: 'Bash' }] }] as never)
+  expect(evs).toHaveLength(1)
+  expect(evs[0]!.text).toBe('Bash')
 })

--- a/packages/web/src/lib/artifactTabs.ts
+++ b/packages/web/src/lib/artifactTabs.ts
@@ -37,7 +37,7 @@ export function isDoc(path: string): boolean {
 
 /** One thing the session did, in the order it did it. */
 export interface LiveEvent {
-  kind: 'wrote' | 'read' | 'ran' | 'thought' | 'delegated'
+  kind: 'wrote' | 'read' | 'ran' | 'thought' | 'delegated' | 'used'
   /** When the turn that produced it was recorded, ISO — absent on a transcript that carries none. */
   at?: string
   /** The path, the command, or the first line of what was said — already trimmed for a row. */
@@ -74,6 +74,23 @@ export interface LiveTurn {
 /** Tools that READ rather than change anything. */
 const READ_TOOLS = new Set(['Read', 'Grep', 'Glob', 'NotebookRead', 'WebFetch', 'WebSearch'])
 const WRITE_TOOLS = new Set(['Write', 'Edit', 'MultiEdit', 'NotebookEdit'])
+
+
+/**
+ * A tool's name as a person reads it.
+ *
+ * An MCP tool arrives as `mcp__<server>__<tool>` — the wire name, not a name anybody would say. It
+ * becomes `<server> · <tool>`, which keeps BOTH halves: `browser_click` alone loses which server
+ * did it, and on a machine running several MCPs that is the interesting half.
+ *
+ * Everything else is returned unchanged. This is a MAPPING, never a filter — the same rule
+ * `canonicalTool` states on the server: a name it does not know passes through as itself, so a new
+ * tool shows up as itself rather than disappearing.
+ */
+export function toolDisplayName(name: string): string {
+  const m = /^mcp__([^_]+(?:_[^_]+)*?)__(.+)$/.exec(name)
+  return m ? `${m[1]} · ${m[2]}` : name
+}
 
 /** One line of a longer text, for a row that has one line to give. */
 function firstLine(s: string, max = 160): string {
@@ -112,6 +129,7 @@ export function liveEvents(turns: readonly LiveTurn[]): LiveEvent[] {
       // A command that writes is BOTH events, in the order they happen: it ran, and then the file
       // appeared. Collapsing them would lose either what was run or what it produced, and the feed
       // is asked for both.
+      const before = out.length
       if (c.name === 'Bash' && c.detail) out.push(ev('ran', c.detail, ref))
       for (const w of c.writes ?? []) out.push(ev('wrote', w, ref))
       if (WRITE_TOOLS.has(c.name) && c.detail) out.push(ev('wrote', c.detail, ref))
@@ -119,6 +137,20 @@ export function liveEvents(turns: readonly LiveTurn[]): LiveEvent[] {
       // A subagent is a delegation, not a command — it is the one tool call that starts more work
       // somewhere else, and reading it as "ran" hides that.
       else if (c.name === 'Agent' || c.name === 'Task') out.push(ev('delegated', c.detail ?? c.name, ref))
+      /*
+       * A CALL THAT MATCHED NOTHING ABOVE IS STILL SOMETHING THAT HAPPENED.
+       *
+       * The chain used to end here, so any tool outside those four sets produced no row at all.
+       * MCP tools are all of them: measured on one subagent, 95 calls — every one
+       * `mcp__playwright__*` — and the panel said "This subagent recorded no actions." It had done
+       * ninety-five. `toolDetail` on the server looks for `command`/`file_path`/`query`/…, none of
+       * which an MCP call carries, so there was no text either.
+       *
+       * So the fallback names the TOOL, which is always known. This is the `canonicalTool` rule
+       * applied to a feed: a MAPPING, never a filter — a name nothing recognises passes through as
+       * itself rather than disappearing, and a tool added tomorrow is visible without a change here.
+       */
+      if (out.length === before) out.push(ev('used', c.detail || toolDisplayName(c.name), ref))
     }
   }
   return out


### PR DESCRIPTION
Opening a subagent said **"This subagent recorded no actions."**

It had recorded **95** — every one an `mcp__playwright__*` call, on a 595 KB transcript.

## The gap

`liveEvents` classified a call as `ran` (Bash), `wrote`, `read` or `delegated` (Agent/Task), and
**anything matching none of those produced no row at all**.

Every MCP tool is in that gap. So a session's MCP work has been invisible in the **Live feed** too,
not only in a subagent — this machine runs playwright, MongoDB, Notion and more.

There was no text to fall back on either: `toolDetail` on the server looks for
`command`/`file_path`/`path`/`pattern`/`query`/`url`/`description`, and an MCP call carries none of
them.

## The fix

The chain now ends with a fallback that names the **tool**, which is always known.

That is the rule `canonicalTool` already states on the server, applied to a feed: **a mapping, never
a filter** — a name nothing recognises passes through as itself rather than disappearing, and a tool
added tomorrow is visible without a change here.

`toolDisplayName` turns the wire name into one a person reads:

```
mcp__playwright__browser_click  →  playwright · browser_click
mcp__MongoDB__find              →  MongoDB · find
ToolSearch                      →  ToolSearch     (unchanged)
```

**Both halves are kept.** `browser_click` alone loses which server did it, and on a machine running
several MCPs that is the interesting half.

## Why `used` is its own verb

Not folded into `ran`, for the reason the file already gives about delegation: `ran` means a shell
command here, and calling a browser click "ran" hides what it was.

`LiveEvent`, `EdgeHint` and both label tables are `Record`s, so the compiler named every place that
had to answer for the new kind — three of them, and it found all three.

A `Bash` call with **no** detail also used to produce nothing; it is now a row saying `Bash`.

## Verification

`bun test` — **6928 pass, 0 fail**; `bun tsc --noEmit` clean. **Proven to catch it**: removing the
fallback turns 3 of the file's cases red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0161UEvuEphUuJEJFygVyaKy
