### PR TITLE
feat(sessions): the composer says how much you have typed

### DIFF
--- a/packages/web/src/components/sessions/SessionChat.tsx
+++ b/packages/web/src/components/sessions/SessionChat.tsx
@@ -37,6 +37,7 @@ import { ChatBubble, type ChatTurn } from './ChatBubble'
 import { WorkingNote } from './WorkingNote'
 import { useTerminalStream } from '../../hooks/useTerminalStream'
 import { isImagePath, openComposerLightbox } from '../../lib/attachmentPreview'
+import { promptCountLabel } from '../../lib/promptCount'
 import { splitImageAttachments } from '../../lib/attachmentPreview'
 import { attachmentUrl } from '../../lib/attachmentUrl'
 import { AttachmentLightbox } from './AttachmentLightbox'
@@ -549,6 +550,8 @@ export function SessionChat({ session, row, lang, act, onArtifacts }: SessionCha
    * cannot leave this disagreeing with the strip beside it.
    */
   const composerImages = attached.filter(a => isImagePath(a.path)).map(a => a.path)
+  /** The character count under the caret's own field. `null` while it is empty — see `promptCount.ts`. */
+  const countLabel = promptCountLabel(draft, pt ? 'pt' : 'en')
   /** …and the index that survives an edit made while the overlay is open. See `openComposerLightbox`. */
   const composerLightboxAt = openComposerLightbox(composerLightbox, composerImages.length)
 
@@ -2038,7 +2041,33 @@ export function SessionChat({ session, row, lang, act, onArtifacts }: SessionCha
                     so they keep their order and their spacing whether or not the conditional two
                     are there — a margin on send alone would push the more button off to the right
                     on its own the moment a turn ended. */}
-                <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginLeft: 'auto' }}>
+                {/* THE CHARACTER COUNT, in the gap the row already had.
+                    It sits between attach and the acting group — `marginLeft: auto` on that group
+                    is what pushed the two halves apart, so this costs the composer NO height and
+                    takes no room from the field. Absent on an empty box (`promptCountLabel`
+                    answers null): a counter reading `0` is a control with nothing to say, standing
+                    where the composer's own hints need to be able to appear.
+                    It counts the FIELD, not the message that will be sent — the attachment paths
+                    are prepended at send time and are not something anybody typed, so including
+                    them would make the number disagree with what is on screen, which is the one
+                    thing a counter beside a text box may not do.
+                    `pointerEvents: none` so it can never take a tap meant for a control beside it,
+                    and it gives way before the buttons do when the row runs out of width. */}
+                {countLabel && (
+                  <span
+                    aria-hidden
+                    style={{
+                      marginLeft: 'auto', minWidth: 0, overflow: 'hidden',
+                      textOverflow: 'ellipsis', whiteSpace: 'nowrap', pointerEvents: 'none',
+                      fontSize: 10.5, lineHeight: 1, color: 'var(--text-tertiary)',
+                      fontVariantNumeric: 'tabular-nums',
+                    }}
+                  >
+                    {countLabel}
+                  </span>
+                )}
+
+                <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginLeft: countLabel ? 6 : 'auto' }}>
                 {/* THE HARNESS MODE, and the one control that changes it.
                     Asked for: "nao consigo alternar entre os modos que os harnesses possuem (auto
                     mode, plan mode etc)", to sit left of the recent-message button.

--- a/packages/web/src/lib/promptCount.test.ts
+++ b/packages/web/src/lib/promptCount.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'bun:test'
+import { promptCharCount, promptCountLabel } from './promptCount'
+
+describe('promptCharCount', () => {
+  it('counts what a person would count', () => {
+    expect(promptCharCount('')).toBe(0)
+    expect(promptCharCount('ok')).toBe(2)
+    expect(promptCharCount('responda apenas: ok')).toBe(19)
+  })
+
+  /**
+   * `String.length` counts UTF-16 CODE UNITS, so an emoji reads as 2 and a flag as 4. Nobody typing
+   * one thinks they typed two, and this number sits next to a field where the whole point is that
+   * it matches what you can see.
+   */
+  it('counts an emoji as one character, not two', () => {
+    expect('🙂'.length).toBe(2) // what the naive reading would have said
+    expect(promptCharCount('🙂')).toBe(1)
+    expect(promptCharCount('oi 🙂')).toBe(4)
+  })
+
+  it('counts an accented letter as one', () => {
+    expect(promptCharCount('não')).toBe(3)
+    expect(promptCharCount('ação')).toBe(4)
+  })
+
+  /** A newline is a character somebody typed. Trimming it would make the count disagree with the field. */
+  it('counts newlines and spaces, because the field holds them', () => {
+    expect(promptCharCount('a\nb')).toBe(3)
+    expect(promptCharCount('  ')).toBe(2)
+  })
+
+  it('answers 0 for nothing at all rather than throwing', () => {
+    expect(promptCharCount(undefined as unknown as string)).toBe(0)
+    expect(promptCharCount(null as unknown as string)).toBe(0)
+  })
+})
+
+describe('promptCountLabel', () => {
+  /**
+   * It is ABSENT on an empty field. A counter reading `0` beside an empty box is a control with
+   * nothing to say taking up room that the hint under the composer needs.
+   */
+  it('says nothing when there is nothing typed', () => {
+    expect(promptCountLabel('', 'pt')).toBeNull()
+    expect(promptCountLabel('', 'en')).toBeNull()
+  })
+
+  it('reads as a plain count in both languages', () => {
+    expect(promptCountLabel('ok', 'en')).toBe('2 characters')
+    expect(promptCountLabel('ok', 'pt')).toBe('2 caracteres')
+  })
+
+  /** One is one. A hard-coded plural on a field somebody is typing into is visible immediately. */
+  it('gets the singular right', () => {
+    expect(promptCountLabel('a', 'en')).toBe('1 character')
+    expect(promptCountLabel('a', 'pt')).toBe('1 caractere')
+  })
+
+  /**
+   * Grouped past a thousand — a pasted block runs to five figures, and `10480` beside a text box is
+   * a number people re-read. Portuguese groups with a dot, English with a comma.
+   */
+  it('groups the thousands the reader’s way', () => {
+    expect(promptCountLabel('x'.repeat(10480), 'en')).toBe('10,480 characters')
+    expect(promptCountLabel('x'.repeat(10480), 'pt')).toBe('10.480 caracteres')
+  })
+})

