### PR TITLE
fix: six numbers the product could not support, and the controls that were missing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2264,6 +2264,33 @@ harness must not break.
   21:00-23:59. Every other figure under that filter has the same boundary; giving the chart alone a
   local day would make it disagree with the cost and the messages beside it, and no day-granular
   split can express a local day for a non-UTC zone.
+- **A SESSION'S GIT STATS ARE READ WHERE IT WORKED, NOT WHERE IT IS FILED.** `project_path` is the
+  transcript's FIRST cwd — the project the session belongs to — and `current_cwd` is where it ended
+  up. They differ exactly in the git-WORKTREE case this file mandates for concurrent work, and a
+  worktree sits on a branch the main checkout's HEAD has never seen: `git log` in the project
+  answers with nothing, so the session card read `Commits 2 · Lines +0 / −0 · Files 0` — a count of
+  commits beside a confident zero of what they changed. Measured on the reporting machine: nothing
+  in the checkout, **+688 / −66 over 25 files** in the worktree, for the very window that produced
+  those commits. `sessionGitPaths` (pure) asks where the session ENDED first and keeps the project
+  as the FALLBACK (a session whose last directory is not a repository at all), and holds ONE entry
+  whenever the session never moved — asking twice for the ordinary case is the git work
+  `git-stats.test.ts` exists to bound. `getSessionFileStats` takes the first directory that has
+  anything to say and never a per-field max across two, which could report lines from the worktree
+  beside a file count from the checkout: a pair that never co-existed. Same distinction
+  `sessionAtCwd` already makes for live-session detection.
+- **THE SESSION CARD'S BASIS TOGGLE IS LOCAL, AND IT IS ABSENT WHEN NO PLAN COVERS THE HARNESS.**
+  `SessionStatsMenu` opens on the DASHBOARD's `costBasis` and can be switched to the other basis to
+  read one session — re-seeded from the global on every open, changing nothing global, so closing
+  the card is what puts it back because nothing was ever moved. The factor is
+  `sessionPlanFactor(planBasis.basis, harness)` — **per harness, never the aggregate**: a session is
+  one harness's spend, and rescaling it by a factor that also covers a subscription paying for
+  something else allocates it against a plan it has nothing to do with (same rule
+  `AgentMetricsPanel` follows). A `null` factor removes the TOGGLE rather than leaving a Plan button
+  whose one outcome is "no registered plan". The row's key is `costBasisLabel`, which follows the
+  basis ACTUALLY applied — `viewCost` hands back the API figure flagged when it cannot produce a
+  plan one, and labelling that "plan" would put a real API cost under the user's subscription. Both
+  money figures in the card (the session's and its subagents') move together: two bases in one card
+  is a card that cannot be added up.
 - **`fleetIndex` IS A LOOKUP, AND ITS `values()` ARE NOT THE FLEET.** It keys every row TWICE on
   purpose — by its own id and by its conversation id, so one map answers a link carrying either —
   so a session that knows its conversation is in it twice. The broadcast picker was built by

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2280,8 +2280,10 @@ harness must not break.
   same reason as `repo-facts.ts`'s negative TTL. And the two costs are separated: Claude's DIRECT
   path is one `stat` and is checked on EVERY call, so a new session is readable the moment its file
   appears, while only the SCAN (a `readdir` plus a `stat` per project — 281 of them on a real
-  machine) is paced by the TTL. **claude, codex and kimi** memoized and are fixed; **antigravity and
-  copilot** re-check their paths every call and are immune by construction; gemini has no reader.
+  machine) is paced by the TTL. **claude, codex and kimi** memoized and are fixed; **antigravity,
+  copilot and gemini** need no memo — each computes or checks its two candidate paths on every call
+  — and are immune by construction. A new reader that needs a DIRECTORY LISTING to find its file
+  needs this memo, and needs it this way round.
 - **A SESSION'S GIT STATS ARE READ WHERE IT WORKED, NOT WHERE IT IS FILED.** `project_path` is the
   transcript's FIRST cwd — the project the session belongs to — and `current_cwd` is where it ended
   up. They differ exactly in the git-WORKTREE case this file mandates for concurrent work, and a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2264,6 +2264,24 @@ harness must not break.
   21:00-23:59. Every other figure under that filter has the same boundary; giving the chart alone a
   local day would make it disagree with the cost and the messages beside it, and no day-granular
   split can express a local day for a non-UTC zone.
+- **A TRANSCRIPT THAT IS NOT THERE YET IS NOT A TRANSCRIPT THAT IS NOWHERE.** Three resolvers
+  memoized their answer by conversation id — the found path AND the `null` — so an unresolvable id
+  cost one scan instead of one per poll. The intent is right; caching the `null` was not. **A
+  harness writes a conversation's transcript when the conversation first says something**, so a
+  session agentop has just started has no file for its first seconds, the chat view's very first
+  poll lands inside that window, and the miss was then handed to every later poll FOR THE LIFE OF
+  THE SERVER PROCESS. Reported on a session created from the wizard: the step-3 prompt never
+  appeared, the next message sat at `delivered to the session — not read yet` for eight minutes,
+  and no reply ever arrived — while the terminal tab, which reads the pane and not the transcript,
+  showed the whole conversation. Confirmed by the clock: the chat came back only because the server
+  was restarted 13 minutes later, which is the only thing that clears a per-process memo.
+  `transcript-path-memo.ts` (pure) is the one rule now — **a found path is remembered forever** (a
+  transcript does not move), **a miss expires** (`TRANSCRIPT_MISS_TTL_MS`), the same shape and the
+  same reason as `repo-facts.ts`'s negative TTL. And the two costs are separated: Claude's DIRECT
+  path is one `stat` and is checked on EVERY call, so a new session is readable the moment its file
+  appears, while only the SCAN (a `readdir` plus a `stat` per project — 281 of them on a real
+  machine) is paced by the TTL. **claude, codex and kimi** memoized and are fixed; **antigravity and
+  copilot** re-check their paths every call and are immune by construction; gemini has no reader.
 - **A SESSION'S GIT STATS ARE READ WHERE IT WORKED, NOT WHERE IT IS FILED.** `project_path` is the
   transcript's FIRST cwd — the project the session belongs to — and `current_cwd` is where it ended
   up. They differ exactly in the git-WORKTREE case this file mandates for concurrent work, and a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2247,6 +2247,32 @@ harness must not break.
   complete. `Today` is its own preset ("only today, in progress") and is not the calendar's "today"
   ("up to today"); both end at the END of the day, so a session a few seconds ahead of the browser's
   clock is not excluded.
+  **THE HOUR CHART IS CUT THE SAME WAY, and it needed its own field to be cuttable at all.**
+  `message_hours` is a LIFETIME array of hour-of-day values carrying no day, so it survived every
+  cut `sliceSession` made around it: with `Today` selected on a real machine the "Usage by hour"
+  chart drew bars in ALL 24 HOURS for someone who had started at 8am, totalling 33.427 against the
+  4.905 messages the card above it reported under the same filter. `SessionDayUsage.hours` is the
+  measurement (hour of the LOCAL clock -> count, written in `jsonl.ts` at the same line that pushes
+  to `message_hours`, so the two can never disagree), `sliceSession` sums it and `expandHours`
+  rebuilds the array — which is what lets the chart, the PDF export and the drilldown read the
+  range's hours without any of them knowing a range exists. `user_message_timestamps` is FILTERED
+  rather than rebuilt: those are instants and carry their own day. A session whose days carry no
+  `hours` (a record written before the field existed) KEEPS its lifetime array, the same rule a
+  session with no `daily` already had — a record that cannot be split is not one that did nothing.
+  **The remaining artefact is the UTC day itself, and it is deliberate**: a `daily` key is a UTC day
+  while an hour bucket is local, so at UTC-3 `Today` legitimately includes the previous evening's
+  21:00-23:59. Every other figure under that filter has the same boundary; giving the chart alone a
+  local day would make it disagree with the cost and the messages beside it, and no day-granular
+  split can express a local day for a non-UTC zone.
+- **A COUNT IS WHAT MATCHED, NEVER WHAT A CAP RETURNED.** The new-session wizard's tabs read
+  `Repositories 12 · Projects 12 · Folders 12` on a machine holding 237 / 211 / 5.284 — they were
+  counting the rows they had been handed, and `PROJECTS_PER_KIND` is 12, so every tab showed the cap
+  whatever the machine held and whatever was typed. `findProjects` returns `{rows, totals}` (the
+  totals from the pure `countPerKind`, over the SAME `kindOf` the cap is applied with, so a row can
+  never be counted under one kind and budgeted under another), `/api/fleet/new` carries
+  `projectTotals`, and `kindCount` / `kindMore` (`web/src/lib/projectTabs.ts`) put the true total on
+  the tab plus "Showing 12 of 237" under the list. `projectTotals` is OPTIONAL on the wire: absent
+  means an older server did not say, and the tabs then count their rows and claim nothing more.
 - **A tag may be pinned to a PERIOD** (`TagDoc.window`, inclusive `yyyy-MM-dd`, each end independently
   optional) — that is what makes a tag answer "I ran harness X on this project from the 4th to the
   18th; what did it cost?" instead of only "these sources, all time". It is an AND on top of the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2264,6 +2264,15 @@ harness must not break.
   21:00-23:59. Every other figure under that filter has the same boundary; giving the chart alone a
   local day would make it disagree with the cost and the messages beside it, and no day-granular
   split can express a local day for a non-UTC zone.
+- **`fleetIndex` IS A LOOKUP, AND ITS `values()` ARE NOT THE FLEET.** It keys every row TWICE on
+  purpose — by its own id and by its conversation id, so one map answers a link carrying either —
+  so a session that knows its conversation is in it twice. The broadcast picker was built by
+  iterating that map and offered `Active 22` on a machine running 11 (8 `waiting` + 3 `working`),
+  over an `All` of 357 against a fleet of 329: every session with a conversation link was listed
+  twice and counted twice, on a button that writes into live assistants. `buildPickRows`
+  (`web/src/lib/sessionPick.ts`, pure) now owns both picker lists and DEDUPES BY ID — deliberately
+  there rather than at the one caller, because the map is correct as a lookup and the next caller to
+  iterate it would hit the same thing.
 - **A COUNT IS WHAT MATCHED, NEVER WHAT A CAP RETURNED.** The new-session wizard's tabs read
   `Repositories 12 · Projects 12 · Folders 12` on a machine holding 237 / 211 / 5.284 — they were
   counting the rows they had been handed, and `PROJECTS_PER_KIND` is 12, so every tab showed the cap

--- a/packages/core/src/projectKind.test.ts
+++ b/packages/core/src/projectKind.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from 'bun:test'
+import { countPerKind, projectKind } from './projectKind'
+
+describe('countPerKind', () => {
+  const rows = [
+    { source: 'repo' }, { source: 'repo' }, { source: 'repo' },
+    { source: 'history' },
+    { source: 'folder' }, { source: 'folder' },
+  ]
+
+  test('counts what MATCHED, which is not what a capped list holds', () => {
+    // THE REPORTED CASE: the wizard's tabs read `Repositories 12 · Projects 12 · Folders 12` on a
+    // machine with far more of each — they were counting the rows the per-kind CAP had returned.
+    // A cap presented as a count is a number that can never be anything but 12.
+    expect(countPerKind(rows, projectKind)).toEqual({ repo: 3, project: 1, folder: 2 })
+  })
+
+  test('a kind with nothing matching counts zero, not absent', () => {
+    expect(countPerKind([{ source: 'folder' }], projectKind).repo).toBe(0)
+  })
+
+  test('an empty search counts zero of everything', () => {
+    expect(countPerKind([], projectKind)).toEqual({ repo: 0, project: 0, folder: 0 })
+  })
+})
+

--- a/packages/core/src/projectKind.ts
+++ b/packages/core/src/projectKind.ts
@@ -81,5 +81,24 @@ export function takePerKind<T>(
   return out
 }
 
+/**
+ * How many of each kind MATCHED — the number the tabs must carry.
+ *
+ * Counted BEFORE `takePerKind`, and that is the whole reason it exists: the wizard's tabs read
+ * `Repositories 12 · Projects 12 · Folders 12` on a machine with twenty repositories, because they
+ * were counting the rows they had been given and the cap is 12. A cap presented as a count is a
+ * number that can never be anything but the cap — it says nothing, and it says it confidently.
+ *
+ * Same `kindOf` the cap is applied with, so a row can never be counted under one kind and budgeted
+ * under another.
+ */
+export function countPerKind<T>(
+  ranked: readonly T[], kindOf: (item: T) => ProjectKind,
+): Record<ProjectKind, number> {
+  const out: Record<ProjectKind, number> = { repo: 0, project: 0, folder: 0 }
+  for (const item of ranked) out[kindOf(item)] += 1
+  return out
+}
+
 /** How many of each kind the wizard offers. Enough to scroll, few enough to read. */
 export const PROJECTS_PER_KIND = 12

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -133,6 +133,23 @@ export interface SessionDayUsage {
   cache_creation_input_tokens: number
   /** Messages of BOTH roles, matching `dailyActivity.messageCount`. */
   messages: number
+  /**
+   * WHEN, on this day: hour of the LOCAL clock -> how many of `message_hours`' entries fell in it.
+   *
+   * The same bucket rule and the same population as `message_hours` (every timestamped line, both
+   * roles), which is what lets a sliced session's `message_hours` be REBUILT from these — see
+   * `expandHours`. It is deliberately not derived from `messages`: that counter has its own
+   * population, and a chart built from one field's total split by another field's shape is an
+   * apportionment, not a measurement.
+   *
+   * It exists because `message_hours` carries no day, so under a date filter a conversation open
+   * since Tuesday put every hour it had ever run in into today's chart — measured as bars across
+   * all 24 hours for someone who had started at 8am.
+   *
+   * Optional: records written before the field existed have none, and absent means NOT RECORDED,
+   * never "no activity".
+   */
+  hours?: Record<string, number>
 }
 
 export interface SessionMeta {

--- a/packages/server/server/cli-start.ts
+++ b/packages/server/server/cli-start.ts
@@ -65,6 +65,7 @@ import type {
   SpawnSessionRequest,
   SpawnSessionResult,
   ProjectOption,
+  ProjectSearchResult,
   ResumeSessionRequest,
   StartOption,
   BootOption,
@@ -3490,9 +3491,9 @@ export function createControlHost(initialLang: CliLang, altScreen: Suspendable):
       })
     },
 
