### PR TITLE
fix(sessions): a dialog is answerable from outside the terminal again

### DIFF
--- a/packages/server/server/cli-i18n.ts
+++ b/packages/server/server/cli-i18n.ts
@@ -158,6 +158,7 @@ export interface CliStrings {
   sessApproveUnknown: (harness: string) => string
   /** Said on a row whose dialog offers OPTIONS and whose harness has no verified way to pick one. */
   sessChooseBlind: (harness: string) => string
+  sessDialogBlind: (harness: string) => string
   /** Refused: the dialog offers N options, so there is nothing to merely "approve". */
   sessNeedsChoice: (n: number) => string
   /** Refused: the question changed between being shown and being answered. */
@@ -549,6 +550,11 @@ const EN: CliStrings = {
     `agentop has not read ${harness}'s dialog, so it will not guess which key answers it.`,
   sessChooseBlind: (harness: string) =>
     `this dialog is a choice, and nobody has verified how to pick an option on ${harness} — attach to answer it there.`,
+  // Deliberately NOT "cannot be answered": it can, on attach. And it says what agentop actually
+  // knows — that the options are there and it could not read them — because a refusal that hides
+  // its reason is indistinguishable from a control that is simply broken.
+  sessDialogBlind: (harness: string) =>
+    `this ${harness} dialog is taller than agentop can read off the screen, so it cannot say what the options are — attach to answer it there.`,
   sessNeedsChoice: (n: number) =>
     `that dialog offers ${n} options, so there is nothing to simply approve — pick one.`,
   sessChoiceGone:
@@ -858,6 +864,8 @@ const PT: CliStrings = {
     `o agentop não leu o diálogo do ${harness}, e não vai chutar qual tecla responde.`,
   sessChooseBlind: (harness: string) =>
     `esse diálogo é uma escolha, e ninguém verificou como selecionar uma opção no ${harness} — anexe para responder lá.`,
+  sessDialogBlind: (harness: string) =>
+    `esse diálogo do ${harness} é mais alto do que o agentop consegue ler da tela, então ele não sabe dizer quais são as opções — anexe para responder lá.`,
   sessNeedsChoice: (n: number) =>
     `esse diálogo tem ${n} opções, então não há o que simplesmente aprovar — escolha uma.`,
   sessChoiceGone:

--- a/packages/server/server/sessions/attention.test.ts
+++ b/packages/server/server/sessions/attention.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'bun:test'
 import { QUIET_MS, approvalTail, attentionOf, digestFrame, frameTail, backgroundWork, dialogHeight
 } from './attention'
+import { rulesFor } from './attention-rules'
 import type { AttentionRules } from './types'
 
 const NOW = 1_786_600_000_000
@@ -409,5 +410,66 @@ describe('approvalTail carries the QUESTION, not just the answers', () => {
     ]
     // Never the whole frame: a question is a sentence or two, not a screen.
     expect(approvalTail(tall, 10).length).toBeLessThanOrEqual(22)
+  })
+})
+
+describe('a QUEUED message pushes the dialog footer off the bottom', () => {
+  const NOW2 = 1_700_000_000_000
+  const rules2 = rulesFor('claude')
+  const read2 = (frame: string[]) => attentionOf({
+    alive: true,
+    lastActivityMs: NOW2 - 30_000,
+    nowMs: NOW2,
+    frame,
+    frameDigest: 'same',
+    prevDigest: 'same',
+    rules: rules2,
+  })
+
+  /**
+   * VERBATIM in shape from the report of 2026-09-07 — an `AskUserQuestion` (the previews variant,
+   * whose footer carries `n to add notes`) with TWO messages queued underneath it.
+   *
+   * The harness draws the input box below the dialog, one row per queued line, so the dialog's
+   * footer sat five rows above the bottom and fell outside `FOOTER_LINES`. The session stopped
+   * reading as blocked, the composer unblocked, and both messages were accepted and marked
+   * `delivered to the session` — into the dialog's own filter. The user sat waiting on a question
+   * that had already been asked.
+   */
+  const QUEUED_UNDER_A_DIALOG = [
+    'Contra o que a sessão atual é comparada?',
+    '',
+    '❯ 1. Últimos 30 dias, todas as sessões (recomendado)',
+    '  2. Do projeto, com fallback global',
+    '  3. Por harness, últimos 30 dias',
+    '────────────────────────────────────────',
+    '  Chat about this',
+    '',
+    'Enter to select · ↑/↓ to navigate · n to add notes · Esc to cancel',
+    '',
+    '❯ /context',
+    '❯ /home/mithrandir/.agentistics/attachments/d3a25822-image.png',
+    '  nao consegui responder por aqui, tive que abrir o terminal.',
+    '  A resposta interativa ainda ta bem bugada, aproveita e corrige isso tbm',
+  ]
+
+  it('is STILL blocked — the footer sank, the question did not go away', () => {
+    expect(read2(QUEUED_UNDER_A_DIALOG)).toBe('waiting-approval')
+  })
+
+  it('reads the same dialog with nothing queued, exactly as before', () => {
+    expect(read2(QUEUED_UNDER_A_DIALOG.slice(0, 9))).toBe('waiting-approval')
+  })
+
+  it('does NOT extend that trust to a quoted footer with no menu above it', () => {
+    // The window only widens over a real `1..n` block. Source code keeps the narrow footer rule,
+    // which is what stops a session editing these very patterns being called blocked.
+    expect(read2([
+      '● Editing attention-rules.ts',
+      '     /Enter to select · ↑\\/↓ to navigate/,',
+      '✻ Leavening… (18m · ↓ 23.0k tokens)',
+      '❯ ',
+      '⏵⏵ auto mode on · esc to interrupt',
+    ])).toBe('working')
   })
 })

--- a/packages/server/server/sessions/attention.ts
+++ b/packages/server/server/sessions/attention.ts
@@ -18,6 +18,7 @@
  * harness nobody probed — which the UI states in words.
  */
 
