### PR TITLE
feat(web): a system note says what it means, and goes where its action is

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2264,6 +2264,24 @@ harness must not break.
   21:00-23:59. Every other figure under that filter has the same boundary; giving the chart alone a
   local day would make it disagree with the cost and the messages beside it, and no day-granular
   split can express a local day for a non-UTC zone.
+- **A SYSTEM NOTE SAYS WHAT IT MEANS, AND GOES WHERE ITS ACTION IS — OR SAYS SO.** A note is the
+  harness acting under the user's role: `chat-envelope.ts` names the KIND in one phrase and drops
+  the BODY, which is right (a `system-reminder` is a page of text nobody wants in a chat) and
+  leaves a chip whose whole content is a label about something the reader can neither see nor
+  reach — reported as "nunca sei o que eles significam". `web/src/lib/chatNote.ts` (pure) is ONE
+  ROW PER NOTE carrying all three answers together — the Portuguese, the one-sentence explanation,
+  and the aside `tab` where its action is. One table and not three, because a note that gained a
+  translation without anyone deciding whether it leads anywhere is the silent half-answer this
+  replaces; `chatNote.test.ts` greps the server's own sources and fails the build when a note can
+  be emitted that this table does not carry — the gap the old `SYSTEM_NOTE_PT` fell into when five
+  readers arrived with notes of their own. **TWO SHAPES, deliberately different**: a note with a
+  destination is a button wearing an arrow that calls `openArtifacts(tab)` — the same call the edge
+  strip makes, so it opens the ASIDE and never a full screen — and a note with nowhere to go tells
+  you instead, on tap as well as hover, because a phone has no hover. One appearance for both would
+  make half the chips silently inert. **`tab` is NOT filled in wherever it would fit**: `command
+  output` would point at the `live` feed, hundreds of rows deep, and with no step id on a chat turn
+  the click lands at the top of a list to be searched — which the edge strip's own comment already
+  calls a navigation control rather than an answer. Those explain and do not navigate.
 - **A TRANSCRIPT THAT IS NOT THERE YET IS NOT A TRANSCRIPT THAT IS NOWHERE.** Three resolvers
   memoized their answer by conversation id — the found path AND the `null` — so an unresolvable id
   cost one scan instead of one per poll. The intent is right; caching the `null` was not. **A

--- a/packages/web/src/components/sessions/ChatBubble.tsx
+++ b/packages/web/src/components/sessions/ChatBubble.tsx
@@ -25,8 +25,11 @@ import remarkGfm from 'remark-gfm'
 // message written across several lines renders as one run-on paragraph — which is what "the
 // messages are not formatted" turned out to mean. `HarnessChat` has always used it.
 import remarkBreaks from 'remark-breaks'
-import { Check, Clock, Copy, CornerUpLeft, Image as ImageIcon, Loader, User } from 'lucide-react'
+import { ArrowUpRight, Check, Clock, Copy, CornerUpLeft, Image as ImageIcon, Loader, User } from 'lucide-react'
 import { HARNESS_COLORS, HARNESS_LABELS } from '../../lib/harness'
+import { chatNote, type ChatNoteTab } from '../../lib/chatNote'
+import { openArtifacts } from '../../lib/artifactsStore'
+import { useIsMobile } from '../../hooks/useIsMobile'
 import { splitSlashLine } from '../../lib/slashLine'
 import { resolveMarkerPaths, splitImageAttachments, splitImageMarkers } from '../../lib/attachmentPreview'
 import type { AttachmentSend } from '@agentistics/core'
