### PR TITLE
fix(sessions): verify a remembered transcript path before answering it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2293,9 +2293,26 @@ harness must not break.
   and no reply ever arrived — while the terminal tab, which reads the pane and not the transcript,
   showed the whole conversation. Confirmed by the clock: the chat came back only because the server
   was restarted 13 minutes later, which is the only thing that clears a per-process memo.
-  `transcript-path-memo.ts` (pure) is the one rule now — **a found path is remembered forever** (a
-  transcript does not move), **a miss expires** (`TRANSCRIPT_MISS_TTL_MS`), the same shape and the
-  same reason as `repo-facts.ts`'s negative TTL. And the two costs are separated: Claude's DIRECT
+  `transcript-path-memo.ts` (pure) is the one rule now — **a miss expires**
+  (`TRANSCRIPT_MISS_TTL_MS`), the same shape and the same reason as `repo-facts.ts`'s negative TTL,
+  and **a found path is remembered until it stops being there**. That second half used to read "a
+  found path is remembered forever (a transcript does not move)", and **a transcript moves**: Claude
+  Code files it under the project directory derived from the session's CURRENT cwd, so a session
+  whose cwd changes has its `<id>.jsonl` re-filed elsewhere — measured 2026-09-08 on a live 2.4 MB
+  conversation that left `-home-mithrandir-agentistics/` for `…--claude-worktrees-session-shell/`.
+  The remembered path then failed every read, `chat-web.ts` turned that into `turns: []`, and on a
+  LIVE session that carries no `unavailable` — so the panel drew **"This conversation has no
+  messages yet" over a full transcript** and the user stopped receiving replies entirely, with the
+  terminal tab the only way to read anything. **A cwd change is not the only route and not the
+  common one**: Claude Code deletes transcripts older than `cleanupPeriodDays` (30 by default) on
+  every startup, which fails identically. The scan that finds the file in its new home was already
+  written and already correct; it was never reached, because the memo answered first. So
+  `resolveMemoizedPath` VERIFIES before answering, forgets a path that is gone, and — because
+  `remember` clears any miss — scans on that same call. It is also the ONE place the
+  remembered → direct → scanned shape lives; it was written by hand in all three resolvers, so this
+  was the same bug three times. Beside it, `chat-web.ts` now REFUSES IN WORDS when a transcript
+  resolves and the READ fails, which was the last step at which a blank pane was still possible.
+  And the two costs are separated: Claude's DIRECT
   path is one `stat` and is checked on EVERY call, so a new session is readable the moment its file
   appears, while only the SCAN (a `readdir` plus a `stat` per project — 281 of them on a real
   machine) is paced by the TTL. **claude, codex and kimi** memoized and are fixed; **antigravity,

