### PR TITLE
feat(tasks): a repository says which deliveries touched it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2006,6 +2006,18 @@ packages/web/src/components/tasks/   board.ts (vocabulary) · TaskTable · TaskB
   silence.
 - **The activity log is board-wide and capped** (2000, oldest dropped). Per-task arrays would put
   the cap per task in a file read on every poll.
+- **A task belongs to a REPOSITORY through its sessions, and the list row says which** — `repos` on
+  `TaskListRow` (`reposOfRows`, pure) is the distinct `git_remote` of the task's sessions, read off
+  the metas the caller passed, which are the SCOPED ones on every surface that filters. Never
+  `Task.repo`: that is inherited once at creation, and a second source for the same question is a
+  second answer. `''` is the "no linked repository" bucket, a real value here as in
+  `sessionInScope`. It is what the Repositories page's **Tasks** tab selects on (`tasksOfRepo` /
+  `repoTaskTotals`, `web/src/lib/repoTasks.ts`), so a delivery spanning two repositories appears
+  under both and counts on each side only what it spent there. That tab is a READ view — every verb
+  goes to `/tasks/:id`, because a second controller for one gesture is the bug `task-reopen.ts`
+  exists to have fixed once — and it counts `sessionsLinked`, never `sessionsUsed`: a row with no
+  conversation link named no repository and contributed no numbers, so counting it would place a
+  session in a repository nothing observed it in.
 - **New `/api/tasks` sub-routes ride the existing `capability-guard.ts` entries** (`/api/tasks`,
   `/api/task-files` → `localShell`). `GET /api/tasks/next` and `/api/tasks/activity` are matched
   BEFORE the generic `<ref>` GET, or they resolve as task references and 404.

--- a/docs/superpowers/specs/2026-09-05-task-measurement-design.md
+++ b/docs/superpowers/specs/2026-09-05-task-measurement-design.md
@@ -657,7 +657,7 @@ Every line is a thing that must be true of the shipped feature, in the order it 
 - [ ] Title / description / comments redacted at both boundaries
 - [ ] `tasks` added to `rotate-identity.ts` and its dates to `DATE_FIELDS`
 - [ ] Central board grouped by machine, with a see-all switch
-- [ ] Repositories → Tasks tab, keyed by the sessions' `git_remote`
+- [x] Repositories → Tasks tab, keyed by the sessions' `git_remote`
 
 **The rules that must still hold**
 - [x] One resolution shared by CLI, HTTP, web and MCP — no surface computes its own rollup

--- a/packages/server/server/sessions/task-report.test.ts
+++ b/packages/server/server/sessions/task-report.test.ts
@@ -1,0 +1,85 @@
+/**
+ * A task belongs to a repository through its SESSIONS, and this pins that rule.
+ *
+ * The Repositories page keys everything on `normalizeGitRemote` and nothing else; `buildTaskList`'s
+ * `repos` is that same key, read off the sessions' metas. The cases below are the ones that decide
+ * whether the Repositories → Tasks tab lists the right rows: a task spanning two repositories, the
+ * "no linked repository" bucket, and a row nobody could place.
+ */
+
+import { describe, expect, it } from 'bun:test'
+import type { SessionMeta } from '@agentistics/core'
+import { buildTaskList, reposOfRows } from './task-report'
+import type { Task } from './task-model'
+import type { ManagedSession } from './types'
+
+const task = (over: Partial<Task> = {}): Task => ({
+  id: 't1', title: 'a delivery', status: 'in_progress',
+  createdAt: '2026-09-05T10:00:00.000Z', updatedAt: '2026-09-05T10:00:00.000Z',
+  ...over,
+})
+
+const row = (over: Partial<ManagedSession> = {}): ManagedSession => ({
+  id: 'r1', harness: 'claude', cwd: '/repo', createdAt: '2026-09-05T10:00:00.000Z',
+  taskId: 't1', conversationId: 'c1',
+  ...over,
+} as ManagedSession)
+
+const meta = (over: Partial<SessionMeta> = {}): SessionMeta => ({
+  session_id: 'c1', project_path: '/repo', start_time: '2026-09-05T10:00:00.000Z',
+  harness: 'claude', git_remote: 'github.com/org/repo',
+  ...over,
+} as SessionMeta)
+
+const metasOf = (...ms: SessionMeta[]) =>
+  new Map(ms.map(m => [m.session_id, m] as [string, SessionMeta]))
+
+const listOf = (rows: ManagedSession[], metas: ReadonlyMap<string, SessionMeta>) =>
+  buildTaskList({ tasks: [task()], attempts: [], rows, metas, costOf: () => 1 })
+
+describe('reposOfRows', () => {
+  it('names every repository the task touched, once, in first-seen order', () => {
+    // A task spanning two repositories appears under BOTH — that is the point of keying on the
+    // sessions rather than on one field.
+    const repos = reposOfRows(
+      [row({ id: 'r1', conversationId: 'c1' }), row({ id: 'r2', conversationId: 'c2' }),
+        row({ id: 'r3', conversationId: 'c3' })],
+      metasOf(
+        meta({ session_id: 'c1', git_remote: 'github.com/org/a' }),
+        meta({ session_id: 'c2', git_remote: 'github.com/org/b' }),
+        meta({ session_id: 'c3', git_remote: 'github.com/org/a' }),
+      ),
+    )
+    expect(repos).toEqual(['github.com/org/a', 'github.com/org/b'])
+  })
+
+  it('keeps the "no linked repository" bucket as a real value', () => {
+    // `''` is the bucket the repositories page already shows, and `sessionInScope` matches it. A
+    // session outside a repository is not a session with no session.
+    const repos = reposOfRows([row()], metasOf(meta({ git_remote: undefined })))
+    expect(repos).toEqual([''])
+  })
+
+  it('names nothing for a row whose conversation is not in the store', () => {
+    // No link, no repository. A `cwd` is not the key this dimension is measured by, and guessing
+    // one from it would file the task under a repository nothing observed.
+    expect(reposOfRows([row({ conversationId: undefined })], metasOf(meta()))).toEqual([])
+    expect(reposOfRows([row({ conversationId: 'gone' })], metasOf(meta()))).toEqual([])
+  })
+})
+
+describe('buildTaskList repos', () => {
+  it('carries the repositories beside the harnesses', () => {
+    const [only] = listOf([row()], metasOf(meta()))
+    expect(only!.repos).toEqual(['github.com/org/repo'])
+    expect(only!.harnesses).toEqual(['claude'])
+  })
+
+  it('names no repository when the caller scoped every session out', () => {
+    // The metas arrive already scoped, so a task with nothing inside the window names nothing —
+    // which is what keeps a repository tab from listing work it has not seen in that window.
+    const [only] = listOf([row()], metasOf())
+    expect(only!.repos).toEqual([])
+    expect(only!.rollup.sessionsUsed).toBe(1)
+  })
+})