+import { readDialog } from './dialog-choice'
 import type { AttentionRules, SessionActivity } from './types'
 
 /**
@@ -95,6 +96,30 @@ export function attentionOf(o: {
   // with strings like `Esc to cancel · Tab to amend` on screen as source code — and one of them was
   // offered a destructive key over a question it had never asked. Reported from a real machine.
   const footer = o.frame.slice(Math.max(0, o.frame.length - FOOTER_LINES)).join('\n')
+  /*
+   * THE FOOTER IS NOT ALWAYS THE LAST LINE, AND ASSUMING IT WAS COST A USER AN AFTERNOON.
+   *
+   * Every dialog probed for this feature drew its footer on the final row, and the four-line window
+   * was sized against that. It holds only while nothing is QUEUED. Type into a session that is
+   * sitting on a question and the harness draws the input box UNDER the dialog, one row per queued
+   * line — so the dialog's footer sinks, leaves the window, and the session stops reading as
+   * blocked.
+   *
+   * That failure FEEDS ITSELF, which is what makes it worse than a missed state: the composer is
+   * unblocked by the very same reading, so the next message is accepted, the box grows another row,
+   * and the footer sinks further. Reported with a screenshot of a question that had been waiting
+   * "sei lá a quanto tempo" behind two queued messages, each marked `delivered to the session`.
+   *
+   * Widening the window is exactly what must NOT be done — matching a footer anywhere in the frame
+   * is what once offered a destructive key to a session that merely had `attention-rules.ts` open.
+   * So the window is widened only when the screen carries a REAL MENU: `readDialog` finds an option
+   * block, and a footer below `1..n` belongs to that block. Source code quoting a footer has no
+   * menu above it, so the narrow window still governs there, and the guarantee is intact.
+   */
+  const optionTop = readDialog(o.frame).top
+  const approvalWindow = optionTop >= 0
+    ? o.frame.slice(optionTop).join('\n')
+    : footer
   const working = (haystack: string) =>
     Boolean(o.rules?.working && o.rules.working.some(re => re.test(haystack)))
   // A frame whose FOOTER says something is interruptible is not a frame sitting on a dialog: the
@@ -103,7 +128,11 @@ export function attentionOf(o: {
   // anything is interruptible INCLUDING BACKGROUND AGENTS, so a whole-frame veto would suppress a
   // genuine permission prompt on a session whose subagents happen to be running. Suppressing a real
   // block is the one error worse than the one being fixed.
-  if (o.rules && !working(footer) && o.rules.approval.some(re => re.test(footer))) {
+  // The VETO stays on the narrow footer even when the match window widened. `esc to interrupt` is
+  // printed whenever anything is interruptible, background subagents included, and a veto read over
+  // the whole dialog block would suppress a real permission prompt on a busy session — the one
+  // error this module calls worse than the one being fixed.
+  if (o.rules && !working(footer) && o.rules.approval.some(re => re.test(approvalWindow))) {
     return 'waiting-approval'
   }
 
@@ -160,9 +189,6 @@ export function approvalTail(frame: readonly string[], max = 10): string[] {
   return lines.slice(start, end)
 }
 
-/** A numbered option row, in the shape `parseDialogOptions` reads. Kept in step with it by test. */
-const OPTION_ROW = /^\s*(?:❯|>)?\s*(\d{1,2})\.\s+\S/
-
 /** How far above the first option the question itself may reach. */
 const QUESTION_LINES = 12
 
@@ -175,49 +201,38 @@ const QUESTION_LINES = 12
  * nothing saying what was being asked — reported with a screenshot whose first line is the middle
  * of a sentence.
  *
- * The dialog's own structure says where it starts: its FIRST OPTION. `parseDialogOptions` already
- * anchors on `1.` for the same reason, bottom-up, because the dialog is the last block on screen.
- * So the window is "everything from a little above option 1", which grows with the dialog instead
- * of guessing at its height.
+ * THIS NO LONGER LOOKS FOR THE ANCHOR ITSELF. It did, with a bound of its own (`max` plus the
+ * question), while `readDialog` searched for the very same `1.` with a different one — two searches
+ * for one block, and the smaller one lost. That is how the preview and the options came to describe
+ * different parts of the screen on the same frame. There is one reader now, and this consumes its
+ * answer.
  *
- * IT ONLY EVER GROWS THE WINDOW, and only when it found an anchor. With no `1.` in range this
- * returns `max` unchanged — the permission-prompt case, and every frame this cannot read. Reaching
- * further up on a frame whose shape is unknown is how the conversation above a dialog ends up
- * printed under "you are about to confirm this", which is the failure `approvalTail`'s own header
- * calls the worst possible way to be wrong.
- *
- * The extra room above option 1 is bounded (`QUESTION_LINES`) for that same reason: a question is a
- * sentence or two, not a screen.
+ * The extra room ABOVE option 1 is still bounded (`QUESTION_LINES`): a question is a sentence or
+ * two, not a screen, and reaching one line too far prints somebody's earlier prose under "you are
+ * about to confirm this".
  */
 export function dialogHeight(frame: readonly string[], max: number): number {
-  // Look no further up than the question could possibly reach — the same bound the return honours.
-  const limit = Math.max(0, max) + QUESTION_LINES
-  const from = Math.max(0, frame.length - limit)
+  const { top } = readDialog(frame)
+  if (top < 0) return Math.max(0, max)
   const blank = (i: number) => (frame[i] ?? '').trim() === ''
-  for (let i = frame.length - 1; i >= from; i--) {
-    const m = OPTION_ROW.exec(frame[i] ?? '')
-    if (!m || m[1] !== '1') continue
-    /*
-     * THE QUESTION IS THE BLOCK IMMEDIATELY ABOVE OPTION 1, and a blank line is what separates it
-     * from the conversation. A flat "N lines above" cannot tell the two apart, and reaching one
-     * line too far prints somebody's earlier prose under "you are about to confirm this".
-     *
-     *   …conversation…      ← must not be reached
-     *   (blank)             ← the boundary
-     *   Devo abrir a issue…  ← the question
-     *   (blank)             ← the dialog's own spacing
-     *     1. …              ← the anchor
-     */
-    let top = i
-    // The dialog's own spacing above option 1.
-    while (top > from && blank(top - 1)) top--
-    // The question itself: the contiguous non-blank block.
-    while (top > from && !blank(top - 1)) top--
-    const height = frame.length - top
-    // Never smaller than the flat window: this only ever grows it.
-    return Math.min(limit, Math.max(Math.max(0, max), height))
-  }
-  return Math.max(0, max)
+  /*
+   * THE QUESTION IS THE BLOCK IMMEDIATELY ABOVE OPTION 1, and a blank line is what separates it
+   * from the conversation. A flat "N lines above" cannot tell the two apart.
+   *
+   *   …conversation…      ← must not be reached
+   *   (blank)             ← the boundary
+   *   Devo abrir a issue…  ← the question
+   *   (blank)             ← the dialog's own spacing
+   *     1. …              ← the anchor
+   */
+  const floor = Math.max(0, top - QUESTION_LINES)
+  let up = top
+  // The dialog's own spacing above option 1.
+  while (up > floor && blank(up - 1)) up--
+  // The question itself: the contiguous non-blank block.
+  while (up > floor && !blank(up - 1)) up--
+  // Never smaller than the flat window: this only ever grows it.
+  return Math.max(Math.max(0, max), frame.length - up)
 }
 
 /** A line that is only box-drawing or rule characters — a frame's furniture, never its content. */

--- a/packages/server/server/sessions/control-session.test.ts
+++ b/packages/server/server/sessions/control-session.test.ts
@@ -105,3 +105,48 @@ describe('which conversation a row continues from', () => {
     }
   })
 })
