### PR TITLE
feat(web): the sessions aside bands by project, and the search takes the top row

### DIFF
--- a/packages/web/src/components/nav/SessionsAside.tsx
+++ b/packages/web/src/components/nav/SessionsAside.tsx
@@ -18,9 +18,10 @@ import { useNavigate, useParams } from 'react-router-dom'
 import { Clock, Pin, PinOff, Plus, RotateCcw, Search, Send, X } from 'lucide-react'
 import type { Filters } from '@agentistics/core'
 import {
-  ACTIVE_STATES, DEFAULT_ORDER, filterSessions, sessionNotify, sortSessions,
-  type ControlSession,
+  ACTIVE_STATES, filterSessions, sessionNotify,
+  type ControlSession, type SessionGroup,
 } from '@agentistics/tui/control/session-fleet'
+import { projectGroups, showsProjectHeadings } from '../../lib/fleetGroups'
 import { rowSelected } from '../../lib/fleetSelection'
 import { filterFleet, ignoredDimensions } from '../../lib/fleetFilter'
 import { NewSessionModal } from '../sessions/NewSessionModal'
@@ -320,19 +321,27 @@ export function SessionsAside({
    * is running, ranked by what needs you most, and everything else beneath it.
    *
    * `DEFAULT_ORDER` (`state`, via `sessionRank`) is the SAME ranking the terminal cockpit breaks
-   * ties on, so "sorted by status" means one thing in both places.
+   * ties on, so "sorted by status" means one thing in both places — `projectGroups` applies it
+   * inside each project band and orders the bands themselves by their most urgent member.
+   *
+   * Inside a band the rows are grouped BY PROJECT (`lib/fleetGroups.ts`), and a band holding one
+   * project draws no heading at all — see that module's header. On a machine whose whole fleet sits
+   * in one checkout this therefore looks exactly as it did.
    */
-  const bands = useMemo((): { label: string; rows: ControlSession[] }[] => {
+  const bands = useMemo((): { label: string; groups: SessionGroup[] }[] => {
     const rest = matched.filter(r => !pinned.has(pinKeyOf(r)))
     return [
-      { label: pt ? 'Ativas' : 'Active', rows: sortSessions(rest.filter(r => active.has(r.state)), DEFAULT_ORDER) },
+      { label: pt ? 'Ativas' : 'Active', groups: projectGroups(rest.filter(r => active.has(r.state)), lang) },
       // Never computed while activeOnly is on — those rows are the ones the switch is withholding,
       // not a second list to render beside it.
-      { label: pt ? 'Inativas' : 'Inactive', rows: activeOnly ? [] : sortSessions(rest.filter(r => !active.has(r.state)), DEFAULT_ORDER) },
+      { label: pt ? 'Inativas' : 'Inactive', groups: activeOnly ? [] : projectGroups(rest.filter(r => !active.has(r.state)), lang) },
     ]
-  }, [matched, pinned, active, activeOnly, pt])
+  }, [matched, pinned, active, activeOnly, pt, lang])
 
-  const total = bands.reduce((n, b) => n + b.rows.length, 0) + pinnedRows.length
+  const total = bands.reduce(
+    (n, b) => n + b.groups.reduce((m, g) => m + g.sessions.length, 0),
+    0,
+  ) + pinnedRows.length
   const filterCount = (filters.harnesses?.length ?? 0) + filters.projects.length
     + (filters.repos?.length ?? 0) + filters.models.length
 
@@ -599,7 +608,7 @@ export function SessionsAside({
                 // The label is not unique — two dimensions can legitimately produce one word, and
                 // an empty band still holds its place in the order.
                 key={`${i}-${b.label}`}
-                label={b.label} rows={b.rows} pinned={pinned}
+                label={b.label} groups={b.groups} pinned={pinned}
                 sessionId={sessionId} tap={tap} onPin={flip}
                 onOpen={s => (onOpenRow ? onOpenRow(s) : navigate(sessionPath(s.id)))}
                 {...(rowsById ? { rowsById } : {})}
@@ -731,9 +740,10 @@ export function SessionsAside({
 
 /** One band of the two-way (active/inactive) split. Absent when it would be empty — an empty
  *  band with a heading and no rows under it is a label pretending to be information. */
-function SessionBand({ label, rows, pinned, sessionId, tap, onPin, onOpen, rowsById, onOpenMenu }: {
+function SessionBand({ label, groups, pinned, sessionId, tap, onPin, onOpen, rowsById, onOpenMenu }: {
   label: string
-  rows: readonly ControlSession[]
+  /** The band's rows, already grouped by project and ordered — see `lib/fleetGroups.ts`. */
+  groups: readonly SessionGroup[]
   pinned: ReadonlySet<string>
   sessionId?: string
   tap?: number
@@ -742,7 +752,11 @@ function SessionBand({ label, rows, pinned, sessionId, tap, onPin, onOpen, rowsB
   rowsById?: Map<string, { verbs: RowVerb[] }>
   onOpenMenu: (session: ControlSession, x: number, y: number, verbs: RowVerb[]) => void
 }) {
-  if (rows.length === 0) return null
+  const count = groups.reduce((n, g) => n + g.sessions.length, 0)
+  if (count === 0) return null
+  // One project under this band names it twice — the band heading is directly above. See the rule
+  // in `fleetGroups.ts`; it is the same one the cockpit's cascade applies to its own root.
+  const headings = showsProjectHeadings(groups)
   return (
     <div style={{ marginBottom: 16 }}>
       <div style={{
@@ -751,23 +765,36 @@ function SessionBand({ label, rows, pinned, sessionId, tap, onPin, onOpen, rowsB
         textTransform: 'uppercase', letterSpacing: '0.06em', color: 'var(--text-tertiary)',
       }}>
         <span style={{ minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis' }}>{label}</span>
-        <span style={{ marginLeft: 'auto', fontWeight: 600, opacity: 0.75 }}>{rows.length}</span>
+        <span style={{ marginLeft: 'auto', fontWeight: 600, opacity: 0.75 }}>{count}</span>
       </div>
-      <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
-        {rows.map(s => (
-          <SessionRow
-            key={s.id}
-            session={s}
-            selected={rowSelected(s, sessionId)}
-            pinned={pinned.has(pinKeyOf(s))}
-            {...(tap ? { tap } : {})}
-            onPin={() => onPin(s)}
-            onOpen={() => onOpen(s)}
-            {...(rowsById?.get(s.id) ? { verbs: rowsById.get(s.id)!.verbs } : {})}
-            onOpenMenu={(x, y, verbs) => onOpenMenu(s, x, y, verbs)}
-          />
-        ))}
-      </div>
+      {groups.map(g => (
+        <div key={g.key} style={{ display: 'flex', flexDirection: 'column', gap: 4, marginBottom: headings ? 10 : 0 }}>
+          {headings && (
+            // Deliberately quieter than the band above it — lowercase, no letter-spacing — so the
+            // two headings read as a hierarchy rather than as two lists.
+            <div style={{
+              display: 'flex', alignItems: 'baseline', gap: 6, padding: '4px 9px 2px',
+              fontSize: 11, fontWeight: 600, color: 'var(--text-tertiary)',
+            }}>
+              <span style={{ minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{g.label}</span>
+              <span style={{ marginLeft: 'auto', opacity: 0.7 }}>{g.sessions.length}</span>
+            </div>
+          )}
+          {g.sessions.map(s => (
+            <SessionRow
+              key={s.id}
+              session={s}
+              selected={rowSelected(s, sessionId)}
+              pinned={pinned.has(pinKeyOf(s))}
+              {...(tap ? { tap } : {})}
+              onPin={() => onPin(s)}
+              onOpen={() => onOpen(s)}
+              {...(rowsById?.get(s.id) ? { verbs: rowsById.get(s.id)!.verbs } : {})}
+              onOpenMenu={(x, y, verbs) => onOpenMenu(s, x, y, verbs)}
+            />
+          ))}
+        </div>
+      ))}
     </div>
   )
 }

--- a/packages/web/src/components/nav/SessionsAside.tsx
+++ b/packages/web/src/components/nav/SessionsAside.tsx
@@ -347,28 +347,96 @@ export function SessionsAside({
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0, gap: 10, paddingTop: 4 }}>
-      {!hideNew && (
-      <button
-        onClick={() => setCreating(true)}
-        style={{
-          display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 7,
-          margin: '0 2px', padding: '9px 12px', borderRadius: 9, cursor: 'pointer', minHeight: tap,
-          border: '1px dashed var(--border)', background: 'transparent',
-          color: 'var(--text-secondary)', fontFamily: 'inherit', fontSize: 12.5, fontWeight: 600,
-        }}
-        onMouseEnter={e => {
-          e.currentTarget.style.borderColor = 'var(--anthropic-orange)'
-          e.currentTarget.style.color = 'var(--anthropic-orange)'
-        }}
-        onMouseLeave={e => {
-          e.currentTarget.style.borderColor = 'var(--border)'
-          e.currentTarget.style.color = 'var(--text-secondary)'
-        }}
-      >
-        <Plus size={14} />
-        {pt ? 'Nova sessão' : 'New session'}
-      </button>
-      )}
+      {/*
+        * ONE ROW: the search, and the two standing verbs as icons beside it.
+        *
+        * Search is what the column is used for on every visit; starting a session and writing to
+        * several are things somebody does occasionally. Two full-width dashed buttons stacked above
+        * the field spent three rows of a 268px column on that ranking inverted — and those rows come
+        * straight out of the list, which is the thing being searched.
+        *
+        * An icon may not carry the meaning alone, so both keep `title` AND `aria-label` with the
+        * words they used to print. `+` is the one solid accent control in the aside because it is
+        * the only one that CREATES something; "send to several" stays quiet beside it. "Reopen what
+        * fell" is deliberately NOT here and keeps its full-width button below: it names a COUNT, and
+        * a count is not something an icon can say.
+        */}
+      <div style={{ display: 'flex', alignItems: 'stretch', gap: 6, padding: '0 2px', minHeight: tap }}>
+        <div style={{ position: 'relative', flex: 1, minWidth: 0, display: 'flex' }}>
+          <Search
+            size={13}
+            style={{ position: 'absolute', left: 10, top: '50%', transform: 'translateY(-50%)', color: 'var(--text-tertiary)', pointerEvents: 'none' }}
+          />
+          <input
+            ref={searchRef}
+            value={query}
+            onChange={e => setQuery(e.target.value)}
+            placeholder={pt ? 'Buscar sessão…' : 'Search sessions…'}
+            style={{
+              flex: 1, minWidth: 0, boxSizing: 'border-box',
+              padding: '9px 26px 9px 30px', borderRadius: 9,
+              border: '1px solid var(--border-subtle)', background: 'var(--bg-elevated)',
+              color: 'var(--text-primary)', fontFamily: 'inherit',
+              // 16px on mobile or iOS Safari zooms the viewport; the global guard in index.css
+              // handles it, so this stays the desktop figure and is not overridden inline.
+              fontSize: 12.5, outline: 'none',
+            }}
+          />
+          {query !== '' && (
+            <button
+              onClick={() => setQuery('')}
+              aria-label={pt ? 'Limpar busca' : 'Clear search'}
+              style={{
+                position: 'absolute', right: 8, top: '50%', transform: 'translateY(-50%)',
+                display: 'flex', border: 'none', background: 'transparent',
+                color: 'var(--text-tertiary)', cursor: 'pointer', padding: 2,
+              }}
+            >
+              <X size={12} />
+            </button>
+          )}
+        </div>
+        {!hideNew && (
+          <button
+            onClick={() => setCreating(true)}
+            aria-label={pt ? 'Nova sessão' : 'New session'}
+            title={pt ? 'Nova sessão' : 'New session'}
+            style={{
+              display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0,
+              width: tap ?? 34, padding: 0, borderRadius: 9, cursor: 'pointer',
+              border: '1px solid var(--anthropic-orange)', background: 'var(--anthropic-orange)',
+              color: '#141414', fontFamily: 'inherit',
+            }}
+            onMouseEnter={e => { e.currentTarget.style.filter = 'brightness(1.1)' }}
+            onMouseLeave={e => { e.currentTarget.style.filter = 'none' }}
+          >
+            <Plus size={17} />
+          </button>
+        )}
+        {showSend && (
+          <button
+            onClick={() => setPicking('send')}
+            aria-label={pt ? 'Enviar prompt em massa' : 'Send a prompt to several'}
+            title={pt ? 'Enviar prompt em massa' : 'Send a prompt to several'}
+            style={{
+              display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0,
+              width: tap ?? 34, padding: 0, borderRadius: 9, cursor: 'pointer',
+              border: '1px solid var(--border-subtle)', background: 'var(--bg-elevated)',
+              color: 'var(--text-tertiary)', fontFamily: 'inherit',
+            }}
+            onMouseEnter={e => {
+              e.currentTarget.style.borderColor = 'var(--anthropic-orange)'
+              e.currentTarget.style.color = 'var(--anthropic-orange)'
+            }}
+            onMouseLeave={e => {
+              e.currentTarget.style.borderColor = 'var(--border-subtle)'
+              e.currentTarget.style.color = 'var(--text-tertiary)'
+            }}
+          >
+            <Send size={14} />
+          </button>
+        )}
+      </div>
 
       {/*
         * THE GROUP VERBS, under "New session" because that is where starting work lives.
@@ -392,29 +460,6 @@ export function SessionsAside({
           {pt
             ? (groupRows.fellRows.length === 1 ? 'Reabrir 1 sessão que caiu' : `Reabrir ${groupRows.fellRows.length} sessões que caíram`)
             : (groupRows.fellRows.length === 1 ? 'Reopen 1 session that fell' : `Reopen ${groupRows.fellRows.length} sessions that fell`)}
-        </button>
-      )}
-
-      {showSend && (
-        <button
-          onClick={() => setPicking('send')}
-          style={{
-            display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 7,
-            margin: '0 2px', padding: '7px 12px', borderRadius: 9, cursor: 'pointer', minHeight: tap,
-            border: '1px dashed var(--border)', background: 'transparent',
-            color: 'var(--text-tertiary)', fontFamily: 'inherit', fontSize: 12, fontWeight: 600,
-          }}
-          onMouseEnter={e => {
-            e.currentTarget.style.borderColor = 'var(--anthropic-orange)'
-            e.currentTarget.style.color = 'var(--anthropic-orange)'
-          }}
-          onMouseLeave={e => {
-            e.currentTarget.style.borderColor = 'var(--border)'
-            e.currentTarget.style.color = 'var(--text-tertiary)'
-          }}
-        >
-          <Send size={13} />
-          {pt ? 'Enviar prompt em massa' : 'Send a prompt to several'}
         </button>
       )}
 
@@ -459,41 +504,6 @@ export function SessionsAside({
           }}
         />
       )}
-
-      <div style={{ position: 'relative', padding: '0 2px' }}>
-        <Search
-          size={13}
-          style={{ position: 'absolute', left: 10, top: '50%', transform: 'translateY(-50%)', color: 'var(--text-tertiary)', pointerEvents: 'none' }}
-        />
-        <input
-          ref={searchRef}
-          value={query}
-          onChange={e => setQuery(e.target.value)}
-          placeholder={pt ? 'Buscar sessão…' : 'Search sessions…'}
-          style={{
-            width: '100%', boxSizing: 'border-box',
-            padding: '9px 26px 9px 30px', borderRadius: 9,
-            border: '1px solid var(--border-subtle)', background: 'var(--bg-elevated)',
-            color: 'var(--text-primary)', fontFamily: 'inherit',
-            // 16px on mobile or iOS Safari zooms the viewport; the global guard in index.css
-            // handles it, so this stays the desktop figure and is not overridden inline.
-            fontSize: 12.5, outline: 'none',
-          }}
-        />
-        {query !== '' && (
-          <button
-            onClick={() => setQuery('')}
-            aria-label={pt ? 'Limpar busca' : 'Clear search'}
-            style={{
-              position: 'absolute', right: 8, top: '50%', transform: 'translateY(-50%)',
-              display: 'flex', border: 'none', background: 'transparent',
-              color: 'var(--text-tertiary)', cursor: 'pointer', padding: 2,
-            }}
-          >
-            <X size={12} />
-          </button>
-        )}
-      </div>
 
       {notice && (
         <p role="status" style={{

--- a/packages/web/src/lib/asideWidth.ts
+++ b/packages/web/src/lib/asideWidth.ts
@@ -25,8 +25,13 @@ export const ASIDE_MAX = 520
  *
  * One figure for both. Each having its own meant the aside resized every time the workspace switch
  * was pressed, which reads as the sidebar breaking rather than as the content changing.
+ *
+ * It went 268 -> 288 when the search field took the top row and the two verbs became icons beside
+ * it: the row now spends ~80px on those, and the 20 buys the search back the width it lost. Only a
+ * machine that has never dragged the handle sees it — a stored width is the user's answer and is
+ * left exactly as it was.
  */
-export const ASIDE_DEFAULT = 268
+export const ASIDE_DEFAULT = 288
 
 /** The stored width, clamped, with anything unreadable falling back to the default. */
 export function resolveAsideWidth(stored: string | null, viewport?: number): number {

--- a/packages/web/src/lib/fleetGroups.test.ts
+++ b/packages/web/src/lib/fleetGroups.test.ts
@@ -1,0 +1,89 @@
+import { expect, test, describe } from 'bun:test'
+import { GONE_PROJECT_KEY, type ControlSession } from '@agentistics/tui/control/session-fleet'
+import { projectGroups, showsProjectHeadings } from './fleetGroups'
+
+function row(o: Partial<ControlSession> & { id: string }): ControlSession {
+  return {
+    title: o.id, harness: 'claude', cwd: '/w', project: 'w',
+    searchFields: {} as ControlSession['searchFields'],
+    state: 'working', stateLabel: 'working', actionable: true, attached: false,
+    ...o,
+  } as ControlSession
+}
+
+describe('projectGroups', () => {
+  test('one band per project, named by the project', () => {
+    const out = projectGroups([
+      row({ id: 'a', project: 'agentistics' }),
+      row({ id: 'b', project: 'aipe' }),
+      row({ id: 'c', project: 'agentistics' }),
+    ], 'en')
+    expect(out.map(g => g.label).sort()).toEqual(['agentistics', 'aipe'])
+    expect(out.find(g => g.label === 'agentistics')!.sessions).toHaveLength(2)
+  })
+
+  test('the band holding the most urgent session comes first', () => {
+    const out = projectGroups([
+      row({ id: 'a', project: 'quiet', state: 'working' }),
+      row({ id: 'b', project: 'blocked', state: 'waiting-approval' }),
+    ], 'en')
+    expect(out[0]!.label).toBe('blocked')
+  })
+
+  test('a session with no project gets a band said in WORDS, never a blank heading', () => {
+    const en = projectGroups([row({ id: 'a', project: '' })], 'en')
+    const pt = projectGroups([row({ id: 'a', project: '' })], 'pt')
+    expect(en[0]!.label).toBe('No project')
+    expect(pt[0]!.label).toBe('Sem projeto')
+  })
+
+  test('a directory that is GONE is its own band, not the no-project one', () => {
+    const out = projectGroups([
+      row({ id: 'a', project: 'x', dirGone: 'the folder is gone' }),
+      row({ id: 'b', project: '' }),
+    ], 'en')
+    const labels = out.map(g => g.label)
+    expect(labels).toContain('Folder is gone')
+    expect(labels).toContain('No project')
+    expect(new Set(labels).size).toBe(2)
+  })
+
+  test('an empty fleet yields no bands', () => {
+    expect(projectGroups([], 'en')).toEqual([])
+  })
+})
+
+describe('showsProjectHeadings', () => {
+  // The rule the whole feature turns on: a heading naming the ONLY project in the band repeats what
+  // the band above it already said and costs a row — the same reason the cascade drops its root when
+  // the grouping is already the project.
+  test('one project draws no heading', () => {
+    expect(showsProjectHeadings(projectGroups([
+      row({ id: 'a', project: 'agentistics' }),
+      row({ id: 'b', project: 'agentistics' }),
+    ], 'en'))).toBe(false)
+  })
+
+  test('two projects draw headings', () => {
+    expect(showsProjectHeadings(projectGroups([
+      row({ id: 'a', project: 'agentistics' }),
+      row({ id: 'b', project: 'aipe' }),
+    ], 'en'))).toBe(true)
+  })
+
+  test('nothing at all draws no heading', () => {
+    expect(showsProjectHeadings([])).toBe(false)
+  })
+})
+
+describe("the grouping key is the TUI's own", () => {
+  test('projectGroup outranks the directory name, and GONE has its own key', () => {
+    const out = projectGroups([
+      row({ id: 'a', project: 'worktree-x', projectGroup: 'agentistics' }),
+      row({ id: 'b', project: 'worktree-y', projectGroup: 'agentistics' }),
+    ], 'en')
+    expect(out).toHaveLength(1)
+    expect(out[0]!.label).toBe('agentistics')
+    expect(out[0]!.key).not.toBe(GONE_PROJECT_KEY)
+  })
+})

--- a/packages/web/src/lib/fleetGroups.ts
+++ b/packages/web/src/lib/fleetGroups.ts
@@ -1,0 +1,83 @@
+/**
+ * fleetGroups.ts — which PROJECT band a fleet row belongs to, for the sidebar — PURE.
+ *
+ * It arranges nothing itself. The bucketing, the band ordering and the ordering inside each band
+ * all come from `groupSessions` in `@agentistics/tui/control/session-fleet` — the very function the
+ * terminal cockpit and `agentop session ls` resolve their bands with. A second implementation of
+ * "which band does this row belong to" is exactly the defect that module exists to remove, and the
+ * project key is the one most worth not re-deriving: it is `projectGroup || (dirGone ? gone :
+ * project)`, so a worktree files under its main checkout and a directory that no longer exists gets
+ * its own bucket instead of being named after a path that resolves to nothing.
+ *
+ * What lives here is the WORDS, which that module deliberately owns none of, and one rule.
+ *
+ * The rule: a band holding ONE project draws no heading (`showsProjectHeadings`). A heading naming
+ * the only project under it repeats what the band above already said and costs a row — the same
+ * reason the cockpit's cascade drops its root when the grouping is already the project. On a
+ * machine whose whole fleet sits in one checkout this feature is therefore INVISIBLE, and that is
+ * the correct amount of screen for it to take.
+ */
+
+import {
+  DEFAULT_ORDER, dimensionWordBook, groupSessions,
+  type ControlSession, type DimensionWordBook, type SessionGroup,
+} from '@agentistics/tui/control/session-fleet'
+
+type Lang = 'pt' | 'en'
+
+/**
+ * The word book, built for the PROJECT dimension only.
+ *
+ * `DimensionWordBook` is a `Record` over every dimension because `groupSessions` takes the whole
+ * book, and the sidebar groups by exactly one of them. The other entries carry their real names so
+ * nothing reads as a placeholder, but they have no `values` map: a `status` band drawn from this
+ * book would be headed by the raw state key. That is a limit, not an oversight — a surface that
+ * groups this fleet by another dimension has to supply that dimension's words, exactly as the
+ * cockpit's `sessionWordBook` does, and must not reach for this one.
+ */
+function wordBook(lang: Lang): DimensionWordBook {
+  const pt = lang === 'pt'
+  return dimensionWordBook({
+    labels: {
+      day: pt ? 'Dia' : 'Day',
+      status: pt ? 'Estado' : 'Status',
+      harness: pt ? 'Assistente' : 'Assistant',
+      model: pt ? 'Modelo' : 'Model',
+      project: pt ? 'Projeto' : 'Project',
+      repo: pt ? 'Repositório' : 'Repository',
+      task: pt ? 'Tarefa' : 'Task',
+      marked: pt ? 'Marcadas' : 'Marked',
+    },
+    // Each absence is its OWN sentence: "the folder was never recorded" and "no model recorded" are
+    // different facts, and one blank heading shared between them is how a list starts lying.
+    unfiled: {
+      day: pt ? 'Sem data' : 'No date',
+      status: pt ? 'Sem estado' : 'No status',
+      harness: pt ? 'Assistente desconhecido' : 'Unknown assistant',
+      model: pt ? 'Sem modelo' : 'No model',
+      project: pt ? 'Sem projeto' : 'No project',
+      repo: pt ? 'Fora de um repositório' : 'Outside a repository',
+      task: pt ? 'Sem tarefa' : 'No task',
+      marked: pt ? 'Não marcadas' : 'Not marked',
+    },
+    states: {},
+    goneProject: pt ? 'Pasta removida' : 'Folder is gone',
+    marked: pt ? 'Marcadas' : 'Marked',
+  })
+}
+
+/**
+ * The fleet as project bands — most urgent band first, and the rows inside each in `DEFAULT_ORDER`.
+ *
+ * `DEFAULT_ORDER` is the same ranking the cockpit breaks ties on, so a session that needs a person
+ * is at the top of its band here for the same reason it is there in the terminal.
+ */
+export function projectGroups(rows: readonly ControlSession[], lang: Lang): SessionGroup[] {
+  if (rows.length === 0) return []
+  return groupSessions(rows, 'project', wordBook(lang), [], DEFAULT_ORDER)
+}
+
+/** Whether these bands are worth heading at all — see the module header for the rule. */
+export function showsProjectHeadings(groups: readonly SessionGroup[]): boolean {
+  return groups.length > 1
+}


### PR DESCRIPTION
## Summary

- The sidebar's fleet bands by PROJECT inside `ACTIVE` / `INACTIVE` — and draws no heading when a band holds one project.
- The search field takes the top row; `+ New session` and `Send a prompt to several` become icons beside it.
- `ASIDE_DEFAULT` 268 → 288, so the search does not pay for the two buttons.

## Motivation

Closes #435.

The list said nothing about WHERE each session was, on a machine with 168 projects; and three rows went to two occasional verbs stacked above the one control the column is used for on every visit — rows that come straight out of the list being searched.

## Changes

- **`packages/web/src/lib/fleetGroups.ts`** (new, pure) — `projectGroups` calls `groupSessions` from `@agentistics/tui/control/session-fleet`, the same function the cockpit and `agentop session ls` resolve their bands with; this module owns only the WORDS that one deliberately holds none of. The project key comes with it: `projectGroup || (dirGone ? gone : project)` files a worktree under its main checkout and gives a directory that no longer exists its own bucket instead of naming it after a path that resolves to nothing. `showsProjectHeadings` is the rule the feature turns on — one project, no heading, the same reason the cockpit's cascade drops its root when the grouping is already the project.
- **`packages/web/src/lib/fleetGroups.test.ts`** (new) — 9 tests: banding, band order by the most urgent member, the no-project and gone-directory buckets said in words, and both sides of the heading rule.
- **`packages/web/src/components/nav/SessionsAside.tsx`** — bands render `SessionGroup[]`; the top row is search + two icon buttons, each with `title` AND `aria-label`. "Reopen N sessions that fell" deliberately keeps its full-width button: it names a COUNT.
- **`packages/web/src/lib/asideWidth.ts`** — the default width, with the reason recorded.

Nothing else moves: no new control, no dimension picker (the one that existed was removed on purpose and stays removed), and no change to how a row is drawn.

## Test plan

- [x] `bun test` — full suite green (9 new)
- [x] `bun tsc --noEmit` clean
- [x] Looked at it running: bands appear for a multi-project history (`parity-driven-development · 3`, `prontuario · 1`) and are ABSENT on a fleet that is all one checkout — which is the intended behaviour, not a no-op
- [x] 1440 and 390: 44px touch targets on mobile, `document.documentElement.scrollWidth <= window.innerWidth` on both

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mt1xebd86fKeNspqcMARD3