### PR TITLE
feat(sessions): a note's badge highlights the item that was used

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2335,13 +2335,34 @@ harness must not break.
   replaces; `chatNote.test.ts` greps the server's own sources and fails the build when a note can
   be emitted that this table does not carry — the gap the old `SYSTEM_NOTE_PT` fell into when five
   readers arrived with notes of their own. **TWO SHAPES, deliberately different**: a note with a
-  destination is a button wearing an arrow that calls `openArtifacts(tab)` — the same call the edge
-  strip makes, so it opens the ASIDE and never a full screen — and a note with nowhere to go tells
-  you instead, on tap as well as hover, because a phone has no hover. One appearance for both would
-  make half the chips silently inert. **`tab` is NOT filled in wherever it would fit**: `command
-  output` would point at the `live` feed, hundreds of rows deep, and with no step id on a chat turn
-  the click lands at the top of a list to be searched — which the edge strip's own comment already
-  calls a navigation control rather than an answer. Those explain and do not navigate.
+  destination is a button wearing an arrow that calls `openArtifacts(tab, ref)` — the same call the
+  edge strip makes, so it opens the ASIDE and never a full screen — and a note with nowhere to go
+  tells you instead, on tap as well as hover, because a phone has no hover. One appearance for both
+  would make half the chips silently inert. **`tab` is NOT filled in wherever it would fit**:
+  `command output` would point at the `live` feed, hundreds of rows deep, with no step id on the
+  turn to land on, and the click would arrive at the top of a list to be searched — which the edge
+  strip's own comment already calls a navigation control rather than an answer. Those explain and do
+  not navigate.
+  **A NOTE THAT CAN NAME THE THING CARRIES IT** (`ChatTurn.systemRef`), and until it did, a chip
+  that navigated still landed on a list to be hunted. The body knew: measured on real transcripts, a
+  skill load carries `Base directory for this skill: <dir>` and a re-invocation carries
+  `(Re-invocation of /<invocation-name> — …`. The BODY stays dropped; only the identity is kept, and
+  it is kept in the form the panel LISTS — `HarnessSkill.name`, prefix and all — through the pure
+  `skillNameFromDir`, which reads the layout off the `SkillSource` the harness already declares
+  rather than re-deriving it. `skill-source.ts` exists for exactly that: `chat-envelope.ts` is a
+  zero-import pure parser and importing the skills READER would have dragged `HOME_DIR` and the
+  whole of `config.ts` into it. A directory matching no declared source yields NO reference rather
+  than its basename — a basename looks like an answer and matches no row. **The aside's focus
+  machinery was already complete and disconnected**: `openArtifacts` has always taken a `ref`,
+  `EventRow` has always answered `focused` by opening itself, scrolling into view and flashing, and
+  the state was computed and faded on a timer — nothing ever passed the prop, so the live feed's own
+  `openArtifacts('live', hint.ref)` landed at the top of the feed too. Both lists are wired now,
+  through the pure `noteFocus.ts`: `ROW_FLASH` is one constant so two tabs cannot disagree about
+  what "the one you asked for" looks like, an ABSENT reference focuses nothing, and a reference NO
+  row carries is SAID in words — a tab that opens and highlights nothing is indistinguishable from a
+  button that did not work. The highlight FADES (4 s), because it answers "which one" and a marker
+  that stays becomes part of the row; re-pressing the same chip re-arms it, since the request is
+  keyed on its own `at`.
 - **A TRANSCRIPT THAT IS NOT THERE YET IS NOT A TRANSCRIPT THAT IS NOWHERE.** Three resolvers
   memoized their answer by conversation id — the found path AND the `null` — so an unresolvable id
   cost one scan instead of one per poll. The intent is right; caching the `null` was not. **A

--- a/packages/server/server/sessions/chat-envelope.test.ts
+++ b/packages/server/server/sessions/chat-envelope.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'bun:test'
+import { describe, expect, it, test } from 'bun:test'
 import { classifyUserEntry, classifyUserText } from './chat-envelope'
 
 describe('classifyUserText', () => {
@@ -169,4 +169,40 @@ describe('the compaction summary', () => {
   const quoted = 'This session is being continued from a previous conversation that ran out of context.'
   expect(classifyUserEntry({ text: quoted }).kind).toBe('person')
   })
+})
+
+/**
+ * A NOTE NAMES A KIND; SOME BODIES ALSO NAME THE THING.
+ *
+ * The chip for `a skill was loaded` opens the skills tab and lands at the top of a list to be
+ * searched — the limitation CLAUDE.md already records. The body knew all along: measured on real
+ * transcripts, a load carries `Base directory for this skill: <dir>` and a re-invocation carries
+ * `(Re-invocation of /<invocation-name> — …`. The BODY is still dropped; only the identity is kept.
+ */
+test('a skill LOAD carries which skill, in the form the panel names it', () => {
+  expect(classifyUserEntry({
+    text: 'Base directory for this skill: /home/u/.claude/plugins/cache/superpowers-dev/superpowers/6.0.2/skills/brainstorming\n\n# Brainstorming',
+    isMeta: true,
+  })).toEqual({ kind: 'system', note: 'a skill was loaded', noteRef: 'superpowers:brainstorming' })
+})
+
+test('a skill RE-INVOCATION carries it too, from its own measured shape', () => {
+  // `(Re-invocation of /claude-code-notifications:ccn — the skill instructions were previously
+  // loaded; …` — the invocation name is already there, behind a leading slash.
+  expect(classifyUserEntry({
+    text: '(Re-invocation of /claude-code-notifications:ccn — the skill instructions were previously loaded)',
+    isMeta: true,
+  })).toEqual({ kind: 'system', note: 'a skill was re-invoked', noteRef: 'claude-code-notifications:ccn' })
+})
+
+test('a note whose body names nothing carries NO reference — an absent one, never an empty one', () => {
+  expect(classifyUserEntry({ text: 'Continue from where you left off.', isMeta: true }))
+    .toEqual({ kind: 'system', note: 'the session was resumed' })
+})
+
+test('a skill directory outside every declared source loads WITHOUT a reference', () => {
+  // The chip then behaves exactly as it does today: it opens the tab and claims nothing about which
+  // row. A basename would look like an answer and match no row.
+  expect(classifyUserEntry({ text: 'Base directory for this skill: /opt/elsewhere/thing', isMeta: true }))
+    .toEqual({ kind: 'system', note: 'a skill was loaded' })
 })

