### PR TITLE
docs(sessions): the design for session suggestions and the behaviour profile

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1383,9 +1383,14 @@ The numbers moved to `~/.claude/projects/<project>/<session-id>/subagents/agent-
 | `costUSD` | `calcCost()` per model of the subagent's own turns |
 | `status` | `toolUseResult.status` (`failed` → `failed`, anything else → `completed`) |
 
-### What is NOT available for Skills and Tasks
+### What is available for Skills, and what is not for Tasks
 
-- **Skills** (`/commit`, `/review-pr`, etc.) are not recorded as individual tool_use events in the JSONL — only a `skill_listing` attachment appears. Skill invocations can only be inferred indirectly from subsequent tool calls.
+- **Skills ARE recorded** — as a `Skill` tool_use whose `input.skill` names the invoked skill
+  (`superpowers:brainstorming`, `artifact-design`, …). Measured 2026-09-08 on one machine: 104
+  invocations of 25 distinct skills across 57 sessions. This entry previously said the opposite —
+  that only a `skill_listing` attachment appeared and invocations could be inferred indirectly — and
+  that was true before the `Skill` tool existed. It is the reason no adapter counts them yet, not a
+  statement that they cannot be counted.
 - **Tasks** (`TaskCreate`/`TaskUpdate`) have subject/description/status but no token or duration data.
 
 ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1386,8 +1386,8 @@ The numbers moved to `~/.claude/projects/<project>/<session-id>/subagents/agent-
 ### What is available for Skills, and what is not for Tasks
 
 - **Skills ARE recorded** — as a `Skill` tool_use whose `input.skill` names the invoked skill
-  (`superpowers:brainstorming`, `artifact-design`, …). Measured 2026-09-08 on one machine: 104
-  invocations of 25 distinct skills across 57 sessions. This entry previously said the opposite —
+  (`superpowers:brainstorming`, `artifact-design`, …). Measured 2026-09-08 on one machine: 103
+  invocations of 26 distinct skills across 57 sessions. This entry previously said the opposite —
   that only a `skill_listing` attachment appeared and invocations could be inferred indirectly — and
   that was true before the `Skill` tool existed. It is the reason no adapter counts them yet, not a
   statement that they cannot be counted.

--- a/docs/superpowers/specs/2026-09-08-session-suggestions-design.md
+++ b/docs/superpowers/specs/2026-09-08-session-suggestions-design.md
@@ -14,7 +14,7 @@ Turn what agentistics already measures about a session into two things a person 
    messages"), which doubles as the sessions tab's empty state.
 
 They are one feature, not two, and the reason is the sentence each card has to produce. `2 compacts`
-is a threshold somebody invented. `2 compacts — 2 of your 407 sessions ever reached that` is a
+is a threshold somebody invented. `2 compacts — 6 of your 700 sessions ever reached that` is a
 measurement. The profile is what makes a suggestion earned rather than a nag, so it is built first.
 
 ## Scope
@@ -26,7 +26,14 @@ the profile, and the migrate orchestration.
 three weeks ago is the same class of bug as offering `start` on a running service). They may come
 later and would reuse `session-profile.ts` untouched.
 
-## Ground truth (measured on one machine, 2026-09-08, 407 Claude sessions)
+## Ground truth (measured on one machine, 2026-09-08, 700 Claude sessions)
+
+**Read the whole history, not the live directory.** The first pass of these figures scanned only
+`~/.claude/projects` and under-measured by 40%: Claude deletes transcripts after `cleanupPeriodDays`,
+so that directory holds 420 sessions reaching back to 2026-08-11, while `~/.agentistics/archive`
+holds 284 more. The corrected numbers below are over the union (700 unique transcripts). See
+"The compacts baseline is bounded by surviving transcripts" for why this is a permanent property of
+these particular metrics rather than a one-off mistake.
 
 Everything the profile can report today, and what it costs to add.
 
@@ -35,25 +42,30 @@ Everything the profile can report today, and what it costs to add.
 | messages | `user_message_count` / `assistant_message_count` | ✅ |
 | active time, cost, tokens | `active_minutes`, `calcCost`, the four counters | ✅ |
 | tool errors by category | `tool_error_categories` | ✅ |
