### PR TITLE
feat(sessions): reopen what fell, and one prompt to several sessions

### DIFF
--- a/packages/server/server/cli-i18n.ts
+++ b/packages/server/server/cli-i18n.ts
@@ -177,6 +177,14 @@ export interface CliStrings {
   sessNoFell: string
   sessFellOpened: (opened: number, skipped: number, held: number) => string
   sessFellNoneOpened: (skipped: number) => string
+  /** Every row that was ticked has since left the group — the list the caller acted on has moved. */
+  sessFellGone: (count: number) => string
+  /** Nothing was ticked. Never read as "all" — see `selectFell`. */
+  sessFellNonePicked: string
+  /** A broadcast that was refused before anything was typed. */
+  sessBroadcastRefused: (reason: string, skipped: number) => string
+  /** What a broadcast did, per outcome. Partial delivery is the NORMAL case. */
+  sessBroadcastDone: (sent: number, failed: number, skipped: number) => string
   /**
    * Refusing to open a conversation a live session already has, and NAMING that session.
    *
@@ -580,6 +588,26 @@ const EN: CliStrings = {
     + (skipped > 0 ? ` ${skipped} could not be reopened.` : ''),
   sessFellNoneOpened: (skipped: number) =>
     `none of the ${skipped} session(s) that fell could be reopened.`,
+  sessFellGone: (count: number) =>
+    `${count} session(s) picked are no longer in that group — they ended, or another window reopened `
+    + 'them already. Nothing was opened.',
+  sessFellNonePicked: 'no session was picked, so nothing was reopened.',
+  sessBroadcastRefused: (reason: string, skipped: number) => {
+    if (reason === 'no-text') return 'nothing was typed, so nothing was sent.'
+    if (reason === 'no-selection') return 'no session was picked. This never means all of them.'
+    if (reason === 'too-many') {
+      return 'that is more sessions than one message may reach at once — pick fewer, or send twice.'
+    }
+    return `none of the ${skipped} session(s) picked can take a prompt right now — see the reason on each.`
+  },
+  sessBroadcastDone: (sent: number, failed: number, skipped: number) => {
+    const parts = [`sent to ${sent} session${sent === 1 ? '' : 's'}`]
+    // Named separately: a REFUSAL at write time (the session was asking after all) and a row that
+    // was never eligible are two different things to do something about.
+    if (failed > 0) parts.push(`${failed} refused it`)
+    if (skipped > 0) parts.push(`${skipped} could not be sent to`)
+    return `${parts.join(', ')}.`
+  },
   sessResumeInUse: (holder: string) =>
     `that conversation is already open in ${holder} — open it there instead of starting a second assistant in it.`,
   sessAdoptFailed: (holder: string) =>
@@ -891,6 +919,24 @@ const PT: CliStrings = {
     + (skipped > 0 ? ` ${skipped} não puderam ser reabertas.` : ''),
   sessFellNoneOpened: (skipped: number) =>
     `nenhuma das ${skipped} sessão(ões) que caíram pôde ser reaberta.`,
+  sessFellGone: (count: number) =>
+    `${count} sessão(ões) escolhida(s) não está(ão) mais nesse grupo — terminaram, ou outra janela já `
+    + 'reabriu. Nada foi aberto.',
+  sessFellNonePicked: 'nenhuma sessão foi escolhida, então nada foi reaberto.',
+  sessBroadcastRefused: (reason: string, skipped: number) => {
+    if (reason === 'no-text') return 'nada foi escrito, então nada foi enviado.'
+    if (reason === 'no-selection') return 'nenhuma sessão foi escolhida. Isso nunca quer dizer todas.'
+    if (reason === 'too-many') {
+      return 'são mais sessões do que uma mensagem alcança de uma vez — escolha menos, ou envie duas vezes.'
+    }
+    return `nenhuma das ${skipped} sessão(ões) escolhida(s) pode receber um prompt agora — veja o motivo em cada uma.`
+  },
+  sessBroadcastDone: (sent: number, failed: number, skipped: number) => {
+    const parts = [`enviado para ${sent} sessão${sent === 1 ? '' : 'ões'}`]
+    if (failed > 0) parts.push(`${failed} recusou`)
+    if (skipped > 0) parts.push(`${skipped} não pôde receber`)
+    return `${parts.join(', ')}.`
+  },
   sessResumeInUse: (holder: string) =>
     `essa conversa já está aberta em ${holder} — abra ela por lá, em vez de colocar um segundo assistente dentro dela.`,
   sessAdoptFailed: (holder: string) =>

--- a/packages/server/server/cli-start.ts
+++ b/packages/server/server/cli-start.ts
@@ -135,6 +135,11 @@ import { answerFollowUp } from './sessions/answer-followup'
 import { liveTranscriptDeps, runTranscriptSearch } from './sessions/transcript-run'
 import { rulesFor } from './sessions/attention-rules'
 import { planCrashGroup, planFellOffer } from './sessions/crash-group'
+import { selectFell } from './sessions/fell-selection'
+import {
+  broadcastReport, planBroadcast, type BroadcastOutcome,
+} from './sessions/broadcast-plan'
+import { sessionRunning } from '@agentistics/tui/control/session-dimensions'
 import { loadHarnessSessions } from './sessions/harness-sessions'
 import { idleServers, isServerCommand } from './idle-servers'
 import { planTaskDelete, taskDeleteIsNoop } from './sessions/task-delete'
@@ -3182,7 +3187,7 @@ export function createControlHost(initialLang: CliLang, altScreen: Suspendable):
      * registry read and one `tmux list-sessions`, and it is the difference between reopening what
      * fell and reopening what fell as of a moment ago.
      */
-    async reopenFell(): Promise<ActionResult> {
+    async reopenFell(ids?: readonly string[]): Promise<ActionResult> {
       const s = S()
       const backend = await resolveBackend()
       const blocked = await backend.unavailable()
@@ -3192,10 +3197,73 @@ export function createControlHost(initialLang: CliLang, altScreen: Suspendable):
       const group = planCrashGroup({ entries: await readRegistry(), backendIds })
       if (!group || group.entries.length === 0) return { ok: false, message: s.sessNoFell }
 
-      const { plan, opened, skipped } = await reopenEntries(group.entries, s)
+      /**
+       * `undefined` is the whole group; `[]` is nothing. The difference is the safety — see
+       * `selectFell`. An id the group does not hold is REPORTED rather than dropped: it means the
+       * caller is acting on a list that has moved, and a count that quietly shrinks is what makes
+       * somebody press again.
+       */
+      const { chosen, unknown } = selectFell(group.entries, ids ?? null)
+      if (chosen.length === 0) {
+        return { ok: false, message: unknown.length > 0 ? s.sessFellGone(unknown.length) : s.sessFellNonePicked }
+      }
+
+      const { plan, opened, skipped } = await reopenEntries(chosen, s)
       return taskReopenSucceeded(plan, opened)
-        ? { ok: true, message: s.sessFellOpened(opened, skipped, plan.heldElsewhere.length) }
-        : { ok: false, message: s.sessFellNoneOpened(skipped) }
+        ? { ok: true, message: s.sessFellOpened(opened, skipped + unknown.length, plan.heldElsewhere.length) }
+        : { ok: false, message: s.sessFellNoneOpened(skipped + unknown.length) }
+    },
+
+    /**
+     * ONE PROMPT, SEVERAL SESSIONS — and every one of them written the ordinary way.
+     *
+     * `promptSession` is called per session precisely because it RE-READS the screen at the moment
+     * it types. A session that was running when the browser drew its list may be sitting on a
+     * permission prompt now, where a typed sentence goes into the dialog's filter and the submit
+     * takes whatever is highlighted. Sending N lines from one poll-old belief would be the one
+     * gesture in this product able to answer a dozen dialogs at once.
+     *
+     * SEQUENTIAL, not parallel. Each send types into a tmux pane and waits for the pane to settle;
+     * `pane-writer.ts` serialises writes per pane, but the sessions here are different panes and
+     * would genuinely run at once — a dozen assistants all starting to work in the same instant is
+     * a load spike on the machine the user is sitting at. One at a time is also what makes the
+     * report readable in the order the list was shown.
+     */
+    async broadcastPrompt(ids: readonly string[], text: string): Promise<ActionResult> {
+      const s = S()
+      const backend = await resolveBackend()
+      const blocked = await backend.unavailable()
+      if (blocked) return { ok: false, message: blocked }
+
+      const fleet = await this.sessions?.()
+      const rows = fleet?.sessions ?? []
+      const plan = planBroadcast({
+        text,
+        ids,
+        rows: rows.map(r => ({
+          id: r.id,
+          title: r.title,
+          running: sessionRunning(r),
+          // The row's own knowledge of an open dialog. The HOST still re-reads at write time; this
+          // only keeps a doomed send out of the list before anything is typed.
+          blocked: (r.approvalLines?.length ?? 0) > 0,
+        })),
+      })
+      if (!plan.ok) return { ok: false, message: s.sessBroadcastRefused(plan.reason, plan.skipped.length) }
+
+      const outcomes: BroadcastOutcome[] = []
+      for (const t of plan.targets) {
+        const out = await this.promptSession!(t.id, text)
+        outcomes.push({ id: t.id, title: t.title, ok: out.ok, message: out.message })
+      }
+      const report = broadcastReport(outcomes, plan.skipped)
+      return {
+        // ANY delivery is a success for the gesture; the sentence carries the rest. A broadcast
+        // where four of five landed is not a failure, and reporting it as one would send somebody
+        // to re-send to the four that already have it.
+        ok: report.sent > 0,
+        message: s.sessBroadcastDone(report.sent, report.failed, report.skipped.length),
+      }
     },
 
     /**

--- a/packages/server/server/sessions/broadcast-plan.test.ts
+++ b/packages/server/server/sessions/broadcast-plan.test.ts
@@ -1,0 +1,109 @@
+import { test, expect } from 'bun:test'
+import { MAX_BROADCAST, broadcastReport, planBroadcast } from './broadcast-plan'
+import type { BroadcastCandidate } from './broadcast-plan'
+
+const row = (id: string, o: Partial<BroadcastCandidate> = {}): BroadcastCandidate => ({
+  id, title: id.toUpperCase(), running: true, blocked: false, ...o,
+})
+
+test('sends to the running rows that were ticked', () => {
+  const p = planBroadcast({ text: 'ship it', ids: ['a', 'b'], rows: [row('a'), row('b'), row('c')] })
+  expect(p.ok).toBe(true)
+  if (!p.ok) throw new Error('expected ok')
+  expect(p.targets.map(t => t.id)).toEqual(['a', 'b'])
+  expect(p.skipped).toEqual([])
+})
+
+/**
+ * A prompt to a row that is not running has nowhere to go, and one to a row sitting on a dialog
+ * goes into the dialog's filter where the submit takes whatever is highlighted. Both are REPORTED:
+ * a count that shrinks between what was ticked and what was sent is what makes somebody re-send.
+ */
+test('names what it will not send to, rather than dropping it', () => {
+  const p = planBroadcast({
+    text: 'go',
+    ids: ['live', 'dead', 'asking'],
+    rows: [row('live'), row('dead', { running: false }), row('asking', { blocked: true })],
+  })
+  expect(p.ok).toBe(true)
+  if (!p.ok) throw new Error('expected ok')
+  expect(p.targets.map(t => t.id)).toEqual(['live'])
+  expect(p.skipped).toEqual([
+    { id: 'dead', title: 'DEAD', reason: 'not-running' },
+    { id: 'asking', title: 'ASKING', reason: 'dialog-open' },
+  ])
+})
+
+test('an id nobody knows is its own reason, and keeps the id as its label', () => {
+  const p = planBroadcast({ text: 'go', ids: ['ghost'], rows: [row('a')] })
+  expect(p.ok).toBe(false)
+  if (p.ok) throw new Error('expected refusal')
+  expect(p.reason).toBe('none-eligible')
+  expect(p.skipped).toEqual([{ id: 'ghost', title: 'ghost', reason: 'unknown' }])
+})
+
+/** Refused, not "sent to nobody" — the mistake has to be visible. */
+test('an empty prompt is refused', () => {
+  expect(planBroadcast({ text: '   ', ids: ['a'], rows: [row('a')] }))
+    .toEqual({ ok: false, reason: 'no-text', skipped: [] })
+})
+
+/**
+ * Unlike `selectFell`, there is NO "all" here. Reopening what a crash took has a defensible one;
+ * typing into every session on the machine does not.
+ */
+test('an empty selection is refused and never read as everything', () => {
+  expect(planBroadcast({ text: 'go', ids: [], rows: [row('a'), row('b')] }))
+    .toEqual({ ok: false, reason: 'no-selection', skipped: [] })
+})
+
+test('the same row ticked twice is one target', () => {
+  const p = planBroadcast({ text: 'go', ids: ['a', 'a'], rows: [row('a')] })
+  if (!p.ok) throw new Error('expected ok')
+  expect(p.targets).toHaveLength(1)
+})
+
+/** A blast radius, not a performance limit: beyond this the list stops being read before pressing. */
+test('refuses more than the cap', () => {
+  const rows = Array.from({ length: MAX_BROADCAST + 1 }, (_, i) => row(`s${i}`))
+  const p = planBroadcast({ text: 'go', ids: rows.map(r => r.id), rows })
+  expect(p.ok).toBe(false)
+  if (p.ok) throw new Error('expected refusal')
+  expect(p.reason).toBe('too-many')
+  // Exactly at the cap is fine.
+  const at = rows.slice(0, MAX_BROADCAST)
+  expect(planBroadcast({ text: 'go', ids: at.map(r => r.id), rows }).ok).toBe(true)
+})
+
+/**
+ * The cap counts TARGETS, not the selection: rows that were going to be skipped anyway cost
+ * nothing, and refusing over them would be refusing over something that was not going to happen.
+ */
+test('rows that would be skipped do not count against the cap', () => {
+  const live = Array.from({ length: MAX_BROADCAST }, (_, i) => row(`l${i}`))
+  const dead = Array.from({ length: 20 }, (_, i) => row(`d${i}`, { running: false }))
+  const p = planBroadcast({
+    text: 'go', ids: [...live, ...dead].map(r => r.id), rows: [...live, ...dead],
+  })
+  expect(p.ok).toBe(true)
+})
+
+/**
+ * PER SESSION, always. A broadcast is the one action here where partial success is NORMAL — one
+ * takes it, one is mid-dialog by the time its turn comes, one has just died — and collapsing that
+ * into "sent to 5 sessions" makes exactly the failures invisible that re-reading each screen at
+ * write time exists to produce.
+ */
+test('the report keeps every outcome, and counts both sides', () => {
+  const r = broadcastReport(
+    [
+      { id: 'a', title: 'A', ok: true, message: 'sent' },
+      { id: 'b', title: 'B', ok: false, message: 'that session is not asking anything right now' },
+    ],
+    [{ id: 'c', title: 'C', reason: 'not-running' }],
+  )
+  expect(r.sent).toBe(1)
+  expect(r.failed).toBe(1)
+  expect(r.skipped).toHaveLength(1)
+  expect(r.outcomes.find(o => o.id === 'b')!.message).toContain('not asking')
+})

--- a/packages/server/server/sessions/broadcast-plan.ts
+++ b/packages/server/server/sessions/broadcast-plan.ts
@@ -1,0 +1,132 @@
+/**
+ * broadcast-plan.ts — PURE: one prompt, several sessions. What goes where, and what comes back.
+ *
+ * The most powerful thing on the fleet screen. `promptSession` types a line into ONE session after
+ * re-reading its screen; this asks for the same line in several, which multiplies both the use and
+ * the damage. So the rules here are about what it REFUSES.
+ *
+ * ## Every session is still checked on its own
+ *
+ * This plan says which sessions are worth ASKING about. It does not send anything and it does not
+ * decide whether a send is safe: `promptSession` re-reads each screen at the moment it writes,
+ * because a session that was working five seconds ago may be sitting on a permission prompt now,
+ * where a typed sentence is an answer to a question nobody read. A broadcast that skipped that
+ * check to save five round trips would be the one gesture in this product able to answer a dozen
+ * dialogs at once.
+ *
+ * That is why `plan` carries no "safe" flag. The only thing it can know from a poll-old list is
+ * which rows could not possibly take a prompt — and it says so per row, so the refusals are
+ * readable BEFORE anything is sent rather than as a list of failures afterwards.
+ *
+ * ## The rules
+ *
+ * - **A session that is not RUNNING is excluded, by name.** A prompt to a `lost` or `exited` row
+ *   has nowhere to go. It is reported rather than dropped: a count that shrinks between what was
+ *   ticked and what was sent is the thing that makes somebody re-send.
+ * - **A session with a DIALOG OPEN is excluded, by name.** The row already knows this — it is the
+ *   same rule the composer keeps — and a sentence typed into a dialog goes into its filter, where
+ *   the submit takes whatever is highlighted.
+ * - **AN EMPTY PROMPT IS REFUSED.** Not "sent to nobody": refused, so the mistake is visible.
+ * - **AN EMPTY SELECTION IS REFUSED**, and never read as "everything". Same rule, same reason, as
+ *   `selectFell`.
+ * - **A cap.** `MAX_BROADCAST` sessions at once. Beyond that this stops being a message and becomes
+ *   a fleet command nobody can take back, and the number is small enough to read in a confirmation.
+ */
+
+/** What a row has to say for itself before this can decide anything. */
+export interface BroadcastCandidate {
+  id: string
+  /** What the row is called, for the confirmation and the report. */
+  title: string
+  /** Is it running right now? */
+  running: boolean
+  /** Is a dialog open on it? A prompt would go into the dialog's filter. */
+  blocked: boolean
+}
+
+/** A session this prompt will be offered to. */
+export interface BroadcastTarget { id: string; title: string }
+
+/** A session it will not, and the reason in a code the caller renders. */
+export interface BroadcastSkip {
+  id: string
+  title: string
+  reason: 'not-running' | 'dialog-open' | 'unknown'
+}
+
+export type BroadcastPlan =
+  | { ok: true; targets: BroadcastTarget[]; skipped: BroadcastSkip[] }
+  | { ok: false; reason: 'no-text' | 'no-selection' | 'none-eligible' | 'too-many'; skipped: BroadcastSkip[] }
+
+/**
+ * How many sessions one broadcast may reach.
+ *
+ * Not a performance limit — it is a blast radius. Beyond a dozen this stops being a message to a
+ * few sessions and becomes a command to a fleet, and the list stops being something a person reads
+ * before pressing. A caller that wants more sends twice, which is a decision made twice.
+ */
+export const MAX_BROADCAST = 12
+
+export function planBroadcast(o: {
+  text: string
+  /** The ids the user ticked. NEVER null: there is no "all" for this — see the header. */
+  ids: readonly string[]
+  /** Every row the caller knows about, from the last poll. */
+  rows: readonly BroadcastCandidate[]
+}): BroadcastPlan {
+  const skipped: BroadcastSkip[] = []
+  if (o.text.trim() === '') return { ok: false, reason: 'no-text', skipped }
+  // Deliberately no `null` case, unlike `selectFell`: reopening what a crash took has a defensible
+  // "all", and typing into every session on the machine does not.
+  if (o.ids.length === 0) return { ok: false, reason: 'no-selection', skipped }
+
+  const known = new Map(o.rows.map(r => [r.id, r]))
+  const seen = new Set<string>()
+  const targets: BroadcastTarget[] = []
+  for (const id of o.ids) {
+    if (seen.has(id)) continue
+    seen.add(id)
+    const row = known.get(id)
+    if (!row) { skipped.push({ id, title: id, reason: 'unknown' }); continue }
+    if (!row.running) { skipped.push({ id, title: row.title, reason: 'not-running' }); continue }
+    if (row.blocked) { skipped.push({ id, title: row.title, reason: 'dialog-open' }); continue }
+    targets.push({ id, title: row.title })
+  }
+
+  // Counted over the TARGETS, not the selection: rows that were going to be skipped anyway cost
+  // nothing, and refusing because of them would be refusing over something that was not going to
+  // happen.
+  if (targets.length > MAX_BROADCAST) return { ok: false, reason: 'too-many', skipped }
+  if (targets.length === 0) return { ok: false, reason: 'none-eligible', skipped }
+  return { ok: true, targets, skipped }
+}
+
+/** What one session's send did. `message` is the host's own sentence, kept verbatim. */
+export interface BroadcastOutcome { id: string; title: string; ok: boolean; message: string }
+
+export interface BroadcastReport {
+  sent: number
+  failed: number
+  /** Rows the plan never attempted, with their reasons. */
+  skipped: BroadcastSkip[]
+  outcomes: BroadcastOutcome[]
+}
+
+/**
+ * The report, from what actually happened.
+ *
+ * PER SESSION, always — never a single "sent to 5 sessions". A broadcast is the one action here
+ * where a partial success is normal: one session takes it, one is mid-dialog by the time its turn
+ * comes, one has just died. Collapsing that into one sentence would make the failures invisible,
+ * and the whole reason to re-read each screen at write time is that failures are EXPECTED.
+ */
+export function broadcastReport(
+  outcomes: readonly BroadcastOutcome[], skipped: readonly BroadcastSkip[],
+): BroadcastReport {
+  return {
+    sent: outcomes.filter(o => o.ok).length,
+    failed: outcomes.filter(o => !o.ok).length,
+    skipped: [...skipped],
+    outcomes: [...outcomes],
+  }
+}

--- a/packages/server/server/sessions/fell-selection.test.ts
+++ b/packages/server/server/sessions/fell-selection.test.ts
@@ -1,0 +1,51 @@
+import { test, expect } from 'bun:test'
+import { selectFell } from './fell-selection'
+import type { ManagedSession } from './types'
+
+const e = (id: string): ManagedSession => ({
+  id, harness: 'claude', cwd: '/p', createdAt: '2026-09-01T00:00:00Z',
+} as unknown as ManagedSession)
+
+const GROUP = [e('a'), e('b'), e('c')]
+
+/**
+ * THE DISTINCTION THIS MODULE EXISTS FOR. `null` is a caller with no selection to make — the
+ * cockpit's `R` on a group already named. `[]` is a person who unticked every row. Collapsing them
+ * would start every assistant on the machine because a list came back empty.
+ */
+test('null reopens everything; an empty list reopens nothing', () => {
+  expect(selectFell(GROUP, null).chosen.map(x => x.id)).toEqual(['a', 'b', 'c'])
+  expect(selectFell(GROUP, []).chosen).toEqual([])
+  expect(selectFell(GROUP, []).unknown).toEqual([])
+})
+
+test('takes exactly what was ticked', () => {
+  expect(selectFell(GROUP, ['a', 'c']).chosen.map(x => x.id)).toEqual(['a', 'c'])
+})
+
+/**
+ * The caller is acting on a list that has moved — the session ended on its own, or another window
+ * reopened it. A count that quietly shrinks is how somebody concludes a button half-worked.
+ */
+test('an unknown id is reported, never silently dropped', () => {
+  const out = selectFell(GROUP, ['a', 'gone'])
+  expect(out.chosen.map(x => x.id)).toEqual(['a'])
+  expect(out.unknown).toEqual(['gone'])
+})
+
+test('the same row ticked twice is one session', () => {
+  expect(selectFell(GROUP, ['b', 'b', 'b']).chosen.map(x => x.id)).toEqual(['b'])
+})
+
+/**
+ * The group is ordered newest-first by `planFellOffer`, and a browser hands back whatever order its
+ * DOM was in. The order that means something is the offered one.
+ */
+test('restores the order they were offered in, whatever order they arrive', () => {
+  expect(selectFell(GROUP, ['c', 'a', 'b']).chosen.map(x => x.id)).toEqual(['a', 'b', 'c'])
+})
+
+test('an empty group yields nothing, and says which ids it could not find', () => {
+  expect(selectFell([], null).chosen).toEqual([])
+  expect(selectFell([], ['a']).unknown).toEqual(['a'])
+})

--- a/packages/server/server/sessions/fell-selection.ts
+++ b/packages/server/server/sessions/fell-selection.ts
@@ -1,0 +1,61 @@
+/**
+ * fell-selection.ts — PURE: WHICH of the sessions that fell to reopen.
+ *
+ * `planCrashGroup` decides which sessions the machine took, and `planFellOffer` reduces those to
+ * rows somebody can read. This is the third question, and it did not exist: reopening was
+ * ALL OR NOTHING. The cockpit's `R` and the fleet's `reopenFell` both took the whole group, so a
+ * laptop that died with eight sessions open offered one button that started eight assistants.
+ *
+ * Asked for: a list where everything is ticked and any of them can be unticked. That is a better
+ * default than the reverse — the common case really is "put my machine back" — and the point is
+ * that it is a default rather than the only answer.
+ *
+ * ## The rules, and why each is a refusal rather than a repair
+ *
+ * - **An EMPTY selection reopens nothing.** It is never read as "all". Unticking every row is a
+ *   decision, and the one thing this must not do is start eight assistants because a list came
+ *   back empty for a reason nobody anticipated.
+ * - **`null` IS "all"**, and is what a caller that has no selection to make passes — the cockpit's
+ *   `R`, which is a single keypress on a group that was already named. The distinction between
+ *   `null` and `[]` is the whole safety of this module and is the first thing its tests pin.
+ * - **An unknown id is REPORTED, never silently dropped.** It means the caller is acting on a list
+ *   that has moved — the session ended on its own, or another window reopened it already — and a
+ *   count that quietly shrinks is how somebody concludes a button half-worked.
+ * - **A duplicate id is one session.** Ids arrive from a browser; the same row ticked twice must
+ *   not spawn twice.
+ */
+
+import type { ManagedSession } from './types'
+
+export interface FellSelection {
+  /** The entries to reopen, in the order they were offered. */
+  chosen: ManagedSession[]
+  /** Ids the caller asked for that are not in the group at all. */
+  unknown: string[]
+}
+
+/**
+ * `ids === null` reopens everything; `[]` reopens nothing. See the header — those two are
+ * deliberately different, and nothing here may collapse them.
+ */
+export function selectFell(
+  entries: readonly ManagedSession[], ids: readonly string[] | null,
+): FellSelection {
+  if (ids === null) return { chosen: [...entries], unknown: [] }
+  const known = new Map(entries.map(e => [e.id, e]))
+  const seen = new Set<string>()
+  const chosen: ManagedSession[] = []
+  const unknown: string[] = []
+  for (const id of ids) {
+    if (seen.has(id)) continue
+    seen.add(id)
+    const entry = known.get(id)
+    if (entry) chosen.push(entry)
+    else unknown.push(id)
+  }
+  // Back into the order they were OFFERED in: the group is ordered newest-first for a reason, and a
+  // caller's array order is whatever the DOM happened to hand back.
+  const rank = new Map(entries.map((e, i) => [e.id, i]))
+  chosen.sort((a, b) => (rank.get(a.id) ?? 0) - (rank.get(b.id) ?? 0))
+  return { chosen, unknown }
+}

--- a/packages/server/server/sessions/fleet-row.ts
+++ b/packages/server/server/sessions/fleet-row.ts
@@ -86,7 +86,7 @@ export type FleetActionId =
    * `deleteTask` removes a piece of work by NAME, which is why it is the one action here whose
    * subject comes from `text`.
    */
-  | 'reopenFell' | 'deleteTask'
+  | 'reopenFell' | 'deleteTask' | 'broadcast'
 
 export interface FleetActionRequest {
   id: string
@@ -95,6 +95,19 @@ export interface FleetActionRequest {
   text?: string
   /** The option NUMBER for `approve` on a numbered dialog. Never defaulted — see `answerSession`. */
   choice?: number
+  /**
+   * The rows a FLEET action acts on: which of the fallen to reopen, which sessions to broadcast to.
+   *
+   * It can only ever NARROW a set the server has already decided. `reopenFell` intersects it with
+   * the group `planCrashGroup` computed here, and `broadcast` with the fleet's own live rows — so a
+   * caller naming arbitrary ids reaches nothing that was not already going to be offered. That is
+   * what makes a list safe to accept at all, and it is checked in `selectFell` / `planBroadcast`
+   * rather than trusted from here.
+   *
+   * For `reopenFell`, ABSENT means the whole group and an EMPTY ARRAY means nothing. The two are
+   * deliberately different; see `selectFell`.
+   */
+  ids?: string[]
 }
 
 /** How a verb is offered to the page: performable, present-but-refused, or absent. */
@@ -125,6 +138,15 @@ export interface FleetRow {
   stateLabel: string
   /** True for a row agentop hosts. An `external`/`closed` row carries no activity and no verbs. */
   actionable: boolean
+  /**
+   * This row is one of the sessions the machine TOOK — a reboot, a laptop closed with it open.
+   *
+   * Only the COUNT used to travel, on the reasoning that the rows are already in this list and
+   * shipping the set twice is two things that can disagree. True, and the mark was never sent — so
+   * the browser had a count with no way to know WHICH rows it was about, and could offer nothing
+   * but all-or-nothing. This is the mark, not a second copy of the set.
+   */
+  fell?: boolean
   task?: string
   note?: string
   model?: string
@@ -206,6 +228,7 @@ export function fleetRow(row: ControlSession, s: ControlStrings): FleetRow {
     state: row.state,
     stateLabel: row.stateLabel,
     actionable: row.actionable,
+    ...(row.fell ? { fell: true } : {}),
     ...(row.task ? { task: row.task } : {}),
     ...(row.note ? { note: row.note } : {}),
     ...(row.model ? { model: row.model } : {}),

--- a/packages/server/server/sessions/fleet-web.ts
+++ b/packages/server/server/sessions/fleet-web.ts
@@ -65,7 +65,13 @@ export interface FleetPayload {
   tasks: string[]
   /** The tasks the user marked FINISHED — a statement about the work, not about any session. */
   finishedTasks?: string[]
-  /** How many sessions FELL together, when some did — the "reopen what fell" offer. */
+  /**
+   * The fall: how many, and when.
+   *
+   * WHICH rows is not repeated here — they are in `sessions`, each marked `fell`, and shipping the
+   * set twice is two things that can disagree about it. The count is what a summary line needs; the
+   * marks are what a list somebody ticks needs.
+   */
   fell?: { count: number; atMs: number }
   /**
    * The same fleet, ARRANGED as the caller asked (`fleet-arrange.ts`).
@@ -227,6 +233,19 @@ export async function runFleetAction(
   const s = controlStrings(lang)
   const host = await hostFor(lang)
   const text = (req.text ?? '').trim()
+  /*
+   * `ids` ARRIVES FROM A BROWSER, so its SHAPE is checked here and nowhere else.
+   *
+   * The route reads the whole body as a `FleetActionRequest`; a declared type is not a parse. A
+   * bare string would iterate as CHARACTERS in the group planners, quietly turning one id into
+   * dozens of one-letter ones — the planners would reject every one of them, so the failure is a
+   * confusing report rather than an unsafe act, but a confusing report is what people file bugs
+   * about. `undefined` survives as `undefined`: for `reopenFell` that means THE WHOLE GROUP, and
+   * collapsing it into an empty array would silently turn "reopen them all" into "reopen nothing".
+   */
+  const ids = Array.isArray(req.ids)
+    ? req.ids.filter((v): v is string => typeof v === 'string' && v.length > 0)
+    : undefined
 
   switch (req.action) {
     case 'approve':
@@ -283,12 +302,25 @@ export async function runFleetAction(
       if (!host.interruptSession) return { ok: false, message: s.sessionsNoHost }
       return await host.interruptSession(req.id)
     }
-    // Acts on the GROUP that fell together, not on a row — the caller names nothing, and the
-    // cockpit's own `task-reopen` arithmetic decides which sessions were in it. A caller that could
-    // pass a list could resurrect anything on this machine.
+    /**
+     * Acts on the GROUP that fell together, not on a row. `ids` can only NARROW that group: the
+     * server computes it with `planCrashGroup` and `selectFell` intersects, so a caller naming
+     * arbitrary ids resurrects nothing — which is what the older "the caller names nothing" rule
+     * was protecting, kept by construction rather than by refusing to listen.
+     *
+     * ABSENT is the whole group (the cockpit's `R`); an EMPTY ARRAY is nothing. Never collapsed.
+     */
     case 'reopenFell':
       if (!host.reopenFell) return { ok: false, message: s.sessionsNoHost }
-      return await host.reopenFell()
+      return await host.reopenFell(ids)
+    /**
+     * ONE PROMPT, SEVERAL SESSIONS. The ids narrow the fleet's own live rows, and every send still
+     * goes through `promptSession`, which re-reads that session's screen as it types — see
+     * `broadcastPrompt`. Nothing here bypasses a single-session rule.
+     */
+    case 'broadcast':
+      if (!host.broadcastPrompt) return { ok: false, message: s.sessionsNoHost }
+      return await host.broadcastPrompt(ids ?? [], text)
     // The one action whose subject is a NAME rather than a row: a task is not a session.
     case 'deleteTask':
       if (!host.deleteTask) return { ok: false, message: s.sessionsNoHost }

--- a/packages/tui/src/control/i18n.ts
+++ b/packages/tui/src/control/i18n.ts
@@ -1035,10 +1035,13 @@ const EN: ControlStrings = {
   sessionsReopenConfirm: task => `Reopen "${task}"?`,
   sessionsFellWord: 'fell together',
   sessionsFellNote: (count, ago) =>
-    `${count} session${count === 1 ? '' : 's'} fell ${ago} — R reopens them`,
+    `${count} session${count === 1 ? '' : 's'} ${count === 1 ? 'was' : 'were'} open when the machine `
+    + `stopped ${ago} — press R to bring ${count === 1 ? 'it' : 'them'} back`,
   sessionsFellConfirm: (count, ago) =>
-    `Reopen the ${count} session${count === 1 ? '' : 's'} that fell ${ago}? `
-    + 'Each comes back as a new session resuming its own conversation; anything still running is left alone.',
+    `Bring back the ${count} session${count === 1 ? '' : 's'} that ${count === 1 ? 'was' : 'were'} open `
+    + `when the machine stopped ${ago}? `
+    + 'Each resumes its own conversation where it left off, under a new session; '
+    + 'anything still running is left alone.',
   sessionsDeleteTaskAsk: (task, count) => count === 0
     ? `Remove the task "${task}"? No session is filed under it.`
     : `Remove the task "${task}"? The ${count} session${count === 1 ? '' : 's'} filed under it `
@@ -1589,12 +1592,15 @@ const PT: ControlStrings = {
   sessionsReopenConfirm: task => `Reabrir "${task}"?`,
   sessionsFellWord: 'caíram juntas',
   sessionsFellNote: (count, ago) =>
-    (count === 1 ? `1 sessão caiu ${ago} — R reabre` : `${count} sessões caíram ${ago} — R reabre todas`),
+    (count === 1
+      ? `1 sessão estava aberta quando a máquina parou ${ago} — R traz de volta`
+      : `${count} sessões estavam abertas quando a máquina parou ${ago} — R traz todas de volta`),
   sessionsFellConfirm: (count, ago) =>
     (count === 1
-      ? `Reabrir a sessão que caiu ${ago}? `
-      : `Reabrir as ${count} sessões que caíram ${ago}? `)
-    + 'Cada uma volta como uma sessão nova retomando a própria conversa; o que ainda estiver rodando fica como está.',
+      ? `Trazer de volta a sessão que estava aberta quando a máquina parou ${ago}? `
+      : `Trazer de volta as ${count} sessões que estavam abertas quando a máquina parou ${ago}? `)
+    + 'Cada uma retoma a própria conversa de onde parou, sob uma sessão nova; '
+    + 'o que ainda estiver rodando fica como está.',
   sessionsDeleteTaskAsk: (task, count) => count === 0
     ? `Remover a tarefa "${task}"? Nenhuma sessão está sob ela.`
     : `Remover a tarefa "${task}"? ${count === 1 ? 'A sessão' : `As ${count} sessões`} sob ela `

--- a/packages/tui/src/control/types.ts
+++ b/packages/tui/src/control/types.ts
@@ -1566,14 +1566,34 @@ export interface ControlHost {
   answerSession?(id: string, choice?: number, text?: string): Promise<ActionResult>
 
   /**
-   * Reopen every session of the last fall, in the background.
+   * Reopen the sessions of the last fall, in the background.
    *
    * The same arithmetic `openTask` runs (`task-reopen.ts`), over the set `ControlSessions.fell`
    * names instead of over a task: a row still running is left alone and reported as such, a row
    * already finished is not resurrected, an unresolvable one is skipped AND counted, and everything
    * reopened retires the row it replaced.
+   *
+   * `ids` NARROWS it to a chosen few. `undefined` means the whole group and is what a caller with
+   * no selection to make passes — the cockpit's `R`, one keypress on a group already named. An
+   * EMPTY ARRAY reopens nothing and is never read as "all": unticking every row in the browser's
+   * list is a decision, and starting eight assistants because a list arrived empty is the accident
+   * `selectFell` exists to make impossible.
    */
-  reopenFell?(): Promise<ActionResult>
+  reopenFell?(ids?: readonly string[]): Promise<ActionResult>
+
+  /**
+   * ONE PROMPT, SEVERAL SESSIONS.
+   *
+   * The most powerful thing on this screen, and it changes none of the rules that make a single
+   * prompt safe: every session is still written by `promptSession`, which RE-READS its screen at
+   * the moment it types. A broadcast that skipped that to save round trips would be the one gesture
+   * here able to answer a dozen dialogs at once.
+   *
+   * The report is PER SESSION. Partial success is the normal outcome — one takes it, one is
+   * mid-dialog by the time its turn comes, one has just died — and "sent to 5 sessions" would hide
+   * exactly the failures the re-read exists to produce.
+   */
+  broadcastPrompt?(ids: readonly string[], text: string): Promise<ActionResult>
 
   renameSession?(id: string, label: string): Promise<ActionResult>
   noteSession?(id: string, text: string): Promise<ActionResult>

--- a/packages/web/src/components/nav/SessionsAside.tsx
+++ b/packages/web/src/components/nav/SessionsAside.tsx
@@ -15,7 +15,7 @@
 import { useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react'
 import { useIsMobile } from '../../hooks/useIsMobile'
 import { useNavigate, useParams } from 'react-router-dom'
-import { Clock, Pin, PinOff, Plus, Search, X } from 'lucide-react'
+import { Clock, Pin, PinOff, Plus, RotateCcw, Search, Send, X } from 'lucide-react'
 import type { Filters } from '@agentistics/core'
 import {
   ACTIVE_STATES, DEFAULT_ORDER, filterSessions, sessionNotify, sortSessions,
@@ -24,6 +24,7 @@ import {
 import { rowSelected } from '../../lib/fleetSelection'
 import { filterFleet, ignoredDimensions } from '../../lib/fleetFilter'
 import { NewSessionModal } from '../sessions/NewSessionModal'
+import { SessionPickModal, type PickModalRow } from '../sessions/SessionPickModal'
 import { rowMenuEntries, type RowVerb } from '../../lib/rowMenu'
 import { SessionRowMenu } from '../sessions/SessionRowMenu'
 import { TaskPicker } from '../tasks/TaskPicker'
@@ -88,9 +89,22 @@ export interface SessionsAsideProps {
    * Absent on a surface that cannot act (a central relaying a machine that has not granted the
    * screen/action switches yet): the menu is then not opened at all, rather than opened inert.
    */
-  rowsById?: Map<string, { verbs: RowVerb[] }>
+  rowsById?: Map<string, {
+    verbs: RowVerb[]
+    /** This row is one of the sessions the machine TOOK — see the server's `FleetRow.fell`. */
+    fell?: boolean
+    title?: string
+    project?: string
+    cwd?: string
+  }>
   /** Performs a verb. Absent exactly where `rowsById` is absent. */
-  act?: (req: { id: string; action: string; text?: string }) => Promise<{ ok: boolean; message: string; id?: string }>
+  act?: (req: {
+    id: string
+    action: string
+    text?: string
+    /** Narrows a GROUP verb (`reopenFell`, `broadcast`). Absent = the whole group. */
+    ids?: readonly string[]
+  }) => Promise<{ ok: boolean; message: string; id?: string }>
 }
 
 /** The colour a state is said in. `running` is its own token, not `success`, which reads teal. */
@@ -143,6 +157,44 @@ export function SessionsAside({
   const { sessionId } = useParams()
   const [query, setQuery] = useState('')
   const [creating, setCreating] = useState(false)
+  /** Which GROUP modal is open, if any. Both are the one picker — see `SessionPickModal`. */
+  const [picking, setPicking] = useState<'reopen' | 'send' | null>(null)
+  const [groupBusy, setGroupBusy] = useState(false)
+
+  /*
+   * THE TWO GROUP VERBS, derived from the rows the server already shaped.
+   *
+   * `fell` is the machine's own crash grouping (`crash-group.ts`), which errs toward EXCLUDING: a
+   * session with no evidence it was ever alive is never in it. We do not re-derive it here — a
+   * second implementation of "which sessions fell together" is exactly the defect this bridge
+   * exists to prevent.
+   *
+   * Who can receive a prompt is likewise the SERVER's answer, read off each row's own `prompt`
+   * verb: it is the same resolution the cockpit acts on, and it already accounts for a session
+   * that is not running and for one sitting on an open dialog (where a typed line goes into the
+   * dialog's filter and the submit takes the highlighted option).
+   */
+  const groupRows = useMemo(() => {
+    const fellRows: PickModalRow[] = []
+    const sendRows: PickModalRow[] = []
+    if (!rowsById) return { fellRows, sendRows }
+    for (const s of rowsById.values() as Iterable<any>) {
+      const row: PickModalRow = {
+        id: s.id ?? '',
+        title: s.title || (pt ? 'sem título' : 'untitled'),
+        ...(s.project ? { detail: s.project } : {}),
+      }
+      if (!row.id) continue
+      if (s.fell) fellRows.push(row)
+      if ((s.verbs as RowVerb[] | undefined)?.some(v => v.action === 'prompt' && v.enabled)) sendRows.push(row)
+    }
+    return { fellRows, sendRows }
+  }, [rowsById, pt])
+
+  const canAct = Boolean(act) && !hideNew
+  const showFell = canAct && groupRows.fellRows.length > 0
+  // One session is not a broadcast — the row's own composer is right there and says so better.
+  const showSend = canAct && groupRows.sendRows.length > 1
   /**
    * The pinned set, from the module that already owns it.
    *
@@ -287,6 +339,76 @@ export function SessionsAside({
         <Plus size={14} />
         {pt ? 'Nova sessão' : 'New session'}
       </button>
+      )}
+
+      {/*
+        * THE GROUP VERBS, under "New session" because that is where starting work lives.
+        *
+        * "Reopen what fell" appears only when something DID fall, and it names the count: a button
+        * that is always there teaches nothing, and a bare "reopen" is a different promise from
+        * "reopen 6 sessions". Neither is offered on a surface that cannot act — a button whose only
+        * outcome is a refusal is a button that teaches the wrong thing.
+        */}
+      {showFell && (
+        <button
+          onClick={() => setPicking('reopen')}
+          style={{
+            display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 7,
+            margin: '0 2px', padding: '9px 12px', borderRadius: 9, cursor: 'pointer', minHeight: tap,
+            border: '1px solid var(--anthropic-orange)', background: 'rgba(232,146,90,0.08)',
+            color: 'var(--anthropic-orange)', fontFamily: 'inherit', fontSize: 12.5, fontWeight: 600,
+          }}
+        >
+          <RotateCcw size={14} />
+          {pt
+            ? (groupRows.fellRows.length === 1 ? 'Reabrir 1 sessão que caiu' : `Reabrir ${groupRows.fellRows.length} sessões que caíram`)
+            : (groupRows.fellRows.length === 1 ? 'Reopen 1 session that fell' : `Reopen ${groupRows.fellRows.length} sessions that fell`)}
+        </button>
+      )}
+
+      {showSend && (
+        <button
+          onClick={() => setPicking('send')}
+          style={{
+            display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 7,
+            margin: '0 2px', padding: '7px 12px', borderRadius: 9, cursor: 'pointer', minHeight: tap,
+            border: '1px dashed var(--border)', background: 'transparent',
+            color: 'var(--text-tertiary)', fontFamily: 'inherit', fontSize: 12, fontWeight: 600,
+          }}
+          onMouseEnter={e => {
+            e.currentTarget.style.borderColor = 'var(--anthropic-orange)'
+            e.currentTarget.style.color = 'var(--anthropic-orange)'
+          }}
+          onMouseLeave={e => {
+            e.currentTarget.style.borderColor = 'var(--border)'
+            e.currentTarget.style.color = 'var(--text-tertiary)'
+          }}
+        >
+          <Send size={13} />
+          {pt ? 'Enviar prompt em massa' : 'Send a prompt to several'}
+        </button>
+      )}
+
+      {picking && act && (
+        <SessionPickModal
+          kind={picking}
+          lang={lang}
+          rows={picking === 'reopen' ? groupRows.fellRows : groupRows.sendRows}
+          busy={groupBusy}
+          onClose={() => { if (!groupBusy) setPicking(null) }}
+          onConfirm={(ids, text) => {
+            setGroupBusy(true)
+            /*
+             * The GROUP is addressed, never a row: the id is the anchor the route needs and `ids`
+             * is what narrows it. Sending `ids` even when every row is ticked is deliberate — the
+             * fleet polls every five seconds, and "all of them" resolved on the server a moment
+             * later is not the list this person just read and agreed to.
+             */
+            void act({ id: ids[0] ?? '', action: picking === 'reopen' ? 'reopenFell' : 'broadcast', ids, ...(text ? { text } : {}) })
+              .then(out => { setNotice(out.message); setPicking(null) })
+              .finally(() => setGroupBusy(false))
+          }}
+        />
       )}
 
       {creating && (

--- a/packages/web/src/components/nav/SessionsAside.tsx
+++ b/packages/web/src/components/nav/SessionsAside.tsx
@@ -96,6 +96,8 @@ export interface SessionsAsideProps {
     title?: string
     project?: string
     cwd?: string
+    /** Already localized by the server — the word the fleet list prints for this row's state. */
+    stateLabel?: string
   }>
   /** Performs a verb. Absent exactly where `rowsById` is absent. */
   act?: (req: {
@@ -197,11 +199,14 @@ export function SessionsAside({
       const verb = (r.verbs as RowVerb[] | undefined)?.find(v => v.action === 'prompt')
       const enabled = Boolean(verb?.enabled)
       if (enabled) sendable++
-      sendRows.push({
-        ...base,
-        enabled,
-        ...(!enabled && verb?.reason ? { reason: verb.reason } : {}),
-      })
+      // The verb carries no reason of its own — `prompt` is enabled by being LIVE and nothing else
+      // (a session sitting on a dialog is refused later by the host, which re-reads the screen).
+      // So the reason is that fact, said with the state the SERVER already localized rather than a
+      // second vocabulary invented here.
+      const stateWord = typeof r.stateLabel === 'string' ? r.stateLabel : ''
+      const reason = verb?.reason
+        ?? (pt ? 'não está rodando' : 'not running') + (stateWord ? ` · ${stateWord}` : '')
+      sendRows.push({ ...base, enabled, ...(enabled ? {} : { reason }) })
     }
     return { fellRows, sendRows, sendable }
   }, [rowsById, pt])

--- a/packages/web/src/components/nav/SessionsAside.tsx
+++ b/packages/web/src/components/nav/SessionsAside.tsx
@@ -177,24 +177,39 @@ export function SessionsAside({
   const groupRows = useMemo(() => {
     const fellRows: PickModalRow[] = []
     const sendRows: PickModalRow[] = []
-    if (!rowsById) return { fellRows, sendRows }
-    for (const s of rowsById.values() as Iterable<any>) {
-      const row: PickModalRow = {
-        id: s.id ?? '',
-        title: s.title || (pt ? 'sem título' : 'untitled'),
-        ...(s.project ? { detail: s.project } : {}),
+    let sendable = 0
+    if (!rowsById) return { fellRows, sendRows, sendable }
+    for (const r of rowsById.values() as Iterable<any>) {
+      const id: string = r.id ?? ''
+      if (!id) continue
+      const base: PickModalRow = {
+        id,
+        title: r.title || (pt ? 'sem título' : 'untitled'),
+        ...(r.project ? { detail: r.project } : r.cwd ? { detail: r.cwd } : {}),
       }
-      if (!row.id) continue
-      if (s.fell) fellRows.push(row)
-      if ((s.verbs as RowVerb[] | undefined)?.some(v => v.action === 'prompt' && v.enabled)) sendRows.push(row)
+      if (r.fell) fellRows.push(base)
+      /*
+       * THE WHOLE FLEET IS OFFERED, and the ones that cannot take a prompt are DISABLED with the
+       * server's own reason beside them — not hidden. A session missing from the list and a session
+       * that cannot be written to look identical from the outside, and the first reads as "agentop
+       * lost it". The `Active` tab is what narrows it for somebody who only wants the runnable ones.
+       */
+      const verb = (r.verbs as RowVerb[] | undefined)?.find(v => v.action === 'prompt')
+      const enabled = Boolean(verb?.enabled)
+      if (enabled) sendable++
+      sendRows.push({
+        ...base,
+        enabled,
+        ...(!enabled && verb?.reason ? { reason: verb.reason } : {}),
+      })
     }
-    return { fellRows, sendRows }
+    return { fellRows, sendRows, sendable }
   }, [rowsById, pt])
 
   const canAct = Boolean(act) && !hideNew
   const showFell = canAct && groupRows.fellRows.length > 0
   // One session is not a broadcast — the row's own composer is right there and says so better.
-  const showSend = canAct && groupRows.sendRows.length > 1
+  const showSend = canAct && groupRows.sendable > 1
   /**
    * The pinned set, from the module that already owns it.
    *

--- a/packages/web/src/components/sessions/NewSessionModal.tsx
+++ b/packages/web/src/components/sessions/NewSessionModal.tsx
@@ -31,6 +31,7 @@ import { projectKind, type ProjectKind } from '@agentistics/core'
 import {
   KIND_TABS, SEARCH_DEBOUNCE_MS, kindEmpty, kindHint, kindLabel, type ProjectTab,
 } from '../../lib/projectTabs'
+import { Field, Muted, inputStyle } from './formBits'
 import { HARNESS_COLORS, HARNESS_LABELS } from '../../lib/harness'
 import { useIsMobile } from '../../hooks/useIsMobile'
 import { effortColor, effortSteps } from '../../lib/effortScale'
@@ -1107,32 +1108,4 @@ function ModelId({ id }: { id: string }) {
   )
 }
 
-const inputStyle: React.CSSProperties = {
-  width: '100%', boxSizing: 'border-box',
-  padding: '9px 12px 9px 30px', borderRadius: 9,
-  border: '1px solid var(--border-subtle)', background: 'var(--bg-elevated)',
-  color: 'var(--text-primary)', fontFamily: 'inherit', fontSize: 13, outline: 'none',
-}
 
-function Field({ label, hint, children }: {
-  label: string; hint?: string; children: React.ReactNode
-}) {
-  return (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: 7 }}>
-      <span style={{
-        fontSize: 11, fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.05em',
-        color: 'var(--text-tertiary)',
-      }}>
-        {label}
-      </span>
-      {children}
-      {hint && (
-        <span style={{ fontSize: 11, lineHeight: 1.5, color: 'var(--text-tertiary)' }}>{hint}</span>
-      )}
-    </div>
-  )
-}
-
-function Muted({ text }: { text: string }) {
-  return <p style={{ margin: 0, padding: '6px 4px', fontSize: 12, lineHeight: 1.5, color: 'var(--text-tertiary)' }}>{text}</p>
-}

--- a/packages/web/src/components/sessions/SessionPickModal.tsx
+++ b/packages/web/src/components/sessions/SessionPickModal.tsx
@@ -3,18 +3,23 @@
  *
  * ONE component for two features, because they differ only in where the ticks start and what the
  * button promises — see `lib/sessionPick.ts`, which holds that arithmetic and is tested apart from
- * any DOM. Two modals would be two places for the header checkbox, the count and the empty state to
- * drift, and this is a screen that starts assistants or writes into them: the number on the button
- * is the last thing anybody checks.
+ * any DOM. Two modals would be two places for the header checkbox, the count, the search and the
+ * empty state to drift, and this is a screen that starts assistants or writes into them: the
+ * number on the button is the last thing anybody checks.
+ *
+ * It is built from `formBits` and wears the new-session wizard's own shell, tab strip and field.
+ * A dialog that invents its own chrome reads as a different product from the one beside it.
  */
 import React, { useEffect, useMemo, useState } from 'react'
-import { X, RotateCcw, Send } from 'lucide-react'
+import { RotateCcw, Search, Send, X } from 'lucide-react'
 import {
-  initialPick, pickAllState, pickConfirmLabel, pickedRows, togglePick, togglePickAll,
-  type PickRow,
+  PICK_TABS, filterPickRows, initialPick, pickAllState, pickConfirmLabel, pickEmpty, pickTabHint,
+  pickTabLabel, pickedRows, togglePick, togglePickAll,
+  type PickRow, type PickTab,
 } from '../../lib/sessionPick'
 import { useIsMobile } from '../../hooks/useIsMobile'
 import { overlayPadding } from '../../lib/mobileOverlay'
+import { Field, Muted, TabStrip, inputStyle } from './formBits'
 
 /**
  * A MIRROR of the server's `MAX_BROADCAST`, kept so the client does not offer what will be refused
@@ -23,10 +28,7 @@ import { overlayPadding } from '../../lib/mobileOverlay'
  */
 const MAX_BROADCAST = 12
 
-export interface PickModalRow extends PickRow {
-  /** Shown under the title — the folder, so two sessions of one repo are told apart. */
-  detail?: string
-}
+export type PickModalRow = PickRow
 
 interface Props {
   kind: 'reopen' | 'send'
@@ -41,28 +43,38 @@ interface Props {
 export function SessionPickModal({ kind, rows, lang, busy, onClose, onConfirm }: Props) {
   const pt = lang === 'pt'
   const isMobile = useIsMobile()
+  const needsText = kind === 'send'
   const [picked, setPicked] = useState<Set<string>>(() => initialPick(rows, kind === 'reopen' ? 'all' : 'none'))
   const [text, setText] = useState('')
+  const [query, setQuery] = useState('')
+  // Reopen has no tabs: every row in it fell, so none of them is running and "Active" would always
+  // be empty. A tab that can only ever be empty is a control that teaches the wrong thing.
+  const [tab, setTab] = useState<PickTab>('active')
 
-  // The fleet polls every five seconds. A row that ended while this was open must not stay tickable,
-  // and one that arrived must not be silently ticked into a `reopen` the user never saw.
+  // The fleet polls every five seconds. A row that ended while this was open must not stay ticked,
+  // and one that arrived must not be silently ticked into a verb the user never saw.
   useEffect(() => {
     setPicked(prev => {
-      const live = new Set(rows.map(r => r.id))
-      const next = new Set([...prev].filter(id => live.has(id)))
+      const takeable = new Set(rows.filter(r => r.enabled !== false).map(r => r.id))
+      const next = new Set([...prev].filter(id => takeable.has(id)))
       return next.size === prev.size ? prev : next
     })
   }, [rows])
 
   useEffect(() => {
-    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose() }
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape' && !busy) onClose() }
     window.addEventListener('keydown', onKey)
     return () => window.removeEventListener('keydown', onKey)
-  }, [onClose])
+  }, [onClose, busy])
 
-  const allState = pickAllState(rows, picked)
+  const shown = useMemo(
+    () => (needsText ? filterPickRows(rows, tab, query) : filterPickRows(rows, 'all', query)),
+    [rows, tab, query, needsText],
+  )
+  // The header box and the button count the WHOLE selection, never the filtered view: a search that
+  // silently shrank what the button was about to do would be the worst kind of quiet.
+  const allState = pickAllState(shown, picked)
   const chosen = useMemo(() => pickedRows(rows, picked), [rows, picked])
-  const needsText = kind === 'send'
   const overCap = needsText && chosen.length > MAX_BROADCAST
   const confirm = pickConfirmLabel(chosen.length, kind, pt)
   const ready = confirm.enabled && !busy && !overCap && (!needsText || text.trim().length > 0)
@@ -78,29 +90,32 @@ export function SessionPickModal({ kind, rows, lang, busy, onClose, onConfirm }:
       : (pt
         ? 'O mesmo prompt vai para cada sessão marcada, uma de cada vez. Nenhuma vem marcada: escolha uma a uma.'
         : 'The same prompt goes to each ticked session, one at a time. None start ticked: pick them yourself.'),
+    sessions: pt ? 'Sessões' : 'Sessions',
+    prompt: pt ? 'Prompt' : 'Prompt',
     all: pt ? 'Marcar todas' : 'Tick all',
     none: pt ? 'Desmarcar todas' : 'Untick all',
-    empty: kind === 'reopen'
-      ? (pt ? 'Nada caiu. Não há o que reabrir.' : 'Nothing fell. There is nothing to reopen.')
-      : (pt ? 'Nenhuma sessão rodando para receber um prompt.' : 'No running session can receive a prompt.'),
+    searchSessions: pt ? 'Buscar por título ou pasta…' : 'Search by title or folder…',
     placeholder: pt ? 'O prompt que cada sessão vai receber…' : 'The prompt each session will receive…',
     cancel: pt ? 'Cancelar' : 'Cancel',
     cap: pt
       ? `No máximo ${MAX_BROADCAST} de uma vez — ${chosen.length} marcadas.`
       : `At most ${MAX_BROADCAST} at a time — ${chosen.length} ticked.`,
+    chosenNote: pt
+      ? `${chosen.length} marcada${chosen.length === 1 ? '' : 's'} no total`
+      : `${chosen.length} ticked in total`,
   }
 
-  const tap = isMobile ? 44 : 32
+  const tap = isMobile ? 44 : 30
 
   return (
     <div
-      onClick={onClose}
+      onClick={() => { if (!busy) onClose() }}
       style={{
-        position: 'fixed', inset: 0, zIndex: 620, display: 'flex',
-        alignItems: isMobile ? 'stretch' : 'center', justifyContent: 'center',
-        background: 'rgba(0,0,0,0.55)', backdropFilter: 'blur(4px)', WebkitBackdropFilter: 'blur(4px)',
+        position: 'fixed', inset: 0, zIndex: 620,
+        background: 'var(--ag-scrim)', backdropFilter: 'blur(3px)',
+        display: 'flex', alignItems: isMobile ? 'stretch' : 'center', justifyContent: 'center',
         // The status bar is not padding we may spend — see `overlayPadding`.
-        padding: overlayPadding(isMobile, 16),
+        padding: overlayPadding(isMobile, 20),
       }}
     >
       <div
@@ -109,127 +124,187 @@ export function SessionPickModal({ kind, rows, lang, busy, onClose, onConfirm }:
         aria-modal="true"
         aria-label={t.title}
         style={{
-          width: '100%', maxWidth: isMobile ? '100%' : 520,
-          height: isMobile ? '100%' : undefined, maxHeight: isMobile ? '100%' : '82vh',
-          display: 'flex', flexDirection: 'column',
-          background: 'var(--bg-elevated, #1a1a1a)',
-          border: isMobile ? 'none' : '1px solid var(--border, var(--ag-tint-4))',
-          borderRadius: isMobile ? 0 : 14,
-          boxShadow: '0 24px 64px rgba(0,0,0,0.7)', overflow: 'hidden',
+          background: 'var(--bg-surface)',
+          border: isMobile ? 'none' : '1px solid var(--border)',
+          borderRadius: isMobile ? 0 : 16,
+          width: '100%', maxWidth: isMobile ? '100%' : 560,
+          height: isMobile ? '100%' : undefined, maxHeight: isMobile ? '100%' : '86vh',
+          display: 'flex', flexDirection: 'column', overflow: 'hidden',
         }}
       >
-        <div style={{
-          display: 'flex', alignItems: 'center', justifyContent: 'space-between',
-          padding: '16px 18px 14px', borderBottom: '1px solid var(--border-subtle, var(--ag-tint-3))',
+        <header style={{
+          display: 'flex', alignItems: 'center', gap: 10,
+          padding: '16px 20px', borderBottom: '1px solid var(--border)',
         }}>
-          <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--text-primary, #e8e8e8)' }}>{t.title}</span>
+          <h2 style={{ margin: 0, fontSize: 15, fontWeight: 700, color: 'var(--text-primary)', flex: 1 }}>
+            {t.title}
+          </h2>
           <button
             onClick={onClose}
             aria-label={t.cancel}
             style={{
-              width: tap, height: tap, borderRadius: 6, background: 'transparent', border: 'none',
-              cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center',
-              color: 'var(--text-tertiary, #666)', padding: 0,
+              display: 'flex', width: tap, height: tap, alignItems: 'center', justifyContent: 'center',
+              borderRadius: 8, border: 'none', background: 'transparent',
+              color: 'var(--text-tertiary)', cursor: 'pointer',
             }}
           >
-            <X size={15} />
+            <X size={16} />
           </button>
-        </div>
-
-        <div style={{ padding: '12px 18px 0' }}>
-          <p style={{ margin: 0, fontSize: 12, lineHeight: 1.55, color: 'var(--text-secondary, #aaa)' }}>{t.lead}</p>
-        </div>
-
-        {rows.length > 0 && (
-          <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '12px 18px 8px' }}>
-            <input
-              id="pick-all"
-              type="checkbox"
-              checked={allState === 'all'}
-              ref={el => { if (el) el.indeterminate = allState === 'some' }}
-              onChange={() => setPicked(togglePickAll(rows, picked))}
-              style={{ width: 15, height: 15, accentColor: 'var(--anthropic-orange, #e8925a)', cursor: 'pointer' }}
-            />
-            <label htmlFor="pick-all" style={{ fontSize: 12, color: 'var(--text-secondary, #aaa)', cursor: 'pointer' }}>
-              {allState === 'all' ? t.none : t.all}
-            </label>
-          </div>
-        )}
-
-        <div style={{ flex: 1, overflowY: 'auto', padding: '0 18px 8px', minHeight: 0 }}>
-          {rows.length === 0 ? (
-            <p style={{ margin: '10px 0', fontSize: 12, color: 'var(--text-tertiary, #666)' }}>{t.empty}</p>
-          ) : rows.map(row => {
-            const on = picked.has(row.id)
-            return (
-              <label
-                key={row.id}
-                style={{
-                  display: 'flex', alignItems: 'flex-start', gap: 9, cursor: 'pointer',
-                  padding: '9px 10px', marginBottom: 5, minHeight: isMobile ? 44 : undefined,
-                  borderRadius: 8, border: '1px solid var(--border-subtle, var(--ag-tint-3))',
-                  background: on ? 'rgba(232,146,90,0.07)' : 'transparent',
-                }}
-              >
-                <input
-                  type="checkbox"
-                  checked={on}
-                  onChange={() => setPicked(togglePick(picked, row.id))}
-                  style={{ width: 15, height: 15, marginTop: 2, accentColor: 'var(--anthropic-orange, #e8925a)', cursor: 'pointer', flexShrink: 0 }}
-                />
-                <span style={{ minWidth: 0 }}>
-                  <span style={{
-                    display: 'block', fontSize: 12.5, color: 'var(--text-primary, #e8e8e8)',
-                    overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
-                  }}>
-                    {row.title}
-                  </span>
-                  {row.detail && (
-                    <span style={{
-                      display: 'block', fontSize: 11, color: 'var(--text-tertiary, #666)', marginTop: 2,
-                      overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
-                    }}>
-                      {row.detail}
-                    </span>
-                  )}
-                </span>
-              </label>
-            )
-          })}
-        </div>
-
-        {needsText && rows.length > 0 && (
-          <div style={{ padding: '4px 18px 0' }}>
-            <textarea
-              value={text}
-              onChange={e => setText(e.target.value)}
-              placeholder={t.placeholder}
-              rows={3}
-              style={{
-                width: '100%', boxSizing: 'border-box', resize: 'vertical',
-                padding: '9px 10px', borderRadius: 8,
-                border: '1px solid var(--border, var(--ag-tint-4))',
-                background: 'var(--ag-tint-1, transparent)', color: 'var(--text-primary, #e8e8e8)',
-                // 16px on mobile or iOS Safari zooms the viewport and breaks the sticky header.
-                fontSize: isMobile ? 16 : 12.5, fontFamily: 'inherit', lineHeight: 1.5,
-              }}
-            />
-            {overCap && (
-              <p role="status" style={{ margin: '6px 0 0', fontSize: 11.5, color: 'var(--accent-red, #e5484d)' }}>{t.cap}</p>
-            )}
-          </div>
-        )}
+        </header>
 
         <div style={{
+          flex: 1, minHeight: 0, overflowY: 'auto',
+          display: 'flex', flexDirection: 'column', gap: 16, padding: '16px 20px',
+        }}>
+          <p style={{ margin: 0, fontSize: 12.5, lineHeight: 1.55, color: 'var(--text-secondary)' }}>
+            {t.lead}
+          </p>
+
+          <Field label={t.sessions}>
+            <div style={{ position: 'relative' }}>
+              <Search size={13} style={{
+                position: 'absolute', left: 10, top: '50%', transform: 'translateY(-50%)',
+                color: 'var(--text-tertiary)', pointerEvents: 'none',
+              }} />
+              <input
+                value={query}
+                onChange={e => setQuery(e.target.value)}
+                placeholder={t.searchSessions}
+                // 16px on mobile or iOS Safari zooms the viewport and breaks the sticky header.
+                style={{ ...inputStyle, ...(isMobile ? { fontSize: 16 } : {}) }}
+              />
+            </div>
+
+            {needsText && (
+              <>
+                <TabStrip
+                  tabs={PICK_TABS}
+                  value={tab}
+                  onPick={setTab}
+                  label={id => pickTabLabel(id, pt)}
+                  count={id => filterPickRows(rows, id, query).length}
+                />
+                <p style={{ margin: '0 0 2px', fontSize: 10.5, lineHeight: 1.45, color: 'var(--text-tertiary)' }}>
+                  {pickTabHint(tab, pt)}
+                </p>
+              </>
+            )}
+
+            {shown.length > 0 && (
+              <label style={{
+                display: 'flex', alignItems: 'center', gap: 8, cursor: 'pointer',
+                minHeight: isMobile ? 44 : undefined,
+              }}>
+                <input
+                  type="checkbox"
+                  checked={allState === 'all'}
+                  ref={el => { if (el) el.indeterminate = allState === 'some' }}
+                  onChange={() => setPicked(togglePickAll(shown, picked))}
+                  style={{ width: 15, height: 15, accentColor: 'var(--anthropic-orange)', cursor: 'pointer' }}
+                />
+                <span style={{ fontSize: 12, color: 'var(--text-secondary)' }}>
+                  {allState === 'all' ? t.none : t.all}
+                </span>
+                {/* The total, because the header box acts on the FILTERED view and the button counts
+                    the whole selection — without this the two numbers look like a bug. */}
+                {chosen.length > 0 && (
+                  <span style={{ marginLeft: 'auto', fontSize: 11, color: 'var(--text-tertiary)' }}>
+                    {t.chosenNote}
+                  </span>
+                )}
+              </label>
+            )}
+
+            <div style={{
+              maxHeight: isMobile ? undefined : 220, overflowY: 'auto',
+              display: 'flex', flexDirection: 'column', gap: 4,
+              border: '1px solid var(--border-subtle)', borderRadius: 10, padding: 6,
+            }}>
+              {shown.length === 0 ? (
+                <Muted text={pickEmpty(needsText ? tab : 'all', query, rows.length > 0, pt)} />
+              ) : shown.map(row => {
+                const off = row.enabled === false
+                const on = picked.has(row.id)
+                return (
+                  <label
+                    key={row.id}
+                    style={{
+                      display: 'flex', alignItems: 'flex-start', gap: 9,
+                      cursor: off ? 'default' : 'pointer', opacity: off ? 0.55 : 1,
+                      padding: '9px 10px', borderRadius: 8,
+                      minHeight: isMobile ? 44 : undefined,
+                      border: `1px solid ${on ? 'var(--anthropic-orange)' : 'var(--border-subtle)'}`,
+                      background: on ? 'var(--bg-elevated)' : 'transparent',
+                    }}
+                  >
+                    <input
+                      type="checkbox"
+                      checked={on}
+                      disabled={off}
+                      onChange={() => setPicked(togglePick(picked, row.id))}
+                      style={{
+                        width: 15, height: 15, marginTop: 2, flexShrink: 0,
+                        accentColor: 'var(--anthropic-orange)', cursor: off ? 'default' : 'pointer',
+                      }}
+                    />
+                    <span style={{ minWidth: 0, flex: 1 }}>
+                      <span style={{
+                        display: 'block', fontSize: 12.5, color: 'var(--text-primary)',
+                        overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+                      }}>
+                        {row.title}
+                      </span>
+                      {row.detail && (
+                        <span style={{
+                          display: 'block', fontSize: 11, color: 'var(--text-tertiary)', marginTop: 2,
+                          overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+                        }}>
+                          {row.detail}
+                        </span>
+                      )}
+                      {/* WHY it cannot be picked. A disabled row that says nothing is
+                          indistinguishable from a broken one. */}
+                      {off && row.reason && (
+                        <span style={{ display: 'block', fontSize: 11, color: 'var(--text-tertiary)', marginTop: 3, fontStyle: 'italic' }}>
+                          {row.reason}
+                        </span>
+                      )}
+                    </span>
+                  </label>
+                )
+              })}
+            </div>
+          </Field>
+
+          {needsText && (
+            <Field label={t.prompt}>
+              <textarea
+                value={text}
+                onChange={e => setText(e.target.value)}
+                placeholder={t.placeholder}
+                rows={3}
+                style={{
+                  ...inputStyle, paddingLeft: 12, resize: 'vertical', lineHeight: 1.5,
+                  ...(isMobile ? { fontSize: 16 } : {}),
+                }}
+              />
+              {overCap && (
+                <span role="status" style={{ fontSize: 11.5, color: 'var(--accent-red)' }}>{t.cap}</span>
+              )}
+            </Field>
+          )}
+        </div>
+
+        <footer style={{
           display: 'flex', alignItems: 'center', justifyContent: 'flex-end', gap: 8,
-          padding: '12px 14px 14px', borderTop: '1px solid var(--border-subtle, var(--ag-tint-3))',
+          padding: '14px 20px', borderTop: '1px solid var(--border)',
         }}>
           <button
             onClick={onClose}
             style={{
-              minHeight: tap, padding: '0 14px', borderRadius: 8, cursor: 'pointer',
-              border: '1px solid var(--border, var(--ag-tint-4))', background: 'transparent',
-              color: 'var(--text-secondary, #aaa)', fontFamily: 'inherit', fontSize: 12.5,
+              minHeight: isMobile ? 44 : 34, padding: '0 14px', borderRadius: 9, cursor: 'pointer',
+              border: '1px solid var(--border)', background: 'transparent',
+              color: 'var(--text-secondary)', fontFamily: 'inherit', fontSize: 12.5,
             }}
           >
             {t.cancel}
@@ -239,18 +314,18 @@ export function SessionPickModal({ kind, rows, lang, busy, onClose, onConfirm }:
             disabled={!ready}
             style={{
               display: 'flex', alignItems: 'center', gap: 7,
-              minHeight: tap, padding: '0 14px', borderRadius: 8,
+              minHeight: isMobile ? 44 : 34, padding: '0 14px', borderRadius: 9,
               cursor: ready ? 'pointer' : 'default', opacity: ready ? 1 : 0.45,
-              border: '1px solid var(--anthropic-orange, #e8925a)',
-              background: ready ? 'rgba(232,146,90,0.12)' : 'transparent',
-              color: 'var(--anthropic-orange, #e8925a)',
-              fontFamily: 'inherit', fontSize: 12.5, fontWeight: 600,
+              border: '1px solid var(--anthropic-orange)',
+              background: ready ? 'var(--bg-elevated)' : 'transparent',
+              color: 'var(--anthropic-orange)',
+              fontFamily: 'inherit', fontSize: 12.5, fontWeight: 650,
             }}
           >
             {kind === 'reopen' ? <RotateCcw size={13} /> : <Send size={13} />}
             {confirm.label}
           </button>
-        </div>
+        </footer>
       </div>
     </div>
   )

--- a/packages/web/src/components/sessions/SessionPickModal.tsx
+++ b/packages/web/src/components/sessions/SessionPickModal.tsx
@@ -1,0 +1,257 @@
+/**
+ * SessionPickModal — tick some sessions, then do one thing to all of them.
+ *
+ * ONE component for two features, because they differ only in where the ticks start and what the
+ * button promises — see `lib/sessionPick.ts`, which holds that arithmetic and is tested apart from
+ * any DOM. Two modals would be two places for the header checkbox, the count and the empty state to
+ * drift, and this is a screen that starts assistants or writes into them: the number on the button
+ * is the last thing anybody checks.
+ */
+import React, { useEffect, useMemo, useState } from 'react'
+import { X, RotateCcw, Send } from 'lucide-react'
+import {
+  initialPick, pickAllState, pickConfirmLabel, pickedRows, togglePick, togglePickAll,
+  type PickRow,
+} from '../../lib/sessionPick'
+import { useIsMobile } from '../../hooks/useIsMobile'
+import { overlayPadding } from '../../lib/mobileOverlay'
+
+/**
+ * A MIRROR of the server's `MAX_BROADCAST`, kept so the client does not offer what will be refused
+ * — the same reason the input channel keeps a copy of the key allowlist. The server stays the
+ * authority: it refuses regardless, and its refusal is what the user is shown.
+ */
+const MAX_BROADCAST = 12
+
+export interface PickModalRow extends PickRow {
+  /** Shown under the title — the folder, so two sessions of one repo are told apart. */
+  detail?: string
+}
+
+interface Props {
+  kind: 'reopen' | 'send'
+  rows: readonly PickModalRow[]
+  lang: 'pt' | 'en'
+  busy?: boolean
+  onClose: () => void
+  /** `text` is present only for `send`. */
+  onConfirm: (ids: string[], text: string) => void
+}
+
+export function SessionPickModal({ kind, rows, lang, busy, onClose, onConfirm }: Props) {
+  const pt = lang === 'pt'
+  const isMobile = useIsMobile()
+  const [picked, setPicked] = useState<Set<string>>(() => initialPick(rows, kind === 'reopen' ? 'all' : 'none'))
+  const [text, setText] = useState('')
+
+  // The fleet polls every five seconds. A row that ended while this was open must not stay tickable,
+  // and one that arrived must not be silently ticked into a `reopen` the user never saw.
+  useEffect(() => {
+    setPicked(prev => {
+      const live = new Set(rows.map(r => r.id))
+      const next = new Set([...prev].filter(id => live.has(id)))
+      return next.size === prev.size ? prev : next
+    })
+  }, [rows])
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose() }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [onClose])
+
+  const allState = pickAllState(rows, picked)
+  const chosen = useMemo(() => pickedRows(rows, picked), [rows, picked])
+  const needsText = kind === 'send'
+  const overCap = needsText && chosen.length > MAX_BROADCAST
+  const confirm = pickConfirmLabel(chosen.length, kind, pt)
+  const ready = confirm.enabled && !busy && !overCap && (!needsText || text.trim().length > 0)
+
+  const t = {
+    title: kind === 'reopen'
+      ? (pt ? 'Reabrir o que caiu' : 'Reopen what fell')
+      : (pt ? 'Enviar prompt em massa' : 'Send a prompt to several sessions'),
+    lead: kind === 'reopen'
+      ? (pt
+        ? 'Estas sessões estavam abertas quando a máquina parou. Vêm todas marcadas — desmarque as que não quiser de volta.'
+        : 'These sessions were open when the machine stopped. They all start ticked — untick any you do not want back.')
+      : (pt
+        ? 'O mesmo prompt vai para cada sessão marcada, uma de cada vez. Nenhuma vem marcada: escolha uma a uma.'
+        : 'The same prompt goes to each ticked session, one at a time. None start ticked: pick them yourself.'),
+    all: pt ? 'Marcar todas' : 'Tick all',
+    none: pt ? 'Desmarcar todas' : 'Untick all',
+    empty: kind === 'reopen'
+      ? (pt ? 'Nada caiu. Não há o que reabrir.' : 'Nothing fell. There is nothing to reopen.')
+      : (pt ? 'Nenhuma sessão rodando para receber um prompt.' : 'No running session can receive a prompt.'),
+    placeholder: pt ? 'O prompt que cada sessão vai receber…' : 'The prompt each session will receive…',
+    cancel: pt ? 'Cancelar' : 'Cancel',
+    cap: pt
+      ? `No máximo ${MAX_BROADCAST} de uma vez — ${chosen.length} marcadas.`
+      : `At most ${MAX_BROADCAST} at a time — ${chosen.length} ticked.`,
+  }
+
+  const tap = isMobile ? 44 : 32
+
+  return (
+    <div
+      onClick={onClose}
+      style={{
+        position: 'fixed', inset: 0, zIndex: 620, display: 'flex',
+        alignItems: isMobile ? 'stretch' : 'center', justifyContent: 'center',
+        background: 'rgba(0,0,0,0.55)', backdropFilter: 'blur(4px)', WebkitBackdropFilter: 'blur(4px)',
+        // The status bar is not padding we may spend — see `overlayPadding`.
+        padding: overlayPadding(isMobile, 16),
+      }}
+    >
+      <div
+        onClick={e => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-label={t.title}
+        style={{
+          width: '100%', maxWidth: isMobile ? '100%' : 520,
+          height: isMobile ? '100%' : undefined, maxHeight: isMobile ? '100%' : '82vh',
+          display: 'flex', flexDirection: 'column',
+          background: 'var(--bg-elevated, #1a1a1a)',
+          border: isMobile ? 'none' : '1px solid var(--border, var(--ag-tint-4))',
+          borderRadius: isMobile ? 0 : 14,
+          boxShadow: '0 24px 64px rgba(0,0,0,0.7)', overflow: 'hidden',
+        }}
+      >
+        <div style={{
+          display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+          padding: '16px 18px 14px', borderBottom: '1px solid var(--border-subtle, var(--ag-tint-3))',
+        }}>
+          <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--text-primary, #e8e8e8)' }}>{t.title}</span>
+          <button
+            onClick={onClose}
+            aria-label={t.cancel}
+            style={{
+              width: tap, height: tap, borderRadius: 6, background: 'transparent', border: 'none',
+              cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center',
+              color: 'var(--text-tertiary, #666)', padding: 0,
+            }}
+          >
+            <X size={15} />
+          </button>
+        </div>
+
+        <div style={{ padding: '12px 18px 0' }}>
+          <p style={{ margin: 0, fontSize: 12, lineHeight: 1.55, color: 'var(--text-secondary, #aaa)' }}>{t.lead}</p>
+        </div>
+
+        {rows.length > 0 && (
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '12px 18px 8px' }}>
+            <input
+              id="pick-all"
+              type="checkbox"
+              checked={allState === 'all'}
+              ref={el => { if (el) el.indeterminate = allState === 'some' }}
+              onChange={() => setPicked(togglePickAll(rows, picked))}
+              style={{ width: 15, height: 15, accentColor: 'var(--anthropic-orange, #e8925a)', cursor: 'pointer' }}
+            />
+            <label htmlFor="pick-all" style={{ fontSize: 12, color: 'var(--text-secondary, #aaa)', cursor: 'pointer' }}>
+              {allState === 'all' ? t.none : t.all}
+            </label>
+          </div>
+        )}
+
+        <div style={{ flex: 1, overflowY: 'auto', padding: '0 18px 8px', minHeight: 0 }}>
+          {rows.length === 0 ? (
+            <p style={{ margin: '10px 0', fontSize: 12, color: 'var(--text-tertiary, #666)' }}>{t.empty}</p>
+          ) : rows.map(row => {
+            const on = picked.has(row.id)
+            return (
+              <label
+                key={row.id}
+                style={{
+                  display: 'flex', alignItems: 'flex-start', gap: 9, cursor: 'pointer',
+                  padding: '9px 10px', marginBottom: 5, minHeight: isMobile ? 44 : undefined,
+                  borderRadius: 8, border: '1px solid var(--border-subtle, var(--ag-tint-3))',
+                  background: on ? 'rgba(232,146,90,0.07)' : 'transparent',
+                }}
+              >
+                <input
+                  type="checkbox"
+                  checked={on}
+                  onChange={() => setPicked(togglePick(picked, row.id))}
+                  style={{ width: 15, height: 15, marginTop: 2, accentColor: 'var(--anthropic-orange, #e8925a)', cursor: 'pointer', flexShrink: 0 }}
+                />
+                <span style={{ minWidth: 0 }}>
+                  <span style={{
+                    display: 'block', fontSize: 12.5, color: 'var(--text-primary, #e8e8e8)',
+                    overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+                  }}>
+                    {row.title}
+                  </span>
+                  {row.detail && (
+                    <span style={{
+                      display: 'block', fontSize: 11, color: 'var(--text-tertiary, #666)', marginTop: 2,
+                      overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+                    }}>
+                      {row.detail}
+                    </span>
+                  )}
+                </span>
+              </label>
+            )
+          })}
+        </div>
+
+        {needsText && rows.length > 0 && (
+          <div style={{ padding: '4px 18px 0' }}>
+            <textarea
+              value={text}
+              onChange={e => setText(e.target.value)}
+              placeholder={t.placeholder}
+              rows={3}
+              style={{
+                width: '100%', boxSizing: 'border-box', resize: 'vertical',
+                padding: '9px 10px', borderRadius: 8,
+                border: '1px solid var(--border, var(--ag-tint-4))',
+                background: 'var(--ag-tint-1, transparent)', color: 'var(--text-primary, #e8e8e8)',
+                // 16px on mobile or iOS Safari zooms the viewport and breaks the sticky header.
+                fontSize: isMobile ? 16 : 12.5, fontFamily: 'inherit', lineHeight: 1.5,
+              }}
+            />
+            {overCap && (
+              <p role="status" style={{ margin: '6px 0 0', fontSize: 11.5, color: 'var(--accent-red, #e5484d)' }}>{t.cap}</p>
+            )}
+          </div>
+        )}
+
+        <div style={{
+          display: 'flex', alignItems: 'center', justifyContent: 'flex-end', gap: 8,
+          padding: '12px 14px 14px', borderTop: '1px solid var(--border-subtle, var(--ag-tint-3))',
+        }}>
+          <button
+            onClick={onClose}
+            style={{
+              minHeight: tap, padding: '0 14px', borderRadius: 8, cursor: 'pointer',
+              border: '1px solid var(--border, var(--ag-tint-4))', background: 'transparent',
+              color: 'var(--text-secondary, #aaa)', fontFamily: 'inherit', fontSize: 12.5,
+            }}
+          >
+            {t.cancel}
+          </button>
+          <button
+            onClick={() => ready && onConfirm(chosen.map(r => r.id), text.trim())}
+            disabled={!ready}
+            style={{
+              display: 'flex', alignItems: 'center', gap: 7,
+              minHeight: tap, padding: '0 14px', borderRadius: 8,
+              cursor: ready ? 'pointer' : 'default', opacity: ready ? 1 : 0.45,
+              border: '1px solid var(--anthropic-orange, #e8925a)',
+              background: ready ? 'rgba(232,146,90,0.12)' : 'transparent',
+              color: 'var(--anthropic-orange, #e8925a)',
+              fontFamily: 'inherit', fontSize: 12.5, fontWeight: 600,
+            }}
+          >
+            {kind === 'reopen' ? <RotateCcw size={13} /> : <Send size={13} />}
+            {confirm.label}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/packages/web/src/components/sessions/formBits.tsx
+++ b/packages/web/src/components/sessions/formBits.tsx
@@ -1,0 +1,86 @@
+/**
+ * formBits — the small pieces every session dialog is built from.
+ *
+ * They were local to `NewSessionModal`, which made the SECOND dialog either import from a modal or
+ * restate them. Restating them is how two screens of one product start looking like two products:
+ * the picker shipped with its own hand-rolled field and its own idea of a label, and read as
+ * foreign next to the wizard one click away.
+ */
+import React from 'react'
+
+/** A search/text field. The left padding is the magnifier's; see the callers. */
+export const inputStyle: React.CSSProperties = {
+  width: '100%', boxSizing: 'border-box',
+  padding: '9px 12px 9px 30px', borderRadius: 9,
+  border: '1px solid var(--border-subtle)', background: 'var(--bg-elevated)',
+  color: 'var(--text-primary)', fontFamily: 'inherit', fontSize: 13, outline: 'none',
+}
+
+export function Field({ label, hint, children }: {
+  label: string; hint?: string; children: React.ReactNode
+}) {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 7 }}>
+      <span style={{
+        fontSize: 11, fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.05em',
+        color: 'var(--text-tertiary)',
+      }}>
+        {label}
+      </span>
+      {children}
+      {hint && (
+        <span style={{ fontSize: 11, lineHeight: 1.5, color: 'var(--text-tertiary)' }}>{hint}</span>
+      )}
+    </div>
+  )
+}
+
+export function Muted({ text }: { text: string }) {
+  return <p style={{ margin: 0, padding: '6px 4px', fontSize: 12, lineHeight: 1.5, color: 'var(--text-tertiary)' }}>{text}</p>
+}
+
+/**
+ * The segmented tab strip both dialogs file their list with.
+ *
+ * The COUNT is dimmed and never coloured — it is a size, not a state — and it is what makes an
+ * empty tab read as "nothing of this kind matched" rather than as a broken filter.
+ */
+export function TabStrip<T extends string>({ tabs, value, onPick, label, count }: {
+  tabs: readonly T[]
+  value: T
+  onPick: (t: T) => void
+  label: (t: T) => string
+  count: (t: T) => number
+}) {
+  return (
+    <div role="tablist" style={{
+      display: 'flex', gap: 3, marginBottom: 8, padding: 3, borderRadius: 9,
+      background: 'var(--bg-elevated)', border: '1px solid var(--border-subtle)',
+    }}>
+      {tabs.map(id => {
+        const on = value === id
+        return (
+          <button
+            key={id}
+            role="tab"
+            aria-selected={on}
+            onClick={() => onPick(id)}
+            style={{
+              flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center',
+              gap: 5, minHeight: 30, borderRadius: 7, border: 'none', cursor: 'pointer',
+              background: on ? 'var(--bg-surface)' : 'transparent',
+              color: on ? 'var(--anthropic-orange)' : 'var(--text-tertiary)',
+              fontFamily: 'inherit', fontSize: 11.5, fontWeight: on ? 650 : 500,
+              minWidth: 0,
+            }}
+          >
+            <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+              {label(id)}
+            </span>
+            <span style={{ fontSize: 10, color: 'var(--text-tertiary)', flexShrink: 0 }}>{count(id)}</span>
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/packages/web/src/lib/fleet.ts
+++ b/packages/web/src/lib/fleet.ts
@@ -31,6 +31,14 @@ export type FleetActionId =
   | 'interrupt'
   /** Advance the harness to its NEXT mode. It cycles; there is no key that picks one. */
   | 'cycleMode'
+  /**
+   * FLEET verbs — they act on a SET, not on the row whose `id` is in the request.
+   *
+   * `reopenFell` takes back what the machine took; `broadcast` types one prompt into several
+   * sessions. Both carry `ids`, and both can only ever NARROW a set the server itself computed —
+   * see `FleetActionRequest.ids`.
+   */
+  | 'reopenFell' | 'broadcast'
 
 /** The verbs this page can PERFORM. The rest are shown, dimmed, with their reason. */
 export const PERFORMABLE: ReadonlySet<FleetActionId> = new Set<FleetActionId>([
@@ -60,6 +68,8 @@ export interface FleetRow {
   state: 'working' | 'waiting' | 'waiting-approval' | 'exited' | 'lost' | 'unknown' | 'closed'
   stateLabel: string
   actionable: boolean
+  /** This row is one of the sessions the machine TOOK — see the server's `FleetRow.fell`. */
+  fell?: boolean
   task?: string
   note?: string
   model?: string
@@ -96,6 +106,13 @@ export interface FleetPayload {
   tasks: string[]
   /** Tasks the user marked finished. A statement about the work, not about any session's state. */
   finishedTasks: string[]
+  /**
+   * The last fall: how many sessions the machine took, and when.
+   *
+   * WHICH rows is not repeated here — they are in `sessions`, each marked `fell`. The count is what
+   * a summary line needs; the marks are what a list somebody ticks needs.
+   */
+  fell?: { count: number; atMs: number }
 }
 
 const EMPTY: FleetPayload = { sessions: [], rows: [], attention: 0, tasks: [], finishedTasks: [] }
@@ -129,6 +146,12 @@ export interface FleetState {
     action: FleetActionId
     text?: string
     choice?: number
+    /**
+     * The rows a GROUP verb acts on — `reopenFell` and `broadcast`. It can only ever NARROW the
+     * group the server already resolved: absent means "all of it", and an empty array means
+     * nothing, which is not the same thing and is never collapsed into it.
+     */
+    ids?: readonly string[]
   }) => Promise<{ ok: boolean; message: string; id?: string }>
 }
 

--- a/packages/web/src/lib/sessionPick.test.ts
+++ b/packages/web/src/lib/sessionPick.test.ts
@@ -1,0 +1,64 @@
+import { test, expect } from 'bun:test'
+import {
+  initialPick, pickAllState, pickConfirmLabel, pickedRows, togglePick, togglePickAll,
+} from './sessionPick'
+
+const rows = [{ id: 'a', title: 'A' }, { id: 'b', title: 'B' }, { id: 'c', title: 'C' }]
+
+/**
+ * The one place the two features differ. Reopening what a crash took has a defensible "all"; typing
+ * into every live session does not.
+ */
+test('reopen opens ticked, broadcast opens empty', () => {
+  expect([...initialPick(rows, 'all')]).toEqual(['a', 'b', 'c'])
+  expect([...initialPick(rows, 'none')]).toEqual([])
+})
+
+test('the header box has three states, and `some` is not `none`', () => {
+  expect(pickAllState(rows, new Set(['a', 'b', 'c']))).toBe('all')
+  expect(pickAllState(rows, new Set())).toBe('none')
+  expect(pickAllState(rows, new Set(['a']))).toBe('some')
+  expect(pickAllState([], new Set())).toBe('none')
+})
+
+/**
+ * A half-ticked list means somebody has been choosing. Of the two readings of one click, the safe
+ * one starts them over rather than silently adding back what they just removed.
+ */
+test('the header box CLEARS from `some`, and from `all`', () => {
+  expect([...togglePickAll(rows, new Set(['a']))]).toEqual(['a', 'b', 'c'])
+  expect([...togglePickAll(rows, new Set(['a', 'b', 'c']))]).toEqual([])
+  expect([...togglePickAll(rows, new Set())]).toEqual(['a', 'b', 'c'])
+})
+
+test('one row toggles on and off without touching the others', () => {
+  const p = togglePick(new Set(['a']), 'b')
+  expect([...p].sort()).toEqual(['a', 'b'])
+  expect([...togglePick(p, 'a')]).toEqual(['b'])
+})
+
+/**
+ * A Set iterates in CLICK order, not reading order. The confirmation's list and the server's report
+ * are checked against the screen, so the two have to agree.
+ */
+test('picked rows come back in the order they were SHOWN', () => {
+  expect(pickedRows(rows, new Set(['c', 'a'])).map(r => r.id)).toEqual(['a', 'c'])
+})
+
+/**
+ * The count is in the label, always: this button starts assistants or writes into them, and the
+ * number is what a person checks before pressing.
+ */
+test('the button carries the count, and singular is not "1 sessions"', () => {
+  expect(pickConfirmLabel(1, 'reopen', true).label).toBe('Reabrir 1 sessão')
+  expect(pickConfirmLabel(3, 'reopen', true).label).toBe('Reabrir 3 sessões')
+  expect(pickConfirmLabel(1, 'send', false).label).toBe('Send to 1 session')
+  expect(pickConfirmLabel(4, 'send', false).label).toBe('Send to 4 sessions')
+})
+
+test('nothing picked is not pressable, and says so instead of showing a zero', () => {
+  const v = pickConfirmLabel(0, 'reopen', true)
+  expect(v.enabled).toBe(false)
+  expect(v.label).not.toContain('0')
+  expect(pickConfirmLabel(0, 'send', false).enabled).toBe(false)
+})

--- a/packages/web/src/lib/sessionPick.test.ts
+++ b/packages/web/src/lib/sessionPick.test.ts
@@ -1,6 +1,16 @@
 import { test, expect } from 'bun:test'
 import {
-  initialPick, pickAllState, pickConfirmLabel, pickedRows, togglePick, togglePickAll,
+  PICK_TABS,
+  filterPickRows,
+  initialPick,
+  pickAllState,
+  pickConfirmLabel,
+  pickEmpty,
+  pickTabHint,
+  pickTabLabel,
+  pickedRows,
+  togglePick,
+  togglePickAll,
 } from './sessionPick'
 
 const rows = [{ id: 'a', title: 'A' }, { id: 'b', title: 'B' }, { id: 'c', title: 'C' }]
@@ -61,4 +71,50 @@ test('nothing picked is not pressable, and says so instead of showing a zero', (
   expect(v.enabled).toBe(false)
   expect(v.label).not.toContain('0')
   expect(pickConfirmLabel(0, 'send', false).enabled).toBe(false)
+})
+
+// ---------------------------------------------------------------------------
+// Tabs, search, and the rows that cannot take the verb.
+// ---------------------------------------------------------------------------
+
+const FLEET = [
+  { id: 'a', title: 'ALM board', detail: '~/agentistics' },
+  { id: 'b', title: 'Mobile composer', detail: '~/agentistics/.claude/worktrees/mob' },
+  { id: 'c', title: 'Old probe', detail: '~/scratch', enabled: false, reason: 'not running' },
+]
+
+test('the active tab withholds what cannot take the verb; all shows the fleet', () => {
+  expect(filterPickRows(FLEET, 'active', '').map(r => r.id)).toEqual(['a', 'b'])
+  expect(filterPickRows(FLEET, 'all', '').map(r => r.id)).toEqual(['a', 'b', 'c'])
+})
+
+// Two sessions of one repository are told apart by the FOLDER and by nothing else.
+test('search reads the title and the folder, case-folded', () => {
+  expect(filterPickRows(FLEET, 'all', 'ALM').map(r => r.id)).toEqual(['a'])
+  expect(filterPickRows(FLEET, 'all', 'alm').map(r => r.id)).toEqual(['a'])
+  expect(filterPickRows(FLEET, 'all', 'worktrees').map(r => r.id)).toEqual(['b'])
+  expect(filterPickRows(FLEET, 'all', '   ').map(r => r.id)).toEqual(['a', 'b', 'c'])
+  expect(filterPickRows(FLEET, 'all', 'nothing here')).toEqual([])
+})
+
+// A count on the button the server is about to refuse is worse than no button.
+test('an un-takeable row is never ticked, by any route', () => {
+  expect([...initialPick(FLEET, 'all')]).toEqual(['a', 'b'])
+  expect([...togglePickAll(FLEET, new Set())]).toEqual(['a', 'b'])
+  // And "all" reads as all once every takeable row is on, despite `c` sitting there.
+  expect(pickAllState(FLEET, new Set(['a', 'b']))).toBe('all')
+  expect(pickAllState(FLEET, new Set(['a']))).toBe('some')
+})
+
+// Clear the box, or switch tab — two different actions, so two different sentences.
+test('the empty state names what emptied the list', () => {
+  const searched = pickEmpty('all', 'zzz', true, true)
+  const nothingRunning = pickEmpty('active', '', true, true)
+  const nothingAtAll = pickEmpty('all', '', false, true)
+  expect(searched).not.toBe(nothingRunning)
+  expect(nothingRunning).not.toBe(nothingAtAll)
+  expect(nothingRunning).toContain('Todas')
+  expect(PICK_TABS).toEqual(['active', 'all'])
+  expect(pickTabLabel('active', true)).toBe('Ativas')
+  expect(pickTabHint('all', true)).not.toBe(pickTabHint('active', true))
 })

--- a/packages/web/src/lib/sessionPick.ts
+++ b/packages/web/src/lib/sessionPick.ts
@@ -1,0 +1,93 @@
+/**
+ * sessionPick.ts — PURE: the arithmetic of "tick some sessions and do a thing to them".
+ *
+ * Two features ask the same question and answer it differently, which is the whole reason this is
+ * one module with a parameter rather than two lists:
+ *
+ *  - **Reopen what fell** starts every row TICKED. Putting the machine back the way it was is the
+ *    common case, and the point of the list is that it is a default rather than the only answer.
+ *  - **Broadcast a prompt** starts every row UNTICKED. Nothing here has a defensible "all": a
+ *    default that types into every live session is a default that eventually types into one nobody
+ *    meant.
+ *
+ * The rest — the header checkbox's three states, what the confirm button says, whether it is
+ * pressable — is identical, and is here so it is tested once.
+ */
+
+/** A row as a picker needs it. Whatever else it carries is the caller's business. */
+export interface PickRow { id: string; title: string }
+
+/** The header box: all, none, or some. A `some` box is INDETERMINATE and must not read as off. */
+export type PickAllState = 'all' | 'none' | 'some'
+
+export function pickAllState(rows: readonly PickRow[], picked: ReadonlySet<string>): PickAllState {
+  if (rows.length === 0 || picked.size === 0) return 'none'
+  const on = rows.filter(r => picked.has(r.id)).length
+  if (on === 0) return 'none'
+  return on === rows.length ? 'all' : 'some'
+}
+
+/**
+ * What the header box does when pressed.
+ *
+ * `some` clears rather than fills. A half-ticked list means somebody has been choosing; the safer
+ * of the two readings of one click is the one that starts them over, not the one that silently
+ * adds back the rows they just removed.
+ */
+export function togglePickAll(rows: readonly PickRow[], picked: ReadonlySet<string>): Set<string> {
+  return pickAllState(rows, picked) === 'all' ? new Set() : new Set(rows.map(r => r.id))
+}
+
+export function togglePick(picked: ReadonlySet<string>, id: string): Set<string> {
+  const next = new Set(picked)
+  if (next.has(id)) next.delete(id)
+  else next.add(id)
+  return next
+}
+
+/** Where a picker opens. See the header — the two features differ here and nowhere else. */
+export function initialPick(rows: readonly PickRow[], mode: 'all' | 'none'): Set<string> {
+  return mode === 'all' ? new Set(rows.map(r => r.id)) : new Set()
+}
+
+/**
+ * The picked rows, IN THE ORDER THEY WERE SHOWN.
+ *
+ * A `Set` iterates in insertion order, which is the order somebody happened to click — not the
+ * order they read. Everything downstream (the confirmation's list, the server's report) is easier
+ * to check against the screen when the two agree.
+ */
+export function pickedRows<T extends PickRow>(rows: readonly T[], picked: ReadonlySet<string>): T[] {
+  return rows.filter(r => picked.has(r.id))
+}
+
+/**
+ * Is the button pressable, and what does it say?
+ *
+ * The COUNT is in the label, always. "Reopen" and "Reopen 5 sessions" are different promises, and
+ * this is a button that starts assistants or writes into them — the number is the thing a person
+ * checks before pressing.
+ */
+export function pickConfirmLabel(
+  count: number, kind: 'reopen' | 'send', pt: boolean,
+): { label: string; enabled: boolean } {
+  if (count === 0) {
+    return {
+      enabled: false,
+      label: kind === 'reopen'
+        ? (pt ? 'Nenhuma escolhida' : 'None picked')
+        : (pt ? 'Nenhuma escolhida' : 'None picked'),
+    }
+  }
+  const one = count === 1
+  return {
+    enabled: true,
+    label: kind === 'reopen'
+      ? (pt
+        ? (one ? 'Reabrir 1 sessão' : `Reabrir ${count} sessões`)
+        : (one ? 'Reopen 1 session' : `Reopen ${count} sessions`))
+      : (pt
+        ? (one ? 'Enviar para 1 sessão' : `Enviar para ${count} sessões`)
+        : (one ? 'Send to 1 session' : `Send to ${count} sessions`)),
+  }
+}

--- a/packages/web/src/lib/sessionPick.ts
+++ b/packages/web/src/lib/sessionPick.ts
@@ -15,16 +15,99 @@
  */
 
 /** A row as a picker needs it. Whatever else it carries is the caller's business. */
-export interface PickRow { id: string; title: string }
+export interface PickRow {
+  id: string
+  title: string
+  /** The folder, so two sessions of one repo are told apart. Searched as well as shown. */
+  detail?: string
+  /**
+   * May this row be picked at all? Absent reads as YES.
+   *
+   * A row that cannot take the verb is SHOWN and disabled rather than hidden, with `reason` beside
+   * it: a control that is silently absent and one that is silently inert teach the same wrong
+   * thing, which is that the session is not there.
+   */
+  enabled?: boolean
+  /** Why it cannot, already localized by the server. Rendered only when `enabled` is false. */
+  reason?: string
+}
+
+/** The list is filed by whether the row can take the verb NOW. `all` keeps the caller's order. */
+export type PickTab = 'active' | 'all'
+
+export const PICK_TABS: readonly PickTab[] = ['active', 'all']
+
+export function pickTabLabel(tab: PickTab, pt: boolean): string {
+  if (tab === 'active') return pt ? 'Ativas' : 'Active'
+  return pt ? 'Todas' : 'All'
+}
+
+/**
+ * What the tab HOLDS, in a sentence.
+ *
+ * The tab names the set and this says what the set IS — the same rule `kindHint` follows in the new
+ * session wizard, and for the same reason: "Active" and "All" are two words that do not, by
+ * themselves, explain why a session is in one and not the other.
+ */
+export function pickTabHint(tab: PickTab, pt: boolean): string {
+  if (tab === 'active') {
+    return pt
+      ? 'Sessões rodando agora, que podem receber o prompt.'
+      : 'Sessions running now, which can take the prompt.'
+  }
+  return pt
+    ? 'Toda a frota. As que não podem receber aparecem esmaecidas, com o motivo.'
+    : 'The whole fleet. The ones that cannot take it are dimmed, with the reason.'
+}
+
+/**
+ * The empty state, chosen by WHAT emptied the list.
+ *
+ * "Nothing matched this search" and "nothing is running" send a reader to two different actions —
+ * clear the box, or switch tab — and one shared empty box would name neither.
+ */
+export function pickEmpty(tab: PickTab, query: string, anyRows: boolean, pt: boolean): string {
+  if (query.trim().length > 0) {
+    return pt ? 'Nada corresponde a essa busca.' : 'Nothing matches this search.'
+  }
+  if (!anyRows) return pt ? 'Nenhuma sessão aqui.' : 'No sessions here.'
+  if (tab === 'active') {
+    return pt
+      ? 'Nenhuma sessão rodando. Veja a frota inteira em "Todas".'
+      : 'No session is running. See the whole fleet under "All".'
+  }
+  return pt ? 'Nenhuma sessão aqui.' : 'No sessions here.'
+}
+
+/**
+ * The rows a tab and a search leave, IN THE ORDER THEY CAME.
+ *
+ * The search reads the title AND the folder, because two sessions of one repository are told apart
+ * by the folder and by nothing else — searching only the title would make the second one
+ * unreachable. Case-folded, trimmed; an empty query filters nothing.
+ */
+export function filterPickRows<T extends PickRow>(
+  rows: readonly T[], tab: PickTab, query: string,
+): T[] {
+  const q = query.trim().toLowerCase()
+  return rows.filter(r => {
+    if (tab === 'active' && r.enabled === false) return false
+    if (q.length === 0) return true
+    return r.title.toLowerCase().includes(q) || (r.detail ?? '').toLowerCase().includes(q)
+  })
+}
 
 /** The header box: all, none, or some. A `some` box is INDETERMINATE and must not read as off. */
 export type PickAllState = 'all' | 'none' | 'some'
 
 export function pickAllState(rows: readonly PickRow[], picked: ReadonlySet<string>): PickAllState {
-  if (rows.length === 0 || picked.size === 0) return 'none'
-  const on = rows.filter(r => picked.has(r.id)).length
+  // `all` is measured against what CAN be picked, or a list holding one un-takeable row could never
+  // read as full and the header box would stay indeterminate with everything reachable ticked.
+  const takeable = rows.filter(r => r.enabled !== false)
+  if (takeable.length === 0 || picked.size === 0) return 'none'
+  const on = takeable.filter(r => picked.has(r.id)).length
   if (on === 0) return 'none'
-  return on === rows.length ? 'all' : 'some'
+  return on === takeable.length ? 'all' : 'some'
 }
 
 /**
@@ -35,7 +118,10 @@ export function pickAllState(rows: readonly PickRow[], picked: ReadonlySet<strin
  * adds back the rows they just removed.
  */
 export function togglePickAll(rows: readonly PickRow[], picked: ReadonlySet<string>): Set<string> {
-  return pickAllState(rows, picked) === 'all' ? new Set() : new Set(rows.map(r => r.id))
+  // Only ever fills with rows that CAN be picked — the header box must not tick a row whose own
+  // checkbox is disabled, which would put a count on the button the server is about to refuse.
+  const takeable = rows.filter(r => r.enabled !== false)
+  return pickAllState(rows, picked) === 'all' ? new Set() : new Set(takeable.map(r => r.id))
 }
 
 export function togglePick(picked: ReadonlySet<string>, id: string): Set<string> {
@@ -47,7 +133,7 @@ export function togglePick(picked: ReadonlySet<string>, id: string): Set<string>
 
 /** Where a picker opens. See the header — the two features differ here and nowhere else. */
 export function initialPick(rows: readonly PickRow[], mode: 'all' | 'none'): Set<string> {
-  return mode === 'all' ? new Set(rows.map(r => r.id)) : new Set()
+  return mode === 'all' ? new Set(rows.filter(r => r.enabled !== false).map(r => r.id)) : new Set()
 }
 
 /**


### PR DESCRIPTION
Two group verbs on the web, both under "New session", both drawn by **one** picker.

## Reopen what fell

Appears only when something did fall, and it names the count — a button that is always there teaches nothing, and a bare "reopen" is a different promise from "reopen 6 sessions". Every row starts **ticked**: putting the machine back the way it was is the common case, and the point of the list is that it is a default rather than the only answer.

The group is the machine's own `planCrashGroup`, **never re-derived in the browser** — a second implementation of "which sessions fell together" is the defect this bridge exists to prevent — and `selectFell` *intersects* what the caller names with it, so ids can only ever narrow.

## Broadcast a prompt

Every row starts **unticked**. Nothing here has a defensible "all": a default that types into every live session eventually types into one nobody meant.

Who may receive a prompt is the **server's** answer, read off each row's own `prompt` verb — the same resolution the cockpit acts on. Each send still goes through `promptSession`, which re-reads that session's screen as it types, so a session sitting on an open dialog is refused there and not from a list a poll old.

`All` shows the **whole fleet** with the un-runnable rows dimmed and the reason printed under them, rather than hiding them: a session missing from a list and a session that cannot be written to look identical from outside, and the first reads as "agentop lost it".

## One picker, and it wears the product's chrome

`lib/sessionPick.ts` is pure and holds everything the two share — the three-state header box, the tab filing, the search, what the button says. `Field`, `Muted`, `inputStyle` and the segmented `TabStrip` moved out of `NewSessionModal` into `formBits` so both dialogs are built from the same pieces; they were local, which left the second dialog either importing from a modal or restating them, and restating is how two screens of one product start looking like two products.

Details that are load-bearing:

- **Search reads the title AND the folder.** Two sessions of one repository are told apart by the folder and by nothing else.
- **Tabs only on the broadcast.** Every row of a reopen fell, so none is running and `Active` could only ever be empty.
- **A row that cannot take the verb is never ticked by any route** — not by the header box, not by the initial fill — or the button would carry a count the server is about to refuse. `pickAllState` measures `all` against what *can* be picked, so a list holding one disabled row can still read as full.
- **The header box acts on the filtered view; the button counts the whole selection.** The total is printed beside it, or the two numbers look like a bug.
- `null` ids mean the whole group, `[]` means nothing, and the two are never collapsed.
- **`ids` arrives from a browser, so its shape is checked at the route boundary.** A declared type is not a parse, and a bare string would iterate as characters.
- The modal pads with `overlayPadding`, not a bare zero — the repo's own lint caught the close button sitting under the iOS status bar.

## The TUI message

"6 sessions fell 2h ago" says nothing about what happened. It now says they were open when the machine stopped — which is the fact — and names the key. Both languages.

## Verification

`tsc` clean · **7195 pass / 0 fail** (`fell-selection` 6, `broadcast-plan` 9, `sessionPick` 11 covering search, tabs, the disabled-row rule and the empty states).

Built and run on a real machine: installed, service restarted, fleet intact, both dialogs reachable. **Not visually reviewed by an automated browser** — no usable one on this machine; the user looked and approved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AMEMsUBxH7gqdN2SNGaRww