@@ -127,54 +130,82 @@ export interface ChatBubbleProps {
  * `onReply` is a fresh closure per render in the parent, so this alone would not have been enough —
  * see `SessionChat.tsx`'s `useCallback` on it.
  */
-/**
- * The Portuguese for each note `chat-envelope.ts` produces.
- *
- * The server composes these in English because it has no language — every other already-localized
- * refusal in this product is worded by the machine, but a note like this is chrome, not a machine's
- * answer. An unmapped note falls through untranslated rather than being dropped: a missing
- * translation is a small thing, a missing line is the defect this exists to fix.
- */
-const SYSTEM_NOTE_PT: Record<string, string> = {
-  'background task reported back': 'tarefa em segundo plano respondeu',
-  'system reminder': 'lembrete do sistema',
-  'local-command caveat': 'aviso de comando local',
-  'command output': 'saída de comando',
-  'slash command': 'comando de barra',
-  'shell command': 'comando de shell',
-  // The notes the FIVE non-claude readers produce (`antigravity-chat.ts`, `codex-chat.ts`,
-  // `copilot-chat.ts`, `kimi-chat.ts`). They arrived with their readers and this table did not grow
-  // with them, so a conversation in any of those harnesses printed English chrome in the middle of
-  // a Portuguese screen. The fall-through above is what kept that a cosmetic gap rather than a
-  // missing line, which is why it survived unnoticed — it is still the right fall-through.
-  'a system message': 'uma mensagem do sistema',
-  'the conversation was truncated': 'a conversa foi truncada',
-  'the harness reported an error': 'o assistente reportou um erro',
-  'instructions from the harness': 'instruções do assistente',
-  'project instructions were loaded': 'instruções do projeto foram carregadas',
-  'the environment was described to the assistant': 'o ambiente foi descrito ao assistente',
-  'the system prompt was set': 'o prompt de sistema foi definido',
-  'the model was changed': 'o modelo foi trocado',
-  'the model was switched': 'o modelo foi trocado',
-  'the session ended': 'a sessão terminou',
-  'the session reported an error': 'a sessão reportou um erro',
-  'the turn was aborted': 'o turno foi interrompido',
-  'context from the editor': 'contexto vindo do editor',
-  'the collaboration mode changed': 'o modo de colaboração mudou',
-  'a reminder about the task list': 'um lembrete sobre a lista de tarefas',
-  'the harness stated its permissions': 'o assistente informou suas permissões',
-  'the permission mode was announced': 'o modo de permissão foi anunciado',
 
-  // The untagged `isMeta` entries — see `chat-envelope.ts`'s second measurement.
-  'a skill was loaded': 'uma skill foi carregada',
-  'a skill was re-invoked': 'uma skill foi reinvocada',
-  'a message from another session': 'uma mensagem de outra sessão',
-  'the conversation was compacted': 'a conversa foi compactada — o resumo do que veio antes',
-  'an image was attached': 'uma imagem foi anexada',
-  'the session was resumed': 'a sessão foi retomada',
-  'an idle notice about another session': 'aviso de ociosidade sobre outra sessão',
-  'a context-usage report': 'relatório de uso de contexto',
-  'injected by the assistant': 'injetado pelo assistente',
+/**
+ * A SYSTEM NOTE — the harness acting under the user's role, named in one phrase.
+ *
+ * Reported as "eu nunca sei o que eles significam": the note names a KIND and the body is
+ * deliberately dropped (a `system-reminder` is a page of text nobody wants in their chat), which
+ * leaves a chip whose whole content is a label about something the reader cannot see or reach.
+ *
+ * TWO SHAPES, and they look different on purpose. A note whose action HAS a place in the aside is
+ * a button that takes you there — `openArtifacts`, the same call the edge strip makes, so it opens
+ * the ASIDE and not a full screen — and it wears an arrow so the affordance is visible before the
+ * click. A note with nowhere to go TELLS you instead, on tap or hover. One appearance for both
+ * would make half the chips silently inert, which this product treats as indistinguishable from
+ * broken.
+ *
+ * The explanation of a NAVIGATING chip lives in its `title`/`aria-label` rather than inline: its
+ * answer is the place it takes you to, and a sentence plus a destination on one 10px chip is two
+ * targets in a control that has room for one.
+ */
+function SystemNote({ note, pt }: { note: string; pt: boolean }) {
+  const { label, help, tab } = chatNote(note, pt)
+  const [shown, setShown] = useState(false)
+  const isMobile = useIsMobile()
+
+  const chip: React.CSSProperties = {
+    fontSize: 10.5, lineHeight: 1.4, color: 'var(--text-tertiary)',
+    padding: '3px 10px', borderRadius: 999,
+    background: 'var(--bg-elevated)', border: '1px solid var(--border-subtle)',
+    maxWidth: '90%', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+    fontFamily: 'inherit',
+    // THE TAP TARGET IS 44px, THE CHIP IS NOT. A conversation can hold a run of these back to
+    // back, and a 44px band per note would push the messages apart; padding plus an equal negative
+    // margin buys the target without changing a pixel of the layout. Mobile only — 44 is the
+    // mobile number, and applying it on a pointer would put a huge invisible box over the text
+    // above and below.
+    ...(isMobile ? { padding: '14px 10px', margin: '-11px 0' } : {}),
+  }
+
+  if (tab !== null) {
+    return (
+      <div style={{ display: 'flex', justifyContent: 'center', padding: '2px 0' }}>
+        <button
+          onClick={() => openArtifacts(tab satisfies ChatNoteTab)}
+          {...(help ? { title: help, 'aria-label': `${label} — ${help}` } : {})}
+          style={{ ...chip, display: 'inline-flex', alignItems: 'center', gap: 5, cursor: 'pointer' }}
+        >
+          <span style={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>{label}</span>
+          <ArrowUpRight size={11} style={{ flexShrink: 0, color: 'var(--anthropic-orange)' }} />
+        </button>
+      </div>
+    )
+  }
+
+  // Nothing to go to. The chip tells you what it was instead — on TAP as well as hover, because a
+  // phone has no hover and this is the half of the report that is about not understanding.
+  return (
+    <div style={{
+      display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 3, padding: '2px 0',
+    }}>
+      <button
+        onClick={() => setShown(v => !v)}
+        aria-expanded={shown}
+        disabled={help === null}
+        {...(help ? { title: help } : {})}
+        style={{ ...chip, cursor: help === null ? 'default' : 'help' }}
+      >
+        {label}{help !== null && ' ⓘ'}
+      </button>
+      {shown && help !== null && (
+        <span role="note" style={{
+          fontSize: 10.5, lineHeight: 1.45, color: 'var(--text-tertiary)',
+          maxWidth: '80%', textAlign: 'center',
+        }}>{help}</span>
+      )}
+    </div>
+  )
 }
 
 export const ChatBubble = memo(function ChatBubble({ turn, lang, harness, provisional, awaiting, awaitingWorking, awaitingSinceMs, onReply, onReplyExcerpt, anchorId, attachmentSends }: ChatBubbleProps) {
@@ -336,20 +367,7 @@ export const ChatBubble = memo(function ChatBubble({ turn, lang, harness, provis
   }
 
   if (turn.system) {
-    return (
-      <div style={{
-        display: 'flex', justifyContent: 'center', padding: '2px 0',
-      }}>
-        <span style={{
-          fontSize: 10.5, lineHeight: 1.4, color: 'var(--text-tertiary)',
-          padding: '3px 10px', borderRadius: 999,
-          background: 'var(--bg-elevated)', border: '1px solid var(--border-subtle)',
-          maxWidth: '90%', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
-        }}>
-          {pt ? SYSTEM_NOTE_PT[turn.system] ?? turn.system : turn.system}
-        </span>
-      </div>
-    )
+    return <SystemNote note={turn.system} pt={pt} />
   }
 
   const color = (HARNESS_COLORS as Record<string, string>)[harness] ?? 'var(--text-secondary)'

--- a/packages/web/src/lib/chatNote.test.ts
+++ b/packages/web/src/lib/chatNote.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'bun:test'
+import { readdirSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { CHAT_NOTES, chatNote } from './chatNote'
+
+describe('chatNote', () => {
+  it('THE REPORTED CASE: a chip says what it means', () => {
+    // "quando aparecem esses cardzinhos embaixo de mensagens eu nunca sei o que eles significam".
+    const r = chatNote('background task reported back', true)
+    expect(r.label).toBe('tarefa em segundo plano respondeu')
+    expect(r.help).toBeTruthy()
+  })
+
+  it('sends the reader to the tab that IS the answer', () => {
+    expect(chatNote('background task reported back', false).tab).toBe('agents')
+    expect(chatNote('a skill was loaded', false).tab).toBe('skills')
+    expect(chatNote('an image was attached', false).tab).toBe('gallery')
+  })
+
+  it('does NOT send a command note to a feed of hundreds with no step to land on', () => {
+    // The edge strip's own comment calls that a mistake: a navigation control rather than an
+    // answer. A chat turn carries no step id, so these explain and do not navigate.
+    expect(chatNote('command output', false).tab).toBe(null)
+    expect(chatNote('shell command', false).tab).toBe(null)
+    expect(chatNote('command output', false).help).toBeTruthy()
+  })
+
+  it('a note nobody has mapped keeps its own words and claims nothing', () => {
+    const r = chatNote('some future note', true)
+    expect(r).toEqual({ label: 'some future note', help: null, tab: null })
+  })
+
+  it('English keeps the note as the server wrote it', () => {
+    expect(chatNote('system reminder', false).label).toBe('system reminder')
+  })
+
+  it('every row carries both languages of both strings', () => {
+    for (const [key, row] of Object.entries(CHAT_NOTES)) {
+      expect(row.pt.length, `${key}: pt`).toBeGreaterThan(0)
+      expect(row.help.en.length, `${key}: help.en`).toBeGreaterThan(0)
+      expect(row.help.pt.length, `${key}: help.pt`).toBeGreaterThan(0)
+      // The help must SAY something, not restate the label.
+      expect(row.help.en.toLowerCase(), `${key}: help repeats the label`).not.toBe(key.toLowerCase())
+    }
+  })
+})
+
+/**
+ * THE TABLE MUST NOT FALL BEHIND THE SERVER.
+ *
+ * `SYSTEM_NOTE_PT` — the table this one replaces — did exactly that: five readers arrived with
+ * their own notes and it never grew, so a conversation in any of them printed English chrome in
+ * the middle of a Portuguese screen. It survived unnoticed because the fall-through is graceful,
+ * which is the right fall-through and the reason the gap needs a test rather than vigilance.
+ *
+ * Greps the server's own sources, the way `tokens.lint.test.ts` greps for two-term token sums.
+ */
+describe('every note the server can emit has a row', () => {
+  const dir = join(import.meta.dir, '../../../server/server/sessions')
+
+  it('finds them all', () => {
+    const emitted = new Set<string>()
+    for (const file of readdirSync(dir)) {
+      if (!file.endsWith('.ts') || file.endsWith('.test.ts')) continue
+      const src = readFileSync(join(dir, file), 'utf-8')
+      for (const m of src.matchAll(/note: '([^']+)'/g)) emitted.add(m[1]!)
+    }
+    // The grep must actually find something, or this test passes by reading nothing.
+    expect(emitted.size).toBeGreaterThan(10)
+    const missing = [...emitted].filter(note => !(note in CHAT_NOTES))
+    expect(missing, `notes with no row in CHAT_NOTES: ${missing.join(', ')}`).toEqual([])
+  })
+})

--- a/packages/web/src/lib/chatNote.ts
+++ b/packages/web/src/lib/chatNote.ts
@@ -1,0 +1,234 @@
+/**
+ * chatNote.ts — PURE: what a system NOTE in the conversation says, what it MEANS, and where its
+ * action lives.
+ *
+ * THE REPORT THIS EXISTS FOR: "quando aparecem esses cardzinhos embaixo de mensagens eu nunca sei
+ * o que eles significam". A note is the harness acting under the user's role — `chat-envelope.ts`
+ * names the kind in one short phrase and deliberately drops the BODY, which is right (a
+ * `system-reminder` is a page of text nobody wants in their chat) and leaves a chip whose whole
+ * content is a label. `background task reported back` is a true sentence about something the
+ * reader cannot see, cannot reach, and has no way to ask about.
+ *
+ * ONE ROW PER NOTE, carrying all three answers together. Deliberately one table and not three: a
+ * note that gained a translation without anyone deciding whether it leads anywhere would be the
+ * silent half-answer this is replacing, and `chatNote.test.ts` fails the build when the server can
+ * emit a note this table does not carry.
+ *
+ * `tab` IS NOT FILLED IN WHEREVER IT WOULD FIT. It names the aside tab where the thing the note is
+ * about actually is — and only where that tab IS the answer. `command output` would point at the
+ * `live` feed, which is hundreds of rows, and without a step id the click lands on the top of a
+ * list the reader then has to search: the codebase already calls that a mistake, in the edge
+ * strip's own comment ("landing on the top of the feed made the strip a navigation control rather
+ * than an answer"). A chat turn carries no step id, so those notes explain and do not navigate.
+ */
+
+/** The aside tabs a note may send someone to. A subset of `ArtifactsAside`'s `TabId`, on purpose. */
+export type ChatNoteTab = 'agents' | 'skills' | 'gallery'
+
+export interface ChatNote {
+  /** The note itself, in Portuguese. English is the key. */
+  pt: string
+  /** One sentence: what this actually was. The half the reader was missing. */
+  help: { en: string; pt: string }
+  /** Where its action is, when the tab IS the answer. Absent means: explain, do not navigate. */
+  tab?: ChatNoteTab
+}
+
+const n = (pt: string, en: string, ptHelp: string, tab?: ChatNoteTab): ChatNote =>
+  ({ pt, help: { en, pt: ptHelp }, ...(tab ? { tab } : {}) })
+
+export const CHAT_NOTES: Record<string, ChatNote> = {
+  'background task reported back': n(
+    'tarefa em segundo plano respondeu',
+    'A subagent this session started finished and handed its answer back.',
+    'Um subagente que esta sessão iniciou terminou e devolveu a resposta.',
+    'agents',
+  ),
+  'a skill was loaded': n(
+    'uma skill foi carregada',
+    'The assistant pulled in a set of instructions for this kind of task.',
+    'O assistente carregou um conjunto de instruções para este tipo de tarefa.',
+    'skills',
+  ),
+  'a skill was re-invoked': n(
+    'uma skill foi reinvocada',
+    'The same instructions were loaded again, later in the conversation.',
+    'As mesmas instruções foram carregadas de novo, mais adiante na conversa.',
+    'skills',
+  ),
+  'an image was attached': n(
+    'uma imagem foi anexada',
+    'A picture was sent into the conversation.',
+    'Uma imagem foi enviada para a conversa.',
+    'gallery',
+  ),
+
+  // ---- Explain only. Each is the harness talking to itself; none has a place to go. ----
+  'system reminder': n(
+    'lembrete do sistema',
+    'The harness re-injected context for itself. Nothing you wrote.',
+    'O assistente reinjetou contexto para si mesmo. Nada que você escreveu.',
+  ),
+  'local-command caveat': n(
+    'aviso de comando local',
+    'A note the harness attaches to a slash command it ran locally.',
+    'Um aviso que o assistente anexa a um comando de barra que rodou localmente.',
+  ),
+  'command output': n(
+    'saída de comando',
+    'What a command printed. The text is in the Live feed, with the step that ran it.',
+    'O que um comando imprimiu. O texto está no feed Live, junto do passo que o rodou.',
+  ),
+  'slash command': n(
+    'comando de barra',
+    'You ran a slash command; what it expanded to is not part of the conversation.',
+    'Você rodou um comando de barra; o que ele expandiu não faz parte da conversa.',
+  ),
+  'shell command': n(
+    'comando de shell',
+    'A command was run in the shell. The step is in the Live feed.',
+    'Um comando foi rodado no shell. O passo está no feed Live.',
+  ),
+  'a system message': n(
+    'uma mensagem do sistema',
+    'The harness wrote this to itself, not to you.',
+    'O assistente escreveu isso para si mesmo, não para você.',
+  ),
+  'the conversation was truncated': n(
+    'a conversa foi truncada',
+    'The harness cut earlier turns to fit the window. They are gone from its view.',
+    'O assistente cortou turnos anteriores para caber na janela. Eles sumiram da visão dele.',
+  ),
+  'the harness reported an error': n(
+    'o assistente reportou um erro',
+    'Something failed on the assistant’s side; the detail is in its own log.',
+    'Algo falhou do lado do assistente; o detalhe está no log dele.',
+  ),
+  'instructions from the harness': n(
+    'instruções do assistente',
+    'Standing instructions the tool gives itself at the start of a turn.',
+    'Instruções permanentes que a ferramenta dá a si mesma no início de um turno.',
+  ),
+  'project instructions were loaded': n(
+    'instruções do projeto foram carregadas',
+    'The repository’s own instruction file (AGENTS.md, CLAUDE.md) was read in.',
+    'O arquivo de instruções do repositório (AGENTS.md, CLAUDE.md) foi lido.',
+  ),
+  'the environment was described to the assistant': n(
+    'o ambiente foi descrito ao assistente',
+    'The machine, the directory and the git state were stated to it.',
+    'A máquina, o diretório e o estado do git foram informados a ele.',
+  ),
+  'the system prompt was set': n(
+    'o prompt de sistema foi definido',
+    'The instructions the assistant runs under were established for this session.',
+    'As instruções sob as quais o assistente roda foram definidas para esta sessão.',
+  ),
+  'the model was changed': n(
+    'o modelo foi trocado',
+    'From here on the conversation is answered by a different model.',
+    'Daqui em diante a conversa é respondida por um modelo diferente.',
+  ),
+  'the model was switched': n(
+    'o modelo foi trocado',
+    'From here on the conversation is answered by a different model.',
+    'Daqui em diante a conversa é respondida por um modelo diferente.',
+  ),
+  'the session ended': n(
+    'a sessão terminou',
+    'The assistant’s process stopped here.',
+    'O processo do assistente parou aqui.',
+  ),
+  'the session reported an error': n(
+    'a sessão reportou um erro',
+    'The session itself failed, not a single command inside it.',
+    'A sessão em si falhou, não um comando isolado dentro dela.',
+  ),
+  'the turn was aborted': n(
+    'o turno foi interrompido',
+    'This turn was stopped before it finished — usually you pressed escape.',
+    'Este turno foi parado antes de terminar — normalmente você apertou esc.',
+  ),
+  'context from the editor': n(
+    'contexto vindo do editor',
+    'The editor told the assistant what file you had open.',
+    'O editor informou ao assistente qual arquivo você tinha aberto.',
+  ),
+  'the collaboration mode changed': n(
+    'o modo de colaboração mudou',
+    'How much the assistant may do on its own changed here.',
+    'Quanto o assistente pode fazer por conta própria mudou aqui.',
+  ),
+  'a reminder about the task list': n(
+    'um lembrete sobre a lista de tarefas',
+    'The harness reminded itself what is still open on its to-do list.',
+    'O assistente relembrou a si mesmo o que ainda está aberto na lista de tarefas dele.',
+  ),
+  'the harness stated its permissions': n(
+    'o assistente informou suas permissões',
+    'It recorded what it is allowed to do without asking.',
+    'Ele registrou o que pode fazer sem perguntar.',
+  ),
+  'the permission mode was announced': n(
+    'o modo de permissão foi anunciado',
+    'It recorded whether it must ask before acting.',
+    'Ele registrou se precisa perguntar antes de agir.',
+  ),
+  'a message from another session': n(
+    'uma mensagem de outra sessão',
+    'Another session on this machine wrote to this one.',
+    'Outra sessão desta máquina escreveu para esta.',
+  ),
+  'the conversation was compacted': n(
+    'a conversa foi compactada — o resumo do que veio antes',
+    'Everything before this was replaced by a summary, to fit the window.',
+    'Tudo antes disto foi trocado por um resumo, para caber na janela.',
+  ),
+  'the session was resumed': n(
+    'a sessão foi retomada',
+    'This conversation was reopened and continued from here.',
+    'Esta conversa foi reaberta e continuou a partir daqui.',
+  ),
+  'an idle notice about another session': n(
+    'aviso de ociosidade sobre outra sessão',
+    'A different session reported it had gone quiet.',
+    'Uma outra sessão avisou que ficou parada.',
+  ),
+  'a context-usage report': n(
+    'relatório de uso de contexto',
+    'How full the window was at that point. The gauge on the header says it now.',
+    'Quão cheia estava a janela naquele ponto. O medidor no cabeçalho diz isso agora.',
+  ),
+  'injected by the assistant': n(
+    'injetado pelo assistente',
+    'Text the harness put here itself, under your role.',
+    'Texto que o assistente colocou aqui sozinho, sob o seu papel.',
+  ),
+}
+
+export interface ResolvedChatNote {
+  /** What the chip prints. */
+  label: string
+  /** What it means, or `null` for a note this table does not carry. */
+  help: string | null
+  /** The aside tab to open, or `null` — explain, do not navigate. */
+  tab: ChatNoteTab | null
+}
+
+/**
+ * Resolve one note. TOTAL: an unmapped note keeps its own text and gains nothing.
+ *
+ * That fall-through is deliberate and predates this table — a missing translation is a small
+ * thing, a missing line is the defect the notes exist to fix. It applies to the other two answers
+ * for the same reason: no help is a gap, an invented sentence about an unknown note is a lie, and
+ * a guessed destination is a click that lands somewhere unrelated.
+ */
+export function chatNote(note: string, pt: boolean): ResolvedChatNote {
+  const row = CHAT_NOTES[note]
+  if (!row) return { label: note, help: null, tab: null }
+  return {
+    label: pt ? row.pt : note,
+    help: pt ? row.help.pt : row.help.en,
+    tab: row.tab ?? null,
+  }
+}


### PR DESCRIPTION
## Summary

- A system note in the conversation now **says what it means**, and — where its action has a place in the aside — **takes you there**, opening the aside and not a full screen.
- `chatNote.ts` is pure and is **one row per note**, carrying the Portuguese, the explanation and the destination together.
- A test greps the server's own sources and fails the build when a note can be emitted that the table does not carry.

## Motivation

Reported as *"quando aparecem esses cardzinhos embaixo de mensagens eu nunca sei o que eles significam"*.

A note is the harness acting under the user's role. `chat-envelope.ts` names the KIND in one phrase and deliberately drops the BODY — which is right, because a `system-reminder` is a page of text nobody wants in their chat — and what is left is a chip whose whole content is a label about something the reader can neither see nor reach. `background task reported back` is a true sentence about a subagent that ran, finished, and is sitting two clicks away in a tab the reader has no reason to associate with it.

## Changes

**`packages/web/src/lib/chatNote.ts` (new, pure)** — one row per note kind: `pt`, `help` (EN+PT, one sentence), and `tab` when the note's action has a place in the aside. One table and not three, deliberately: a note that gained a translation without anyone deciding whether it leads anywhere is the silent half-answer this replaces. Replaces `SYSTEM_NOTE_PT`, which lived inside `ChatBubble.tsx`.

**`chatNote.test.ts` (new)** — besides the behaviour, it greps `packages/server/server/sessions/*.ts` for every `note: '…'` the server can emit and fails when one has no row. That is the gap the old table fell into: five readers arrived with notes of their own and it never grew, so a conversation in any of them printed English chrome in the middle of a Portuguese screen. It survived unnoticed because the fall-through is graceful — which is the right fall-through, and the reason this needs a test rather than vigilance.

**`ChatBubble.tsx`** — `SystemNote`, in two shapes that look different on purpose:
- **with a destination**: a button wearing an arrow, calling `openArtifacts(tab)` — the same call the edge strip makes, so it opens the ASIDE. Its explanation is in `title`/`aria-label`: its answer is the place it takes you to, and a sentence plus a destination on one 10px chip is two targets in a control with room for one.
- **without one**: tells you instead, on tap as well as hover, because a phone has no hover.

One appearance for both would leave half the chips silently inert, which this product treats as indistinguishable from broken.

**What is deliberately NOT mapped.** `command output` and `shell command` would point at the `live` feed — hundreds of rows — and a chat turn carries no step id, so the click would land at the top of a list to be searched. The edge strip's own comment already calls that a navigation control rather than an answer. Those explain, and their sentence names where the thing is. Resolving them properly means passing the turn's timestamp and teaching the aside to find the nearest step; that is a change to the aside and is better made on its own.

## Test plan

- [x] `bun tsc --noEmit` clean; **7318 tests pass** (7 new).
- [x] Verified in a browser against a preview server with an isolated `AGENTISTICS_DIR`: the arrow chip opened the aside on **Gallery**; the `ⓘ` chip revealed and hid its sentence with `aria-expanded` following; `title`/`aria-label` carry the explanation on the navigating chip.
- [x] **Mobile shipped in the same change**, per CLAUDE.md: at 390px the tap target measures **45px** (44 is the rule) and `document.documentElement.scrollWidth === window.innerWidth`. The first attempt measured 43px; the padding was corrected with an exact negative margin so the target grew without moving a pixel of the conversation's layout.
- [x] Rebased onto `origin/dev` after #433 landed and re-verified.

**Design note for reviewers:** the alternative was making every chip navigate to the Live step nearest its timestamp. Rejected with the user: for a note that is pure protocol that lands on a step unrelated to the chip's text, which is a wrong answer rather than no answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RbCoRwuBkWuCRhzCFDnpJ5