-| MCP servers used | `mcp__*` keys in `tool_counts` | ✅ (6 distinct, 77 sessions) |
-| subagents | `agentMetrics` / `Agent` tool_use | ✅ (538 calls, 34 sessions) |
-| **skills** | `Skill` tool_use, `input.skill` | ✅ (25 distinct, 57 sessions) — **CLAUDE.md says otherwise and is stale** |
+| MCP servers used | `mcp__*` keys in `tool_counts` | ✅ (10 distinct, 88 sessions) |
+| subagents | `agentMetrics` / `Agent` tool_use | ✅ (585 calls, 50 sessions) |
+| **skills** | `Skill` tool_use, `input.skill` | ✅ (103 invocations, 26 distinct, 57 sessions) — **CLAUDE.md says otherwise and is stale** |
 | **compacts** | `compact_boundary` + `compactMetadata` | ❌ **new field** |
 | context level | `context_tokens` / `resolveContextWindow` | ✅ (gated by `contextWindow`) |
 
 `compactMetadata` carries `trigger` (`auto`/`manual`), `preTokens`, `postTokens`,
-`cumulativeDroppedTokens` and `durationMs`. Across those 407 sessions: **19 compacts in 14 sessions,
-42 minutes spent compacting, 30M tokens dropped.**
+`cumulativeDroppedTokens` and `durationMs`. Across those 700 sessions: **46 compacts in 23 sessions,
+83 minutes spent compacting, 30M tokens dropped.**
 
 ### Two measured facts that decide the design
 
-**Messages are heavily skewed: median 61, mean 131, p90 248, max 3.866.** The mean is 2,1x the
+**Messages are heavily skewed: median 30, mean 92, p90 185, max 3.911.** The mean is 3,1x the
 median and describes no session anybody has. So the profile reports the **median** by default. The
 mean is used only where the question is literally a rate.
 
-**Compacts are RARE: median 0, mean 0,05. Fourteen of 407 sessions had one; TWO had two.** This kills
-the ratio framing for that metric — "5x your average" is not a sentence when the average is 0,05, and
-dividing by a zero median is not a sentence at all. See "Two ways to state a deviation" below.
+**Compacts are RARE, with a long tail.** Median 0, mean 0,066: 23 of 700 sessions had one at all,
+and only 6 had two or more — but the tail runs 1 (x17), 2, 4 (x2), 5, 6, **8**. This kills the ratio
+framing for that metric: "5x your average" is not a sentence when the average is 0,066, and dividing
+by a zero median is not a sentence at all. See "Two ways to state a deviation" below.
+
+The tail is the reason the trigger is worth having at all. A session at 8 compacts has spent real
+time and dropped real context, and it is invisible in every average that includes the 677 sessions
+that never compacted once.
 
 ## Architecture
 
@@ -97,7 +109,7 @@ or subagents. One shared `n` would compute the skills average over sessions that
 had one — a denominator that is quietly wrong in the direction of "you use fewer skills than you
 think".
 
-Measured: 407 sessions carry messages, 57 carry skills, 34 carry subagents.
+Measured over the 700: 692 carry messages, 57 carry skills, 50 carry subagents.
 
 ### What it reports
 
@@ -122,10 +134,10 @@ interface Suggestion {
 
 A card may only ever say something true, and which sentence is true depends on the baseline:
 
-- **Ratio** — when the median is meaningfully above zero. *"340 messages — your median is 61 (30d,
-  n=407)."*
-- **Rarity** — when the median is zero or near it, which is the compacts case. *"2 compacts — 2 of
-  your 407 sessions ever reached that."*
+- **Ratio** — when the median is meaningfully above zero. *"340 messages — your median is 30 (30d,
+  n=692)."*
+- **Rarity** — when the median is zero or near it, which is the compacts case. *"2 compacts — 6 of
+  your 700 sessions ever reached that."*
 
 Picking the ratio unconditionally is how a rare event gets reported as a division by almost-zero and
 reads as a fault in the dashboard rather than a fact about the session.
@@ -142,8 +154,8 @@ reads as a fault in the dashboard rather than a fact about the session.
 **Context is the trigger that matters and compacts is the symptom.** After two compacts the session
 is already at ~10k post-compact tokens: the handoff you would migrate has mostly been thrown away.
 The context trigger fires *before* the loss. The compacts trigger stays because it is the most legible
-sentence there is — it names minutes and tokens already spent — but it fires on roughly 0,5% of
-sessions and must not be mistaken for the load-bearing one.
+sentence there is — it names minutes and tokens already spent — but it fires on roughly 0,9% of
+sessions (6 of 700) and must not be mistaken for the load-bearing one.
 
 ### Anti-nag rules
 