--- a/packages/server/server/sessions/chat-envelope.ts
+++ b/packages/server/server/sessions/chat-envelope.ts
@@ -66,6 +66,11 @@
  * the direction that has to be safe.
  */
 
+// The PURE half of the skills table — never the reader, which would drag `config.ts` and its
+// import-time environment reads into this parser. See `skill-source.ts`'s header.
+import { HARNESS_SKILLS, skillNameFromDir } from './skill-source'
+
+
 /** What a `user` entry turns out to be. */
 export type UserEntry =
   /** The person typed this. `text` is theirs, verbatim. */
@@ -74,7 +79,20 @@ export type UserEntry =
    * The harness wrote this under the user role. `note` names the kind in one short phrase; the
    * BODY is deliberately absent — see the header.
    */
-  | { kind: 'system'; note: string }
+  | {
+      kind: 'system'
+      note: string
+      /**
+       * WHICH thing the note is about, where the body named one — a skill's invocation name today.
+       *
+       * The note names a KIND, which is all a chip could ever say, so clicking one opened the aside
+       * tab and left the reader hunting the list. Some bodies do carry the identity and it was
+       * simply thrown away with the rest of the body. Absent whenever the body names nothing this
+       * product can resolve: an absent reference makes the chip behave exactly as it always has,
+       * while a guessed one would match no row and look broken.
+       */
+      noteRef?: string
+    }
 
 /**
  * Envelopes the harness writes, and what each one is.
@@ -145,9 +163,27 @@ export function classifyUserText(text: string): UserEntry {
  * generic one. That is why a new shape appearing upstream cannot regress anything here: it is
  * already `system`, it just says less.
  */