+
+describe('a dialog agentop can SEE and cannot READ', () => {
+  /*
+   * THE REPORTED BUG, 2026-09-07.
+   *
+   * A claude `AskUserQuestion` with four described options was drawn into an 80x24 pane (the tmux
+   * default the spawner used to accept), so its question and option `1.` were redrawn off the top
+   * and never reached `capture-pane`. `readDialog` correctly refused — and the refusal, being an
+   * empty option list, read downstream as "there is nothing to choose between". The card offered a
+   * bare confirm button, which takes whichever row is HIGHLIGHTED, on a six-option question.
+   *
+   * The user could not answer from the browser and opened the terminal instead. They were right not
+   * to press it.
+   */
+  const asking = (over: Partial<SessionView> = {}) => view({
+    status: 'running',
+    activity: 'waiting-approval',
+    approvalLines: ['  4. [ ] Erros repetidos', '  5. [ ] Type something', 'Esc to cancel'],
+    ...over,
+  })
+
+  it('offers NO confirm button — the empty list was a refusal, not an absence', () => {
+    const c = toControlSession(asking({ dialogUnreadable: 'no-anchor' }), S, LIVE)
+    expect(c.canApprove).toBeUndefined()
+  })
+
+  it('says why, naming what does work, instead of leaving a control silently inert', () => {
+    const c = toControlSession(asking({ dialogUnreadable: 'no-anchor' }), S, LIVE)
+    expect(c.dialogBlind).toBe(S.sessDialogBlind('claude'))
+    expect(c.dialogBlind).toContain('attach')
+  })
+
+  it('still offers the confirm where there is genuinely nothing to choose between', () => {
+    // The codex-shaped `Press enter to continue`: no options AND no refusal. Unchanged.
+    const c = toControlSession(asking(), S, LIVE)
+    expect(c.canApprove).toBe(true)
+    expect(c.dialogBlind).toBeUndefined()
+  })
+
+  it('is silent on a session that is not asking anything', () => {
+    const c = toControlSession(view({ status: 'running', activity: 'working' }), S, LIVE)
+    expect(c.dialogBlind).toBeUndefined()
+    expect(c.canApprove).toBeUndefined()
+  })
+})

