### PR TITLE
fix(web): a 44px finger stops costing 44px of paint, and no value leaves its card

### DIFF
--- a/packages/web/src/components/ModelBreakdown.tsx
+++ b/packages/web/src/components/ModelBreakdown.tsx
@@ -140,9 +140,10 @@ export function ModelBreakdown({ modelUsage, note, currency = 'USD', brlRate = 1
   const totalCacheRead = entries.reduce((s, [, u]) => s + u.cacheReadInputTokens, 0)
   const totalCacheWrite = entries.reduce((s, [, u]) => s + u.cacheCreationInputTokens, 0)
 
+  // 44px is the finger's, not the paint's — every consumer of this style carries `.ag-tap`,
+  // which projects the target invisibly. At `borderRadius: 999` a 44px-tall pill is an ellipse.
   const chip = (active: boolean): React.CSSProperties => ({
-    padding: isMobile ? '0 11px' : '4px 10px',
-    minHeight: isMobile ? 44 : undefined,
+    padding: isMobile ? '5px 12px' : '4px 10px',
     borderRadius: 999, cursor: 'pointer', fontFamily: 'inherit', fontSize: 11.5,
     border: `1px solid ${active ? 'var(--anthropic-orange)' : 'var(--border)'}`,
     background: active ? 'var(--anthropic-orange-dim)' : 'var(--bg-card)',
@@ -170,9 +171,9 @@ export function ModelBreakdown({ modelUsage, note, currency = 'USD', brlRate = 1
       <div style={{ display: 'flex', gap: 5, flexWrap: 'wrap' }}>
         {([['cost', pt ? 'Custo' : 'Cost'], ['tokens', 'Tokens'], ['model', pt ? 'Nome' : 'Name']] as Array<[SortKey, string]>)
           .map(([k, label]) => (
-            <button key={k} onClick={() => setSortKey(k)} style={chip(sortKey === k)}>{label}</button>
+            <button key={k} onClick={() => setSortKey(k)} className="ag-tap" style={chip(sortKey === k)}>{label}</button>
           ))}
-        <button onClick={() => setByProvider(v => !v)} style={chip(byProvider)}>
+        <button onClick={() => setByProvider(v => !v)} className="ag-tap" style={chip(byProvider)}>
           {pt ? 'Por provedor' : 'By provider'}
         </button>
       </div>

--- a/packages/web/src/components/RecentSessions.tsx
+++ b/packages/web/src/components/RecentSessions.tsx
@@ -751,8 +751,10 @@ export function RecentSessions({ sessions, lang, onSelect, pinnedIds, activities
         <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 10, flexWrap: 'wrap' }}>
           {/* Shortcuts & Sort */}
           <div style={{ display: 'flex', alignItems: 'center', gap: 12, flexWrap: 'wrap' }}>
-            {/* Status shortcuts */}
-            <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+            {/* Status shortcuts. `flexWrap` because these rows do NOT wrap on their own: the sort
+                row in particular ran straight off the right edge of the card on a phone, taking its
+                last key ("Files") with it — the parent wraps, the inner rows did not. */}
+            <div style={{ display: 'flex', alignItems: 'center', gap: 4, flexWrap: 'wrap', minWidth: 0 }}>
               <Filter size={12} style={{ color: 'var(--text-tertiary)', flexShrink: 0 }} />
               {shortcutOptions.map(opt => (
                 <PillButton key={opt.key} active={statusShortcut === opt.key} onClick={() => { setStatusShortcut(opt.key); setPage(0) }}>
@@ -765,7 +767,7 @@ export function RecentSessions({ sessions, lang, onSelect, pinnedIds, activities
             <div style={{ width: 1, height: 16, background: 'var(--border-subtle)' }} />
 
             {/* Sort keys */}
-            <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 4, flexWrap: 'wrap', minWidth: 0 }}>
               <ArrowUpDown size={12} style={{ color: 'var(--text-tertiary)', flexShrink: 0 }} />
               {sortOptions.map(opt => (
                 <PillButton key={opt.key} active={sortKey === opt.key} onClick={() => changeSort(opt.key)}>
@@ -777,8 +779,10 @@ export function RecentSessions({ sessions, lang, onSelect, pinnedIds, activities
           </div>
 
           {/* Search Input & View Mode */}
-          <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexShrink: 0 }}>
-            <div style={{ position: 'relative', width: 180 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8, flex: '1 1 auto', justifyContent: 'flex-end', minWidth: 0 }}>
+            {/* The search field gives way before the row does — a fixed 180 beside a
+                `flexShrink: 0` wrapper is what pushed this block past the card's right edge. */}
+            <div style={{ position: 'relative', flex: '1 1 180px', minWidth: 130, maxWidth: 240 }}>
               <Search
                 size={12}
                 style={{
@@ -2296,9 +2300,12 @@ function PinButton({ sessionId, lang }: { sessionId: string; lang: 'pt' | 'en' }
           : (lang === 'pt' ? `Fixar no topo (até ${MAX_PINNED})` : `Pin to top (up to ${MAX_PINNED})`)}
         aria-label={pinned ? (lang === 'pt' ? 'Desafixar' : 'Unpin') : (lang === 'pt' ? 'Fixar' : 'Pin')}
         aria-pressed={pinned}
+        // `.ag-tap-icon` and not a 44x44 box: on a phone this drew an empty square the height of
+        // three rows of the card it sits on, and the title beside it lost the width to it.
+        className="ag-tap-icon"
         style={{
           display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
-          width: isMobile ? 44 : 30, height: isMobile ? 44 : 30, borderRadius: 8,
+          width: 30, height: 30, borderRadius: 8,
           border: pinned ? '1px solid var(--anthropic-orange)' : '1px solid var(--border-subtle)',
           background: pinned ? 'rgba(232,105,11,0.1)' : 'transparent',
           color: pinned ? 'var(--anthropic-orange)' : 'var(--text-tertiary)',

--- a/packages/web/src/components/ScopedSessions.tsx
+++ b/packages/web/src/components/ScopedSessions.tsx
@@ -1,0 +1,198 @@
+/**
+ * ScopedSessions.tsx — the session list a REPOSITORY or a PROJECT shows.
+ *
+ * These two places used to render `RecentSessions`, which is the dashboard's full session BROWSER:
+ * group-by (none/status/repo/project/harness/model/marked), a status filter, a six-key sort, a
+ * search field, a list-or-grid toggle, per-row pins, and a drilldown modal. Inside a tab that is
+ * already scoped to one repository, nearly all of that re-asks a question the page has already
+ * answered — "group by repo" under a repo, "filter by project" under a project — and it costs the
+ * whole width and about eight rows of vertical chrome before the first session appears. On a phone
+ * that was the entire first screen.
+ *
+ * So this is the two things the tab is actually for: WHAT EACH SESSION SPENT, and THE WAY IN. The
+ * way in is the sessions workspace (`/sessions/:id`) and not the drilldown modal, because the
+ * workspace is where a session is read, continued and acted on — a modal here would be a second,
+ * poorer reader for a conversation the product already has a home for. A session the fleet no
+ * longer holds is not a broken link: that page says so in a sentence of its own.
+ *
+ * Nothing here filters or sorts by anything the caller did not already decide, with one exception —
+ * `MORE_STEP` reveals more rows. That is paging, not a question: a repository with 300 sessions
+ * cannot be one list, and the button says how many are left rather than silently truncating.
+ */
+import React, { useMemo, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { ChevronRight, Clock } from 'lucide-react'
+import {
+  calcCost, fmt, fmtCost, formatModel, sessionCostUSD, sessionLabel, sessionTokens,
+  sessionTokenTotal, totalTokensExplained, type HarnessId, type SessionMeta,
+} from '@agentistics/core'
+import { HARNESS_COLORS, HARNESS_LABELS } from '../lib/harness'
+import { useIsMobile } from '../hooks/useIsMobile'
+
+/** How many more rows one press of the reveal button adds. */
+const MORE_STEP = 30
+/** How many rows the list opens with. */
+const FIRST_PAGE = 20
+
+/** Cost of one session, priced per model; the blended-free fallback prices all four counters at
+ *  the unknown-model rate rather than pricing cache as fresh input (~10x too high). Mirrors
+ *  `sessCost` in RepoDetailPage — the same rule, not a second one. */
+function sessionCost(s: SessionMeta): number {
+  const byModel = sessionCostUSD(s)
+  if (byModel !== null) return byModel
+  return calcCost({
+    inputTokens: s.input_tokens ?? 0,
+    outputTokens: s.output_tokens ?? 0,
+    cacheReadInputTokens: s.cache_read_input_tokens ?? 0,
+    cacheCreationInputTokens: s.cache_creation_input_tokens ?? 0,
+    webSearchRequests: 0,
+    costUSD: 0,
+  }, '')
+}
+
+function fmtDay(iso: string, pt: boolean): string {
+  if (!iso) return '—'
+  const d = new Date(iso)
+  if (!Number.isFinite(d.getTime())) return '—'
+  return d.toLocaleDateString(pt ? 'pt-BR' : 'en-US', { day: '2-digit', month: 'short' })
+    + ' ' + d.toLocaleTimeString(pt ? 'pt-BR' : 'en-US', { hour: '2-digit', minute: '2-digit' })
+}
+
+/** Active minutes as a duration, or `—`. Never a 0: a session with no usable timing has not been
+ *  measured at zero, it has not been measured (see `SessionMeta.active_minutes`). */
+function fmtActive(min: number | undefined, pt: boolean): string {
+  if (min === undefined) return '—'
+  if (min < 60) return `${Math.round(min)}min`
+  const h = Math.floor(min / 60)
+  const m = Math.round(min % 60)
+  return m === 0 ? `${h}h` : `${h}h${String(m).padStart(2, '0')}`
+}
+
+function Metric({ label, value, title, accent }: {
+  label: string; value: string; title?: string; accent?: boolean
+}) {
+  return (
+    <div title={title} style={{ display: 'flex', flexDirection: 'column', gap: 1, minWidth: 0 }}>
+      <span style={{
+        fontSize: 12.5, fontWeight: 700, fontVariantNumeric: 'tabular-nums',
+        color: accent ? 'var(--anthropic-orange)' : 'var(--text-primary)',
+        overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+      }}>{value}</span>
+      <span style={{
+        fontSize: 9.5, color: 'var(--text-tertiary)', textTransform: 'uppercase',
+        letterSpacing: '0.05em', whiteSpace: 'nowrap',
+      }}>{label}</span>
+    </div>
+  )
+}
+
+interface Props {
+  sessions: SessionMeta[]
+  lang: 'pt' | 'en'
+  currency: 'USD' | 'BRL'
+  brlRate: number
+}
+
+export function ScopedSessions({ sessions, lang, currency, brlRate }: Props) {
+  const pt = lang === 'pt'
+  const isMobile = useIsMobile()
+  const [shown, setShown] = useState(FIRST_PAGE)
+
+  // Most recent first. The caller decided WHICH sessions; the only ordering that needs no control
+  // beside it is the one every reader assumes.
+  const ordered = useMemo(
+    () => [...sessions].sort((a, b) => (b.start_time || '').localeCompare(a.start_time || '')),
+    [sessions],
+  )
+
+  if (ordered.length === 0) {
+    return (
+      <div style={{ fontSize: 13, color: 'var(--text-tertiary)', padding: '18px 2px', lineHeight: 1.6 }}>
+        {pt ? 'Nenhuma sessão neste recorte.' : 'No sessions in this scope.'}
+      </div>
+    )
+  }
+
+  const rest = ordered.length - shown
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+      {ordered.slice(0, shown).map(s => {
+        const harness = (s.harness ?? 'claude') as HarnessId
+        const tokens = sessionTokenTotal(s)
+        const messages = (s.user_message_count ?? 0) + (s.assistant_message_count ?? 0)
+        const tools = Object.values(s.tool_counts ?? {}).reduce((a, b) => a + b, 0)
+        return (
+          <Link
+            key={s.session_id}
+            to={`/sessions/${encodeURIComponent(s.session_id)}`}
+            title={pt ? 'Abrir em Sessões' : 'Open in Sessions'}
+            style={{
+              display: 'flex', alignItems: 'center', gap: 12, textDecoration: 'none',
+              padding: isMobile ? '11px 12px' : '10px 14px',
+              background: 'var(--bg-elevated)', border: '1px solid var(--border)',
+              borderRadius: 'var(--radius-md)', color: 'inherit', minWidth: 0,
+            }}
+          >
+            <span style={{
+              display: 'flex', flexDirection: 'column', gap: 3, minWidth: 0,
+              // The identity column is the one that gives way; every metric beside it is a short,
+              // fixed-width figure and would only ellipsis into uselessness.
+              flex: '1 1 auto',
+            }}>
+              <span style={{
+                fontSize: 13, fontWeight: 600, color: 'var(--text-primary)',
+                overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+              }}>{sessionLabel(s)}</span>
+              <span style={{
+                display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap',
+                fontSize: 10.5, color: 'var(--text-tertiary)',
+              }}>
+                <span style={{ display: 'inline-flex', alignItems: 'center', gap: 3, whiteSpace: 'nowrap' }}>
+                  <Clock size={10} /> {fmtDay(s.start_time, pt)}
+                </span>
+                <span style={{ color: HARNESS_COLORS[harness] ?? 'var(--text-tertiary)', whiteSpace: 'nowrap' }}>
+                  {HARNESS_LABELS[harness] ?? harness}
+                </span>
+                {s.model && <span style={{ whiteSpace: 'nowrap' }}>{formatModel(s.model)}</span>}
+              </span>
+            </span>
+
+            {/* The metrics. A wrapping row rather than a grid: it has no cell count, so it cannot
+                strand a lone figure on a second line at any width. */}
+            <span style={{
+              display: 'flex', alignItems: 'center', justifyContent: 'flex-end',
+              gap: isMobile ? 14 : 18, flexWrap: 'wrap', flexShrink: 0,
+            }}>
+              <Metric label={pt ? 'Custo' : 'Cost'} value={fmtCost(sessionCost(s), currency, brlRate)} accent />
+              <Metric
+                label="Tokens"
+                value={fmt(tokens)}
+                title={totalTokensExplained(sessionTokens(s), lang)}
+              />
+              {!isMobile && <Metric label={pt ? 'Mensagens' : 'Messages'} value={fmt(messages)} />}
+              {!isMobile && <Metric label={pt ? 'Ferramentas' : 'Tools'} value={fmt(tools)} />}
+              <Metric label={pt ? 'Tempo ativo' : 'Active time'} value={fmtActive(s.active_minutes, pt)} />
+            </span>
+
+            <ChevronRight size={16} color="var(--text-tertiary)" style={{ flexShrink: 0 }} />
+          </Link>
+        )
+      })}
+
+      {rest > 0 && (
+        <button
+          onClick={() => setShown(n => n + MORE_STEP)}
+          style={{
+            alignSelf: 'center', marginTop: 4, padding: isMobile ? '11px 18px' : '7px 16px',
+            minHeight: isMobile ? 44 : undefined,
+            borderRadius: 8, border: '1px solid var(--border)', background: 'var(--bg-elevated)',
+            color: 'var(--text-secondary)', fontFamily: 'inherit', fontSize: 12.5, cursor: 'pointer',
+          }}
+        >
+          {pt ? `Mostrar mais ${Math.min(rest, MORE_STEP)} · faltam ${rest}` : `Show ${Math.min(rest, MORE_STEP)} more · ${rest} left`}
+        </button>
+      )}
+    </div>
+  )
+}

--- a/packages/web/src/components/Section.tsx
+++ b/packages/web/src/components/Section.tsx
@@ -29,16 +29,27 @@ export function Section({ title, children, action, onExpand, flashId, style: ext
         ...extraStyle,
       }}
     >
+      {/* `flexWrap` and not a mobile branch: what decides this is whether the ACTION fits beside the
+          title, which is a question about the two contents and the column they are in — a 390px
+          phone with a bare title has room, and a laptop showing a filter row plus a search field
+          does not. Without it the two were squeezed against each other and the title broke into
+          two lines while the action's own controls wrapped beside it (the Repositories header:
+          "20 / repositories" stacked next to a search box). `minWidth: 0` on each side is what
+          lets either one give way; `flex: 1` on the action keeps it right-aligned on one line and
+          full-width once it has wrapped under. */}
       <div style={{
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'space-between',
+        flexWrap: 'wrap',
+        columnGap: 12,
+        rowGap: 10,
         marginBottom: 18,
       }}>
-        <div style={{ fontSize: 13, fontWeight: 600, color: 'var(--text-primary)', display: 'flex', alignItems: 'center', gap: 8 }}>
+        <div style={{ fontSize: 13, fontWeight: 600, color: 'var(--text-primary)', display: 'flex', alignItems: 'center', gap: 8, minWidth: 0 }}>
           {title}
         </div>
-        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'flex-end', gap: 8, flex: '1 1 auto', minWidth: 0 }}>
           {action}
           {onExpand && (
             <button

--- a/packages/web/src/components/Section.tsx
+++ b/packages/web/src/components/Section.tsx
@@ -49,7 +49,12 @@ export function Section({ title, children, action, onExpand, flashId, style: ext
         <div style={{ fontSize: 13, fontWeight: 600, color: 'var(--text-primary)', display: 'flex', alignItems: 'center', gap: 8, minWidth: 0 }}>
           {title}
         </div>
-        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'flex-end', gap: 8, flex: '1 1 auto', minWidth: 0 }}>
+        {/* No `justify-content` of its own, and `flex: 0 1 auto` rather than `1 1 auto`: the parent's
+            `space-between` already puts this at the right edge while it shares a line with the
+            title, and applies per LINE — so once it wraps onto a line of its own it starts at the
+            left, where a row of controls belongs. Growing it and pinning it right did the opposite:
+            the Repositories controls sat in the far corner under an empty half-row. */}
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, flex: '0 1 auto', minWidth: 0 }}>
           {action}
           {onExpand && (
             <button

--- a/packages/web/src/components/StatTile.tsx
+++ b/packages/web/src/components/StatTile.tsx
@@ -1,0 +1,82 @@
+/**
+ * StatTile.tsx — the KPI tile: one big figure over an uppercase caption.
+ *
+ * It existed TWICE, in RepoDetailPage and TagDetailPage, and the two copies had already drifted
+ * into different failure modes for the same input: the repo one had no `overflow`, so a long value
+ * was painted straight through the card's right edge; the tag one clipped it to an ellipsis. One
+ * tile, one behaviour.
+ *
+ * ── Why the figure is sized in `cqi` ──────────────────────────────────────────────────────────
+ * The value is a headline and must not wrap: a two-line tile is as tall as two lines, and a grid
+ * row is as tall as its tallest cell, so ONE wrapped tile leaves every tile beside it two thirds
+ * empty. (That is exactly what the first fix here did — it stopped the overflow by allowing the
+ * wrap, and traded a value outside its box for a row of half-empty boxes.)
+ *
+ * Not wrapping means the figure has to FIT, and what it has to fit inside is a grid track whose
+ * width nothing in JavaScript knows at render time. So the tile is a size container
+ * (`container-type: inline-size`) and the font size is stated as the smaller of the design size and
+ * the size at which this many characters still fit:
+ *
+ *     font-size: min(18px, (100 / (len * CHAR_EM))cqi)
+ *
+ * `1cqi` is 1 % of the tile's own content box, so the second term is self-correcting at every
+ * width — a 3-character count keeps the full 18px on a narrow phone tile, while `USD 15,884.06`
+ * steps down only as far as its column actually requires. `CHAR_EM` is the average advance of a
+ * digit in the UI font at weight 700, with margin.
+ *
+ * `containerType` is what makes `cqi` mean anything here; a browser that does not understand the
+ * unit drops the whole declaration and falls back to `.ag-stat-value`'s plain 18px in index.css.
+ * `nowrap` + `ellipsis` is the backstop under both: if the estimate is ever wrong the figure is
+ * clipped inside the card rather than painted outside it, and `title` still carries it whole.
+ */
+import React from 'react'
+
+/** The design size of the figure, and the ceiling `min()` never goes above. */
+const BASE_PX = 18
+/** Average advance per character, in em, for a bold digit in the UI font — with margin. */
+const CHAR_EM = 0.62
+
+export function statValueFontSize(value: string): string {
+  const len = Math.max(value.length, 1)
+  return `min(${BASE_PX}px, ${(100 / (len * CHAR_EM)).toFixed(2)}cqi)`
+}
+
+/**
+ * The one column rule for a KPI strip. `150px` and not `120px`: at 120 a 430px phone fits three
+ * tiles ~100px wide, which no money figure fits in at any legible size — the strip was three
+ * columns of shrunken, wrapped numbers. Two wider tiles read better and, because nothing wraps
+ * any more, cost no more height.
+ */
+export const STAT_TILE_GRID = 'repeat(auto-fit, minmax(150px, 1fr))'
+
+export function StatTile({ label, value, accent, title }: {
+  label: string
+  value: string
+  accent?: boolean
+  title?: string
+}) {
+  return (
+    <div
+      title={title ?? value}
+      style={{
+        display: 'flex', flexDirection: 'column', gap: 3, padding: '11px 13px', minWidth: 0,
+        background: 'var(--bg-card)', border: '1px solid var(--border)', borderRadius: 'var(--radius-lg)',
+        containerType: 'inline-size',
+      }}
+    >
+      <span
+        className="ag-stat-value"
+        style={{
+          fontSize: statValueFontSize(value),
+          fontWeight: 700, lineHeight: 1.2, fontVariantNumeric: 'tabular-nums',
+          color: accent ? 'var(--anthropic-orange)' : 'var(--text-primary)',
+          whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis',
+        }}
+      >{value}</span>
+      <span style={{
+        fontSize: 10.5, color: 'var(--text-tertiary)', textTransform: 'uppercase',
+        letterSpacing: '0.05em', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis',
+      }}>{label}</span>
+    </div>
+  )
+}

--- a/packages/web/src/components/TopBoards.tsx
+++ b/packages/web/src/components/TopBoards.tsx
@@ -324,9 +324,9 @@ export function TopBoards({ sessions, lang, currency, brlRate, onSelectSession }
           <button
             key={m}
             onClick={() => setMetric(m)}
+            className="ag-tap"
             style={{
-              padding: isMobile ? '8px 14px' : '4px 10px',
-              minHeight: isMobile ? 44 : undefined,
+              padding: isMobile ? '5px 12px' : '4px 10px',
               borderRadius: 999,
               border: `1px solid ${metric === m ? 'var(--anthropic-orange)' : 'var(--border)'}`,
               background: metric === m ? 'var(--anthropic-orange)' : 'transparent',

--- a/packages/web/src/components/a11y/LensMenu.tsx
+++ b/packages/web/src/components/a11y/LensMenu.tsx
@@ -63,8 +63,9 @@ export function LensMenu({ lens, x, y, text, isMobile, global, onChange, onSetGl
   // it already yields last).
   const readout: React.CSSProperties = { minWidth: 36, textAlign: 'right', flexShrink: 0 }
 
+  // Every consumer carries `.ag-tap`, which is where the 44px finger target lives now.
   const chip = (on: boolean): React.CSSProperties => ({
-    padding: isMobile ? '10px 12px' : '5px 10px', minHeight: isMobile ? 44 : undefined,
+    padding: isMobile ? '6px 12px' : '5px 10px',
     borderRadius: 7, fontSize: 12, cursor: 'pointer', fontFamily: 'inherit',
     border: '1px solid ' + (on ? 'var(--anthropic-orange)' : 'var(--border)'),
     background: on ? 'var(--anthropic-orange-dim)' : 'transparent',
@@ -92,7 +93,7 @@ export function LensMenu({ lens, x, y, text, isMobile, global, onChange, onSetGl
           <span>{text.shape}</span>
           <span style={{ display: 'flex', gap: 6 }}>
             {(['rect', 'circle'] as const).map(s => (
-              <button key={s} style={chip(lens.shape === s)} onClick={() => onChange({ shape: s })}>
+              <button key={s} className="ag-tap" style={chip(lens.shape === s)} onClick={() => onChange({ shape: s })}>
                 {s === 'rect' ? text.rect : text.circle}
               </button>
             ))}

--- a/packages/web/src/components/team/ConnectionCard.tsx
+++ b/packages/web/src/components/team/ConnectionCard.tsx
@@ -311,10 +311,11 @@ export function ConnectionCard({
           type="button"
           onClick={() => setNoticesOpen(true)}
           title={COPY.noticesBtn[lang]}
+          className="ag-tap"
           style={{
             display: 'inline-flex', alignItems: 'center', justifyContent: 'center', gap: 5,
             flexShrink: 0, marginRight: 12,
-            minHeight: isMobile ? 44 : 30, padding: isMobile ? '0 12px' : '0 10px',
+            minHeight: 30, padding: isMobile ? '0 12px' : '0 10px',
             borderRadius: 999, fontFamily: 'inherit', fontSize: 11.5, fontWeight: 700, cursor: 'pointer',
             border: `1px solid ${notices.tone === 'alarm' ? 'var(--accent-red)' : 'var(--anthropic-orange)'}`,
             background: 'transparent',

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -301,6 +301,51 @@ html.ag-viewport-locked > body {
   .ag-settings button.ag-switch {
     min-height: 0;
   }
+  /* A chip on a settings page opts out of the sweep above the same way, and takes its target from
+     `.ag-tap` below instead. */
+  .ag-settings button.ag-tap,
+  .ag-settings button.ag-tap-icon {
+    min-height: 0;
+  }
+}
+
+/* --- .ag-tap / .ag-tap-icon: a 44px touch target that costs the layout no height ---------------
+   A chip is small ON PURPOSE: 11px of label inside a `border-radius: 999` pill. Give it
+   `min-height: 44px` and it stops being a chip — at ~62px wide it comes out an ELLIPSE, and a row
+   of them reads as a row of eggs rather than as a filter. That is the whole of the "the UI is
+   chubby" report: the rule was right (a finger needs 44px) and the way it was paid was wrong — the
+   PAINTED control grew.
+
+   So the paint and the target are separated. The control keeps its natural height and the class
+   projects an invisible 44px box centred on it, which is what the finger actually hits. `::after`
+   is a child of the control, so the press lands on the control's own handler; there is no listener
+   and no wrapper element of our own.
+
+   `.ag-tap` expands VERTICALLY ONLY (`left: 0; right: 0`), so a chip can never steal the tap of the
+   chip beside it in its row. `.ag-tap-icon` is for an icon-only button, which is narrow on both
+   axes and has to grow on both — use it only where the button has real space around it. Both live
+   inside the mobile query: a mouse-driven layout is untouched.
+
+   A row that wraps with a gap under ~14px overlaps by a pixel or two. The later sibling paints on
+   top, so the overlap resolves in favour of the chip LOWER on screen — the one the thumb is
+   travelling towards.
+
+   Use it for CHIPS, PILLS, TOGGLES and ICON-ONLY buttons: controls whose smallness is their
+   meaning. A dialog's "Save", a menu row, a primary action SHOULD be 44px of paint, and keep it.
+   Do not put it on anything containing its own interactive child (an input, a nested link): the
+   overlay sits above the content and would take that child's clicks. */
+@media (max-width: 767px) {
+  .ag-tap, .ag-tap-icon { position: relative; }
+  .ag-tap::after, .ag-tap-icon::after {
+    content: '';
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    height: 100%;
+    min-height: 44px;
+  }
+  .ag-tap::after { left: 0; right: 0; }
+  .ag-tap-icon::after { left: 50%; width: 100%; min-width: 44px; transform: translate(-50%, -50%); }
 }
 
 /* ── The focus ring ──────────────────────────────────────────────────────────

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -309,6 +309,13 @@ html.ag-viewport-locked > body {
   }
 }
 
+/* --- .ag-stat-value: the KPI figure's fallback size ------------------------------------------
+   `StatTile` states the figure as `min(18px, N cqi)`, which self-corrects to the tile's real
+   width. A browser that does not know `cqi` drops that whole declaration — this is what it lands
+   on, and it is the same 18px the `min()` caps at. Never remove it in favour of the inline value:
+   an inline style that the browser rejects leaves NO font-size at all. */
+.ag-stat-value { font-size: 18px; }
+
 /* --- .ag-tap / .ag-tap-icon: a 44px touch target that costs the layout no height ---------------
    A chip is small ON PURPOSE: 11px of label inside a `border-radius: 999` pill. Give it
    `min-height: 44px` and it stops being a chip — at ~62px wide it comes out an ELLIPSE, and a row

--- a/packages/web/src/pages/RepoDetailPage.tsx
+++ b/packages/web/src/pages/RepoDetailPage.tsx
@@ -23,6 +23,7 @@ import { ModelBreakdown } from '../components/ModelBreakdown'
 import { ActivityChart } from '../components/ActivityChart'
 import { RecentSessions } from '../components/RecentSessions'
 import { ScopedSessions } from '../components/ScopedSessions'
+import { StatTile, STAT_TILE_GRID } from '../components/StatTile'
 import { MetricNote } from '../components/MetricNote'
 
 type Tab = 'overview' | 'members' | 'compare' | 'actions' | 'sessions' | 'workflows'
@@ -143,15 +144,15 @@ export default function RepoDetailPage() {
       </div>
 
       {/* KPI row */}
-      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(120px, 1fr))', gap: 10 }}>
+      <div style={{ display: 'grid', gridTemplateColumns: STAT_TILE_GRID, gap: 10 }}>
         <StatTile label={pt ? 'Sessões' : 'Sessions'} value={String(scoped.totalSessions)} />
         <StatTile label={pt ? 'Custo' : 'Cost'} value={fmtCost(scoped.totalCostUSD, currency, brlRate)} accent />
         {/* ONE tokens tile — the total of all four billed counters, where this used to be input
             and output as two tiles (the pair that comes to 0,34 % of the volume). The four
             counters themselves are the line UNDER this strip, not tiles in it: the grid is
-            `repeat(auto-fit, minmax(120px, 1fr))`, which fits `floor((W + gap) / 130)` columns —
-            ten at ~1400px — so taking the strip to eleven tiles stranded the last one alone on a
-            second row. `scoped.tokenTotals` is the same filtered model usage `totalCostUSD` above
+            `STAT_TILE_GRID`, an `auto-fit` over `minmax(150px, 1fr)` — about eight columns at
+            ~1400px — so taking the strip past that count strands the last tile alone on a second
+            row. `scoped.tokenTotals` is the same filtered model usage `totalCostUSD` above
             is priced from, so the tokens and the money describe the same turns under the repo
             scope. */}
         <StatTile
@@ -234,7 +235,7 @@ export default function RepoDetailPage() {
             </div>
           ) : (
             <>
-              <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(120px, 1fr))', gap: 10, marginBottom: 14 }}>
+              <div style={{ display: 'grid', gridTemplateColumns: STAT_TILE_GRID, gap: 10, marginBottom: 14 }}>
                 <StatTile label={pt ? 'Runs' : 'Runs'} value={String(ciSessions.length)} />
                 <StatTile label={pt ? 'Tokens' : 'Tokens'} value={fmt(ciSessions.reduce((a, s) => a + sessionTokenTotal(s), 0))} />
                 <StatTile label="Commits" value={String(ciSessions.reduce((a, s) => a + (s.git_commits ?? 0), 0))} />
@@ -378,27 +379,6 @@ function MemberComparePanel({ sessions, lang, currency, brlRate }: {
           ))}
         </div>
       </div>
-    </div>
-  )
-}
-
-function StatTile({ label, value, accent, title }: { label: string; value: string; accent?: boolean; title?: string }) {
-  return (
-    <div title={title} style={{
-      display: 'flex', flexDirection: 'column', gap: 3, padding: '12px 14px', minWidth: 0,
-      background: 'var(--bg-card)', border: '1px solid var(--border)', borderRadius: 'var(--radius-lg)',
-    }}>
-      {/* No `nowrap`: the Lines tile is two figures ("+517.3K −61.2K") and at a 120px column it was
-          painted straight through the card's right edge — the tile has no `overflow`, so the text
-          simply left the box. Wrapping at the space costs a second line on the widest tile and
-          keeps every digit. `minWidth: 0` is what lets the tile shrink inside its grid track at
-          all; without it the track floors at the value's intrinsic width and the ROW overflows
-          instead of the cell. */}
-      <span style={{
-        fontSize: 18, fontWeight: 700, lineHeight: 1.15, minWidth: 0,
-        color: accent ? 'var(--anthropic-orange)' : 'var(--text-primary)',
-      }}>{value}</span>
-      <span style={{ fontSize: 10.5, color: 'var(--text-tertiary)', textTransform: 'uppercase', letterSpacing: '0.05em' }}>{label}</span>
     </div>
   )
 }

--- a/packages/web/src/pages/RepoDetailPage.tsx
+++ b/packages/web/src/pages/RepoDetailPage.tsx
@@ -22,6 +22,7 @@ import { Section } from '../components/Section'
 import { ModelBreakdown } from '../components/ModelBreakdown'
 import { ActivityChart } from '../components/ActivityChart'
 import { RecentSessions } from '../components/RecentSessions'
+import { ScopedSessions } from '../components/ScopedSessions'
 import { MetricNote } from '../components/MetricNote'
 
 type Tab = 'overview' | 'members' | 'compare' | 'actions' | 'sessions' | 'workflows'
@@ -250,9 +251,15 @@ export default function RepoDetailPage() {
       )}
 
       {tab === 'sessions' && (
-        <Section title={<><Clock size={14} /> {pt ? 'Sessões recentes' : 'Recent sessions'}</>}>
-          {/* RecentSessions has its own built-in sort (date/tokens/messages/tools/files). */}
-          <RecentSessions sessions={sessions} lang={lang} onSelect={setSelectedSession} />
+        <Section title={<><Clock size={14} /> {pt ? 'Sessões' : 'Sessions'}</>}>
+          {/* `ScopedSessions`, not `RecentSessions`: this tab is already scoped to ONE repository,
+              so the browser's group-by, status filter, six-key sort, search and grid toggle re-ask
+              questions the page has answered — and cost the first screen of a phone before a single
+              session appeared. What is left is what the tab is for: each session's metrics, and the
+              way into it. See the module comment on ScopedSessions for the rest.
+              The Actions tab above keeps `RecentSessions` on purpose: a CI runner's session was
+              never on this machine's fleet, so it has no /sessions row to link to. */}
+          <ScopedSessions sessions={sessions} lang={lang} currency={currency} brlRate={brlRate} />
         </Section>
       )}
 
@@ -378,10 +385,19 @@ function MemberComparePanel({ sessions, lang, currency, brlRate }: {
 function StatTile({ label, value, accent, title }: { label: string; value: string; accent?: boolean; title?: string }) {
   return (
     <div title={title} style={{
-      display: 'flex', flexDirection: 'column', gap: 3, padding: '12px 14px',
+      display: 'flex', flexDirection: 'column', gap: 3, padding: '12px 14px', minWidth: 0,
       background: 'var(--bg-card)', border: '1px solid var(--border)', borderRadius: 'var(--radius-lg)',
     }}>
-      <span style={{ fontSize: 18, fontWeight: 700, color: accent ? 'var(--anthropic-orange)' : 'var(--text-primary)', whiteSpace: 'nowrap' }}>{value}</span>
+      {/* No `nowrap`: the Lines tile is two figures ("+517.3K −61.2K") and at a 120px column it was
+          painted straight through the card's right edge — the tile has no `overflow`, so the text
+          simply left the box. Wrapping at the space costs a second line on the widest tile and
+          keeps every digit. `minWidth: 0` is what lets the tile shrink inside its grid track at
+          all; without it the track floors at the value's intrinsic width and the ROW overflows
+          instead of the cell. */}
+      <span style={{
+        fontSize: 18, fontWeight: 700, lineHeight: 1.15, minWidth: 0,
+        color: accent ? 'var(--anthropic-orange)' : 'var(--text-primary)',
+      }}>{value}</span>
       <span style={{ fontSize: 10.5, color: 'var(--text-tertiary)', textTransform: 'uppercase', letterSpacing: '0.05em' }}>{label}</span>
     </div>
   )

--- a/packages/web/src/pages/RepositoriesPage.tsx
+++ b/packages/web/src/pages/RepositoriesPage.tsx
@@ -67,9 +67,9 @@ export default function RepositoriesPage() {
 
       <Section
         flashId="repositories"
-        title={<><GitBranch size={14} /> {(() => { const n = sorted.length; return pt ? `${n} repositório${n === 1 ? '' : 's'}` : `${n} repositor${n === 1 ? 'y' : 'ies'}` })()}</>}
+        title={<><GitBranch size={14} /> <span style={{ whiteSpace: 'nowrap' }}>{(() => { const n = sorted.length; return pt ? `${n} repositório${n === 1 ? '' : 's'}` : `${n} repositor${n === 1 ? 'y' : 'ies'}` })()}</span></>}
         action={
-          <div style={{ display: 'flex', alignItems: 'center', gap: 10, flexWrap: 'wrap' }}>
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'flex-end', gap: 8, flexWrap: 'wrap', minWidth: 0 }}>
             {unlinkedCount > 0 && (
               <button
                 onClick={() => setShowUnlinked(v => !v)}
@@ -106,7 +106,9 @@ export default function RepositoriesPage() {
               onKey={setSortKey}
               onDir={() => setSortDir(d => (d === 'desc' ? 'asc' : 'desc'))}
             />
-            <div style={{ position: 'relative', display: 'flex', alignItems: 'center' }}>
+            {/* The search field is what gives way: it takes the width the chips beside it left over
+                and floors at 120px rather than holding a fixed 130 and pushing the row apart. */}
+            <div style={{ position: 'relative', display: 'flex', alignItems: 'center', flex: '1 1 130px', minWidth: 120, maxWidth: 220 }}>
               <Search size={13} color="var(--text-tertiary)" style={{ position: 'absolute', left: 8, pointerEvents: 'none' }} />
               <input
                 value={query}
@@ -115,7 +117,7 @@ export default function RepositoriesPage() {
                 style={{
                   fontSize: 12, fontFamily: 'inherit', color: 'var(--text-primary)',
                   background: 'var(--bg-elevated)', border: '1px solid var(--border)', borderRadius: 7,
-                  padding: '5px 8px 5px 26px', width: 130, outline: 'none',
+                  padding: '5px 8px 5px 26px', width: '100%', minWidth: 0, outline: 'none',
                 }}
               />
             </div>

--- a/packages/web/src/pages/RepositoriesPage.tsx
+++ b/packages/web/src/pages/RepositoriesPage.tsx
@@ -69,7 +69,7 @@ export default function RepositoriesPage() {
         flashId="repositories"
         title={<><GitBranch size={14} /> <span style={{ whiteSpace: 'nowrap' }}>{(() => { const n = sorted.length; return pt ? `${n} repositório${n === 1 ? '' : 's'}` : `${n} repositor${n === 1 ? 'y' : 'ies'}` })()}</span></>}
         action={
-          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'flex-end', gap: 8, flexWrap: 'wrap', minWidth: 0 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap', minWidth: 0 }}>
             {unlinkedCount > 0 && (
               <button
                 onClick={() => setShowUnlinked(v => !v)}
@@ -108,7 +108,7 @@ export default function RepositoriesPage() {
             />
             {/* The search field is what gives way: it takes the width the chips beside it left over
                 and floors at 120px rather than holding a fixed 130 and pushing the row apart. */}
-            <div style={{ position: 'relative', display: 'flex', alignItems: 'center', flex: '1 1 130px', minWidth: 120, maxWidth: 220 }}>
+            <div style={{ position: 'relative', display: 'flex', alignItems: 'center', flex: '1 1 130px', minWidth: 120 }}>
               <Search size={13} color="var(--text-tertiary)" style={{ position: 'absolute', left: 8, pointerEvents: 'none' }} />
               <input
                 value={query}

--- a/packages/web/src/pages/TagDetailPage.tsx
+++ b/packages/web/src/pages/TagDetailPage.tsx
@@ -16,6 +16,7 @@ import { MetricNote } from '../components/MetricNote'
 import { HARNESS_LABELS } from '../lib/harness'
 import { ConfirmModal, SectionHeader } from './settings/primitives'
 import { useIsMobile } from '../hooks/useIsMobile'
+import { StatTile, STAT_TILE_GRID } from '../components/StatTile'
 
 // GET /api/tags/:id response. Aggregate-only by design (spec rule 2): the server never sends the
 // session rows behind a tag, so every value rendered here is a count or a sum it already computed.
@@ -119,21 +120,6 @@ const iconBtn: React.CSSProperties = {
 }
 
 /** The KPI tile used across the app: big number over an uppercase caption. */
-function StatTile({ label, value, accent, title }: { label: string; value: string; accent?: boolean; title?: string }) {
-  return (
-    <div title={title} style={{
-      display: 'flex', flexDirection: 'column', gap: 3, padding: '12px 14px', minWidth: 0,
-      background: 'var(--bg-card)', border: '1px solid var(--border)', borderRadius: 'var(--radius-lg)',
-    }}>
-      <span style={{
-        fontSize: 18, fontWeight: 700, color: accent ? 'var(--anthropic-orange)' : 'var(--text-primary)',
-        overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
-      }}>{value}</span>
-      <span style={{ fontSize: 10.5, color: 'var(--text-tertiary)', textTransform: 'uppercase', letterSpacing: '0.05em' }}>{label}</span>
-    </div>
-  )
-}
-
 type Metric = 'costUSD' | 'sessions' | 'tokens'
 
 /** Overlay needs three distinguishable series, so it cannot use the tag's single colour. */
@@ -419,15 +405,15 @@ export default function TagDetailPage() {
         {/* Just "Total" — a total is deduplicated by definition. The per-source note below is where
             the overlap is explained, which is the only place it can surprise anyone. */}
         <SectionHeader label={pt ? 'Total' : 'Total'} />
-        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(130px, 1fr))', gap: 10 }}>
+        <div style={{ display: 'grid', gridTemplateColumns: STAT_TILE_GRID, gap: 10 }}>
           <StatTile label={pt ? 'Custo' : 'Cost'} value={fmtCost(tag.aggregate.costUSD, currency, brlRate)} accent />
           <StatTile label={pt ? 'Sessões' : 'Sessions'} value={tag.aggregate.sessions.toLocaleString()} />
           {/* ONE tokens tile, with the four counters on the line below the strip. It was the total
               plus input and output as three tiles, under a note explaining why two of them did not
               add up to the first — an apology for the missing pair rather than the pair. Adding
               them as tiles was the first fix and the wrong one: this grid is `auto-fit` over
-              `minmax(130px, 1fr)`, so past a certain count the last tile is stranded alone on a
-              second row. */}
+              `minmax(150px, 1fr)` (STAT_TILE_GRID), so past a certain count the last tile is
+              stranded alone on a second row. */}
           <StatTile
             label="Tokens"
             value={fmt(totalTokens)}

--- a/packages/web/src/pages/TagDetailPage.tsx
+++ b/packages/web/src/pages/TagDetailPage.tsx
@@ -108,8 +108,11 @@ const card: React.CSSProperties = {
   background: 'var(--bg-card)', border: '1px solid var(--border)',
   borderRadius: 'var(--radius-lg)', padding: 16, minWidth: 0,
 }
+// 44px was applied on every screen (a module object cannot read `useIsMobile()`), so the pencil
+// and the trash beside the tag's title were each the height of the title block. The mobile target
+// is `.ag-tap-icon`'s invisible box on both consumers.
 const iconBtn: React.CSSProperties = {
-  width: 44, height: 44, flexShrink: 0, borderRadius: 8,
+  width: 30, height: 30, flexShrink: 0, borderRadius: 8,
   border: '1px solid var(--border)', background: 'transparent', color: 'var(--text-secondary)',
   cursor: 'pointer', display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
   fontFamily: 'inherit',
@@ -391,6 +394,7 @@ export default function TagDetailPage() {
               type="button"
               aria-label={pt ? 'Editar tag' : 'Edit tag'}
               title={pt ? 'Editar' : 'Edit'}
+              className="ag-tap-icon"
               style={iconBtn}
               onClick={() => navigate('/tags', { state: { editTagId: tag._id } })}
             >
@@ -400,6 +404,7 @@ export default function TagDetailPage() {
               type="button"
               aria-label={pt ? 'Excluir tag' : 'Delete tag'}
               title={pt ? 'Excluir' : 'Delete'}
+              className="ag-tap-icon"
               style={{ ...iconBtn, color: '#ef4444' }}
               onClick={() => setConfirmDelete(true)}
             >
@@ -461,12 +466,13 @@ export default function TagDetailPage() {
                 type="button"
                 disabled={overlay}
                 onClick={() => setMetric(m)}
+                className="ag-tap"
                 style={{
-                  // 44px is the MOBILE touch target; applying it on desktop too gave these a
-                  // button-sized footprint for a segmented control. Desktop follows the project's
-                  // control density (see TabSelect in settings/primitives).
-                  padding: isMobile ? '0 12px' : '0 10px',
-                  minHeight: isMobile ? 44 : 28,
+                  // The 44px MOBILE touch target is `.ag-tap`'s invisible box, not the pill: a
+                  // segmented control painted at 44px is the "chubby" shape this page was reported
+                  // for. Desktop follows the project's control density (TabSelect, primitives).
+                  padding: isMobile ? '5px 12px' : '0 10px',
+                  minHeight: isMobile ? undefined : 28,
                   borderRadius: 7, cursor: 'pointer', fontFamily: 'inherit',
                   border: metric === m ? `1px solid ${color}60` : '1px solid var(--border)',
                   background: metric === m ? `${color}18` : 'transparent',
@@ -485,9 +491,10 @@ export default function TagDetailPage() {
               onClick={() => setOverlay(o => !o)}
               aria-pressed={overlay}
               title={pt ? 'Sobrepor as três séries (escala normalizada)' : 'Overlay all three series (normalised scale)'}
+              className="ag-tap"
               style={{
-                padding: isMobile ? '0 12px' : '0 10px',
-                minHeight: isMobile ? 44 : 28,
+                padding: isMobile ? '5px 12px' : '0 10px',
+                minHeight: isMobile ? undefined : 28,
                 borderRadius: 7, cursor: 'pointer', fontFamily: 'inherit',
                 border: overlay ? `1px solid ${color}60` : '1px solid var(--border)',
                 background: overlay ? `${color}18` : 'transparent',

--- a/packages/web/src/pages/TagsPage.tsx
+++ b/packages/web/src/pages/TagsPage.tsx
@@ -119,16 +119,22 @@ const input: React.CSSProperties = {
   borderRadius: 7, fontSize: 13, color: 'var(--text-primary)', fontFamily: 'inherit',
   outline: 'none', width: '100%', boxSizing: 'border-box',
 }
+// A MODULE-LEVEL style object cannot see `useIsMobile()`, so the 44px it used to carry applied on
+// DESKTOP too — a 12.5px label in a 44px box, which is the "chubby" report for this page. The
+// height is now the control's own and the finger target is `.ag-tap`'s invisible box, which every
+// consumer carries; that class is the one thing here that IS mobile-only.
 const primaryBtn: React.CSSProperties = {
   display: 'inline-flex', alignItems: 'center', justifyContent: 'center', gap: 6,
-  padding: '0 14px', minHeight: 44, borderRadius: 7, border: '1px solid var(--anthropic-orange)',
+  padding: '0 14px', minHeight: 34, borderRadius: 7, border: '1px solid var(--anthropic-orange)',
   background: 'var(--anthropic-orange-dim)', color: 'var(--anthropic-orange)',
   fontSize: 12.5, fontWeight: 600, cursor: 'pointer', fontFamily: 'inherit',
 }
 const trashBtn: React.CSSProperties = {
   border: 'none', background: 'transparent', color: '#ef4444', cursor: 'pointer',
   display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
-  width: 44, height: 44, flexShrink: 0,
+  // Same as `primaryBtn`: 44x44 was applied on every screen, so a source row carried a delete
+  // button the height of the row and a half. `.ag-tap-icon` restores the mobile target invisibly.
+  width: 28, height: 28, flexShrink: 0,
 }
 
 /**
@@ -516,7 +522,7 @@ export default function TagsPage() {
           </div>
         </div>
         {mayWrite && (
-          <button type="button" onClick={openCreate} style={{ ...primaryBtn, width: isMobile ? '100%' : undefined }}>
+          <button type="button" className="ag-tap" onClick={openCreate} style={{ ...primaryBtn, width: isMobile ? '100%' : undefined }}>
             <Plus size={14} /> {pt ? 'Nova tag' : 'New tag'}
           </button>
         )}
@@ -661,7 +667,7 @@ export default function TagsPage() {
         lang={lang}
         dirty={dirty}
         footer={
-          <button type="button" style={{ ...primaryBtn, opacity: saving ? 0.6 : 1 }} disabled={saving} onClick={() => void save()}>
+          <button type="button" className="ag-tap" style={{ ...primaryBtn, opacity: saving ? 0.6 : 1 }} disabled={saving} onClick={() => void save()}>
             {saving ? (pt ? 'Salvando…' : 'Saving…') : (pt ? 'Salvar' : 'Save')}
           </button>
         }
@@ -693,8 +699,11 @@ export default function TagsPage() {
                   aria-label={c}
                   aria-pressed={selected}
                   onClick={() => setColor(c)}
+                  className="ag-tap-icon"
                   style={{
-                    width: 44, height: 44, padding: 0, border: 'none', background: 'transparent',
+                    // The swatch inside is 26px; the button was 44 on every screen, so the colour
+                    // row was two thirds air and wrapped a line early on a narrow card.
+                    width: 32, height: 32, padding: 0, border: 'none', background: 'transparent',
                     cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center',
                   }}
                 >
@@ -715,8 +724,9 @@ export default function TagsPage() {
                 consistent instead of showing the OS swatch chrome. */}
             <label
               title={pt ? 'Cor personalizada' : 'Custom colour'}
+              className="ag-tap-icon"
               style={{
-                width: 44, height: 44, cursor: 'pointer', position: 'relative',
+                width: 32, height: 32, cursor: 'pointer', position: 'relative',
                 display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0,
               }}
             >
@@ -1043,7 +1053,7 @@ function SourceList({ sources, typeLabel, valueLabel, emptyLabel, onRemove }: {
             overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', flex: 1,
           }}>{valueLabel(s)}</span>
           {onRemove && (
-            <button type="button" style={trashBtn} aria-label="Remove" onClick={() => onRemove(i)}>
+            <button type="button" className="ag-tap-icon" style={trashBtn} aria-label="Remove" onClick={() => onRemove(i)}>
               <Trash2 size={14} />
             </button>
           )}

--- a/packages/web/src/pages/TopUsagePage.tsx
+++ b/packages/web/src/pages/TopUsagePage.tsx
@@ -125,9 +125,9 @@ export default function TopUsagePage() {
             <button
               key={m.id}
               onClick={() => setMetric(m.id)}
+              className="ag-tap"
               style={{
-                padding: isMobile ? '0 12px' : '5px 11px',
-                minHeight: isMobile ? 44 : undefined,
+                padding: isMobile ? '6px 12px' : '5px 11px',
                 borderRadius: 999, cursor: 'pointer', fontFamily: 'inherit', fontSize: 12,
                 border: `1px solid ${metric === m.id ? 'var(--anthropic-orange)' : 'var(--border)'}`,
                 background: metric === m.id ? 'var(--anthropic-orange-dim)' : 'var(--bg-elevated)',

--- a/packages/web/src/pages/settings/AccessibilitySettings.tsx
+++ b/packages/web/src/pages/settings/AccessibilitySettings.tsx
@@ -38,8 +38,10 @@ function StyleEditor({
     minWidth: 58, textAlign: 'right', color: 'var(--text-primary)',
     fontWeight: 600, fontVariantNumeric: 'tabular-nums',
   }
+  // The 44px target is the invisible `.ag-tap` box on each button, not paint: a two-word chip
+  // stretched to 44px is the "chubby" shape this screen was reported for.
   const chip = (on: boolean): React.CSSProperties => ({
-    padding: isMobile ? '11px 14px' : '6px 12px', minHeight: isMobile ? 44 : undefined,
+    padding: isMobile ? '7px 13px' : '6px 12px',
     borderRadius: 8, fontSize: 13, cursor: 'pointer', fontFamily: 'inherit',
     border: '1px solid ' + (on ? 'var(--anthropic-orange)' : 'var(--border)'),
     background: on ? 'var(--anthropic-orange-dim)' : 'transparent',
@@ -61,7 +63,7 @@ function StyleEditor({
         <span style={label}>{text.shape}</span>
         <span style={{ display: 'flex', gap: 8 }}>
           {(['rect', 'circle'] as const).map(s => (
-            <button key={s} style={chip(style.shape === s)}
+            <button key={s} className="ag-tap" style={chip(style.shape === s)}
               onClick={() => onChange({ ...style, shape: s, height: s === 'circle' ? style.width : style.height })}>
               {s === 'rect' ? text.rect : text.circle}
             </button>
@@ -180,16 +182,23 @@ export default function AccessibilitySettings() {
             aria-checked={a11y.prefs.enabled}
             aria-label={text.enable}
             onClick={() => a11y.setEnabled(!a11y.prefs.enabled)}
+            // Same 34x20 track as `Toggle`/`RowSwitch` in primitives.tsx — this screen had rolled
+            // its own at 52x44 on mobile, which at `borderRadius: 999` is not a switch but an egg.
+            // `.ag-tap` restores the 44px finger target as an invisible box around it, and also
+            // opts the button out of the `.ag-settings button { min-height: 44px }` sweep that
+            // deformed it in the first place (index.css) — the same job `.ag-switch` does there.
+            className="ag-tap"
             style={{
-              width: 52, minWidth: 52, height: isMobile ? 44 : 30, borderRadius: 999,
-              cursor: 'pointer', border: '1px solid var(--border)', position: 'relative', flexShrink: 0,
-              background: a11y.prefs.enabled ? 'var(--anthropic-orange)' : 'var(--bg-elevated)',
+              width: 34, minWidth: 34, height: 20, borderRadius: 10, padding: 0,
+              cursor: 'pointer', border: 'none', position: 'relative', flexShrink: 0,
+              transition: 'background 0.2s',
+              background: a11y.prefs.enabled ? 'var(--anthropic-orange)' : 'var(--text-tertiary)',
             }}
           >
             <span style={{
-              position: 'absolute', top: '50%', transform: 'translateY(-50%)',
-              left: a11y.prefs.enabled ? 26 : 4, width: 20, height: 20, borderRadius: '50%',
-              background: '#fff', transition: 'left 0.15s',
+              position: 'absolute', top: 3,
+              left: a11y.prefs.enabled ? 17 : 3, width: 14, height: 14, borderRadius: '50%',
+              background: '#fff', transition: 'left 0.2s', boxShadow: '0 1px 3px rgba(0,0,0,0.3)',
             }} />
           </button>
         </div>

--- a/packages/web/src/pages/settings/BackupSettings.tsx
+++ b/packages/web/src/pages/settings/BackupSettings.tsx
@@ -1362,7 +1362,7 @@ function HistoryPager({ page, pages, total, pageSize, pt, onChange }: {
   const to = Math.min(total, from + pageSize - 1)
   const btnStyle = (enabled: boolean): React.CSSProperties => ({
     display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
-    width: 44, height: 44, borderRadius: 7,
+    width: 32, height: 32, borderRadius: 7,
     border: '1px solid var(--border)', background: 'transparent',
     color: enabled ? 'var(--text-secondary)' : 'var(--text-tertiary)',
     cursor: enabled ? 'pointer' : 'not-allowed', opacity: enabled ? 1 : 0.4,
@@ -1379,14 +1379,18 @@ function HistoryPager({ page, pages, total, pageSize, pt, onChange }: {
         <button
           type="button" aria-label={pt ? 'Página anterior' : 'Previous page'}
           disabled={page === 0} onClick={() => onChange(page - 1)}
-          style={{ ...btnStyle(page > 0), minHeight: isMobile ? 44 : 36, minWidth: isMobile ? 44 : 36, width: isMobile ? 44 : 36, height: isMobile ? 44 : 36 }}
+          // Two chevrons under a table: at 44x44 on a phone (and 36 everywhere else) the pager was
+          // taller than the rows it pages through. `.ag-tap-icon` puts the 44px back invisibly.
+          className="ag-tap-icon"
+          style={btnStyle(page > 0)}
         >
           <ChevronLeft size={16} />
         </button>
         <button
           type="button" aria-label={pt ? 'Próxima página' : 'Next page'}
           disabled={page >= pages - 1} onClick={() => onChange(page + 1)}
-          style={{ ...btnStyle(page < pages - 1), minHeight: isMobile ? 44 : 36, minWidth: isMobile ? 44 : 36, width: isMobile ? 44 : 36, height: isMobile ? 44 : 36 }}
+          className="ag-tap-icon"
+          style={btnStyle(page < pages - 1)}
         >
           <ChevronRight size={16} />
         </button>

--- a/packages/web/src/pages/settings/PricingSettings.tsx
+++ b/packages/web/src/pages/settings/PricingSettings.tsx
@@ -359,9 +359,9 @@ export default function PricingSettings() {
             <button
               key={g}
               onClick={() => setGroup(g)}
+              className="ag-tap"
               style={{
-                padding: isMobile ? '0 12px' : '5px 11px',
-                minHeight: isMobile ? 44 : undefined,
+                padding: isMobile ? '6px 12px' : '5px 11px',
                 borderRadius: 999, cursor: 'pointer', fontFamily: 'inherit', fontSize: 12,
                 border: `1px solid ${groupBy === g ? 'var(--anthropic-orange)' : 'var(--border)'}`,
                 background: groupBy === g ? 'var(--anthropic-orange-dim)' : 'var(--bg-elevated)',

--- a/packages/web/src/pages/settings/UsersSettings.tsx
+++ b/packages/web/src/pages/settings/UsersSettings.tsx
@@ -89,7 +89,10 @@ function TagChip({ label, color, isMobile, onRemove, removeLabel }: {
     <span style={{
       display: 'inline-flex', alignItems: 'center', gap: 6,
       padding: onRemove ? '5px 4px 5px 10px' : '5px 10px',
-      minHeight: isMobile ? 44 : undefined, boxSizing: 'border-box',
+      boxSizing: 'border-box',
+      // No 44px here and no `.ag-tap`: this is a LABEL, not a control — the only thing to press is
+      // the X inside it, and an overlay on the wrapper would sit on top of that button and take
+      // its clicks. At `borderRadius: 999` the 44px it used to carry also made it an ellipse.
       borderRadius: 999, fontSize: 11.5, background: 'var(--bg-elevated)',
       border: '1px solid var(--border)', color: 'var(--text-secondary)',
     }}>
@@ -103,10 +106,13 @@ function TagChip({ label, color, isMobile, onRemove, removeLabel }: {
           type="button"
           onClick={onRemove}
           aria-label={removeLabel}
+          // The chip's only control, so it is the one that carries the finger target — as an
+          // invisible box, or a 44x44 X turns a 12px chip into a button with a label stuck to it.
+          className="ag-tap-icon"
           style={{
             border: 'none', background: 'transparent', color: 'var(--text-tertiary)', cursor: 'pointer',
             display: 'inline-flex', alignItems: 'center', justifyContent: 'center', padding: 0, flexShrink: 0,
-            width: isMobile ? 44 : 20, height: isMobile ? 44 : 20,
+            width: 20, height: 20,
           }}
         >
           <X size={12} />
@@ -1027,7 +1033,11 @@ export default function UsersSettings() {
                     />
                   </div>
                   <button type="button" onClick={() => removeRow(i)}
-                    style={{ ...trashBtn, minWidth: isMobile ? 44 : undefined, minHeight: isMobile ? 44 : undefined, justifyContent: 'center' }}
+                    // The icon is 14px and the row it sits in is a pair of selects; a 44x44 box
+                    // beside them was the tallest thing in the row. `.ag-tap-icon` keeps the finger
+                    // target and opts the button out of the `.ag-settings button` 44px sweep.
+                    className="ag-tap-icon"
+                    style={{ ...trashBtn, minWidth: 28, minHeight: 28, justifyContent: 'center' }}
                     aria-label={pt ? 'Remover time' : 'Remove team'}>
                     <Trash2 size={14} />
                   </button>
@@ -1315,7 +1325,11 @@ export default function UsersSettings() {
                     />
                   </div>
                   <button type="button" onClick={() => removeERow(i)}
-                    style={{ ...trashBtn, minWidth: isMobile ? 44 : undefined, minHeight: isMobile ? 44 : undefined, justifyContent: 'center' }}
+                    // The icon is 14px and the row it sits in is a pair of selects; a 44x44 box
+                    // beside them was the tallest thing in the row. `.ag-tap-icon` keeps the finger
+                    // target and opts the button out of the `.ag-settings button` 44px sweep.
+                    className="ag-tap-icon"
+                    style={{ ...trashBtn, minWidth: 28, minHeight: 28, justifyContent: 'center' }}
                     aria-label={pt ? 'Remover time' : 'Remove team'}>
                     <Trash2 size={14} />
                   </button>


### PR DESCRIPTION
## Summary

- Separates the touch TARGET from the PAINT: `.ag-tap` / `.ag-tap-icon` project an invisible 44px box around a control that keeps its natural size, so a chip stops rendering as an ellipse and an icon button stops being an empty 44×44 square. Swept across the whole web package.
- Stops three things being painted outside their box: the KPI tile's figure, the `Section` header's action row, and `RecentSessions`' sort keys.
- Makes the repository detail's **Sessions** tab a lean metrics list that links into `/sessions/:id`, instead of embedding the full session browser inside a tab already scoped to one repository.
- Adds `touchTarget.lint.test.ts`, so the pattern cannot come back.

## Motivation

Closes #419.

The 44px touch-target rule was right and the way it was being paid was wrong. `minHeight: isMobile ? 44` was written at ~100 call sites and grows the PAINTED control, so an 11px label inside a `border-radius: 999` pill comes out as an egg. Worse, the same 44 is written into module-level style objects — objects that cannot read `useIsMobile()` — so it applied on the **desktop** too, against the rule `CLAUDE.md` states explicitly ("44px is the *mobile* number: applying it on desktop too turns a segmented control into a row of buttons").

The overflow faults share a cause: a value declared `nowrap` in a box with no `overflow` and no `min-width: 0` cannot shrink inside its grid track, so the ROW overflows instead of the cell.

And the pattern **spreads**: the `tasks/*` area landed on `dev` written the same way while this fix was in flight. That is why the last commit is a lint test rather than more prose.

## Changes

**`index.css`** — `.ag-tap` (vertical only, so a chip can never steal the tap of the chip beside it) and `.ag-tap-icon` (both axes, for icon-only buttons), both inside the mobile query, both opted out of the `.ag-settings button { min-height: 44px }` sweep. Plus `.ag-stat-value`, the plain 18px a browser without `cqi` falls back to. The header comments say what the classes are **not** for: a dialog's "Save", a full-width form action, a menu row and a native form control should be 44px of paint, and keep it.

**`components/StatTile.tsx` (new)** — the KPI tile, which existed TWICE with the copies already drifted into different failure modes for the same input: one painted through the card edge, the other clipped to an ellipsis. The figure must not wrap (a grid row is as tall as its tallest cell, so one two-line tile leaves every tile beside it two thirds empty), so it has to FIT a track whose width no JavaScript knows at render time. The tile is a size container and the size is `min(18px, (100 / (len * 0.62))cqi)` — self-correcting at every width. `nowrap` + `ellipsis` is the backstop; `title` carries the value whole. `STAT_TILE_GRID` is the one column rule both strips use: `minmax(150px, 1fr)`, two columns on a phone rather than three ~100px tiles no money figure fits in.

**`components/ScopedSessions.tsx` (new)** — the repository Sessions tab: one row per session with cost, tokens (all four counters, through `sessionTokens`), messages, tools and active time, linking to `/sessions/:id`. Paging by a reveal button; no filters, sort, search or grid toggle. The Actions tab deliberately keeps `RecentSessions` — a CI runner's session was never on this machine's fleet and has no `/sessions` row to link to.

**`components/Section.tsx`** — the header wraps, and the action row is `flex: 0 1 auto` with no `justify-content` of its own. `justify-content` applies per LINE, and the parent's `space-between` already right-aligns the action while it shares a line with the title — so pinning it right only ever did harm on the wrapped line, where it left the controls in the far corner under an empty half-row.

**`touchTarget.lint.test.ts` (new)** — greps the web source and fails the build on three shapes: a `borderRadius: 999` pill carrying `minHeight: isMobile ? 44`; a 44×44 icon square (`width`/`minWidth` AND `height` both `isMobile ? 44`); and 44px baked into a module-level style object. `@touch-intentional` plus a reason waives one. Comments are blanked (length-preserved) before scanning, because a doc comment explaining the rule necessarily quotes the shape it forbids.

Writing that guard **found 14 sites the manual sweep had missed** — it had classified on `minHeight` alone and these pin `width`/`height` instead: the session action kebab, four in `ArtifactsAside`, the hardware modal's three, the terminal zoom row's three, the notification bell, the magnifier and hide-lenses triggers, the notices modal, and `MfaSetup`'s copy button (module-level, so 44×44 on the desktop as well).

**Converted overall** — 28 chips and 14 icon buttons across `tasks/*`, `ArtifactsAside`, `GalleryTab`, `RecentSessions`, `NotificationBell`, `FiltersBar`, `HardwareModal`, `MfaSetup`, `SessionActions`, the a11y triggers, `team/*`, `TopBoards`, `TopUsagePage`, `ModelBreakdown`, `TagDetailPage`, `TagsPage`, and the settings pages. `AccessibilitySettings`' hand-rolled 52×44 switch is now the same 34×20 track as `Toggle`/`RowSwitch`.

**Deliberately left at 44px, and not findings** — clickable menu rows; rows whose tap target is a `Checkbox` or radio inside them (`.ag-tap`'s overlay would sit on top of that child and take its clicks); native `<select>`s; full-width form actions. Three sites the first pass converted are reverted here for that last reason. `FiltersBar`'s `mobileTarget` carries the waiver marker: that object IS the mobile target and its consumers spread it only when `isMobile`.

## Test plan

- [x] `bun tsc --noEmit` — clean
- [x] `bun test` — 7126 pass, 0 fail (the lint test's 4 included)
- [x] `bun run build` — clean; verified `cqi` + `inline-size` reach the `StatTile` chunk and `.ag-stat-value{font-size:18px}` reaches the CSS bundle
- [x] Rebased on `origin/dev` and re-verified there; none of `dev`'s new commits touch the files changed here
- [ ] **Reviewer, at 390–430px:** the `/top` "Rank by" pills, the `/repositories` header (controls start at the LEFT under the title, search fills its line), the `/repo/:id` KPI strip in **both USD and BRL** (two columns, every value on one line, no dead space), and the Sessions tab.
- [ ] **Reviewer, on the desktop:** `/tags` and `/tags/:id` — buttons, colour swatches and trash icons are no longer 44px; the repo KPI strip still fits one row.
- [ ] **The `.ag-tap` overlap:** on a wrapped chip row the invisible boxes meet by a pixel or two. Tapping a chip must not fire the chip on the line above or below.
- [ ] `Section`'s header changed for EVERY card in the app — a pass over Home / Costs / Projects / Tools / Compare for a title or action that moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CCQohJyXScMmERzK1BgNAV