--- a/packages/web/src/lib/promptCount.ts
+++ b/packages/web/src/lib/promptCount.ts
@@ -1,0 +1,43 @@
+/**
+ * promptCount.ts — PURE. How many characters are in the box, said the way a person counts them.
+ *
+ * `String.length` is UTF-16 CODE UNITS, so `🙂` reads as 2 and a flag emoji as 4. Nobody typing one
+ * thinks they typed two, and this number sits directly beside the field it describes — it is the
+ * one figure in the product a reader can check by eye, so being off by one on a smiley is not a
+ * rounding difference, it is the counter being wrong in front of them. Iterating the string counts
+ * CODE POINTS, which is what matches the caret for everything anyone types here.
+ *
+ * (Grapheme clusters would be closer still — a family emoji is several code points joined by
+ * zero-width joiners — and `Intl.Segmenter` is how you would do it. It is deliberately not used:
+ * it is not in every browser this dashboard opens in, and the failure mode of the fallback is a
+ * counter that silently disagrees with itself between machines. One rule everywhere beats a better
+ * rule in some places, for a number whose whole job is to be predictable.)
+ */
+
+/** Characters as the caret moves over them. `0` for anything that is not a string. */
+export function promptCharCount(text: string): number {
+  if (typeof text !== 'string' || text === '') return 0
+  let n = 0
+  // `for…of` walks code points, so a surrogate pair counts once.
+  for (const _ of text) n++
+  return n
+}
+
+/** Thousands grouped the reader's way — `10.480` in pt, `10,480` in en. */
+function grouped(n: number, lang: 'pt' | 'en'): string {
+  return n.toLocaleString(lang === 'pt' ? 'pt-BR' : 'en-US')
+}
+
+/**
+ * The label to put under the field, or `null` when there is nothing to say.
+ *
+ * ABSENT on an empty field rather than reading `0`: the composer's footer already carries the hint
+ * about what Enter does and what an attachment means, and a counter with nothing to count would
+ * take room from a sentence that is doing work.
+ */
+export function promptCountLabel(text: string, lang: 'pt' | 'en'): string | null {
+  const n = promptCharCount(text)
+  if (n === 0) return null
+  if (lang === 'pt') return `${grouped(n, 'pt')} ${n === 1 ? 'caractere' : 'caracteres'}`
+  return `${grouped(n, 'en')} ${n === 1 ? 'character' : 'characters'}`
+}


### PR DESCRIPTION
## Summary

A character count under the caret, in the gap the composer's control row already had — between
attach and the acting group, where `marginLeft: auto` was already pushing the two halves apart. It
costs the composer **no height** and takes nothing from the field.

Three decisions worth naming:

- **It counts CODE POINTS, not `String.length`.** That reads `🙂` as 2 and a flag as 4, and nobody
  typing one thinks they typed two. This is the one figure in the product a reader can check by eye,
  so being off by one on a smiley is not a rounding difference — it is the counter being wrong in
  front of them. `Intl.Segmenter` would be closer still for a joined family emoji and is
  deliberately **not** used: it is not in every browser this dashboard opens in, and the fallback's
  failure mode is a counter that disagrees with itself between machines. One rule everywhere beats a
  better rule in some places, for a number whose whole job is to be predictable.
- **It counts the FIELD, not the message that will be sent.** Attachment paths are prepended at send
  time and are not something anybody typed; counting them would make the number disagree with what
  is on screen, which is the one thing a counter beside a text box may not do.
- **Absent on an empty field** rather than reading `0` — that is where the composer's own hints
  appear (the skill hint, the answering-a-dialog notice), and a control with nothing to say should
  not stand in their room.

## Motivation

Asked for directly: a character counter in the prompt input.

The same request also asked for an **average characters per prompt** metric (one for the person, one
for the assistant), with the caveat "if the calculation is too costly from reading lots of
characters, just do the counter". That half is **not** in this PR, and the caveat turned out not to
be the reason: the parsers already hold each message's text in hand while counting
`user_message_count` / `assistant_message_count`, so summing lengths is `+= n` with **zero extra
I/O**. The reasons to keep it separate are different and are being taken to the metrics work that is
already in flight — the harness contract (a metric must mean the same across all six adapters) and
the fact that `stats-cache.json` holds no character data, so Claude's deep history cannot answer it
and the figure needs an explicit "over the sessions still on disk" caveat rather than a confident
average.

## Test plan

- `bun tsc --noEmit` clean; **7257 tests pass, 0 fail**.
- New pure tests (`promptCount.test.ts`, 9): an emoji counts as one (pinned against
  `'🙂'.length === 2`, so the naive reading is in the test as the thing being avoided); accented
  letters count as one; newlines and spaces count, because the field holds them; a non-string
  answers `0` instead of throwing; the label is absent when empty, correct in the singular, and
  groups thousands the reader's way (`10.480` in pt, `10,480` in en).
- **Not clicked through in a browser**: the Playwright profile on this machine is held by another
  session. The counter is verified present in the running binary; the placement is worth an eye.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QBZMpjfSZ2Tn2qK95Mb4vs
