### PR TITLE
feat(sessions): every harness has a readable conversation, and the attached picture opens

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -943,9 +943,42 @@ pricing table — the adapter strips the provider prefix so the table can key on
 `kimi-*` ids are not in `MODEL_PRICING` yet and would take the shared fallback rate like any unknown
 id; add them when verified rates are published.
 
-### Gemini caveat — bootstrap stubs vs. real sessions
+### Gemini caveat — bootstrap stubs, and the journal shape that hid three months of sessions
 
-Gemini CLI writes `~/.gemini/tmp/<project>/chats/*.jsonl` files but many are bootstrap-only stubs with no real conversation content. The Gemini parser (`adapters/gemini-parse.ts`) filters these out — only chats containing a genuine user message or model response are counted. Gemini's local files do not carry token/cost data; real Gemini token metrics would require OTel integration (Phase 3).
+Gemini CLI writes `~/.gemini/tmp/<project>/chats/*.jsonl` files but many are bootstrap-only stubs with no real conversation content. The Gemini parser (`adapters/gemini-parse.ts`) filters these out — only chats containing a genuine user message or model response are counted.
+
+**A TURN IS APPENDED AS ITS OWN LINE, and reading only the snapshot dropped almost every session.**
+The journal is: a HEADER (`{sessionId, projectHash, startTime, lastUpdated, kind}`), then a SEED —
+`{"$set":{"messages":[…]}}`, written once near the top and **empty for a fresh session** — then each
+turn as its own top-level record `{id, timestamp, type, content, model?}`, with
+`{"$set":{"lastUpdated":…}}` patches after every one. `parseJsonl` collected messages **only** from
+`$set.messages`, so a fresh session yielded zero, `hasGenuineContent` stayed false, and the whole
+session was discarded as a bootstrap stub. Measured 2026-09-08: of 34 chat files, 7 carried
+`$set.messages` and **27 did not**; the adapter's newest session was from **2026-04-10**, so months
+of gemini work were missing from every surface in the product — the dashboard, Compare, the costs,
+the session list — not only from the chat view. Both sources are now read through one `id`-keyed
+gate, because a resumed session's seed repeats turns that then arrive again as their own lines and
+counting them twice would inflate every message count. `buildJsonlSessionMeta` also filled
+`first_prompt`, which it had hardcoded to `''`: `sessionLabel()` falls back to it and gemini writes
+no title, so every gemini session was listed with a blank name.
+
+**Gemini HAS a chat reader** (`sessions/gemini-chat.ts`, pure). It was `null` in
+`HARNESS_TRANSCRIPTS` for a long time and the reason was a LINK fact, not a format one — a reader is
+only ever offered a `conversationId`, and gemini has no `assignId` and no id-taking `resume`. What
+made it reachable is that `planFirstSightingClaims` deliberately includes gemini and claims the
+**synthetic** id the store is already keyed on (`${dirName}/${fileBase}`), which is not a UUID
+resolving to nothing but the chat file's own path. That id is therefore treated as untrusted input
+by `resolve`: exactly two segments, no traversal, or it answers `null`. `info` and `error` records
+are the harness talking about itself and are dropped rather than given a speaker, and the
+`<session_context>` block gemini writes under the USER role is injected context, not something the
+person said.
+
+**Tokens are NOT yet read for gemini, and that is now a decision rather than an absence.** The
+appended `gemini` records carry `tokens{input,output,cached,…}` and `model` — visible in the same
+files this parser now reads — so `HARNESS_CAPABILITIES.tokens`/`cost` COULD be flipped. They have
+not been, because turning them on changes money on every cost surface in the product and needs its
+own verification against a bill, exactly as `antigravity-protobuf.ts`'s header records for agy. Do
+it deliberately, with the reconciliation written down; do not flip it as a side effect. Gemini's local files do not carry token/cost data; real Gemini token metrics would require OTel integration (Phase 3).
 
 ### Compare page — `computeHarnessSummaries`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -281,8 +281,38 @@ packages/server/server/          — server-side modules (never bundled by Vite)
   │                          accepts a UUID and is deliberately EXCLUDED: its id in this product is
   │                          synthetic (`${dir}/${file}`), so a recorded UUID would resolve to
   │                          nothing while LOOKING like an exact link. Where no link can ever exist
-  │                          (codex, kimi, gemini, agy) `conversationLinkable` is false and the row
-  │                          SAYS so. And a row that knows its conversation never falls back to the
+  │                          (codex, kimi, gemini) `conversationLinkable` is false and the row
+  │                          SAYS so. **AGY IS NO LONGER ONE OF THEM.** It has no assign flag —
+  │                          measured against agy 1.1.27 on 2026-09-08, `agy --conversation
+  │                          <fresh-uuid>` answers `warning: conversation "…" not found` and creates
+  │                          one under an id of its OWN — and no session record; and the
+  │                          harness-and-directory fallback is closed for it IN PARTICULAR, because
+  │                          the adapter takes `project_path` from the GLOBAL `history.jsonl` and agy
+  │                          writes that file only for a prompt TYPED IN ITS UI. A session agentop
+  │                          starts is handed its first prompt as `--prompt-interactive`, so its store
+  │                          record carries `project_path: ""`, `loadConversations` drops it, and even
+  │                          `planFirstSightingClaims` never sees it as a candidate. Measured the same
+  │                          day: 15 of 38 agy conversations had a cwd, and the 23 without were
+  │                          exactly the ones agentop had opened — so EVERY agy session agentop
+  │                          started was unlinkable BY CONSTRUCTION, and its chat view was
+  │                          permanently empty while its terminal worked perfectly. The THIRD route
+  │                          is `HARNESS_PROCESS_LOGS` (pure `agy-conversation.ts` + IO
+  │                          `process-conversation.ts`): agy opens
+  │                          `~/.gemini/antigravity-cli/log/cli-<YYYYMMDD_HHMMSS>.log` per process and
+  │                          HOLDS IT OPEN (verified in `/proc/<pid>/fd` of a live agy under tmux),
+  │                          writing `Created conversation <uuid>` into it — so the chain `managed row
+  │                          -> tmux pane pid -> open fd -> log -> conversation` is exact at every
+  │                          step. It is its OWN table beside `HARNESS_SESSION_SOURCES` rather than a
+  │                          widening of it: "a JSON file per session keyed by pid" and "the process's
+  │                          own open log, read by regex" share no rule but the question they answer.
+  │                          LAST wins on several `Created` lines (one process can open a second
+  │                          conversation, and the one it is writing is the newest); a
+  │                          `getConversationDetail: found conversation` line is a LOOKUP and never a
+  │                          creation; two DISTINCT logs on one process REFUSE. Recorded as
+  │                          `assigned`, not `observed` — it is the harness's own statement, not the
+  │                          time-and-directory claim. STATED LIMIT: it is a `/proc` read, so off
+  │                          Linux there is no link and `chat-web.ts` says "this session has no linked
+  │                          conversation yet", which is true.
   │                          guess even when the store has not caught up: "not yet" and "some other
   │                          conversation in this directory" are different answers.
   │                          **A MANAGED row now carries the conversation's metrics too** — tokens,