-    async searchProjects(query: string): Promise<ProjectOption[]> {
+    async searchProjects(query: string): Promise<ProjectSearchResult> {
       const found = await findProjects(query, process.cwd())
-      return found.map(c => ({
+      return { totals: found.totals, options: found.rows.map(c => ({
         path: c.path,
         // Name and repo travel SEPARATELY: the picker aligns them into columns, and a pre-joined
         // label is one cell holding two facts that no column arithmetic can take apart again.
@@ -3500,7 +3501,7 @@ export function createControlHost(initialLang: CliLang, altScreen: Suspendable):
         ...(c.remote ? { repo: repoShortName(c.remote) } : {}),
         detail: candidatePath(c, homedir()),
         source: c.source,
-      }))
+      })) }
     },
 
     /**

--- a/packages/server/server/git-stats.test.ts
+++ b/packages/server/server/git-stats.test.ts
@@ -15,7 +15,7 @@ import { promisify } from 'util'
 import { mkdtemp, mkdir, writeFile } from 'fs/promises'
 import { tmpdir } from 'os'
 import { join } from 'path'
-import { getProjectGitStats, clearGitStatsCache, gitStatsWalkCount } from './git'
+import { getProjectGitStats, clearGitStatsCache, gitStatsWalkCount, getGitFileStats, getSessionFileStats, sessionGitPaths } from './git'
 
 const execAsync = promisify(exec)
 
@@ -193,4 +193,109 @@ test('concurrent callers for one repo share a single in-flight walk', async () =
   for (const s of all) expect(s?.commits).toBe(2)
   // Eight callers, one walk: the later ones joined the in-flight promise.
   expect(gitStatsWalkCount()).toBe(1)
+})
+
+/** Commit with an explicit date, so a window can exclude the fixture's own setup commits.
+ *  `run` strips every inherited `GIT_*` variable (see its header) and that is exactly the pair we
+ *  need here, so this one adds them back deliberately. `--after`/`--before` filter on the
+ *  COMMITTER date, which is why both are set. */
+function commitAt(dir: string, message: string, whenIso: string): Promise<{ stdout: string; stderr: string }> {
+  const env = {
+    ...Object.fromEntries(Object.entries(process.env).filter(([k]) => !k.startsWith('GIT_'))),
+    GIT_AUTHOR_DATE: whenIso,
+    GIT_COMMITTER_DATE: whenIso,
+  }
+  return execAsync(`git add -A && git commit -q -m "${message}"`, { cwd: dir, env })
+}
+
+const HOURS_AGO = (n: number) => new Date(Date.now() - n * 3_600_000).toISOString()
+
+/**
+ * A SESSION'S COMMITS ARE WHERE IT WORKED, and this repository mandates that that is a WORKTREE.
+ *
+ * `getGitFileStats` was asked of `project_path` — the FIRST cwd of the transcript, which is the
+ * project the session belongs to. A session that moved into `.claude/worktrees/<name>` commits on
+ * a branch the main checkout's HEAD has never seen, so the walk found nothing and the session card
+ * read `Commits 2 · Lines +0 / −0 · Files 0`: a count of commits beside a confident zero of what
+ * they changed. Measured on the reporting machine: nothing in the checkout, +688 / −66 over 25
+ * files in the worktree, for the very window that produced the 2 commits.
+ *
+ * Same distinction `sessionAtCwd` already makes for live-session detection, applied to git.
+ */
+test('sessionGitPaths asks where the session ENDED first, then the project', () => {
+  expect(sessionGitPaths('/repo', '/repo/.claude/worktrees/w'))
+    .toEqual(['/repo/.claude/worktrees/w', '/repo'])
+  // A session that never moved has ONE place to ask — asking twice would double the git work for
+  // the ordinary case, which is the storm this file exists to pin.
+  expect(sessionGitPaths('/repo', '/repo')).toEqual(['/repo'])
+  expect(sessionGitPaths('/repo', undefined)).toEqual(['/repo'])
+  expect(sessionGitPaths('', '/repo/w')).toEqual(['/repo/w'])
+})
+
+test('THE REPORTED CASE: a session that committed in a worktree is not reported as 0 lines', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'gitsess-'))
+  const repo = join(root, 'repo')
+  // The repository's own history, well before the session's window.
+  await mkdir(repo, { recursive: true })
+  await run('git init -q .', { cwd: repo })
+  await run('git config user.email t@t.t && git config user.name t', { cwd: repo })
+  await writeFile(join(repo, 'a.txt'), 'a\n')
+  await commitAt(repo, 'base', HOURS_AGO(5))
+  const tree = join(root, 'wt')
+  await addWorktree(repo, tree, 'feature')
+
+  const after = HOURS_AGO(1)
+  // The session's work: one commit, on the worktree's own branch, inside the window.
+  await writeFile(join(tree, 'new.txt'), 'one\ntwo\nthree\n')
+  await commitAt(tree, 'work', new Date().toISOString())
+  const before = new Date(Date.now() + 60_000).toISOString()
+
+  // The old reading: the main checkout's HEAD has never seen that commit.
+  const atProject = await getGitFileStats(repo, after, before)
+  expect(atProject.linesAdded).toBe(0)
+  expect(atProject.filesModified).toBe(0)
+
+  // The session's own: asked where it was actually working.
+  const forSession = await getSessionFileStats(repo, tree, after, before)
+  expect(forSession.linesAdded).toBe(3)
+  expect(forSession.filesModified).toBe(1)
+})
+
+test('a session that stayed in the project still reads the project', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'gitsess2-'))
+  const repo = join(root, 'repo')
+  await mkdir(repo, { recursive: true })
+  await run('git init -q .', { cwd: repo })
+  await run('git config user.email t@t.t && git config user.name t', { cwd: repo })
+  await writeFile(join(repo, 'a.txt'), 'a\n')
+  await commitAt(repo, 'base', HOURS_AGO(5))
+
+  const after = HOURS_AGO(1)
+  await writeFile(join(repo, 'b.txt'), 'x\ny\n')
+  await commitAt(repo, 'work', new Date().toISOString())
+  const before = new Date(Date.now() + 60_000).toISOString()
+
+  const forSession = await getSessionFileStats(repo, repo, after, before)
+  expect(forSession.filesModified).toBe(1)
+  expect(forSession.linesAdded).toBe(2)
+})
+
+test('a cwd that is not a repository falls back to the project', async () => {
+  // A session whose last directory is `/tmp/...` — the fallback is what keeps its commits visible.
+  const root = await mkdtemp(join(tmpdir(), 'gitsess3-'))
+  const repo = join(root, 'repo')
+  await mkdir(repo, { recursive: true })
+  await run('git init -q .', { cwd: repo })
+  await run('git config user.email t@t.t && git config user.name t', { cwd: repo })
+  await writeFile(join(repo, 'a.txt'), 'a\n')
+  await commitAt(repo, 'base', HOURS_AGO(5))
+  const elsewhere = await mkdtemp(join(tmpdir(), 'nowhere-'))
+
+  const after = HOURS_AGO(1)
+  await writeFile(join(repo, 'c.txt'), 'x\n')
+  await commitAt(repo, 'work', new Date().toISOString())
+  const before = new Date(Date.now() + 60_000).toISOString()
+
+  const forSession = await getSessionFileStats(repo, elsewhere, after, before)
+  expect(forSession.filesModified).toBe(1)
 })

--- a/packages/server/server/git.ts
+++ b/packages/server/server/git.ts
@@ -135,6 +135,53 @@ export async function getCommitsInWindow(
   }
 }
 
+/**
+ * The directories to ask about a SESSION's commits, best first.
+ *
+ * A session is filed under the directory it was OPENED in (`project_path`, the transcript's first
+ * `cwd`) and may have moved — into a git worktree, which is how this repository mandates concurrent
+ * work is done. A worktree is checked out on its own branch, so the main checkout's HEAD has never
+ * seen the commits made there and `git log` in the project answers with NOTHING. Reported as
+ * `Commits 2 · Lines +0 / −0 · Files 0` on a session card: a count of commits beside a confident
+ * zero of what they changed. Measured on the reporting machine — nothing in the checkout, +688/−66
+ * over 25 files in the worktree, for the very window that produced those two commits.
+ *
+ * It is the same distinction `sessionAtCwd` already makes for live-session detection, and it goes
+ * the same way: the two disagree precisely in the worktree case, and the more specific one is
+ * right. The project stays as a FALLBACK, for a session whose last directory is not a repository
+ * at all (a `cd /tmp`), and the list holds ONE entry whenever the session never moved — asking
+ * twice for the ordinary case is the git work this module's other tests exist to bound.
+ */
+export function sessionGitPaths(projectPath: string, currentCwd?: string): string[] {
+  const out: string[] = []
+  for (const p of [currentCwd, projectPath]) {
+    if (p && !out.includes(p)) out.push(p)
+  }
+  return out
+}
+
+/**
+ * What this SESSION's window changed, asked of the directory it was actually working in.
+ *
+ * One coherent answer from ONE directory — never a per-field max across two, which could take the
+ * lines from a worktree and the file count from the checkout and report a pair that never
+ * co-existed. The first directory that has anything to say wins.
+ */
+export async function getSessionFileStats(
+  projectPath: string,
+  currentCwd: string | undefined,
+  afterIso: string,
+  beforeIso: string,
+): Promise<{ linesAdded: number; linesRemoved: number; filesModified: number }> {
+  const empty = { linesAdded: 0, linesRemoved: 0, filesModified: 0 }
+  const paths = sessionGitPaths(projectPath, currentCwd)
+  for (const path of paths) {
+    const stats = await getGitFileStats(path, afterIso, beforeIso)
+    if (stats.filesModified > 0) return stats
+  }
+  return empty
+}
+
 export async function getGitFileStats(
   projectPath: string,
   afterIso: string,

--- a/packages/server/server/jsonl.ts
+++ b/packages/server/server/jsonl.ts
@@ -239,7 +239,7 @@ export async function parseSessionJsonl(
     const key = iso.slice(0, 10)
     let d = daily.get(key)
     if (!d) {
-      d = { input_tokens: 0, output_tokens: 0, cache_read_input_tokens: 0, cache_creation_input_tokens: 0, messages: 0 }
+      d = { input_tokens: 0, output_tokens: 0, cache_read_input_tokens: 0, cache_creation_input_tokens: 0, messages: 0, hours: {} }
       daily.set(key, d)
     }
     return d
@@ -310,7 +310,21 @@ export async function parseSessionJsonl(
     if (ts) {
       if (!startTime) startTime = ts
       lastTime = ts
-      try { messageHours.push(new Date(ts).getHours()) } catch { /* skip */ }
+      /**
+       * WHEN this line happened, twice: once lifetime and once ON ITS OWN DAY.
+       *
+       * The same value into both, from the same parse, so the day split can never disagree with
+       * the lifetime array about what hour a line fell in — the whole point of `hours` is that a
+       * date-filtered chart can be rebuilt from it and read the same as the unfiltered one.
+       * Local clock, per the harness contract (§ timestamps); the DAY key stays UTC, per
+       * `tagSessionDay`, which is the rule every other day series in this product uses.
+       */
+      try {
+        const hour = new Date(ts).getHours()
+        messageHours.push(hour)
+        const d = dayOf(ts)
+        if (d) { d.hours ??= {}; d.hours[hour] = (d.hours[hour] ?? 0) + 1 }
+      } catch { /* skip */ }
       const tsMs = Date.parse(ts)
       if (!Number.isNaN(tsMs)) {
         turnEvent = { ts: tsMs }

--- a/packages/server/server/jsonl.ts
+++ b/packages/server/server/jsonl.ts
@@ -1,7 +1,7 @@
 import { readFile } from 'fs/promises'
 import type { SessionDayUsage, SessionMeta, TurnEvent } from '@agentistics/core'
 import { activeMinutesOf } from '@agentistics/core'
-import { getGitFileStats } from './git'
+import { getSessionFileStats } from './git'
 import { countGitCommands } from './harness-activity'
 import { extractAgentMetrics } from './agent-metrics'
 import { enrichFromSubagentTranscripts } from './subagent-metrics'
@@ -503,8 +503,17 @@ export async function parseSessionJsonl(
     : 0
 
   const projectPath = cwd || fallbackPath
+  /**
+   * Asked where the session was WORKING, not where it was filed — see `sessionGitPaths`.
+   *
+   * `projectPath` is the transcript's FIRST cwd; `lastCwd` is where it ended up, and the two
+   * differ exactly when the session moved into a git worktree, which is how this repository
+   * mandates concurrent work is done. The worktree's branch is one the main checkout's HEAD has
+   * never seen, so asking the project answered with nothing and the card read `Commits 2 · Lines
+   * +0 / −0 · Files 0`.
+   */
   const gitFileStats = gitCommits > 0
-    ? await getGitFileStats(projectPath, startTime, lastTime)
+    ? await getSessionFileStats(projectPath, lastCwd, startTime, lastTime)
     : { linesAdded: 0, linesRemoved: 0, filesModified: 0 }
   // Use whichever count is higher: git-tracked files changed or files Claude directly edited
   const filesModifiedCount = Math.max(gitFileStats.filesModified, claudeFilesModified.size)

--- a/packages/server/server/sessions/chat-tail.test.ts
+++ b/packages/server/server/sessions/chat-tail.test.ts
@@ -450,3 +450,70 @@ describe('the tool call carries the id its step is opened with', () => {
     expect(call?.ref).toBeUndefined()
   })
 })
+
+/**
+ * THE REPORTED CASE — a session created from the wizard was un-chattable for the life of the
+ * server process.
+ *
+ * A harness writes a conversation's transcript when the conversation first SAYS something, so a
+ * session agentop has just started has no file for its first seconds. The chat view's very first
+ * poll lands inside that window, and the `null` it got back used to be cached by conversation id
+ * forever: the step-3 prompt never appeared, every later message sat at "delivered to the session
+ * — not read yet", and no reply ever arrived, while the terminal tab — which reads the pane, not
+ * the transcript — showed the whole conversation.
+ */
+describe('a transcript that does not exist YET', () => {
+  const CWD = '/home/u/proj'
+  let root: string
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), 'chat-tail-late-'))
+    forgetChatTailPaths(); forgetChatTailContent()
+  })
+  afterEach(async () => { await rm(root, { recursive: true, force: true }) })
+
+  test('is found the moment it appears, not after a restart', async () => {
+    // The first poll: nothing on disk.
+    expect(await resolveChatTranscriptPath(CWD, SESSION_ID, root)).toBe(null)
+
+    // The session says its first thing and the harness writes the file.
+    const dir = join(root, '-home-u-proj')
+    await mkdir(dir, { recursive: true })
+    const file = join(dir, `${SESSION_ID}.jsonl`)
+    await writeFile(file, line({ type: 'user', message: { content: 'oi' } }) + '\n')
+
+    // The next poll finds it. Before the fix this returned the remembered `null` forever.
+    expect(await resolveChatTranscriptPath(CWD, SESSION_ID, root)).toBe(file)
+  })
+
+  test('a miss does not spend the whole-tree SCAN on every poll', async () => {
+    // The reason the `null` was cached at all. The direct path is one `stat` and is always
+    // checked; the scan is a readdir plus a stat per project, and stays paced by the miss TTL.
+    const other = join(root, '-somewhere-else')
+    await mkdir(other, { recursive: true })
+    const now = 1_000_000
+    expect(await resolveChatTranscriptPath(CWD, SESSION_ID, root, now)).toBe(null)
+
+    // Inside the TTL the answer is still null — and the file placed OUTSIDE the direct path is
+    // deliberately not found yet, which is what proves the scan was skipped.
+    const stray = join(other, `${SESSION_ID}.jsonl`)
+    await writeFile(stray, line({ type: 'user', message: { content: 'oi' } }) + '\n')
+    expect(await resolveChatTranscriptPath(CWD, SESSION_ID, root, now + 1000)).toBe(null)
+
+    // Past it, the scan runs again and finds it.
+    expect(await resolveChatTranscriptPath(CWD, SESSION_ID, root, now + 31_000)).toBe(stray)
+  })
+
+  test('a path once found is never re-scanned for', async () => {
+    const dir = join(root, '-home-u-proj')
+    await mkdir(dir, { recursive: true })
+    const file = join(dir, `${SESSION_ID}.jsonl`)
+    await writeFile(file, line({ type: 'user', message: { content: 'oi' } }) + '\n')
+    expect(await resolveChatTranscriptPath(CWD, SESSION_ID, root)).toBe(file)
+    // Removing the tree does not un-answer it: a transcript does not move, and a read that fails
+    // is the reader's business, not the resolver's.
+    await rm(root, { recursive: true, force: true })
+    expect(await resolveChatTranscriptPath(CWD, SESSION_ID, root)).toBe(file)
+  })
+})
+