--- a/packages/server/server/sessions/task-report.ts
+++ b/packages/server/server/sessions/task-report.ts
@@ -59,6 +59,21 @@ export interface TaskListRow {
   counts: { comments: number; subtasks: number; subtasksDone: number; files: number }
   /** Distinct harnesses of this task's sessions, in first-seen order. */
   harnesses: string[]
+  /**
+   * Distinct repositories of this task's sessions, in first-seen order — the key the Repositories
+   * page uses (`normalizeGitRemote`, already stamped onto `SessionMeta.git_remote`), and `''` for
+   * the "no linked repository" bucket, which is a real value here exactly as it is in
+   * `sessionInScope`.
+   *
+   * Read off the SESSIONS and never off `Task.repo`: a task belongs to a repository through the
+   * work that happened in it, so one spanning two repositories names both, and a field somebody
+   * typed (or inherited once, at creation) would be a second answer to the same question.
+   *
+   * Derived from the metas the caller passed, which are the SCOPED ones on every surface that
+   * filters — so a task with no session inside the current window names no repository at all,
+   * rather than one it has not touched since.
+   */
+  repos: string[]
 }
 
 export interface TaskDetail {
@@ -142,6 +157,28 @@ export function attemptViews(
   return views
 }
 
+/**
+ * The repositories a task's rows touched, in first-seen order.
+ *
+ * Only a row whose conversation resolves in the store can name one: a row with no link reported no
+ * repository, and inventing one from its `cwd` would be a second key for a dimension whose only key
+ * is the normalized remote. A task all of whose rows are unlinked therefore names nothing, which is
+ * the honest answer and not an empty repository.
+ */
+export function reposOfRows(
+  rows: readonly ManagedSession[],
+  metas: ReadonlyMap<string, SessionMeta>,
+): string[] {
+  const out: string[] = []
+  for (const r of rows) {
+    const meta = r.conversationId ? metas.get(r.conversationId) : undefined
+    if (!meta) continue
+    const remote = meta.git_remote ?? ''
+    if (!out.includes(remote)) out.push(remote)
+  }
+  return out
+}
+
 export function buildTaskList(o: {
   tasks: readonly Task[]
   attempts: readonly Attempt[]
@@ -166,6 +203,7 @@ export function buildTaskList(o: {
         files: (o.files ?? []).filter(f => f.taskId === task.id).length,
       },
       harnesses: [...new Set(mine.map(r => r.harness))],
+      repos: reposOfRows(mine, o.metas),
     }
   })
 }