@@ -189,6 +201,35 @@ The sessions tab already explains **why** the list is empty, and those sentences
 different places. **That sentence stays.** The profile renders below it — it is what fills the dead
 space, never what replaces the explanation.
 
+## The compacts baseline is bounded by surviving transcripts
+
+`compact_count`, `skill_uses` and the subagent counts are **transcript-derived**: they exist only
+while the raw JSONL does. That is not true of the metrics already on `SessionMeta`, which the
+consolidate store keeps forever, and it has three consequences the profile must state rather than
+paper over.
+
+Measured on this machine, 2026-09-08:
+
+| | count |
+|---|---|
+| sessions in the consolidate store | 708 |
+| with a surviving transcript (live + archive) | 700 |
+| live only (`~/.claude/projects`, back to 2026-08-11) | 420 |
+
+- **Eight sessions are already unrecoverable** for these metrics — the store knows them, no transcript
+  does.
+- **The 284-session archive is frozen.** It exists because `archiveMode` used to be `full`; it is
+  `consolidate` now, so nothing is being added to it. From here on, a transcript that ages past
+  `cleanupPeriodDays` is gone.
+- **Therefore the field must be stamped early.** Once `compact_count` is written onto `SessionMeta`
+  and persisted, it survives the cleanup like every other metric — but only from the day it ships.
+  Backfill is a one-shot opportunity bounded by what is on disk when the feature lands, and it
+  shrinks every day.
+
+The `n` per metric already carries this honestly: the compacts baseline simply reports the smaller
+denominator it actually had. What it must never do is compute the average over the store's 708 while
+counting compacts from 700.
+
 ## The frontier, asserted in a test
 
 A suggestion **carries facts and a proposed action; nothing in these modules executes anything**.
@@ -210,7 +251,7 @@ store and the team uploader like any other metric.
 
 `CLAUDE.md` states that Skills "are not recorded as individual tool_use events in the JSONL — only a
 `skill_listing` attachment appears". That is no longer true: there is a `Skill` tool whose
-`input.skill` names the skill, and this machine has 104 such invocations of 25 distinct skills across 57 sessions. The line
+`input.skill` names the skill, and this machine has 103 such invocations of 26 distinct skills across 57 sessions. The line
 is corrected as part of this work, because this is the feature that depends on it.
 
 ## Open questions