--- a/packages/server/server/sessions/chat-tail.ts
+++ b/packages/server/server/sessions/chat-tail.ts
@@ -29,17 +29,25 @@ import { commandSummary, hasUnreadableWrite, shellWrites } from './shell-writes'
 import { classifyUserEntry, type UserEntry } from './chat-envelope'
 import type { ChatTurn } from './chat-turn'
 import { MAX_TAIL_BYTES, TAIL_BYTES, readTailBytes, windowLines } from './transcript-window'
+import { createTranscriptPathMemo } from './transcript-path-memo'
 
 // The turn shape now lives in `chat-turn.ts` — every harness reader produces it, and this module
 // is only one of them. Re-exported so nothing that already imports it from here has to move.
 export type { ChatTurn } from './chat-turn'
 
-/** Resolved paths and one-time-scan misses, keyed by conversation id. Never re-scanned once known. */
-const pathCache = new Map<string, string | null>()
+/**
+ * Where each conversation's transcript is — POSITIVES forever, misses only briefly.
+ *
+ * A `null` used to be cached here for the life of the process, and a session created from the
+ * wizard has no transcript for the first seconds of its life: the chat view's first poll landed
+ * inside that window and the conversation was unreadable until the server restarted. See
+ * `transcript-path-memo.ts`.
+ */
+const pathMemo = createTranscriptPathMemo()
 
 /** Reset the memo. Tests only. */
 export function forgetChatTailPaths(): void {
-  pathCache.clear()
+  pathMemo.clear()
 }
 
 function encodeProjectDir(cwd: string): string {
@@ -64,8 +72,15 @@ async function scanForTranscript(sessionId: string, projectsDir: string): Promis
 /**
  * The absolute path to a live Claude conversation's transcript, or `null` when it cannot be found.
  *
- * `null` is cached too — a session whose directory encoding is ambiguous costs one scan, not one
- * scan per poll for the rest of its life.
+ * TWO COSTS, and only the expensive one is memoized. The DIRECT path — the session's own cwd,
+ * encoded — is a single `stat`, and it is where a transcript actually is; it is checked on EVERY
+ * call, so a session whose file did not exist a moment ago is readable the moment it does. The
+ * SCAN (a `readdir` plus a `stat` per project directory, 281 of them on a real machine) is the one
+ * a miss must not be allowed to repeat every poll, and `transcript-path-memo.ts` is what bounds it.
+ *
+ * Caching the `null` itself is what broke: a session created from the wizard has no transcript
+ * until it first says something, the chat view's first poll lands inside that window, and the
+ * conversation was then unreadable for the life of the server process.
  *
  * `projectsDir` defaults to the real `PROJECTS_DIR` and is overridable only so tests can point it
  * at a fixture tree without needing a subprocess — `config.ts`'s constants are fixed at import
@@ -75,15 +90,20 @@ export async function resolveChatTranscriptPath(
   cwd: string,
   sessionId: string,
   projectsDir: string = PROJECTS_DIR,
+  now: number = Date.now(),
 ): Promise<string | null> {
   if (!UUID_RE.test(sessionId)) return null
-  const cached = pathCache.get(sessionId)
-  if (cached !== undefined) return cached
+  const known = pathMemo.get(sessionId)
+  if (known !== undefined) return known
 
   const direct = join(projectsDir, encodeProjectDir(cwd), `${sessionId}.jsonl`)
-  const resolved = (await exists(direct)) ? direct : await scanForTranscript(sessionId, projectsDir)
-  pathCache.set(sessionId, resolved)
-  return resolved
+  if (await exists(direct)) { pathMemo.remember(sessionId, direct); return direct }
+
+  if (!pathMemo.mayScan(sessionId, now)) return null
+  pathMemo.missed(sessionId, now)
+  const scanned = await scanForTranscript(sessionId, projectsDir)
+  if (scanned !== null) pathMemo.remember(sessionId, scanned)
+  return scanned
 }
 
 interface Cached {

--- a/packages/server/server/sessions/fleet-web.ts
+++ b/packages/server/server/sessions/fleet-web.ts
@@ -16,13 +16,14 @@
  * host per request would fire one per poll.
  */
 
-import type { HarnessId } from '@agentistics/core'
+import type { HarnessId, ProjectKind } from '@agentistics/core'
 import type { StartHost } from '../cli-start'
 import type { CliLang } from '../cli-lang'
 import { recordPrompt } from './pending-prompts'
 import { conversationOfRow } from './row-conversation'
 import { controlStrings } from '@agentistics/tui/control/i18n'
 import type { ControlSession } from '@agentistics/tui/control/session-fleet'
+import type { ProjectSearchResult } from '@agentistics/tui/control'
 import { sessionRunning } from '@agentistics/tui/control/session-dimensions' 
 import { fleetRow, type FleetActionRequest, type FleetRow } from './fleet-row'
 import { planFleetSpawn, type FleetSpawnBody } from './fleet-spawn'
@@ -611,6 +612,12 @@ export async function readFleetPullRequests(
 }
 
 /** The questions a start EARNS, and the places it could happen — the wizard, as data. */
+/** What a search that could not run answers: no rows, and no claim about how many there are. */
+const EMPTY_PROJECT_SEARCH: ProjectSearchResult = {
+  options: [],
+  totals: { repo: 0, project: 0, folder: 0 },
+}
+
 export interface FleetNewOptions {
   /**
    * Derived by the host from the spawn specs, so a harness with no spec is ABSENT rather than
@@ -643,8 +650,16 @@ export interface FleetNewOptions {
     /** The effort used when none is passed, under exactly `defaultModel`'s rule. */
     defaultEffort?: string
   }[]
-  /** Ranked places, from the LOCAL store — so the picker answers with no network and a cold cache. */
+  /** Ranked places, from the LOCAL store — so the picker answers with no network and a cold cache.
+   *  CAPPED per kind: what fits on screen, never how many there are. See `projectTotals`. */
   projects: { path: string; label: string; repo?: string; detail: string; source: string }[]
+  /**
+   * How many places of each kind MATCHED, before the cap — the number the tabs carry.
+   *
+   * Optional so a client reading an older central still parses; absent means "this server does not
+   * say", and the wizard then counts its rows and stops claiming a total it cannot know.
+   */
+  projectTotals?: Record<ProjectKind, number>
   /** The tasks that already exist here, so filing the new session is a pick, not a spelling test. */
   tasks: string[]
   /**
@@ -669,7 +684,9 @@ export async function readNewOptions(lang: CliLang, query: string): Promise<Flee
     type Defaults = Awaited<ReturnType<typeof readHarnessDefaults>>
     const [harnesses, projects, tasks] = await Promise.all([
       host.startableHarnesses(),
-      host.searchProjects ? host.searchProjects(query).catch(() => []) : Promise.resolve([]),
+      host.searchProjects
+        ? host.searchProjects(query).catch(() => EMPTY_PROJECT_SEARCH)
+        : Promise.resolve(EMPTY_PROJECT_SEARCH),
       host.sessionTasks ? host.sessionTasks().catch(() => []) : Promise.resolve([]),
     ])
     // What each CLI will actually do here with no flags, read from THIS MACHINE's own settings
@@ -698,13 +715,21 @@ export async function readNewOptions(lang: CliLang, query: string): Promise<Flee
           ...(defaultEffort ? { defaultEffort } : {}),
         }
       }),
-      projects: projects.map(p => ({
+      projects: projects.options.map(p => ({
         path: p.path,
         label: p.label,
         ...(p.repo ? { repo: p.repo } : {}),
         detail: p.detail,
         source: p.source,
       })),
+      /**
+       * HOW MANY of each kind matched, which is NOT how many rows came back.
+       *
+       * The rows are capped per kind so a tab can never be emptied by another kind's budget; the
+       * tabs then counted the rows and read `12 · 12 · 12` on a machine with twenty repositories.
+       * A cap shown as a count is a number that can never be anything but the cap.
+       */
+      projectTotals: projects.totals,
       tasks,
     }
   } catch (e) {

--- a/packages/server/server/sessions/harness-transcript.test.ts
+++ b/packages/server/server/sessions/harness-transcript.test.ts
@@ -291,3 +291,48 @@ describe('the window says it is a window, on every harness', () => {
     }
   })
 })
+
+/**
+ * EVERY HARNESS WHOSE RESOLVER MEMOIZES: a session's transcript does not exist until the
+ * conversation first says something, so the first poll after a spawn always misses — and a miss
+ * remembered for the life of the process makes that conversation unreadable for the life of the
+ * process. Reported on a claude session started from the wizard; codex and kimi memoize the same
+ * way and would fail the same way. Antigravity and copilot re-check their two paths on every call
+ * and are immune by construction, which is why they are absent here.
+ */
+describe('a transcript that appears AFTER the first miss', () => {
+  const ID = '99999999-8888-4777-8666-555555555555'
+
+  it('codex: is found once the rollout is written', async () => {
+    forgetCodexTranscriptPaths()
+    const root = await mkdtemp(join(tmpdir(), 'codex-late-'))
+    const at = 5_000_000
+    expect(await resolveCodexTranscript({ conversationId: ID }, root, at)).toBeNull()
+
+    const dir = join(root, '2026', '09', '08')
+    await mkdir(dir, { recursive: true })
+    const file = join(dir, `rollout-2026-09-08T10-00-00-${ID}.jsonl`)
+    await writeFile(file, '')
+
+    // Inside the TTL the scan is deliberately not repeated; past it, the file is found.
+    expect(await resolveCodexTranscript({ conversationId: ID }, root, at + 1_000)).toBeNull()
+    expect(await resolveCodexTranscript({ conversationId: ID }, root, at + 31_000)).toBe(file)
+    await rm(root, { recursive: true, force: true })
+  })
+
+  it('kimi: is found once the wire is written', async () => {
+    forgetKimiTranscriptPaths()
+    const root = await mkdtemp(join(tmpdir(), 'kimi-late-'))
+    const at = 5_000_000
+    expect(await resolveKimiTranscript({ conversationId: ID }, root, at)).toBeNull()
+
+    const dir = join(root, 'wd_x', `session_${ID}`, 'agents', 'main')
+    await mkdir(dir, { recursive: true })
+    const wire = join(dir, 'wire.jsonl')
+    await writeFile(wire, '')
+
+    expect(await resolveKimiTranscript({ conversationId: ID }, root, at + 31_000)).toBe(wire)
+    await rm(root, { recursive: true, force: true })
+  })
+})
+

--- a/packages/server/server/sessions/harness-transcript.ts
+++ b/packages/server/server/sessions/harness-transcript.ts
@@ -35,6 +35,7 @@ import { parseKimiChat } from './kimi-chat'
 import type { ChatTurn } from './chat-turn'
 import { readChatWindow, readRecentChatTurns, resolveChatTranscriptPath } from './chat-tail'
 import { readTailWindow } from './transcript-window'