-const META_KINDS: Array<{ test: RegExp; note: string }> = [
-  { test: /^Base directory for this skill:/, note: 'a skill was loaded' },
-  { test: /^\(Re-invocation of/, note: 'a skill was re-invoked' },
+const META_KINDS: Array<{ test: RegExp; note: string; ref?: (text: string) => string | undefined }> = [
+  // Measured on real transcripts: `Base directory for this skill: <dir>` on the first line, the
+  // skill's own document below it. `skillNameFromDir` turns that directory into the INVOCATION
+  // name, which is what `HarnessSkill.name` is and what the panel lists.
+  {
+    test: /^Base directory for this skill:/,
+    note: 'a skill was loaded',
+    ref: text => {
+      const dir = /^Base directory for this skill:[ \t]*(.+)$/m.exec(text)?.[1]?.trim()
+      if (!dir) return undefined
+      const source = HARNESS_SKILLS.claude
+      return (source ? skillNameFromDir(dir, source) : null) ?? undefined
+    },
+  },
+  // Measured: `(Re-invocation of /claude-code-notifications:ccn — the skill instructions were
+  // previously loaded; …`. Here the invocation name is already written out, behind a slash.
+  {
+    test: /^\(Re-invocation of/,
+    note: 'a skill was re-invoked',
+    ref: text => /^\(Re-invocation of \/([^\s—]+)/.exec(text)?.[1],
+  },
   { test: /^Another Claude session sent a message:/, note: 'a message from another session' },
   // agentop's own peer message, from the event channel — the same family, and measured beside it.
   { test: /^The coordinator sent a message/, note: 'a message from another session' },
@@ -206,5 +242,6 @@ export function classifyUserEntry(
   // An unrecognised meta entry is still the harness — the flag said so. It gets a truthful generic
   // note rather than being shown, because the alternative is attributing to a person something
   // they did not write.
-  return { kind: 'system', note: kind?.note ?? 'injected by the assistant' }
+  const ref = kind?.ref?.(trimmed)
+  return { kind: 'system', note: kind?.note ?? 'injected by the assistant', ...(ref ? { noteRef: ref } : {}) }
 }

--- a/packages/server/server/sessions/chat-tail.test.ts
+++ b/packages/server/server/sessions/chat-tail.test.ts
@@ -549,3 +549,32 @@ describe('a transcript that does not exist YET', () => {
   })
 })
 
+
+describe('a system note carries WHICH thing it is about, where the body named one', () => {
+  let root: string
+  beforeEach(async () => { root = await mkdtemp(join(tmpdir(), 'chat-tail-ref-')); forgetChatTailContent() })
+  afterEach(async () => { await rm(root, { recursive: true, force: true }) })
+
+  async function turnsOf(text: string) {
+    const file = join(root, 'x.jsonl')
+    await writeFile(file, line({ type: 'user', isMeta: true, message: { content: text } }) + '\n')
+    forgetChatTailContent()
+    return (await readChatWindow(file, 10)).turns
+  }
+
+  test('a skill load reaches the browser naming the skill', async () => {
+    // Without this the chip opens the skills tab and lands at the top of a list to be searched —
+    // the limitation CLAUDE.md records. The identity was in the body all along.
+    const [turn] = await turnsOf(
+      'Base directory for this skill: /home/u/.claude/plugins/cache/superpowers-dev/superpowers/6.0.2/skills/brainstorming',
+    )
+    expect(turn?.system).toBe('a skill was loaded')
+    expect(turn?.systemRef).toBe('superpowers:brainstorming')
+  })
+
+  test('a note that names nothing carries no reference at all', async () => {
+    const [turn] = await turnsOf('Continue from where you left off.')
+    expect(turn?.system).toBe('the session was resumed')
+    expect(turn?.systemRef).toBeUndefined()
+  })
+})

--- a/packages/server/server/sessions/chat-tail.ts
+++ b/packages/server/server/sessions/chat-tail.ts
@@ -265,7 +265,12 @@ function queuedPromptText(prompt: unknown): string | null {
 function userTurn(entry: UserEntry): ChatTurn {
   return entry.kind === 'person'
     ? { role: 'user', text: entry.text }
-    : { role: 'user', text: entry.note, system: entry.note }
+    : {
+        role: 'user',
+        text: entry.note,
+        system: entry.note,
+        ...(entry.noteRef ? { systemRef: entry.noteRef } : {}),
+      }
 }
 
 function extractAssistantText(e: Record<string, unknown>): string | null {

--- a/packages/server/server/sessions/chat-turn.ts
+++ b/packages/server/server/sessions/chat-turn.ts
@@ -121,4 +121,13 @@ export interface ChatTurn {
    * `chat-envelope.ts` for the measured list and why two of those envelopes are the person's.
    */
   system?: string
+  /**
+   * WHICH thing the note is about, where its body named one — a skill's invocation name today.
+   *
+   * `system` names a KIND, which is all the chip could ever say, so clicking one opened the aside
+   * tab and left the reader hunting the list for the row that was actually used. The identity was
+   * in the body and was thrown away with it. Absent whenever the body names nothing resolvable:
+   * the chip then behaves exactly as it always has, and a guessed reference would match no row.
+   */
+  systemRef?: string
 }

--- a/packages/server/server/sessions/harness-skills.test.ts
+++ b/packages/server/server/sessions/harness-skills.test.ts
@@ -1,8 +1,8 @@
-import { describe, expect, it } from 'bun:test'
+import { describe, expect, it, test } from 'bun:test'
 import { mkdir, mkdtemp, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { HARNESS_SKILLS, parseSkillFrontmatter, readHarnessSkills, skillLine, skillsReason } from './harness-skills'
+import { HARNESS_SKILLS, parseSkillFrontmatter, readHarnessSkills, skillLine, skillNameFromDir, skillsReason } from './harness-skills'
 
 describe('parseSkillFrontmatter', () => {
   it('reads name and description out of the frontmatter', () => {
@@ -82,4 +82,48 @@ describe('readHarnessSkills', () => {
     expect(out.some(s => s.name === 'not-a-skill')).toBe(false)
     expect(await readHarnessSkills('claude', join(dir, 'gone'))).toBeArray()
   })
+})
+
+/**
+ * THE INJECTED ENTRY NAMES THE SKILL, AND THE NOTE THREW IT AWAY.
+ *
+ * `chat-envelope.ts` turns `Base directory for this skill: …` into the note `a skill was loaded`
+ * and drops the body — so the chip could open the skills tab and never say WHICH row. Measured on a
+ * real transcript, the body carries the base directory and nothing else is needed:
+ *
+ *   Base directory for this skill: …/superpowers-dev/superpowers/6.0.2/skills/brainstorming
+ *
+ * The name has to come out as the INVOCATION name, because that is what `HarnessSkill.name` is and
+ * what the panel lists; `path` deliberately never crosses to the browser. So the layout is read
+ * from `HARNESS_SKILLS` itself rather than re-derived here — one declaration, two readers.
+ */
+test('a PLUGIN skill directory yields the invocation name, prefix included', () => {
+  expect(skillNameFromDir(
+    '/home/u/.claude/plugins/cache/superpowers-dev/superpowers/6.0.2/skills/brainstorming',
+    HARNESS_SKILLS.claude!,
+  )).toBe('superpowers:brainstorming')
+})
+
+test('a USER skill directory yields the bare name', () => {
+  expect(skillNameFromDir('/home/u/.claude/skills/graphify', HARNESS_SKILLS.claude!)).toBe('graphify')
+})
+
+test('a PROJECT skill directory yields the bare name too — same segment, same rule', () => {
+  expect(skillNameFromDir('/home/u/work/repo/.claude/skills/deploy', HARNESS_SKILLS.claude!))
+    .toBe('deploy')
+})
+
+test('a trailing separator does not become part of the name', () => {
+  expect(skillNameFromDir('/home/u/.claude/skills/graphify/', HARNESS_SKILLS.claude!)).toBe('graphify')
+})
+
+test('a directory outside every declared source names NOTHING, rather than guessing', () => {
+  // A basename would be a plausible-looking answer that resolves to no row in the panel, which is
+  // the confident-wrong-value this repo refuses everywhere else.
+  expect(skillNameFromDir('/tmp/whatever/skills/x', HARNESS_SKILLS.claude!)).toBeNull()
+  expect(skillNameFromDir('', HARNESS_SKILLS.claude!)).toBeNull()
+})
+
+test('a plugin path too short to carry a plugin segment names nothing', () => {
+  expect(skillNameFromDir('/home/u/.claude/plugins/cache/skills/x', HARNESS_SKILLS.claude!)).toBeNull()
 })

--- a/packages/server/server/sessions/harness-skills.ts
+++ b/packages/server/server/sessions/harness-skills.ts
@@ -34,93 +34,13 @@
 
 import { join } from 'node:path'
 import type { HarnessId } from '@agentistics/core'
+import { HARNESS_SKILLS, type HarnessSkill, parseSkillFrontmatter } from './skill-source'
 import { HOME_DIR } from '../config'
 
-export interface HarnessSkill {
-  /** The INVOCATION name, prefix included — what `skillLine` turns into a typed line. */
-  name: string
-  description: string
-  scope: 'user' | 'plugin' | 'project'
-  /**
-   * The `SKILL.md` this was read from.
-   *
-   * Carried so the panel can SHOW a skill rather than only name it — and it is the server that
-   * holds it, never the browser: the detail route takes a skill NAME and resolves it back through
-   * this same list, so no path a client sent is ever opened. That is the whole reason this field
-   * exists here instead of on the wire.
-   */
-  path: string
-}
+// The PURE half lives in `skill-source.ts` and is re-exported, so every existing importer of this
+// module is untouched. See that file's header for why the split exists.
+export * from './skill-source'
 
-export interface SkillSource {
-  /** `<HOME_DIR>/<dir>/<name>/SKILL.md`. */
-  userDirs: string[]
-  /**
-   * `<HOME_DIR>/<root>/<marketplace>/<plugin>/<version>/skills/<name>/SKILL.md`, invoked as
-   * `<plugin>:<name>`. A fixed depth rather than a search: it is the layout the CLI writes, and a
-   * recursive hunt for `SKILL.md` under a home directory is a different and much slower promise.
-   */
-  pluginRoots: string[]
-  /** `<cwd>/<dir>/<name>/SKILL.md`. */
-  projectDirs: string[]
-  /** The line typed to invoke one. `{name}` is replaced. */
-  line: string
-}
-
-export const HARNESS_SKILLS: Record<HarnessId, SkillSource | null> = {
-  // Verified against claude 2.1.260 on this machine — see the layout in the header.
-  claude: {
-    userDirs: ['.claude/skills'],
-    pluginRoots: ['.claude/plugins/cache'],
-    projectDirs: ['.claude/skills'],
-    line: '/{name}',
-  },
-  // No documented skill mechanism reachable from a typed line.
-  codex: null,
-  gemini: null,
-  copilot: null,
-  antigravity: null,
-  kimi: null,
-}
-
-/** Why the picker is absent, so the menu says it instead of leaving a hole. */
-export function skillsReason(harness: string, lang: 'en' | 'pt'): string | null {
-  if (HARNESS_SKILLS[harness as HarnessId]) return null
-  return lang === 'pt'
-    ? 'Invocar skills a partir daqui só está verificado no Claude Code.'
-    : 'Invoking skills from here is only verified for Claude Code.'
-}
-
-/**
- * PURE: the `name` and `description` out of a SKILL.md's frontmatter.
- *
- * Deliberately a small hand parser rather than a YAML dependency: it reads two scalar keys out of
- * a leading `---` block, and it is TOTAL — a malformed, unterminated or empty document yields `{}`
- * rather than throwing. A skill file somebody is midway through editing must not take the picker
- * down with it.
- */
-export function parseSkillFrontmatter(text: string): { name?: string; description?: string } {
-  if (!text.startsWith('---')) return {}
-  const end = text.indexOf('\n---', 3)
-  if (end === -1) return {}
-  const out: { name?: string; description?: string } = {}
-  for (const line of text.slice(3, end).split('\n')) {
-    const m = /^\s*(name|description)\s*:\s*(.*)$/.exec(line)
-    if (!m) continue
-    const value = m[2]!.trim().replace(/^["']|["']$/g, '')
-    if (value !== '') out[m[1] as 'name' | 'description'] = value
-  }
-  return out
-}
-
-/** The line to type for a skill, or null where the harness has none. */
-export function skillLine(harness: string, name: string): string | null {
-  const spec = HARNESS_SKILLS[harness as HarnessId]
-  if (!spec || name === '') return null
-  return spec.line.replace('{name}', name)
-}
-
-/** The IO half. Unreadable directories and files are skipped, never thrown. */
 export async function readHarnessSkills(harness: string, cwd: string): Promise<HarnessSkill[]> {
   const spec = HARNESS_SKILLS[harness as HarnessId]
   if (!spec) return []
@@ -164,3 +84,4 @@ export async function readHarnessSkills(harness: string, cwd: string): Promise<H
 
   return [...found.values()].sort((a, b) => a.name.localeCompare(b.name))
 }
+

--- a/packages/server/server/sessions/skill-source.ts
+++ b/packages/server/server/sessions/skill-source.ts
@@ -1,0 +1,157 @@
+/**
+ * skill-source.ts — PURE: what a skill IS, where each harness keeps them, and how one is named.
+ *
+ * Split out of `harness-skills.ts` so a module with no business touching the filesystem can read
+ * these rules. `chat-envelope.ts` needs `skillNameFromDir` to say WHICH skill a note is about, and
+ * it is a zero-import pure parser: importing the reader would have dragged `HOME_DIR` and the whole
+ * of `config.ts` — which reads the environment at import time — into it. Only `readHarnessSkills`
+ * ever needed a home directory, so the split falls exactly along that line.
+ *
+ * `harness-skills.ts` re-exports everything here, so every existing importer is untouched.
+ */
+
+import type { HarnessId } from '@agentistics/core'
+
+export interface HarnessSkill {
+  /** The INVOCATION name, prefix included — what `skillLine` turns into a typed line. */
+  name: string
+  description: string
+  scope: 'user' | 'plugin' | 'project'
+  /**
+   * The `SKILL.md` this was read from.
+   *
+   * Carried so the panel can SHOW a skill rather than only name it — and it is the server that
+   * holds it, never the browser: the detail route takes a skill NAME and resolves it back through
+   * this same list, so no path a client sent is ever opened. That is the whole reason this field
+   * exists here instead of on the wire.
+   */
+  path: string
+}
+
+export interface SkillSource {
+  /** `<HOME_DIR>/<dir>/<name>/SKILL.md`. */
+  userDirs: string[]
+  /**
+   * `<HOME_DIR>/<root>/<marketplace>/<plugin>/<version>/skills/<name>/SKILL.md`, invoked as
+   * `<plugin>:<name>`. A fixed depth rather than a search: it is the layout the CLI writes, and a
+   * recursive hunt for `SKILL.md` under a home directory is a different and much slower promise.
+   */
+  pluginRoots: string[]
+  /** `<cwd>/<dir>/<name>/SKILL.md`. */
+  projectDirs: string[]
+  /** The line typed to invoke one. `{name}` is replaced. */
+  line: string
+}
+
+export const HARNESS_SKILLS: Record<HarnessId, SkillSource | null> = {
+  // Verified against claude 2.1.260 on this machine — see the layout in the header.
+  claude: {
+    userDirs: ['.claude/skills'],
+    pluginRoots: ['.claude/plugins/cache'],
+    projectDirs: ['.claude/skills'],
+    line: '/{name}',
+  },
+  // No documented skill mechanism reachable from a typed line.
+  codex: null,
+  gemini: null,
+  copilot: null,
+  antigravity: null,
+  kimi: null,
+}
+
+/** Why the picker is absent, so the menu says it instead of leaving a hole. */
+export function skillsReason(harness: string, lang: 'en' | 'pt'): string | null {
+  if (HARNESS_SKILLS[harness as HarnessId]) return null
+  return lang === 'pt'
+    ? 'Invocar skills a partir daqui só está verificado no Claude Code.'
+    : 'Invoking skills from here is only verified for Claude Code.'
+}
+
+/**
+ * PURE: the `name` and `description` out of a SKILL.md's frontmatter.
+ *
+ * Deliberately a small hand parser rather than a YAML dependency: it reads two scalar keys out of
+ * a leading `---` block, and it is TOTAL — a malformed, unterminated or empty document yields `{}`
+ * rather than throwing. A skill file somebody is midway through editing must not take the picker
+ * down with it.
+ */
+export function parseSkillFrontmatter(text: string): { name?: string; description?: string } {
+  if (!text.startsWith('---')) return {}
+  const end = text.indexOf('\n---', 3)
+  if (end === -1) return {}
+  const out: { name?: string; description?: string } = {}
+  for (const line of text.slice(3, end).split('\n')) {
+    const m = /^\s*(name|description)\s*:\s*(.*)$/.exec(line)
+    if (!m) continue
+    const value = m[2]!.trim().replace(/^["']|["']$/g, '')
+    if (value !== '') out[m[1] as 'name' | 'description'] = value
+  }
+  return out
+}
+
+/** The line to type for a skill, or null where the harness has none. */
+export function skillLine(harness: string, name: string): string | null {
+  const spec = HARNESS_SKILLS[harness as HarnessId]
+  if (!spec || name === '') return null
+  return spec.line.replace('{name}', name)
+}
+
+/** The IO half. Unreadable directories and files are skipped, never thrown. */
+/** Where `needle` sits inside `hay` as a run of consecutive segments, or -1. */
+function segmentRun(hay: readonly string[], needle: readonly string[]): number {
+  if (needle.length === 0 || needle.length > hay.length) return -1
+  for (let i = 0; i + needle.length <= hay.length; i++) {
+    let ok = true
+    for (let j = 0; j < needle.length; j++) if (hay[i + j] !== needle[j]) { ok = false; break }
+    if (ok) return i
+  }
+  return -1
+}
+
+/**
+ * PURE: the INVOCATION name of the skill whose base directory this is, or `null`.
+ *
+ * The injected entry that produces the `a skill was loaded` note carries exactly one useful fact —
+ * `Base directory for this skill: <dir>` — and `chat-envelope.ts` used to drop it, so the chip
+ * could open the skills tab and never say WHICH row. This is what turns that directory back into
+ * something the panel can match.
+ *
+ * It must come out as the INVOCATION name, prefix and all, because that is what `HarnessSkill.name`
+ * is and what the panel lists; `path` deliberately never crosses to the browser. And the layouts
+ * are read from the `SkillSource` this harness already declares rather than re-derived here — the
+ * plugin shape (`<root>/<marketplace>/<plugin>/<version>/skills/<name>`, invoked `<plugin>:<name>`)
+ * is stated once, in `HARNESS_SKILLS`, and two readers now depend on that one statement.
+ *
+ * A directory matching NO declared source answers `null` rather than falling back to its basename.
+ * A basename would look like an answer and resolve to no row in the panel, which is the confident
+ * wrong value this codebase refuses everywhere else — the caller then simply omits the reference
+ * and the chip behaves exactly as it does today.
+ */
+export function skillNameFromDir(dir: string, source: SkillSource): string | null {
+  const parts = dir.split('/').filter(p => p !== '')
+  if (parts.length === 0) return null
+  const name = parts[parts.length - 1]!
+
+  for (const root of source.pluginRoots) {
+    const rootParts = root.split('/').filter(p => p !== '')
+    const at = segmentRun(parts, rootParts)
+    if (at === -1) continue
+    // <root>/<marketplace>/<plugin>/<version>/skills/<name> — a FIXED depth, for the reason
+    // `SkillSource.pluginRoots` gives: it is the layout the CLI writes, not something to search for.
+    const nameAt = at + rootParts.length + 4
+    if (nameAt !== parts.length - 1) continue
+    if (parts[nameAt - 1] !== 'skills') continue
+    const plugin = parts[at + rootParts.length + 1]
+    if (!plugin) continue
+    return `${plugin}:${name}`
+  }
+
+  for (const dirSeg of [...source.userDirs, ...source.projectDirs]) {
+    const segParts = dirSeg.split('/').filter(p => p !== '')
+    const at = segmentRun(parts, segParts)
+    if (at === -1) continue
+    if (at + segParts.length !== parts.length - 1) continue
+    return name
+  }
+  return null
+}

--- a/packages/web/src/components/sessions/ArtifactsAside.tsx
+++ b/packages/web/src/components/sessions/ArtifactsAside.tsx
@@ -31,6 +31,7 @@
 
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { asideCache, asideKey } from '../../lib/asideCache'
+import { focusMissNotice, isFocusedRow, rowsCarry, ROW_FLASH } from '../../lib/noteFocus'
 import { Activity, BookOpen, Bot, Brain, ChevronDown, ChevronLeft, ChevronRight, ClipboardList, ExternalLink, Eye, FileEdit, FilePlus2, FileText, Files, GitBranch, GitPullRequest, Image, LayoutGrid, Loader, PanelRightClose, Pencil, Plug, Plus, Send, Sparkles, Terminal, Trash2, Workflow, X } from 'lucide-react'
 import type { Artifact } from '../../lib/sessionArtifacts'
 import {
@@ -1153,6 +1154,11 @@ export function ArtifactsAside({
         {feed.map((e, i) => (
           <EventRow
             key={i} e={e} pt={pt} now={now} sessionId={sessionId}
+            // THE ROW THE STRIP ASKED FOR. `EventRow` has answered `focused` since it was written —
+            // it opens itself, scrolls into view and flashes — and nothing ever passed it, so
+            // `openArtifacts('live', hint.ref)` landed at the top of a feed to be searched. The
+            // state was computed and faded on a timer the whole time; only this line was missing.
+            focused={e.ref !== undefined && isFocusedRow(e.ref, focusStep)}
             // A WROTE row is a link to the file it names. Only when that file is actually in the
             // Files list: the feed shows every write the transcript recorded, while Files shows the
             // ones still readable on disk, and offering to open a deleted file would be a row whose
@@ -1397,30 +1403,29 @@ export function ArtifactsAside({
                   {skillsNote}
                 </p>
               )}
+              {/*
+                * A REFERENCE NO ROW CARRIES IS SAID, never swallowed. The chip promised to show
+                * which skill was used; a tab that opens and highlights nothing is indistinguishable
+                * from a button that did not work. It happens for real — a skill loaded from a
+                * directory this machine no longer lists, or a list that has not arrived yet.
+                */}
+              {focusStep !== undefined && !rowsCarry(skills.map(sk => sk.name), focusStep) && (
+                <p style={{
+                  margin: '0 0 8px', padding: '7px 10px', borderRadius: 8, fontSize: 11,
+                  lineHeight: 1.5, color: 'var(--text-secondary)',
+                  background: 'var(--bg-elevated)', border: '1px solid var(--border-subtle)',
+                }}>
+                  {focusMissNotice(focusStep, pt)}
+                </p>
+              )}
               {skillGroups.map(group => (
                 <Band key={group.key || '_own'} label={`${group.label} · ${group.skills.length}`}>
                   {group.skills.map(sk => (
-                    <button
-                      key={sk.name}
-                      onClick={() => setOpenSkill(sk.name)}
-                      style={{
-                        display: 'block', width: '100%', textAlign: 'left',
-                        padding: '8px 10px', marginBottom: 6, borderRadius: 9, cursor: 'pointer',
-                        background: 'var(--bg-elevated)', border: '1px solid var(--border-subtle)',
-                        fontFamily: 'inherit',
-                      }}
-                    >
-                      <span style={{
-                        display: 'block', fontSize: 12, fontWeight: 650, color: 'var(--text-primary)',
-                        fontFamily: 'var(--font-mono, ui-monospace, monospace)',
-                      }}>/{shortName(sk)}</span>
-                      {sk.description && (
-                        <span style={{
-                          display: 'block', marginTop: 3, fontSize: 11, lineHeight: 1.5,
-                          color: 'var(--text-tertiary)',
-                        }}>{sk.description}</span>
-                      )}
-                    </button>
+                    <SkillButton
+                      key={sk.name} sk={sk} label={shortName(sk)}
+                      focused={isFocusedRow(sk.name, focusStep)}
+                      onOpen={() => setOpenSkill(sk.name)}
+                    />
                   ))}
                 </Band>
               ))}
@@ -1765,6 +1770,52 @@ function StepBlock({ label, text, tone }: { label: string; text: string; tone?: 
   )
 }
 
+/**
+ * ONE SKILL, and the row a note's chip can point AT.
+ *
+ * A component rather than the inline `<button>` it replaced, for one reason: a row that scrolls
+ * itself into view needs a ref and an effect, and neither can live inside a `.map`. The behaviour is
+ * `EventRow`'s, deliberately — same flash (`ROW_FLASH`), same `scrollIntoView`, because "the one you
+ * asked for" must not look like two different things in two tabs of one panel.
+ */
+function SkillButton({ sk, label, focused, onOpen }: {
+  sk: { name: string; description?: string }
+  label: string
+  focused: boolean
+  onOpen: () => void
+}) {
+  const ref = useRef<HTMLButtonElement | null>(null)
+  useEffect(() => {
+    // `nearest` and not `center`: the row is often already on screen, and yanking a list that did
+    // not need to move is its own kind of lost place.
+    if (focused) ref.current?.scrollIntoView({ block: 'nearest' })
+  }, [focused])
+  return (
+    <button
+      ref={ref}
+      onClick={onOpen}
+      style={{
+        display: 'block', width: '100%', textAlign: 'left',
+        padding: '8px 10px', marginBottom: 6, borderRadius: 9, cursor: 'pointer',
+        background: 'var(--bg-elevated)', border: '1px solid var(--border-subtle)',
+        fontFamily: 'inherit',
+        ...(focused ? { animation: ROW_FLASH } : {}),
+      }}
+    >
+      <span style={{
+        display: 'block', fontSize: 12, fontWeight: 650, color: 'var(--text-primary)',
+        fontFamily: 'var(--font-mono, ui-monospace, monospace)',
+      }}>/{label}</span>
+      {sk.description && (
+        <span style={{
+          display: 'block', marginTop: 3, fontSize: 11, lineHeight: 1.5,
+          color: 'var(--text-tertiary)',
+        }}>{sk.description}</span>
+      )}
+    </button>
+  )
+}
+
 function EventRow({ e, pt, now, onOpen, status, sessionId, agentId, focused }: {
   e: LiveEvent; pt: boolean; now: number; onOpen?: () => void; status?: WriteStatus
   sessionId: string
@@ -1820,7 +1871,7 @@ function EventRow({ e, pt, now, onOpen, status, sessionId, agentId, focused }: {
       style={{
         borderRadius: 7,
         background: open ? 'var(--bg-elevated)' : 'transparent',
-        ...(focused === true ? { animation: 'ag-row-flash 1.6s ease-in-out 2' } : {}),
+        ...(focused === true ? { animation: ROW_FLASH } : {}),
       }}
     >
     <div style={{ display: 'flex', alignItems: 'flex-start' }}>

--- a/packages/web/src/components/sessions/ChatBubble.tsx
+++ b/packages/web/src/components/sessions/ChatBubble.tsx
@@ -60,6 +60,15 @@ export interface ChatTurn {
    * circled in a screenshot with "I didn't send that". See `chat-envelope.ts`.
    */
   system?: string
+  /**
+   * WHICH thing that note is about, where its body named one — a skill's invocation name today.
+   *
+   * `system` names a KIND, so the chip could only open the aside tab and leave the reader hunting
+   * the list. Passed to `openArtifacts` so the row that was actually used scrolls into view and
+   * flashes. Absent for every note whose body names nothing resolvable, and the chip then behaves
+   * exactly as it always has.
+   */
+  systemRef?: string
   /** Carried by the transcript; deliberately not rendered here. See the header. */
   tools?: Array<{ name: string; detail?: string }>
   /** Carried by the transcript; deliberately not rendered here. See the header. */
@@ -149,7 +158,7 @@ export interface ChatBubbleProps {
  * answer is the place it takes you to, and a sentence plus a destination on one 10px chip is two
  * targets in a control that has room for one.
  */
-function SystemNote({ note, pt }: { note: string; pt: boolean }) {
+function SystemNote({ note, noteRef, pt }: { note: string; noteRef?: string; pt: boolean }) {
   const { label, help, tab } = chatNote(note, pt)
   const [shown, setShown] = useState(false)
   const isMobile = useIsMobile()
@@ -172,7 +181,9 @@ function SystemNote({ note, pt }: { note: string; pt: boolean }) {
     return (
       <div style={{ display: 'flex', justifyContent: 'center', padding: '2px 0' }}>
         <button
-          onClick={() => openArtifacts(tab satisfies ChatNoteTab)}
+          // The REFERENCE goes with the tab. Without it this lands at the top of a list to be
+          // searched — the limitation CLAUDE.md records — and the body named the thing all along.
+          onClick={() => openArtifacts(tab satisfies ChatNoteTab, noteRef)}
           {...(help ? { title: help, 'aria-label': `${label} — ${help}` } : {})}
           style={{ ...chip, display: 'inline-flex', alignItems: 'center', gap: 5, cursor: 'pointer' }}
         >
@@ -367,7 +378,7 @@ export const ChatBubble = memo(function ChatBubble({ turn, lang, harness, provis
   }
 
   if (turn.system) {
-    return <SystemNote note={turn.system} pt={pt} />
+    return <SystemNote note={turn.system} noteRef={turn.systemRef} pt={pt} />
   }
 
   const color = (HARNESS_COLORS as Record<string, string>)[harness] ?? 'var(--text-secondary)'

--- a/packages/web/src/lib/noteFocus.test.ts
+++ b/packages/web/src/lib/noteFocus.test.ts
@@ -1,0 +1,31 @@
+import { expect, test } from 'bun:test'
+import { focusMissNotice, isFocusedRow, rowsCarry } from './noteFocus'
+
+test('the row the chip named is the focused one, and only it', () => {
+  expect(isFocusedRow('superpowers:brainstorming', 'superpowers:brainstorming')).toBe(true)
+  expect(isFocusedRow('graphify', 'superpowers:brainstorming')).toBe(false)
+})
+
+test('NO reference focuses NOTHING — never every row', () => {
+  // The chip opens the tab with no reference whenever the note named nothing resolvable, and the
+  // list must then look exactly as it always has.
+  expect(isFocusedRow('graphify', undefined)).toBe(false)
+})
+
+test('a list that carries the reference needs no notice', () => {
+  expect(rowsCarry(['a', 'superpowers:brainstorming'], 'superpowers:brainstorming')).toBe(true)
+})
+
+test('a reference no row carries is REPORTED, not silently ignored', () => {
+  // The honest case: a skill loaded from a directory this machine no longer lists, or a list that
+  // has not loaded. Opening the tab and highlighting nothing looks identical to a broken button.
+  expect(rowsCarry(['a', 'b'], 'superpowers:brainstorming')).toBe(false)
+  expect(focusMissNotice('superpowers:brainstorming', true))
+    .toContain('superpowers:brainstorming')
+  expect(focusMissNotice('superpowers:brainstorming', false).toLowerCase())
+    .toContain('not in this list')
+})
+
+test('with no reference there is nothing to miss', () => {
+  expect(rowsCarry(['a'], undefined)).toBe(true)
+})

--- a/packages/web/src/lib/noteFocus.ts
+++ b/packages/web/src/lib/noteFocus.ts
@@ -1,0 +1,42 @@
+/**
+ * noteFocus.ts — PURE: which row a chat note's chip asked for, and what to say when there is none.
+ *
+ * A system note names a KIND (`a skill was loaded`), so its chip could only ever open the aside tab
+ * and leave the reader hunting the list — the limitation CLAUDE.md records for `command output`,
+ * and until now the reality for skills too, whose body named the skill all along. The server now
+ * carries that identity as `ChatTurn.systemRef`, `openArtifacts(tab, ref)` already carried a
+ * reference for the live feed, and this holds the two rules both lists answer.
+ *
+ * NOTHING HERE INVENTS A MATCH. An absent reference focuses nothing and the list looks exactly as
+ * it always has; a reference no row carries is REPORTED, because a tab that opens and highlights
+ * nothing is indistinguishable from a button that did not work.
+ */
+
+/** The flash a focused row wears. One constant, so two lists cannot disagree about what it means. */
+export const ROW_FLASH = 'ag-row-flash 1.6s ease-in-out 2'
+
+/**
+ * Is this row the one the chip named?
+ *
+ * `ref` is `undefined` whenever the note named nothing resolvable — the common case for every note
+ * whose body carries no identity — and that must focus NO row rather than all of them.
+ */
+export function isFocusedRow(key: string, ref: string | undefined): boolean {
+  return ref !== undefined && key === ref
+}
+
+/** Does any row carry the reference? Vacuously true when there is no reference to carry. */
+export function rowsCarry(keys: readonly string[], ref: string | undefined): boolean {
+  return ref === undefined || keys.includes(ref)
+}
+
+/**
+ * The sentence for a reference no row carries — a skill loaded from somewhere this machine no
+ * longer lists, or a list that has not arrived yet. It NAMES the thing, because "something you used
+ * is missing" sends nobody anywhere.
+ */
+export function focusMissNotice(ref: string, pt: boolean): string {
+  return pt
+    ? `“${ref}” foi usada nesta conversa e não está nesta lista.`
+    : `“${ref}” was used in this conversation and is not in this list.`
+}


### PR DESCRIPTION
Closes #446

## Summary

A system note now carries WHICH thing it is about (`ChatTurn.systemRef`), the chip passes it to `openArtifacts(tab, ref)`, and the row scrolls into view and flashes. Both lists are wired — the skills tab, and the live feed whose focus path was already written and never connected.

## The identity was in the body

Measured on real transcripts: a load carries `Base directory for this skill: <dir>`, a re-invocation carries `(Re-invocation of /<invocation-name> — …`. The BODY stays dropped, as it must; only the identity is kept, in the form the panel LISTS — `HarnessSkill.name`, prefix and all — through the pure `skillNameFromDir`, which reads the layout off the `SkillSource` the harness already declares rather than re-deriving it.

A directory matching no declared source yields NO reference rather than its basename: a basename looks like an answer and matches no row.

## The focus machinery was complete and disconnected

`openArtifacts` has always taken a `ref`; `ArtifactsAside` computes `focusStep` and fades it on a timer; `EventRow` implements `focused` by opening itself, scrolling into view and flashing. **Nothing ever passed the prop** — `grep focusStep` returned the `useState`, the timer and the setter, and no consumer. So `openArtifacts('live', hint.ref)` from `SessionsPage` landed at the top of the feed too. One line fixes that path; `SkillButton` gives the skills tab the same behaviour.

## Rules, in the pure `noteFocus.ts`

- `ROW_FLASH` is ONE constant, so two tabs cannot disagree about what "the one you asked for" looks like.
- An ABSENT reference focuses nothing — never every row.
- A reference NO row carries is **said in words**. A tab that opens and highlights nothing is indistinguishable from a button that did not work; it happens for real when a skill was loaded from a directory this machine no longer lists.
- The highlight FADES (4s): it answers "which one", and a marker that stays becomes part of the row. Re-pressing the same chip re-arms it, because the request is keyed on its own `at`.

## Why `skill-source.ts` exists

`chat-envelope.ts` is a zero-import pure parser. Importing the skills READER would have dragged `HOME_DIR` and the whole of `config.ts` — which reads the environment at import time — into it. Only `readHarnessSkills` ever needed a home directory, so the split falls exactly along that line, and `harness-skills.ts` re-exports everything: no existing importer changed.

## Test plan

- `bun tsc --noEmit` — clean.
- `bun test` — **7426 pass, 0 fail** (pre-commit hook ran both).
- `harness-skills.test.ts` — plugin path → `superpowers:brainstorming`; user and project paths → the bare name; a trailing separator; a directory outside every declared source → `null`; a plugin path too short to carry a plugin segment → `null`.
- `chat-envelope.test.ts` — a load and a re-invocation each carry the reference from their own measured shape; a note whose body names nothing carries none; a skill outside every source loads without one.
- `chat-tail.test.ts` — the reference reaches the browser on the turn, and is absent when there is none.
- `noteFocus.test.ts` — an absent reference focuses nothing; a reference no row carries is reported and the sentence NAMES it.

**Not verified at 390px.** The change adds no new layout primitive: a CSS animation on an existing row, `scrollIntoView`, and one `<p>` that copies the shape of the `skillsNote` paragraph directly above it in the same column. Worth a look on a phone before release, but there is nothing here that reflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVZTKeH2GD6bxgR2EP4mns