--- a/packages/web/src/components/tasks/RepoTasksTab.tsx
+++ b/packages/web/src/components/tasks/RepoTasksTab.tsx
@@ -1,0 +1,202 @@
+/**
+ * RepoTasksTab — the deliveries that touched one repository.
+ *
+ * It is a READ view. Every verb a task has — status, claim, comments, subtasks, files — lives on
+ * the board, and a row here opens it. Wiring the board's operating surface into this tab would be a
+ * second copy of the `TasksPage` controller, and two controllers for one gesture is exactly the bug
+ * `task-reopen.ts` exists to have fixed once.
+ *
+ * It computes nothing about a delivery: every figure arrives already decided from `/api/tasks`,
+ * scoped to this repository by the same filter that scopes every other tab of the page. What it
+ * owns is the honesty of the rendering — a `null` is `N/A` and never `0`, an open task shows no
+ * delivery date, and a task that also spent Copilot credits says so rather than letting a dollar
+ * figure read as the whole bill.
+ */
+
+import { useMemo, type CSSProperties } from 'react'
+import { SquareArrowOutUpRight } from 'lucide-react'
+import { fmtCost, sortRows, type SortSpec } from '@agentistics/core'
+import { useIsMobile } from '../../hooks/useIsMobile'
+import type { TaskListRow } from '../../lib/tasks'
+import {
+  NA, PRIORITY, STATUS, fmtInt, fmtTokens, harnessColor, microLabel, numeric, pill, surface,
+  type BoardStatus,
+} from './board'
+import { TaskProgressBar } from './TaskProgressBar'
+
+/**
+ * Most recently touched first.
+ *
+ * The board's own default is the MANUAL order, which on a subset that was never dragged falls back
+ * to creation date and puts the oldest delivered task at the top — the wrong first row for a
+ * question about what is happening in this repository. It still goes through the shared `sortRows`:
+ * this view picks a key, it does not invent an ordering.
+ */
+const REPO_SORT: SortSpec = { key: 'updated', dir: 'desc' }
+
+export interface RepoTasksTabProps {
+  /** Already narrowed to this repository by `tasksOfRepo`. */
+  rows: TaskListRow[]
+  lang: 'pt' | 'en'
+  currency: 'USD' | 'BRL'
+  brlRate: number
+  onOpen: (taskId: string) => void
+}
+
+/** A local day, formatted the way the rest of the dashboard writes a date. */
+function fmtDay(iso: string | undefined, lang: 'pt' | 'en'): string | null {
+  if (!iso) return null
+  const t = Date.parse(iso)
+  if (!Number.isFinite(t)) return null
+  return new Date(t).toLocaleDateString(lang === 'pt' ? 'pt-BR' : 'en-US', {
+    day: '2-digit', month: 'short',
+  })
+}
+
+function StatusPill({ status }: { status: string }) {
+  const s = STATUS[status as BoardStatus] ?? STATUS.backlog
+  return <span style={{ ...pill(s.color), background: s.dim }}>{s.label}</span>
+}
+
+function Harnesses({ harnesses }: { harnesses: string[] }) {
+  if (harnesses.length === 0) return <span style={{ color: 'var(--text-tertiary)' }}>{NA}</span>
+  return (
+    <span style={{ display: 'inline-flex', gap: 4, flexWrap: 'wrap' }}>
+      {harnesses.map(h => (
+        <span key={h} style={{ ...pill(harnessColor(h)), fontSize: 10 }}>{h}</span>
+      ))}
+    </span>
+  )
+}
+
+export function RepoTasksTab(p: RepoTasksTabProps) {
+  const isMobile = useIsMobile()
+  const pt = p.lang === 'pt'
+  const rows = useMemo(() => sortRows(p.rows, REPO_SORT), [p.rows])
+  const cost = (n: number | null) => (n === null ? NA : fmtCost(n, p.currency, p.brlRate))
+
+  if (rows.length === 0) {
+    return (
+      <div style={{ color: 'var(--text-tertiary)', fontSize: 13, padding: 20, textAlign: 'center', lineHeight: 1.6 }}>
+        {pt
+          ? 'Nenhuma entrega tocou este repositório na janela selecionada. Uma task pertence a um repositório pelas sessões filiadas a ela.'
+          : 'No delivery touched this repository in the selected window. A task belongs to a repository through the sessions filed under it.'}
+      </div>
+    )
+  }
+
+  // ------------------------------------------------------------------ mobile: the same rows, as cards
+  if (isMobile) {
+    return (
+      <div style={{ display: 'grid', gap: 8 }}>
+        {rows.map(r => {
+          const prio = PRIORITY[r.task.priority ?? 'none'] ?? PRIORITY.none!
+          return (
+            <button
+              key={r.task.id}
+              onClick={() => p.onOpen(r.task.id)}
+              style={{
+                ...surface, padding: 12, display: 'grid', gap: 8, textAlign: 'left', width: '100%',
+                minHeight: 44, color: 'var(--text-primary)', cursor: 'pointer', font: 'inherit',
+              }}
+            >
+              <div style={{ display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}>
+                <StatusPill status={r.task.status} />
+                {r.task.priority && r.task.priority !== 'none' && (
+                  <span style={{ ...pill(prio.color), background: prio.dim, fontSize: 10 }}>{prio.label}</span>
+                )}
+              </div>
+              <span style={{ fontSize: 13.5, fontWeight: 600, lineHeight: 1.35 }}>{r.task.title}</span>
+              {r.counts.subtasks > 0 && (
+                <TaskProgressBar done={r.counts.subtasksDone} total={r.counts.subtasks} />
+              )}
+              <div style={{ display: 'flex', gap: 14, flexWrap: 'wrap', ...numeric, fontSize: 11.5 }}>
+                <span>{fmtInt(r.rollup.sessionsLinked)} <span style={microLabel}>{pt ? 'sessões' : 'sessions'}</span></span>
+                <span>{fmtInt(r.rollup.rounds)} <span style={microLabel}>{pt ? 'rodadas' : 'rounds'}</span></span>
+                <span>{fmtTokens(r.rollup.tokens)} <span style={microLabel}>tokens</span></span>
+                <span style={{ color: 'var(--anthropic-orange)' }}>{cost(r.rollup.costUSD)}</span>
+              </div>
+              <Harnesses harnesses={r.harnesses} />
+            </button>
+          )
+        })}
+      </div>
+    )
+  }
+
+  // ------------------------------------------------------------------ desktop: a table, scrolling in its own box
+  const th: CSSProperties = {
+    ...microLabel, textAlign: 'left', padding: '7px 10px', fontWeight: 600,
+    borderBottom: '1px solid var(--border)', whiteSpace: 'nowrap',
+  }
+  const td: CSSProperties = {
+    padding: '8px 10px', fontSize: 12.5, borderBottom: '1px solid var(--border)',
+    verticalAlign: 'middle',
+  }
+  const tdNum: CSSProperties = { ...td, ...numeric, textAlign: 'right' }
+
+  return (
+    <div style={{ ...surface, overflowX: 'auto' }}>
+      <table style={{ width: '100%', borderCollapse: 'collapse', minWidth: 780 }}>
+        <thead>
+          <tr>
+            <th style={th}>{pt ? 'Entrega' : 'Delivery'}</th>
+            <th style={th}>Status</th>
+            <th style={th}>{pt ? 'Progresso' : 'Progress'}</th>
+            <th style={{ ...th, textAlign: 'right' }}>{pt ? 'Sessões' : 'Sessions'}</th>
+            <th style={{ ...th, textAlign: 'right' }}>{pt ? 'Rodadas' : 'Rounds'}</th>
+            <th style={{ ...th, textAlign: 'right' }}>Tokens</th>
+            <th style={{ ...th, textAlign: 'right' }}>{pt ? 'Custo' : 'Cost'}</th>
+            <th style={th}>Harnesses</th>
+            <th style={th}>{pt ? 'Entregue em' : 'Delivered'}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map(r => {
+            const delivered = fmtDay(r.task.deliveredAt, p.lang)
+            return (
+              <tr
+                key={r.task.id}
+                onClick={() => p.onOpen(r.task.id)}
+                style={{ cursor: 'pointer' }}
+                onMouseEnter={e => { e.currentTarget.style.background = 'var(--bg-elevated)' }}
+                onMouseLeave={e => { e.currentTarget.style.background = 'transparent' }}
+              >
+                <td style={{ ...td, maxWidth: 320 }}>
+                  <span style={{
+                    display: 'inline-flex', alignItems: 'center', gap: 6, fontWeight: 600,
+                    color: 'var(--text-primary)',
+                  }}>
+                    <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', maxWidth: 290 }}>
+                      {r.task.title}
+                    </span>
+                    <SquareArrowOutUpRight size={11} style={{ color: 'var(--text-tertiary)', flexShrink: 0 }} />
+                  </span>
+                </td>
+                <td style={td}><StatusPill status={r.task.status} /></td>
+                <td style={{ ...td, minWidth: 120 }}>
+                  {r.counts.subtasks > 0
+                    ? <TaskProgressBar done={r.counts.subtasksDone} total={r.counts.subtasks} />
+                    : <span style={{ color: 'var(--text-tertiary)', fontSize: 11 }}>—</span>}
+                </td>
+                {/* `sessionsLinked`, not `sessionsUsed`: a row with no conversation link named no
+                    repository and contributed no numbers, so counting it here would place a session
+                    in a repository nothing observed it in. */}
+                <td style={tdNum}>{fmtInt(r.rollup.sessionsLinked)}</td>
+                <td style={tdNum}>{fmtInt(r.rollup.rounds)}</td>
+                <td style={tdNum}>{fmtTokens(r.rollup.tokens)}</td>
+                <td style={{ ...tdNum, color: 'var(--anthropic-orange)' }}>{cost(r.rollup.costUSD)}</td>
+                <td style={td}><Harnesses harnesses={r.harnesses} /></td>
+                {/* An open task has no delivery date — "still running" is not a date, and a
+                    duration "so far" beside a delivered one reads as the same measurement. */}
+                <td style={{ ...td, color: 'var(--text-secondary)', whiteSpace: 'nowrap' }}>
+                  {delivered ?? <span style={{ color: 'var(--text-tertiary)' }}>—</span>}
+                </td>
+              </tr>
+            )
+          })}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/packages/web/src/lib/repoTasks.test.ts
+++ b/packages/web/src/lib/repoTasks.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'bun:test'
+import { repoTaskTotals, tasksOfRepo } from './repoTasks'
+import type { TaskListRow } from './tasks'
+
+const row = (over: Partial<TaskListRow> & { id?: string } = {}): TaskListRow => ({
+  task: {
+    id: over.id ?? 't1', title: 'a delivery', status: 'in_progress',
+    createdAt: '2026-09-05T10:00:00.000Z', updatedAt: '2026-09-05T10:00:00.000Z',
+    ...(over.task ?? {}),
+  },
+  attempts: 1,
+  rollup: {
+    sessionsUsed: 1, sessionsLinked: 1, provenance: { assigned: 1, observed: 0, none: 0 },
+    rounds: 4, activeMinutes: 10, tokens: 1000, costUSD: 2,
+    costMeasuredSessions: 0, costEstimatedSessions: 1, credits: null, mixedCurrency: false,
+    ...(over.rollup ?? {}),
+  },
+  counts: { comments: 0, subtasks: 0, subtasksDone: 0, files: 0, ...(over.counts ?? {}) },
+  harnesses: over.harnesses ?? ['claude'],
+  repos: over.repos ?? ['github.com/org/a'],
+})
+
+describe('tasksOfRepo', () => {
+  it('keeps a task that touched this repository, whichever others it also touched', () => {
+    const rows = [
+      row({ id: 't1', repos: ['github.com/org/a'] }),
+      row({ id: 't2', repos: ['github.com/org/b', 'github.com/org/a'] }),
+      row({ id: 't3', repos: ['github.com/org/b'] }),
+    ]
+    expect(tasksOfRepo(rows, 'github.com/org/a').map(r => r.task.id)).toEqual(['t1', 't2'])
+  })
+
+  it('treats `` as the "no linked repository" bucket, not as "every repository"', () => {
+    const rows = [row({ id: 't1', repos: [''] }), row({ id: 't2', repos: ['github.com/org/a'] })]
+    expect(tasksOfRepo(rows, '').map(r => r.task.id)).toEqual(['t1'])
+  })
+
+  it('drops a task whose sessions were all scoped out — it names no repository at all', () => {
+    expect(tasksOfRepo([row({ repos: [] })], 'github.com/org/a')).toEqual([])
+  })
+})
+
+describe('repoTaskTotals', () => {
+  it('counts in flight, delivered and abandoned apart', () => {
+    const t = repoTaskTotals([
+      row({ id: 't1', task: { status: 'in_progress' } as never }),
+      row({ id: 't2', task: { status: 'done' } as never }),
+      row({ id: 't3', task: { status: 'abandoned' } as never }),
+      row({ id: 't4', task: { status: 'blocked' } as never }),
+    ])
+    expect(t.tasks).toBe(4)
+    // Counted as LINKED sessions: what this repository could actually see.
+    expect(t.sessions).toBe(4)
+    expect(t.inFlight).toBe(2)
+    expect(t.delivered).toBe(1)
+    expect(t.abandoned).toBe(1)
+  })
+
+  it('reports a total nobody could measure as null, never as zero', () => {
+    // Every task on a harness that reports no cost: the repository has not delivered for free.
+    const t = repoTaskTotals([
+      row({ id: 't1', rollup: { costUSD: null, tokens: null } as never }),
+      row({ id: 't2', rollup: { costUSD: null, tokens: null } as never }),
+    ])
+    expect(t.costUSD).toBeNull()
+    expect(t.tokens).toBeNull()
+  })
+
+  it('sums what was reported and ignores what was not', () => {
+    const t = repoTaskTotals([
+      row({ id: 't1', rollup: { costUSD: 2, tokens: 1000 } as never }),
+      row({ id: 't2', rollup: { costUSD: null, tokens: 500 } as never }),
+    ])
+    expect(t.costUSD).toBe(2)
+    expect(t.tokens).toBe(1500)
+  })
+
+  it('counts only the sessions the repository could see', () => {
+    // A task spanning two repositories files rows on both sides; only the ones whose conversation
+    // resolved here contributed anything, and only those may be counted here.
+    const t = repoTaskTotals([
+      row({ id: 't1', rollup: { sessionsUsed: 4, sessionsLinked: 1 } as never }),
+    ])
+    expect(t.sessions).toBe(1)
+  })
+
+  it('counts the tasks that also spent credits, and never adds them to the dollars', () => {
+    const t = repoTaskTotals([
+      row({ id: 't1', rollup: { costUSD: 2, credits: { nanoAiu: 5, premiumRequests: 1 }, mixedCurrency: true } as never }),
+      row({ id: 't2' }),
+    ])
+    expect(t.creditTasks).toBe(1)
+    expect(t.costUSD).toBe(4)
+  })
+})

--- a/packages/web/src/lib/repoTasks.ts
+++ b/packages/web/src/lib/repoTasks.ts
@@ -1,0 +1,80 @@
+/**
+ * repoTasks.ts — PURE. Which deliveries touched a repository, and what they add up to there.
+ *
+ * A task belongs to a repository through its SESSIONS' `git_remote` — never through a field
+ * somebody typed — which is the rule the repository dimension already follows everywhere else
+ * (`normalizeGitRemote` is the only key). The server does that half: `buildTaskList` reports the
+ * distinct remotes of each task's sessions, read off the metas it was given, which on this page are
+ * already scoped to this repository and to the page's date/harness filters.
+ *
+ * So the membership test here is a lookup and not a derivation. What this module owns is the
+ * arithmetic of the tiles above the list, and the one rule that arithmetic must not break: a total
+ * nobody could measure is `null`, never `0`. A repository whose tasks all ran on a harness that
+ * reports no cost has not delivered for free.
+ */
+
+import type { TaskListRow } from './tasks'
+
+/**
+ * The rows of one repository.
+ *
+ * `remote` is the normalized remote, and `''` is the "no linked repository" bucket the repositories
+ * page already shows — a real value here, exactly as it is in the server's `sessionInScope`. On an
+ * unlinked folder page the caller passes `''` and the rows arrived scoped by project, so the empty
+ * bucket means "a session in this folder that named no repository".
+ */
+export function tasksOfRepo(rows: readonly TaskListRow[], remote: string): TaskListRow[] {
+  return rows.filter(r => r.repos.includes(remote))
+}
+
+export interface RepoTaskTotals {
+  tasks: number
+  /** Neither delivered nor abandoned — the work still going on in this repository. */
+  inFlight: number
+  delivered: number
+  abandoned: number
+  /**
+   * The sessions this repository can actually account for — `sessionsLinked`, never `sessionsUsed`.
+   *
+   * A row with no conversation link contributes no numbers anywhere and named no repository, so
+   * counting it here would attribute a session to a repository nothing observed in it. On a task
+   * spanning two repositories that difference is the whole point: it must not report all of its
+   * sessions on each side.
+   */
+  sessions: number
+  /** Null when not one of these tasks could be priced. Never a reassuring `0`. */
+  costUSD: number | null
+  tokens: number | null
+  /**
+   * How many of these tasks also spent Copilot credits. Credits are not dollars and are never
+   * summed into `costUSD`; the count exists so the tile can SAY the total is short.
+   */
+  creditTasks: number
+}
+
+/** The sum of what was reported, or `null` when nothing was. Mirrors the server's `sumOrNull`. */
+function sumOrNull(values: readonly (number | null)[]): number | null {
+  const real = values.filter((v): v is number => typeof v === 'number' && Number.isFinite(v))
+  return real.length === 0 ? null : real.reduce((a, b) => a + b, 0)
+}
+
+/**
+ * The tiles over the list.
+ *
+ * Every figure summed here was already decided by `task-rollup.ts` on the server and is scoped to
+ * this repository by the same filter that scoped the rows — a task spanning two repositories
+ * therefore contributes only what it spent in THIS one. Each task appears once, so nothing is
+ * double counted.
+ */
+export function repoTaskTotals(rows: readonly TaskListRow[]): RepoTaskTotals {
+  return {
+    tasks: rows.length,
+    inFlight: rows.filter(r => r.task.status !== 'done' && r.task.status !== 'abandoned').length,
+    delivered: rows.filter(r => r.task.status === 'done').length,
+    abandoned: rows.filter(r => r.task.status === 'abandoned').length,
+    sessions: rows.reduce((a, r) => a + r.rollup.sessionsLinked, 0),
+    costUSD: sumOrNull(rows.map(r => r.rollup.costUSD)),
+    tokens: sumOrNull(rows.map(r => r.rollup.tokens)),
+    creditTasks: rows.filter(r => r.rollup.credits !== null).length,
+  }
+}

--- a/packages/web/src/lib/tasks.ts
+++ b/packages/web/src/lib/tasks.ts
@@ -112,6 +112,12 @@ export interface TaskListRow {
   rollup: AttemptRollup
   counts: { comments: number; subtasks: number; subtasksDone: number; files: number }
   harnesses: string[]
+  /**
+   * The repositories this task's sessions touched — normalized remotes, `''` for the "no linked
+   * repository" bucket. Decided on the server from the sessions themselves (see `reposOfRows`), so
+   * the Repositories page and the board can never disagree about which deliveries belong where.
+   */
+  repos: string[]
 }
 
 export interface Bucket { key: string; sessions: number; tokens: number | null }

--- a/packages/web/src/pages/RepoDetailPage.tsx
+++ b/packages/web/src/pages/RepoDetailPage.tsx
@@ -4,7 +4,7 @@ import { useOutletContext, useParams, useNavigate } from 'react-router-dom'
 import {
   GitBranch, ArrowLeft, ExternalLink, Link2Off, Users, Zap, Workflow as WorkflowIcon, GitCompare,
   Clock, GitCommit, ChevronDown, DollarSign, Cpu, Wrench, Bot, FileCode, MessageSquare, Database, AlertTriangle,
-  EyeOff,
+  EyeOff, ClipboardList,
 } from 'lucide-react'
 import type { AppContext, } from '../lib/app-context'
 import type { SessionMeta, MemberPresence, HarnessId, WorkflowRun, WorkflowAgent } from '@agentistics/core'
@@ -23,8 +23,12 @@ import { ModelBreakdown } from '../components/ModelBreakdown'
 import { ActivityChart } from '../components/ActivityChart'
 import { RecentSessions } from '../components/RecentSessions'
 import { MetricNote } from '../components/MetricNote'
+import { BetaTag } from '../components/BetaTag'
+import { RepoTasksTab } from '../components/tasks/RepoTasksTab'
+import { repoTaskTotals, tasksOfRepo } from '../lib/repoTasks'
+import { useTaskList } from '../lib/tasks'
 
-type Tab = 'overview' | 'members' | 'compare' | 'actions' | 'sessions' | 'workflows'
+type Tab = 'overview' | 'members' | 'compare' | 'actions' | 'sessions' | 'tasks' | 'workflows'
 
 export default function RepoDetailPage() {
   const ctx = useOutletContext<AppContext>()
@@ -59,6 +63,17 @@ export default function RepoDetailPage() {
     () => new Map((data.sessions ?? []).map(s => [s.session_id, s] as [string, SessionMeta])),
     [data.sessions],
   )
+  // The board, scoped by the SAME filters as every other tab — `/api/tasks` already takes `repos`
+  // and `projects`, so nothing here re-derives a scope. A central (or a profile with no host power)
+  // answers `refused`, which arrives as an empty list and simply leaves the tab out.
+  const { rows: taskRows } = useTaskList(scopedFilters)
+  // A task belongs to a repository through its SESSIONS' `git_remote` — `''` on a `folder:` route
+  // is the "no linked repository" bucket, and the rows there arrived scoped by project.
+  const repoTasks = useMemo(
+    () => tasksOfRepo(taskRows ?? [], isFolder ? '' : remote),
+    [taskRows, isFolder, remote],
+  )
+  const taskTotals = useMemo(() => repoTaskTotals(repoTasks), [repoTasks])
 
   if (!scoped) return null
 
@@ -75,12 +90,13 @@ export default function RepoDetailPage() {
   const hiddenKey = linked ? canonicalRepoKey(remote) : NO_REPO_KEY
   const hiddenLabels = deniedRepoLabels?.get(hiddenKey)
 
-  const tabs: { id: Tab; label: string; icon: React.ReactNode; show: boolean; badge?: number }[] = [
+  const tabs: { id: Tab; label: string; icon: React.ReactNode; show: boolean; badge?: number; beta?: boolean }[] = [
     { id: 'overview', label: pt ? 'Visão geral' : 'Overview', icon: <GitBranch size={13} />, show: true },
     { id: 'members', label: pt ? 'Membros' : 'Members', icon: <Users size={13} />, show: isCentral, badge: scoped.repoStats[0]?.members.length },
     { id: 'compare', label: pt ? 'Comparar' : 'Compare', icon: <GitCompare size={13} />, show: isCentral && (scoped.repoStats[0]?.members.length ?? 0) > 1 },
     { id: 'actions', label: 'Actions', icon: <Zap size={13} />, show: ciSessions.length > 0, badge: ciSessions.length || undefined },
     { id: 'sessions', label: pt ? 'Sessões' : 'Sessions', icon: <Clock size={13} />, show: true },
+    { id: 'tasks', label: pt ? 'Entregas' : 'Tasks', icon: <ClipboardList size={13} />, show: repoTasks.length > 0, badge: repoTasks.length || undefined, beta: true },
     { id: 'workflows', label: 'Dynamic Workflows', icon: <WorkflowIcon size={13} />, show: workflows.length > 0 && workflows.some(w => capable(harnessOf(w), 'dynamicWorkflows')), badge: workflows.length },
   ]
 
@@ -188,6 +204,9 @@ export default function RepoDetailPage() {
               {t.badge != null && t.badge > 0 && (
                 <span style={{ fontSize: 10, fontWeight: 700, color: 'var(--text-tertiary)', background: 'var(--bg-elevated)', borderRadius: 8, padding: '1px 6px' }}>{t.badge}</span>
               )}
+              {/* Every ALM surface carries the mark — one that appears on five of six reads as the
+                  unmarked one being the finished part. */}
+              {t.beta && <BetaTag what={t.label} compact />}
             </button>
           )
         })}
@@ -253,6 +272,42 @@ export default function RepoDetailPage() {
         <Section title={<><Clock size={14} /> {pt ? 'Sessões recentes' : 'Recent sessions'}</>}>
           {/* RecentSessions has its own built-in sort (date/tokens/messages/tools/files). */}
           <RecentSessions sessions={sessions} lang={lang} onSelect={setSelectedSession} />
+        </Section>
+      )}
+
+      {tab === 'tasks' && (
+        <Section title={<span style={{ display: 'inline-flex', alignItems: 'center', gap: 7 }}><ClipboardList size={14} /> {pt ? 'Entregas neste repositório' : 'Tasks in this repository'} <BetaTag what={pt ? 'O board de entregas' : 'The delivery board'} /></span>}>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(120px, 1fr))', gap: 10, marginBottom: 14 }}>
+            <StatTile label={pt ? 'Entregas' : 'Tasks'} value={String(taskTotals.tasks)} />
+            <StatTile label={pt ? 'Em andamento' : 'In flight'} value={String(taskTotals.inFlight)} />
+            <StatTile label={pt ? 'Entregues' : 'Delivered'} value={String(taskTotals.delivered)} />
+            {taskTotals.abandoned > 0 && (
+              <StatTile label={pt ? 'Abandonadas' : 'Abandoned'} value={String(taskTotals.abandoned)} />
+            )}
+            <StatTile label={pt ? 'Sessões' : 'Sessions'} value={String(taskTotals.sessions)} />
+            {/* `N/A`, never a `0`: a repository whose deliveries nobody could price has not
+                delivered for free. */}
+            <StatTile label={pt ? 'Custo' : 'Cost'} value={taskTotals.costUSD === null ? 'N/A' : fmtCost(taskTotals.costUSD, currency, brlRate)} accent />
+          </div>
+          <MetricNote style={{ marginTop: 0, marginBottom: 12 }}>
+            {pt
+              ? 'Uma entrega pertence a este repositório pelo `git_remote` das sessões filiadas a ela — nunca por um campo digitado —, então uma que atravessa dois repositórios aparece nos dois, e aqui conta só o que gastou neste. Só as sessões que este repositório viu são contadas: uma sessão sem conversa vinculada não entra em nenhum número. Os filtros do topo da página valem aqui.'
+              : 'A delivery belongs to this repository through its sessions\u2019 `git_remote` \u2014 never through a field somebody typed \u2014 so one spanning two repositories appears under both, and counts here only what it spent in this one. Only the sessions this repository could see are counted: one with no linked conversation contributes to no figure. The filters at the top of the page apply here too.'}
+          </MetricNote>
+          {taskTotals.creditTasks > 0 && (
+            <MetricNote style={{ marginTop: 0, marginBottom: 12 }}>
+              {pt
+                ? `${taskTotals.creditTasks} ${taskTotals.creditTasks === 1 ? 'entrega também gastou' : 'entregas também gastaram'} créditos do Copilot. Créditos não são dólares e não entram no custo acima.`
+                : `${taskTotals.creditTasks} ${taskTotals.creditTasks === 1 ? 'delivery also spent' : 'deliveries also spent'} Copilot credits. Credits are not dollars and are not in the cost above.`}
+            </MetricNote>
+          )}
+          <RepoTasksTab
+            rows={repoTasks}
+            lang={pt ? 'pt' : 'en'}
+            currency={currency}
+            brlRate={brlRate}
+            onOpen={id => navigate(`/tasks/${encodeURIComponent(id)}`)}
+          />
         </Section>
       )}
 


### PR DESCRIPTION
## Summary

A repository says which deliveries touched it: a **Tasks** tab on `/repo/:id`, grouping the board's
tasks by the `git_remote` of the sessions filed under them.

Closes #422

## Motivation

The board answers "what did this task cost". The repositories page answers "what did this repo
cost". Neither answered the question in between — *which work was this repository for* — even though
the join already existed: `SessionMeta.git_remote` is stamped on every session, and a task's
sessions carry it.

## Test plan

- `bun test` — green (7.135)
- `bun tsc --noEmit` — clean
- Verified in a browser at 1440px and 390px

## Notes

The tab follows the page's existing rule: it appears only when the repo HAS tasks, the same way the
"Actions" tab appears only when the repo has CI sessions — an empty tab is a promise that something
might be behind it.

Written by another session; opened and merged from the ALM session at the user's direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FGkcvwXs6YneNVwSySTcZr