--- a/docs/superpowers/specs/2026-09-08-session-suggestions-design.md
+++ b/docs/superpowers/specs/2026-09-08-session-suggestions-design.md
@@ -1,0 +1,226 @@
+# Session suggestions and the behaviour profile — design
+
+**Date:** 2026-09-08
+**Status:** Approved (brainstorming) — pending implementation plan
+**Author:** Bryan Soares (with Claude)
+
+## Goal
+
+Turn what agentistics already measures about a session into two things a person can act on:
+
+1. **Suggestions** — a card on a RUNNING session that states a measured fact and offers one action
+   (send a prompt, migrate the session, answer a dialog).
+2. **A behaviour profile** — the baselines those facts are read against ("you usually have 61
+   messages"), which doubles as the sessions tab's empty state.
+
+They are one feature, not two, and the reason is the sentence each card has to produce. `2 compacts`
+is a threshold somebody invented. `2 compacts — 2 of your 407 sessions ever reached that` is a
+measurement. The profile is what makes a suggestion earned rather than a nag, so it is built first.
+
+## Scope
+
+**In:** live sessions only (running rows, on the surfaces that show them), the four triggers below,
+the profile, and the migrate orchestration.
+
+**Out:** retrospective suggestions on finished sessions (a "migrate" button on a session that ended
+three weeks ago is the same class of bug as offering `start` on a running service). They may come
+later and would reuse `session-profile.ts` untouched.
+
+## Ground truth (measured on one machine, 2026-09-08, 407 Claude sessions)
+
+Everything the profile can report today, and what it costs to add.
+
+| Metric | Source | Available now? |
+|---|---|---|
+| messages | `user_message_count` / `assistant_message_count` | ✅ |
+| active time, cost, tokens | `active_minutes`, `calcCost`, the four counters | ✅ |
+| tool errors by category | `tool_error_categories` | ✅ |
+| MCP servers used | `mcp__*` keys in `tool_counts` | ✅ (6 distinct, 77 sessions) |
+| subagents | `agentMetrics` / `Agent` tool_use | ✅ (538 calls, 34 sessions) |
+| **skills** | `Skill` tool_use, `input.skill` | ✅ (25 distinct, 57 sessions) — **CLAUDE.md says otherwise and is stale** |
+| **compacts** | `compact_boundary` + `compactMetadata` | ❌ **new field** |
+| context level | `context_tokens` / `resolveContextWindow` | ✅ (gated by `contextWindow`) |
+
+`compactMetadata` carries `trigger` (`auto`/`manual`), `preTokens`, `postTokens`,
+`cumulativeDroppedTokens` and `durationMs`. Across those 407 sessions: **19 compacts in 14 sessions,
+42 minutes spent compacting, 30M tokens dropped.**
+
+### Two measured facts that decide the design
+
+**Messages are heavily skewed: median 61, mean 131, p90 248, max 3.866.** The mean is 2,1x the
+median and describes no session anybody has. So the profile reports the **median** by default. The
+mean is used only where the question is literally a rate.
+
+**Compacts are RARE: median 0, mean 0,05. Fourteen of 407 sessions had one; TWO had two.** This kills
+the ratio framing for that metric — "5x your average" is not a sentence when the average is 0,05, and
+dividing by a zero median is not a sentence at all. See "Two ways to state a deviation" below.
+
+## Architecture
+
+Two pure modules in `@agentistics/core`. No surface holds any of this logic — the same shape as
+`task-reopen.ts` and `attention.ts`, and for the same reason: this must read identically in the
+cockpit, the VS Code panel, the web dashboard and `agentop session ls`.
+
+```
+session-profile.ts      (SessionMeta[], now) -> Baseline          PURE
+session-suggestions.ts  (FleetRow, Baseline) -> Suggestion[]      PURE
+```
+
+### Where the baseline is computed and how it travels
+
+Computed **server-side, once, cached** — it is a scan of the consolidate store — and shipped on the
+**`/api/fleet` payload** as a few hundred bytes.
+
+It must NOT be derived client-side from `/api/data`. That response is megabytes on a 300s timer while
+the fleet poll is 5s and a few kilobytes; deriving the profile in the client would spend a megabyte a
+minute to move a number that changes once per session. This is the rule `docs/vscode-extension.md`
+already states for the two timers.
+
+## `session-profile.ts`
+
+`profileOf(sessions: SessionMeta[], nowMs: number): Baseline`
+
+Pure and total. It **receives `now`** rather than reading the clock, so it is testable.
+
+### The window
+
+**The last 30 days, all sessions**, by the UTC day rule `start_time.slice(0, 10)` — the same rule
+`tagSessionDay` and the billing basis use. There are two day rules in this repo and mixing them
+drifts a session across the boundary; a rolling 30-day window is also what lets the profile follow a
+change of habit instead of averaging over a year.
+
+### `n` is PER METRIC, never a sample size
+
+`agentMetrics` and `skill_uses` exist only for sessions with `_source: 'jsonl'`. A session whose
+transcript Claude already deleted counts toward messages and cost and **cannot** count toward skills
+or subagents. One shared `n` would compute the skills average over sessions that could never have
+had one — a denominator that is quietly wrong in the direction of "you use fewer skills than you
+think".
+
+Measured: 407 sessions carry messages, 57 carry skills, 34 carry subagents.
+
+### What it reports
+
+Per metric: `median`, `mean`, `n`, and the count of sessions above zero. Metrics: compacts, messages,
+active minutes, cost, tokens, tool errors (by category), distinct skills, distinct MCP servers,
+subagents, tools per turn.
+
+## `session-suggestions.ts`
+
+`suggestionsFor(row: FleetRow, baseline: Baseline): Suggestion[]`
+
+```ts
+interface Suggestion {
+  id: SuggestionId
+  facts: { observed: number; baseline: number; n: number; kind: 'ratio' | 'rarity' }
+  sentence: string          // localized EN/PT, carrying the numbers
+  action: { kind: 'migrate' } | { kind: 'prompt'; draft: string } | { kind: 'approve' } | { kind: 'none' }
+}
+```
+
+### Two ways to state a deviation, chosen by the data
+
+A card may only ever say something true, and which sentence is true depends on the baseline:
+
+- **Ratio** — when the median is meaningfully above zero. *"340 messages — your median is 61 (30d,
+  n=407)."*
+- **Rarity** — when the median is zero or near it, which is the compacts case. *"2 compacts — 2 of
+  your 407 sessions ever reached that."*
+
+Picking the ratio unconditionally is how a rare event gets reported as a division by almost-zero and
+reads as a fault in the dashboard rather than a fact about the session.
+
+### The triggers
+
+| Trigger | Reads | Action | Capability |
+|---|---|---|---|
+| context ≥85%, no compact yet | `context_tokens` / `resolveContextWindow` | **migrate** | `contextWindow` |
+| ≥2 compacts | `compact_count` | migrate, stating what it already cost | `compaction` (claude only) |
+| waiting on approval > N min | `attention.ts` + the poll | approve / open | all six |
+| N tool errors of one category | `tool_error_categories` | prompt (editable) | where the adapter fills it |
+
+**Context is the trigger that matters and compacts is the symptom.** After two compacts the session
+is already at ~10k post-compact tokens: the handoff you would migrate has mostly been thrown away.
+The context trigger fires *before* the loss. The compacts trigger stays because it is the most legible
+sentence there is — it names minutes and tokens already spent — but it fires on roughly 0,5% of
+sessions and must not be mistaken for the load-bearing one.
+
+### Anti-nag rules
+
+- Every card carries its **measured numbers in the sentence**. Never "consider starting a new
+  session".
+- **At most 3 per session**, ranked. Ten suggestions is zero suggestions.
+- **Dismissal is per session**, not per rule. Dismissing once for a session where it was wrong must
+  not blind the user on a session where it matters.
+- A capability-gated trigger is **absent** where the harness cannot produce it — never a card reading
+  zero. Same rule `HARNESS_CAPABILITIES` applies to metrics.
+
+### A prompt is editable before it is sent
+
+The `prompt` action opens the draft in the composer. A canned prompt fired blind into somebody's
+session is the same failure as an approve button that takes the highlighted row — the mistake
+`dialog-choice.ts` exists to prevent, in a different costume.
+
+## Migration
+
+One button. `agentop` orchestrates the whole thing; the user does not read the handoff first, and the
+safeguards are what make that acceptable:
+
+```
+ask for handoff → PERSIST to disk → spawn successor → confirm it is up → retire the predecessor
+```
+
+- **The handoff is written to `~/.agentistics/handoffs/<sessionId>.md` before anything is retired.**
+  Even fully automatic, the artefact survives; if every later step fails, the work is on disk.
+- **The successor must be confirmed on two consecutive polls** before the predecessor is touched —
+  the discipline `event-plan.ts` already states, for the same reason: one poll is a repaint.
+- **On timeout, or if the handoff never appears, the predecessor STAYS ALIVE** and a sentence says
+  why. Nothing is retired that cannot be proven replaced — the rule `task-reopen.ts` holds.
+- The predecessor is **retired** with `endedMs` and a `succeededBy` link, so
+  `collapseSupersededSessions` already handles the pair and the fleet shows one lineage rather than
+  two loose rows.
+- **The session never kills itself.** It would be killing the pane it lives in, mid-turn. The server
+  spawns and retires; the prompt only writes.
+
+## The empty state
+
+The sessions tab already explains **why** the list is empty, and those sentences are load-bearing:
+"nothing is running", "the filter withheld it" and "the search found nothing" send a person to three
+different places. **That sentence stays.** The profile renders below it — it is what fills the dead
+space, never what replaces the explanation.
+
+## The frontier, asserted in a test
+
+A suggestion **carries facts and a proposed action; nothing in these modules executes anything**.
+Execution is always a human click reaching `/api/fleet/act`. `suggestions-frontier.test.ts` greps the
+modules' own source and fails on an IO call — the same shape as `events-frontier.test.ts`.
+
+## New fields
+
+- `SessionMeta.compact_count`, `compact_ms`, `compact_dropped_tokens` — aggregates of
+  `compactMetadata`. Not the list: nobody needs the `preservedSegment` uuids.
+- `SessionMeta.skill_uses?: Record<string, number>` — from the `Skill` tool_use.
+- `HARNESS_CAPABILITIES.compaction` — `true` for claude only. The other five have no equivalent
+  marker, so the compacts card is absent there rather than zero.
+
+These are numbers, so they do not enter `DATE_FIELDS`, but they must travel through the consolidate
+store and the team uploader like any other metric.
+
+## Documentation debt this closes
+
+`CLAUDE.md` states that Skills "are not recorded as individual tool_use events in the JSONL — only a
+`skill_listing` attachment appears". That is no longer true: there is a `Skill` tool whose
+`input.skill` names the skill, and this machine has 104 such invocations of 25 distinct skills across 57 sessions. The line
+is corrected as part of this work, because this is the feature that depends on it.
+
+## Open questions
+
+- **The two `N` thresholds are not chosen yet** — how long a session must have been waiting on
+  approval, and how many errors of one category count as repetition. Both should come from the
+  profile rather than from taste, which is the point of building it first; the waiting one must
+  additionally differ from the header's waiting counter, which fires immediately, or the card is a
+  second copy of a signal one glance away.
+- **Whether the profile is per harness.** Decided against for v1 (one 30-day baseline over all
+  sessions), but a claude-only metric compared against a mixed baseline is a mild version of the
+  cache-blind problem the billing basis documents. Revisit if the fleet becomes genuinely multi-harness.
+


