### PR TITLE
fix(sessions): a reply's quote ends where the reply begins

### DIFF
--- a/packages/web/src/components/sessions/SessionChat.tsx
+++ b/packages/web/src/components/sessions/SessionChat.tsx
@@ -52,7 +52,7 @@ import {
   applySkill, emptyPickerReason, filterSkills, flattenGroups, groupSkills, slashMisplaced,
   slashQuery, stepSkill,
 } from '../../lib/skillMenu'
-import { markExcerpt, quoteFor, replyAuthor, replyPreview, type ReplyTarget } from '../../lib/replyQuote'
+import { composeReply, markExcerpt, quoteFor, replyAuthor, replyPreview, type ReplyTarget } from '../../lib/replyQuote'
 import { pendingEchoes } from '@agentistics/core'
 import {
   applyDraftRequest, consumeDraftRequest, getDraftRequest, useDraftRequest,
@@ -1181,7 +1181,10 @@ export function SessionChat({ session, row, lang, act, onArtifacts }: SessionCha
     // Quote first, then the paths, then what was typed. The quote is trimmed to a few lines: a
     // reply that repeats forty lines back at the session costs it context for no benefit.
     const quote = replyTo ? quoteFor(replyTo) : ''
-    const full = [quote, ...attached.map(a => a.path), text].filter(x => x !== '').join('\n')
+    // `composeReply` puts a BLANK LINE between the blocks, and that is not formatting: joined with a
+    // single newline, CommonMark's lazy continuation pulls what was typed into the blockquote, and
+    // the person's own words render inside the grey bar as if the session had said them.
+    const full = composeReply({ quote, paths: attached.map(a => a.path), text })
     /**
      * THE COMPOSER EMPTIES ON THE KEYSTROKE, NOT ON THE ANSWER.
      *

--- a/packages/web/src/lib/replyQuote.test.ts
+++ b/packages/web/src/lib/replyQuote.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from 'bun:test'
-import { markExcerpt, parseReply, quoteFor, quoteLines, replyAuthor, replyPreview } from './replyQuote'
+import { markExcerpt, parseReply, quoteFor, quoteLines, replyAuthor, replyPreview, composeReply } from './replyQuote'
 
 test('a quote is "> "-prefixed, line by line', () => {
   expect(quoteLines('one\ntwo')).toBe('> one\n> two')
@@ -98,4 +98,34 @@ test('the excerpt mark is honoured only when it is literally true', () => {
     .toEqual({ role: 'assistant', text: 'x', excerpt: true })
   expect(parseReply('{"role":"assistant","text":"x","excerpt":"yes"}'))
     .toEqual({ role: 'assistant', text: 'x' })
+})
+
+// --- the quote ends where the reply begins ----------------------------------
+//
+// These were joined with a single newline, and CommonMark's LAZY CONTINUATION pulls a plain line
+// following a `>` line into the blockquote. The person's own words rendered inside the grey bar,
+// as if the session had said them.
+
+test('a blank line separates the quote from what was typed', () => {
+  expect(composeReply({ quote: '> disse isso', paths: [], text: 'reabre essa sessao' }))
+    .toBe('> disse isso\n\nreabre essa sessao')
+})
+
+test('the paths get their own block too — a bare path is not something the session said', () => {
+  expect(composeReply({ quote: '> disse isso', paths: ['/a/x.png', '/a/y.png'], text: 'olha' }))
+    .toBe('> disse isso\n\n/a/x.png\n/a/y.png\n\nolha')
+})
+
+test('a message with no quote is exactly what was typed, with no leading blank line', () => {
+  expect(composeReply({ quote: '', paths: [], text: 'oi' })).toBe('oi')
+  expect(composeReply({ quote: '', paths: ['/a/x.png'], text: 'oi' })).toBe('/a/x.png\n\noi')
+})
+
+test('a quote with nothing typed after it is just the quote', () => {
+  expect(composeReply({ quote: '> disse isso', paths: [], text: '' })).toBe('> disse isso')
+})
+
+test('a multi-line quote keeps its own lines together', () => {
+  expect(composeReply({ quote: '> uma\n> duas', paths: [], text: 'resposta' }))
+    .toBe('> uma\n> duas\n\nresposta')
 })

--- a/packages/web/src/lib/replyQuote.ts
+++ b/packages/web/src/lib/replyQuote.ts
@@ -153,3 +153,33 @@ export function parseReply(raw: string | null): ReplyTarget | null {
     return excerpt ? { role, text, excerpt: true } : { role, text }
   } catch { return null }
 }
+
+
+/**
+ * The message a reply actually sends: the quote, then the attachment paths, then what was typed.
+ *
+ * THE BLANK LINE AFTER THE QUOTE IS THE POINT. These were joined with a single `\n`, which is
+ * valid Markdown for something else entirely: CommonMark's LAZY CONTINUATION pulls a plain line
+ * that follows a `>` line straight into the blockquote. So
+ *
+ *     > what the session said
+ *     reabre essa sessao e manda meu prompt
+ *
+ * renders as ONE quote containing both — the person's own words sat inside the grey bar, credited
+ * to the turn they were answering. Reported exactly that way: "apenas a parte mencionada deve ficar
+ * nessa linha vertical cinza, a minha parte do texto deve ficar como texto branco e fora dessa
+ * barra".
+ *
+ * A blank line ends the block, and everything after it is the writer's own paragraph. The paths get
+ * the same treatment for the same reason — a bare path swallowed by the quote reads as something
+ * the session said rather than a file being handed to it.
+ *
+ * Empty parts are dropped, so a message with no quote is exactly what was typed and gains no
+ * leading blank line.
+ */
+export function composeReply(
+  { quote, paths, text }: { quote: string; paths: readonly string[]; text: string },
+): string {
+  const blocks = [quote, paths.join('\n'), text].map(b => b.trim()).filter(b => b !== '')
+  return blocks.join('\n\n')
+}


### PR DESCRIPTION
Replying to a message or an excerpt put the person's **own words inside the grey quote bar**,
credited to the turn they were answering.

> "apenas a parte mencionada deve ficar nessa linha vertical cinza, a minha parte do texto deve
> ficar como texto branco e fora dessa barra vertical cinza"

## It was not styling

The message was assembled as:

```ts
[quote, ...paths, text].join('\n')
```

A single newline is valid Markdown for something else entirely. CommonMark's **lazy continuation**
pulls a plain line following a `>` line straight into the blockquote:

```
> what the session said
reabre essa sessao e manda meu prompt
```

is **one** quote containing both. A blank line ends the block, and everything after it is the
writer's own paragraph.

The **paths** get the same treatment for the same reason — a bare path swallowed by the quote reads
as something the session said rather than a file being handed to it.

## Where the rule lives

`composeReply`, beside the quoting it completes, so it is testable and stated once. Empty parts are
dropped: a message with no quote is exactly what was typed and gains no leading blank line.

## Verification

`bun test` — **6948 pass, 0 fail**; `bun tsc --noEmit` clean. **Proven to catch it**: joining with a
single newline again turns 4 of the file's cases red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0161UEvuEphUuJEJFygVyaKy