--- a/docs/session-manager.md
+++ b/docs/session-manager.md
@@ -232,7 +232,26 @@ never inferred**: agentop hands the id to the CLI when it starts the session (`c
 `copilot --session-id`) or when it reopens one, so there is nothing left to guess. Claude also writes
 its own record while the process lives, which is read as well.
 
-For codex, kimi, gemini and antigravity no such link can exist — those CLIs invent an id and never
+**antigravity is linked a third way.** It has no assign flag — measured against agy 1.1.27 on
+2026-09-08, `agy --conversation <fresh-uuid>` answers `warning: conversation "…" not found` and then
+creates one under an id of its own — and it writes no session record. What it does do is open one
+log per process, `~/.gemini/antigravity-cli/log/cli-<YYYYMMDD_HHMMSS>.log`, **hold it open** for the
+life of that process, and write `Created conversation <uuid>` into it. So the chain *managed row →
+tmux pane pid → open file descriptor → log → conversation* is exact at every step, and agentop reads
+it (`agy-conversation.ts` for the rules, `process-conversation.ts` for the two reads).
+
+That route mattered more for agy than it would for anyone else, because for a session **agentop
+started** even the harness-and-directory fallback below is closed: the adapter takes a
+conversation's `project_path` from the global `history.jsonl`, and agy writes that file only for a
+prompt typed in its own UI — a session agentop starts is handed its first prompt as
+`--prompt-interactive`, so its record carries an empty `project_path` and is not a candidate for
+anything. Measured the same day: 15 of 38 agy conversations here had a directory recorded, and the
+23 without were exactly the ones agentop had opened. Its chat view was therefore permanently empty
+while its terminal worked perfectly. The limit worth stating: this is a `/proc` read, so off Linux
+there is no link and the chat view says "this session has no linked conversation yet", which is
+true.
+
+For codex, kimi and gemini no such link can exist — those CLIs invent an id and never
 report it — so the row says so rather than showing a guess. The fallback everything else uses matches
 by harness and directory, which gives *every* session of one repository the same conversation: good
 enough to offer a reopen you confirm by its title, not good enough to be presented as the conversation
@@ -401,9 +420,10 @@ A reader for its file format would be code nothing can reach. Its format is none
 `harness-transcript.ts` so the measurement is not spent twice: it is a patch log rather than one
 message per line.
 
-The same applies, per row, to any harness whose session was **started fresh** without an id —
-antigravity, codex and kimi only gain the link on a reopen, so a freshly spawned row of those three
-is blind until it is reopened, and says so.
+The same applies, per row, to any harness whose session was **started fresh** without an id.
+codex and kimi only gain the link on a reopen (or once the first-sighting claim can settle it), so a
+freshly spawned row of those two is blind until then, and says so. **antigravity is no longer one of
+them** — its per-process log names the conversation it created; see above.
 
 #### Three rules every reader follows
 

--- a/packages/server/server/adapters/gemini-parse.test.ts
+++ b/packages/server/server/adapters/gemini-parse.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from 'bun:test'
+import { describe, test, test as it, expect } from 'bun:test'
 import { parseGeminiChat } from './gemini-parse'
 
 // ---------------------------------------------------------------------------
@@ -344,4 +344,91 @@ test('gemini tools land in the shared vocabulary, like every other harness', () 
   expect(s.tool_counts['Bash']).toBe(2)
   expect(s.tool_counts['Read']).toBe(1)
   expect(s.tool_counts['run_shell_command']).toBeUndefined()
+})
+
+/**
+ * THE JOURNAL APPENDS EACH MESSAGE AS ITS OWN LINE, and for a while nothing here read those.
+ *
+ * `parseJsonl` collected messages ONLY from `$set.messages` snapshots. Gemini CLI now writes that
+ * snapshot once, at the top of the file — EMPTY for a fresh session — and then appends every turn
+ * as a top-level `{id, timestamp, type, content}` record, with the `$set` lines after it carrying
+ * nothing but `lastUpdated`. So every such file collected zero messages, `hasGenuineContent` stayed
+ * false, and the whole session was dropped as a bootstrap stub.
+ *
+ * Measured on this machine 2026-09-08: of 34 chat files, 7 still carried `$set.messages` and 27 did
+ * not — and the adapter's newest session was from 2026-04-10, months of gemini work missing from
+ * every surface in the product, not only from the chat view.
+ *
+ * The fixture below is the real shape, captured from
+ * `~/.gemini/tmp/agentistics/chats/session-2026-09-08T14-11-2a2b4e9d.jsonl` (gemini 0.55.x).
+ */
+describe('gemini journal — appended message records', () => {
+  const APPENDED = [
+    JSON.stringify({
+      sessionId: '2a2b4e9d-c1ac-4b92-8a23-d2dc9a2158a2',
+      projectHash: 'ce276284a10422f5496a58c38fa491f7891a1bf27',
+      startTime: '2026-09-08T14:11:24.125Z',
+      lastUpdated: '2026-09-08T14:11:24.125Z',
+      kind: 'main',
+    }),
+    JSON.stringify({ $set: { messages: [], lastUpdated: '2026-09-08T14:11:24.125Z' } }),
+    JSON.stringify({
+      id: '5295492b-11e0-43a0-89db-62ab3d4769ef',
+      timestamp: '2026-09-08T14:11:33.230Z',
+      type: 'user',
+      content: [{ text: 'responda apenas: ok' }],
+    }),
+    JSON.stringify({ $set: { lastUpdated: '2026-09-08T14:11:33.230Z' } }),
+    JSON.stringify({
+      id: '9f1ae60b-59d7-46ed-8684-f6d479b2f05a',
+      timestamp: '2026-09-08T14:12:18.661Z',
+      type: 'gemini',
+      content: 'ok',
+      model: 'gemini-3.5-flash',
+    }),
+    JSON.stringify({ $set: { lastUpdated: '2026-09-08T14:12:18.661Z' } }),
+  ].join('\n')
+
+  it('reads a session whose turns are appended, not snapshotted', () => {
+    const s = parseGeminiChat(APPENDED, 'agentistics/session-x', '/home/mithrandir/agentistics')
+    expect(s).not.toBeNull()
+    expect(s!.user_message_count).toBe(1)
+    expect(s!.assistant_message_count).toBe(1)
+    expect(s!.first_prompt).toBe('responda apenas: ok')
+  })
+
+  /**
+   * The two shapes coexist inside one file — the opening snapshot can hold turns a resumed session
+   * already had, and the same message then arrives again as its own line. `seenIds` already existed
+   * for the snapshot case; it has to cover both sources or a resumed session counts every earlier
+   * turn twice.
+   */
+  it('counts a message once when it appears in BOTH the snapshot and its own line', () => {
+    const msg = {
+      id: 'dup-1',
+      timestamp: '2026-09-08T14:11:33.230Z',
+      type: 'user',
+      content: 'responda apenas: ok',
+    }
+    const both = [
+      JSON.stringify({ sessionId: 's', startTime: '2026-09-08T14:11:24.125Z' }),
+      JSON.stringify({ $set: { messages: [msg] } }),
+      JSON.stringify(msg),
+      JSON.stringify({ id: 'a-1', timestamp: '2026-09-08T14:12:18.661Z', type: 'gemini', content: 'ok' }),
+    ].join('\n')
+    const s = parseGeminiChat(both, 'agentistics/session-y', '/home/mithrandir/agentistics')
+    expect(s).not.toBeNull()
+    expect(s!.user_message_count).toBe(1)
+    expect(s!.assistant_message_count).toBe(1)
+  })
+
+  /** A `$set` carrying only `lastUpdated` is not a message and must not become one. */
+  it('does not invent a message out of a bare lastUpdated patch', () => {
+    const onlyPatches = [
+      JSON.stringify({ sessionId: 's', startTime: '2026-09-08T14:11:24.125Z' }),
+      JSON.stringify({ $set: { messages: [] } }),
+      JSON.stringify({ $set: { lastUpdated: '2026-09-08T14:11:33.230Z' } }),
+    ].join('\n')
+    expect(parseGeminiChat(onlyPatches, 'agentistics/session-z', '/p')).toBeNull()
+  })
 })

--- a/packages/server/server/adapters/gemini-parse.ts
+++ b/packages/server/server/adapters/gemini-parse.ts
@@ -223,6 +223,23 @@ function parseJsonl(content: string, fallbackId: string, projectPath: string): S
   const seenIds = new Set<string>()
   const allMessages: Array<{ type: string; timestamp?: string; text?: string }> = []
 
+  // One message, from either source, counted once. `seenIds` spans BOTH: a resumed session's
+  // opening snapshot repeats turns that then arrive again as their own lines, and counting those
+  // twice would inflate every message count in the product.
+  const take = (msg: any): void => {
+    if (!msg || typeof msg !== 'object') return
+    const id = msg.id as string | undefined
+    if (id !== undefined) {
+      if (seenIds.has(id)) return
+      seenIds.add(id)
+    }
+    allMessages.push({
+      type: msg.type as string,
+      timestamp: msg.timestamp as string | undefined,
+      text: extractMessageText(msg),
+    })
+  }
+
   for (const raw of lines) {
     let parsed: any
     try { parsed = JSON.parse(raw) } catch { continue }
@@ -241,20 +258,26 @@ function parseJsonl(content: string, fallbackId: string, projectPath: string): S
     // MongoDB-style state op: {"$set": {"messages": [...]}}
     const messages = parsed['$set']?.messages
     if (Array.isArray(messages)) {
-      for (const msg of messages) {
-        const id = msg.id as string | undefined
-        const text = extractMessageText(msg)
-        if (id) {
-          if (!seenIds.has(id)) {
-            seenIds.add(id)
-            allMessages.push({ type: msg.type as string, timestamp: msg.timestamp as string | undefined, text })
-          }
-        } else {
-          // No id: always include (rare case)
-          allMessages.push({ type: msg.type as string, timestamp: msg.timestamp as string | undefined, text })
-        }
-      }
+      for (const msg of messages) take(msg)
+      continue
     }
+
+    // A `$set` that carries anything else is a PATCH of the session's own fields — the journal
+    // writes `{"$set":{"lastUpdated":…}}` after every turn — and a patch is not a message.
+    if (parsed['$set'] !== undefined) continue
+
+    // AN APPENDED MESSAGE RECORD, which is how the journal writes a turn today.
+    //
+    // The snapshot above is written ONCE, at the top of the file, and is EMPTY for a fresh session;
+    // every turn afterwards arrives as its own top-level line. Reading only the snapshot therefore
+    // collected nothing at all, `hasGenuineContent` stayed false, and the session was dropped as a
+    // bootstrap stub — measured 2026-09-08 on this machine, 27 of 34 chat files, and an adapter
+    // whose newest session was from 2026-04-10.
+    //
+    // `type` is what makes it a message rather than some future record shape: an unrecognised line
+    // is skipped, exactly as one that will not parse is, because inventing a turn is the expensive
+    // direction here — this count is what decides whether the session exists at all.
+    if (typeof parsed.type === 'string') take(parsed)
   }
 
   return buildJsonlSessionMeta({
@@ -288,6 +311,11 @@ function buildJsonlSessionMeta(data: JsonlParsedData): SessionMeta | null {
   let hasGenuineContent = false
   // Same reconstruction as parseRichJson — see computeActiveTime() / docs/harness-contract.md.
   const turnEvents: TurnEvent[] = []
+  // The session's LABEL. `sessionLabel()` falls back to `first_prompt` when a harness writes no
+  // title, and gemini writes none — so leaving this empty, as this path did, gives every gemini
+  // session a blank name in every list it appears in. Taken from the FIRST message that already
+  // passed `isGenuineUserMessage`, so an injected context block never becomes the title.
+  let firstPrompt = ''
 
   for (const msg of messages) {
     const isUser = msg.type === 'user'
@@ -307,6 +335,7 @@ function buildJsonlSessionMeta(data: JsonlParsedData): SessionMeta | null {
       counted = true
     } else if (isUser && isGenuineUserMessage(msg.text ?? '')) {
       hasGenuineContent = true
+      if (!firstPrompt) firstPrompt = (msg.text ?? '').trim()
       userMessages++
       if (turnEvent) turnEvent.userPrompt = true
       if (msg.timestamp) userMessageTimestamps.push(msg.timestamp)
@@ -344,7 +373,7 @@ function buildJsonlSessionMeta(data: JsonlParsedData): SessionMeta | null {
     output_tokens: 0,
     cache_read_input_tokens: 0,
     cache_creation_input_tokens: 0,
-    first_prompt: '',
+    first_prompt: firstPrompt,
     user_interruptions: 0,
     user_response_times: [],
     tool_errors: 0,

--- a/packages/server/server/cli-start.ts
+++ b/packages/server/server/cli-start.ts
@@ -141,6 +141,7 @@ import {
 } from './sessions/broadcast-plan'
 import { sessionRunning } from '@agentistics/tui/control/session-dimensions'
 import { loadHarnessSessions } from './sessions/harness-sessions'
+import { readProcessConversation } from './sessions/process-conversation'
 import { idleServers, isServerCommand } from './idle-servers'
 import { planTaskDelete, taskDeleteIsNoop } from './sessions/task-delete'
 import { memoryBudget } from './sessions/memory-budget'
@@ -1462,6 +1463,11 @@ async function ensureSessionsPoller(): Promise<SessionsPoller> {
     // keep apart — see `ManagedSession.conversationLink`.
     recordConversation: (id, conversationId, conversationLink) =>
       patchSession(id, { conversationId, conversationLink }),
+    // The per-process log link — antigravity's only exact answer, and the reason its chat view was
+    // permanently empty while its terminal worked. Wired HERE and deliberately not on
+    // `cli-session.ts`'s poller: that one is a one-shot command and writes nothing, exactly as it
+    // takes no heartbeat.
+    readProcessConversation,
     // The `/rename` name, persisted so the title survives the process — same once-per-change
     // discipline. See `ManagedSession.harnessName` and `pickTitle`.
     recordHarnessName: (id, name, since) =>
@@ -1544,6 +1550,10 @@ async function spawnManaged(req: {
   if (!planned.ok) return { ok: false, message: explainSpawnError(planned.error, s) }
 
   const id = newSessionId()
+  // Stamped BEFORE the launch, for the reason `cli-session.ts` records at its own two spawn sites:
+  // `planFirstSightingClaims` asks whether a conversation began AFTER we spawned, and a timestamp
+  // taken once the call has returned can already be later than the conversation the child opened.
+  const spawnedAt = new Date().toISOString()
   try {
     await backend.spawn({
       id,
@@ -1563,7 +1573,7 @@ async function spawnManaged(req: {
     id,
     harness: req.harness,
     cwd: req.cwd,
-    createdAt: new Date().toISOString(),
+    createdAt: spawnedAt,
     // Stamped at birth, not left to the first heartbeat: a session started and lost inside the same
     // minute would otherwise carry no evidence it was ever alive, and would sit out the very crash
     // it was part of. See `crash-group.ts`.

--- a/packages/server/server/sessions/agy-conversation.test.ts
+++ b/packages/server/server/sessions/agy-conversation.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'bun:test'
+import { agyLogFromFds, conversationFromAgyLog } from './agy-conversation'
+
+/**
+ * The fixtures are REAL lines, captured on 2026-09-08 from agy 1.1.27 on this machine — the log of
+ * the process agentop spawned at 10:03:56, which created conversation 39783297-…. A format this
+ * undocumented is worth pinning against bytes somebody actually saw.
+ */
+const REAL_LINE =
+  'ERROR: logging before google.Init: I0908 10:03:58.569478     218 server.go:1153] '
+  + 'Created conversation 39783297-b1b0-49bf-9f56-b809ee1933db'
+
+const REAL_LOG = [
+  'ERROR: logging before google.Init: I0908 10:03:50.150653      82 server.go:1530] Starting language server process with pid 613917',
+  REAL_LINE,
+  'ERROR: logging before google.Init: I0908 10:03:58.571000     218 server.go:1160] getConversationDetail: found conversation 39783297-b1b0-49bf-9f56-b809ee1933db (active=true)',
+].join('\n')
+
+describe('conversationFromAgyLog', () => {
+  it('reads the conversation agy says it created', () => {
+    expect(conversationFromAgyLog(REAL_LOG)).toBe('39783297-b1b0-49bf-9f56-b809ee1933db')
+  })
+
+  it('answers null for a log that created nothing', () => {
+    const noneYet = [
+      'ERROR: logging before google.Init: I0908 10:32:50.150653      82 server.go:1530] Starting language server process with pid 613917',
+      'ERROR: logging before google.Init: E0908 10:32:50.415817      60 errorreport.go:224] You are not logged into Antigravity.',
+    ].join('\n')
+    expect(conversationFromAgyLog(noneYet)).toBeNull()
+  })
+
+  it('answers null for an empty log', () => {
+    expect(conversationFromAgyLog('')).toBeNull()
+  })
+
+  /**
+   * One process can create a second conversation (agy's own `/new`). The one it is WRITING is the
+   * last one it made, so a reader that took the first would name a conversation the session has
+   * already left — and it would look perfectly right, which is the failure mode this whole feature
+   * exists to avoid.
+   */
+  it('takes the LAST conversation when one process created several', () => {
+    const twice = [
+      REAL_LINE,
+      'ERROR: logging before google.Init: I0908 10:41:02.100000     218 server.go:1153] '
+      + 'Created conversation aacfe2ab-ef77-470d-804b-099bfe8e40be',
+    ].join('\n')
+    expect(conversationFromAgyLog(twice)).toBe('aacfe2ab-ef77-470d-804b-099bfe8e40be')
+  })
+
+  /** A line that merely mentions a conversation is not a line that created one. */
+  it('ignores a conversation it only looked up', () => {
+    const lookupOnly =
+      'ERROR: logging before google.Init: I0908 10:03:58.571000     218 server.go:1160] '
+      + 'getConversationDetail: found conversation 39783297-b1b0-49bf-9f56-b809ee1933db (active=true)'
+    expect(conversationFromAgyLog(lookupOnly)).toBeNull()
+  })
+
+  /** Undocumented format, read like one: anything that is not a uuid is not an answer. */
+  it('refuses a created line whose id is not a uuid', () => {
+    expect(conversationFromAgyLog('server.go:1153] Created conversation not-a-uuid')).toBeNull()
+  })
+})
+
+describe('agyLogFromFds', () => {
+  const LOG = '/home/mithrandir/.gemini/antigravity-cli/log/cli-20260908_100356.log'
+
+  it('picks agy\'s own log out of the process\'s open files', () => {
+    expect(agyLogFromFds([
+      '/dev/pts/3',
+      '/home/mithrandir/.gemini/antigravity-cli/conversation_summaries.db',
+      '/home/mithrandir/.gemini/antigravity-cli/conversation_summaries.db-wal',
+      '/home/mithrandir/.gemini/antigravity-cli/crashes/crash_613917_f08b6119.log',
+      LOG,
+    ])).toBe(LOG)
+  })
+
+  it('answers null when the process has no agy log open', () => {
+    expect(agyLogFromFds(['/dev/pts/3', '/home/mithrandir/.bashrc'])).toBeNull()
+  })
+
+  it('answers null for a process with no open files at all', () => {
+    expect(agyLogFromFds([])).toBeNull()
+  })
+
+  /**
+   * A crash log sits in the same tree and ends in `.log`, and it carries a pid rather than a
+   * conversation. Matching it would hand the reader a file that names nothing.
+   */
+  it('does not mistake a crash log for the session log', () => {
+    expect(agyLogFromFds([
+      '/home/mithrandir/.gemini/antigravity-cli/crashes/crash_613917_f08b6119-5e4c-48de-b201-5ccb16dee285.log',
+    ])).toBeNull()
+  })
+
+  /**
+   * Two session logs open at once is a shape nobody has seen and nothing here can resolve: picking
+   * either would be a guess wearing a measurement's clothes. Same rule as `planFirstSightingClaims`
+   * — every ambiguity errs toward refusing.
+   */
+  it('refuses when two session logs are open', () => {
+    expect(agyLogFromFds([
+      LOG,
+      '/home/mithrandir/.gemini/antigravity-cli/log/cli-20260908_103250.log',
+    ])).toBeNull()
+  })
+
+  /** The same file counted twice (a dup'd fd) is still one file, and must not read as ambiguity. */
+  it('accepts the same log appearing on two descriptors', () => {
+    expect(agyLogFromFds([LOG, LOG])).toBe(LOG)
+  })
+})

--- a/packages/server/server/sessions/agy-conversation.ts
+++ b/packages/server/server/sessions/agy-conversation.ts
@@ -1,0 +1,107 @@
+/**
+ * agy-conversation.ts — PURE. Which conversation an antigravity process is writing, read off the
+ * log agy keeps open for itself.
+ *
+ * ## Why this exists at all
+ *
+ * `SpawnSpec.assignId` is how every other exact link is made, and agy has no such flag. Measured
+ * 2026-09-08 against agy 1.1.27: `agy --conversation <fresh-uuid> -p "say ok"` answers
+ * `warning: conversation "…" not found`, replies normally, and creates a conversation under an id
+ * of its OWN — `--conversation` resumes and never assigns. So that route is closed.
+ *
+ * The fallback everything else leans on — find the conversation in the store by harness and
+ * directory — is closed here too, and for a reason peculiar to agy: the adapter takes a
+ * conversation's `project_path` from the GLOBAL `~/.gemini/antigravity-cli/history.jsonl`, and agy
+ * writes that file only for a prompt TYPED IN ITS UI. A session agentop starts is given its first
+ * prompt as `--prompt-interactive`, so it never appears there and its store record carries
+ * `project_path: ""`. Measured on this machine the same day: 15 of 38 agy conversations had a cwd,
+ * and the 23 without were exactly the ones agentop had opened. A conversation with no cwd is
+ * dropped by `loadConversations`, so `planFirstSightingClaims` never even sees it as a candidate —
+ * which is why every agy session agentop starts was unlinkable BY CONSTRUCTION, and why its chat
+ * view had nothing to read while the terminal worked perfectly.
+ *
+ * ## What replaces it, and why it is exact rather than another guess
+ *
+ * agy opens one log per process, `~/.gemini/antigravity-cli/log/cli-<YYYYMMDD_HHMMSS>.log`, and
+ * HOLDS IT OPEN — verified in `/proc/<pid>/fd` of a live agy started under tmux. Into it it writes
+ * one line per conversation it creates:
+ *
+ *     … 218 server.go:1153] Created conversation 39783297-b1b0-49bf-9f56-b809ee1933db
+ *
+ * So the chain is `managed row -> tmux pane pid -> open fd -> log -> conversation`, and every link
+ * in it is a fact somebody can point at. Nothing is inferred from a directory, which is the
+ * standing guess `session-view.ts`'s `metricsOf` refuses precisely because it gives every session
+ * of one repository the same conversation.
+ *
+ * ## Read like the private file it is
+ *
+ * The format is undocumented and internal to agy; it can change shape in any release. So every
+ * function here is TOTAL and answers `null` for anything it does not positively recognise — the
+ * same discipline `antigravity-protobuf.ts` and `harness-session-file.ts` keep. An absent link
+ * leaves the row exactly as it behaves today; a wrong one puts somebody else's conversation on
+ * screen under this session's name, which the reader cannot detect and the user cannot either.
+ *
+ * ## The stated limit
+ *
+ * The fd is a `/proc` read, so this works on Linux and answers nothing anywhere else. That is a
+ * degradation, not a lie: with no link the chat view says "this session has no linked conversation
+ * yet" (`chat-web.ts`), which is true.
+ */
+
+/** A conversation id as agy writes it: a plain lowercase UUID. */
+const UUID = '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
+
+/**
+ * The one line that means "this process now owns that conversation".
+ *
+ * Anchored on agy's own wording, and deliberately NOT on the `server.go:1153` frame beside it: a
+ * source line number is the single most volatile thing in that log, and matching it would make the
+ * reader fail on the next release for no gain. `getConversationDetail: found conversation …` names
+ * a conversation the process merely LOOKED UP, which is not the same fact, so `Created` carries the
+ * whole meaning and the test pins that difference.
+ */
+const CREATED_RE = new RegExp(String.raw`Created conversation (${UUID})\b`, 'g')
+
+/**
+ * agy's own per-process log — the file, not the directory.
+ *
+ * `crashes/crash_<pid>_<uuid>.log` lives in the same tree and also ends in `.log`, and the uuid in
+ * ITS name is a crash id, not a conversation. Keying on the `log/cli-<timestamp>.log` shape is what
+ * keeps the two apart.
+ */
+const AGY_LOG_RE = new RegExp(String.raw`/antigravity-cli/log/cli-\d{8}_\d{6}\.log$`)
+
+/**
+ * The conversation agy last said it CREATED, or `null`.
+ *
+ * Last wins: one process can create a second conversation (agy's own `/new`), and the one it is
+ * writing now is the most recent. Taking the first would name a conversation the session has
+ * already left, and it would look entirely right.
+ */
+export function conversationFromAgyLog(text: string): string | null {
+  if (!text) return null
+  let last: string | null = null
+  // `matchAll` over a fresh regex each call: a `g` flag carries `lastIndex` across calls, and a
+  // module-level one shared between reads would skip lines depending on what was read before it.
+  for (const m of text.matchAll(new RegExp(CREATED_RE.source, 'g'))) {
+    if (m[1]) last = m[1]
+  }
+  return last
+}
+
+/**
+ * agy's session log among a process's open files, or `null`.
+ *
+ * Refuses on ambiguity, like every other rule in this feature: two distinct session logs open at
+ * once is a shape nobody has observed and nothing here can resolve, so picking one would be a guess
+ * wearing a measurement's clothes. The same path on two descriptors is one file, not two, and is
+ * accepted.
+ */
+export function agyLogFromFds(targets: readonly string[]): string | null {
+  const found = new Set<string>()
+  for (const t of targets) {
+    if (AGY_LOG_RE.test(t)) found.add(t)
+  }
+  if (found.size !== 1) return null
+  return [...found][0]!
+}

--- a/packages/server/server/sessions/chat-web.test.ts
+++ b/packages/server/server/sessions/chat-web.test.ts
@@ -60,18 +60,21 @@ test('an unknown id still reports that the session left this machine, never an e
  * pane with no sentence on it. The link was never the problem; there was no reader.
  */
 test('a harness nobody has written a reader for is refused in words, and NAMED', async () => {
-  // Gemini is the only one, and permanently: it can never carry a conversation id (no `assignId`,
-  // and its `--resume` takes "latest" or an index) — see `harness-transcript.ts`.
-  const out = await readSessionChat(hostWith('waiting', 'gemini'), 'en', 'sess1')
+  // NO SHIPPED HARNESS EXERCISES THIS TODAY — gemini was the last `null` and now has a reader —
+  // and the path must stay tested regardless: it is what the NEXT harness falls into on the day
+  // its id is added and its reader is not. The cast is the point of the test, not a shortcut
+  // around the types: it stands in for that harness. Deleting this with the last null would leave
+  // the blank-pane defect this whole refusal exists to prevent untested until it recurred.
+  const out = await readSessionChat(hostWith('waiting', 'quokka' as never), 'en', 'sess1')
   expect(out.turns).toEqual([])
-  expect(out.unavailable).toContain('gemini')
+  expect(out.unavailable).toContain('quokka')
 })
 
 test('a harness that HAS a reader falls through to the transcript rules, not to that refusal', async () => {
   // Each of these resolves against its own store, where this id does not exist — so it must land
   // on the live/not-yet branch, exactly as claude does, and NOT on "no reader". This test is what
   // failed when codex gained a reader, which is the point: adding one is visible here.
-  for (const harness of ['antigravity', 'codex', 'copilot', 'kimi'] as const) {
+  for (const harness of ['antigravity', 'codex', 'copilot', 'kimi', 'gemini'] as const) {
     const out = await readSessionChat(hostWith('waiting', harness), 'en', 'sess1')
     expect(out.unavailable).toBeUndefined()
     expect(out.live).toBe(true)

--- a/packages/server/server/sessions/cli-session.ts
+++ b/packages/server/server/sessions/cli-session.ts
@@ -208,6 +208,16 @@ async function start(
   if (!planned.ok) { console.error(explainPlanError(planned.error)); return 1 }
 
   const id = newSessionId()
+  // Stamped BEFORE the process is launched, not after it has been checked for a crash.
+  //
+  // `planFirstSightingClaims` asks whether a conversation began AFTER we spawned, and this is the
+  // only timestamp it has. `spawnFailure` deliberately WAITS to see whether the child dies, so a
+  // record stamped after it is seconds late — measured 2026-09-08: a kimi session whose own store
+  // record began at 13:58:50.831 was recorded as spawned at 13:58:52.914, so its conversation
+  // failed the `startedMs > spawnedMs` test and that row stayed unlinked, with an empty chat view,
+  // for good. The moment we launched is the moment the claim means; the moment we finished
+  // checking is not.
+  const spawnedAt = new Date().toISOString()
   try {
     await backend.spawn({ id, cwd, argv: planned.plan.argv, ...spawnPromptArg(planned.plan, cmd.harness) })
   } catch (e) {
@@ -229,7 +239,7 @@ async function start(
     id,
     harness: cmd.harness,
     cwd,
-    createdAt: new Date().toISOString(),
+    createdAt: spawnedAt,
     ...(cmd.model ? { model: cmd.model } : {}),
     ...(cmd.effort ? { effort: cmd.effort } : {}),
     ...(cmd.label ? { label: cmd.label } : {}),
@@ -377,6 +387,16 @@ async function batch(
     if (!planned.ok) { failed.push({ harness: spec.harness, reason: explainPlanError(planned.error) }); continue }
 
     const id = newSessionId()
+    // Stamped BEFORE the process is launched, not after it has been checked for a crash.
+    //
+    // `planFirstSightingClaims` asks whether a conversation began AFTER we spawned, and this is the
+    // only timestamp it has. `spawnFailure` deliberately WAITS to see whether the child dies, so a
+    // record stamped after it is seconds late — measured 2026-09-08: a kimi session whose own store
+    // record began at 13:58:50.831 was recorded as spawned at 13:58:52.914, so its conversation
+    // failed the `startedMs > spawnedMs` test and that row stayed unlinked, with an empty chat view,
+    // for good. The moment we launched is the moment the claim means; the moment we finished
+    // checking is not.
+    const spawnedAt = new Date().toISOString()
     try {
       await backend.spawn({
         id, cwd, argv: planned.plan.argv,
@@ -399,7 +419,7 @@ async function batch(
       id,
       harness: spec.harness,
       cwd,
-      createdAt: new Date().toISOString(),
+      createdAt: spawnedAt,
       task: cmd.task,
       // Stamped at SPAWN — the one moment the association is a fact. See `ManagedSession.taskId`.
       ...(resolved?.taskId ? { taskId: resolved.taskId } : {}),

--- a/packages/server/server/sessions/gemini-chat.test.ts
+++ b/packages/server/server/sessions/gemini-chat.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'bun:test'
+import { parseGeminiChatTurns } from './gemini-chat'
+
+/**
+ * VERBATIM shapes from `~/.gemini/tmp/agentistics/chats/session-2026-09-08T14-11-2a2b4e9d.jsonl`,
+ * captured 2026-09-08 against gemini 0.55.x — the file the harness wrote for a session agentop had
+ * just started.
+ */
+const HEADER = JSON.stringify({
+  sessionId: '2a2b4e9d-c1ac-4b92-8a23-d2dc9a2158a2',
+  projectHash: 'ce276284a10422f5496a58c38fa491f7891a1bf27',
+  startTime: '2026-09-08T14:11:24.125Z',
+  lastUpdated: '2026-09-08T14:11:24.125Z',
+  kind: 'main',
+})
+const SEED = JSON.stringify({ $set: { messages: [], lastUpdated: '2026-09-08T14:11:24.125Z' } })
+const PATCH = JSON.stringify({ $set: { lastUpdated: '2026-09-08T14:12:18.661Z' } })
+const USER = JSON.stringify({
+  id: '5295492b-11e0-43a0-89db-62ab3d4769ef',
+  timestamp: '2026-09-08T14:11:33.230Z',
+  type: 'user',
+  content: [{ text: 'responda apenas: ok' }],
+})
+const MODEL = JSON.stringify({
+  id: '9f1ae60b-59d7-46ed-8684-f6d479b2f05a',
+  timestamp: '2026-09-08T14:12:18.661Z',
+  type: 'gemini',
+  content: 'ok',
+  model: 'gemini-3.5-flash',
+})
+
+const lines = (...l: string[]) => l
+
+describe('parseGeminiChatTurns', () => {
+  it('reads the conversation, oldest first, with both roles', () => {
+    const turns = parseGeminiChatTurns(lines(HEADER, SEED, USER, PATCH, MODEL, PATCH), 50)
+    expect(turns.map(t => [t.role, t.text])).toEqual([
+      ['user', 'responda apenas: ok'],
+      ['assistant', 'ok'],
+    ])
+    expect(turns[0]!.at).toBe('2026-09-08T14:11:33.230Z')
+  })
+
+  /** The header and the `lastUpdated` patches are bookkeeping. Neither is a turn. */
+  it('draws no turn from the header or a bare patch', () => {
+    expect(parseGeminiChatTurns(lines(HEADER, SEED, PATCH, PATCH), 50)).toEqual([])
+  })
+
+  /**
+   * A resumed session's opening snapshot repeats turns that then arrive again as their own lines.
+   * Same rule as the metrics parser: `id` decides, and one turn is one turn.
+   */
+  it('counts a turn once when the snapshot and its own line both carry it', () => {
+    const msg = {
+      id: 'dup-1', timestamp: '2026-09-08T14:11:33.230Z', type: 'user', content: 'oi',
+    }
+    const turns = parseGeminiChatTurns(
+      lines(HEADER, JSON.stringify({ $set: { messages: [msg] } }), JSON.stringify(msg)), 50)
+    expect(turns.map(t => t.text)).toEqual(['oi'])
+  })
+
+  /**
+   * `info` and `error` are the harness talking about itself, not either party talking. They are
+   * dropped rather than attributed to somebody — the same rule `antigravity-chat.ts` applies to a
+   * `SYSTEM_MESSAGE`.
+   */
+  it('drops the harness\'s own notices instead of giving them a speaker', () => {
+    const info = JSON.stringify({ id: 'i-1', type: 'info', content: 'Loaded cached credentials.' })
+    const err = JSON.stringify({ id: 'e-1', type: 'error', content: 'quota exceeded' })
+    expect(parseGeminiChatTurns(lines(HEADER, info, err, MODEL), 50).map(t => t.role))
+      .toEqual(['assistant'])
+  })
+
+  /**
+   * gemini writes a `<session_context>` bootstrap block under the USER role on startup. It is not
+   * something the person said, and showing it makes every session open on a wall of injected
+   * context — the same rule every other reader here applies to an injected entry.
+   */
+  it('drops the injected session context, and keeps the message after it', () => {
+    const boot = JSON.stringify({
+      id: 'b-1', type: 'user',
+      content: '<session_context>cwd=/home/x\nfiles=…</session_context>',
+    })
+    const turns = parseGeminiChatTurns(lines(HEADER, boot, USER), 50)
+    expect(turns.map(t => t.text)).toEqual(['responda apenas: ok'])
+  })
+
+  /** The window is the LAST `max` turns — a chat opens on what was just said. */
+  it('keeps the newest turns when the window is smaller than the conversation', () => {
+    const many = [HEADER]
+    for (let i = 0; i < 6; i++) {
+      many.push(JSON.stringify({ id: `u${i}`, type: 'user', content: `m${i}` }))
+    }
+    expect(parseGeminiChatTurns(many, 2).map(t => t.text)).toEqual(['m4', 'm5'])
+  })
+
+  /** A line that will not parse costs that line, never the conversation. */
+  it('skips an unparseable line and reads the rest', () => {
+    expect(parseGeminiChatTurns(lines(HEADER, '{ not json', USER), 50).map(t => t.text))
+      .toEqual(['responda apenas: ok'])
+  })
+
+  it('answers with nothing for an empty file', () => {
+    expect(parseGeminiChatTurns([], 50)).toEqual([])
+  })
+})

--- a/packages/server/server/sessions/gemini-chat.ts
+++ b/packages/server/server/sessions/gemini-chat.ts
@@ -1,0 +1,131 @@
+/**
+ * gemini-chat.ts — PURE. Gemini's conversation, read from its own chat journal.
+ *
+ * ## Why this exists now and did not before
+ *
+ * `harness-transcript.ts` carried `gemini: null` with a reason, and the reason was a LINK fact
+ * rather than a format one: a reader is only ever offered a `conversationId`, gemini has no
+ * `assignId` and no id-taking `resume`, so the entry would have been code nothing could reach.
+ *
+ * What changed is that the link arrived from the other side. `planFirstSightingClaims` deliberately
+ * includes gemini, and the id it claims is the SYNTHETIC one this product already keys the store on
+ * — `${dirName}/${fileBase}` — which names a file directly:
+ * `~/.gemini/tmp/<dirName>/chats/<fileBase>.jsonl`. So the id a gemini row now carries is not a
+ * UUID that resolves to nothing; it is the path, in the only form this product ever knew it by.
+ *
+ * ## The journal, measured rather than assumed
+ *
+ * Captured 2026-09-08 from gemini 0.55.x. One JSON document per line:
+ *
+ *  - a HEADER — `{sessionId, projectHash, startTime, lastUpdated, kind}`;
+ *  - a SEED — `{"$set":{"messages":[…]}}`, written once near the top and EMPTY for a fresh session
+ *    (it repeats earlier turns for a resumed one);
+ *  - the TURNS, appended each as their own top-level record
+ *    `{id, timestamp, type, content, model?}`;
+ *  - PATCHES — `{"$set":{"lastUpdated":…}}` after every turn, which are bookkeeping and not turns.
+ *
+ * The appended records are the part `gemini-parse.ts` was missing, and missing them is why 27 of
+ * 34 chat files on this machine parsed to nothing at all. This module reads BOTH sources through
+ * one `id`-keyed gate, because a resumed session carries the same turn in each.
+ *
+ * ## What is NOT a turn
+ *
+ * `info` and `error` are the harness talking about itself; they are dropped rather than attributed
+ * to a speaker, the same way `antigravity-chat.ts` refuses to draw a `SYSTEM_MESSAGE` as a message.
+ * And gemini writes a `<session_context>` bootstrap block under the USER role, which is not
+ * something the person said — every other reader here applies the same rule to its own harness's
+ * injected entry, and showing it would open every session on a wall of context nobody typed.
+ */
+
+import type { ChatTurn } from './chat-turn'
+
+/** The bootstrap block gemini writes under the user role on startup. Not a person talking. */
+const SESSION_CONTEXT = /^<session_context>/
+
+/** Gemini's own message types, mapped onto the two roles a turn can have. `null` = not a turn. */
+function roleOf(type: unknown): ChatTurn['role'] | null {
+  if (type === 'user') return 'user'
+  // `model` is the older name for the same thing and is accepted, so a transcript written by an
+  // earlier gemini still reads. Anything else — `info`, `error`, or a type nobody has seen — is
+  // NOT given a speaker: inventing one is the expensive direction in a record of what was said.
+  if (type === 'gemini' || type === 'model') return 'assistant'
+  return null
+}
+
+/** The text of one message, whichever of the two shapes it uses. */
+function textOf(msg: Record<string, unknown>): string {
+  const content = msg.content
+  if (typeof content === 'string') return content
+  if (Array.isArray(content)) {
+    return content
+      .map(part => (part && typeof part === 'object' ? String((part as { text?: unknown }).text ?? '') : ''))
+      .join('')
+  }
+  return ''
+}
+
+/**
+ * The conversation, oldest first, capped at `max` turns FROM THE END.
+ *
+ * Takes the file's lines rather than its bytes so `readTailWindow` can hand it the tail of a long
+ * journal without this module knowing anything about files — the same shape `parseCopilotChat`
+ * takes, and for the same reason.
+ *
+ * Never throws: a line that will not parse costs that line and nothing else.
+ */
+export function parseGeminiChatTurns(lines: readonly string[], max: number): ChatTurn[] {
+  const turns: ChatTurn[] = []
+  // Spans BOTH sources. A resumed session's seed repeats turns that then arrive again as their own
+  // lines, and showing a turn twice reads as the assistant repeating itself.
+  const seen = new Set<string>()
+
+  const take = (raw: unknown): void => {
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return
+    const msg = raw as Record<string, unknown>
+    const id = typeof msg.id === 'string' ? msg.id : undefined
+    if (id !== undefined) {
+      if (seen.has(id)) return
+      seen.add(id)
+    }
+    const role = roleOf(msg.type)
+    if (!role) return
+    const text = textOf(msg).trim()
+    if (!text) return
+    if (role === 'user' && SESSION_CONTEXT.test(text)) return
+    turns.push({
+      role,
+      text,
+      ...(typeof msg.timestamp === 'string' && msg.timestamp ? { at: msg.timestamp } : {}),
+    })
+  }
+
+  for (const line of lines) {
+    const trimmed = line.trim()
+    if (!trimmed) continue
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(trimmed)
+    } catch {
+      continue
+    }
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) continue
+    const obj = parsed as Record<string, unknown>
+
+    // The seed. Its `messages` are turns; every other `$set` is a patch of the session's own
+    // fields, and a `lastUpdated` is not something anybody said.
+    const set = obj.$set
+    if (set !== undefined) {
+      const seeded = (set as { messages?: unknown })?.messages
+      if (Array.isArray(seeded)) for (const m of seeded) take(m)
+      continue
+    }
+
+    // The header carries no `type`, so it is skipped by `roleOf` anyway; the explicit check keeps
+    // that an intention rather than a side effect.
+    if (obj.sessionId !== undefined && obj.type === undefined) continue
+
+    take(obj)
+  }
+
+  return max >= 0 && turns.length > max ? turns.slice(turns.length - max) : turns
+}

--- a/packages/server/server/sessions/harness-session-file.test.ts
+++ b/packages/server/server/sessions/harness-session-file.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from 'bun:test'
 import { HARNESS_ORDER } from '@agentistics/core'
 import {
-  HARNESS_SESSION_SOURCES, chosenName, parseHarnessSessionFile, pickTitle, tmuxSessionName,
+  HARNESS_PROCESS_LOGS, HARNESS_SESSION_SOURCES, chosenName, parseHarnessSessionFile, pickTitle,
+  tmuxSessionName,
 } from './harness-session-file'
 
 /**
@@ -208,5 +209,35 @@ describe('chosenName — the nameSource values seen in real files', () => {
     // A rejection list, not an allow list. An unknown fourth value in an undocumented, internal
     // format must not silently blank a name.
     expect(chosenName({ name: 'whatever', nameSource: 'something-new' })).toBe('whatever')
+  })
+})
+
+/**
+ * The second shape a harness can record its own live session in: not a file it writes ABOUT the
+ * session, but the log it keeps open FOR the process. Kept as its own table rather than widened
+ * into `HARNESS_SESSION_SOURCES`, whose every rule ("a directory of JSON records keyed by pid")
+ * would have had to be qualified — two shapes under one name is two sets of rules.
+ */
+describe('HARNESS_PROCESS_LOGS', () => {
+  it('has decided about every harness — absence is a decision', () => {
+    expect(Object.keys(HARNESS_PROCESS_LOGS).sort()).toEqual([...HARNESS_ORDER].sort())
+  })
+
+  it('is antigravity only, because it is the one harness with no other way to be linked', () => {
+    for (const id of HARNESS_ORDER) {
+      if (id === 'antigravity') expect(HARNESS_PROCESS_LOGS[id]).not.toBeNull()
+      else expect(HARNESS_PROCESS_LOGS[id], id).toBeNull()
+    }
+  })
+
+  it('reads a real captured line through the table, not only through the module', () => {
+    const src = HARNESS_PROCESS_LOGS.antigravity!
+    expect(src.conversationFrom(
+      'ERROR: logging before google.Init: I0908 10:03:58.569478     218 server.go:1153] '
+      + 'Created conversation 39783297-b1b0-49bf-9f56-b809ee1933db',
+    )).toBe('39783297-b1b0-49bf-9f56-b809ee1933db')
+    expect(src.logFromFds([
+      '/dev/pts/3', '/home/mithrandir/.gemini/antigravity-cli/log/cli-20260908_100356.log',
+    ])).toBe('/home/mithrandir/.gemini/antigravity-cli/log/cli-20260908_100356.log')
   })
 })

--- a/packages/server/server/sessions/harness-session-file.ts
+++ b/packages/server/server/sessions/harness-session-file.ts
@@ -38,6 +38,7 @@
  */
 
 import type { HarnessId } from '@agentistics/core'
+import { agyLogFromFds, conversationFromAgyLog } from './agy-conversation'
 
 /** One harness session record, reduced to the fields anything here may rely on. */
 export interface HarnessSessionFile {
@@ -263,5 +264,42 @@ export const HARNESS_SESSION_SOURCES: Record<HarnessId, HarnessSessionSource | n
   gemini: null,
   copilot: null,
   antigravity: null,
+  kimi: null,
+}
+
+/**
+ * The OTHER shape a harness can betray its own live conversation in: a log it keeps OPEN.
+ *
+ * `HARNESS_SESSION_SOURCES` above is one shape — a directory of JSON records a harness writes ABOUT
+ * its sessions — and every rule it carries is about that shape. antigravity has nothing of the
+ * kind, and it has no assign flag either (`agy --conversation <fresh-uuid>` answers
+ * `warning: conversation "…" not found` and creates one under an id of its own; measured against
+ * agy 1.1.27 on 2026-09-08). What it DOES have is one log per process, held open for the life of
+ * that process, naming the conversation it created. See `agy-conversation.ts` for why that is the
+ * only exact answer available for this harness.
+ *
+ * Two tables rather than one widened table: "a file per session, keyed by pid, parsed as JSON" and
+ * "the process's own open log, read by regex" share no rule beyond the question they answer, and
+ * folding them together would qualify every sentence in both.
+ *
+ * The functions live with the harness that needs them, so the day a second harness turns out to do
+ * this its reader lands beside its own parser and not in here.
+ */
+export interface HarnessProcessLog {
+  /** Pick this harness's own log out of a process's open fd targets. Refuses on ambiguity. */
+  logFromFds(targets: readonly string[]): string | null
+  /** The conversation that log says the process created, or `null`. */
+  conversationFrom(text: string): string | null
+}
+
+export const HARNESS_PROCESS_LOGS: Record<HarnessId, HarnessProcessLog | null> = {
+  antigravity: { logFromFds: agyLogFromFds, conversationFrom: conversationFromAgyLog },
+  // Nobody has read a per-process log for the other five, and one that has not been read is one
+  // that must not be guessed at. claude is `null` HERE and non-null above: it already has two exact
+  // links and needs no third.
+  claude: null,
+  codex: null,
+  gemini: null,
+  copilot: null,
   kimi: null,
 }

--- a/packages/server/server/sessions/harness-transcript.test.ts
+++ b/packages/server/server/sessions/harness-transcript.test.ts
@@ -21,18 +21,14 @@ describe('the reader registry', () => {
       .toEqual(['antigravity', 'claude', 'codex', 'copilot', 'gemini', 'kimi'])
   })
 
-  it('GEMINI is the one null, and it is a LINK fact rather than a missing reader', () => {
-    // A reader is only ever offered a conversationId, and gemini has neither `assignId` nor a
-    // `resume` that takes one — so a gemini row can never carry one and an entry here would be
-    // unreachable code. `conversationBlind` already says so on the row.
-    expect(transcriptReaderFor('gemini')).toBeNull()
-  })
-
-  it('every harness that CAN carry an exact conversation id has a reader', () => {
-    // The five with `assignId` or `resume` in `spawn-spec.ts`. If one of these goes null, a row
-    // that knows exactly which conversation it is in stops being readable.
-    for (const h of ['claude', 'codex', 'copilot', 'kimi', 'antigravity'] as const) {
-      expect(transcriptReaderFor(h)).not.toBeNull()
+  it('has no nulls left — gemini was the last, and its reason was the LINK', () => {
+    // It read `expect(transcriptReaderFor('gemini')).toBeNull()` for as long as a gemini row could
+    // not carry a conversation id: no `assignId`, and a `--resume` that takes "latest" or an index.
+    // `planFirstSightingClaims` includes gemini deliberately and claims the SYNTHETIC id the store
+    // is already keyed on, which names the chat file directly — so the entry stopped being
+    // unreachable code and became a reader. A null here is now a gap, not a finding.
+    for (const h of ['claude', 'codex', 'copilot', 'kimi', 'antigravity', 'gemini'] as const) {
+      expect(transcriptReaderFor(h), h).not.toBeNull()
     }
   })
 

--- a/packages/server/server/sessions/harness-transcript.ts
+++ b/packages/server/server/sessions/harness-transcript.ts
@@ -25,11 +25,12 @@
 import { readFile, readdir, stat } from 'node:fs/promises'
 import { join } from 'node:path'
 import type { HarnessId } from '@agentistics/core'
-import { ANTIGRAVITY_BRAIN_DIR, CODEX_SESSIONS_DIR, COPILOT_DIR, KIMI_DIR } from '../config'
+import { ANTIGRAVITY_BRAIN_DIR, CODEX_SESSIONS_DIR, COPILOT_DIR, GEMINI_DIR, KIMI_DIR } from '../config'
 import { UUID_RE } from '../git'
 import { parseAntigravityChat } from './antigravity-chat'
 import { parseCodexChat } from './codex-chat'
 import { parseCopilotChat } from './copilot-chat'
+import { parseGeminiChatTurns } from './gemini-chat'
 import { parseKimiChat } from './kimi-chat'
 import type { ChatTurn } from './chat-turn'
 import { readChatWindow, readRecentChatTurns, resolveChatTranscriptPath } from './chat-tail'
@@ -218,6 +219,35 @@ export async function resolveCopilotTranscript(
   return (await exists(p)) ? p : null
 }
 
+/**
+ * Gemini files a chat at `~/.gemini/tmp/<project>/chats/<file>.jsonl`, and the conversation id this
+ * product uses IS `<project>/<file>` — so the path needs no directory listing and no memo, unlike
+ * codex's and kimi's. It is also the reason the id has to be checked rather than interpolated: it
+ * is the only conversation id in this table that is a path fragment.
+ */
+async function resolveGeminiTranscript(ref: TranscriptRef): Promise<string | null> {
+  const parts = ref.conversationId.split('/')
+  // Exactly `<project>/<file>`, and neither half may leave the chats directory. A `.` or `..`, an
+  // empty segment or a nested path is refused outright — an id that cannot be trusted is an id
+  // that names no file, which is the same answer as a conversation nobody has written yet.
+  if (parts.length !== 2) return null
+  if (parts.some(p => p === '' || p === '.' || p === '..' || p.includes('\\'))) return null
+  const path = join(GEMINI_DIR, 'tmp', parts[0]!, 'chats', `${parts[1]!}.jsonl`)
+  return (await exists(path)) ? path : null
+}
+
+const GEMINI: HarnessTranscript = {
+  resolve: ref => resolveGeminiTranscript(ref),
+  async read(path, max) {
+    let content: string
+    try { content = await readFile(path, 'utf-8') } catch { return { turns: [], older: false } }
+    return windowed(parseGeminiChatTurns(content.split('\n'), max + 1), max)
+  },
+  async readRecent(path, max) {
+    return readTailWindow(path, max, lines => parseGeminiChatTurns(lines, max))
+  },
+}
+
 const COPILOT: HarnessTranscript = {
   resolve: ref => resolveCopilotTranscript(ref),
   async read(path, max) {
@@ -298,24 +328,25 @@ const CLAUDE: HarnessTranscript = {
 /**
  * The reader for each harness, and the one `null` that is not a gap.
  *
- * GEMINI CAN NEVER BE READ HERE, and that is a fact about the LINK rather than about the format.
- * A reader is only ever offered a `conversationId`, and `ManagedSession.conversationId` exists only
- * where agentop handed the id to the CLI. Measured against `spawn-spec.ts`: claude and copilot have
- * `assignId`, and codex, kimi and antigravity have `resume` — so every one of those five can carry
- * an exact id. **Gemini has neither** (`-r, --resume` takes "latest" or an index, not an id, and
- * `--session-id` is deliberately excluded because gemini's id in this product is synthetic —
- * `${dir}/${file}` — so a recorded UUID would resolve to nothing while LOOKING exact). A gemini row
- * therefore never has a conversation id at all, `conversationBlind` already says so in words, and
- * `SessionsPage` hides the chat tab on such a row.
+ * GEMINI IS READ THROUGH THE ID THIS PRODUCT ALREADY KEYS IT BY, and it took a link to get here.
+ * This entry was `null` for a long time, with a reason that was a LINK fact and not a format one: a
+ * reader is only ever offered a `conversationId`, gemini has no `assignId` and its `-r, --resume`
+ * takes "latest" or an index rather than an id, so an entry would have been code nothing could
+ * reach. What changed is that `planFirstSightingClaims` deliberately includes gemini, and the id it
+ * claims is the SYNTHETIC one the store is keyed on — `${dirName}/${fileBase}` — which is not a
+ * UUID resolving to nothing but the chat file's own path in the only form this product knew it by.
  *
- * So a gemini entry here would be code nothing can reach, plus a claim the product cannot honour.
- * Its chat file WAS read and understood — it is a patch log, not one message per line: a header,
- * then `{"$set":{messages:[…]}}` seeding the list once (measured: 1 seed, always at line 1, in 4 of
- * 12 files) and bare message objects appended after it, with types `user` / `gemini` / `info` /
- * `error` and a `<session_context>` bootstrap block the harness writes under the user role. That
- * note is here so the next reader of this file does not spend the measurement again, and so the
- * absence reads as a finding rather than as a to-do. It becomes writable the day gemini accepts an
- * id agentop can hand it — not before.
+ * That id is a PATH, so `resolve` treats it as untrusted: exactly two segments, neither of them a
+ * traversal, or it answers `null`. An id reaching a `readFile` is the one place this table touches
+ * something shaped like user input.
+ *
+ * The format was measured twice, and the second reading is the one in `gemini-chat.ts`. The note
+ * that used to live here called it "a patch log, not one message per line", which was half right
+ * and cost the product months of gemini sessions: the SEED is a patch (`{"$set":{messages:[…]}}`,
+ * once, empty for a fresh session) and every turn AFTER it is appended as its own line. Reading
+ * only the seed is why `gemini-parse.ts` dropped 27 of the 34 chat files on this machine and why
+ * the adapter's newest session was from 2026-04-10. Both sources are read, through one `id`-keyed
+ * gate, because a resumed session carries the same turn in each.
  */
 export const HARNESS_TRANSCRIPTS: Record<HarnessId, HarnessTranscript | null> = {
   claude: CLAUDE,
@@ -323,7 +354,7 @@ export const HARNESS_TRANSCRIPTS: Record<HarnessId, HarnessTranscript | null> = 
   codex: CODEX,
   copilot: COPILOT,
   kimi: KIMI,
-  gemini: null,
+  gemini: GEMINI,
 }
 
 /**

--- a/packages/server/server/sessions/process-conversation.ts
+++ b/packages/server/server/sessions/process-conversation.ts
@@ -1,0 +1,72 @@
+/**
+ * process-conversation.ts — the IO half of `agy-conversation.ts`: which conversation the process
+ * behind one of our panes is writing, read from the log that process holds OPEN.
+ *
+ * The pure module holds every RULE (which file, which line, and every refusal); this one only
+ * performs the two reads and never decides anything. Same split as
+ * `harness-session-file.ts` / `harness-sessions.ts`, and for the same reason: the rules are what
+ * needs pinning against real bytes, and the filesystem is what must never throw into the poll.
+ *
+ * ## Cost, and why it is asked so narrowly
+ *
+ * The poll runs every five seconds over the whole fleet. A `/proc/<pid>/fd` sweep is a `readdir`
+ * plus a `readlink` per descriptor, and the log read is the whole file — so the CALLER asks only
+ * for a row that has NO link yet and whose harness has an entry in `HARNESS_PROCESS_LOGS`. On a
+ * fleet with no antigravity in it this module is never called at all, and a linked agy row is asked
+ * exactly once: `recordConversation` writes the id, and the next poll skips it.
+ *
+ * Failure is ABSENCE, always. No `/proc` (not Linux), a pid that has exited between the pane listing
+ * and this read, a descriptor whose target cannot be resolved, an unreadable log: the answer is
+ * `null`, the row keeps behaving exactly as it does today, and `conversationBlind`'s degradation
+ * sentence in `chat-web.ts` is what the user sees. Nothing here may throw into the poll.
+ */
+
+import { readFile, readdir, readlink } from 'node:fs/promises'
+import { join } from 'node:path'
+import type { HarnessId } from '@agentistics/core'
+import { HARNESS_PROCESS_LOGS } from './harness-session-file'
+
+/** Every path this process currently holds open. `[]` for anything that cannot be read. */
+async function openFiles(pid: number): Promise<string[]> {
+  const dir = `/proc/${pid}/fd`
+  let names: string[]
+  try {
+    names = await readdir(dir)
+  } catch {
+    return [] // not Linux, the process has exited, or the descriptors are not ours to read
+  }
+  const out: string[] = []
+  for (const name of names) {
+    try {
+      out.push(await readlink(join(dir, name)))
+    } catch {
+      // A descriptor closed between the listing and the resolve, or a link we may not follow. One
+      // missing entry is one fewer candidate, never a failed read of the rest.
+    }
+  }
+  return out
+}
+
+/**
+ * The conversation the process at `pid` is writing, or `null` when nothing here can say.
+ *
+ * `null` covers every distinguishable failure on purpose: this answer feeds
+ * `recordConversation`, which writes a link that is then treated as exact everywhere, so the only
+ * two outcomes worth having are a conversation somebody can point at and no answer at all.
+ */
+export async function readProcessConversation(
+  harness: HarnessId,
+  pid: number,
+): Promise<string | null> {
+  const source = HARNESS_PROCESS_LOGS[harness]
+  if (!source) return null
+
+  const log = source.logFromFds(await openFiles(pid))
+  if (!log) return null
+
+  try {
+    return source.conversationFrom(await readFile(log, 'utf-8'))
+  } catch {
+    return null
+  }
+}

--- a/packages/server/server/sessions/sessions-host.ts
+++ b/packages/server/server/sessions/sessions-host.ts
@@ -11,6 +11,7 @@
  * the same defect `liveEmptyNotice` exists to prevent on the dashboard.
  */
 
+import type { HarnessId } from '@agentistics/core'
 import { createLimiter } from '../utils'
 import type { HarnessProcess } from '../live-sessions'
 import { rulesFor } from './attention-rules'
@@ -25,6 +26,7 @@ import { readDialog, type DialogOption, type DialogUnreadable } from './dialog-c
 import { planAdoptions } from './session-adopt'
 // The claim for harnesses that cannot be handed a conversation id. See `task-attribution.ts`.
 import { planFirstSightingClaims } from './task-attribution'
+import { HARNESS_PROCESS_LOGS } from './harness-session-file'
 import { loadConversations, type Conversation } from './conversations'
 import { HEARTBEAT_MS, planCrashGroup, type CrashGroup } from './crash-group'
 import { emptyHarnessSessionIndex, type HarnessSessionIndex } from './harness-sessions'
@@ -138,6 +140,13 @@ export function createSessionsPoller(o: {
      */
     link: 'assigned' | 'observed',
   ) => Promise<unknown>
+  /**
+   * The conversation the process behind one of our panes is writing, from the log that process
+   * holds open. `null` whenever nothing can say — see `process-conversation.ts`.
+   *
+   * Injected like every other read here, so the poller stays testable without a `/proc`.
+   */
+  readProcessConversation?: (harness: HarnessId, pid: number) => Promise<string | null>
   /**
    * Persist the name a managed row was given INSIDE the harness (`/rename`), so the title survives
    * the process.
@@ -378,6 +387,37 @@ export function createSessionsPoller(o: {
       }
       markFleetPhase(`poll: recordConversation x${recordConvWrites}`, recordConvStart)
 
+      // The pane pids, read ONCE for the two things below that need them: the per-process
+      // conversation link, and the hardware sample further down. Two `tmux list-panes` calls a poll
+      // for one answer is a second place for them to disagree about which pid is which row.
+      const panePids = await o.backend.listPanePids?.().catch(() => new Map<string, number>())
+
+      // The OTHER exact link: the conversation named in the log the harness's own process holds
+      // OPEN (`HARNESS_PROCESS_LOGS` — antigravity only today; see `agy-conversation.ts` for why
+      // that harness has neither an assign flag nor a session record, and why even the
+      // harness-and-directory fallback is closed for a session agentop started).
+      //
+      // Recorded as `assigned` rather than `observed`: this is the harness's own statement about
+      // the conversation it created, read out of the process WE spawned into WE own's pane — not
+      // the first-sighting claim below, which infers from time and directory and refuses on any
+      // ambiguity. Asked only of a row with NO link yet, and only for a harness that has an entry,
+      // so it costs one `/proc` sweep per unlinked agy session and nothing at all on a fleet
+      // without one.
+      const procLinkStart = performance.now()
+      let procLinkWrites = 0
+      if (o.recordConversation && o.readProcessConversation) {
+        for (const m of registry) {
+          if (m.conversationId || !HARNESS_PROCESS_LOGS[m.harness]) continue
+          const pid = panePids?.get(m.id)
+          if (!pid) continue
+          const found = await o.readProcessConversation(m.harness, pid).catch(() => null)
+          if (!found) continue
+          procLinkWrites++
+          await o.recordConversation(m.id, found, 'assigned').catch(() => undefined)
+        }
+      }
+      markFleetPhase(`poll: processConversation x${procLinkWrites}`, procLinkStart)
+
       // The conversation link for the harnesses no `assignId` can be given (codex, kimi,
       // antigravity, gemini): claimed ONCE, at first sighting, and refused on any ambiguity. Written
       // through the same `recordConversation` as the exact link above, because a second path to one
@@ -436,7 +476,6 @@ export function createSessionsPoller(o: {
       const sessionHardware = new Map<string, { pid?: number; cpuPercent?: number | null; rssBytes?: number | null }>()
       const procStatStart = performance.now()
       if (canReadProc) {
-        const panePids = await o.backend.listPanePids?.().catch(() => new Map<string, number>())
         for (const r of reconciled) {
           const own = harnessSessions.byManagedId.get(r.id)
           const harness = r.managed?.harness

--- a/packages/server/server/sessions/spawn-spec.test.ts
+++ b/packages/server/server/sessions/spawn-spec.test.ts
@@ -220,13 +220,18 @@ describe('conversationLinkable', () => {
     // session we started it under); copilot on the flag alone.
     expect(conversationLinkable('claude')).toBe(true)
     expect(conversationLinkable('copilot')).toBe(true)
+    // antigravity on a third: it has NO assign flag (`--conversation` resumes and refuses an
+    // unknown id — measured against agy 1.1.27) and writes no session record, but it holds its own
+    // per-process log open, and that log names the conversation it created. See
+    // `agy-conversation.ts`; the chain pid -> fd -> log -> conversation is exact at every step.
+    expect(conversationLinkable('antigravity')).toBe(true)
   })
 
   it('is false where every answer would be a harness-and-directory guess', () => {
     // The guess gives every session of one repository the same conversation — the bug that reopened
     // three rows onto one conversation. It is fine to OFFER, and this flag is what stops it being
     // presented as the conversation the row is in.
-    for (const harness of ['codex', 'kimi', 'gemini', 'antigravity'] as const) {
+    for (const harness of ['codex', 'kimi', 'gemini'] as const) {
       expect(conversationLinkable(harness)).toBe(false)
     }
   })

--- a/packages/server/server/sessions/spawn-spec.ts
+++ b/packages/server/server/sessions/spawn-spec.ts
@@ -61,7 +61,7 @@
  */
 
 import type { HarnessId } from '@agentistics/core'
-import { HARNESS_SESSION_SOURCES } from './harness-session-file'
+import { HARNESS_PROCESS_LOGS, HARNESS_SESSION_SOURCES } from './harness-session-file'
 import type { InitialPrompt, SpawnRequest, SpawnPlanResult, SpawnSpec } from './types'
 
 export const SPAWN_SPECS: Record<HarnessId, SpawnSpec | null> = {
@@ -226,21 +226,36 @@ export const SPAWN_SPECS: Record<HarnessId, SpawnSpec | null> = {
 /**
  * Can agentop ever know EXACTLY which conversation a fresh session of this harness is writing?
  *
- * Two ways exist and this is both of them: we told the CLI which id to use (`assignId`), or the
- * harness keeps a record of its own live sessions that can be matched back to our row
- * (`HARNESS_SESSION_SOURCES` — Claude's `~/.claude/sessions/<pid>.json`, which carries the tmux
- * session name we started it under).
+ * THREE ways exist and this is all of them:
  *
- * `false` is the answer for codex, kimi, gemini and antigravity, and it must be SAID rather than
- * papered over: everything downstream then falls back to `conversationForProcess`, which matches by
- * harness and directory and therefore gives every session of one repository the same conversation.
- * That guess is good enough to OFFER a reopen a person confirms by title, and not good enough to be
+ *  1. we told the CLI which id to use (`assignId` — claude, copilot);
+ *  2. the harness keeps a record of its own live sessions that can be matched back to our row
+ *     (`HARNESS_SESSION_SOURCES` — Claude's `~/.claude/sessions/<pid>.json`, which carries the tmux
+ *     session name we started it under);
+ *  3. the harness holds a per-process LOG open that names the conversation it created
+ *     (`HARNESS_PROCESS_LOGS` — antigravity, reached through the tmux pane pid's own file
+ *     descriptors; see `agy-conversation.ts`).
+ *
+ * The third was added because agy has neither of the first two and the fallback everything else
+ * leans on is closed for it in particular: its store record carries no `project_path` for a session
+ * agentop started, so even the harness-and-directory guess had nothing to match on. Its chat view
+ * was therefore permanently empty while its terminal worked, which is the defect this answers.
+ *
+ * `false` is still the answer for codex, kimi and gemini, and it must be SAID rather than papered
+ * over: everything downstream then falls back to `conversationForProcess`, which matches by harness
+ * and directory and therefore gives every session of one repository the same conversation. That
+ * guess is good enough to OFFER a reopen a person confirms by title, and not good enough to be
  * presented as the conversation this row is in. The same rule `HARNESS_CAPABILITIES` applies to a
  * metric, applied to a link.
+ *
+ * STATED LIMIT: route 3 is a `/proc` read, so it answers nothing off Linux. That degrades to no
+ * link, which `chat-web.ts` reports as "this session has no linked conversation yet" — true, and
+ * the one thing this may never do is claim a conversation it cannot name.
  */
 export function conversationLinkable(harness: HarnessId): boolean {
   return SPAWN_SPECS[harness]?.assignId !== undefined
     || HARNESS_SESSION_SOURCES[harness] !== null
+    || HARNESS_PROCESS_LOGS[harness] !== null
 }
 
 /** Decide the exact argv (and any text to type in) for a requested session. */

--- a/packages/web/src/components/sessions/SessionChat.tsx
+++ b/packages/web/src/components/sessions/SessionChat.tsx
@@ -36,9 +36,10 @@ import { ApprovalCard } from './ApprovalCard'
 import { ChatBubble, type ChatTurn } from './ChatBubble'
 import { WorkingNote } from './WorkingNote'
 import { useTerminalStream } from '../../hooks/useTerminalStream'
-import { isImagePath } from '../../lib/attachmentPreview'
+import { isImagePath, openComposerLightbox } from '../../lib/attachmentPreview'
 import { splitImageAttachments } from '../../lib/attachmentPreview'
 import { attachmentUrl } from '../../lib/attachmentUrl'
+import { AttachmentLightbox } from './AttachmentLightbox'
 import { liveTurnText, stripAnsi } from '../../lib/liveTurn'
 import { scratchKey, sessionScratch } from '../../lib/sessionScratch'
 import { chatReadAt, firstFrameStale, refreshChat, subscribeChat } from '../../lib/chatFeed'
@@ -530,6 +531,26 @@ export function SessionChat({ session, row, lang, act, onArtifacts }: SessionCha
    * pointed at. The chip says the name; the message carries the path.
    */
   const [attached, setAttached] = useState<Attachment[]>(() => sessionScratch.readAttachments(scratchId))
+  /**
+   * Which attached image the composer is showing full-size, or `null`.
+   *
+   * A thumbnail here was a picture you could not open — reported exactly that way — while the very
+   * same square in a SENT message opens `AttachmentLightbox`. The component is reused rather than
+   * copied: what you attached and what you sent are the same picture, so they get the same viewer.
+   * Its scope is what is attached RIGHT NOW, which is the caller's decision to make (see that
+   * component's header) and is the only list this control can honestly step through.
+   */
+  const [composerLightbox, setComposerLightbox] = useState<number | null>(null)
+  /**
+   * The images among what is attached, in the order the strip draws them.
+   *
+   * Only images: a text attachment has no picture to step to, and including it would make
+   * `ArrowRight` land on a blank frame. Derived at the render rather than stored, so removing one
+   * cannot leave this disagreeing with the strip beside it.
+   */
+  const composerImages = attached.filter(a => isImagePath(a.path)).map(a => a.path)
+  /** …and the index that survives an edit made while the overlay is open. See `openComposerLightbox`. */
+  const composerLightboxAt = openComposerLightbox(composerLightbox, composerImages.length)
 
   /**
    * Every change to the attachment list, persisted against the session it belongs to — the same
@@ -1623,10 +1644,25 @@ export function SessionChat({ session, row, lang, act, onArtifacts }: SessionCha
                       borderRadius: 8, overflow: 'hidden', flexShrink: 0,
                       border: '1px solid var(--border-subtle)', background: 'var(--bg-elevated)',
                     }}>
-                      <img
-                        src={attachmentUrl(a.path)} alt=""
-                        style={{ width: '100%', height: '100%', objectFit: 'cover', display: 'block' }}
-                      />
+                      {/* The picture OPENS. It is a button and not a click handler on the `img`,
+                          so it is reachable by keyboard and announced as something that does
+                          something — and it stays a SIBLING of the remove control rather than its
+                          parent, because a button inside a button is invalid and the inner one
+                          stops being clickable in some browsers. */}
+                      <button
+                        type="button"
+                        onClick={() => setComposerLightbox(composerImages.indexOf(a.path))}
+                        aria-label={pt ? `Ver ${a.name}` : `View ${a.name}`}
+                        style={{
+                          display: 'block', width: '100%', height: '100%', padding: 0,
+                          border: 'none', background: 'transparent', cursor: 'zoom-in',
+                        }}
+                      >
+                        <img
+                          src={attachmentUrl(a.path)} alt=""
+                          style={{ width: '100%', height: '100%', objectFit: 'cover', display: 'block' }}
+                        />
+                      </button>
                       <button
                         onClick={() => editAttached(list => list.filter(x => x.path !== a.path))}
                         aria-label={pt ? `Remover ${a.name}` : `Remove ${a.name}`}
@@ -2426,6 +2462,21 @@ export function SessionChat({ session, row, lang, act, onArtifacts }: SessionCha
           </div>
         </div>
       )}
+
+      {/* THE ATTACHED PICTURE, full size. The same component a sent message opens, over the images
+          attached right now — reused rather than reimplemented, so what you attached and what you
+          sent are viewed the same way. `composerLightboxAt` is what keeps it honest when the list
+          is edited underneath it. */}
+      {composerLightboxAt !== null && (
+        <AttachmentLightbox
+          paths={composerImages}
+          index={composerLightboxAt}
+          onIndexChange={setComposerLightbox}
+          onClose={() => setComposerLightbox(null)}
+          lang={lang}
+        />
+      )}
+
     </div>
   )
 }
@@ -2456,6 +2507,8 @@ function Loading({ pt }: { pt: boolean }) {
     }}>
       <Loader size={16} className="ag-working-spin" />
       {pt ? 'Lendo a conversa…' : 'Reading the conversation…'}
+
+
     </div>
   )
 }

--- a/packages/web/src/lib/attachmentPreview.test.ts
+++ b/packages/web/src/lib/attachmentPreview.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, test } from 'bun:test'
-import { isImagePath, splitImageAttachments, splitImageMarkers, resolveMarkerPaths, SEND_WINDOW_MS } from './attachmentPreview'
+import { describe, expect, test, test as it } from 'bun:test'
+import { isImagePath, openComposerLightbox, splitImageAttachments, splitImageMarkers, resolveMarkerPaths, SEND_WINDOW_MS } from './attachmentPreview'
 
 describe('isImagePath', () => {
   test('recognises known image extensions, case-insensitively', () => {
@@ -102,4 +102,40 @@ test('the ordinals are a count, never an index', () => {
   const s = [snd(T - 2, '/a/a.png'), snd(T - 1, '/a/b.png')]
   expect(resolveMarkerPaths({ markers: [4, 5], turnAtMs: T, sends: s }))
     .toEqual(resolveMarkerPaths({ markers: [1, 2], turnAtMs: T, sends: s }))
+})
+
+/**
+ * THE COMPOSER'S OWN LIGHTBOX INDEX.
+ *
+ * A thumbnail in the composer opens the same `AttachmentLightbox` a sent message does, over the
+ * images CURRENTLY attached — and that list is editable underneath it. Removing the picture being
+ * viewed, or every picture, must close the overlay rather than leave it open on a path that is no
+ * longer there; the lightbox renders nothing for a missing path, so without this the reader is left
+ * looking at a black screen with no image and a close button they have to find.
+ */
+describe('openComposerLightbox', () => {
+  it('keeps a valid index', () => {
+    expect(openComposerLightbox(1, 3)).toBe(1)
+    expect(openComposerLightbox(0, 1)).toBe(0)
+  })
+
+  it('closes when nothing is attached any more', () => {
+    expect(openComposerLightbox(0, 0)).toBeNull()
+  })
+
+  it('closes when the image being viewed was the one removed', () => {
+    // Two images, viewing the second, the second is removed: index 1 no longer names anything.
+    // Deliberately NOT clamped to the last image — the reader asked for THAT picture, and silently
+    // showing a different one is a worse answer than closing.
+    expect(openComposerLightbox(1, 1)).toBeNull()
+  })
+
+  it('stays closed when it was never open', () => {
+    expect(openComposerLightbox(null, 3)).toBeNull()
+  })
+
+  it('refuses an index that is not a real position', () => {
+    expect(openComposerLightbox(-1, 3)).toBeNull()
+    expect(openComposerLightbox(1.5, 3)).toBeNull()
+  })
 })

--- a/packages/web/src/lib/attachmentPreview.ts
+++ b/packages/web/src/lib/attachmentPreview.ts
@@ -130,3 +130,22 @@ export function resolveMarkerPaths(input: {
   if (inWindow.length !== input.markers.length) return null
   return inWindow.map(s => s.path)
 }
+
+/**
+ * Which image the composer's lightbox is showing, or `null` for closed.
+ *
+ * The composer's attachment list is editable while the overlay is open, so the index it was opened
+ * at can stop naming anything — and `AttachmentLightbox` renders nothing for a missing path, which
+ * leaves a black overlay with no picture in it. This is the one place that decides, so the rule is
+ * stated once rather than re-derived at the render.
+ *
+ * It CLOSES rather than clamps. Sliding to the last remaining image after the reader removed the
+ * one they were looking at answers a question nobody asked, and it does it silently — the same
+ * reason `parseDialogOptions` refuses a half-read option list instead of offering what it managed
+ * to read.
+ */
+export function openComposerLightbox(open: number | null, count: number): number | null {
+  if (open === null) return null
+  if (!Number.isInteger(open) || open < 0) return null
+  return open < count ? open : null
+}


### PR DESCRIPTION
## Summary

Every one of the six harnesses now has a readable conversation in the Sessions workspace, and the
image you attach in the composer opens like the one you sent.

Three findings, each measured on this machine on 2026-09-08 and each with its own commit:

**1. Antigravity had a reader and no LINK.** `antigravity-chat.ts` has shipped since #376; what was
missing is the conversation id. agy has no assign flag — `agy --conversation <fresh-uuid>` answers
`warning: conversation "…" not found` and creates one under an id of its own (agy 1.1.27) — and no
session record. And the harness-and-directory fallback is closed for it in particular: the adapter
takes `project_path` from the global `history.jsonl`, which agy writes only for a prompt typed in
its own UI, so a session agentop starts (`--prompt-interactive`) lands in the store with an empty
`project_path`, is dropped by `loadConversations`, and is never even a candidate. **15 of 38 agy
conversations here had a directory; the 23 without were exactly the ones agentop had opened.** The
third route is the log agy holds OPEN — `Created conversation <uuid>` in
`~/.gemini/antigravity-cli/log/cli-<ts>.log`, verified in `/proc/<pid>/fd` of a live agy under
tmux — so `managed row → tmux pane pid → open fd → log → conversation` is exact at every step.

**2. `createdAt` was stamped after `spawnFailure`, which deliberately waits.** So a row was recorded
seconds late and `planFirstSightingClaims` — which asks whether a conversation began AFTER we
spawned — failed against its OWN conversation. Measured: a kimi session whose store record began at
13:58:50.831 was recorded as spawned at 13:58:52.914 and stayed unlinked for good. Taken before the
launch now, at all three fresh-spawn sites.

**3. Gemini was dropping three months of sessions, product-wide.** `parseJsonl` collected messages
only from `$set.messages` snapshots; the journal writes that snapshot once — **empty for a fresh
session** — and appends every turn as its own top-level record. **Of 34 chat files, 7 carried
`$set.messages` and 27 did not, and the adapter's newest session was 2026-04-10.** That is the
dashboard, Compare, the costs and the session list, not only the chat view. The adapter goes from
15 sessions to 22 here. `first_prompt` was also hardcoded `''`, so every one of those sessions
would have been listed with a blank name. And gemini gets a reader: it was `null` for a LINK
reason, and `planFirstSightingClaims` includes gemini deliberately and claims the SYNTHETIC id the
store is already keyed on — which is the chat file's own path, so `resolve` treats it as untrusted
(exactly two segments, no traversal, or `null`).

Plus: the composer's image thumbnail opens `AttachmentLightbox`, the same component a sent message
uses. `openComposerLightbox` is pure and CLOSES rather than clamps when the viewed image is
removed — showing a different picture than the one asked for is a silent wrong answer.

**Tokens stay OFF for gemini.** Its appended records do carry `tokens{…}` and `model`, so the
capability could be flipped — and that changes money on every cost surface, so it needs its own
reconciliation against a bill, exactly as agy's protobuf mapping got. Recorded in CLAUDE.md as a
decision rather than left as an absence.

## Motivation

Reported as "sessions in the web UI only work for Claude Code" and then, after the first pass,
"gemini ainda não está exibindo corretamente" — which was right, and led to the third finding.
Advances #355, which is the audit that names this exact gap; the remaining items there (the
artifacts panel, the Live feed, the gallery and recall, per harness) are not audited by this PR.

## Test plan

- `bun tsc --noEmit` clean; **7225 tests pass, 0 fail**.
- New pure tests: `agy-conversation.test.ts` (12), `gemini-chat.test.ts` (8), the appended-journal
  cases in `gemini-parse.test.ts`, and `openComposerLightbox` in `attachmentPreview.test.ts`.
- The two tests that pinned the old gemini decision are updated, not deleted —
  `chat-web.test.ts` keeps testing the no-reader refusal through a harness id that does not exist,
  because that path is what the NEXT harness falls into.
- **Driven live against all six harnesses on one machine.** A session per harness, all under one
  task; every row carries a conversation id and `GET /api/fleet/chat` returns turns for each
  (claude 2, antigravity 2, codex 4, kimi 1, copilot 4, gemini 2), and all six stream their
  terminal over `/api/fleet/stream`.
- The composer lightbox was **not** clicked through in a browser: the Playwright profile on this
  machine was held by another session and killing it would have disturbed that session's work. The
  control is verified present in the built bundle (the button, its `zoom-in` cursor and its
  `View ${name}` label wrapping the attachment `img`) and its one rule is unit-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QBZMpjfSZ2Tn2qK95Mb4vs