### PR DESCRIPTION
## Summary

- Adds `docs/superpowers/specs/2026-09-08-session-suggestions-design.md` — the design for suggestions on a running session and the behaviour profile they are read against.
- Corrects a stale `CLAUDE.md` claim this feature depends on: **Skills ARE recorded** as a `Skill` tool_use.

Design only. No behaviour changes.

## Motivation

Part of #417 — this is its design, not its delivery, so it deliberately does not close it.

The feature is two things that are really one. A suggestion needs a baseline or it is a nag: `2 compacts` is a threshold somebody invented, while `2 compacts — 6 of your 700 sessions ever reached that` is a measurement. So the profile is specified first and the suggestions read from it.

## Changes

**`docs/superpowers/specs/2026-09-08-session-suggestions-design.md`** — two pure modules in `@agentistics/core` (`session-profile.ts`, `session-suggestions.ts`), the baseline delivery path, four triggers, the anti-nag rules, the migrate orchestration, and the frontier assertion.

**`CLAUDE.md`** — the "What is NOT available for Skills and Tasks" entry said skills are not recorded as tool_use events and can only be inferred indirectly. That was true before the `Skill` tool existed. Measured 2026-09-08: **103 invocations of 26 distinct skills across 57 sessions**, each naming itself in `input.skill`. The heading changed with it, since it now contradicted its own first bullet.