+import { createTranscriptPathMemo } from './transcript-path-memo'
 
 /** Everything a reader is told about the session whose conversation is wanted. */
 export interface TranscriptRef {
@@ -144,11 +145,11 @@ const ANTIGRAVITY: HarnessTranscript = {
  * memoized — a machine keeps a directory per day forever, so an unresolvable id must cost one scan
  * and not one per poll. Same rule, same reason, as `resolveChatTranscriptPath`'s own cache.
  */
-const codexPathCache = new Map<string, string | null>()
+const codexPathMemo = createTranscriptPathMemo()
 
 /** Reset the memo. Tests only. */
 export function forgetCodexTranscriptPaths(): void {
-  codexPathCache.clear()
+  codexPathMemo.clear()
 }
 
 async function subdirs(dir: string): Promise<string[]> {
@@ -179,14 +180,23 @@ export async function resolveCodexTranscript(
   ref: TranscriptRef,
   // Overridable for tests only — see `resolveAntigravityTranscript`'s note.
   sessionsDir: string = CODEX_SESSIONS_DIR,
+  // Injectable only so a test can step past the miss TTL without waiting it out.
+  now: number = Date.now(),
 ): Promise<string | null> {
   // Codex's ids are UUIDv7; `UUID_RE` is version-agnostic, so this rejects a path fragment without
   // rejecting the real thing.
   if (!UUID_RE.test(ref.conversationId)) return null
-  const cached = codexPathCache.get(ref.conversationId)
-  if (cached !== undefined) return cached
+  const known = codexPathMemo.get(ref.conversationId)
+  if (known !== undefined) return known
+  // A MISS EXPIRES. Codex writes a rollout when the conversation first says something, so a
+  // session agentop has just started has no file — and remembering that answer for the life of the
+  // process made the conversation unreadable for the life of the process. See
+  // `transcript-path-memo.ts`; codex has no cheap direct path, so the scan itself is what the TTL
+  // paces.
+  if (!codexPathMemo.mayScan(ref.conversationId, now)) return null
+  codexPathMemo.missed(ref.conversationId, now)
   const found = await scanCodexRollout(ref.conversationId, sessionsDir)
-  codexPathCache.set(ref.conversationId, found)
+  if (found !== null) codexPathMemo.remember(ref.conversationId, found)
   return found
 }
 
@@ -272,11 +282,11 @@ const COPILOT: HarnessTranscript = {
  * heading. Measured: every one of the 14 sessions on this machine has exactly one agent, `main`. The
  * fallback to the first agent directory costs nothing and covers a session that somehow has none.
  */
-const kimiPathCache = new Map<string, string | null>()
+const kimiPathMemo = createTranscriptPathMemo()
 
 /** Reset the memo. Tests only. */
 export function forgetKimiTranscriptPaths(): void {
-  kimiPathCache.clear()
+  kimiPathMemo.clear()
 }
 
 async function findKimiWire(id: string, root: string): Promise<string | null> {
@@ -296,12 +306,17 @@ async function findKimiWire(id: string, root: string): Promise<string | null> {
 export async function resolveKimiTranscript(
   ref: TranscriptRef,
   sessionsDir: string = join(KIMI_DIR, 'sessions'),
+  // Injectable only so a test can step past the miss TTL without waiting it out.
+  now: number = Date.now(),
 ): Promise<string | null> {
   if (!UUID_RE.test(ref.conversationId)) return null
-  const cached = kimiPathCache.get(ref.conversationId)
-  if (cached !== undefined) return cached
+  const known = kimiPathMemo.get(ref.conversationId)
+  if (known !== undefined) return known
+  // A MISS EXPIRES — same reason as codex's above.
+  if (!kimiPathMemo.mayScan(ref.conversationId, now)) return null
+  kimiPathMemo.missed(ref.conversationId, now)
   const found = await findKimiWire(ref.conversationId, sessionsDir)
-  kimiPathCache.set(ref.conversationId, found)
+  if (found !== null) kimiPathMemo.remember(ref.conversationId, found)
   return found
 }
 

--- a/packages/server/server/sessions/project-source.ts
+++ b/packages/server/server/sessions/project-source.ts
@@ -17,7 +17,7 @@
  */
 
 import { homedir } from 'node:os'
-import { PROJECTS_PER_KIND, projectKind, takePerKind } from '@agentistics/core'
+import { countPerKind, PROJECTS_PER_KIND, projectKind, takePerKind, type ProjectKind } from '@agentistics/core'
 import { loadConsolidated } from '../consolidate'
 import { isDirectory, scanDirectories } from './dir-scan'
 import {
@@ -74,9 +74,22 @@ export function forgetProjects(): void {
  * `cwd` is always a candidate, with or without history — starting where you already are is the
  * single most common thing anyone wants, and routing that through a search would bury it.
  */
+export interface ProjectSearch {
+  /** The rows to offer, ranked then capped per kind. */
+  rows: ProjectCandidate[]
+  /**
+   * How many MATCHED, per kind — before the cap.
+   *
+   * The tabs carry these. Counting the returned rows instead made every tab read `12`, which is the
+   * cap: a number that can never be anything else, stated as though it were a fact about the
+   * machine. `rows` is what fits on screen; this is what is there.
+   */
+  totals: Record<ProjectKind, number>
+}
+
 export async function findProjects(
   query: string, cwd: string, perKind = PROJECTS_PER_KIND,
-): Promise<ProjectCandidate[]> {
+): Promise<ProjectSearch> {
   const known = await allCandidates()
 
   const fixed: ProjectCandidate[] = [{
@@ -107,7 +120,10 @@ export async function findProjects(
    * to push the one you want off the list. See `takePerKind`.
    */
   const ranked = searchCandidates(withFixedCandidates(known, fixed), query, Number.MAX_SAFE_INTEGER)
-  return takePerKind(ranked, c => projectKind(c), perKind)
+  return {
+    rows: takePerKind(ranked, c => projectKind(c), perKind),
+    totals: countPerKind(ranked, c => projectKind(c)),
+  }
 }
 
 function baseName(path: string): string {

--- a/packages/server/server/sessions/spawn-web.ts
+++ b/packages/server/server/sessions/spawn-web.ts
@@ -71,7 +71,7 @@ export async function webHarnesses(host: StartHost): Promise<WebHarnessOption[]>
 export async function webProjects(host: StartHost, query: string): Promise<WebProjectOption[]> {
   if (!host.searchProjects) return []
   const found = await host.searchProjects(query)
-  return found.map(p => ({
+  return found.options.map(p => ({
     path: p.path,
     label: p.label,
     ...(p.repo ? { repo: p.repo } : {}),

--- a/packages/server/server/sessions/transcript-path-memo.test.ts
+++ b/packages/server/server/sessions/transcript-path-memo.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from 'bun:test'
+import { createTranscriptPathMemo, TRANSCRIPT_MISS_TTL_MS } from './transcript-path-memo'
+
+describe('transcript path memo — a miss is a fact about the MOMENT', () => {
+  const ID = 'c1'
+
+  test('a found path is remembered', () => {
+    const m = createTranscriptPathMemo()
+    m.remember(ID, '/p/c1.jsonl')
+    expect(m.get(ID)).toBe('/p/c1.jsonl')
+  })
+
+  test('THE REPORTED CASE: a miss does not answer forever', () => {
+    // A session created from the wizard has no transcript for the first seconds of its life, and
+    // the chat view's first poll lands inside that window. Caching that `null` for the process made
+    // the conversation unreadable until the server restarted: messages stuck at "not read yet",
+    // replies never arriving, the whole conversation visible in the terminal tab all along.
+    const m = createTranscriptPathMemo(1000)
+    m.missed(ID, 0)
+    expect(m.mayScan(ID, 500)).toBe(false)
+    expect(m.mayScan(ID, 1000)).toBe(true)
+  })
+
+  test('an id never seen may always be scanned for', () => {
+    expect(createTranscriptPathMemo().mayScan('never', 0)).toBe(true)
+  })
+
+  test('finding it settles the question — no miss survives to gate a later scan', () => {
+    const m = createTranscriptPathMemo(10_000)
+    m.missed(ID, 0)
+    m.remember(ID, '/p/c1.jsonl')
+    expect(m.mayScan(ID, 1)).toBe(true)
+    expect(m.get(ID)).toBe('/p/c1.jsonl')
+  })
+
+  test('the default TTL is far longer than one chat poll and far shorter than a session', () => {
+    // The number is the only thing standing between "one scan per poll" and "one scan per miss",
+    // so it is pinned rather than left to drift.
+    expect(TRANSCRIPT_MISS_TTL_MS).toBe(30_000)
+  })
+})

--- a/packages/server/server/sessions/transcript-path-memo.ts
+++ b/packages/server/server/sessions/transcript-path-memo.ts
@@ -1,0 +1,59 @@
+/**
+ * transcript-path-memo.ts — PURE: remembering where a transcript is, and NOT remembering that it
+ * is nowhere.
+ *
+ * THE BUG THIS EXISTS FOR. Three resolvers cached their answer by conversation id — the found path
+ * AND the `null` — to keep an unresolvable id costing one scan instead of one scan per poll. The
+ * intent is right and the consequence was not: **a harness writes a conversation's transcript when
+ * the conversation first says something**, so a session created from the wizard has no file for the
+ * first seconds of its life, the chat view's very first poll lands inside that window, and the
+ * `null` it got back was then handed to every later poll for the life of the server process.
+ *
+ * Reported exactly that way: a session started from the UI whose step-3 prompt "never appeared",
+ * whose next message sat at `delivered to the session — not read yet` for eight minutes, and whose
+ * replies never arrived — while the terminal tab, which reads the pane and not the transcript,
+ * showed the whole conversation. Nothing was lost and nothing was queued; the chat was reading a
+ * remembered "there is no file here".
+ *
+ * So: **a found path is remembered forever** (a transcript does not move, and that is a fact about
+ * the conversation), and **a miss is remembered only for a while** (it is a fact about the moment).
+ * Same rule, and the same reason, as `repo-facts.ts`'s negative TTL.
+ */
+
+/**
+ * How long a MISS is allowed to stop the expensive scan.
+ *
+ * The chat view polls every 3s, so this is the difference between one scan per poll and one per
+ * half-minute for a conversation that genuinely has no transcript. It is NOT how long a new
+ * session waits to become readable: every resolver checks its CHEAP direct path on every call and
+ * only the scan is gated — see `resolveChatTranscriptPath`.
+ */
+export const TRANSCRIPT_MISS_TTL_MS = 30_000
+
+export interface TranscriptPathMemo {
+  /** The path this conversation's transcript was found at, or `undefined` if it never has been. */
+  get(id: string): string | undefined
+  /** Remember a path. Clears any miss — the question is settled. */
+  remember(id: string, path: string): void
+  /** Record that a scan came back empty at `now`. */
+  missed(id: string, now: number): void
+  /** May the expensive scan be spent on this id now? `false` only inside a fresh miss's TTL. */
+  mayScan(id: string, now: number): boolean
+  /** Tests only. */
+  clear(): void
+}
+
+export function createTranscriptPathMemo(ttlMs = TRANSCRIPT_MISS_TTL_MS): TranscriptPathMemo {
+  const found = new Map<string, string>()
+  const missedAt = new Map<string, number>()
+  return {
+    get: id => found.get(id),
+    remember(id, path) { found.set(id, path); missedAt.delete(id) },
+    missed(id, now) { missedAt.set(id, now) },
+    mayScan(id, now) {
+      const at = missedAt.get(id)
+      return at === undefined || now - at >= ttlMs
+    },
+    clear() { found.clear(); missedAt.clear() },
+  }
+}

--- a/packages/tui/scripts/preview.tsx
+++ b/packages/tui/scripts/preview.tsx
@@ -49,6 +49,7 @@ import {
   DEFAULT_SESSION_VIEW,
 } from '../src/control/types'
 import type { HarnessId } from '@agentistics/core'
+import { countPerKind, projectKind } from '@agentistics/core'
 import { GROUPINGS, type SessionGroupingId } from '../src/control/sessions'
 import type { CliLang } from '../src/control/lang'
 // The real string table, not a copy of it. Every label on this screen arrives from the host already
@@ -470,8 +471,11 @@ function fakeHost(opts: Options, apiUrl?: string): ControlHost {
       { id: 'codex', label: 'codex', modelSuggestions: ['gpt-5.4', 'gpt-5.4-mini'], supportsModel: true, efforts: [] },
       { id: 'kimi', label: 'kimi', modelSuggestions: ['kimi-k3'], supportsModel: true, efforts: [] },
     ],
-    searchProjects: async (query: string) => FAKE_PROJECTS
-      .filter(p => p.label.toLowerCase().includes(query.trim().toLowerCase())),
+    searchProjects: async (query: string) => {
+      const options = FAKE_PROJECTS
+        .filter(p => p.label.toLowerCase().includes(query.trim().toLowerCase()))
+      return { options, totals: countPerKind(options, projectKind) }
+    },
     // `--fail-spawn` drives the wizard's REFUSAL path, which is the one that used to eat the
     // prompt: it closed the wizard and put the reason on a status line one row tall.
     spawnSession: async () => (opts.failSpawn

--- a/packages/tui/src/control/index.ts
+++ b/packages/tui/src/control/index.ts
@@ -187,6 +187,7 @@ export type {
   SpawnSessionRequest,
   SpawnSessionResult,
   ProjectOption,
+  ProjectSearchResult,
   RestoreCandidate,
   ResumeSessionRequest,
   StartHow,

--- a/packages/tui/src/control/tabs/SessionWizard.tsx
+++ b/packages/tui/src/control/tabs/SessionWizard.tsx
@@ -463,9 +463,9 @@ function ProjectSearch({ host, strings: s, width, height, isActive, onPick }: {
     const search = host.searchProjects
     if (!search) return
     let alive = true
-    void search.call(host, query).then(list => {
+    void search.call(host, query).then(found => {
       if (!alive) return
-      setOptions(list)
+      setOptions(found.options)
       // A new result set means the old position points at something else entirely.
       setIndex(0)
     })

--- a/packages/tui/src/control/types.ts
+++ b/packages/tui/src/control/types.ts
@@ -7,7 +7,7 @@
  * lets the whole surface be rewritten without changing a single behaviour.
  */
 
-import type { HarnessId } from '@agentistics/core'
+import type { HarnessId, ProjectKind } from '@agentistics/core'
 import type { CliLang } from './lang'
 import type { GithubSection } from './backup'
 import type { SearchFields, SearchScope } from './search-scope'
@@ -1696,11 +1696,26 @@ export interface ControlHost {
    */
   startableHarnesses?(): Promise<SessionHarnessOption[]>
 
-  /** Places a new session could start, ranked. `query` may be empty, which opens on recency. */
-  searchProjects?(query: string): Promise<ProjectOption[]>
+  /**
+   * Places a new session could start, ranked — with HOW MANY of each kind matched.
+   *
+   * The two travel together because they come from one search. `options` is what fits on screen
+   * (capped per kind so a tab can never be emptied by a different kind's budget); `totals` is what
+   * is actually there. Counting `options` instead is what made the web wizard's tabs read
+   * `Repositories 12 · Projects 12 · Folders 12` on a machine with twenty repositories — the cap,
+   * shown as a fact about the machine.
+   */
+  searchProjects?(query: string): Promise<ProjectSearchResult>
 
   /** Start one. An attached request comes back with a ticket the shell hands to `ControlExit`. */
   spawnSession?(req: SpawnSessionRequest): Promise<SpawnSessionResult>
+}
+
+/** One search of the places a session could start: what to show, and how much there is. */
+export interface ProjectSearchResult {
+  options: ProjectOption[]
+  /** Matches per kind BEFORE the cap — see `countPerKind`. */
+  totals: Record<ProjectKind, number>
 }
 
 /** One harness the wizard may offer, and the shape of the questions it earns. */

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -16,7 +16,7 @@ import {
 } from 'lucide-react'
 import { useData, useDerivedStats, LIVE_INTERVAL_OPTIONS, LIVE_INTERVAL_OPTIONS_RISKY } from './hooks/useData'
 import { usePlanBasis } from './hooks/usePlanBasis'
-import { planScopeHarnesses, planScopeNote } from './lib/costBasis'
+import { planScopeHarnesses, planScopeNote, sessionPlanFactor } from './lib/costBasis'
 import { bootLoading } from './lib/bootPhase'
 import { DEFAULT_CARD_ORDER, migrateCardOrder, type CardId } from './lib/cardOrder'
 import { BillingIntroModal } from './components/BillingIntroModal'
@@ -3185,6 +3185,8 @@ export default function AppLayout() {
           lang={lang === 'pt' ? 'pt' : 'en'}
           currency={currency}
           brlRate={brlRate}
+          costBasis={costBasis}
+          planFactor={sessionPlanFactor(planBasis.basis, selectedFleetSession.harness)}
           {...(selectedFleetSession.model ? { startedModel: selectedFleetSession.model } : {})}
           {...(selectedFleetSession.effort ? { startedEffort: selectedFleetSession.effort } : {})}
         />

--- a/packages/web/src/components/nav/SessionsAside.tsx
+++ b/packages/web/src/components/nav/SessionsAside.tsx
@@ -24,7 +24,8 @@ import {
 import { rowSelected } from '../../lib/fleetSelection'
 import { filterFleet, ignoredDimensions } from '../../lib/fleetFilter'
 import { NewSessionModal } from '../sessions/NewSessionModal'
-import { SessionPickModal, type PickModalRow } from '../sessions/SessionPickModal'
+import { SessionPickModal } from '../sessions/SessionPickModal'
+import { buildPickRows } from '../../lib/sessionPick'
 import { rowMenuEntries, type RowVerb } from '../../lib/rowMenu'
 import { SessionRowMenu } from '../sessions/SessionRowMenu'
 import { TaskPicker } from '../tasks/TaskPicker'
@@ -176,40 +177,14 @@ export function SessionsAside({
    * that is not running and for one sitting on an open dialog (where a typed line goes into the
    * dialog's filter and the submit takes the highlighted option).
    */
-  const groupRows = useMemo(() => {
-    const fellRows: PickModalRow[] = []
-    const sendRows: PickModalRow[] = []
-    let sendable = 0
-    if (!rowsById) return { fellRows, sendRows, sendable }
-    for (const r of rowsById.values() as Iterable<any>) {
-      const id: string = r.id ?? ''
-      if (!id) continue
-      const base: PickModalRow = {
-        id,
-        title: r.title || (pt ? 'sem título' : 'untitled'),
-        ...(r.project ? { detail: r.project } : r.cwd ? { detail: r.cwd } : {}),
-      }
-      if (r.fell) fellRows.push(base)
-      /*
-       * THE WHOLE FLEET IS OFFERED, and the ones that cannot take a prompt are DISABLED with the
-       * server's own reason beside them — not hidden. A session missing from the list and a session
-       * that cannot be written to look identical from the outside, and the first reads as "agentop
-       * lost it". The `Active` tab is what narrows it for somebody who only wants the runnable ones.
-       */
-      const verb = (r.verbs as RowVerb[] | undefined)?.find(v => v.action === 'prompt')
-      const enabled = Boolean(verb?.enabled)
-      if (enabled) sendable++
-      // The verb carries no reason of its own — `prompt` is enabled by being LIVE and nothing else
-      // (a session sitting on a dialog is refused later by the host, which re-reads the screen).
-      // So the reason is that fact, said with the state the SERVER already localized rather than a
-      // second vocabulary invented here.
-      const stateWord = typeof r.stateLabel === 'string' ? r.stateLabel : ''
-      const reason = verb?.reason
-        ?? (pt ? 'não está rodando' : 'not running') + (stateWord ? ` · ${stateWord}` : '')
-      sendRows.push({ ...base, enabled, ...(enabled ? {} : { reason }) })
-    }
-    return { fellRows, sendRows, sendable }
-  }, [rowsById, pt])
+  const groupRows = useMemo(
+    // ONE ROW PER SESSION: `rowsById` is keyed TWICE per row on purpose (by its own id and by its
+    // conversation id, so one map answers a link carrying either), and iterating its values offered
+    // and counted every session that knows its conversation twice — reported as `Active 22` on a
+    // machine running 11. `buildPickRows` owns the dedupe and the rest of this arithmetic.
+    () => buildPickRows(rowsById ? rowsById.values() : [], pt),
+    [rowsById, pt],
+  )
 
   const canAct = Boolean(act) && !hideNew
   const showFell = canAct && groupRows.fellRows.length > 0

--- a/packages/web/src/components/sessions/NewSessionModal.tsx
+++ b/packages/web/src/components/sessions/NewSessionModal.tsx
@@ -29,8 +29,10 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 import { ChevronDown, ChevronLeft, ChevronRight, Check, FolderClock, FolderGit2, Folder, Loader, Paperclip, Search, X } from 'lucide-react'
 import { projectKind, type ProjectKind } from '@agentistics/core'
 import {
-  KIND_TABS, SEARCH_DEBOUNCE_MS, kindEmpty, kindHint, kindLabel, type ProjectTab,
+  KIND_TABS, SEARCH_DEBOUNCE_MS, kindCount, kindEmpty, kindHint, kindLabel, kindMore, kindMoreText,
+  type ProjectTab,
 } from '../../lib/projectTabs'
+import { attachmentRoom, MAX_ATTACHMENTS, planPaste } from '../../lib/pastePlan'
 import { Field, Muted, inputStyle } from './formBits'
 import { HARNESS_COLORS, HARNESS_LABELS } from '../../lib/harness'
 import { useIsMobile } from '../../hooks/useIsMobile'
@@ -95,6 +97,15 @@ export function NewSessionModal({ lang, onClose, onStarted, initialTask }: NewSe
   const pt = lang === 'pt'
   const [harnesses, setHarnesses] = useState<HarnessOption[] | null>(null)
   const [projects, setProjects] = useState<ProjectOption[]>([])
+  /**
+   * How many places of each kind MATCHED — which is not how many rows came back.
+   *
+   * The server caps its answer per kind so a tab can never be emptied by another kind's budget, and
+   * the tabs then counted the rows: `Repositories 12 · Projects 12 · Folders 12` on a machine with
+   * twenty repositories. `undefined` means this server does not say, and the tabs fall back to
+   * counting rows rather than to a guess.
+   */
+  const [projectTotals, setProjectTotals] = useState<Record<ProjectKind, number> | undefined>(undefined)
   const [tasks, setTasks] = useState<string[]>([])
   const [query, setQuery] = useState('')
   /**
@@ -164,10 +175,12 @@ export function NewSessionModal({ lang, onClose, onStarted, initialTask }: NewSe
         if (!res.ok || !alive) return
         const json = await res.json() as {
           harnesses: HarnessOption[]; projects: ProjectOption[]; tasks: string[]
+          projectTotals?: Record<ProjectKind, number>
         }
         if (!alive) return
         setHarnesses(json.harnesses)
         setProjects(json.projects)
+        setProjectTotals(json.projectTotals)
         setTasks(json.tasks)
         // Pre-select the only assistant there is. A one-item picker is a question with one answer.
         setHarness(h => h ?? (json.harnesses.length === 1 ? json.harnesses[0]! : null))
@@ -195,6 +208,12 @@ export function NewSessionModal({ lang, onClose, onStarted, initialTask }: NewSe
 
   /** What the list is showing. `all` keeps the server's ranking, which is the useful default. */
   const shownProjects = kindTab === 'all' ? projects : byKind[kindTab]
+  /** Whether rows are being held back, and how many — `null` whenever that cannot be known. */
+  const shownMore = kindMore(
+    shownProjects.length,
+    projectTotals ? kindCount(kindTab, shownProjects.length, projectTotals) : undefined,
+    shownProjects.length > 0,
+  )
 
   // Reset the answers a DIFFERENT assistant does not accept. Carrying `effort: 'high'` across to a
   // harness whose set does not contain it would send a flag the CLI rejects at spawn.
@@ -318,8 +337,17 @@ export function NewSessionModal({ lang, onClose, onStarted, initialTask }: NewSe
    * assistant would be told to read a file that is not there — a failure the person cannot see and
    * the session cannot explain.
    */
-  async function pick(list: FileList | null): Promise<void> {
-    const files = Array.from(list ?? [])
+  async function pick(list: FileList | readonly File[] | null): Promise<void> {
+    const picked = Array.from(list ?? [])
+    if (picked.length === 0) return
+    // The same cap the session composer applies, from the same module — a wizard that accepts
+    // fifteen and a composer that accepts ten are two rules for one act.
+    const files = picked.slice(0, attachmentRoom(attachments.length))
+    if (files.length < picked.length) {
+      setNotice(pt
+        ? `No máximo ${MAX_ATTACHMENTS} anexos.`
+        : `At most ${MAX_ATTACHMENTS} attachments.`)
+    }
     if (files.length === 0) return
     setUploading(true)
     for (const file of files) {
@@ -339,6 +367,36 @@ export function NewSessionModal({ lang, onClose, onStarted, initialTask }: NewSe
     }
     setUploading(false)
     if (fileRef.current) fileRef.current.value = ''
+  }
+
+  /**
+   * PASTE INTO THE MESSAGE, files included — reported as "let me ctrl+V a file here".
+   *
+   * `planPaste` is the session composer's own decision, unchanged and shared: a paste carrying
+   * FILES becomes attachments, ordinary text falls through to the field (which handles the caret
+   * and the undo stack better than any manual insert), and a very large block of text is attached
+   * as a file instead. That last one matters here for the same reason it matters there — several
+   * harnesses take their first prompt by having it TYPED into a pane (see `spawn-spec.ts`), so a
+   * 4.000-line paste is not a message.
+   *
+   * The button stays: a paste is the shortcut, never the only way in.
+   */
+  function onPastePrompt(e: React.ClipboardEvent<HTMLTextAreaElement>): void {
+    const plan = planPaste({
+      files: Array.from(e.clipboardData.files),
+      text: e.clipboardData.getData('text/plain'),
+      existing: attachments.length,
+    })
+    // An ordinary paste is left alone — the textarea does it better than we would.
+    if (plan.kind === 'text') return
+    e.preventDefault()
+    if (plan.kind === 'files') { void pick(plan.files); return }
+    if (plan.kind === 'textFile') {
+      void pick([new File([plan.text], plan.name, { type: 'text/plain' })])
+      setNotice(pt
+        ? 'O texto colado era grande demais para a primeira mensagem, então foi anexado como arquivo.'
+        : 'The pasted text was too large for a first message, so it was attached as a file.')
+    }
   }
 
   /**
@@ -715,7 +773,7 @@ export function NewSessionModal({ lang, onClose, onStarted, initialTask }: NewSe
             }}>
               {KIND_TABS.map(id => {
                 const on = kindTab === id
-                const n = id === 'all' ? projects.length : byKind[id].length
+                const n = kindCount(id, id === 'all' ? projects.length : byKind[id].length, projectTotals)
                 return (
                   <button
                     key={id}
@@ -746,7 +804,13 @@ export function NewSessionModal({ lang, onClose, onStarted, initialTask }: NewSe
                 folder and nothing on screen ever said what the difference was. */}
             <p style={{
               margin: '0 0 8px', fontSize: 10.5, lineHeight: 1.45, color: 'var(--text-tertiary)',
-            }}>{kindHint(kindTab, pt)}</p>
+            }}>
+              {kindHint(kindTab, pt)}
+              {/* AND HOW MANY OF THEM ARE ON SCREEN. The tab now carries the true total, so
+                  without this line a tab reading 21 over a list of 12 looks like a broken list
+                  rather than a capped one — and the way to reach the other nine is to type. */}
+              {shownMore && <> {kindMoreText(shownMore, pt)}</>}
+            </p>
 
             <div style={{
               maxHeight: 190, overflowY: 'auto', display: 'flex', flexDirection: 'column', gap: 4,
@@ -813,10 +877,22 @@ export function NewSessionModal({ lang, onClose, onStarted, initialTask }: NewSe
 
           {/* STEP 3 — WHAT. The first message, and the files it points at. */}
           {step === 'message' && (<>
-          <Field label={pt ? 'Primeira mensagem (opcional)' : 'First message (optional)'}>
+          <Field
+            label={pt ? 'Primeira mensagem (opcional)' : 'First message (optional)'}
+            hint={pt
+              ? 'Cole (Ctrl+V) ou arraste arquivos aqui para anexá-los.'
+              : 'Paste (Ctrl+V) or drop files here to attach them.'}
+          >
             <textarea
               value={prompt}
               onChange={e => setPrompt(e.target.value)}
+              onPaste={onPastePrompt}
+              onDragOver={e => { if (e.dataTransfer.types.includes('Files')) e.preventDefault() }}
+              onDrop={e => {
+                if (e.dataTransfer.files.length === 0) return
+                e.preventDefault()
+                void pick(e.dataTransfer.files)
+              }}
               rows={3}
               placeholder={pt ? 'O que a sessão deve fazer…' : 'What the session should do…'}
               style={{ ...inputStyle, paddingLeft: 12, resize: 'vertical', minHeight: 68 }}

--- a/packages/web/src/components/sessions/SessionStatsMenu.tsx
+++ b/packages/web/src/components/sessions/SessionStatsMenu.tsx
@@ -18,9 +18,10 @@ import { useEffect, useRef, useState } from 'react'
 import { sessionTime } from '../../lib/sessionTime'
 import { asideCache, asideKey } from '../../lib/asideCache'
 import { BarChart3, X } from 'lucide-react'
-import { fmt, fmtCost, type HarnessId, type SessionMeta } from '@agentistics/core'
+import { fmt, fmtCost, type CostBasis, type HarnessId, type SessionMeta } from '@agentistics/core'
 import { HARNESS_LABELS } from '../../lib/harness'
 import { sessionStats, statReason } from '../../lib/sessionStats'
+import { costBasisLabel, viewCost } from '../../lib/costBasis'
 
 export interface SessionStatsMenuProps {
   harness: string
@@ -49,10 +50,29 @@ export interface SessionStatsMenuProps {
    * panel with a piece off the screen.
    */
   touch?: boolean
+  /**
+   * The basis the DASHBOARD is on, which is where this card opens.
+   *
+   * The card can be switched to the other one to compare, and that switch is LOCAL: it lasts as
+   * long as the card is open and changes nothing global. The dashboard's basis is a decision about
+   * how the user reads their money; looking at one session in the other basis for a moment is not.
+   */
+  costBasis?: CostBasis
+  /**
+   * `C/A` for THIS session's harness — `planAllocation(basis).byHarness[harness]`.
+   *
+   * Per-harness and never the aggregate: a session is one harness's spend, and pricing it against
+   * a factor that also covers a subscription paying for something else is not an allocation of
+   * anything. `null` (or absent) means no plan covers this harness, and then there is NO toggle —
+   * an offer whose only outcome is "no registered plan" is the dead control this product refuses
+   * everywhere else.
+   */
+  planFactor?: number | null
 }
 
 export function SessionStatsMenu({
   harness, sessionId, meta, lang, currency, brlRate, startedModel, startedEffort, touch = false,
+  costBasis = 'api', planFactor = null,
 }: SessionStatsMenuProps) {
   const pt = lang === 'pt'
   const [open, setOpen] = useState(false)
@@ -80,6 +100,17 @@ export function SessionStatsMenu({
       .catch(() => { if (alive) setFacts(f => f ?? { unavailable: pt ? 'Não foi possível ler.' : 'Could not read it.' }) })
     return () => { alive = false }
   }, [open, factsKey, sessionId, pt])
+  /**
+   * THE BASIS THIS CARD IS SHOWING — local, and paired with the dashboard every time it opens.
+   *
+   * The toggle exists so one session can be read in the other basis for a moment; it is not a
+   * decision about how the user reads their money, which is what the dashboard's switch is. So it
+   * is re-seeded from `costBasis` on every open, and closing the card is what puts it back — there
+   * is nothing to put back, because nothing global was ever changed.
+   */
+  const [basisHere, setBasisHere] = useState<CostBasis>(costBasis)
+  useEffect(() => { if (open) setBasisHere(costBasis) }, [open, costBasis])
+
   const boxRef = useRef<HTMLDivElement | null>(null)
 
   useEffect(() => {
@@ -99,6 +130,15 @@ export function SessionStatsMenu({
   const h = harness as HarnessId
   const s = sessionStats(h, sessionId, meta)
   const money = (usd: number) => fmtCost(usd, currency, brlRate)
+  /**
+   * The plan side is offered only when it can actually be produced for THIS harness — see
+   * `planFactor`. `viewCost` is what applies it, and it refuses rather than inventing: a basis it
+   * cannot produce comes back as the API figure flagged, and `costBasisLabel` then says API.
+   */
+  const canSwitchBasis = typeof planFactor === 'number' && Number.isFinite(planFactor)
+  const inBasis = (usd: number) =>
+    viewCost(usd, { basis: basisHere, factor: canSwitchBasis ? planFactor : null, allocated: true })
+  const cost = s.costUSD === null ? null : inBasis(s.costUSD)
   const label = (HARNESS_LABELS as Record<string, string>)[harness] ?? harness
 
   /** The sentence for an absent figure — see the header. */
@@ -220,9 +260,38 @@ export function SessionStatsMenu({
           </Block>
 
           <Block title={pt ? 'Custo' : 'Cost'}>
-            {s.costUSD === null
+            {/* THE TOGGLE IS ONLY HERE WHEN A PLAN COVERS THIS HARNESS. Without a factor the plan
+                side could only ever answer "no registered plan", and a control whose one outcome is
+                a refusal teaches the same wrong thing as a missing one. */}
+            {canSwitchBasis && (
+              <div role="group" aria-label={pt ? 'Base do custo' : 'Cost basis'} style={{
+                display: 'flex', gap: 2, padding: 2, marginBottom: 6, borderRadius: 7,
+                background: 'var(--bg-elevated)', border: '1px solid var(--border-subtle)',
+              }}>
+                {(['api', 'plan'] as const).map(b => {
+                  const on = basisHere === b
+                  return (
+                    <button
+                      key={b}
+                      onClick={() => setBasisHere(b)}
+                      aria-pressed={on}
+                      style={{
+                        flex: 1, minHeight: touch ? 32 : 22, borderRadius: 5, border: 'none',
+                        cursor: 'pointer', fontFamily: 'inherit', fontSize: 10.5,
+                        fontWeight: on ? 700 : 500,
+                        background: on ? 'var(--bg-surface)' : 'transparent',
+                        color: on ? 'var(--anthropic-orange)' : 'var(--text-tertiary)',
+                      }}
+                    >
+                      {b === 'api' ? 'API' : (pt ? 'Plano' : 'Plan')}
+                    </button>
+                  )
+                })}
+              </div>
+            )}
+            {cost === null
               ? <Absent text={na('cost')} />
-              : <Line k={pt ? 'Estimado (API)' : 'Estimated (API)'} v={money(s.costUSD)} />}
+              : <Line k={costBasisLabel(cost, pt)} v={money(cost.usd)} />}
           </Block>
 
           {/* ASKED FOR: how long this session has been going. Two figures, not one, and the pair is
@@ -260,7 +329,9 @@ export function SessionStatsMenu({
                   <>
                     <Line k={pt ? 'Rodaram' : 'Ran'} v={fmt(s.subagents.count)} />
                     <Line k="Tokens" v={fmt(s.subagents.tokens)} />
-                    <Line k={pt ? 'Custo' : 'Cost'} v={money(s.subagents.costUSD)} />
+                    {/* The same basis as the card's own cost row: two money figures in one card
+                        under two different bases is a card that cannot be added up. */}
+                    <Line k={pt ? 'Custo' : 'Cost'} v={money(inBasis(s.subagents.costUSD).usd)} />
                   </>
                 )
             ) : <Absent text={na('agents')} />}

--- a/packages/web/src/hooks/useData.test.ts
+++ b/packages/web/src/hooks/useData.test.ts
@@ -1797,3 +1797,79 @@ describe('the activity calendar counts the days a session WORKED', () => {
     expect(on4.sessions).toBe(2)
   })
 })
+
+/**
+ * THE REPORTED CASE — "the Today filter is lying A LOT: there is an activity chart for the whole
+ * day when I did nothing before 8am".
+ *
+ * `message_hours` is a LIFETIME array carrying no day, so a conversation open since Tuesday put
+ * every hour it had ever run in into today's chart. Measured on the reporter's machine: bars in
+ * all 24 hours, totalling 33.427 against the 4.905 messages the same filter reported one card
+ * above it.
+ */
+describe('the hour chart under a date filter', () => {
+  const DAY = '2026-09-08'
+  const OTHER = '2026-09-06'
+  const hoursOf = (h: Record<string, number>) => h
+
+  const openSinceSaturday = {
+    session_id: 'long', harness: 'claude', project_path: '/p',
+    start_time: '2026-09-06T16:00:00.000Z',
+    input_tokens: 100, output_tokens: 100,
+    // The lifetime array: afternoon and evening on the 6th, morning on the 8th.
+    message_hours: [16, 16, 16, 22, 22, 8, 9, 9],
+    user_message_timestamps: [`${OTHER}T19:00:00.000Z`, `${DAY}T12:00:00.000Z`],
+    daily: {
+      [OTHER]: { input_tokens: 50, output_tokens: 50, cache_read_input_tokens: 0, cache_creation_input_tokens: 0, messages: 5, hours: hoursOf({ '16': 3, '22': 2 }) },
+      [DAY]: { input_tokens: 50, output_tokens: 50, cache_read_input_tokens: 0, cache_creation_input_tokens: 0, messages: 3, hours: hoursOf({ '8': 1, '9': 2 }) },
+    },
+  } as unknown as SessionMeta
+
+  const data = {
+    statsCache: { dailyTokens: {}, dailyActivity: [], dailyModelTokens: [], modelUsage: {}, hourCounts: {}, lastComputedDate: '2026-01-01' },
+    sessions: [openSinceSaturday], projects: [], allSessions: [], harnesses: ['claude'],
+  } as unknown as import('@agentistics/core').AppData
+
+  const onDay = (day: string): import('@agentistics/core').Filters =>
+    ({ dateRange: 'all', customStart: day, customEnd: day, projects: [], models: [] })
+
+  test('a day gets THAT day\'s hours, not every hour the session ever ran in', () => {
+    const d = computeDerivedStats(data, onDay(DAY))!
+    expect(d.hourCounts).toEqual({ 8: 1, 9: 2 })
+  })
+
+  test('the session is still selected — it worked today, it just did not work all day', () => {
+    // The bug that would replace this one: filing the session on its START day drops it from
+    // today entirely, and "today" reads empty for anyone whose conversation has been open a while.
+    expect(computeDerivedStats(data, onDay(DAY))!.totalSessions).toBe(1)
+  })
+
+  test('another day gets its own hours', () => {
+    expect(computeDerivedStats(data, onDay(OTHER))!.hourCounts).toEqual({ 16: 3, 22: 2 })
+  })
+
+  test('the tooltip\'s timestamps are cut to the range too', () => {
+    const d = computeDerivedStats(data, onDay(DAY))!
+    expect(Object.keys(d.hourMeta)).toHaveLength(1)
+  })
+
+  test('unfiltered, the lifetime array is what it has always been', () => {
+    const all = computeDerivedStats(data, { dateRange: 'all', customStart: '', customEnd: '', projects: [], models: [] })!
+    expect(all.hourCounts).toEqual({ 16: 3, 22: 2, 8: 1, 9: 2 })
+  })
+
+  test('a session with no per-day hours KEEPS its lifetime array — never an invented empty day', () => {
+    // Records written before the field existed. Under-reporting them would be the same class of
+    // error in the other direction, and it would be invisible.
+    const old = {
+      ...openSinceSaturday, session_id: 'old',
+      daily: { [DAY]: { input_tokens: 1, output_tokens: 1, cache_read_input_tokens: 0, cache_creation_input_tokens: 0, messages: 3 } },
+    } as unknown as SessionMeta
+    const d = computeDerivedStats(
+      { ...data, sessions: [old] } as unknown as import('@agentistics/core').AppData,
+      onDay(DAY),
+    )!
+    expect(d.hourCounts).toEqual({ 16: 3, 22: 2, 8: 1, 9: 2 })
+  })
+})
+

--- a/packages/web/src/hooks/useData.ts
+++ b/packages/web/src/hooks/useData.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
-import { activeInDays, activeInWindow, daysBetween, MAX_RANGE_DAYS, sliceSession, type DayUsage } from '../lib/sessionDaySlice'
+import { activeInDays, activeInWindow, dayKey, daysBetween, expandHours, MAX_RANGE_DAYS, sliceSession, type DayUsage } from '../lib/sessionDaySlice'
 import type { AppData, Filters, DateRange, AgentInvocation, HarnessId, SessionMeta, TokenBreakdown } from '@agentistics/core'
 import { calcStreak, calcCost, sessionModelUsage, sessionCostUSD, getModelPrice, MODEL_PRICING, HARNESS_CAPABILITIES, filterByUsers, filterByHarnesses, filterByTeams, filterByMachines, resolveMachineCacheScope, distinctHarnesses, mergeStatsCaches, repoShortName, HARNESS_ORDER, EMPTY_TOKENS, addTokens, sessionTokens, sessionTokenTotal, sumTokens, totalTokens, usageTokenTotal, usageTokens } from '@agentistics/core'
 import { subDays, isAfter, isBefore, parseISO, format, differenceInCalendarDays, addDays, getDay } from 'date-fns'
@@ -1284,6 +1284,29 @@ export function computeDerivedStats(
         // lifetime messages to take a ratio from, they go to the user side, which is what an
         // unattributable message already does everywhere else.
         ...splitMessages(cut.messages, s.user_message_count ?? 0, s.assistant_message_count ?? 0),
+        /**
+         * WHEN, cut to the range as well — the chart's own counter.
+         *
+         * `message_hours` is a lifetime array carrying no day, so a conversation open since
+         * Tuesday brought every hour it had ever run in into today's chart: measured with `Today`
+         * selected on a real machine, bars across all 24 hours for someone who started at 8am,
+         * totalling 33.427 against the 4.905 messages the same filter reported one card above.
+         *
+         * Rebuilt from the day split rather than filtered, because an hour is not a day and the
+         * lifetime array has nothing on it to filter BY. A session whose days carry no `hours`
+         * (written before the field existed) KEEPS its lifetime array — the rule this projection
+         * already applies to a session with no `daily` at all: a record that cannot be split is
+         * not a record that did nothing.
+         */
+        ...(cut.hours && Object.keys(cut.hours).length > 0
+          ? { message_hours: expandHours(cut.hours) }
+          : {}),
+        /**
+         * The tooltip's "first and last message in this hour" — filtered, not rebuilt, because
+         * these ARE instants and carry their own day. Same UTC day rule as `rangeDays`.
+         */
+        user_message_timestamps: (s.user_message_timestamps ?? [])
+          .filter(ts => rangeDays.has(dayKey(ts))),
       }
     })
 

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -588,6 +588,19 @@ input[type="range"],
 input[type="checkbox"],
 input[type="radio"] { accent-color: var(--anthropic-orange); }
 
+/* THE CARET IS THE PRODUCT'S COLOUR TOO.
+ *
+ * The blinking bar in a text field is drawn by the browser in its own foreground colour — white on
+ * this dark theme — and it is the one piece of chrome the eye is looking straight at while typing.
+ * One selector rather than a rule per field, for the same reason the accent block above is one: a
+ * new input is correct by existing, and a caret that is orange in the composer and white in the
+ * search box is the kind of inconsistency nobody can point at and everybody sees.
+ *
+ * `caret-color` only — the text, the selection and the focus ring are untouched. */
+input,
+textarea,
+[contenteditable] { caret-color: var(--anthropic-orange); }
+
 .ag-chat-md a { color: var(--anthropic-orange); text-decoration: none; }
 .ag-chat-md a:hover { text-decoration: underline; }
 

--- a/packages/web/src/lib/costBasis.test.ts
+++ b/packages/web/src/lib/costBasis.test.ts
@@ -1,5 +1,5 @@
-import { describe, test, expect } from 'bun:test'
-import { costBasisMarker, formatMultiple, planCostSubtitle, planScopeHarnesses, planScopeNote, viewCost } from './costBasis'
+import { describe, expect, it, test } from 'bun:test'
+import { costBasisLabel, costBasisMarker, formatMultiple, sessionPlanFactor, planCostSubtitle, planScopeHarnesses, planScopeNote, viewCost } from './costBasis'
 
 describe('viewCost', () => {
   test('api basis is an identity', () => {
@@ -163,3 +163,51 @@ describe('formatMultiple', () => {
     expect(formatMultiple(8.5, 'en')).toBe('8.50×')
   })
 })
+
+describe('costBasisLabel — the row says WHICH basis it is showing', () => {
+  it('names the API estimate as an estimate', () => {
+    expect(costBasisLabel(viewCost(10, { basis: 'api', factor: null }), true)).toBe('Estimado (API)')
+    expect(costBasisLabel(viewCost(10, { basis: 'api', factor: null }), false)).toBe('Estimated (API)')
+  })
+
+  it('names a plan figure an ALLOCATION, because no session was billed on its own', () => {
+    const v = viewCost(10, { basis: 'plan', factor: 0.5, allocated: true })
+    expect(v.usd).toBe(5)
+    expect(costBasisLabel(v, true)).toBe('Rateado (plano)')
+    expect(costBasisLabel(v, false)).toBe('Allocated (plan)')
+  })
+
+  it('a plan figure that could not be produced says so, and never wears the plan label', () => {
+    // `viewCost` hands back the API number flagged. The label must follow the basis ACTUALLY used,
+    // or a real API figure is shown under a heading claiming it is the user's plan cost.
+    const v = viewCost(10, { basis: 'plan', factor: null })
+    expect(v.unavailable).toBe(true)
+    expect(costBasisLabel(v, false)).toBe('Estimated (API)')
+  })
+})
+
+describe('sessionPlanFactor — a session allocates against ITS OWN harness', () => {
+  const basis = {
+    planCostUSD: 50, apiCostUSD: 200, multiple: 4, effectiveCostPerMTokens: null,
+    coverage: { computable: true } as never,
+    perHarness: {
+      claude: { planCostUSD: 50, apiCostUSD: 200, coverage: { computable: true } },
+      codex: { planCostUSD: 0, apiCostUSD: 0, coverage: { computable: false } },
+    },
+    uncoveredHarnesses: ['codex'],
+  } as never as import('@agentistics/core').AggregatePlanBasis
+
+  it('is the covered harness own C/A, not the aggregate', () => {
+    expect(sessionPlanFactor(basis, 'claude')).toBeCloseTo(0.25, 6)
+  })
+
+  it('is null for a harness no plan covers — which is what removes the toggle', () => {
+    expect(sessionPlanFactor(basis, 'codex')).toBe(null)
+    expect(sessionPlanFactor(basis, 'gemini')).toBe(null)
+  })
+
+  it('is null with no basis at all — a central, or nobody has registered a plan', () => {
+    expect(sessionPlanFactor(null, 'claude')).toBe(null)
+  })
+})
+

--- a/packages/web/src/lib/costBasis.ts
+++ b/packages/web/src/lib/costBasis.ts
@@ -11,7 +11,7 @@
  * plan figure is an ALLOCATION — no row was individually billed — and a label that can be
  * forgotten will be.
  */
-import type { AggregatePlanBasis, CostBasis, HarnessId } from '@agentistics/core'
+import { planAllocation, type AggregatePlanBasis, type CostBasis, type HarnessId } from '@agentistics/core'
 
 export interface CostView {
   usd: number
@@ -48,6 +48,22 @@ export function viewCost(
     allocated: opts.allocated ?? false,
     unavailable: false,
   }
+}
+
+/**
+ * The KEY of a cost row: which basis the number beside it is in.
+ *
+ * It follows `view.basis` — what was ACTUALLY applied — never what was requested. A plan figure
+ * that could not be produced comes back as the API number flagged `unavailable`, and labelling
+ * that "plan" would put a real API cost under a heading claiming it is the user's subscription.
+ *
+ * "Allocated" rather than "plan cost": within a session, a plan figure is a SHARE of a
+ * subscription — nothing was billed for this conversation on its own — and a label that can be
+ * forgotten will be.
+ */
+export function costBasisLabel(view: CostView, pt: boolean): string {
+  if (view.basis === 'plan') return pt ? 'Rateado (plano)' : 'Allocated (plan)'
+  return pt ? 'Estimado (API)' : 'Estimated (API)'
 }
 
 /**
@@ -147,4 +163,23 @@ export function formatMultiple(multiple: number | null, lang: 'pt' | 'en'): stri
   const decimals = multiple >= 100 ? 0 : multiple >= 10 ? 1 : 2
   const value = multiple.toFixed(decimals)
   return lang === 'pt' ? `${value.replace('.', ',')}×` : `${value}×`
+}
+
+/**
+ * `C/A` for ONE session — the factor a per-session plan figure is allocated by.
+ *
+ * PER HARNESS, never the aggregate. A session is one harness's spend, and rescaling it by a factor
+ * that also covers a subscription paying for something else allocates it against a plan it has
+ * nothing to do with — the same rule `AgentMetricsPanel` follows for a Claude-only metric.
+ *
+ * `null` whenever no plan covers that harness, which is what makes the basis toggle ABSENT rather
+ * than present and answering "no registered plan".
+ */
+export function sessionPlanFactor(
+  basis: AggregatePlanBasis | null,
+  harness: string,
+): number | null {
+  if (!basis) return null
+  const factor = planAllocation(basis).byHarness[harness as HarnessId]
+  return typeof factor === 'number' && Number.isFinite(factor) ? factor : null
 }

--- a/packages/web/src/lib/fleet.ts
+++ b/packages/web/src/lib/fleet.ts
@@ -500,6 +500,12 @@ export function useFleet(lang: 'pt' | 'en', enabled = true): FleetState {
  * uuid handed to `claude --session-id`), the second is what a `closed` row — one read straight out
  * of the conversation store — is already named by. A managed row's own id is a tmux session name
  * and can never collide with a conversation id, so one map answers both without ambiguity.
+ *
+ * **It is a LOOKUP, and its `values()` are not the fleet.** A row that knows its conversation is in
+ * here TWICE, by design — so iterating this map counts those sessions twice. That shipped: the
+ * broadcast picker was built from `rowsById.values()` and offered `Active 22` on a machine running
+ * 11, over an `All` of 357 against a fleet of 329. Use `fleet.sessions`, or `buildPickRows`, which
+ * dedupes by id for exactly this reason.
  */
 export function fleetIndex(rows: readonly FleetRow[]): Map<string, FleetRow> {
   const map = new Map<string, FleetRow>()

--- a/packages/web/src/lib/projectTabs.test.ts
+++ b/packages/web/src/lib/projectTabs.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'bun:test'
 import { projectKind, takePerKind, type ProjectKind } from '@agentistics/core'
-import { KIND_TABS, kindEmpty, kindHint, kindLabel } from './projectTabs'
+import { KIND_TABS, kindCount, kindEmpty, kindHint, kindLabel, kindMore } from './projectTabs'
 
 describe('the tabs', () => {
   it('opens on All, and offers exactly three kinds beside it', () => {
@@ -116,3 +116,36 @@ describe('takePerKind — a folder named like your repo cannot push your repo of
     expect(takePerKind([row('folder')], c => projectKind(c), -1)).toEqual([])
   })
 })
+
+describe('kindCount / kindMore — the tabs say what is THERE, not what fits', () => {
+  /**
+   * THE REPORTED CASE: the tabs read `Repositories 12 · Projects 12 · Folders 12` on a machine
+   * with about twenty repositories. Twelve is `PROJECTS_PER_KIND`, the per-kind cap — so every tab
+   * showed the same number, always, whatever the machine held.
+   */
+  const totals = { repo: 21, project: 34, folder: 58 }
+
+  it('a tab counts what matched, not the rows it was given', () => {
+    expect(kindCount('repo', 12, totals)).toBe(21)
+  })
+
+  it('ALL counts every kind, not the rows on screen', () => {
+    expect(kindCount('all', 36, totals)).toBe(113)
+  })
+
+  it('with no totals from the server the tab counts its rows — and claims nothing more', () => {
+    // An older server does not send them. Counting the rows is then the only true statement
+    // available, and `kindMore` must stay silent rather than infer a cap.
+    expect(kindCount('repo', 12, undefined)).toBe(12)
+    expect(kindMore(12, undefined, true)).toBe(null)
+  })
+
+  it('says how many of how many, but only when some are being held back', () => {
+    expect(kindMore(12, 21, true)).toEqual({ shown: 12, total: 21 })
+    expect(kindMore(21, 21, true)).toBe(null)
+    // Never claims more exist than are shown: a total below the row count is a disagreement, and
+    // the honest answer to a disagreement is to say nothing.
+    expect(kindMore(12, 5, true)).toBe(null)
+  })
+})
+

--- a/packages/web/src/lib/projectTabs.ts
+++ b/packages/web/src/lib/projectTabs.ts
@@ -80,3 +80,44 @@ export function kindEmpty(tab: ProjectTab, query: string, anyProjects: boolean, 
 
 /** How long the field runs ahead of the search. Imperceptible, and one request per word. */
 export const SEARCH_DEBOUNCE_MS = 180
+
+/**
+ * The number a tab carries: HOW MANY MATCHED, never how many rows arrived.
+ *
+ * The rows are capped per kind by the server (`PROJECTS_PER_KIND`), so counting them made every
+ * tab read `12` on a machine with twenty repositories — a cap presented as a fact about the
+ * machine, and one that could never move whatever the person typed.
+ *
+ * `totals` absent means the SERVER did not say (an older one). The rows are then the only true
+ * statement available, so they are what is shown — and `kindMore` stays silent, because "there are
+ * more" is exactly the thing that cannot be known without them.
+ */
+export function kindCount(
+  tab: ProjectTab, rows: number, totals: Record<ProjectKind, number> | undefined,
+): number {
+  if (!totals) return rows
+  if (tab === 'all') return totals.repo + totals.project + totals.folder
+  return totals[tab]
+}
+
+/**
+ * "12 of 21" — said only when rows are actually being held back.
+ *
+ * `null` covers all three ways there is nothing to say: nothing known, nothing withheld, or a
+ * total that contradicts the rows (fewer than are on screen). A disagreement is answered with
+ * silence rather than with whichever number happens to be larger.
+ */
+export function kindMore(
+  rows: number, total: number | undefined, hasRows: boolean,
+): { shown: number; total: number } | null {
+  if (!hasRows || total === undefined) return null
+  if (total <= rows) return null
+  return { shown: rows, total }
+}
+
+/** The sentence for `kindMore`, in the user's language. */
+export function kindMoreText(more: { shown: number; total: number }, pt: boolean): string {
+  return pt
+    ? `Mostrando ${more.shown} de ${more.total}. Digite para encontrar os outros.`
+    : `Showing ${more.shown} of ${more.total}. Type to reach the rest.`
+}

--- a/packages/web/src/lib/sessionDaySlice.test.ts
+++ b/packages/web/src/lib/sessionDaySlice.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'bun:test'
-import { activeInDays, activeInWindow, dayKey, dayKeyOfMs, daysBetween, MAX_RANGE_DAYS, sliceSession } from './sessionDaySlice'
+import { activeInDays, activeInWindow, dayKey, dayKeyOfMs, daysBetween, expandHours, MAX_RANGE_DAYS, sliceSession } from './sessionDaySlice'
 
 const day = (n: number) => ({
   input_tokens: n, output_tokens: n, cache_read_input_tokens: n,
@@ -148,5 +148,50 @@ describe('dayKeyOfMs', () => {
     expect(dayKeyOfMs(Date.parse('2026-09-06T23:59:59.999Z'))).toBe('2026-09-06')
     expect(dayKeyOfMs(0)).toBe('1970-01-01')
     expect(dayKeyOfMs(Number.NaN)).toBe('')
+  })
+})
+
+describe('the hours a session worked INSIDE the range', () => {
+  /**
+   * THE REPORTED CASE — the "Usage by hour" chart under `Today` drew bars across the whole day on
+   * a machine whose owner started at 8am. `message_hours` is a LIFETIME array with no day on it,
+   * so a conversation open since the 3rd brought every hour it had ever run in into today's chart.
+   */
+  const OPEN_SINCE_TUESDAY = {
+    start_time: '2026-09-03T23:23:46.121Z',
+    daily: {
+      '2026-09-03': { ...day(10), hours: { '16': 40, '22': 12 } },
+      '2026-09-08': { ...day(30), hours: { '8': 19, '9': 15 } },
+    },
+  }
+
+  it('today gets today\'s hours, not every hour the session ever ran in', () => {
+    const out = sliceSession(OPEN_SINCE_TUESDAY, new Set(['2026-09-08']))!
+    expect(out.hours).toEqual({ 8: 19, 9: 15 })
+  })
+
+  it('a multi-day range sums the same hour across its days', () => {
+    const out = sliceSession(
+      { daily: { a: { ...day(1), hours: { '9': 2 } }, b: { ...day(1), hours: { '9': 3, '10': 1 } } } },
+      new Set(['a', 'b']),
+    )!
+    expect(out.hours).toEqual({ 9: 5, 10: 1 })
+  })
+
+  it('a day with no hours recorded contributes none — never a guess', () => {
+    // Records written before the field existed. The caller keeps the old rule for those; what it
+    // must never get from here is an invented distribution.
+    const out = sliceSession({ daily: { '2026-09-08': day(30) } }, new Set(['2026-09-08']))!
+    expect(out.hours).toEqual({})
+  })
+
+  it('expandHours is one entry per message, in hour order — the shape message_hours has', () => {
+    expect(expandHours({ 9: 2, 8: 1 })).toEqual([8, 9, 9])
+  })
+
+  it('expandHours refuses what is not an hour of a day', () => {
+    // A key that is not 0..23 cannot be drawn on a 24-bar chart, and repeating a junk value as
+    // many times as it claims is how one bad record becomes a hang.
+    expect(expandHours({ 24: 5, '-1': 5, x: 5, 9: 1 })).toEqual([9])
   })
 })

--- a/packages/web/src/lib/sessionDaySlice.ts
+++ b/packages/web/src/lib/sessionDaySlice.ts
@@ -29,6 +29,20 @@ export interface DayUsage {
   cache_read_input_tokens: number
   cache_creation_input_tokens: number
   messages: number
+  /**
+   * WHEN, on this day, keyed by hour of the LOCAL clock — the same clock `message_hours` is
+   * bucketed on, and the same one the "Usage by hour" chart draws.
+   *
+   * It is here for the same reason the counters are: `message_hours` is a lifetime array carrying
+   * no day, so a conversation open since Tuesday put every hour it had ever run in into today's
+   * chart. Measured with `Today` selected on a real machine: bars across all 24 hours for someone
+   * who had started at 8am.
+   *
+   * OPTIONAL, and absent means "not recorded", never "no activity" — records written before the
+   * field existed have none, and the caller keeps the old rule for those rather than drawing an
+   * empty day over a session that plainly worked.
+   */
+  hours?: Record<string, number>
 }
 
 /** The subset of a session this module reads. Structural, so `SessionMeta` stays the source. */
@@ -85,7 +99,7 @@ export function daysBetween(startMs: number, endMs: number, max = MAX_RANGE_DAYS
 export function sliceSession(s: SliceableSession, days: ReadonlySet<string>): DayUsage | null {
   const daily = s.daily
   if (!daily) return null
-  const out: DayUsage = { ...EMPTY_DAY }
+  const out: DayUsage = { ...EMPTY_DAY, hours: {} }
   for (const key of Object.keys(daily)) {
     if (!days.has(key)) continue
     const d = daily[key]
@@ -95,6 +109,29 @@ export function sliceSession(s: SliceableSession, days: ReadonlySet<string>): Da
     out.cache_read_input_tokens += d.cache_read_input_tokens || 0
     out.cache_creation_input_tokens += d.cache_creation_input_tokens || 0
     out.messages += d.messages || 0
+    for (const [hour, n] of Object.entries(d.hours ?? {})) {
+      out.hours![hour] = (out.hours![hour] ?? 0) + (n || 0)
+    }
+  }
+  return out
+}
+
+/**
+ * An hour map back into the shape `message_hours` has: one entry per message, ascending.
+ *
+ * The projection in `useDerivedStats` replaces a sliced session's `message_hours` with this, so
+ * every consumer of that field — the chart, the PDF export, the drilldown — reads the range's
+ * hours without any of them having to know a range exists.
+ *
+ * A key outside 0..23 is DROPPED rather than drawn: it cannot go on a 24-bar chart, and repeating
+ * one as many times as its count claims is how a single bad record becomes a hang.
+ */
+export function expandHours(hours: Record<string, number> | undefined): number[] {
+  if (!hours) return []
+  const out: number[] = []
+  for (let h = 0; h <= 23; h++) {
+    const n = hours[String(h)] ?? 0
+    for (let i = 0; i < n; i++) out.push(h)
   }
   return out
 }

--- a/packages/web/src/lib/sessionPick.test.ts
+++ b/packages/web/src/lib/sessionPick.test.ts
@@ -1,6 +1,7 @@
-import { test, expect } from 'bun:test'
+import { describe, expect, it, test } from 'bun:test'
 import {
   PICK_TABS,
+  buildPickRows,
   filterPickRows,
   initialPick,
   pickAllState,
@@ -118,3 +119,58 @@ test('the empty state names what emptied the list', () => {
   expect(pickTabLabel('active', true)).toBe('Ativas')
   expect(pickTabHint('all', true)).not.toBe(pickTabHint('active', true))
 })
+
+describe('buildPickRows — one row per SESSION, whatever the caller iterated', () => {
+  const live = (id: string, conversationId?: string) => ({
+    id,
+    ...(conversationId ? { conversationId } : {}),
+    title: `session ${id}`,
+    project: 'agentistics',
+    verbs: [{ action: 'prompt', enabled: true }],
+  })
+  const dead = (id: string) => ({
+    id, title: `session ${id}`, stateLabel: 'exited', fell: true,
+    verbs: [{ action: 'prompt', enabled: false }],
+  })
+
+  /**
+   * THE REPORTED CASE — the broadcast picker's `Active` tab read **22** on a machine running
+   * **11**, and `All` read 358 against a fleet of 330.
+   *
+   * `fleetIndex` keys every row TWICE on purpose (by its own id AND by its conversation id, so one
+   * map answers a link carrying either), and the picker was built by iterating that map's VALUES.
+   * Every session that knows its conversation was therefore offered twice and counted twice.
+   */
+  it('a row reached under two keys is ONE row', () => {
+    const a = live('agentop-1', 'uuid-1')
+    const index = new Map([['agentop-1', a], ['uuid-1', a], ['agentop-2', live('agentop-2')]])
+    const out = buildPickRows(index.values(), false)
+    expect(out.sendRows).toHaveLength(2)
+    expect(out.sendable).toBe(2)
+  })
+
+  it('counts only what can actually take the prompt', () => {
+    const out = buildPickRows([live('a'), dead('b'), live('c')], false)
+    expect(out.sendable).toBe(2)
+    // The un-takeable row is SHOWN and disabled, never hidden — a missing session reads as lost.
+    expect(out.sendRows).toHaveLength(3)
+    expect(out.sendRows.find(r => r.id === 'b')?.enabled).toBe(false)
+    expect(out.sendRows.find(r => r.id === 'b')?.reason).toBeTruthy()
+  })
+
+  it('a row that fell is offered for reopening, once', () => {
+    const d = dead('gone')
+    const index = new Map([['gone', d], ['uuid-gone', d]])
+    expect(buildPickRows(index.values(), false).fellRows).toHaveLength(1)
+  })
+
+  it('a row with no id is not a row', () => {
+    expect(buildPickRows([{ id: '', title: 'x', verbs: [] }], false).sendRows).toHaveLength(0)
+  })
+
+  it('keeps the order it was given — the order the list drew', () => {
+    const out = buildPickRows([live('b'), live('a')], false)
+    expect(out.sendRows.map(r => r.id)).toEqual(['b', 'a'])
+  })
+})
+

--- a/packages/web/src/lib/sessionPick.ts
+++ b/packages/web/src/lib/sessionPick.ts
@@ -177,3 +177,84 @@ export function pickConfirmLabel(
         : (one ? 'Send to 1 session' : `Send to ${count} sessions`)),
   }
 }
+
+/** What `buildPickRows` reads off a fleet row. Structural, so `FleetRow` stays the source. */
+export interface PickSource {
+  id?: string
+  title?: string
+  project?: string
+  cwd?: string
+  /** This row is one of the sessions the machine TOOK — the server's `FleetRow.fell`. */
+  fell?: boolean
+  /** Already localized by the server — the word the fleet list prints for this row's state. */
+  stateLabel?: string
+  verbs?: readonly { action?: string; enabled?: boolean; reason?: string }[]
+}
+
+/** A picker row plus the two fields the modal renders. */
+export interface PickModalSource extends PickRow {}
+
+export interface PickRowsResult {
+  /** Rows for "reopen what fell". */
+  fellRows: PickModalSource[]
+  /** The WHOLE fleet, with the ones that cannot take a prompt disabled and given a reason. */
+  sendRows: PickModalSource[]
+  /** How many of `sendRows` can actually take the prompt — what decides the verb is offered. */
+  sendable: number
+}
+
+/**
+ * The two picker lists, from whatever the caller is holding — and ONE ROW PER SESSION.
+ *
+ * The dedupe is the reason this is a function rather than a loop in the component. `fleetIndex`
+ * keys every row TWICE on purpose — by its own id AND by its conversation id, so one map answers a
+ * link carrying either — and the picker was built by iterating that map's VALUES. Every session
+ * that knows its conversation was offered twice and counted twice: reported as `Active 22` on a
+ * machine running 11, over an `All` of 358 against a fleet of 330. A count on a button that starts
+ * assistants or writes into them is the one number that has to be right.
+ *
+ * Deduping HERE rather than fixing the one caller is deliberate: the map is correct as a lookup and
+ * every future caller iterating it would hit the same thing, and a row is one row whatever
+ * container it arrived in.
+ *
+ * Order is the caller's — the order the list drew — and a row with no id is not a row.
+ */
+export function buildPickRows(rows: Iterable<PickSource>, pt: boolean): PickRowsResult {
+  const fellRows: PickModalSource[] = []
+  const sendRows: PickModalSource[] = []
+  const seen = new Set<string>()
+  let sendable = 0
+
+  for (const r of rows) {
+    const id = r.id ?? ''
+    if (!id || seen.has(id)) continue
+    seen.add(id)
+
+    const base: PickModalSource = {
+      id,
+      title: r.title || (pt ? 'sem título' : 'untitled'),
+      ...(r.project ? { detail: r.project } : r.cwd ? { detail: r.cwd } : {}),
+    }
+    if (r.fell) fellRows.push(base)
+
+    /*
+     * THE WHOLE FLEET IS OFFERED, and the ones that cannot take a prompt are DISABLED with the
+     * server's own reason beside them — not hidden. A session missing from the list and a session
+     * that cannot be written to look identical from the outside, and the first reads as "agentop
+     * lost it". The `Active` tab is what narrows it for somebody who only wants the runnable ones.
+     */
+    const verb = r.verbs?.find(v => v.action === 'prompt')
+    const enabled = Boolean(verb?.enabled)
+    if (enabled) sendable++
+    // The verb carries no reason of its own — `prompt` is enabled by being LIVE and nothing else
+    // (a session sitting on a dialog is refused later by the host, which re-reads the screen). So
+    // the reason is that fact, said with the state the SERVER already localized rather than a
+    // second vocabulary invented here.
+    const stateWord = typeof r.stateLabel === 'string' ? r.stateLabel : ''
+    const reason = verb?.reason
+      ?? (pt ? 'não está rodando' : 'not running') + (stateWord ? ` · ${stateWord}` : '')
+    sendRows.push({ ...base, enabled, ...(enabled ? {} : { reason }) })
+  }
+
+  return { fellRows, sendRows, sendable }
+}

--- a/packages/web/src/pages/SessionsPage.tsx
+++ b/packages/web/src/pages/SessionsPage.tsx
@@ -53,6 +53,7 @@ import { SessionActions } from '../components/sessions/SessionActions'
 import { filterFleet } from '../lib/fleetFilter'
 import { FiltersSheet } from '../components/sessions/FiltersSheet'
 import { sessionPath } from '../lib/sessionRoute'
+import { sessionPlanFactor } from '../lib/costBasis'
 
 /** The dimensions a live fleet row can be narrowed by — the same set on both layouts. */
 const FLEET_FILTER_DIMS: Array<'harnesses' | 'repos' | 'projects' | 'models'> =
@@ -691,6 +692,8 @@ export default function SessionsPage() {
                 lang={pt ? 'pt' : 'en'}
                 currency={currency}
                 brlRate={brlRate}
+                costBasis={ctx.costBasis}
+                planFactor={sessionPlanFactor(ctx.planBasis.basis, selected.harness)}
                 touch
                 {...(selected.model ? { startedModel: selected.model } : {})}
                 {...(selected.effort ? { startedEffort: selected.effort } : {})}


### PR DESCRIPTION
## Summary

- **Six reported bugs and one asked-for control**, all found on this machine and each fixed at the rule that produced it rather than at the symptom.
- Every fix is pinned by a test; the two that could be watched failing before the fix were.
- `CLAUDE.md` updated in the same PR for each invariant, per AGENTS.md.

## Motivation

No Issue existed for any of these — they were reported live, one screenshot at a time, while the session was open. Each one is a number the product stated confidently and could not support:

1. **The hour chart under `Today` drew bars across all 24 hours** for someone who started at 8am — 33.427 entries against the 4.905 messages the card above it reported under the same filter. `message_hours` is a LIFETIME array with no day on it, so it survived every cut `sliceSession` makes around it: a conversation open since Tuesday brought its whole history into today.
2. **The new-session wizard's tabs read `Repositories 12 · Projects 12 · Folders 12`** on a machine holding 237 / 211 / 5.284. Twelve is `PROJECTS_PER_KIND` — a cap shown as a count is a number that can never be anything else.
3. **A file could not be pasted into the wizard's first message.** Asked for; the button stayed.
4. **The broadcast picker offered `Active 22` on a machine running 11** (8 `waiting` + 3 `working`), over an `All` of 357 against a fleet of 329. `fleetIndex` keys every row twice on purpose and the picker iterated its values.
5. **A session card read `Commits 2 · Lines +0 / −0 · Files 0`.** The git walk asked `project_path` while the session had moved into a worktree, whose branch the main checkout's HEAD has never seen. Measured for that same window: nothing in the checkout, **+688 / −66 over 25 files** in the worktree.
6. **A session created from the wizard was un-chattable for the life of the server process** — the step-3 prompt never appeared, later messages sat at `delivered to the session — not read yet`, replies never arrived, while the terminal tab showed the whole conversation. Three resolvers cached the `null` from a transcript that did not exist YET.
7. **The session card had no way to read one conversation against the registered plan**, and the typing caret was the browser's white.

## Changes

**The date filter reaches the hour chart** — `SessionDayUsage.hours` (hour of the LOCAL clock → count, written in `jsonl.ts` on the same line that pushes to `message_hours`, so the two cannot disagree), `sliceSession` sums it, `expandHours` rebuilds the array, so the chart, the PDF export and the drilldown read the range without knowing a range exists. `user_message_timestamps` is FILTERED, not rebuilt — those are instants. A session whose days carry no `hours` keeps its lifetime array, the rule a session with no `daily` already had.

**A tab counts what matched** — `countPerKind` (pure, core) beside the cap it is applied with, `findProjects` returns `{rows, totals}`, `/api/fleet/new` carries `projectTotals` (optional on the wire — an older server does not say, and the tabs then count their rows and claim nothing more), `kindCount`/`kindMore` put the true total on the tab plus "Showing 12 of 237" under the list.

**Paste** — the session composer's own `planPaste`, unchanged and shared. Drop works too.

**The picker counts sessions** — `buildPickRows` (pure) owns both picker lists and dedupes by id. Deliberately there and not at the one caller: the map is correct as a lookup, `SessionsAside` still uses it as one, and the next caller to iterate it would hit the same thing. `fleetIndex`'s header now says its values are not the fleet.

**Git stats are read where the session worked** — `sessionGitPaths` (pure) asks the directory the session ENDED in first and keeps the project as the fallback; ONE entry when it never moved, because asking twice for the ordinary case is the git work `git-stats.test.ts` exists to bound. `getSessionFileStats` takes the first directory that answers, never a per-field max across two — that could report lines from the worktree beside a file count from the checkout.

**A miss is a fact about the moment** — `transcript-path-memo.ts` (pure): a found path is remembered forever, a miss expires. Same shape and reason as `repo-facts.ts`'s negative TTL. The two costs are separated so the fix is not paid for in scans: Claude's DIRECT path is one `stat`, checked on every call, so a new session is readable the moment its file appears; only the SCAN (a `readdir` plus a `stat` per project) is paced by the TTL.

**The session card** — a LOCAL API|Plan toggle that opens on the dashboard's basis, is re-seeded from it on every open and changes nothing global. `sessionPlanFactor` is per HARNESS, never the aggregate; a null factor removes the toggle rather than leaving a button whose one outcome is "no registered plan". `costBasisLabel` follows the basis actually applied.

**The caret** — one selector, the same reason the `accent-color` block above it is one.

## Test plan

- [x] `bun tsc --noEmit` clean; **7300 tests pass** (4 test files and 49 tests added).
- [x] **Watched failing before the fix**: the transcript-memo regression (reverted `chat-tail.ts`, ran the one test, restored) and the picker count.
- [x] **Measured against the live machine, not asserted**: hour chart 33.427 → the four hours actually worked; picker 22/357 → 11/329 against 8 `waiting` + 3 `working`; wizard totals 237/211/5.284 on the wire; git stats +688/−66 over 25 files reproduced by running the patched parser over this session's own transcript.
- [x] **Verified in a browser** against a preview server with an isolated `AGENTISTICS_DIR`: the hour chart, the wizard's tabs and its "showing N of M", a real file pasted into the composer and uploaded, the picker's `Active 11 / All 330`, the basis toggle switching and resetting on reopen, and the caret computing `rgb(217, 119, 6)` on every field with no inline override.
- [x] Rebased onto `origin/dev` after #427 landed and re-verified — that PR added a gemini reader, which needs no memo; the CLAUDE.md claim was corrected rather than left stale.

**Reviewers:** the one judgement call worth a second opinion is that `Today` still starts at 21:00 the previous evening at UTC-3 — the `daily` key is a UTC day while an hour bucket is local. Every other figure under that filter has the same boundary, and giving the chart alone a local day would make it disagree with the cost and messages beside it. Left as it is, documented; changing the day rule is its own, transversal decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RbCoRwuBkWuCRhzCFDnpJ5
