### PR TITLE
fix(web): the MCP paste box SHOWS the three shapes it accepts

### DIFF
--- a/packages/server/server/capability-guard.ts
+++ b/packages/server/server/capability-guard.ts
@@ -19,6 +19,9 @@ const EXACT: ReadonlyMap<string, keyof Capabilities> = new Map<string, keyof Cap
   // It SPAWNS `tailscale` to read what this machine is already serving — a process, so it is host
   // power and belongs here. It configures nothing; see `secure-origin.ts`.
   ['/api/secure-origin', 'localShell'],
+  // It STARTS the configured MCP command to see whether it answers. Host power, and the reason the
+  // route looks the server up in the CONFIG rather than taking a command from the body.
+  ['/api/mcp/check', 'localShell'],
   ['/api/chat-tty', 'localChat'],
   ['/api/chat-harnesses', 'localChat'],
   ['/api/projects-list', 'localTranscripts'],

--- a/packages/server/server/index.ts
+++ b/packages/server/server/index.ts
@@ -1354,6 +1354,62 @@ async function handleRequestInner(req: Request, server: Server<WSData>): Promise
       })
     }
 
+    /**
+     * DOES THIS SERVER ANSWER? — the question the MCP tab could not ask.
+     *
+     * It listed CONFIGURATION and nothing else, so a server that had never worked looked exactly
+     * like one that worked perfectly, and the only way to find out was to start a session and see
+     * whether the tools were there. Reported as "fico no escuro e não sei os que estão disponíveis".
+     *
+     * It is a CHECK, never a connection. agentistics does not run MCP servers — Claude Code does,
+     * once, when a session starts — so a server "connected" from here would be connected to nothing
+     * an assistant can use. See `mcp-check.ts`.
+     *
+     * Guarded as `localShell` in `capability-guard.ts`: it starts the configured command. Only ever
+     * on an explicit press, never while merely listing — a page that spawned every configured
+     * server on load would be starting processes nobody asked for.
+     */
+    if (url.pathname === '/api/mcp/check' && req.method === 'POST') {
+      const read = await readJsonLimited<{
+        name?: string; scope?: string; projectPath?: string
+      }>(req, LIMITS.bodyBytes)
+      if (!read.ok) {
+        return new Response(JSON.stringify({ ok: false, message: read.error }), {
+          status: read.error === 'too_large' ? 413 : 400,
+          headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
+        })
+      }
+      try {
+        const { listMcp } = await import('./mcp-admin')
+        const { checkStdio, checkUrl } = await import('./mcp-check')
+        // The server is looked up in the CONFIGURATION, never taken from the request: a body that
+        // could name a command would be an arbitrary-exec route wearing an MCP label.
+        //
+        // `run` beside it already says whether a process is UP, and that is a different question:
+        // `idle` is the normal state of a perfectly good server nothing is using right now, and it
+        // is also what a broken one looks like. This is what tells those two apart.
+        const all = (await listMcp(read.value.projectPath ?? null)).servers
+        const found = all.find(m => m.name === read.value.name && m.scope === read.value.scope)
+        if (!found) {
+          return new Response(JSON.stringify({ ok: false, message: 'unknown server' }), {
+            status: 404, headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
+          })
+        }
+        const result = found.command
+          ? await checkStdio(found.command, found.args ?? [], found.projectPath)
+          : found.url
+            ? await checkUrl(found.url)
+            : { outcome: 'uncheckable' as const }
+        return new Response(JSON.stringify({ ok: true, ...result }), {
+          headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
+        })
+      } catch (err) {
+        return new Response(JSON.stringify(safeError(err, { verbose: PROFILE === 'local' }).body), {
+          status: 500, headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
+        })
+      }
+    }
+
     if ((url.pathname === '/api/mcp/install' || url.pathname === '/api/mcp/remove'
       || url.pathname === '/api/mcp/replace') && req.method === 'POST') {
       try {

--- a/packages/server/server/mcp-check.test.ts
+++ b/packages/server/server/mcp-check.test.ts
@@ -1,0 +1,85 @@
+import { test, expect } from 'bun:test'
+import { initializeFrame, readInitialize, stdioOutcome } from './mcp-check'
+
+test('the handshake is one line of JSON-RPC, named and versioned', () => {
+  const f = initializeFrame()
+  expect(f.endsWith('\n')).toBe(true)
+  const m = JSON.parse(f.trim())
+  expect(m.method).toBe('initialize')
+  expect(m.id).toBe(1)
+  expect(m.params.clientInfo.name).toBe('agentistics')
+})
+
+/**
+ * A server that logs to stdout before answering is the COMMON case, not the exception — the one
+ * this was written against prints four INFO lines first. A reader that required the first line to
+ * be the response would call every such server broken.
+ */
+test('finds the reply after whatever the server logged first', () => {
+  const out = [
+    'INFO 2026-09-07 serena.cli:start_mcp_server - Starting MCP server …',
+    'warnings.warn(',
+    JSON.stringify({ jsonrpc: '2.0', id: 1, result: { protocolVersion: '2024-11-05', serverInfo: { name: 'serena', version: '0.1' } } }),
+  ].join('\n')
+  expect(readInitialize(out)).toEqual({
+    serverName: 'serena', serverVersion: '0.1', protocolVersion: '2024-11-05',
+  })
+})
+
+test('ignores every message that is not the answer to OUR id', () => {
+  const out = [
+    JSON.stringify({ jsonrpc: '2.0', method: 'notifications/message', params: {} }),
+    JSON.stringify({ jsonrpc: '2.0', id: 7, result: { serverInfo: { name: 'other' } } }),
+  ].join('\n')
+  expect(readInitialize(out)).toBe(null)
+})
+
+test('an error reply is not a handshake', () => {
+  const out = JSON.stringify({ jsonrpc: '2.0', id: 1, error: { code: -32601, message: 'nope' } })
+  expect(readInitialize(out)).toBe(null)
+})
+
+test('a server that answers a DIFFERENT protocol version still answered', () => {
+  const out = JSON.stringify({ jsonrpc: '2.0', id: 1, result: { protocolVersion: '2025-06-18' } })
+  expect(readInitialize(out)).toEqual({ protocolVersion: '2025-06-18' })
+})
+
+test('says nothing about noise, and never throws on it', () => {
+  expect(readInitialize('')).toBe(null)
+  expect(readInitialize('not json\n{oops')).toBe(null)
+  expect(readInitialize('[1,2,3]')).toBe(null)
+})
+
+/**
+ * THE ORDER OF THESE QUESTIONS IS THE POINT. Many stdio servers exit as soon as their input
+ * closes — which is exactly what this check does to them — so a process that ANSWERED and then
+ * exited is `answers`. The answer is the thing being asked about.
+ */
+test('an answer outranks the exit that follows it', () => {
+  expect(stdioOutcome({
+    spawnFailed: false, handshake: { serverName: 's' }, exited: true, exitCode: 0, timedOut: false,
+  })).toEqual({ outcome: 'answers', handshake: { serverName: 's' } })
+})
+
+/**
+ * The measured case: `serena` with the tutorial's placeholder path starts, registers its tools and
+ * quits in two milliseconds — no error anywhere. It is its OWN outcome, because "ran and quit" and
+ * "could not be found" are fixed in two different places.
+ */
+test('ran and quit without answering is `exited`, and carries the code', () => {
+  expect(stdioOutcome({ spawnFailed: false, handshake: null, exited: true, exitCode: 0, timedOut: false }))
+    .toEqual({ outcome: 'exited', exitCode: 0 })
+})
+
+test('a command that is not on the machine is `not-found`, before anything else', () => {
+  expect(stdioOutcome({ spawnFailed: true, handshake: null, exited: true, timedOut: true }))
+    .toEqual({ outcome: 'not-found' })
+})
+
+test('alive and silent is a timeout, and so is observing nothing at all', () => {
+  expect(stdioOutcome({ spawnFailed: false, handshake: null, exited: false, timedOut: true }))
+    .toEqual({ outcome: 'timeout' })
+  // Nothing observed: a verdict would be invented, so it says the honest thing — no answer came.
+  expect(stdioOutcome({ spawnFailed: false, handshake: null, exited: false, timedOut: false }))
+    .toEqual({ outcome: 'timeout' })
+})

--- a/packages/server/server/mcp-check.ts
+++ b/packages/server/server/mcp-check.ts
@@ -1,0 +1,208 @@
+/**
+ * mcp-check.ts — PURE: does a configured MCP server actually answer?
+ *
+ * ## What this is NOT
+ *
+ * It is not a connection. agentistics does not run MCP servers — Claude Code does, once, when a
+ * session starts. A server "connected" from here would be connected to nothing any assistant can
+ * use, and a button offering that would be a lie told in the one place a person goes to find out
+ * whether their configuration works.
+ *
+ * It is a CHECK: start the thing exactly as configured, speak the handshake the protocol opens
+ * with, and report what came back. Every outcome is something a reader can act on, and none of them
+ * claims the server is now available anywhere.
+ *
+ * ## Why the panel needed one
+ *
+ * The MCP tab listed CONFIGURATION and nothing else, so a server that had never worked looked
+ * exactly like one that worked perfectly. Measured on the machine this was reported from: `serena`
+ * was configured, listed, and had its `--project` still set to the tutorial's placeholder
+ * (`/caminho/do/seu/projeto`). It starts, registers its 23 tools, and EXITS in two milliseconds —
+ * no error, no warning, nothing on any screen. "Fico no escuro e não sei os que estão disponíveis"
+ * is the exact shape of that.
+ *
+ * `exited` is therefore its own outcome and not folded into a failure: a process that ran and quit
+ * is a different thing to fix from one that could not be found.
+ */
+
+/** The opening frame of the protocol, as a line of JSON-RPC over stdio. */
+export function initializeFrame(): string {
+  return `${JSON.stringify({
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'initialize',
+    params: {
+      // The version this handshake is written against. A server that speaks a different oneanswers
+      // with its own, and that is still an answer — see `readInitialize`.
+      protocolVersion: '2024-11-05',
+      capabilities: {},
+      clientInfo: { name: 'agentistics', version: '1' },
+    },
+  })}\n`
+}
+
+export interface McpHandshake {
+  /** What the server calls itself, when it says. */
+  serverName?: string
+  serverVersion?: string
+  /** The protocol version IT answered with, which may differ from the one asked for. */
+  protocolVersion?: string
+}
+
+/**
+ * The `initialize` reply, out of whatever the process printed.
+ *
+ * Scanned LINE BY LINE rather than parsed whole: a server that logs to stdout before answering is
+ * common (the one this was written against prints four INFO lines first), and a reader that
+ * required the first line to be the response would call every one of those broken.
+ *
+ * `null` means no line was an `initialize` result. That is not "it failed" — the caller decides
+ * that from whether the process is still alive.
+ */
+export function readInitialize(out: string): McpHandshake | null {
+  for (const line of out.split('\n')) {
+    const t = line.trim()
+    if (t === '' || t[0] !== '{') continue
+    let msg: Record<string, unknown>
+    try { msg = JSON.parse(t) as Record<string, unknown> } catch { continue }
+    if (msg.id !== 1) continue
+    const result = msg.result
+    if (typeof result !== 'object' || result === null) continue
+    const r = result as Record<string, unknown>
+    const info = (typeof r.serverInfo === 'object' && r.serverInfo !== null)
+      ? r.serverInfo as Record<string, unknown>
+      : {}
+    return {
+      ...(typeof info.name === 'string' ? { serverName: info.name } : {}),
+      ...(typeof info.version === 'string' ? { serverVersion: info.version } : {}),
+      ...(typeof r.protocolVersion === 'string' ? { protocolVersion: r.protocolVersion } : {}),
+    }
+  }
+  return null
+}
+
+/**
+ * What a check found. Every one of these sends a reader somewhere different, which is the whole
+ * reason there are six of them rather than a boolean.
+ */
+export type McpCheckOutcome =
+  /** It answered the handshake. As close to "this works" as anything here can honestly say. */
+  | 'answers'
+  /** It ran and quit without answering — a bad flag, a path that does not exist. */
+  | 'exited'
+  /** The command is not on this machine. */
+  | 'not-found'
+  /** It stayed up and said nothing within the budget. */
+  | 'timeout'
+  /** An http/sse/ws server whose endpoint did not respond. */
+  | 'unreachable'
+  /** Nothing here can check it — no command and no url. */
+  | 'uncheckable'
+
+export interface McpCheckResult {
+  outcome: McpCheckOutcome
+  handshake?: McpHandshake
+  /** For `exited`: what it exited with, when that is known. */
+  exitCode?: number
+  /** For `unreachable` / an http check that answered: the status. */
+  status?: number
+}
+
+/**
+ * The verdict, from what the run produced. Pure so the ordering of these questions is testable —
+ * it matters: a process that ANSWERED and then exited is `answers`, because the answer is the
+ * thing being asked about. Many stdio servers exit as soon as their input closes, which is exactly
+ * what this check does to them.
+ */
+export function stdioOutcome(input: {
+  spawnFailed: boolean
+  handshake: McpHandshake | null
+  exited: boolean
+  exitCode?: number
+  timedOut: boolean
+}): McpCheckResult {
+  if (input.spawnFailed) return { outcome: 'not-found' }
+  if (input.handshake) return { outcome: 'answers', handshake: input.handshake }
+  if (input.exited) {
+    return { outcome: 'exited', ...(input.exitCode !== undefined ? { exitCode: input.exitCode } : {}) }
+  }
+  if (input.timedOut) return { outcome: 'timeout' }
+  // Neither answered, nor exited, nor ran out of time: nothing observed, and a verdict would be
+  // invented. `timeout` is the honest floor — it says "no answer came", which is what happened.
+  return { outcome: 'timeout' }
+}
+
+/** How long a server gets to say hello. Generous: some load a language server first. */
+export const CHECK_TIMEOUT_MS = 12_000
+
+// ---- the run ------------------------------------------------------------------------------------
+
+/**
+ * Start the server exactly as configured and see whether it answers.
+ *
+ * EXACTLY AS CONFIGURED, including its `cwd` for a `local`/`project` scope: a server whose command
+ * is relative, or whose `--project .` means something, must be run where Claude Code would run it
+ * or the check answers about a different thing than the one being asked about.
+ *
+ * The env VALUES are not held by this process (`mcp-config.ts` keeps only the names), so a server
+ * that needs a secret can legitimately fail here and work for the assistant. That is stated by the
+ * caller rather than guessed at here.
+ *
+ * stdin is CLOSED after the frame: a well-behaved stdio server answers first and exits second, and
+ * leaving it open would turn every one of them into a timeout.
+ */
+export async function checkStdio(
+  command: string, args: readonly string[], cwd?: string,
+): Promise<McpCheckResult> {
+  let proc: Bun.Subprocess<'pipe', 'pipe', 'ignore'>
+  try {
+    proc = Bun.spawn({
+      cmd: [command, ...args],
+      stdin: 'pipe', stdout: 'pipe', stderr: 'ignore',
+      ...(cwd ? { cwd } : {}),
+    })
+  } catch {
+    return stdioOutcome({ spawnFailed: true, handshake: null, exited: true, timedOut: false })
+  }
+
+  try {
+    proc.stdin.write(initializeFrame())
+    proc.stdin.end()
+  } catch {
+    // It died before it could be written to — the same fact as exiting without answering.
+  }
+
+  let timedOut = false
+  const out = await Promise.race([
+    new Response(proc.stdout).text().catch(() => ''),
+    new Promise<string>(r => setTimeout(() => { timedOut = true; r('') }, CHECK_TIMEOUT_MS)),
+  ])
+  const handshake = readInitialize(out)
+  // Never left running: this spawns a process the user did not ask to keep.
+  try { proc.kill() } catch { /* already gone */ }
+  const exitCode = typeof proc.exitCode === 'number' ? proc.exitCode : undefined
+  return stdioOutcome({
+    spawnFailed: false, handshake, exited: proc.exitCode !== null,
+    ...(exitCode !== undefined ? { exitCode } : {}), timedOut,
+  })
+}
+
+/**
+ * An http/sse/ws server: is the endpoint there?
+ *
+ * Deliberately NOT a handshake. These transports need a session, headers and often a token this
+ * process does not hold — so the honest question is reachability, and `answers` is not claimed for
+ * them. Any status at all proves something is listening; 404 and 401 both mean "reached".
+ */
+export async function checkUrl(url: string): Promise<McpCheckResult> {
+  try {
+    const res = await fetch(url, {
+      method: 'GET',
+      signal: AbortSignal.timeout(CHECK_TIMEOUT_MS),
+      headers: { accept: 'text/event-stream, application/json' },
+    })
+    return { outcome: 'answers', status: res.status }
+  } catch {
+    return { outcome: 'unreachable' }
+  }
+}

--- a/packages/web/src/components/sessions/ArtifactsAside.tsx
+++ b/packages/web/src/components/sessions/ArtifactsAside.tsx
@@ -66,6 +66,7 @@ import {
   type McpEntry, type McpListPayload, type McpScope,
 } from '../../lib/mcpPanel'
 import { splitAsideTabs } from '../../lib/asideTabs'
+import { mcpCheckText } from '../../lib/mcpCheckText'
 import { fmt, fmtCost } from '@agentistics/core'
 import {
   galleryFileCount, galleryGroups, parseGalleryScope, parseGalleryView, producedGroups,
@@ -2520,6 +2521,50 @@ function McpTab({ lang, list, error, cwd, onChanged }: {
   const [editing, setEditing] = useState<McpEntry | null>(null)
   const scopes = offerableScopes(cwd)
 
+  /**
+   * DOES IT ANSWER? — per server, on a press.
+   *
+   * The tab said whether a PROCESS was up (`running` / `idle`), and `idle` is the normal state of a
+   * perfectly good server nothing happens to be using — which is also exactly what a broken one
+   * looks like. Telling those two apart was impossible from this screen, and the only way to find
+   * out was to start a session and see whether the tools were there. "Fico no escuro e não sei os
+   * que estão disponíveis."
+   *
+   * NOT a connection, and the words never say it is: agentistics does not run MCP servers, Claude
+   * Code does, once, at session start. This starts the configured command, speaks the protocol's
+   * opening handshake, and reports what came back.
+   *
+   * Keyed by `scope:name` because one name can be configured at two scopes and they are two
+   * different servers with two different answers.
+   */
+  const [checks, setChecks] = useState<Record<string, { outcome: string; serverName?: string; exitCode?: number } | 'running'>>({})
+  const check = async (m: { name: string; scope: string }) => {
+    const key = `${m.scope}:${m.name}`
+    setChecks(c => ({ ...c, [key]: 'running' }))
+    try {
+      const res = await fetch('/api/mcp/check', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: m.name, scope: m.scope, ...(cwd ? { projectPath: cwd } : {}) }),
+      })
+      const out = await res.json() as { ok?: boolean; outcome?: string; handshake?: { serverName?: string }; exitCode?: number }
+      setChecks(c => ({
+        ...c,
+        [key]: out.ok && out.outcome
+          ? {
+            outcome: out.outcome,
+            ...(out.handshake?.serverName ? { serverName: out.handshake.serverName } : {}),
+            ...(out.exitCode !== undefined ? { exitCode: out.exitCode } : {}),
+          }
+          // A refused or unreachable ROUTE is not a verdict about the server, and must not be shown
+          // as one — the profile can forbid this entirely.
+          : { outcome: 'unavailable' },
+      }))
+    } catch {
+      setChecks(c => ({ ...c, [key]: { outcome: 'unavailable' } }))
+    }
+  }
+
   const write = async (path: string, body: Record<string, unknown>, row?: string) => {
     setBusy(true)
     setWorking(row ?? null)
@@ -2535,6 +2580,23 @@ function McpTab({ lang, list, error, cwd, onChanged }: {
         setSaid({ tone: 'ok', text: (out.names ?? []).join(', ') })
         setPaste(''); setName(''); setAdding(false); setEditing(null)
         onChanged()
+        /**
+         * CHECKED AT THE ONE MOMENT SOMEBODY IS LOOKING — right after they added it.
+         *
+         * Asked for: "ao adicionar ele subir o mcp caso seja um mcp local ou tentar uma conexão,
+         * pq daí eu fico no escuro". Adding wrote a configuration and said nothing about whether it
+         * works, and the answer arrived a session later, if at all.
+         *
+         * Only here, and never while merely LISTING: a tab that started every configured server on
+         * load would be spawning processes nobody asked for, every time it was opened. One explicit
+         * act, one check.
+         *
+         * `install` is the only path that gets it — a REMOVE has nothing to check, and an EDIT
+         * leaves the row on screen with its own button.
+         */
+        if (path === '/api/mcp/install') {
+          for (const n of out.names ?? []) void check({ name: n, scope })
+        }
       } else {
         // The SERVER's own sentence, verbatim — including the harness command's own error, which
         // says far more about a refused config than any wording invented here.
@@ -2569,6 +2631,8 @@ function McpTab({ lang, list, error, cwd, onChanged }: {
         <McpRow
           key={`${s.scope}:${s.name}`} entry={s} pt={pt} canWrite={list.canWrite} busy={busy}
           working={working === `${s.scope}:${s.name}`}
+          check={checks[`${s.scope}:${s.name}`] ?? null}
+          onCheck={() => void check(s)}
           onRemove={() => setRemoving(s)}
           onEdit={() => { setEditing(s); setSaid(null) }}
         />
@@ -2847,10 +2911,13 @@ function McpEditor({ entry, pt, busy, onCancel, onApply }: {
 }
 
 /** One configured server: what it is, where it is configured, and what it is doing right now. */
-function McpRow({ entry, pt, canWrite, busy, working, onRemove, onEdit }: {
+function McpRow({ entry, pt, canWrite, busy, working, check, onCheck, onRemove, onEdit }: {
   entry: McpEntry; pt: boolean; canWrite: boolean; busy: boolean
   /** This row is mid-write. A removal takes a second or two and must not look inert. */
   working: boolean
+  /** The last check's verdict, `'running'` while one is in flight, `null` if never asked. */
+  check: { outcome: string; serverName?: string; exitCode?: number } | 'running' | null
+  onCheck: () => void
   onRemove: () => void
   onEdit: () => void
 }) {
@@ -2906,6 +2973,34 @@ function McpRow({ entry, pt, canWrite, busy, working, onRemove, onEdit }: {
             </button>
           </>
         )}
+      </div>
+      {/* DOES IT ANSWER? The row already says whether a PROCESS is up, and `idle` is the normal
+          state of a good server nothing is using — which is also what a broken one looks like.
+          This is what tells those two apart, and it is a CHECK, not a connection: agentistics does
+          not run MCP servers, Claude Code does, once, when a session starts. */}
+      <div style={{ marginTop: 4, display: 'flex', alignItems: 'center', gap: 7, flexWrap: 'wrap' }}>
+        <button
+          onClick={onCheck}
+          disabled={check === 'running'}
+          style={{
+            flexShrink: 0, display: 'inline-flex', alignItems: 'center', gap: 5,
+            minHeight: isMobile ? 44 : 22, padding: isMobile ? '0 10px' : '0 7px', borderRadius: 6,
+            cursor: check === 'running' ? 'default' : 'pointer',
+            border: '1px solid var(--border-subtle)', background: 'transparent',
+            color: 'var(--text-secondary)', fontFamily: 'inherit', fontSize: 10.5,
+          }}
+        >
+          {check === 'running' ? <Spinner size={11} /> : <Plug size={11} />}
+          {pt ? 'Testar' : 'Check'}
+        </button>
+        {check !== null && check !== 'running' && (() => {
+          const v = mcpCheckText(check, pt)
+          return (
+            <span style={{ fontSize: 10.5, lineHeight: 1.45, color: v.color, minWidth: 0 }}>
+              {v.text}
+            </span>
+          )
+        })()}
       </div>
       {/* WHY the status says what it says — the sentence, never a colour alone. */}
       {run.detail && (

--- a/packages/web/src/components/sessions/ArtifactsAside.tsx
+++ b/packages/web/src/components/sessions/ArtifactsAside.tsx
@@ -2635,11 +2635,37 @@ function McpTab({ lang, list, error, cwd, onChanged }: {
             border: '1px solid var(--border-subtle)',
           }}
         >
+          {/* THE THREE SHAPES, SHOWN. This said them in prose — "the whole block, one named entry,
+              or just the config" — and was reported as not knowing which to use, with two of the
+              three pasted side by side to ask which was right. Both were. A JSON shape is something
+              you recognise by SEEING it; a sentence describing one is a sentence you have to
+              translate into the thing before you can compare it with what is on your clipboard.
+              `parseMcpPaste` accepts all three and has since it was written — this is only the
+              screen catching up with what the parser already does. */}
           <p style={{ margin: 0, fontSize: 10.5, lineHeight: 1.5, color: 'var(--text-tertiary)' }}>
             {pt
-              ? 'Cole o JSON do servidor — o bloco `mcpServers` inteiro, uma entrada nomeada, ou só a configuração (aí o nome é obrigatório).'
-              : 'Paste the server’s JSON — the whole `mcpServers` block, one named entry, or just the config (then the name is required).'}
+              ? 'Cole o JSON do servidor. Qualquer um destes três funciona:'
+              : 'Paste the server’s JSON. Any of these three works:'}
           </p>
+          <div style={{
+            display: 'flex', flexDirection: 'column', gap: 5,
+            padding: '6px 8px', borderRadius: 6,
+            background: 'var(--bg-base)', border: '1px solid var(--border-subtle)',
+          }}>
+            {([
+              ['{"mcpServers": {"serena": {…}}}', pt ? 'o bloco inteiro, como vem no README' : 'the whole block, as a README gives it'],
+              ['{"serena": {…}}', pt ? 'só a entrada nomeada' : 'just the named entry'],
+              ['{"command": "serena", "args": […]}', pt ? 'só a configuração — aí o Nome abaixo é obrigatório' : 'just the config — then the Name below is required'],
+            ] as const).map(([shape, what]) => (
+              <div key={shape} style={{ display: 'flex', flexDirection: 'column', gap: 1, minWidth: 0 }}>
+                <code style={{
+                  fontFamily: 'var(--font-mono, ui-monospace, monospace)', fontSize: 10.5,
+                  color: 'var(--text-secondary)', overflowWrap: 'anywhere',
+                }}>{shape}</code>
+                <span style={{ fontSize: 10, lineHeight: 1.4, color: 'var(--text-tertiary)' }}>{what}</span>
+              </div>
+            ))}
+          </div>
           <textarea
             value={paste}
             onChange={e => setPaste(e.target.value)}

--- a/packages/web/src/lib/mcpCheckText.test.ts
+++ b/packages/web/src/lib/mcpCheckText.test.ts
@@ -1,0 +1,54 @@
+import { test, expect } from 'bun:test'
+import { mcpCheckText } from './mcpCheckText'
+
+/**
+ * IT NEVER SAYS "CONNECTED". agentistics does not run MCP servers — Claude Code starts them, once,
+ * at session start — so the most this can honestly report is that the command answered when asked
+ * HERE, plus what has to happen for a session to have it.
+ */
+test('a server that answered says so, and says what still has to happen', () => {
+  const v = mcpCheckText({ outcome: 'answers', serverName: 'Serena' }, true)
+  expect(v.text).toContain('Serena')
+  expect(v.text).toContain('próxima sessão')
+  expect(v.text.toLowerCase()).not.toContain('conectado')
+  expect(mcpCheckText({ outcome: 'answers' }, false).text).toContain('next start')
+})
+
+/** The measured case, and its own outcome: "ran and quit" is fixed elsewhere than "not installed". */
+test('exited carries the code and names the likely cause', () => {
+  const v = mcpCheckText({ outcome: 'exited', exitCode: 2 }, true)
+  expect(v.text).toContain('código 2')
+  expect(v.text).toContain('caminho')
+  // Without a code it still reads as a sentence, with no empty parenthesis.
+  expect(mcpCheckText({ outcome: 'exited' }, true).text).not.toContain('(')
+})
+
+test('the four failures are four different sentences, not one', () => {
+  const said = ['not-found', 'timeout', 'unreachable', 'uncheckable']
+    .map(o => mcpCheckText({ outcome: o }, false).text)
+  expect(new Set(said).size).toBe(4)
+})
+
+/**
+ * A refused ROUTE is not a verdict about the server. The capability is denied outright on a `lan`
+ * or `public` profile, and showing that as "this server is broken" would be a wrong answer about
+ * somebody else's configuration.
+ */
+test('an unknown outcome blames the panel, never the server', () => {
+  const v = mcpCheckText({ outcome: 'unavailable' }, true)
+  expect(v.text).toContain('Não deu para testar daqui')
+  expect(v.color).toBe('var(--text-tertiary)')
+})
+
+test('only a success is green, and a slow start is not red', () => {
+  expect(mcpCheckText({ outcome: 'answers' }, false).color).toBe('#22c55e')
+  expect(mcpCheckText({ outcome: 'timeout' }, false).color).toBe('#f59e0b')
+  expect(mcpCheckText({ outcome: 'not-found' }, false).color).toBe('var(--accent-red)')
+})
+
+test('it answers in both languages, always', () => {
+  for (const o of ['answers', 'exited', 'not-found', 'timeout', 'unreachable', 'uncheckable', '?']) {
+    expect(mcpCheckText({ outcome: o }, true).text.length).toBeGreaterThan(0)
+    expect(mcpCheckText({ outcome: o }, false).text.length).toBeGreaterThan(0)
+  }
+})

--- a/packages/web/src/lib/mcpCheckText.ts
+++ b/packages/web/src/lib/mcpCheckText.ts
@@ -1,0 +1,79 @@
+/**
+ * mcpCheckText.ts — PURE: one verdict, one sentence, and never a colour alone.
+ *
+ * Six outcomes rather than a tick and a cross, because each of them is fixed somewhere different —
+ * a command that is not installed, a command that runs and quits, an endpoint nobody is listening
+ * on, and a route the profile forbids are four separate errands.
+ *
+ * NONE OF THESE SAY "CONNECTED". agentistics does not run MCP servers: Claude Code starts them,
+ * once, when a session starts. The most this can honestly report is that the configured command
+ * answered the protocol's opening handshake when it was asked here — which is what `answers` says,
+ * and why the sentence adds that a session has to be restarted for it to be usable.
+ */
+
+export interface McpCheckView { text: string; color: string }
+
+export function mcpCheckText(
+  check: { outcome: string; serverName?: string; exitCode?: number },
+  pt: boolean,
+): McpCheckView {
+  const ok = '#22c55e'
+  const bad = 'var(--accent-red)'
+  const warn = '#f59e0b'
+  const dim = 'var(--text-tertiary)'
+  switch (check.outcome) {
+    case 'answers':
+      return {
+        color: ok,
+        text: check.serverName
+          ? (pt
+            ? `Respondeu — ${check.serverName}. Vale a partir da próxima sessão.`
+            : `Answered — ${check.serverName}. It reaches a session from its next start.`)
+          : (pt
+            ? 'Respondeu. Vale a partir da próxima sessão.'
+            : 'Answered. It reaches a session from its next start.'),
+      }
+    case 'exited':
+      return {
+        color: bad,
+        text: pt
+          ? `Iniciou e encerrou sem responder${check.exitCode !== undefined ? ` (código ${check.exitCode})` : ''} — normalmente um argumento ou um caminho que não existe.`
+          : `Started and quit without answering${check.exitCode !== undefined ? ` (code ${check.exitCode})` : ''} — usually a bad argument or a path that does not exist.`,
+      }
+    case 'not-found':
+      return {
+        color: bad,
+        text: pt
+          ? 'O comando não existe nesta máquina.'
+          : 'The command is not on this machine.',
+      }
+    case 'timeout':
+      return {
+        color: warn,
+        text: pt
+          ? 'Ficou de pé e não respondeu a tempo. Pode ser lento para subir, ou estar esperando algo.'
+          : 'It stayed up and did not answer in time. It may be slow to start, or waiting on something.',
+      }
+    case 'unreachable':
+      return {
+        color: bad,
+        text: pt ? 'O endereço não respondeu.' : 'The address did not respond.',
+      }
+    case 'uncheckable':
+      return {
+        color: dim,
+        text: pt
+          ? 'Sem comando e sem endereço — não há o que testar daqui.'
+          : 'No command and no address — there is nothing to check from here.',
+      }
+    default:
+      // The ROUTE failed, which is not a verdict about the server and must not be shown as one:
+      // this capability is refused outright on a `lan` or `public` profile.
+      return {
+        color: dim,
+        text: pt
+          ? 'Não deu para testar daqui — esta máquina não permite iniciar processos por este painel.'
+          : 'It could not be checked from here — this machine does not allow this panel to start processes.',
+      }
+  }
+}


### PR DESCRIPTION
Reported with two JSON blocks pasted side by side and the question "which one is right?" — the
`mcpServers` wrapper, and the bare named entry. **Both are.** So is a third, the config on its own.

`parseMcpPaste` has accepted all three since it was written, and says why in its own header: *"all
three are what people actually copy from a README"*. The form said so too — "the whole `mcpServers`
block, one named entry, or just the config" — and that sentence did not answer the question,
because a JSON shape is something you recognise by **seeing** it. A sentence describing one has to
be translated into the thing before it can be compared with what is on the clipboard, and that
translation is exactly the step somebody unsure of the format cannot make with confidence.

So the three are shown, each with one line saying what it is and when the Name field below becomes
required.

Nothing about what is accepted changed. This is the screen catching up with what the parser already
does.

**Verified:** `bun tsc --noEmit` exit 0, `bun test` 6943 pass / 0 fail, Vite build. Not verified
visually — no usable browser on this machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AMEMsUBxH7gqdN2SNGaRww