## Decisions worth reviewing

Two measurements taken while writing this changed the design, and both are in the spec with their numbers:

- **Messages are heavily skewed** — median 30, mean 92, p90 185, max 3.911. The mean is 3,1x the median and describes no session anybody has, so the profile reports **medians** by default.
- **Compacts are rare, with a long tail** — median 0, mean 0,066; 23 of 700 sessions had one at all and 6 had two or more, but the tail runs 1 (x17), 2, 4 (x2), 5, 6, **8**. This kills the ratio framing: "5x your average" is not a sentence when the average is 0,066, and dividing by a zero median is not a sentence at all. So a deviation is stated as a **ratio** only where the median is meaningfully above zero and as **rarity** otherwise.

A consequence worth arguing about: the `≥2 compacts` trigger fires on roughly **0,9% of sessions** (6 of 700). It stays because it is the most legible card there is, and because the tail is invisible in any average that includes the 677 sessions which never compacted once — but the context trigger is the load-bearing one, since after two compacts the handoff you would migrate has mostly been thrown away already.

## Test plan

- [x] `bun tsc --noEmit` clean and `bun test` green (**6964 pass, 0 fail**) via the pre-commit hook — docs-only, so this is a no-regression check rather than evidence of anything.
- [x] Every figure re-measured on 2026-09-08 over the **union of `~/.claude/projects` and `~/.agentistics/archive`** (700 unique transcripts). **The first version of this spec was wrong**: it scanned the live directory alone, which is 420 sessions back to 2026-08-11, and under-reported compacts by 2,4x. Caught in review by someone who knew one of their sessions had five and asked how many had four — the answer was zero and should have been two. Second commit on this branch carries the correction.
- [x] Self-reviewed for placeholders and internal consistency: two undefined `N` thresholds were moved into "Open questions" rather than left implied in the trigger table.

**What reviewers should check**

- The `ratio` vs `rarity` split is the load-bearing idea here. If it is wrong, the cards are wrong. It survived the re-measurement unchanged, which is mild evidence for it.
- **"The compacts baseline is bounded by surviving transcripts"** is new in the second commit and is the part with a deadline: these metrics exist only while the raw JSONL does, eight sessions in the store already have none, and the archive is frozen. Backfill shrinks every day the field is not stamped.
- Scope: retrospective suggestions on finished sessions are explicitly **out**. Say so now if that is the half you actually wanted.
- The two open `N` thresholds (how long a session must be waiting on approval; how many errors of one category count as repetition) are deliberately unresolved — they should come from the profile rather than from taste, which is the argument for building the profile first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019LT77q1YCgYQ6L8d1RRcM3
