### PR TITLE
fix(sessions): a dialog with no numbers is answerable, instead of confirming the row it starts on

### DIFF
--- a/packages/server/server/cli-start.ts
+++ b/packages/server/server/cli-start.ts
@@ -127,11 +127,11 @@ import { markFleetPhase, timeFleetPhase } from './sessions/fleet-profile'
 // rows from the same decision rather than mapping the fleet a second time.
 import { toControlSession } from './sessions/control-session'
 import { planTaskReopen, taskReopenSucceeded, type TaskReopenPlan } from './sessions/task-reopen'
-import { approvalFor, choiceKey, fieldIsOpen, isFreeTextOption } from './sessions/approval-spec'
+import { approvalFor, choiceKey, fieldIsOpen, isFreeTextOption, readsMarkerSelect } from './sessions/approval-spec'
 // Carrying a rename through to the harness. Shared with `agentop session rename` — one gesture, one
 // implementation, for the reason `task-reopen.ts` exists.
 import { renameInHarness, renameMessage } from './sessions/rename'
-import { needsChoice, parseDialogOptions } from './sessions/dialog-choice'
+import { needsChoice, parseDialogOptions, readDialog } from './sessions/dialog-choice'
 import { answerFollowUp } from './sessions/answer-followup'
 import { liveTranscriptDeps, runTranscriptSearch } from './sessions/transcript-run'
 import { rulesFor } from './sessions/attention-rules'
@@ -3341,7 +3341,51 @@ export function createControlHost(initialLang: CliLang, altScreen: Suspendable):
       }
 
       // What is on the screen RIGHT NOW, not what was drawn up to a poll ago.