--- a/packages/server/server/sessions/control-session.ts
+++ b/packages/server/server/sessions/control-session.ts
@@ -191,8 +191,20 @@ export function toControlSession(
     // A bare confirm is only ever offered where there is NOTHING to choose between — the
     // codex-shaped `Press enter to continue`. On a numbered dialog it would take whichever row is
     // highlighted, which on "only my fix / promote everything / stop here" is picking for somebody.
-    ...(state === 'waiting-approval' && approvalFor(v.harness) && !needsChoice(v.dialogOptions ?? [])
+    //
+    // `!needsChoice(...)` ALONE WAS NOT THAT TEST, and the gap was reported: an empty option list
+    // is also what the reader returns when it REFUSES, so a dialog it had just declined to read
+    // came out here as "nothing to choose between" and drew the confirm button on a six-option
+    // `AskUserQuestion`. That is the exact accident `dialog-choice.ts` exists to prevent, arriving
+    // through its own refusal. The refusal is now a value and it is named here.
+    ...(state === 'waiting-approval' && approvalFor(v.harness)
+      && !needsChoice(v.dialogOptions ?? []) && !v.dialogUnreadable
       ? { canApprove: true as const }
+      : {}),
+    // A dialog agentop can SEE and cannot READ. Said in words naming what does work, exactly like
+    // `chooseBlind` beside it — a verb that is simply absent reads as a broken control.
+    ...(state === 'waiting-approval' && v.dialogUnreadable && harness
+      ? { dialogBlind: s.sessDialogBlind(harness) }
       : {}),
     // Said only where it is TRUE, which is a narrower place than `approvalBlind`: that one explains
     // why a blocked session may be reading as plain `waiting`, this one explains why a session that

--- a/packages/server/server/sessions/dialog-choice.test.ts
+++ b/packages/server/server/sessions/dialog-choice.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'bun:test'
-import { needsChoice, parseDialogOptions } from './dialog-choice'
+import { needsChoice, parseDialogOptions, readDialog } from './dialog-choice'
 
 /**
  * VERBATIM from a live claude 2.1.232 Write permission prompt, 2026-08-14.
@@ -132,5 +132,132 @@ describe('needsChoice', () => {
     expect(needsChoice(parseDialogOptions(WRITE_PERMISSION))).toBe(true)
     expect(needsChoice(parseDialogOptions(ASK_QUESTION))).toBe(true)
     expect(needsChoice([])).toBe(false)
+  })
+})
+
+
+/**
+ * THE DIALOG FROM THE REPORT, 2026-09-07 — a multi-select `AskUserQuestion` with four options,
+ * each carrying a description that WRAPS, plus the free-text row expanded into a field and the
+ * `Chat about this` escape hatch below the rule.
+ *
+ * Reconstructed from the reported screenshot, re-wrapped at the NARROW width it was drawn at
+ * (44 columns of description) — which is the condition that reproduces it. The user could not
+ * answer it from the browser and had to open the terminal: the preview began in the middle of a
+ * sentence ("…causa'. Puramente informativo") and the card offered a bare confirm button.
+ *
+ * What makes it the regression fixture is its HEIGHT. Option 1 sits far more than 40 lines above
+ * the bottom — not because the dialog is unusual, but because the window was narrow enough for the
+ * descriptions to wrap onto four lines each. The same dialog on a wide terminal fits and parses.
+ */
+const TALL_ASK = [
+  'Vou fazer isso num worktree a partir de origin/dev.',
+  '',
+  '────────────────────────────────────────────────────────',
+  ' ☐ Gatilhos v1',
+  '',
+  'Quais gatilhos entram na v1? (o compact que você',
+  'citou é o sintoma; o contexto é a causa)',
+  '',
+  '❯ 1. [ ] Contexto ≥85% sem compact ainda',
+  '        context_tokens / resolveContextWindow.',
+  '        Dispara ANTES da perda — o handoff sai da',
+  '        sessão cheia, não de um resumo de resumo. Só',
+  '        funciona em claude/codex/antigravity',
+  '        (contextWindow: true); gemini/copilot/kimi',
+  '        não medem contexto e simplesmente não',
+  '        recebem esse card.',
+  '  2. [ ] ≥2 compacts na sessão',
+  '        compact_boundary + compactMetadata. Diz o',
+  '        custo já pago com número (\'2 compacts,',
+  '        3m29s, 2,9M descartados\'). Só Claude — exige',
+  '        um HARNESS_CAPABILITIES.compaction novo. É',
+  '        tarde para um handoff bom, mas é o sinal',
+  '        mais legível.',
+  '  3. [ ] Esperando aprovação há >N min',
+  '        attention.ts já sabe disso; o card só',
+  '        empacota a ação que já existe',
+  '        (aprovar/abrir). Barato, funciona nos 6',
+  '        harnesses, mas é quase redundante com o',
+  '        contador de \'precisa de você\' no header.',
+  '  4. [ ] Erros repetidos da mesma categoria',
+  '        tool_error_categories. Prompt sugerido:',
+  '        \'esses N erros são todos X, ataca a causa\'.',
+  '        Puramente informativo/prompt, sem migração.',
+  '        Disponível onde o adapter preenche a',
+  '        categoria.',
+  '  5. [ ] Type something',
+  '      Submit',
+  '────────────────────────────────────────────────────────',
+  '  6. Chat about this',
+  '',
+  'Enter to select · ↑/↓ to navigate · Esc to cancel',
+  '',
+  '  ❯ /context',
+]
+
+describe('readDialog — the tall dialog that stranded a user', () => {
+  it('reads a dialog whose option 1 is far more than 40 lines up', () => {
+    const out = readDialog(TALL_ASK)
+    expect(out.kind).toBe('options')
+    expect(out.options.map(o => o.number)).toEqual([1, 2, 3, 4, 5, 6])
+    expect(out.options[0]!.selected).toBe(true)
+  })
+
+  it('points the preview at the option block, not at a flat ten lines', () => {
+    const out = readDialog(TALL_ASK)
+    expect(TALL_ASK[out.top]).toContain('Contexto ≥85%')
+  })
+
+  it('never reaches the prose above the dialog', () => {
+    expect(readDialog(TALL_ASK).options.some(o => o.label.includes('worktree'))).toBe(false)
+  })
+})
+
+describe('readDialog — the two different empties', () => {
+  it('says `none` when there is no menu: a confirm key is the right answer there', () => {
+    const out = readDialog(['Press enter to continue', ''])
+    expect(out.kind).toBe('none')
+    expect(out.options).toEqual([])
+  })
+
+  it('says `unreadable` when option 1 is out of reach — NOT `none`', () => {
+    // The block is real; its top ran off the frame. Offering a confirm here picks the
+    // highlighted row blind, which is the accident this module exists to prevent.
+    const frame = ['  3. c', '  4. d', '❯ 5. e', '', 'Esc to cancel']
+    const out = readDialog(frame)
+    expect(out.kind).toBe('unreadable')
+    expect(out.reason).toBe('no-anchor')
+    expect(out.options).toEqual([])
+  })
+
+  it('says `unreadable` on a gap, and on two cursors', () => {
+    expect(readDialog([' 1. a', ' 3. c']).reason).toBe('gap')
+    expect(readDialog(['❯ 1. a', '❯ 2. b']).reason).toBe('two-cursors')
+  })
+
+  it('a single option is `none` — a statement, not a menu', () => {
+    expect(readDialog([' 1. Yes', '', 'Esc to cancel']).kind).toBe('none')
+  })
+
+  it('numbered prose far above the menu is not joined to it', () => {
+    const frame = [
+      '1. primeiro ponto de uma lista em prosa',
+      ...Array.from({ length: 16 }, (_, i) => `linha de prosa ${i}`),
+      '  2. b',
+      '  3. c',
+      '',
+      'Esc to cancel',
+    ]
+    // It found 3 and 2, then the gap to `1.` is wider than one option's description.
+    expect(readDialog(frame).kind).toBe('unreadable')
+  })
+})
+
+describe('parseDialogOptions stays the thin reading', () => {
+  it('agrees with readDialog on every fixture', () => {
+    for (const f of [WRITE_PERMISSION, ASK_QUESTION, TALL_ASK]) {
+      expect(parseDialogOptions(f)).toEqual(readDialog(f).options)
+    }
   })
 })

--- a/packages/server/server/sessions/dialog-choice.ts
+++ b/packages/server/server/sessions/dialog-choice.ts
@@ -69,46 +69,119 @@ export interface DialogOption {
 const OPTION = /^\s*(❯|>)?\s*(\d{1,2})\.\s+(\S.*?)\s*$/
 
 /**
- * How far up the frame to look for the block.
+ * How far up the frame to look for the dialog's LAST option row.
  *
- * The dialog is at the bottom and the tallest real one measured is well inside this. A bound
- * matters because the scan is looking for a `1.` to stop at, and without one it would read the
- * whole scrollback on a frame that has no menu in it at all.
+ * Below the last option there is only chrome — a rule, a footer, the input box — so this is a
+ * bound on the harness's furniture, which does not grow. It is NOT a bound on the dialog.
  */
-const SCAN_LINES = 40
+const LAST_OPTION_LINES = 40
 
 /**
- * The options on screen, in order — PURE, and EMPTY when they cannot be read with confidence.
+ * How far apart two option rows of ONE menu may sit.
  *
- * Empty is a real answer and the caller must treat it as one: it means "this is a dialog, and
- * agentop cannot tell you what it is offering". Inventing a list there is exactly the failure this
- * module was written to remove.
+ * This replaced a flat 40-line ceiling on the whole block, and the distinction matters because a
+ * flat line count is not a bound on the DIALOG — it is a bound on the TERMINAL WIDTH. The same
+ * `AskUserQuestion` whose descriptions wrap onto two lines at 120 columns wraps onto four at 60,
+ * and crosses any fixed ceiling purely by the window being narrow. That is exactly how this
+ * survived its own tests: measured wide, reported from a narrow window.
+ *
+ * The gap is the structural fact instead. Between option k and option k+1 there is only option k's
+ * own description, so the block extends as far as its options do and stops where prose begins.
  */
-export function parseDialogOptions(frame: readonly string[]): DialogOption[] {
-  const from = Math.max(0, frame.length - SCAN_LINES)
-  const found: DialogOption[] = []
+const MAX_OPTION_GAP = 14
 
-  // Bottom-up, stopping at `1.` — the dialog is the last block on the screen, and its first option
-  // is where that block begins.
-  for (let i = frame.length - 1; i >= from; i--) {
+/** Why a dialog that IS on screen could not be read. Each is a fact about the frame. */
+export type DialogUnreadable =
+  /** Option rows were found and the scan never reached `1.` — the block ran off the top. */
+  | 'no-anchor'
+  /** The numbers did not come out `1..n`: a gap, a repeat, or a wrong start. */
+  | 'gap'
+  /** Two highlighted rows. A frame this parser does not understand. */
+  | 'two-cursors'
+
+/**
+ * WHAT THE SCREEN IS OFFERING — PURE, and the ONE reader of the block.
+ *
+ * `kind` is the whole point of this type. An empty option list used to be the only answer for two
+ * situations that could not be more different:
+ *
+ *  - `none`       — there is no menu. The codex-shaped `Press enter to continue`. A bare confirm
+ *                   key is the RIGHT answer here, because there is nothing to choose between.
+ *  - `unreadable` — there IS a menu and agentop could not read it. A bare confirm key takes
+ *                   whichever row is highlighted, which is choosing for the user among things that
+ *                   do different work.
+ *
+ * The caller read `[]` as the first and got the second, and the confirm button appeared on a
+ * six-option `AskUserQuestion` that the reader had just refused. That is the exact accident this
+ * module was written to remove, reintroduced through its own refusal. So the refusal is now a
+ * VALUE, and a caller that wants to offer a confirm has to ask for `none` by name.
+ */
+export interface DialogRead {
+  kind: 'options' | 'none' | 'unreadable'
+  /** The options, in order. EMPTY unless `kind` is `options` — a half-read list is never offered. */
+  options: DialogOption[]
+  /** Present only on `unreadable`. */
+  reason?: DialogUnreadable
+  /** Index of the TOPMOST option row reached, `-1` when none was. Feeds the preview's window. */
+  top: number
+}
+
+/**
+ * Read the dialog off the frame — PURE.
+ *
+ * Bottom-up, because the dialog is the last block on the screen, stopping at `1.` because that is
+ * where the block begins. Everything the old `parseDialogOptions` refused it still refuses; it now
+ * says WHICH refusal, and hands back where the block starts so the preview and the options can
+ * never describe different parts of the screen.
+ */
+export function readDialog(frame: readonly string[]): DialogRead {
+  const found: DialogOption[] = []
+  let top = -1
+  let anchored = false
+
+  for (let i = frame.length - 1; i >= 0; i--) {
+    // The LAST option is near the bottom, under nothing but chrome. Past this bound with nothing
+    // found, there is no dialog here — and reading further would be reading the scrollback.
+    if (found.length === 0 && frame.length - 1 - i > LAST_OPTION_LINES) break
     const m = OPTION.exec(frame[i] ?? '')
     if (!m) continue
-    const number = Number(m[2])
-    found.push({ number, label: m[3]!, selected: m[1] !== undefined })
-    if (number === 1) break
+    // Too far above the previous option to be part of the same menu: this is prose that happens to
+    // be numbered, and joining it to the block would invent a menu.
+    if (found.length > 0 && top - i > MAX_OPTION_GAP) break
+    found.push({ number: Number(m[2]), label: m[3]!, selected: m[1] !== undefined })
+    top = i
+    if (Number(m[2]) === 1) { anchored = true; break }
   }
 
   found.reverse()
 
+  // Nothing numbered at the bottom at all: there is no menu to read.
+  if (found.length === 0) return { kind: 'none', options: [], top: -1 }
+  // Rows were found and `1.` never was. The block is real and its top is out of reach.
+  if (!anchored) return { kind: 'unreadable', reason: 'no-anchor', options: [], top }
   // A menu is at least a choice. One option is a statement, and the caller confirms it instead.
-  if (found.length < 2) return []
+  if (found.length < 2) return { kind: 'none', options: [], top }
   // Exactly `1..n`, in order. A gap, a repeat or a wrong start means this was not read correctly —
   // and half-read options are worse than none, because they would be offered as if they were whole.
-  if (found.some((o, i) => o.number !== i + 1)) return []
+  if (found.some((o, i) => o.number !== i + 1)) return { kind: 'unreadable', reason: 'gap', options: [], top }
   // At most one highlighted row. Two cursors is a frame this parser does not understand.
-  if (found.filter(o => o.selected).length > 1) return []
+  if (found.filter(o => o.selected).length > 1) {
+    return { kind: 'unreadable', reason: 'two-cursors', options: [], top }
+  }
 
-  return found
+  return { kind: 'options', options: found, top }
+}
+
+/**
+ * The options on screen, in order — EMPTY when they cannot be read with confidence.
+ *
+ * A thin reading of `readDialog`, kept because most callers only want the list. **A caller deciding
+ * whether to send a confirm key must NOT use this** — `[]` conflates "no menu" with "unreadable
+ * menu", and that conflation is what put a blind confirm button on a six-option dialog. Ask
+ * `readDialog(...).kind === 'none'`.
+ */
+export function parseDialogOptions(frame: readonly string[]): DialogOption[] {
+  return readDialog(frame).options
 }
 
 /**

--- a/packages/server/server/sessions/fleet-row.ts
+++ b/packages/server/server/sessions/fleet-row.ts
@@ -140,6 +140,8 @@ export interface FleetRow {
   approvalBlind?: string
   approveBlind?: string
   chooseBlind?: string
+  /** Why a visible dialog could not be read. Carries the refusal, never a fallback confirm. */
+  dialogBlind?: string
   conversationBlind?: string
   /** `agentop session attach <handle>` — what a browser offers instead of attaching. */
   attachCommand: string
@@ -173,7 +175,7 @@ export function verbReason(
   s: ControlStrings,
 ): string | undefined {
   if (row.state === 'unknown' && action !== 'resume') return s.sessionsExternalNote
-  if (action === 'approve') return row.chooseBlind ?? row.approveBlind ?? row.approvalBlind
+  if (action === 'approve') return row.dialogBlind ?? row.chooseBlind ?? row.approveBlind ?? row.approvalBlind
   if (action === 'resume' && !row.resume) return row.conversationBlind
   return undefined
 }
@@ -215,6 +217,7 @@ export function fleetRow(row: ControlSession, s: ControlStrings): FleetRow {
     ...(row.approvalBlind ? { approvalBlind: row.approvalBlind } : {}),
     ...(row.approveBlind ? { approveBlind: row.approveBlind } : {}),
     ...(row.chooseBlind ? { chooseBlind: row.chooseBlind } : {}),
+    ...(row.dialogBlind ? { dialogBlind: row.dialogBlind } : {}),
     ...(row.conversationBlind ? { conversationBlind: row.conversationBlind } : {}),
     attachCommand: `agentop session attach ${sessionHandleOf(row.id)}`,
     verbs,

--- a/packages/server/server/sessions/session-view.ts
+++ b/packages/server/server/sessions/session-view.ts
@@ -14,7 +14,7 @@ import { capClosedConversations } from './closed-cap'
 import { matchesQuery, type SearchFields } from '@agentistics/tui/control/search-scope'
 import { type HarnessProcess, sessionAtCwd } from '../live-sessions'
 import { rulesFor } from './attention-rules'
-import type { DialogOption } from './dialog-choice'
+import type { DialogOption, DialogUnreadable } from './dialog-choice'
 import { chosenName, tmuxSessionName, type HarnessSessionFile } from './harness-session-file'
 import type { HarnessSessionIndex } from './harness-sessions'
 import { idFromTmuxName } from './tmux-cli'
@@ -109,6 +109,14 @@ export interface SessionView {
    * a keystroke that confirms the highlighted row is choosing on the user's behalf.
    */
   dialogOptions?: DialogOption[]
+  /**
+   * WHY the dialog on screen could not be read, when it could not be.
+   *
+   * Distinct from an empty `dialogOptions`, and that distinction is the whole point: no options
+   * means either "nothing to choose between" (a confirm key is right) or "a menu agentop failed to
+   * read" (a confirm key takes whichever row is highlighted). Only the first may reach a button.
+   */
+  dialogUnreadable?: DialogUnreadable
   /**
    * This session was taken by the machine along with the others, and is offered back with them.
    *
@@ -440,6 +448,8 @@ export function buildSessionViews(o: {
   modes?: ReadonlyMap<string, { id: string; label: string }>
   /** The options that dialog offers, keyed by session id. Absent where they could not be read. */
   dialogOptions?: ReadonlyMap<string, DialogOption[]>
+  /** Why the dialog could not be read, keyed by session id — see `SessionView.dialogUnreadable`. */
+  dialogUnreadable?: ReadonlyMap<string, DialogUnreadable>
   /** The ids `crash-group.ts` decided fell together. A set, because the question is about a set. */
   fell?: ReadonlySet<string>
   /**
@@ -580,6 +590,9 @@ export function buildSessionViews(o: {
         : {}),
       ...(activity === 'waiting-approval' && (o.dialogOptions?.get(r.id)?.length ?? 0) > 0
         ? { dialogOptions: o.dialogOptions!.get(r.id)! }
+        : {}),
+      ...(activity === 'waiting-approval' && o.dialogUnreadable?.get(r.id)
+        ? { dialogUnreadable: o.dialogUnreadable.get(r.id)! }
         : {}),
       // Unlike the dialog above, the mode is NOT gated on an activity: a session is in a mode while
       // it works, while it waits, and while it is asking. It is gated on the frame having named

--- a/packages/server/server/sessions/sessions-host.ts
+++ b/packages/server/server/sessions/sessions-host.ts
@@ -20,7 +20,7 @@ import { EMPTY_CONFIRM_MEMORY, confirmActivities, type ConfirmMemory } from './a
 import type { ChatTurn } from './chat-turn'
 import { transcriptReaderFor } from './harness-transcript'
 import { markFleetPhase } from './fleet-profile'
-import { parseDialogOptions, type DialogOption } from './dialog-choice'
+import { readDialog, type DialogOption, type DialogUnreadable } from './dialog-choice'
 // Taking a running session back when its registry record is gone. See `session-adopt.ts`.
 import { planAdoptions } from './session-adopt'
 // The claim for harnesses that cannot be handed a conversation id. See `task-attribution.ts`.
@@ -265,6 +265,14 @@ export function createSessionsPoller(o: {
       /** The harness mode each running session is in — see `mode-spec.ts`. */
       const modes = new Map<string, { id: string; label: string }>()
       const dialogOptions = new Map<string, DialogOption[]>()
+      /*
+       * WHY THE REFUSAL IS CARRIED AND NOT JUST THE OPTIONS.
+       *
+       * An empty option list means two opposite things — "there is no menu" and "there IS a menu
+       * and it could not be read" — and the second one must never reach a confirm button. Carrying
+       * only the options threw that distinction away at the source. See `readDialog`.
+       */
+      const dialogUnreadable = new Map<string, DialogUnreadable>()
       const chatTails = new Map<string, ChatTurn[]>()
 
       const captureStart = performance.now()
@@ -339,8 +347,9 @@ export function createSessionsPoller(o: {
           // Read from the SAME frame that decided the state, so what is offered and what the state
           // says can never describe different moments. Empty when the screen cannot be parsed with
           // confidence, which the UI reports rather than papering over.
-          const options = parseDialogOptions(frame)
-          if (options.length > 0) dialogOptions.set(r.id, options)
+          const dialog = readDialog(frame)
+          if (dialog.options.length > 0) dialogOptions.set(r.id, dialog.options)
+          if (dialog.kind === 'unreadable') dialogUnreadable.set(r.id, dialog.reason!)
         }
       })))
       markFleetPhase(`poll: capture+chatTail x${reconciled.length} (concurrency ${CAPTURE_CONCURRENCY})`, captureStart)
@@ -475,6 +484,7 @@ export function createSessionsPoller(o: {
         approvals,
         modes,
         dialogOptions,
+        dialogUnreadable,
         processes,
         conversations,
         harnessSessions,

--- a/packages/server/server/sessions/tmux-cli.test.ts
+++ b/packages/server/server/sessions/tmux-cli.test.ts
@@ -5,7 +5,7 @@ import {
   parseTmuxList, sendKeysEnterArgs, sendKeysLiteralArgs,
   sendKeysNamedArgs, trimCapture,
   tmuxName,
-  serverOptionsArgs, HISTORY_LIMIT,
+  serverOptionsArgs, HISTORY_LIMIT, PANE_COLS, PANE_ROWS,
   resolveDefaultTerminal, resolveTruecolorTerm, spawnArgs,
   type TerminalProfile, tmuxListIsEmptyState,
 } from './tmux-cli'
@@ -32,8 +32,8 @@ describe('newSessionArgs', () => {
   it('uses our socket, detaches, sets the cwd, and separates the command with --', () => {
     expect(newSessionArgs({ id: 'a1', cwd: '/home/u/p', argv: ['claude', '--model', 'opus', 'fix it'] }))
       .toEqual([
-        '-L', 'agentop', 'new-session', '-d', '-s', 'agentop-a1', '-c', '/home/u/p',
-        '--', 'claude', '--model', 'opus', 'fix it',
+        '-L', 'agentop', 'new-session', '-d', '-s', 'agentop-a1', '-x', '120', '-y', '50',
+        '-c', '/home/u/p', '--', 'claude', '--model', 'opus', 'fix it',
       ])
   })
 
@@ -43,10 +43,27 @@ describe('newSessionArgs', () => {
     // `--`, or tmux reads it as one of the harness's own arguments.
     const args = newSessionArgs({ id: 'a1', cwd: '/home/u/p', argv: ['claude'], truecolor: true })
     expect(args).toEqual([
-      '-L', 'agentop', 'new-session', '-d', '-s', 'agentop-a1', '-c', '/home/u/p',
-      '-e', 'COLORTERM=truecolor', '--', 'claude',
+      '-L', 'agentop', 'new-session', '-d', '-s', 'agentop-a1', '-x', '120', '-y', '50',
+      '-c', '/home/u/p', '-e', 'COLORTERM=truecolor', '--', 'claude',
     ])
     expect(args.indexOf('-e')).toBeLessThan(args.indexOf('--'))
+  })
+
+  it('BORNS THE PANE BIG ENOUGH FOR A DIALOG — never at the 80x24 tmux default', () => {
+    /*
+     * The regression this exists for: a detached pane defaults to 80x24, a claude
+     * `AskUserQuestion` with four described options is taller than 24 rows, and its question and
+     * option `1.` are redrawn off the top before `capture-pane` ever reads it. Every surface that
+     * does not attach — the web dashboard, the VS Code panel, the cockpit — then shows a dialog
+     * that begins mid-sentence and cannot say what is being asked.
+     */
+    const args = newSessionArgs({ id: 'a1', cwd: '/home/u/p', argv: ['claude'] })
+    expect(args).toContain('-x')
+    expect(args).toContain('-y')
+    expect(args[args.indexOf('-x') + 1]).toBe(String(PANE_COLS))
+    expect(PANE_ROWS).toBeGreaterThan(24)
+    // The geometry must precede `--`, like every other tmux flag here.
+    expect(args.indexOf('-y')).toBeLessThan(args.indexOf('--'))
   })
 
   it('adds nothing when the invoker is not truecolor', () => {

--- a/packages/server/server/sessions/tmux-cli.ts
+++ b/packages/server/server/sessions/tmux-cli.ts
@@ -90,9 +90,39 @@ export function resolveTruecolorTerm(env: { TERM?: string; COLORTERM?: string })
  * it inherits it. The client-side half — tmux actually forwarding RGB on attach — is the
  * `terminal-features` capability in `serverOptionsArgs`.
  */
+/**
+ * THE SIZE A DETACHED PANE IS BORN AT — and the reason it is stated instead of defaulted.
+ *
+ * `tmux new-session -d` with no `-x`/`-y` creates an 80x24 pane (measured on 3.2a). Twenty-four
+ * rows is smaller than the dialogs these harnesses draw: a claude `AskUserQuestion` with four
+ * described options is comfortably past thirty. The top of such a dialog — its question, and
+ * option `1.` — is redrawn off the pane and never reaches `capture-pane`.
+ *
+ * Everything downstream then fails in a way that looks like a parser bug and is not one:
+ * `readDialog` cannot find its anchor, `approvalTail` shows a window that begins mid-sentence, and
+ * the card ends up unable to say what the session is asking. Reported with a screenshot of exactly
+ * that, from a session running in an 80x24 pane this module had created.
+ *
+ * It is invisible from the terminal, which is why it lasted: attaching resizes the pane to the
+ * client, so a person looking at the same dialog on attach sees all of it. Only the surfaces that
+ * never attach — the web dashboard, the VS Code panel, the cockpit — read the 24-row pane.
+ *
+ * Width is generous for the same reason rather than for its own: every column a description does
+ * not wrap into is a row the dialog does not need.
+ *
+ * No compatibility floor is added: `-x`/`-y` on `new-session` is tmux 2.9, older than the `-e` this
+ * same function already passes (3.2).
+ */
+export const PANE_COLS = 120
+export const PANE_ROWS = 50
+
 export function newSessionArgs(o: { id: string; cwd: string; argv: string[]; truecolor?: boolean }): string[] {
   const env = o.truecolor ? ['-e', 'COLORTERM=truecolor'] : []
-  return sock(['new-session', '-d', '-s', tmuxName(o.id), '-c', o.cwd, ...env, '--', ...o.argv])
+  return sock([
+    'new-session', '-d', '-s', tmuxName(o.id),
+    '-x', String(PANE_COLS), '-y', String(PANE_ROWS),
+    '-c', o.cwd, ...env, '--', ...o.argv,
+  ])
 }
 
 export function killSessionArgs(id: string): string[] {
@@ -227,6 +257,11 @@ export function serverOptionsArgs(profile: TerminalProfile): string[][] {
   if (profile.truecolorTerm) {
     opts.push(sock(['set-option', '-ga', 'terminal-features', `,${profile.truecolorTerm}:RGB`]))
   }
+  // `-x`/`-y` sets the size at BIRTH; this is what it goes back to. With `window-size` at its
+  // default (`latest`) a pane follows the newest client, so the first attach resizes it to that
+  // terminal and the detach drops it to `default-size` — 80x24 again, and the dialog is unreadable
+  // from every surface once more. Set on OUR socket only, so no session of the user's is touched.
+  opts.push(sock(['set-option', '-g', 'default-size', `${PANE_COLS}x${PANE_ROWS}`]))
   opts.push(
     // Keeps a finished session listable, with its last frame still capturable — the `exited` state.
     sock(['set-option', '-g', 'remain-on-exit', 'on']),

--- a/packages/tui/src/control/tabs/Sessions.tsx
+++ b/packages/tui/src/control/tabs/Sessions.tsx
@@ -895,7 +895,10 @@ export function Sessions({
       // A dialog whose options are readable but unpickable is a refusal that NAMES why and points
       // at attaching, which works — so it opens the question rather than swallowing the keypress.
       if ((selected.dialogOptions?.length ?? 0) > 1) return actOn('approve')
-      const why = selected.approveBlind ?? s.sessionsNotAsking
+      // `sessionsNotAsking` is a CLAIM ABOUT THE SESSION and it is false here: a row with a
+      // `dialogBlind` is asking something agentop could not read. Saying "not asking anything"
+      // sends somebody away from a question that is genuinely waiting on them.
+      const why = selected.dialogBlind ?? selected.approveBlind ?? s.sessionsNotAsking
       void run(async () => ({ ok: false, message: why }))
       return
     }
@@ -2860,7 +2863,10 @@ function Question({
                 off at "nobody has verified how to pick an option on ge…" tells nobody anything.
                 Bounded so it cannot grow over the rows the pane was given. */}
             <WrappedText
-              text={session.chooseBlind ?? s.sessionsChooseBlind}
+              // `dialogBlind` FIRST: "nobody verified how to pick an option here" and "the dialog
+              // is taller than agentop can read" are different facts with different remedies, and
+              // the generic string states the wrong one confidently.
+              text={session.dialogBlind ?? session.chooseBlind ?? s.sessionsChooseBlind}
               width={width}
               maxRows={Math.max(1, rows - preview.length - 2)}
             />

--- a/packages/tui/src/control/types.ts
+++ b/packages/tui/src/control/types.ts
@@ -787,6 +787,8 @@ export interface ControlSession {
    * quietly picks for them is not.
    */
   chooseBlind?: string
+  /** A dialog agentop can SEE and cannot READ — see `DialogUnreadable`. Never a confirm button. */
+  dialogBlind?: string
   /**
    * This session was taken by the machine along with the others, and comes back with them.
    *

--- a/packages/vscode/src/protocol.ts
+++ b/packages/vscode/src/protocol.ts
@@ -64,6 +64,7 @@ export interface FleetRow {
   approvalBlind?: string
   approveBlind?: string
   chooseBlind?: string
+  dialogBlind?: string
   conversationBlind?: string
   attachCommand: string
   verbs: FleetVerb[]

--- a/packages/vscode/src/webview/main.ts
+++ b/packages/vscode/src/webview/main.ts
@@ -834,8 +834,8 @@ function renderApproval(row: FleetRow): HTMLElement {
       ))
     }
     box.append(options)
-  } else if (row.approveBlind ?? row.chooseBlind ?? row.approvalBlind) {
-    box.append(el('div', 'dim', row.chooseBlind ?? row.approveBlind ?? row.approvalBlind!))
+  } else if (row.dialogBlind ?? row.approveBlind ?? row.chooseBlind ?? row.approvalBlind) {
+    box.append(el('div', 'dim', row.dialogBlind ?? row.chooseBlind ?? row.approveBlind ?? row.approvalBlind!))
   }
   return box
 }

--- a/packages/web/src/components/sessions/ApprovalCard.tsx
+++ b/packages/web/src/components/sessions/ApprovalCard.tsx
@@ -245,7 +245,7 @@ export function ApprovalCard({ row, lang, act, onWrite, answering = null }: Appr
         </button>
       ) : (
         <p style={{ margin: 0, fontSize: 12, lineHeight: 1.55, color: 'var(--text-secondary)' }}>
-          {approve?.reason ?? row.approveBlind ?? (pt
+          {row.dialogBlind ?? approve?.reason ?? row.approveBlind ?? (pt
             ? 'Esta pergunta não pode ser respondida daqui. Abra a sessão no terminal.'
             : 'This question cannot be answered from here. Open the session in the terminal.')}
         </p>

--- a/packages/web/src/lib/fleet.ts
+++ b/packages/web/src/lib/fleet.ts
@@ -74,6 +74,8 @@ export interface FleetRow {
   approvalBlind?: string
   approveBlind?: string
   chooseBlind?: string
+  /** A dialog agentop can see and cannot read. Renders as a refusal, never as a confirm button. */
+  dialogBlind?: string
   conversationBlind?: string
   attachCommand: string
   verbs: FleetVerb[]


### PR DESCRIPTION
## Summary

- Panes are born **120x50** instead of the tmux default 80x24 — a `AskUserQuestion` with described options is taller than 24 rows, so its question and option `1.` never reached `capture-pane`.
- `readDialog` replaces `parseDialogOptions` as the one reader of the dialog block and says **why** it refused, so a dialog agentop cannot read no longer reaches a bare confirm button.
- The approval footer is matched over the **option block** when one is on screen, so a queued message pushing the footer down no longer makes a blocked session read as free.

## Motivation

Fixes #415.

A session sitting on a question was unanswerable from every surface that does not attach — the web dashboard, the VS Code panel, the cockpit. Reported twice from a real machine, with screenshots, in two different shapes.

**The card appeared truncated and offered a blind confirm.** `parseDialogOptions` returns `[]` both when there is no menu and when there is one it could not read; `!needsChoice([])` read the second as the first, so `canApprove` turned on for a dialog the reader had *just declined to read*. The button sends the bare confirm key, which takes whichever row is highlighted — on a six-option question that is choosing for the user. It is the exact accident `dialog-choice.ts` exists to prevent, arriving through its own refusal.

**Or no card appeared at all, and the composer accepted messages.** The footer was matched in the last four lines, which holds only while nothing is queued. The harness draws its input box *under* the dialog, one row per queued line, so the footer sank out of the window and the state stopped being `waiting-approval`. That failure feeds itself: the composer is unblocked by the same reading, so the next message is accepted and the box grows another row. Two messages were marked `delivered to the session` into the dialog's own filter while a person waited.

Underneath both: the pane. It is invisible from the terminal because attaching resizes the pane to the client, which is why it lasted — only the surfaces that never attach read the 24-row pane.

## Changes

**The cause**
- `sessions/tmux-cli.ts` — `PANE_COLS`/`PANE_ROWS` (120x50) passed as `-x`/`-y` on `new-session`, plus `default-size` on our own socket so the geometry survives the first attach/detach cycle. No compatibility floor added: `-x`/`-y` is tmux 2.9, older than the `-e` this same function already passed (3.2).

**The hole**
- `sessions/dialog-choice.ts` — `readDialog` is now the single reader and returns `kind: 'options' | 'none' | 'unreadable'` plus the anchor's index. `parseDialogOptions` stays as a thin reading, documented as unusable for the confirm decision. The block's extent is bounded by the **gap between option rows** rather than a flat line count — a flat count is a bound on the terminal *width*, not on the dialog, which is how this survived its own tests.
- `sessions/control-session.ts` — `canApprove` requires `none` by name; an unreadable dialog gets `dialogBlind`.
- `sessions/sessions-host.ts`, `sessions/session-view.ts`, `sessions/fleet-row.ts` — carry the refusal.
- `cli-i18n.ts` — `sessDialogBlind`, EN + PT.

**One reader for one block**
- `sessions/attention.ts` — `dialogHeight` consumes `readDialog`'s anchor instead of searching for the same `1.` with a smaller bound of its own (22 vs 40), which is why the preview began mid-sentence.

**The sunken footer**
- `sessions/attention.ts` — the approval window widens to the option block **only when a real `1..n` menu is on screen**. Source code quoting a footer has no menu above it, so the narrow rule still governs there and the guarantee that stopped a destructive key being offered to a session with `attention-rules.ts` open is intact. The working-marker veto deliberately stays on the narrow footer — suppressing a real permission prompt on a busy session is the worse error.

**Rendering the refusal**
- `web/src/lib/fleet.ts`, `web/.../ApprovalCard.tsx`, `vscode/src/protocol.ts`, `vscode/src/webview/main.ts`, `tui/src/control/types.ts`, `tui/.../tabs/Sessions.tsx`.
- The cockpit read neither refusal, so pressing `a` on such a row answered *"this session is not asking anything"* — false, and false in the reassuring direction.
- `dialogBlind` had to be declared in four types: `tsc` passed without them because spreads skip excess-property checks, so the field existed at runtime and in no type.

## Test plan

- [x] `bun tsc --noEmit` clean.
- [x] `bun test` — **6965 pass, 0 fail** (after rebase onto current `dev`).
- [x] `bun run build:binary` compiles and the binary runs (`agentop v2.15.0`) — the CLAUDE.md rule for TUI work; the `react-devtools-core` class of failure only appears at compile time.
- [x] **Every regression test was confirmed to fail without its fix**, by reverting the guard and re-running: `offers NO confirm button — the empty list was a refusal, not an absence`, and `is STILL blocked — the footer sank, the question did not go away`.
- [x] tmux behaviour probed on a throwaway socket, not assumed: `new-session -d` → `80x24`; with `-x 200 -y 50` → `200x50`; `default-size` honoured on 3.2a.
- [x] Fixtures are the reported frames — the tall `AskUserQuestion`, and the dialog with two messages queued under its footer.

**What reviewers should check**

- The widened approval window is the risky half. It must not re-open the quotation bug: `does NOT extend that trust to a quoted footer with no menu above it` covers it, but a second opinion on whether a `1..n` block above a footer is a strong enough discriminator is worth having.
- **Not verified end-to-end on a live session.** Everything above is unit tests plus tmux probes; nobody has yet started a session with this build, driven it onto a tall dialog and looked at the card in a browser. Spawning one writes to the shared `managed-sessions.json` beside live sessions, which is the registry race `registry.ts` documents, so it was left for a deliberate check.
- **Existing sessions stay 80x24** — the geometry applies to new sessions. Live ones can be fixed without restarting: `tmux -L agentop list-windows -a -F '#{session_name}' | xargs -I{} tmux -L agentop resize-window -t {} -x 120 -y 50`.
- The footer of the reported dialog carried `n to add notes`, a variant nobody had probed. It matched anyway (the rule anchors on `Enter to select · ↑/↓ to navigate`), so no rule changed — but per CLAUDE.md's own advice, assume there is another dialog shape until somebody has looked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019LT77q1YCgYQ6L8d1RRcM3
