### PR TITLE
fix(sessions): the submit check cannot answer on an animating pane, and now says so

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2362,6 +2362,24 @@ harness must not break.
   copilot and gemini** need no memo — each computes or checks its two candidate paths on every call
   — and are immune by construction. A new reader that needs a DIRECTORY LISTING to find its file
   needs this memo, and needs it this way round.
+- **A CHECK THAT CANNOT ANSWER MUST SAY SO, NOT RETURN THE CONVENIENT ANSWER.** `sendTextTo` types a
+  prompt and sends `Enter`, and `submit-check.ts` exists because tmux's exit code says the keys were
+  WRITTEN and nothing about the harness having acted on them. Its test was `frameChanged` over the
+  whole pane — "what a submit reliably does is change the frame: the input empties" — which is true
+  of a STILL pane and meaningless on a BUSY one: a session mid-turn advances its spinner glyph, its
+  elapsed timers and its token counter on its own. Measured 2026-09-08 on a live pane, two captures
+  200 ms apart with NOTHING sent between them, three lines differed. So the check returned `true` on
+  the first 60 ms poll of every send to a working session, the bounded retry NEVER fired, and a
+  swallowed return was reported as delivered — the composer cleared and the row said "delivered · it
+  reads this when its turn ends" over a prompt still in the harness's input box, found there with 36
+  minutes on the clock. **That is the worst place to lose the retry**: a busy session is exactly
+  where the return is at risk (the input arrives as one burst, the harness reads it as a paste, and
+  a return landing inside that burst is a newline) and also the only place a successful submit shows
+  nothing, because the message goes to a queue rather than starting a turn. So the pane is ASKED
+  whether it animates — two captures before the return, nothing sent between — and `needsSecondReturn`
+  resolves every case it cannot settle TOWARD the keystroke: a redundant return on an emptied input
+  does nothing, a missing one strands a message until somebody opens the terminal. A still pane keeps
+  the old behaviour exactly.
 - **A SESSION'S GIT STATS ARE READ WHERE IT WORKED, NOT WHERE IT IS FILED.** `project_path` is the
   transcript's FIRST cwd — the project the session belongs to — and `current_cwd` is where it ended
   up. They differ exactly in the git-WORKTREE case this file mandates for concurrent work, and a