-      const options = parseDialogOptions(frame)
+      const read = readDialog(frame, { marker: readsMarkerSelect(managed.harness) })
+      const options = read.options
+
+      /*
+       * A NUMBERLESS dialog is answered by MOVING onto the row, and it has its own branch because
+       * every step below assumes a digit exists. claude's trust prompt is the case:
+       *
+       *     ❯ No, exit
+       *       Yes, I trust this folder
+       *
+       * `readDialog` used to answer `none` there — no numbers, no menu — so the caller fell through
+       * to the bare confirm at the bottom of this function, which sends `Enter` and takes the
+       * HIGHLIGHTED row. The highlighted row is `No, exit`. Reported by a user who could only quit
+       * from the web and had to open the terminal to say yes.
+       */
+      if (read.select === 'marker' && needsChoice(options)) {
+        if (choice === undefined) return { ok: false, message: s.sessNeedsChoice(options.length) }
+        const picked = options.find(o => o.number === choice)
+        // The question CHANGED between being shown and being answered — same refusal as the
+        // numbered path, and for the same reason: an answer to a question that has moved on is
+        // wrong and invisible.
+        if (!picked) return { ok: false, message: s.sessChoiceGone }
+        const move = spec.move
+        // Nobody has driven this harness's select. A confirm key here would take the highlighted
+        // row, which is the defect this whole branch exists to remove.
+        if (!move || !backend.sendMoveChoice) {
+          return { ok: false, message: s.sessChooseUnknown(managed.harness) }
+        }
+        const from = options.findIndex(o => o.selected)
+        // No cursor on a list this parser said HAS one: the frame moved under us between the two
+        // reads. Refused rather than guessed from row zero, which would move the wrong distance.
+        if (from < 0) return { ok: false, message: s.sessChoiceGone }
+        const steps = (picked.number - 1) - from
+        const keys = Array.from({ length: Math.abs(steps) }, () => (steps > 0 ? move.down : move.up))
+        const out = await backend.sendMoveChoice(id, keys, spec.key, after => {
+          // The look, and it is deliberately about the LABEL rather than the position: a redraw
+          // that added or removed a row would leave the right index pointing at the wrong option.
+          const now = readDialog(after)
+          return now.select === 'marker' && now.options.find(o => o.selected)?.label === picked.label
+        })
+        if (out === 'wrong-row') return { ok: false, message: s.sessChoiceGone }
+        return out === 'sent'
+          ? { ok: true, message: s.sessAnswered(picked.label) }
+          : { ok: false, message: s.sessSendFailed(id) }
+      }
 
       if (needsChoice(options)) {
         // A numbered dialog is NEVER answered with a bare confirm. `Enter` takes whichever row is

--- a/packages/server/server/sessions/approval-spec.ts
+++ b/packages/server/server/sessions/approval-spec.ts
@@ -71,6 +71,47 @@ export interface ApprovalSpec {
    */
   choice?: { kind: 'digit'; probed: string }
   /**
+   * How to reach a row on a dialog that printed NO numbers — the only way there is to move onto it.
+   *
+   * `choice` above answers a numbered dialog and cannot answer this one: there is no digit to type.
+   * Claude's trust prompt is the case (`❯ No, exit` / `  Yes, I trust this folder`), and it is the
+   * dialog where the old fallback cost the most — a bare confirm there takes `No, exit`, so from
+   * the web the only reachable answer was quitting. Reported by a user who had to open the terminal
+   * to say yes.
+   *
+   * MEASURED on claude 2.1.x under tmux on 2026-09-08, on the harness's own select component (the
+   * `/model` picker, which draws the same widget): `Down` moved the `❯` from row 2 to row 3, two
+   * `Up`s walked it back to row 1, and `Escape` closed the dialog. The trust prompt itself was NOT
+   * driven — it does not reappear on a machine that has already trusted its folders, and neither
+   * the onboarding nor the login select reaches it — which is exactly why the caller VERIFIES the
+   * cursor landed on the intended label before it confirms, instead of trusting this count.
+   *
+   * ABSENT means nobody has driven this harness's select, and a numberless dialog is then refused
+   * in words. Never fall back to `key`: that is the defect this field exists to close.
+   */
+  move?: { down: string; up: string; probed: string }
+  /**
+   * This harness's NUMBERLESS select is one contiguous line per option — so the shape reader may
+   * run on its frames.
+   *
+   * A GATE and not a flag, because the shape is not universal and reading it wrong is expensive.
+   * MEASURED 2026-09-08 by driving a live `kimi` 0.41.0 in a fresh directory: its trust prompt is
+   * numberless too, and each option carries a DESCRIPTION line at the SAME indentation, with blank
+   * lines between the option groups —
+   *
+   *      ❯ Trust this folder
+   *        Enable project MCP servers. Remembered for this folder.
+   *
+   *        Don't trust
+   *
+   * — so a contiguous-rows rule reads "Trust this folder" and its own description as two options
+   * and never reaches `Don't trust`. Half-read options are worse than none because they get
+   * OFFERED, so kimi is left OFF and its dialogs read exactly as they did before. claude's is one
+   * line per option (`❯ No, exit` / `  Yes, I trust this folder`, captured from a live session the
+   * same day), which is the only shape this reader models.
+   */
+  markerSelect?: { probed: string }
+  /**
    * How the SCREEN says a free-text field is open and taking keys.
    *
    * WHY IT CANNOT BE INFERRED FROM THE OPTION LIST. The check that shipped read the list: a field
@@ -101,6 +142,8 @@ export const APPROVAL_SPECS: Record<HarnessId, ApprovalSpec | null> = {
     key: 'Enter',
     probed: 'claude 2.1.231, 2026-08-13',
     choice: { kind: 'digit', probed: 'claude 2.1.232, 2026-08-14 (permission prompt + AskUserQuestion)' },
+    move: { down: 'Down', up: 'Up', probed: 'claude 2.1.x, 2026-09-08 (/model picker, driven under tmux)' },
+    markerSelect: { probed: 'claude, 2026-09-08 (trust prompt, captured from a live session)' },
     fieldOpen: {
       pattern: /ctrl\+g to edit in VS Code/i,
       probed: 'claude 2.1.263, 2026-09-08 (AskUserQuestion "Type something.")',
@@ -153,6 +196,27 @@ export function choiceKey(spec: ApprovalSpec | undefined, n: number): string | n
   // Only single digits are typeable as one key. A dialog with more than nine options would need a
   // different mechanism, and inventing one for a case nobody has seen is how a guess ships.
   return spec.choice.kind === 'digit' && n <= 9 ? String(n) : null
+}
+
+/**
+ * Can this harness pick a row on a dialog of THIS shape? — PURE.
+ *
+ * The two shapes need two different capabilities and a caller that asks only about `choice` offers
+ * a picker it cannot honour on a numberless dialog — or, worse, withholds one it could. `null`
+ * (the read found no menu) is not a pick at all.
+ */
+export function canPick(
+  spec: ApprovalSpec | undefined,
+  select: 'numbered' | 'marker' | null,
+): boolean {
+  if (select === 'numbered') return !!spec?.choice
+  if (select === 'marker') return !!spec?.move
+  return false
+}
+
+/** Whether the NUMBERLESS shape reader may run on this harness's frames — see `markerSelect`. */
+export function readsMarkerSelect(harness: HarnessId | undefined): boolean {
+  return !!approvalFor(harness)?.markerSelect
 }
 
 /** The spec for a harness, or `undefined` when its dialog was never read. */

--- a/packages/server/server/sessions/backend-tmux.ts
+++ b/packages/server/server/sessions/backend-tmux.ts
@@ -316,6 +316,33 @@ export const tmuxBackend: SessionBackend = {
     })
   },
 
