### PR TITLE
fix(web): the stop button gives the slot back the moment you type

### DIFF
--- a/packages/web/src/components/sessions/SessionChat.tsx
+++ b/packages/web/src/components/sessions/SessionChat.tsx
@@ -29,6 +29,7 @@
 
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { ArrowDown, ChevronUp, CornerUpLeft, History, Loader, Mic, Paperclip, RotateCcw, Send, SlidersHorizontal, Square, X } from 'lucide-react'
+import { hasSomethingToSend, stopShown as isStopShown } from '../../lib/composerAction'
 import type { ControlSession } from '@agentistics/tui/control/session-fleet'
 import type { FleetActionId, FleetRow } from '../../lib/fleet'
 import { modeStyle } from '../../lib/modeStyle'
@@ -1063,7 +1064,14 @@ export function SessionChat({ session, row, lang, act, onArtifacts }: SessionCha
    * thing left to do to a working session is stop it; a single character means the opposite.
    * Attachments count as something written — a message that is only files is still a message.
    */
-  const stopShown = working && !!stopVerb?.enabled && draft.trim() === '' && attached.length === 0
+  const stopShown = isStopShown({
+    working,
+    stopEnabled: !!stopVerb?.enabled,
+    draft,
+    attachments: attached.length,
+  })
+  /** What the send button could send. The same predicate decides its label, its colour and `stopShown`. */
+  const somethingToSend = hasSomethingToSend({ draft, attachments: attached.length })
   const [stopping, setStopping] = useState(false)
   async function stopNow() {
     if (!stopVerb?.enabled || stopping) return
@@ -2147,8 +2155,14 @@ export function SessionChat({ session, row, lang, act, onArtifacts }: SessionCha
                     every time a turn ended send jumped left under a thumb already moving toward it;
                     moving stop to the head of the group only shortened the jump. Sharing one slot
                     removes it: the control under your thumb is always the one you want, and
-                    nothing else shifts at all. */}
-                {working && stopVerb?.enabled ? (
+                    nothing else shifts at all.
+
+                    `stopShown` DECIDES IT, and this reads that one expression rather than
+                    re-deriving it. It was re-derived here as `working && stopVerb?.enabled`, which
+                    is the same rule minus the draft — so the stop button stayed up while somebody
+                    typed, and the send button they were typing toward never appeared. `stopShown`
+                    was sitting one screen up, correct and unused. */}
+                {stopShown ? (
                   <button
                     onClick={() => void stopNow()}
                     disabled={stopping}
@@ -2169,14 +2183,14 @@ export function SessionChat({ session, row, lang, act, onArtifacts }: SessionCha
                 ) : (
                   <button
                     onClick={() => void send()}
-                    disabled={!canPrompt || sending || (draft.trim() === '' && attached.length === 0)}
+                    disabled={!canPrompt || sending || !somethingToSend}
                     aria-label={pt ? 'Enviar' : 'Send'}
                     style={{
                       display: 'flex', alignItems: 'center', justifyContent: 'center',
                       width: 34, height: 34, borderRadius: 9, border: 'none', flexShrink: 0,
-                      background: (draft.trim() === '' && attached.length === 0) || !canPrompt ? 'transparent' : 'var(--anthropic-orange)',
-                      color: (draft.trim() === '' && attached.length === 0) || !canPrompt ? 'var(--text-tertiary)' : '#fff',
-                      cursor: (draft.trim() === '' && attached.length === 0) || !canPrompt ? 'default' : 'pointer',
+                      background: !somethingToSend || !canPrompt ? 'transparent' : 'var(--anthropic-orange)',
+                      color: !somethingToSend || !canPrompt ? 'var(--text-tertiary)' : '#fff',
+                      cursor: !somethingToSend || !canPrompt ? 'default' : 'pointer',
                     }}
                   >
                     {sending ? <Loader size={15} className="ag-working-spin" /> : <Send size={15} />}

--- a/packages/web/src/lib/composerAction.test.ts
+++ b/packages/web/src/lib/composerAction.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'bun:test'
+import { hasSomethingToSend, stopShown } from './composerAction'
+
+const base = { working: true, stopEnabled: true, draft: '', attachments: 0 }
+
+describe('the shared slot', () => {
+  it('shows STOP on a working session with nothing written', () => {
+    expect(stopShown(base)).toBe(true)
+  })
+
+  it('THE REGRESSION: shows SEND the moment a character is typed', () => {
+    // Reported with a screenshot: ten characters in the composer beside a red stop square. The
+    // rule was correct in one place and re-derived without the draft in the place that drew.
+    expect(stopShown({ ...base, draft: 'quando eu ' })).toBe(false)
+  })
+
+  it('goes back to STOP when the draft is emptied again', () => {
+    expect(stopShown({ ...base, draft: 'a' })).toBe(false)
+    expect(stopShown({ ...base, draft: '' })).toBe(true)
+  })
+
+  it('treats whitespace as nothing written', () => {
+    // A stray space is not a message, and a send button that would post it is a trap.
+    expect(stopShown({ ...base, draft: '   \n ' })).toBe(true)
+  })
+
+  it('counts attachments as something to send, with no text at all', () => {
+    // A message that is only files is still a message.
+    expect(stopShown({ ...base, attachments: 1 })).toBe(false)
+  })
+
+  it('never shows STOP on a session that is not working', () => {
+    expect(stopShown({ ...base, working: false })).toBe(false)
+    expect(stopShown({ ...base, working: false, draft: 'x' })).toBe(false)
+  })
+
+  it('never shows STOP where the row does not offer one', () => {
+    // A stop on a row that cannot take it sends Escape into the session's prompt.
+    expect(stopShown({ ...base, stopEnabled: false })).toBe(false)
+  })
+})
+
+describe('hasSomethingToSend', () => {
+  it('is the same predicate the send button disables itself on', () => {
+    expect(hasSomethingToSend({ draft: '', attachments: 0 })).toBe(false)
+    expect(hasSomethingToSend({ draft: ' ', attachments: 0 })).toBe(false)
+    expect(hasSomethingToSend({ draft: 'x', attachments: 0 })).toBe(true)
+    expect(hasSomethingToSend({ draft: '', attachments: 2 })).toBe(true)
+  })
+})

--- a/packages/web/src/lib/composerAction.ts
+++ b/packages/web/src/lib/composerAction.ts
@@ -1,0 +1,40 @@
+/**
+ * composerAction.ts — PURE: which face the composer's one action button is wearing.
+ *
+ * The button shares a slot: STOP while the session works, SEND otherwise. Sharing the slot is what
+ * stops the control under a thumb moving when a turn ends — but it means one expression has to
+ * decide, and that expression is here rather than inline in the JSX.
+ *
+ * IT LIVED IN TWO PLACES AND THEY DISAGREED. The rule was written correctly as a local
+ * `stopShown`, and the JSX re-derived it as `working && stopVerb?.enabled` — the same rule minus
+ * the draft. A merge that took one side's markup and the other side's variable left the weaker
+ * copy drawing and the correct one unused, so the stop button stayed up while somebody typed and
+ * the send button they were typing toward never appeared. Reported with a screenshot of ten
+ * characters sitting beside a red square.
+ *
+ * THE DRAFT IS WHAT DECIDES between the two faces. Nothing written means there is nothing to send,
+ * so the only thing left to do to a working session is stop it; a single character means the
+ * opposite. Attachments count as something written — a message that is only files is still a
+ * message.
+ */
+
+export interface ComposerActionInput {
+  /** Is the session producing right now? */
+  working: boolean
+  /** Does the row actually OFFER a stop? A stop on an idle session sends Escape into its prompt. */
+  stopEnabled: boolean
+  /** The composer's text, verbatim. */
+  draft: string
+  /** How many files are attached. */
+  attachments: number
+}
+
+/** True when the shared slot shows STOP. False means it shows SEND. */
+export function stopShown(o: ComposerActionInput): boolean {
+  return o.working && o.stopEnabled && !hasSomethingToSend(o)
+}
+
+/** Is there anything the send button could send — text, or files, or both? */
+export function hasSomethingToSend(o: Pick<ComposerActionInput, 'draft' | 'attachments'>): boolean {
+  return o.draft.trim() !== '' || o.attachments > 0
+}


### PR DESCRIPTION
## Summary

- The composer's shared action slot gives itself back to SEND the moment anything is typed, and returns to STOP when the field is emptied.
- The rule that decides it is now a pure, tested module instead of an expression two places re-derived differently.

## Motivation

Fixes #442.

The slot shows STOP while a session works and SEND otherwise, and the DRAFT is what decides between the two faces. That rule was written correctly as a local `stopShown` — and the JSX re-derived it as `working && stopVerb?.enabled`, which is the same rule **minus the draft**.

`4ea88915`, whose subject reads *"where both sides fixed the same thing, the better one won"*, took one side's markup and the other side's variable. The weaker copy was the one drawing; `stopShown` sat one screen above it, correct and unused. So the red square stayed up while somebody typed and the send button they were typing toward never appeared.

## Changes

**`packages/web/src/lib/composerAction.ts`** (new, pure) — `stopShown()` and `hasSomethingToSend()`, with the reason the module exists in its header. Extracted rather than left inline because the bug's cause was the rule having two homes, and only a named function can be pinned by a test.

**`packages/web/src/lib/composerAction.test.ts`** (new) — eight cases, including the reported regression (a character flips the slot), the return trip (emptying flips it back), whitespace not counting as a message, an attachment with no text counting as one, and the two preconditions (not working, or a row that offers no stop).

**`packages/web/src/components/sessions/SessionChat.tsx`** — the slot reads `stopShown` instead of re-deriving it, and the send button reads one `somethingToSend` for its `disabled` and its three colours instead of spelling the emptiness check out four separate times. That repetition is what let the two copies drift with nothing failing.

## Test plan

- [x] `bun tsc --noEmit` clean.
- [x] `bun test` — **7362 pass / 0 fail**.
- [x] The new test fails against the old expression: `stopShown` with `draft: 'quando eu '` returned `true` under `working && stopVerb?.enabled` and returns `false` now.
- [x] Checked that the swap actually delivers a usable button rather than a differently-inert one: `canPrompt` is `!loading && session.actionable && (!blocked || answeringNow) && payload.live !== false` — it does not include `working`, so the send button is enabled on a working session once there is text. Nothing else in the file gates the composer on `working`.

**What reviewers should check**

- Whether `stopShown`'s preconditions are still right: a stop is offered only where the row's `interrupt` verb is enabled, because a stop on an idle session sends Escape into its prompt.
- The behaviour on a session sitting on a dialog is deliberately unchanged — `blocked` still denies `canPrompt`, so the composer stays refused there for the reason `dialog-choice.ts` documents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019LT77q1YCgYQ6L8d1RRcM3