--- a/packages/server/server/sessions/backend-tmux.ts
+++ b/packages/server/server/sessions/backend-tmux.ts
@@ -14,7 +14,7 @@ import {
 import { dependencyCommandLine } from './dependency-plan'
 import { probeDependency } from './dependency-probe'
 import { planPromptDelivery } from './initial-prompt'
-import { frameChanged } from './submit-check'
+import { frameChanged, needsSecondReturn } from './submit-check'
 import { writeToPane } from './pane-writer'
 import type {
   BackendInitialPrompt, BackendSession, BackendSpawn, SessionBackend, TerminalCapture,
@@ -129,15 +129,35 @@ async function typeAndSubmit(id: string, text: string): Promise<boolean> {
   // not the prompt's own words.
   await sleep(SUBMIT_SETTLE_MS)
   const typedFrame = await captureFrame(id)
+
+  // DOES THIS PANE REPAINT ON ITS OWN? Two captures with nothing sent between them, which is the
+  // only way to find out. A session mid-turn advances its spinner glyph, its elapsed timers and its
+  // token counter, so the post-return comparison below answered `true` however the submit went —
+  // on exactly the sessions the retry exists for. See `needsSecondReturn` for the measurement.
+  await sleep(SUBMIT_POLL_MS)
+  const settleFrame = await captureFrame(id)
+  const animating = frameChanged(typedFrame, settleFrame)
+
   if ((await tmux(sendKeysNamedArgs(id, 'Enter'))).code !== 0) return false
+
+  // The comparison is only SPENT where it can answer, and it is made against the LAST pre-return
+  // capture — against `typedFrame` the animation between the two would count as movement all over
+  // again. On an animating pane it is skipped outright: it would return true on the first poll and
+  // cost a poll to learn nothing, so a busy send now gets faster rather than slower.
+  //
   // POLLED, not slept. A fixed wait spends its whole budget on every message — measured at ~820ms
   // per send, which a person feels on every keystroke of a conversation ("DEMORA MUITO pra enviar
-  // as mensagens"). The pane usually moves within one or two frames, so the common case now costs
-  // one poll and the budget is only spent when the submit genuinely did not show.
-  if (!(await paneMoved(id, typedFrame))) {
-    // The pane did not move. That is NOT proof the submit was swallowed — measured: a screen that
-    // redraws identically looks the same either way — so it buys one more return rather than a
-    // verdict. An extra return on an emptied input does nothing.
+  // as mensagens"). The pane usually moves within one or two frames, so the common case costs one
+  // poll and the budget is only spent when the submit genuinely did not show.
+  const moved = animating ? false : await paneMoved(id, settleFrame)
+
+  if (needsSecondReturn(animating, moved)) {
+    // Settled first, for the reason the gap above exists at all: two returns microseconds apart are
+    // one burst to a terminal UI reading them, and the second would be swallowed with the first.
+    await sleep(SUBMIT_SETTLE_MS)
+    // NOT proof the submit was swallowed — a screen that redraws identically looks the same either
+    // way — so this buys one more return rather than a verdict. An extra return on an emptied input
+    // does nothing; a missing one strands the message until somebody opens the terminal.
     await tmux(sendKeysNamedArgs(id, 'Enter'))
   }
   return true

--- a/packages/server/server/sessions/submit-check.test.ts
+++ b/packages/server/server/sessions/submit-check.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from 'bun:test'
-import { frameChanged } from './submit-check'
+import { frameChanged, needsSecondReturn } from './submit-check'
 
 test('an input that emptied is a change', () => {
   expect(frameChanged(['> hello there', '  auto mode on'], ['> ', '  auto mode on'])).toBe(true)
@@ -16,4 +16,37 @@ test('trailing blank lines are not a change — a TUI repaints its own padding',
 
 test('a blank line in the MIDDLE is a change — only the tail is padding', () => {
   expect(frameChanged(['a', 'b'], ['a', '', 'b'])).toBe(true)
+})
+
+/**
+ * THE CHECK WAS A CONSTANT `true` ON EXACTLY THE SESSIONS IT EXISTS FOR.
+ *
+ * `frameChanged` is right about an IDLE pane and says nothing about a BUSY one: a session mid-turn
+ * repaints its own spinner, its elapsed timers and its token counter, so any two captures differ
+ * however the submit went. Measured 2026-09-08 on a live pane, two captures 200 ms apart with
+ * NOTHING sent to it:
+ *
+ *     < ● UI fixes: delivery picker… · 1m 28s     >   UI fixes: delivery picker… · 1m 29s
+ *     < * Drizzling… (37m 47s · ↓ 56.8k tokens)   > ✻ Drizzling… (37m 47s · ↓ 56.8k tokens)
+ *
+ * So `paneMoved` returned true on its first 60 ms poll of every send to a working session, the
+ * bounded retry never fired, and a swallowed return was reported as delivered — the composer
+ * cleared and the row said "delivered · it reads this when its turn ends" over a prompt sitting
+ * unsent in the harness's input box. Observed with 36 minutes on the clock.
+ */
+test('an ANIMATING pane always buys the extra return — the check cannot answer there', () => {
+  // Whatever the post-return comparison said, it was measuring the spinner.
+  expect(needsSecondReturn(true, true)).toBe(true)
+  expect(needsSecondReturn(true, false)).toBe(true)
+})
+
+test('a STILL pane keeps today’s behaviour exactly', () => {
+  expect(needsSecondReturn(false, true)).toBe(false)
+  expect(needsSecondReturn(false, false)).toBe(true)
+})
+
+test('the safe default is pressing return again, because that is the harmless direction', () => {
+  // An extra return on an emptied input does nothing; a missing one strands the message. So every
+  // case this cannot settle resolves toward the keystroke.
+  for (const moved of [true, false]) expect(needsSecondReturn(true, moved)).toBe(true)
 })

--- a/packages/server/server/sessions/submit-check.ts
+++ b/packages/server/server/sessions/submit-check.ts
@@ -44,3 +44,37 @@ function trim(lines: readonly string[]): string[] {
   while (out.length > 0 && (out[out.length - 1] ?? '').trim() === '') out.pop()
   return out
 }
+
+/**
+ * Should a second return be sent?
+ *
+ * THE CHECK ABOVE ANSWERS ONLY FOR A STILL PANE, and for one release nothing said so. `frameChanged`
+ * asks "did anything on screen change" as a proxy for "did the input empty", and a session MID-TURN
+ * changes on its own: the spinner glyph, the elapsed timers and the token counter all advance
+ * between any two captures. Measured 2026-09-08 on a live pane, two captures 200 ms apart with
+ * nothing sent to it, three lines differed. So the proxy was `true` on the first 60 ms poll of every
+ * send to a working session, the bounded retry never fired, and a swallowed return was reported as
+ * delivered: the composer cleared and the row said "delivered · it reads this when its turn ends"
+ * over a prompt still sitting in the harness's input box, found there with 36 minutes on the clock.
+ *
+ * That is the worst possible place to lose the retry. A BUSY session is exactly where the return is
+ * at risk — the input arrives as one fast burst, the harness reads it as a paste, and a return
+ * landing inside that burst becomes a newline rather than a submit — and it is also the only place
+ * where a submit produces no obvious change, because the message goes to a queue instead of
+ * starting a turn.
+ *
+ * So the pane is ASKED whether it animates, by comparing two captures taken before the return with
+ * nothing sent between them, and:
+ *
+ * - **animating** — the comparison cannot answer, so press return again. This is not a guess; it is
+ *   the module's own rule applied honestly: "nothing moved" was never evidence, only a reason to
+ *   press return once more, and on an emptied input that costs nothing.
+ * - **still** — today's behaviour exactly, unchanged and untouched.
+ *
+ * Every case this cannot settle therefore resolves toward the keystroke, because the two errors are
+ * not symmetric: a redundant return on an empty input does nothing, while a missing one strands a
+ * message for as long as nobody opens the terminal.
+ */
+export function needsSecondReturn(animating: boolean, movedAfterReturn: boolean): boolean {
+  return animating || !movedAfterReturn
+}


### PR DESCRIPTION
Fixes #444

## Summary

The pane is now ASKED whether it repaints on its own — two captures before the return, nothing sent between them — and `needsSecondReturn` resolves every case the check cannot settle **toward the keystroke**. A still pane keeps today's behaviour exactly.

## Motivation

A message sent from the dashboard sat unsent in the session's composer for 36 minutes while the row said `entregue à sessão há 13 min — ela lê ao terminar o turno`.

`submit-check.ts` exists for this exact report and its header quotes it. It sends a second `Enter` when the pane does not move. **It was disabled on precisely the sessions it exists for**: the test was `frameChanged` over the whole pane, and a session mid-turn advances its spinner glyph, its elapsed timers and its token counter on its own. Measured on the live pane, two captures 200 ms apart with nothing sent between them, three lines differed. So the check returned `true` on the first 60 ms poll of every send to a working session and the retry never fired.

Worst place to lose it: a busy session is where the return is most at risk — the text arrives as one burst, the harness reads it as a paste, and a return inside that burst is a newline — and also the only place where a successful submit shows nothing, because the message is queued rather than starting a turn.

## What changed

- **`submit-check.ts`** — `needsSecondReturn(animating, movedAfterReturn)`, pure, with the measurement in its doc comment. `frameChanged` is untouched.
- **`backend-tmux.ts`** — one extra capture one poll interval after the first, before the return, to measure whether the pane animates. The post-return comparison is made against the LAST pre-return capture (against the earlier one the animation would count as movement all over again) and is skipped entirely on an animating pane. The second return is preceded by a settle, for the reason the first gap exists: two returns microseconds apart are one burst.
- **`CLAUDE.md`** — the rule and its measurement, which were recorded nowhere outside the module.

## Cost

A still pane pays one capture plus 60 ms. **A busy pane gets faster**: it skips a poll of up to 600 ms that could only ever have learned nothing.

## Why the default leans to pressing return again

The two errors are not symmetric. A redundant return on an emptied input does nothing; a missing one strands a message until somebody opens the terminal. That is the module's own rule — *"nothing moved is not evidence of anything; it is only a reason to press return once more"* — applied where it had stopped being applied.

## Test plan

- `bun tsc --noEmit` — clean.
- `bun test` — **7399 pass, 0 fail** (pre-commit hook ran both).
- `submit-check.test.ts` — new: an animating pane always buys the extra return whatever the post-return comparison said; a still pane keeps both of today's outcomes; and the uncertain case resolves toward the keystroke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVZTKeH2GD6bxgR2EP4mns