+  /**
+   * Move the cursor, LOOK, then confirm — the numberless dialog's answer.
+   *
+   * The look is the point. Everything else here is an assumption: that the widget wraps or does not,
+   * that one press moves one row, that the list has not been redrawn since the poll. `landed` tests
+   * the only thing that settles it — where the cursor IS, in the frame as it stands a moment before
+   * the confirm — so a miscount costs a refusal instead of the wrong answer to a question about
+   * somebody's folder. Nothing is sent after a failed look.
+   */
+  async sendMoveChoice(
+    id: string, keys: readonly string[], confirmKey: string, landed: (frame: string[]) => boolean,
+  ): Promise<'sent' | 'wrong-row' | 'failed'> {
+    return writeToPane(id, async () => {
+      for (const key of keys) {
+        const before = await captureFrame(id)
+        if ((await tmux(sendKeysNamedArgs(id, key))).code !== 0) return 'failed'
+        // A moved highlight IS a frame change; waiting for it is waiting for the widget to redraw.
+        // Bounded, exactly like `sendChoiceText`: a pane that will not move must not hold the
+        // request open, and the look below is what decides the outcome either way.
+        await paneMoved(id, before)
+      }
+      await sleep(SUBMIT_SETTLE_MS)
+      if (!landed(await captureFrame(id))) return 'wrong-row'
+      return (await tmux(sendKeysNamedArgs(id, confirmKey))).code === 0 ? 'sent' : 'failed'
+    })
+  },
+
   async sendTextRaw(id: string, text: string) {
     // Literal only, NO Enter — the first half of `sendTextTo`. This is what the browser's key-by-key
     // channel needs: a character appears without submitting a turn. Locked like every other write:

--- a/packages/server/server/sessions/control-session.ts
+++ b/packages/server/server/sessions/control-session.ts
@@ -16,7 +16,7 @@
 import { contextFraction, fmt, fmtCost } from '@agentistics/core'
 import type { ControlSession, SessionState } from '@agentistics/tui/control'
 import type { CliStrings } from '../cli-i18n'
-import { approvalFor, isFreeTextOption } from './approval-spec'
+import { approvalFor, canPick, isFreeTextOption } from './approval-spec'
 import { needsChoice } from './dialog-choice'
 import { pickTitle } from './harness-session-file'
 import type { ResolvedRepoFacts } from './repo-facts'
@@ -178,10 +178,14 @@ export function toControlSession(
     // Picking one of them needs a VERIFIED way to select by number on this harness. Only claude has
     // one; everywhere else the options are shown and the answer is a refusal that names why, because
     // falling back to the confirm key would choose for the user among things that differ.
-    ...(needsChoice(v.dialogOptions ?? []) && approvalFor(v.harness)?.choice
+    // The capability asked for is the one THIS dialog's shape needs: a digit for a numbered list, a
+    // move for a numberless one. Asking only about `choice` withheld the picker from claude's trust
+    // prompt — which prints no numbers — and left the bare confirm in its place, so the only
+    // reachable answer was the highlighted `No, exit`.
+    ...(needsChoice(v.dialogOptions ?? []) && canPick(approvalFor(v.harness), v.dialogSelect ?? null)
       ? { canChoose: true as const }
       : {}),
-    ...(needsChoice(v.dialogOptions ?? []) && !approvalFor(v.harness)?.choice && harness
+    ...(needsChoice(v.dialogOptions ?? []) && !canPick(approvalFor(v.harness), v.dialogSelect ?? null) && harness
       ? { chooseBlind: s.sessChooseBlind(harness) }
       : {}),
     // The verb exists only where BOTH halves are true: the session is asking, and somebody has read

--- a/packages/server/server/sessions/dialog-choice.ts
+++ b/packages/server/server/sessions/dialog-choice.ts
@@ -120,6 +120,17 @@ export interface DialogRead {
   kind: 'options' | 'none' | 'unreadable'
   /** The options, in order. EMPTY unless `kind` is `options` — a half-read list is never offered. */
   options: DialogOption[]
+  /**
+   * HOW one of them is picked — and the reason this field exists is that the answer differs.
+   *
+   * `numbered` — the dialog printed `1.`…`n.` and typing the digit selects. `marker` — it printed
+   * no numbers at all (claude's trust prompt: `❯ No, exit` / `  Yes, I trust this folder`), so the
+   * only way to reach a row is to MOVE the cursor onto it. `number` on those options is a POSITION,
+   * never something to type; a caller that sends it as a digit is typing into the dialog.
+   *
+   * `null` whenever `kind` is not `options`.
+   */
+  select: 'numbered' | 'marker' | null
   /** Present only on `unreadable`. */
   reason?: DialogUnreadable
   /** Index of the TOPMOST option row reached, `-1` when none was. Feeds the preview's window. */
@@ -134,7 +145,18 @@ export interface DialogRead {
  * says WHICH refusal, and hands back where the block starts so the preview and the options can
  * never describe different parts of the screen.
  */
-export function readDialog(frame: readonly string[]): DialogRead {
+export function readDialog(
+  frame: readonly string[],
+  /**
+   * Whether to try the NUMBERLESS shape when no numbers are found.
+   *
+   * Off by default, and that is the safe direction: a caller that does not know which harness drew
+   * this frame must not go looking for a menu with the weaker signal. `ApprovalSpec.markerSelect`
+   * is what turns it on, per harness and only where the shape has been measured — see that field
+   * for the kimi frame that makes this a gate rather than a flag.
+   */
+  opts: { marker?: boolean } = {},
+): DialogRead {
   const found: DialogOption[] = []
   let top = -1
   let anchored = false
@@ -155,21 +177,109 @@ export function readDialog(frame: readonly string[]): DialogRead {
 
   found.reverse()
 
-  // Nothing numbered at the bottom at all: there is no menu to read.
-  if (found.length === 0) return { kind: 'none', options: [], top: -1 }
+  // Nothing numbered at the bottom at all. It may still be a menu — claude's trust prompt prints
+  // none — so the marker shape gets its turn. This is the ONLY place it runs: a frame whose numbers
+  // were found and then refused keeps that refusal, or a `gap` would be re-read as two loose rows.
+  if (found.length === 0) return opts.marker ? readMarkerSelect(frame) : { kind: 'none', options: [], select: null, top: -1 }
   // Rows were found and `1.` never was. The block is real and its top is out of reach.
-  if (!anchored) return { kind: 'unreadable', reason: 'no-anchor', options: [], top }
+  if (!anchored) return { kind: 'unreadable', reason: 'no-anchor', options: [], select: null, top }
   // A menu is at least a choice. One option is a statement, and the caller confirms it instead.
-  if (found.length < 2) return { kind: 'none', options: [], top }
+  if (found.length < 2) return { kind: 'none', options: [], select: null, top }
   // Exactly `1..n`, in order. A gap, a repeat or a wrong start means this was not read correctly —
   // and half-read options are worse than none, because they would be offered as if they were whole.
-  if (found.some((o, i) => o.number !== i + 1)) return { kind: 'unreadable', reason: 'gap', options: [], top }
+  if (found.some((o, i) => o.number !== i + 1)) return { kind: 'unreadable', reason: 'gap', options: [], select: null, top }
   // At most one highlighted row. Two cursors is a frame this parser does not understand.
   if (found.filter(o => o.selected).length > 1) {
-    return { kind: 'unreadable', reason: 'two-cursors', options: [], top }
+    return { kind: 'unreadable', reason: 'two-cursors', options: [], select: null, top }
   }
 
-  return { kind: 'options', options: found, top }
+  return { kind: 'options', options: found, select: 'numbered', top }
+}
+
+/**
+ * The select cursor, and ONLY the cursor.
+ *
+ * `readDialog`'s numbered rule also accepts a plain `>`, because there the digit carries the proof
+ * that it is a menu. Here nothing else does, and a `>`-quoted block — two lines of somebody's mail,
+ * a diff, a markdown quote — has exactly the shape this scan looks for. `❯` is the glyph claude's
+ * select component draws and prose does not.
+ */
+const MARKER = /^(\s*)❯ (\S.*?)\s*$/
+
+/**
+ * A sibling row: its text STARTS at the cursor's label column, exactly.
+ *
+ * Both halves are load-bearing. Nothing before the column (or the row belongs to some other block),
+ * and a non-space AT it — testing only that the prefix is blank accepts a row indented further,
+ * which is how an unrelated paragraph two columns to the right joined the menu.
+ */
+const siblingAt = (line: string, col: number): string | null => {
+  if (line.length <= col) return null
+  if (line.slice(0, col).trim() !== '') return null
+  if (line[col] === ' ') return null
+  return line.slice(col).trimEnd()
+}
+
+/**
+ * A menu with NO numbers, read off the frame — PURE.
+ *
+ * Claude's trust prompt is the case, and it is the one dialog where being wrong costs the most: the
+ * highlighted row is `No, exit`, so the bare confirm the caller used to fall back to answered every
+ * one of them by quitting. Reported by a user who could only reach that row from the web and had to
+ * open the terminal to say yes.
+ *
+ * The shape is a cursor row plus the rows CONTIGUOUS with it at the same indentation. That is a
+ * weaker signal than `1..n`, so it is fenced accordingly: the `❯` glyph only, at most one of them,
+ * a label on the cursor row (the composer's own `❯ ` is empty and must never read as a menu), at
+ * least one sibling (one row is a statement — the codex `Press enter to continue` — and a caller
+ * confirms those), and a blank line or a change of indentation ends the block.
+ *
+ * Provenance: the trust frame was captured from a live session on 2026-09-08; the numbered frames
+ * and the idle composer in `dialog-marker.test.ts` were captured the same day from claude 2.1.x
+ * driven under tmux, which is what pins that this scan leaves them alone.
+ */
+function readMarkerSelect(frame: readonly string[]): DialogRead {
+  const cursors: number[] = []
+  for (let i = frame.length - 1; i >= 0; i--) {
+    if (frame.length - 1 - i > LAST_OPTION_LINES) break
+    if (MARKER.test(frame[i] ?? '')) cursors.push(i)
+  }
+  if (cursors.length === 0) return { kind: 'none', options: [], select: null, top: -1 }
+  // Two highlighted rows is the same fact the numbered path refuses under this name: a frame this
+  // parser does not understand, and guessing which cursor is the real one is how a menu gets
+  // half-read and offered anyway.
+  if (cursors.length > 1) return { kind: 'unreadable', reason: 'two-cursors', options: [], select: null, top: cursors[cursors.length - 1]! }
+
+  const at = cursors[0]!
+  const m = MARKER.exec(frame[at] ?? '')!
+  // The label's own column — the cursor glyph plus its space. A sibling is a row that starts its
+  // text exactly there; anything else belongs to some other block.
+  const col = m[1]!.length + 2
+  const rows: { i: number; label: string }[] = [{ i: at, label: m[2]! }]
+
+  for (let i = at - 1; i >= 0; i--) {
+    const label = siblingAt(frame[i] ?? '', col)
+    if (label === null || MARKER.test(frame[i] ?? '')) break
+    rows.unshift({ i, label })
+  }
+  for (let i = at + 1; i < frame.length; i++) {
+    const label = siblingAt(frame[i] ?? '', col)
+    if (label === null || MARKER.test(frame[i] ?? '')) break
+    rows.push({ i, label })
+  }
+
+  // One row is a statement, not a choice — and the caller may confirm it, which is exactly what
+  // `none` grants and `unreadable` withholds.
+  if (rows.length < 2) return { kind: 'none', options: [], select: null, top: at }
+
+  return {
+    kind: 'options',
+    select: 'marker',
+    top: rows[0]!.i,
+    // `number` is the POSITION, 1-based, so every caller can address an option the same way it
+    // addresses a numbered one. `select: 'marker'` is what stops it being typed as a digit.
+    options: rows.map((r, n) => ({ number: n + 1, label: r.label, selected: r.i === at })),
+  }
 }
 
 /**
@@ -180,8 +290,11 @@ export function readDialog(frame: readonly string[]): DialogRead {
  * menu", and that conflation is what put a blind confirm button on a six-option dialog. Ask
  * `readDialog(...).kind === 'none'`.
  */
-export function parseDialogOptions(frame: readonly string[]): DialogOption[] {
-  return readDialog(frame).options
+export function parseDialogOptions(
+  frame: readonly string[],
+  opts: { marker?: boolean } = {},
+): DialogOption[] {
+  return readDialog(frame, opts).options
 }
 
 /**

--- a/packages/server/server/sessions/dialog-marker.test.ts
+++ b/packages/server/server/sessions/dialog-marker.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, test } from 'bun:test'
+import { readDialog } from './dialog-choice'
+
+/**
+ * The TRUST dialog — the one this whole shape exists for.
+ *
+ * Captured from a live claude session on 2026-09-08, through agentop's own `approvalLines` preview
+ * (the user was shown exactly these rows and could only answer the highlighted one). It carries NO
+ * numbers, which is why the numbered reader answered `none` and the UI drew a bare confirm — and a
+ * bare confirm here sends `Enter`, which takes `No, exit`.
+ */
+const TRUST = [
+  'project, or work from your team). If not, take a moment to review what\'s in this folder first.',
+  '',
+  'Claude Code\'ll be able to read, edit, and execute files here.',
+  '',
+  'Security guide',
+  '',
+  '❯ No, exit',
+  '  Yes, I trust this folder',
+  '',
+  'Enter to confirm · Esc to cancel',
+]
+
+/** claude's model picker, captured live on 2026-09-08. Numbered — must stay on the numbered path. */
+const NUMBERED = [
+  '   Select model',
+  '   Switch between Claude models. Your pick becomes the default for new sessions.',
+  '',
+  '     1. Default (recommended)  Opus 5 with 1M context · Best for everyday, complex tasks',
+  '   ❯ 2. Opus (1M context) ✔    Opus 5 with 1M context · Best for everyday, complex tasks',
+  '     3. Fable                  Fable 5.1 · Most capable for your hardest tasks',
+  '',
+  '   Enter to set as default · s to use this session only · Esc to cancel',
+]
+
+/** An IDLE claude prompt, captured live on 2026-09-08: the composer's own `❯` and nothing under it. */
+const IDLE = [
+  '                                                              ● high · /effort',
+  '────────────────────────────────────────────────────────────────────────────',
+  '❯ ',
+  '────────────────────────────────────────────────────────────────────────────',
+  '  ⏵⏵ auto mode on (shift+tab to cycle) · ← 6 agents',
+]
+
+describe('the numberless select', () => {
+  test('the trust dialog reads as two options, the highlighted one marked', () => {
+    const d = readDialog(TRUST, { marker: true })
+    expect(d.kind).toBe('options')
+    expect(d.select).toBe('marker')
+    expect(d.options.map(o => o.label)).toEqual(['No, exit', 'Yes, I trust this folder'])
+    expect(d.options.map(o => o.selected)).toEqual([true, false])
+  })
+
+  test('its numbers are POSITIONS, so a caller can address one without a printed digit', () => {
+    const d = readDialog(TRUST, { marker: true })
+    expect(d.options.map(o => o.number)).toEqual([1, 2])
+  })
+
+  test('the top is where the block starts, so the preview and the options describe one place', () => {
+    expect(readDialog(TRUST, { marker: true }).top).toBe(6)
+  })
+})
+
+/**
+ * kimi 0.41.0's trust prompt, captured by driving a live session in a fresh directory on
+ * 2026-09-08. Numberless like claude's — and NOT the same shape: every option carries a description
+ * line at the SAME indentation, with blank lines between the groups.
+ */
+const KIMI_TRUST = [
+  '  Trust this folder?',
+  '  ↑↓ navigate · Enter select · Esc exit',
+  '',
+  '  /tmp/agkimi-wAb8iS',
+  '',
+  '  Project-level MCP servers are disabled until you explicitly choose Trust. Trust starts the',
+  '  listed project MCP targets and remembers this folder.',
+  '',
+  '   ❯ Trust this folder',
+  '     Enable project MCP servers. Remembered for this folder.',
+  '',
+  '     Don\'t trust',
+  '     Exit Kimi Code. Asked again next launch.',
+]
+
+describe('the gate', () => {
+  // The DEFAULT is off, and every caller that does not know which harness drew the frame keeps it
+  // off. `attention.ts` is the one that matters: its window rule is written for a numbered block.
+  test('the shape reader does not run unless it is asked for', () => {
+    expect(readDialog(TRUST).kind).toBe('none')
+    expect(readDialog(TRUST).select).toBeNull()
+  })
+
+  test("kimi's numberless prompt would be HALF-READ, which is why kimi is not gated on", () => {
+    // Asked for anyway, this is what comes out: the first option and its own DESCRIPTION, and
+    // `Don't trust` never reached. Offering that is worse than offering nothing — the assertion
+    // exists so nobody turns kimi on without modelling the description lines first.
+    const forced = readDialog(KIMI_TRUST, { marker: true })
+    expect(forced.options.map(o => o.label)).toEqual([
+      'Trust this folder',
+      'Enable project MCP servers. Remembered for this folder.',
+    ])
+    // And with the gate as it ships, kimi reads exactly as it did before this reader existed.
+    expect(readDialog(KIMI_TRUST).kind).toBe('none')
+  })
+})
+
+describe('what it must NOT read as a menu', () => {
+  test('a numbered dialog stays numbered — the marker scan never runs on it', () => {
+    const d = readDialog(NUMBERED, { marker: true })
+    expect(d.kind).toBe('options')
+    expect(d.select).toBe('numbered')
+    expect(d.options.map(o => o.number)).toEqual([1, 2, 3])
+    expect(d.options.find(o => o.selected)?.number).toBe(2)
+  })
+
+  test('the idle composer is not a menu: its cursor row is empty and has no siblings', () => {
+    const d = readDialog(IDLE, { marker: true })
+    expect(d.kind).toBe('none')
+    expect(d.options).toEqual([])
+  })
+
+  test('a cursor row with nothing beside it is a statement, not a choice', () => {
+    // The codex-shaped `Press enter to continue`: one row, so a bare confirm is still the right
+    // answer and this reader must not turn it into a one-option menu.
+    const d = readDialog(['Something happened.', '', '❯ Press enter to continue', ''], { marker: true })
+    expect(d.kind).toBe('none')
+  })
+
+  test('two cursors is a frame this parser does not understand, and it says so', () => {
+    const d = readDialog(['❯ one', '❯ two'], { marker: true })
+    expect(d.kind).toBe('unreadable')
+    expect(d.reason).toBe('two-cursors')
+  })
+
+  test('a quoted `>` block is never a menu — only the select cursor counts', () => {
+    const d = readDialog(['> quoted line one', '> quoted line two', '', 'Enter to confirm'], { marker: true })
+    expect(d.kind).toBe('none')
+  })
+
+  test('rows at a different indentation than the cursor are not its siblings', () => {
+    const d = readDialog(['        far away', '❯ No, exit', '            also far', ''], { marker: true })
+    expect(d.kind).toBe('none')
+  })
+
+  test('a blank line ends the block', () => {
+    const d = readDialog(['  not mine', '', '❯ No, exit', '  Yes, I trust this folder'], { marker: true })
+    expect(d.options.map(o => o.label)).toEqual(['No, exit', 'Yes, I trust this folder'])
+  })
+})

--- a/packages/server/server/sessions/session-view.ts
+++ b/packages/server/server/sessions/session-view.ts
@@ -110,6 +110,13 @@ export interface SessionView {
    */
   dialogOptions?: DialogOption[]
   /**
+   * HOW one of `dialogOptions` is picked — `numbered` (type the digit) or `marker` (move onto it).
+   *
+   * Carried rather than re-derived downstream, because the two need different capabilities of the
+   * harness and a surface that assumes "numbered" offers a digit the dialog never printed.
+   */
+  dialogSelect?: 'numbered' | 'marker'
+  /**
    * WHY the dialog on screen could not be read, when it could not be.
    *
    * Distinct from an empty `dialogOptions`, and that distinction is the whole point: no options
@@ -448,6 +455,8 @@ export function buildSessionViews(o: {
   modes?: ReadonlyMap<string, { id: string; label: string }>
   /** The options that dialog offers, keyed by session id. Absent where they could not be read. */
   dialogOptions?: ReadonlyMap<string, DialogOption[]>
+  /** How those options are picked, keyed by session id — see `SessionView.dialogSelect`. */
+  dialogSelect?: ReadonlyMap<string, 'numbered' | 'marker'>
   /** Why the dialog could not be read, keyed by session id — see `SessionView.dialogUnreadable`. */
   dialogUnreadable?: ReadonlyMap<string, DialogUnreadable>
   /** The ids `crash-group.ts` decided fell together. A set, because the question is about a set. */
@@ -590,6 +599,9 @@ export function buildSessionViews(o: {
         : {}),
       ...(activity === 'waiting-approval' && (o.dialogOptions?.get(r.id)?.length ?? 0) > 0
         ? { dialogOptions: o.dialogOptions!.get(r.id)! }
+        : {}),
+      ...(activity === 'waiting-approval' && o.dialogSelect?.get(r.id)
+        ? { dialogSelect: o.dialogSelect.get(r.id)! }
         : {}),
       ...(activity === 'waiting-approval' && o.dialogUnreadable?.get(r.id)
         ? { dialogUnreadable: o.dialogUnreadable.get(r.id)! }

--- a/packages/server/server/sessions/sessions-host.ts
+++ b/packages/server/server/sessions/sessions-host.ts
@@ -22,6 +22,7 @@ import type { ChatTurn } from './chat-turn'
 import { transcriptReaderFor } from './harness-transcript'
 import { markFleetPhase } from './fleet-profile'
 import { readDialog, type DialogOption, type DialogUnreadable } from './dialog-choice'
+import { readsMarkerSelect } from './approval-spec'
 // Taking a running session back when its registry record is gone. See `session-adopt.ts`.
 import { planAdoptions } from './session-adopt'
 // The claim for harnesses that cannot be handed a conversation id. See `task-attribution.ts`.
@@ -274,6 +275,7 @@ export function createSessionsPoller(o: {
       /** The harness mode each running session is in — see `mode-spec.ts`. */
       const modes = new Map<string, { id: string; label: string }>()
       const dialogOptions = new Map<string, DialogOption[]>()
+      const dialogSelect = new Map<string, 'numbered' | 'marker'>()
       /*
        * WHY THE REFUSAL IS CARRIED AND NOT JUST THE OPTIONS.
        *
@@ -356,8 +358,11 @@ export function createSessionsPoller(o: {
           // Read from the SAME frame that decided the state, so what is offered and what the state
           // says can never describe different moments. Empty when the screen cannot be parsed with
           // confidence, which the UI reports rather than papering over.
-          const dialog = readDialog(frame)
+          const dialog = readDialog(frame, { marker: readsMarkerSelect(harness) })
           if (dialog.options.length > 0) dialogOptions.set(r.id, dialog.options)
+          // From the SAME read as the options: how they are picked is a fact about this frame, and
+          // deriving it again downstream is how a numberless dialog gets offered a digit.
+          if (dialog.select) dialogSelect.set(r.id, dialog.select)
           if (dialog.kind === 'unreadable') dialogUnreadable.set(r.id, dialog.reason!)
         }
       })))
@@ -523,6 +528,7 @@ export function createSessionsPoller(o: {
         approvals,
         modes,
         dialogOptions,
+        dialogSelect,
         dialogUnreadable,
         processes,
         conversations,

--- a/packages/server/server/sessions/types.ts
+++ b/packages/server/server/sessions/types.ts
@@ -446,6 +446,23 @@ export interface SessionBackend {
   sendChoiceText?(
     id: string, key: string, text: string, opened: (frame: string[]) => boolean,
   ): Promise<'sent' | 'no-field' | 'failed'>
+  /**
+   * Answer a NUMBERLESS dialog: move the cursor onto the row, LOOK, and only then confirm.
+   *
+   * There is no digit to type on claude's trust prompt (`❯ No, exit` / `  Yes, I trust this
+   * folder`), so the only way to reach the other row is to move onto it — and a count of arrow
+   * presses is an assumption about a widget nobody has driven in that exact dialog. `landed` is the
+   * caller's check, run on the frame AFTER the moves and BEFORE the confirm: it answers "is the
+   * highlighted row the one the person picked". `wrong-row` means it was not, and NOTHING was
+   * confirmed — the dialog is left exactly as it was found, which is the one outcome that is always
+   * recoverable.
+   *
+   * One call and not three for the same reason `sendChoiceText` is one: `writeToPane` locks per
+   * pane, and three locked calls leave two gaps another writer can land in.
+   */
+  sendMoveChoice?(
+    id: string, keys: readonly string[], confirmKey: string, landed: (frame: string[]) => boolean,
+  ): Promise<'sent' | 'wrong-row' | 'failed'>
   sendTextRaw(id: string, text: string): Promise<boolean>
   /**
    * Press ONE named key — the backend's own vocabulary (`Enter`, `Escape`).


### PR DESCRIPTION
## Summary

- A NUMBERLESS dialog (claude's trust prompt) is read as a menu and its options are listed and pickable.
- Picking one MOVES the cursor onto it, RE-READS the frame, and confirms only if the highlighted label is the one that was picked.
- The shape reader is gated per harness; only claude is on, and the kimi measurement that keeps it off there is recorded and pinned by a test.

## Motivation

Closes #437.

`Enter` takes the HIGHLIGHTED row, and on this dialog that row is `No, exit`. So the workspace's one button answered "do you trust this folder" by quitting, and saying yes meant opening the terminal.

## Changes

- **`sessions/dialog-choice.ts`** — `readDialog(frame, { marker })` gains the numberless shape: a `❯` row plus the rows contiguous with it at the same indentation. `DialogRead.select` (`numbered` | `marker`) says how a row is picked, carried rather than re-derived downstream. Fenced: the `❯` glyph only (a `>`-quoted block has this exact shape), one cursor at most, a label on the cursor row (the composer's own `❯ ` is empty), at least one sibling, and a blank line or a change of indentation ends the block. **Default OFF**, so `attention.ts` — whose window rule is written for a numbered block — is untouched.
- **`sessions/approval-spec.ts`** — `move` (how to reach a row: `Down`/`Up`, measured by driving claude's own select under tmux on 2026-09-08), `markerSelect` (whose shape has been measured), `canPick(spec, select)` and `readsMarkerSelect(harness)`.
- **`sessions/types.ts` + `backend-tmux.ts`** — `sendMoveChoice(id, keys, confirmKey, landed)`: one locked call, because `writeToPane` locks per pane and three locked calls leave two gaps. `landed` runs on the frame AFTER the moves and BEFORE the confirm; `wrong-row` means nothing was sent and the dialog is exactly as it was found.
- **`sessions/sessions-host.ts` + `session-view.ts` + `control-session.ts`** — `dialogSelect` travels with the options from the same read, and `canChoose` asks for the capability THIS shape needs (a digit for a numbered list, a move for a numberless one) instead of only `choice`.
- **`cli-start.ts`** — the marker branch in `answerSession`. It verifies by LABEL, not by index: a redraw that added a row would leave the right index pointing at the wrong option.

The wire is unchanged — the client already receives `dialogOptions` + `canChoose` and sends the picked number.

## Test plan

- [x] `bun test` — 7354 pass, 0 fail (12 new in `dialog-marker.test.ts`)
- [x] `bun tsc --noEmit` clean
- [x] The trust frame is the REAL one, captured from the live session that reported this; the numbered picker and the idle composer beside it were captured the same day by driving claude under tmux, and pin that neither is touched
- [x] kimi 0.41.0 driven in a fresh directory: its numberless prompt is a DIFFERENT shape (a description line per option), it would be half-read, and the test asserts both that and that the gate leaves it reading exactly as before
- [ ] The trust prompt itself could not be driven here (it does not reappear on a machine that has already trusted its folders, and neither the onboarding nor the login select reaches it) — which is precisely why the act verifies the landing before confirming rather than trusting the step count

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mt1xebd86fKeNspqcMARD3