--- a/packages/server/server/sessions/chat-tail.test.ts
+++ b/packages/server/server/sessions/chat-tail.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
-import { mkdtemp, mkdir, rm, writeFile, utimes } from 'node:fs/promises'
+import { mkdtemp, mkdir, rename, rm, writeFile, utimes } from 'node:fs/promises'
 import {
   forgetChatTailContent, forgetChatTailPaths, readChatWindow, readRecentChatTurns,
   resolveChatTranscriptPath,
@@ -504,16 +504,48 @@ describe('a transcript that does not exist YET', () => {
     expect(await resolveChatTranscriptPath(CWD, SESSION_ID, root, now + 31_000)).toBe(stray)
   })
 
-  test('a path once found is never re-scanned for', async () => {
+  test('a path once found is not re-scanned for WHILE IT IS STILL THERE', async () => {
     const dir = join(root, '-home-u-proj')
     await mkdir(dir, { recursive: true })
     const file = join(dir, `${SESSION_ID}.jsonl`)
     await writeFile(file, line({ type: 'user', message: { content: 'oi' } }) + '\n')
     expect(await resolveChatTranscriptPath(CWD, SESSION_ID, root)).toBe(file)
-    // Removing the tree does not un-answer it: a transcript does not move, and a read that fails
-    // is the reader's business, not the resolver's.
-    await rm(root, { recursive: true, force: true })
     expect(await resolveChatTranscriptPath(CWD, SESSION_ID, root)).toBe(file)
+  })
+
+  test('THE REPORTED CASE: the transcript MOVED, and the memo must not go on answering the old path', async () => {
+    // This test used to assert the opposite, in these words: "removing the tree does not un-answer
+    // it: a transcript does not move". It does. Claude Code files a transcript under the project
+    // directory derived from the session's CURRENT cwd, so a session whose cwd changes has its
+    // `<id>.jsonl` re-filed elsewhere — measured 2026-09-08 on a live 2.4 MB conversation. The
+    // stale answer then failed every read, `chat-web.ts` turned that into `turns: []`, and because
+    // the session was live it carried no refusal: the panel said "This conversation has no messages
+    // yet" over a full transcript, and the user stopped receiving replies altogether.
+    const here = join(root, '-home-u-proj')
+    await mkdir(here, { recursive: true })
+    const first = join(here, `${SESSION_ID}.jsonl`)
+    await writeFile(first, line({ type: 'user', message: { content: 'oi' } }) + '\n')
+    expect(await resolveChatTranscriptPath(CWD, SESSION_ID, root)).toBe(first)
+
+    // The cwd changed under the session: same conversation, another project directory.
+    const there = join(root, '-home-u-proj--worktrees-x')
+    await mkdir(there, { recursive: true })
+    const moved = join(there, `${SESSION_ID}.jsonl`)
+    await rename(first, moved)
+
+    expect(await resolveChatTranscriptPath(CWD, SESSION_ID, root)).toBe(moved)
+  })
+
+  test('THE DELETION CASE: a transcript Claude Code cleaned up stops being answered', async () => {
+    // No cwd change needed. Claude Code deletes transcripts older than `cleanupPeriodDays` (30 by
+    // default) on every startup, so a long-lived server holds a path to a file removed under it.
+    const dir = join(root, '-home-u-proj')
+    await mkdir(dir, { recursive: true })
+    const file = join(dir, `${SESSION_ID}.jsonl`)
+    await writeFile(file, line({ type: 'user', message: { content: 'oi' } }) + '\n')
+    expect(await resolveChatTranscriptPath(CWD, SESSION_ID, root)).toBe(file)
+    await rm(root, { recursive: true, force: true })
+    expect(await resolveChatTranscriptPath(CWD, SESSION_ID, root)).toBe(null)
   })
 })
 

--- a/packages/server/server/sessions/chat-tail.ts
+++ b/packages/server/server/sessions/chat-tail.ts
@@ -29,7 +29,7 @@ import { commandSummary, hasUnreadableWrite, shellWrites } from './shell-writes'
 import { classifyUserEntry, type UserEntry } from './chat-envelope'
 import type { ChatTurn } from './chat-turn'
 import { MAX_TAIL_BYTES, TAIL_BYTES, readTailBytes, windowLines } from './transcript-window'
-import { createTranscriptPathMemo } from './transcript-path-memo'
+import { createTranscriptPathMemo, resolveMemoizedPath } from './transcript-path-memo'
 
 // The turn shape now lives in `chat-turn.ts` — every harness reader produces it, and this module
 // is only one of them. Re-exported so nothing that already imports it from here has to move.
@@ -93,17 +93,18 @@ export async function resolveChatTranscriptPath(
   now: number = Date.now(),
 ): Promise<string | null> {
   if (!UUID_RE.test(sessionId)) return null
-  const known = pathMemo.get(sessionId)
-  if (known !== undefined) return known
-
-  const direct = join(projectsDir, encodeProjectDir(cwd), `${sessionId}.jsonl`)
-  if (await exists(direct)) { pathMemo.remember(sessionId, direct); return direct }
-
-  if (!pathMemo.mayScan(sessionId, now)) return null
-  pathMemo.missed(sessionId, now)
-  const scanned = await scanForTranscript(sessionId, projectsDir)
-  if (scanned !== null) pathMemo.remember(sessionId, scanned)
-  return scanned
+  // The remembered path is VERIFIED before it is answered — Claude Code re-files a transcript under
+  // the project directory of the session's CURRENT cwd, and deletes it outright after 30 days. See
+  // `resolveMemoizedPath`, which is where all three resolvers' shared shape lives.
+  return resolveMemoizedPath(pathMemo, sessionId, {
+    exists,
+    direct: async () => {
+      const p = join(projectsDir, encodeProjectDir(cwd), `${sessionId}.jsonl`)
+      return await exists(p) ? p : null
+    },
+    scan: () => scanForTranscript(sessionId, projectsDir),
+    now,
+  })
 }
 
 interface Cached {

--- a/packages/server/server/sessions/chat-web.test.ts
+++ b/packages/server/server/sessions/chat-web.test.ts
@@ -85,3 +85,36 @@ test('a row whose harness the registry has forgotten says THAT, not "we cannot r
   const out = await readSessionChat(hostWith('waiting', ''), 'en', 'sess1')
   expect(out.unavailable).toContain('which assistant')
 })
+
+/**
+ * THE LAST STEP AT WHICH A BLANK PANE WAS STILL POSSIBLE.
+ *
+ * The link and the format are refused in words above. A transcript that RESOLVED and then failed to
+ * read was not: the catch flattened it into `turns: []`, and on a live session that carries no
+ * `unavailable` — so the view drew "This conversation has no messages yet" over a conversation that
+ * was entirely on disk. Reported 2026-09-08, reached through the stale path memo (fixed in
+ * `transcript-path-memo.ts`); this is the guard that makes the NEXT cause say something.
+ */
+test('a transcript that resolves but cannot be READ is refused in words, never as an empty chat', async () => {
+  const brokenReader = () => ({
+    resolve: async () => '/some/found/transcript.jsonl',
+    read: async () => { throw new Error('EISDIR') },
+    readRecent: async () => ({ turns: [], older: false }),
+  })
+  const out = await readSessionChat(hostWith('waiting'), 'en', 'sess1', brokenReader as never)
+  expect(out.turns).toEqual([])
+  expect(out.live).toBe(true)
+  expect(out.unavailable).toContain('could not be read')
+})
+
+test('a reader that resolves and reads fine still carries no refusal', async () => {
+  // The guard must not fire on the ordinary path: an empty conversation stays empty and keeps the
+  // composer, which is what the first test in this file exists to protect.
+  const okReader = () => ({
+    resolve: async () => '/some/found/transcript.jsonl',
+    read: async () => ({ turns: [], older: false }),
+    readRecent: async () => ({ turns: [], older: false }),
+  })
+  const out = await readSessionChat(hostWith('waiting'), 'en', 'sess1', okReader as never)
+  expect(out.unavailable).toBeUndefined()
+})

--- a/packages/server/server/sessions/chat-web.ts
+++ b/packages/server/server/sessions/chat-web.ts
@@ -80,6 +80,11 @@ export async function readSessionChat(
   host: StartHost,
   lang: CliLang,
   id: string,
+  // Injectable for tests only — the same seam `resolveChatTranscriptPath` gives `projectsDir` and
+  // `now`. Without it the "found but unreadable" refusal below can only be reached by making a real
+  // file unreadable under a `PROJECTS_DIR` fixed at import time, which is why that branch went
+  // untested long enough to become a blank pane in front of a user.
+  readerFor: typeof transcriptReaderFor = transcriptReaderFor,
 ): Promise<ChatPayload> {
   const s = controlStrings(lang)
   if (!host.sessions) return { turns: [], unavailable: s.sessionsNoHost, live: false }
@@ -132,7 +137,7 @@ export async function readSessionChat(
     }
   }
 
-  const reader = transcriptReaderFor(row.harness)
+  const reader = readerFor(row.harness)
   if (!reader) {
     const name = row.harness
     return {
@@ -185,8 +190,23 @@ export async function readSessionChat(
   // briefly an optional `readWindow` that only Claude implemented, which gives the other four the
   // silent version of the bug the notice exists to fix: the antigravity transcript this reader was
   // written against holds 1239 turns, so a 400-turn window cuts it and says nothing.
-  const read = await reader.read(path, MAX_TURNS)
-    .catch(() => ({ turns: [] as ChatTurn[], older: false }))
+  // A READ THAT FAILED IS NOT AN EMPTY CONVERSATION. This catch used to flatten the two into
+  // `turns: []`, which on a LIVE session carries no `unavailable` — so a transcript that resolved
+  // and then could not be read drew "This conversation has no messages yet" over a conversation
+  // that was entirely there. That is the same confident-empty this module exists to refuse, reached
+  // one step later than the link and format refusals above. The cause behind the report was the
+  // stale memo in `transcript-path-memo.ts`; this is the symptom guard beside it, so the next cause
+  // says something instead of drawing a blank pane.
+  const read = await reader.read(path, MAX_TURNS).catch(() => null)
+  if (read === null) {
+    return {
+      turns: [],
+      unavailable: lang === 'pt'
+        ? 'A transcrição desta conversa foi encontrada nesta máquina, mas não pôde ser lida.'
+        : 'This conversation’s transcript was found on this machine, but could not be read.',
+      live,
+    }
+  }
   // What is still waiting, judged against the user turns THIS read returned. The window matters and
   // is the right one: a message queued a minute ago cannot be older than the last 400 turns, and
   // comparing against a wider slice would cost a second read to learn nothing.

--- a/packages/server/server/sessions/harness-transcript.ts
+++ b/packages/server/server/sessions/harness-transcript.ts
@@ -35,7 +35,7 @@ import { parseKimiChat } from './kimi-chat'
 import type { ChatTurn } from './chat-turn'
 import { readChatWindow, readRecentChatTurns, resolveChatTranscriptPath } from './chat-tail'
 import { readTailWindow } from './transcript-window'
-import { createTranscriptPathMemo } from './transcript-path-memo'
+import { createTranscriptPathMemo, resolveMemoizedPath } from './transcript-path-memo'
 
 /** Everything a reader is told about the session whose conversation is wanted. */
 export interface TranscriptRef {
@@ -186,18 +186,16 @@ export async function resolveCodexTranscript(
   // Codex's ids are UUIDv7; `UUID_RE` is version-agnostic, so this rejects a path fragment without
   // rejecting the real thing.
   if (!UUID_RE.test(ref.conversationId)) return null
-  const known = codexPathMemo.get(ref.conversationId)
-  if (known !== undefined) return known
-  // A MISS EXPIRES. Codex writes a rollout when the conversation first says something, so a
-  // session agentop has just started has no file — and remembering that answer for the life of the
-  // process made the conversation unreadable for the life of the process. See
-  // `transcript-path-memo.ts`; codex has no cheap direct path, so the scan itself is what the TTL
-  // paces.
-  if (!codexPathMemo.mayScan(ref.conversationId, now)) return null
-  codexPathMemo.missed(ref.conversationId, now)
-  const found = await scanCodexRollout(ref.conversationId, sessionsDir)
-  if (found !== null) codexPathMemo.remember(ref.conversationId, found)
-  return found
+  // A MISS EXPIRES and a HIT IS VERIFIED — both rules live in `resolveMemoizedPath`. Codex writes a
+  // rollout when the conversation first says something, so a session agentop has just started has
+  // no file, and remembering that answer for the life of the process made the conversation
+  // unreadable for the life of the process. Codex has no cheap direct path, so the scan itself is
+  // what the TTL paces.
+  return resolveMemoizedPath(codexPathMemo, ref.conversationId, {
+    exists,
+    scan: () => scanCodexRollout(ref.conversationId, sessionsDir),
+    now,
+  })
 }
 
 const CODEX: HarnessTranscript = {
@@ -310,14 +308,12 @@ export async function resolveKimiTranscript(
   now: number = Date.now(),
 ): Promise<string | null> {
   if (!UUID_RE.test(ref.conversationId)) return null
-  const known = kimiPathMemo.get(ref.conversationId)
-  if (known !== undefined) return known
-  // A MISS EXPIRES — same reason as codex's above.
-  if (!kimiPathMemo.mayScan(ref.conversationId, now)) return null
-  kimiPathMemo.missed(ref.conversationId, now)
-  const found = await findKimiWire(ref.conversationId, sessionsDir)
-  if (found !== null) kimiPathMemo.remember(ref.conversationId, found)
-  return found
+  // A MISS EXPIRES and a HIT IS VERIFIED — same reasons as codex's above.
+  return resolveMemoizedPath(kimiPathMemo, ref.conversationId, {
+    exists,
+    scan: () => findKimiWire(ref.conversationId, sessionsDir),
+    now,
+  })
 }
 
 const KIMI: HarnessTranscript = {

--- a/packages/server/server/sessions/transcript-path-memo.test.ts
+++ b/packages/server/server/sessions/transcript-path-memo.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test'
-import { createTranscriptPathMemo, TRANSCRIPT_MISS_TTL_MS } from './transcript-path-memo'
+import { createTranscriptPathMemo, resolveMemoizedPath, TRANSCRIPT_MISS_TTL_MS } from './transcript-path-memo'
 
 describe('transcript path memo — a miss is a fact about the MOMENT', () => {
   const ID = 'c1'
@@ -37,5 +37,87 @@ describe('transcript path memo — a miss is a fact about the MOMENT', () => {
     // The number is the only thing standing between "one scan per poll" and "one scan per miss",
     // so it is pinned rather than left to drift.
     expect(TRANSCRIPT_MISS_TTL_MS).toBe(30_000)
+  })
+})
+
+describe('a remembered path is verified — a transcript DOES move', () => {
+  const ID = 'c1'
+  const HERE = '/p/a/c1.jsonl'
+  const THERE = '/p/b/c1.jsonl'
+  const never = async () => null
+  const noFiles = async () => false
+  const onlyThere = async (p: string) => p === THERE
+
+  test('THE REPORTED CASE: the file moved, so the memo is dropped and the scan finds it', async () => {
+    // Measured 2026-09-08: a live session's cwd changed, Claude Code re-filed the whole 2.4 MB
+    // transcript under another project directory, and the chat panel drew "no messages yet" over
+    // it — because the memo answered the old path and nothing ever checked it was still there.
+    const m = createTranscriptPathMemo()
+    m.remember(ID, HERE)
+    const got = await resolveMemoizedPath(m, ID, {
+      exists: onlyThere, scan: async () => THERE, now: 0,
+    })
+    expect(got).toBe(THERE)
+    expect(m.get(ID)).toBe(THERE)
+  })
+
+  test('a remembered path that is still there costs one stat and no scan', async () => {
+    const m = createTranscriptPathMemo()
+    m.remember(ID, HERE)
+    let scans = 0
+    const got = await resolveMemoizedPath(m, ID, {
+      exists: async () => true,
+      scan: async () => { scans++; return null },
+      now: 0,
+    })
+    expect(got).toBe(HERE)
+    expect(scans).toBe(0)
+  })
+
+  test('a STALE hit never buys the miss TTL — the scan runs on that very call', async () => {
+    // Forgetting alone would be half a fix: if the stale path could leave a miss standing, the
+    // conversation would stay unreadable for the length of the TTL after every move.
+    const m = createTranscriptPathMemo(30_000)
+    m.remember(ID, HERE)
+    let scans = 0
+    await resolveMemoizedPath(m, ID, {
+      exists: noFiles, scan: async () => { scans++; return null }, now: 0,
+    })
+    expect(scans).toBe(1)
+  })
+
+  test('THE DELETION CASE: Claude Code removes transcripts after 30 days, and it reads the same', async () => {
+    // No cwd change needed to reach this. A long-lived server that once resolved a conversation
+    // holds a path to a file that is eventually deleted under it.
+    const m = createTranscriptPathMemo()
+    m.remember(ID, HERE)
+    const got = await resolveMemoizedPath(m, ID, { exists: noFiles, scan: never, now: 0 })
+    expect(got).toBeNull()
+    expect(m.get(ID)).toBeUndefined()
+  })
+
+  test('the DIRECT path is preferred to a scan and is remembered', async () => {
+    const m = createTranscriptPathMemo()
+    let scans = 0
+    const got = await resolveMemoizedPath(m, ID, {
+      exists: noFiles,
+      direct: async () => HERE,
+      scan: async () => { scans++; return THERE },
+      now: 0,
+    })
+    expect(got).toBe(HERE)
+    expect(scans).toBe(0)
+    expect(m.get(ID)).toBe(HERE)
+  })
+
+  test('a fresh miss still withholds the scan — the old guarantee is intact', async () => {
+    const m = createTranscriptPathMemo(30_000)
+    let scans = 0
+    const scan = async () => { scans++; return null }
+    await resolveMemoizedPath(m, ID, { exists: noFiles, scan, now: 0 })
+    await resolveMemoizedPath(m, ID, { exists: noFiles, scan, now: 1_000 })
+    expect(scans).toBe(1)
+    await resolveMemoizedPath(m, ID, { exists: noFiles, scan, now: 30_000 })
+    expect(scans).toBe(2)
   })
 })

--- a/packages/server/server/sessions/transcript-path-memo.ts
+++ b/packages/server/server/sessions/transcript-path-memo.ts
@@ -15,9 +15,12 @@
  * showed the whole conversation. Nothing was lost and nothing was queued; the chat was reading a
  * remembered "there is no file here".
  *
- * So: **a found path is remembered forever** (a transcript does not move, and that is a fact about
- * the conversation), and **a miss is remembered only for a while** (it is a fact about the moment).
- * Same rule, and the same reason, as `repo-facts.ts`'s negative TTL.
+ * So: **a miss is remembered only for a while** (it is a fact about the moment) — same rule, and the
+ * same reason, as `repo-facts.ts`'s negative TTL — and **a found path is remembered until it stops
+ * being there**, which is a weaker claim than the one this module shipped with. It said "a found
+ * path is remembered forever (a transcript does not move)". It moves, and it is also deleted; that
+ * sentence cost a user every reply for the length of a session. `resolveMemoizedPath` at the foot of
+ * this file is where the corrected rule lives, and its comment carries the measurement.
  */
 
 /**
@@ -35,6 +38,9 @@ export interface TranscriptPathMemo {
   get(id: string): string | undefined
   /** Remember a path. Clears any miss — the question is settled. */
   remember(id: string, path: string): void
+  /** Drop a remembered path that is no longer on disk. Leaves NO miss behind, so the resolve
+   *  that discovered the staleness may scan on that same call — see `resolveMemoizedPath`. */
+  forget(id: string): void
   /** Record that a scan came back empty at `now`. */
   missed(id: string, now: number): void
   /** May the expensive scan be spent on this id now? `false` only inside a fresh miss's TTL. */
@@ -49,6 +55,7 @@ export function createTranscriptPathMemo(ttlMs = TRANSCRIPT_MISS_TTL_MS): Transc
   return {
     get: id => found.get(id),
     remember(id, path) { found.set(id, path); missedAt.delete(id) },
+    forget(id) { found.delete(id) },
     missed(id, now) { missedAt.set(id, now) },
     mayScan(id, now) {
       const at = missedAt.get(id)
@@ -56,4 +63,78 @@ export function createTranscriptPathMemo(ttlMs = TRANSCRIPT_MISS_TTL_MS): Transc
     },
     clear() { found.clear(); missedAt.clear() },
   }
+}
+
+/**
+ * A REMEMBERED PATH IS STILL A GUESS UNTIL IT IS STATTED, and the header above used to say
+ * otherwise: "a found path is remembered forever — a transcript does not move". It does move.
+ *
+ * Claude Code files a transcript under the project directory derived from the session's CURRENT
+ * cwd, so a session whose cwd changes has its `<conversation-id>.jsonl` MOVED wholesale to another
+ * project directory. Measured 2026-09-08 on a live session: the file left
+ * `~/.claude/projects/-home-mithrandir-agentistics/` and reappeared, whole and still being written,
+ * under `…--claude-worktrees-session-shell/`. Every later resolve answered the remembered path,
+ * `readChatWindow` failed on a file that was not there, the catch turned that into `turns: []`, and
+ * because the session was LIVE the payload carried no `unavailable` — so the panel drew "This
+ * conversation has no messages yet" over a 2.4 MB transcript. The user stopped seeing replies
+ * entirely and had to attach to the terminal to read anything.
+ *
+ * The cwd change is not the only way to get there, and not the common one. **Claude Code deletes
+ * transcripts older than `cleanupPeriodDays` (30 by default) on every startup** — so any long-lived
+ * server that once resolved a conversation holds a path to a file that is eventually deleted under
+ * it, and answers with it forever. A moved file and a deleted file fail identically here.
+ *
+ * The scan that would find the file in its new home was already written and already correct. It was
+ * simply never reached, because the memo answered first. So: verify before answering, and on a
+ * remembered path that is gone, FORGET it and resolve again from scratch. `remember` clears any
+ * miss, so a forgotten id is free to scan immediately — a stale path must never buy the miss TTL.
+ *
+ * The cost is ONE `stat` on a memo hit, which is exactly what a memo MISS already spent on its
+ * direct path. It is not a new class of work, and it is the whole of the fix.
+ */
+
+/** Is this path still on disk? Injected so this module stays pure and testable without a fixture. */
+export type PathExists = (path: string) => Promise<boolean>
+
+export interface MemoizedResolve {
+  exists: PathExists
+  /**
+   * The CHEAP guess, tried on every call before any scan — Claude's cwd-encoded project directory.
+   * Absent for the resolvers that have no direct form and can only search.
+   */
+  direct?: () => Promise<string | null>
+  /** The EXPENSIVE search. Gated by the miss TTL, never by a stale hit. */
+  scan: () => Promise<string | null>
+  now: number
+}
+
+/**
+ * The one shape all three transcript resolvers share: remembered, then direct, then scanned.
+ *
+ * It lives here rather than being written out in `chat-tail.ts`, in `resolveCodexTranscript` and in
+ * `resolveKimiTranscript` because it WAS written out in all three, identically, and the staleness
+ * above was therefore three bugs. A rule with three copies is the defect `task-reopen.ts` exists to
+ * have fixed once.
+ */
+export async function resolveMemoizedPath(
+  memo: TranscriptPathMemo,
+  id: string,
+  o: MemoizedResolve,
+): Promise<string | null> {
+  const known = memo.get(id)
+  if (known !== undefined) {
+    if (await o.exists(known)) return known
+    // Moved or deleted. Forgetting is not enough on its own — it is what lets the scan below run
+    // on this very call instead of on the far side of a TTL the stale hit never paid.
+    memo.forget(id)
+  }
+  if (o.direct) {
+    const d = await o.direct()
+    if (d !== null) { memo.remember(id, d); return d }
+  }
+  if (!memo.mayScan(id, o.now)) return null
+  memo.missed(id, o.now)
+  const found = await o.scan()
+  if (found !== null) memo.remember(id, found)
+  return found
 }


### PR DESCRIPTION
Fixes #440

## Summary

A remembered transcript path is now **verified before it is answered**. If the file is gone, the memo forgets it and the resolution starts over — reaching the scan that was already there and already correct.

Three resolvers (claude, codex, kimi) wrote that shape by hand, so this was the same bug three times. The rule now lives once, in `resolveMemoizedPath`.

## Motivation

The session chat panel drew `This conversation has no messages yet` over a 2.4 MB conversation, and the user stopped receiving replies altogether — the terminal tab was the only way to read anything.

`transcript-path-memo.ts` carried the premise in writing: *"a found path is remembered forever — a transcript does not move"*. It moves. Claude Code files a transcript under the project directory derived from the session's **current** cwd, so a session whose cwd changes has its `<id>.jsonl` re-filed elsewhere (measured 2026-09-08). And no cwd change is needed to reach the same place: Claude Code deletes transcripts older than `cleanupPeriodDays` (30 by default) on every startup, which fails identically.

## What changed

- **`transcript-path-memo.ts`** — `forget(id)`, plus `resolveMemoizedPath`, which owns the shared remembered → direct → scanned shape. A forgotten id leaves **no miss behind**, so the scan runs on that same call; a stale path must never buy the 30s TTL. The false premise in the module header is corrected in place, with the measurement.
- **`chat-tail.ts`, `harness-transcript.ts`** — the three resolvers now call it instead of restating it.
- **`chat-web.ts`** — the symptom guard beside the cause: a transcript that resolves and then fails to READ became `turns: []`, which on a live session carries no `unavailable` — the same blank pane, one step later. It is now refused in words. `readSessionChat` gained the `readerFor` injection point that branch needed to be testable at all.

## Cost

One `stat` on a memo hit — exactly what a memo MISS already spent on its direct path. Not a new class of work.

## Test plan

- `bun tsc --noEmit` — clean.
- `bun test` — **7352 pass, 0 fail** (pre-commit hook ran both).
- `transcript-path-memo.test.ts` — new: the reported move; a live path costing no scan; a stale hit not buying the TTL; the 30-day deletion case; direct preferred over scan; and the original miss-TTL guarantee still intact.
- `chat-tail.test.ts` — **the test that asserted the false premise is inverted.** It said in as many words *"removing the tree does not un-answer it: a transcript does not move"*. In its place: the reported move, and the deletion case.
- `chat-web.test.ts` — new: a transcript that resolves but cannot be read is refused in words; and the guard does not fire on an ordinary empty conversation, which is what keeps the composer on a brand-new session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVZTKeH2GD6bxgR2EP4mns