### PR TITLE
feat(web): commands you can see, MCPs you can reference, and a mode chip that keeps up

### DIFF
--- a/packages/server/server/capability-guard.test.ts
+++ b/packages/server/server/capability-guard.test.ts
@@ -111,6 +111,11 @@ describe('routeCapability', () => {
     expect(routeCapability('/api/mcpanything')).toBeNull()
   })
 
+  it('maps /api/mcp/check and /api/mcp/tools to localShell, not the mcpAdmin prefix — reading config and RUNNING a server are different powers', () => {
+    expect(routeCapability('/api/mcp/check')).toBe('localShell')
+    expect(routeCapability('/api/mcp/tools')).toBe('localShell')
+  })
+
   it('returns null for ordinary metric routes', () => {
     expect(routeCapability('/api/data')).toBeNull()
     expect(routeCapability('/api/tags/abc')).toBeNull()

--- a/packages/server/server/capability-guard.ts
+++ b/packages/server/server/capability-guard.ts
@@ -22,6 +22,10 @@ const EXACT: ReadonlyMap<string, keyof Capabilities> = new Map<string, keyof Cap
   // It STARTS the configured MCP command to see whether it answers. Host power, and the reason the
   // route looks the server up in the CONFIG rather than taking a command from the body.
   ['/api/mcp/check', 'localShell'],
+  // Same reason as `/api/mcp/check`, one line up: it starts every configured server's command to
+  // ask `tools/list`, so it rides `localShell` rather than the `mcpAdmin` prefix below — reading
+  // and writing the CONFIGURATION is a different power from RUNNING it.
+  ['/api/mcp/tools', 'localShell'],
   ['/api/chat-tty', 'localChat'],
   ['/api/chat-harnesses', 'localChat'],
   ['/api/projects-list', 'localTranscripts'],

--- a/packages/server/server/index.ts
+++ b/packages/server/server/index.ts
@@ -1410,6 +1410,46 @@ async function handleRequestInner(req: Request, server: Server<WSData>): Promise
       }
     }
 
+    /**
+     * WHAT TOOLS DOES EACH CONFIGURED SERVER OFFER? — what the web composer's `@<server>` /
+     * `@<server>:<tool>` references need before either half can be offered.
+     *
+     * Reuses the SAME `initialize` handshake `/api/mcp/check` performs and extends it with
+     * `tools/list` over the same connection — see `mcp-tools.ts`. Answers are CACHED per server for
+     * a few minutes: the composer can open on every keystroke, and spawning a
+     * language-server-backed MCP server that often is its own outage. A server that could not be
+     * reached is reported unreachable with a reason, never as a server with zero tools — the
+     * confident-zero error this repo forbids everywhere.
+     *
+     * Guarded as `localShell`, like `/api/mcp/check`: it starts every configured server's command.
+     */
+    if (url.pathname === '/api/mcp/tools' && req.method === 'GET') {
+      try {
+        const { listMcp } = await import('./mcp-admin')
+        const { peekServerTools, toolsView } = await import('./mcp-tools')
+        const { servers } = await listMcp(url.searchParams.get('projectPath'))
+        /*
+         * NEVER AWAIT THE PROBE HERE. Measured on one machine's five configured servers: the one
+         * running from `bun` answered in 236ms with 19 tools, and the other four — three spawned
+         * through `npx`, one an HTTP/SSE endpoint — did not answer inside three minutes between
+         * them. The composer opens on a keystroke and cannot wait for that.
+         *
+         * It does not need to. `@<server>` only needs the NAMES, which the config knows instantly;
+         * only the tool list behind `:` needs a probe. So each server comes back with whatever is
+         * already known, `peekServerTools` starts the fetch for what is not, and a server that has
+         * not answered yet is reported as NOT ASKED — never as a server with no tools.
+         */
+        const views = servers.map(s => toolsView(s, peekServerTools(s)))
+        return new Response(JSON.stringify({ servers: views }), {
+          headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
+        })
+      } catch (err) {
+        return new Response(JSON.stringify(safeError(err, { verbose: PROFILE === 'local' }).body), {
+          status: 500, headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
+        })
+      }
+    }
+
     if ((url.pathname === '/api/mcp/install' || url.pathname === '/api/mcp/remove'
       || url.pathname === '/api/mcp/replace') && req.method === 'POST') {
       try {

--- a/packages/server/server/mcp-tools.test.ts
+++ b/packages/server/server/mcp-tools.test.ts
@@ -1,0 +1,195 @@
+import { test, expect } from 'bun:test'
+import {
+  toolsListFrame, initializedNotification, readToolsList, toolsCacheKey, toolsView,
+  McpToolsCache, type McpToolsProbe,
+} from './mcp-tools'
+
+test('the tools/list frame is one line of JSON-RPC, id 2 so it cannot be mistaken for the handshake', () => {
+  const f = toolsListFrame()
+  expect(f.endsWith('\n')).toBe(true)
+  const m = JSON.parse(f.trim())
+  expect(m.method).toBe('tools/list')
+  expect(m.id).toBe(2)
+  expect(m.id).not.toBe(1) // 1 is `initializeFrame`'s id — see mcp-check.ts
+})
+
+test('the initialized notification carries no id — it is a notification, not a request', () => {
+  const f = initializedNotification()
+  expect(f.endsWith('\n')).toBe(true)
+  const m = JSON.parse(f.trim())
+  expect(m.method).toBe('notifications/initialized')
+  expect(m.id).toBeUndefined()
+})
+
+test('a reply with tools, one of them missing a description', () => {
+  const out = JSON.stringify({
+    jsonrpc: '2.0', id: 2,
+    result: { tools: [{ name: 'find_symbol', description: 'Find a symbol' }, { name: 'list_dir' }] },
+  })
+  expect(readToolsList(out)).toEqual({
+    answered: true,
+    tools: [{ name: 'find_symbol', description: 'Find a symbol' }, { name: 'list_dir' }],
+  })
+})
+
+test('a reply that genuinely has no tools is answered, and the list is empty', () => {
+  const out = JSON.stringify({ jsonrpc: '2.0', id: 2, result: { tools: [] } })
+  expect(readToolsList(out)).toEqual({ answered: true, tools: [] })
+})
+
+test('scans past whatever the server logged before the reply, like readInitialize does', () => {
+  const out = [
+    'INFO starting…',
+    JSON.stringify({ jsonrpc: '2.0', id: 1, result: { serverInfo: { name: 's' } } }),
+    JSON.stringify({ jsonrpc: '2.0', id: 2, result: { tools: [{ name: 'a' }] } }),
+  ].join('\n')
+  expect(readToolsList(out)).toEqual({ answered: true, tools: [{ name: 'a' }] })
+})
+
+test('malformed or unexpected content in the matched reply yields an empty list, never a throw', () => {
+  // result.tools is not an array
+  expect(readToolsList(JSON.stringify({ jsonrpc: '2.0', id: 2, result: { tools: 'nope' } })))
+    .toEqual({ answered: true, tools: [] })
+  // result itself is missing
+  expect(readToolsList(JSON.stringify({ jsonrpc: '2.0', id: 2 })))
+    .toEqual({ answered: true, tools: [] })
+  // an error reply still answers our request — it is not a handshake failure, it is a real "no"
+  expect(readToolsList(JSON.stringify({ jsonrpc: '2.0', id: 2, error: { code: -32601, message: 'nope' } })))
+    .toEqual({ answered: true, tools: [] })
+  // a tool entry with a non-string / empty name is dropped rather than crashing the parse
+  expect(readToolsList(JSON.stringify({
+    jsonrpc: '2.0', id: 2, result: { tools: [{ name: 42 }, { name: '' }, { name: 'ok' }] },
+  }))).toEqual({ answered: true, tools: [{ name: 'ok' }] })
+})
+
+test('never throws on garbage input, and reports unanswered rather than guessing', () => {
+  expect(readToolsList('')).toEqual({ answered: false, tools: [] })
+  expect(readToolsList('not json\n{oops')).toEqual({ answered: false, tools: [] })
+  expect(readToolsList('[1,2,3]')).toEqual({ answered: false, tools: [] })
+})
+
+test('ignores a reply addressed to a different id, including the handshake\'s own', () => {
+  const out = JSON.stringify({ jsonrpc: '2.0', id: 1, result: { tools: [{ name: 'a' }] } })
+  expect(readToolsList(out)).toEqual({ answered: false, tools: [] })
+})
+
+test('the cache key includes scope and projectPath, so two directories never collide', () => {
+  expect(toolsCacheKey({ name: 'serena', scope: 'user' })).not.toBe(
+    toolsCacheKey({ name: 'serena', scope: 'local', projectPath: '/a' }),
+  )
+  expect(toolsCacheKey({ name: 'serena', scope: 'local', projectPath: '/a' })).not.toBe(
+    toolsCacheKey({ name: 'serena', scope: 'local', projectPath: '/b' }),
+  )
+})
+
+test('toolsView never carries a command, args or env — only what the wire needs', () => {
+  const view = toolsView(
+    { name: 'serena', scope: 'user', transport: 'stdio' },
+    { reachable: true, tools: [{ name: 'find_symbol' }] },
+  )
+  expect(view).toEqual({
+    name: 'serena', scope: 'user', transport: 'stdio', status: 'ready',
+    tools: [{ name: 'find_symbol' }],
+  })
+  expect(Object.keys(view)).not.toContain('command')
+  expect(Object.keys(view)).not.toContain('args')
+  expect(Object.keys(view)).not.toContain('config')
+})
+
+test('toolsView on a failed probe reports the outcome, and no tools key at all', () => {
+  const view = toolsView(
+    { name: 'broken', scope: 'user', transport: 'stdio' },
+    { reachable: false, outcome: 'exited', exitCode: 1 },
+  )
+  expect(view).toEqual({
+    name: 'broken', scope: 'user', transport: 'stdio', status: 'unreachable', outcome: 'exited', exitCode: 1,
+  })
+  expect('tools' in view).toBe(false)
+})
+
+// ---------------------------------------------------------------------------------------------
+// McpToolsCache — the one thing this whole module exists to get right: a failed probe is cached
+// as a failure, never quietly reread later as "asked, got zero tools".
+// ---------------------------------------------------------------------------------------------
+
+test('a successful probe is served from cache within its TTL, without calling the fetcher again', async () => {
+  const cache = new McpToolsCache(1000, 1000)
+  let calls = 0
+  const fetcher = async (): Promise<McpToolsProbe> => { calls++; return { reachable: true, tools: [{ name: 'a' }] } }
+  const first = await cache.get('k', fetcher, 0)
+  const second = await cache.get('k', fetcher, 500)
+  expect(first).toEqual({ reachable: true, tools: [{ name: 'a' }] })
+  expect(second).toEqual({ reachable: true, tools: [{ name: 'a' }] })
+  expect(calls).toBe(1)
+})
+
+test('a failed probe stays a failure on a cache hit — never becomes a confident zero', async () => {
+  const cache = new McpToolsCache(1000, 1000)
+  const fetcher = async (): Promise<McpToolsProbe> => ({ reachable: false, outcome: 'timeout' })
+  const first = await cache.get('k', fetcher, 0)
+  const second = await cache.get('k', fetcher, 500)
+  expect(first).toEqual({ reachable: false, outcome: 'timeout' })
+  expect(second).toEqual({ reachable: false, outcome: 'timeout' })
+  // Never reinterpreted as a reachable server with an empty tool list.
+  expect(second).not.toEqual({ reachable: true, tools: [] })
+})
+
+test('a failure expires sooner than a success, so a fixed machine is retried without waiting the full window', async () => {
+  const cache = new McpToolsCache(10_000, 100)
+  let calls = 0
+  const fetcher = async (): Promise<McpToolsProbe> => {
+    calls++
+    return calls === 1 ? { reachable: false, outcome: 'exited' } : { reachable: true, tools: [{ name: 'a' }] }
+  }
+  const first = await cache.get('k', fetcher, 0)
+  expect(first).toEqual({ reachable: false, outcome: 'exited' })
+  // Still within the failure TTL: cached failure, no re-fetch.
+  const stillCached = await cache.get('k', fetcher, 50)
+  expect(stillCached).toEqual({ reachable: false, outcome: 'exited' })
+  expect(calls).toBe(1)
+  // Past the failure TTL: re-fetches and now gets the real answer.
+  const recovered = await cache.get('k', fetcher, 200)
+  expect(recovered).toEqual({ reachable: true, tools: [{ name: 'a' }] })
+  expect(calls).toBe(2)
+})
+
+test('two different keys never share an entry', async () => {
+  const cache = new McpToolsCache(1000, 1000)
+  const a = await cache.get('a', async () => ({ reachable: true, tools: [{ name: 'x' }] }), 0)
+  const b = await cache.get('b', async () => ({ reachable: false, outcome: 'not-found' }), 0)
+  expect(a).toEqual({ reachable: true, tools: [{ name: 'x' }] })
+  expect(b).toEqual({ reachable: false, outcome: 'not-found' })
+})
+
+test('clear() drops every entry, forcing a re-fetch', async () => {
+  const cache = new McpToolsCache(10_000, 10_000)
+  let calls = 0
+  const fetcher = async (): Promise<McpToolsProbe> => { calls++; return { reachable: true, tools: [] } }
+  await cache.get('k', fetcher, 0)
+  cache.clear()
+  await cache.get('k', fetcher, 1)
+  expect(calls).toBe(2)
+})
+
+test('a server nobody has asked yet is PENDING, which is not offering no tools', () => {
+  // The composer opens on a keystroke and cannot wait for a server that spawns through `npx`.
+  // Measured: one server answered in 236ms with 19 tools, four others did not answer inside three
+  // minutes between them. So the route reports what it knows and says the rest is still being asked.
+  const view = toolsView({ name: 'serena', scope: 'user', transport: 'stdio' }, null)
+  expect(view.status).toBe('pending')
+  expect(view.tools).toBeUndefined()
+  expect(view.outcome).toBeUndefined()
+})
+
+test('peek returns null and starts exactly one probe per key', async () => {
+  const cache = new McpToolsCache()
+  let calls = 0
+  const fetcher = async (): Promise<McpToolsProbe> => { calls++; return { reachable: true, tools: [] } }
+  expect(cache.peek('k', fetcher)).toBeNull()
+  expect(cache.peek('k', fetcher)).toBeNull()
+  await new Promise(r => setTimeout(r, 10))
+  expect(calls).toBe(1)
+  // Once it has landed, peek answers without asking again.
+  expect(cache.peek('k', fetcher)?.reachable).toBe(true)
+  expect(calls).toBe(1)
+})

--- a/packages/server/server/mcp-tools.ts
+++ b/packages/server/server/mcp-tools.ts
@@ -1,0 +1,343 @@
+/**
+ * mcp-tools.ts — what tools does a configured MCP server actually offer?
+ *
+ * ## Why this needs its own question
+ *
+ * `mcp-check.ts` answers "does this server answer at all?" by speaking `initialize` and stopping.
+ * That is enough to tell a person their configuration works, but it is not enough for the web
+ * composer's `@<server>` / `@<server>:<tool>` references — those need the server's TOOL NAMES, and
+ * `initialize`'s reply carries none. The next line of the protocol, `tools/list`, does.
+ *
+ * This module never reimplements the handshake: it imports `initializeFrame` / `readInitialize` /
+ * `stdioOutcome` / `CHECK_TIMEOUT_MS` from `mcp-check.ts` and extends the same one-shot exchange
+ * with two more pipelined frames. A server that cannot even say hello is exactly as unreachable for
+ * this question as it is for that one, and the two must never disagree about it.
+ *
+ * ## Never a confident zero
+ *
+ * A server that could not be reached has an UNKNOWN tool list, not an empty one. `McpToolsProbe`
+ * therefore has two shapes rather than a `tools: []` default, and the cache stores whichever shape
+ * the probe actually returned — a failed spawn is remembered as a failure, never quietly reread as
+ * "a server with nothing to offer". Composer autocomplete is the one caller of this module today,
+ * and an empty menu reads to a person exactly like "this server has no tools" — the one sentence
+ * this file may never say by accident.
+ */
+
+import { CHECK_TIMEOUT_MS, initializeFrame, readInitialize, stdioOutcome, type McpCheckOutcome } from './mcp-check'
+import type { McpScope, McpServer, McpTransport } from './mcp-config'
+
+/** One tool, as `tools/list` names it. */
+export interface McpToolInfo {
+  name: string
+  description?: string
+}
+
+/**
+ * The `tools/list` request frame, as a line of JSON-RPC over stdio. `id: 2` — `initialize` is
+ * always `id: 1` — so a reply can be told apart from the handshake's even when both arrive in one
+ * captured chunk of stdout.
+ */
+export function toolsListFrame(): string {
+  return `${JSON.stringify({ jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} })}\n`
+}
+
+/**
+ * The notification the protocol expects between `initialize`'s reply and any other request. Sent
+ * unconditionally, pipelined right after `initializeFrame()` — see `fetchStdioTools` for why
+ * waiting for the actual reply first is not needed here.
+ */
+export function initializedNotification(): string {
+  return `${JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' })}\n`
+}
+
+/**
+ * What `tools/list`'s reply said, out of whatever the process printed.
+ *
+ * `answered` is the fact this file is built around: it is `true` the moment a line addresses OUR
+ * request (`id: 2`), success or error, and `false` when nothing ever did. That is what lets the
+ * caller tell "the server said hello and truly has no tools" (`answered: true, tools: []`) apart
+ * from "the server never got this far" (`answered: false`) — a single `McpToolInfo[]` return could
+ * not carry that difference, and losing it is exactly the confident-zero bug this module exists to
+ * avoid.
+ *
+ * Total: unparseable JSON, a non-object result, a non-array `tools`, or a tool with a non-string
+ * name are all read as "nothing usable here" rather than thrown on — mirroring `readInitialize`'s
+ * own line-by-line scan, including scanning past noise the server logged first.
+ */
+export function readToolsList(out: string): { answered: boolean; tools: McpToolInfo[] } {
+  for (const line of out.split('\n')) {
+    const t = line.trim()
+    if (t === '' || t[0] !== '{') continue
+    let msg: Record<string, unknown>
+    try { msg = JSON.parse(t) as Record<string, unknown> } catch { continue }
+    if (msg.id !== 2) continue
+
+    const result = msg.result
+    if (typeof result !== 'object' || result === null) return { answered: true, tools: [] }
+    const tools = (result as Record<string, unknown>).tools
+    if (!Array.isArray(tools)) return { answered: true, tools: [] }
+
+    const list: McpToolInfo[] = []
+    for (const item of tools) {
+      if (typeof item !== 'object' || item === null) continue
+      const rec = item as Record<string, unknown>
+      if (typeof rec.name !== 'string' || rec.name === '') continue
+      list.push({
+        name: rec.name,
+        ...(typeof rec.description === 'string' && rec.description !== '' ? { description: rec.description } : {}),
+      })
+    }
+    return { answered: true, tools: list }
+  }
+  return { answered: false, tools: [] }
+}
+
+/** What asking one server for its tools found. Two shapes on purpose — see the header comment. */
+export type McpToolsProbe =
+  | { reachable: true; tools: McpToolInfo[] }
+  | { reachable: false; outcome: McpCheckOutcome; exitCode?: number }
+
+/**
+ * Start the server exactly as configured, speak `initialize` + the `initialized` notification +
+ * `tools/list`, and report what came back.
+ *
+ * All three frames are written and stdin is closed BEFORE reading anything back — stdio is FIFO,
+ * so a well-behaved server processes them in the order they were sent regardless of when it
+ * chooses to answer the first one. This is deliberately the same shape `checkStdio` uses (write,
+ * close stdin, read until EOF or the timeout), extended by two more frames, rather than a
+ * request/reply-per-turn protocol client: the latter would duplicate `checkStdio`'s process
+ * lifecycle handling for no capability this question needs.
+ *
+ * The `initialize` half of the read is judged by `stdioOutcome` — the EXACT function
+ * `/api/mcp/check` judges it by — so a server this reports as unreachable is unreachable by the
+ * same standard the check panel already uses. Only once that judges `answers` does a missing
+ * `tools/list` reply become this function's own concern.
+ */
+export async function fetchStdioTools(
+  command: string, args: readonly string[], cwd?: string,
+): Promise<McpToolsProbe> {
+  let proc: Bun.Subprocess<'pipe', 'pipe', 'ignore'>
+  try {
+    proc = Bun.spawn({
+      cmd: [command, ...args],
+      stdin: 'pipe', stdout: 'pipe', stderr: 'ignore',
+      ...(cwd ? { cwd } : {}),
+    })
+  } catch {
+    return { reachable: false, outcome: 'not-found' }
+  }
+
+  try {
+    proc.stdin.write(initializeFrame())
+    proc.stdin.write(initializedNotification())
+    proc.stdin.write(toolsListFrame())
+    proc.stdin.end()
+  } catch {
+  }
+
+  let timedOut = false
+  const out = await Promise.race([
+    new Response(proc.stdout).text().catch(() => ''),
+    new Promise<string>(r => setTimeout(() => { timedOut = true; r('') }, CHECK_TIMEOUT_MS)),
+  ])
+  // The LOSING side of that race keeps reading — a `tools/list` timeout is exactly the case where
+  // the server never closed its own stdout, so without this the process (measured: a real
+  // `mongodb-mcp-server` left running for minutes, one per failed probe on every cache-failure-TTL
+  // retry) outlives the request that spawned it. `checkStdio` gets away without this because its
+  // callers so far have all been servers that answer or exit quickly; this one is asked on every
+  // composer keystroke and a slow server is the exact case that must not leak.
+  try { proc.kill() } catch {
+  }
+
+  const handshake = readInitialize(out)
+  const exitCode = typeof proc.exitCode === 'number' ? proc.exitCode : undefined
+  const check = stdioOutcome({
+    spawnFailed: false, handshake, exited: proc.exitCode !== null,
+    ...(exitCode !== undefined ? { exitCode } : {}), timedOut,
+  })
+  if (check.outcome !== 'answers') {
+    return {
+      reachable: false, outcome: check.outcome,
+      ...(check.exitCode !== undefined ? { exitCode: check.exitCode } : {}),
+    }
+  }
+
+  const reply = readToolsList(out)
+  if (reply.answered) return { reachable: true, tools: reply.tools }
+
+  // It said hello and then never answered `tools/list` — hung, crashed mid-reply, or silently
+  // ignores a capability it never declared. Reported the same way an unanswered `initialize` is:
+  // a fact about THIS run, never a cached "zero tools".
+  return {
+    reachable: false, outcome: timedOut ? 'timeout' : 'exited',
+    ...(exitCode !== undefined ? { exitCode } : {}),
+  }
+}
+
+/**
+ * One server, whichever transport it uses.
+ *
+ * http/sse/ws are reported `uncheckable`, the same code `mcp-check.ts` uses for a server with
+ * neither a command nor a url: those transports need a session and headers this process holds no
+ * client for (see `checkUrl`'s own comment — it answers reachability only, never a handshake), and
+ * listing tools needs the handshake. That is a statement about what THIS PROCESS can ask, never a
+ * claim that the server has no tools.
+ */
+export async function fetchServerTools(
+  server: Pick<McpServer, 'command' | 'args' | 'projectPath' | 'url'>,
+): Promise<McpToolsProbe> {
+  if (server.command) return fetchStdioTools(server.command, server.args ?? [], server.projectPath)
+  return { reachable: false, outcome: 'uncheckable' }
+}
+
+/** How long a real answer is kept, and how long a failure is — see `McpToolsCache`'s own comment. */
+export const TOOLS_CACHE_TTL_MS = 5 * 60_000
+export const TOOLS_FAILURE_TTL_MS = 30_000
+
+interface CacheEntry {
+  probe: McpToolsProbe
+  expiresAt: number
+}
+
+/**
+ * Per-server memo for `fetchServerTools`.
+ *
+ * The composer can open on every keystroke, and spawning a language-server-backed MCP server (the
+ * one this repo has measured takes noticeably long to answer even a bare `initialize`) on every one
+ * of them would be its own outage — hence a cache at all. But a FAILED probe is kept for a much
+ * shorter window than a real answer (`TOOLS_FAILURE_TTL_MS` vs `TOOLS_CACHE_TTL_MS`), and it is
+ * kept as a FAILURE: `probe.reachable` on a cache hit is exactly what it was on the miss that filled
+ * it. A cache that quietly turned "could not ask" into "asked, got nothing" the moment it got old
+ * enough would be the exact bug this module was written to not have.
+ */
+export class McpToolsCache {
+  private readonly entries = new Map<string, CacheEntry>()
+
+  constructor(
+    private readonly successTtlMs: number = TOOLS_CACHE_TTL_MS,
+    private readonly failureTtlMs: number = TOOLS_FAILURE_TTL_MS,
+  ) {
+  }
+
+  async get(key: string, fetcher: () => Promise<McpToolsProbe>, now: number = Date.now()): Promise<McpToolsProbe> {
+    const cached = this.entries.get(key)
+    if (cached && cached.expiresAt > now) return cached.probe
+    const probe = await this.run(key, fetcher, now)
+    return probe
+  }
+
+  /**
+   * WHAT IS KNOWN RIGHT NOW, WITHOUT WAITING — and a probe started for what is not.
+   *
+   * `get` blocks until the server answers, which is right for a health check somebody pressed and
+   * wrong for the composer. Measured on one machine's five configured servers: the one that runs
+   * from `bun` answered in 236ms with 19 tools, and the other four — three spawned through `npx`,
+   * one an HTTP/SSE endpoint — did not answer inside three minutes between them. A composer that
+   * opens on a keystroke cannot await that, and `@` does not need to: the server NAMES come from
+   * the config and are known instantly. Only the tool list behind `:` needs the probe.
+   *
+   * So this returns the cached answer or `null`, and starts the fetch that will fill it. The caller
+   * says "not asked yet" rather than "no tools", and the next open has the answer.
+   */
+  peek(key: string, fetcher: () => Promise<McpToolsProbe>, now: number = Date.now()): McpToolsProbe | null {
+    const cached = this.entries.get(key)
+    if (cached && cached.expiresAt > now) return cached.probe
+    if (!this.inFlight.has(key)) {
+      // Never awaited, and never allowed to reject into a caller that has already returned.
+      const run = this.run(key, fetcher, now).catch(() => undefined).finally(() => this.inFlight.delete(key))
+      this.inFlight.set(key, run)
+    }
+    return null
+  }
+
+  private readonly inFlight = new Map<string, Promise<unknown>>()
+
+  private async run(key: string, fetcher: () => Promise<McpToolsProbe>, now: number): Promise<McpToolsProbe> {
+    const probe = await fetcher()
+    const ttl = probe.reachable ? this.successTtlMs : this.failureTtlMs
+    this.entries.set(key, { probe, expiresAt: now + ttl })
+    return probe
+  }
+
+  /** Tests only, and a config write that might make a previously-unreachable server answer now. */
+  clear(): void {
+    this.entries.clear()
+  }
+}
+
+const defaultCache = new McpToolsCache()
+
+/**
+ * The cache key for one configured server. `scope` + `projectPath` are part of it because the same
+ * NAME can be configured differently in `local` vs `project` vs `user` scope, or for two different
+ * directories' `local` scope — `mcp-check.ts`'s own `/api/mcp/check` route looks a server up by
+ * name AND scope for the same reason.
+ */
+export function toolsCacheKey(server: Pick<McpServer, 'name' | 'scope' | 'projectPath'>): string {
+  return `${server.scope}:${server.projectPath ?? ''}:${server.name}`
+}
+
+/**
+ * What is already known about a server's tools, without waiting for it to answer.
+ *
+ * `null` means NOT ASKED YET, which is a third thing beside "reachable with these tools" and
+ * "unreachable for this reason" — and the composer must say so rather than showing an empty list.
+ * A probe is started, so the next call has the answer.
+ */
+export function peekServerTools(
+  server: Pick<McpServer, 'name' | 'scope' | 'projectPath' | 'command' | 'args' | 'url'>,
+  cache: McpToolsCache = defaultCache,
+): McpToolsProbe | null {
+  return cache.peek(toolsCacheKey(server), () => fetchServerTools(server))
+}
+
+/** `fetchServerTools`, memoized. The default cache is process-wide; tests pass their own. */
+export async function getServerTools(
+  server: Pick<McpServer, 'name' | 'scope' | 'projectPath' | 'command' | 'args' | 'url'>,
+  cache: McpToolsCache = defaultCache,
+): Promise<McpToolsProbe> {
+  return cache.get(toolsCacheKey(server), () => fetchServerTools(server))
+}
+
+/** Tests only. */
+export function resetMcpToolsCache(): void {
+  defaultCache.clear()
+}
+
+/** What the route hands back for one server — never the server's command, args, or env. */
+export interface McpServerToolsView {
+  name: string
+  scope: McpScope
+  transport: McpTransport
+  /**
+   * THREE STATES, not two. `'pending'` is "nobody has asked this server yet", and it is a different
+   * fact from "asked, and it offers nothing" — the composer must say so rather than draw an empty
+   * list. The server names are known from the config either way, so `@` works immediately and only
+   * the tool list behind `:` waits.
+   */
+  status: 'ready' | 'unreachable' | 'pending'
+  tools?: McpToolInfo[]
+  outcome?: McpCheckOutcome
+  exitCode?: number
+}
+
+/**
+ * A server plus its probe, shaped for the wire. Deliberately narrow: no `command`, `args`, `envKeys`
+ * or `config` — this route answers "what tools", not "how is it configured", and `mcp-config.ts`'s
+ * own env-stripping rule exists precisely because a value from that configuration must never cross
+ * this boundary.
+ */
+export function toolsView(
+  server: Pick<McpServer, 'name' | 'scope' | 'transport'>,
+  probe: McpToolsProbe | null,
+): McpServerToolsView {
+  const base = { name: server.name, scope: server.scope, transport: server.transport }
+  // `null` is the probe that has not come back yet — see `McpServerToolsView.status`.
+  if (probe === null) return { ...base, status: 'pending' }
+  if (probe.reachable) return { ...base, status: 'ready', tools: probe.tools }
+  return {
+    ...base, status: 'unreachable',
+    outcome: probe.outcome,
+    ...(probe.exitCode !== undefined ? { exitCode: probe.exitCode } : {}),
+  }
+}

--- a/packages/web/src/components/sessions/SessionChat.tsx
+++ b/packages/web/src/components/sessions/SessionChat.tsx
@@ -46,6 +46,7 @@ import { liveTurnText, stripAnsi } from '../../lib/liveTurn'
 import { scratchKey, sessionScratch } from '../../lib/sessionScratch'
 import { chatReadAt, firstFrameStale, refreshChat, subscribeChat } from '../../lib/chatFeed'
 import { composerMaxHeight } from '../../lib/composerHeight'
+import { nudgeFleet } from '../../lib/fleet'
 import { artifactsFromTurns, hasUnlistedWrites, type Artifact } from '../../lib/sessionArtifacts'
 import type { LiveTurn } from '../../lib/artifactTabs'
 import { MAX_ATTACHMENTS, attachmentRoom, planPaste } from '../../lib/pastePlan'
@@ -2097,7 +2098,13 @@ export function SessionChat({ session, row, lang, act, onArtifacts }: SessionCha
                 {row?.mode && !answeringNow && (
                   <button
                     onClick={() => void act({ id: session.id, action: 'cycleMode' })
-                      .then(out => setNotice(out.message))}
+                      .then(out => {
+                        setNotice(out.message)
+                        // The chip's word comes from the next capture of the pane, not from this
+                        // reply — so without a nudge it kept showing the OLD mode until the 5s
+                        // poll came round, and the button read as broken.
+                        nudgeFleet()
+                      })}
                     disabled={!canPrompt}
                     aria-label={pt ? `Modo: ${row.mode.label}. Trocar para o próximo.` : `Mode: ${row.mode.label}. Switch to the next.`}
                     title={pt

--- a/packages/web/src/components/sessions/SessionChat.tsx
+++ b/packages/web/src/components/sessions/SessionChat.tsx
@@ -56,6 +56,11 @@ import {
   applySkill, emptyPickerReason, filterSkills, flattenGroups, groupSkills, slashMisplaced,
   slashQuery, stepSkill,
 } from '../../lib/skillMenu'
+import {
+  applyAtServer, applyAtTool, atLevel, atQuery, atServerStatusText, atToolViewReason,
+  emptyAtServerReason, emptyAtToolReason, filterAtServers, findAtServer, resolveAtToolView,
+  type MenuMcpServer,
+} from '../../lib/atMenu'
 import { composeReply, markExcerpt, quoteFor, replyAuthor, replyPreview, type ReplyTarget } from '../../lib/replyQuote'
 import { pendingEchoes } from '@agentistics/core'
 import {
@@ -457,6 +462,110 @@ export function SessionChat({ session, row, lang, act, onArtifacts }: SessionCha
       .catch(() => { if (alive) setSkills([]) })
     return () => { alive = false }
   }, [moreOpen, slashText, skills, session.id, pt])
+
+  /**
+   * TYPING `@` REFERENCES AN MCP SERVER — two levels, the second reached by typing `:` after a
+   * server's name, exactly as asked for ("com : uma lista de ferramentas aparece"). Every decision
+   * — the trigger, the two levels, the filter, what a pick writes — lives in `atMenu.ts`; this is
+   * only the wiring, mirroring the `/` picker above rather than inventing a second interaction
+   * model.
+   *
+   * `null` is "not asked yet", same distinction `skills` keeps: `/api/mcp/tools` answers server
+   * NAMES instantly but a `pending` one's tool count arrives later, which is why this keeps
+   * POLLING (below) for as long as the picker could still be showing one.
+   */
+  const [mcpServers, setMcpServers] = useState<MenuMcpServer[] | null>(null)
+  /** Escape closes the picker while the `@word` it was triggered by is still on screen — see `slashDismissed`. */
+  const [atDismissed, setAtDismissed] = useState(false)
+  const [atIndex, setAtIndex] = useState(0)
+  const atPickerRef = useRef<HTMLDivElement | null>(null)
+  const atText = useMemo(() => atQuery(draft.slice(0, caret)), [draft, caret])
+  useEffect(() => { if (atText === null) setAtDismissed(false) }, [atText])
+  // A new query (server filter OR tool filter) is a new list — see `slashIndex`'s own reasoning.
+  useEffect(() => { setAtIndex(0) }, [atText])
+  const atLvl = useMemo(() => (atText === null ? null : atLevel(atText)), [atText])
+
+  useEffect(() => {
+    // Fetched once, the first time the `@` picker opens — same reasoning as the skill fetch just
+    // above: most sessions are read rather than driven, and answering this starts every configured
+    // server's command.
+    if (atText === null || mcpServers !== null) return
+    let alive = true
+    const q = session.cwd ? `?projectPath=${encodeURIComponent(session.cwd)}` : ''
+    fetch(`/api/mcp/tools${q}`)
+      .then(r => (r.ok ? r.json() : null))
+      .then((d: { servers?: MenuMcpServer[] } | null) => { if (alive) setMcpServers(d?.servers ?? []) })
+      .catch(() => { if (alive) setMcpServers([]) })
+    return () => { alive = false }
+  }, [atText, mcpServers, session.cwd])
+
+  useEffect(() => {
+    // A `pending` server's tool count is not yet known — `/api/mcp/tools` never waits for it (see
+    // its own header), so getting past `pending` means asking again. Only while the picker could
+    // still be showing the answer, and stopped the moment nothing is pending any more.
+    if (atText === null || mcpServers === null || !mcpServers.some(s => s.status === 'pending')) return
+    const q = session.cwd ? `?projectPath=${encodeURIComponent(session.cwd)}` : ''
+    const t = setTimeout(() => {
+      fetch(`/api/mcp/tools${q}`)
+        .then(r => (r.ok ? r.json() : null))
+        .then((d: { servers?: MenuMcpServer[] } | null) => { if (d?.servers) setMcpServers(d.servers) })
+        .catch(() => { /* the next poll tries again */ })
+    }, 1500)
+    return () => clearTimeout(t)
+  }, [atText, mcpServers, session.cwd])
+
+  /** The SERVER level's filtered list — empty until `mcpServers` has answered. */
+  const atServers = useMemo(() => {
+    if (mcpServers === null || atLvl === null || atLvl.level !== 'server') return []
+    return filterAtServers(mcpServers, atLvl.serverText)
+  }, [mcpServers, atLvl])
+  /** The TOOL level's resolved view — `null` until both the servers and the level are known. */
+  const atTools = useMemo(() => {
+    if (mcpServers === null || atLvl === null || atLvl.level !== 'tool') return null
+    return resolveAtToolView(mcpServers, atLvl.serverText, atLvl.toolText)
+  }, [mcpServers, atLvl])
+  /** The flat, navigable list for THIS level — servers, or a ready server's tools. */
+  const atFlatLen = atLvl?.level === 'tool'
+    ? (atTools?.kind === 'tools' ? atTools.tools.length : 0)
+    : atServers.length
+  // Same reasoning as the skill picker's own scroll effect — a cursor stepped past the fold is
+  // invisible and still the thing enter acts on.
+  useEffect(() => {
+    const el = atPickerRef.current?.querySelector(`[data-at-index="${atIndex}"]`)
+    el?.scrollIntoView({ block: 'nearest' })
+  }, [atIndex, atServers, atTools])
+
+  /** Rule 4: a bare server mention, no `:` typed. Writes `@name ` and closes. */
+  const insertAtServer = useCallback((name: string) => {
+    const at = textareaRef.current?.selectionStart ?? caret
+    const out = applyAtServer(draft, at, name)
+    editDraft(out.text)
+    setCaret(out.caret)
+    requestAnimationFrame(() => {
+      const node = textareaRef.current
+      if (!node) return
+      node.focus()
+      node.setSelectionRange(out.caret, out.caret)
+    })
+  }, [draft, caret, editDraft])
+
+  /**
+   * A tool picked at the tool level. Writes `@server:tool ` and REOPENS an empty `@server:`
+   * trigger right after it — see `applyAtTool`'s own header for why that is the whole mechanism
+   * behind choosing more than one before the picker closes.
+   */
+  const insertAtTool = useCallback((server: string, tool: string) => {
+    const at = textareaRef.current?.selectionStart ?? caret
+    const out = applyAtTool(draft, at, server, tool)
+    editDraft(out.text)
+    setCaret(out.caret)
+    requestAnimationFrame(() => {
+      const node = textareaRef.current
+      if (!node) return
+      node.focus()
+      node.setSelectionRange(out.caret, out.caret)
+    })
+  }, [draft, caret, editDraft])
 
   /** Switch the model mid-conversation by TYPING the harness's own command — see modelSwitch.ts. */
   const switchModel = useCallback(async (model: string) => {
@@ -1034,6 +1143,12 @@ export function SessionChat({ session, row, lang, act, onArtifacts }: SessionCha
    * is already disabled there, so there is nothing to type a `/` into and no control left inert.
    */
   const skillPickerOpen = canPrompt && !blocked && !slashDismissed && slashText !== null
+  /**
+   * The `@` picker is open. Same refusals `skillPickerOpen` states for the same reason — a
+   * reference typed into a session sitting on a dialog goes into that dialog's own filter, and the
+   * submit takes the highlighted option.
+   */
+  const atOpen = canPrompt && !blocked && !atDismissed && atText !== null
   /** The row's own reopen verb, if it has one. Enabled by the server, never inferred here. */
   const reopen = row?.verbs.find(v => v.action === 'resume')
   const [reopening, setReopening] = useState(false)
@@ -1567,6 +1682,128 @@ export function SessionChat({ session, row, lang, act, onArtifacts }: SessionCha
               )}
             </div>
           )}
+          {/* THE MCP PICKER, opened by typing `@` at the start of a word. Two levels — the
+              configured SERVERS, and (once `:` is typed after one) that server's TOOLS — driven
+              entirely by the text itself, exactly as `atMenu.ts`'s header explains. */}
+          {atOpen && (
+            <div
+              ref={atPickerRef}
+              role="listbox"
+              aria-label="MCP"
+              style={{
+                position: 'absolute', bottom: '100%', left: 0, right: 0, zIndex: 60,
+                marginBottom: 8, padding: 4, borderRadius: 12,
+                background: 'var(--bg-elevated)', border: '1px solid var(--border)',
+                boxShadow: '0 10px 30px rgba(0,0,0,0.38)',
+                maxHeight: isMobile ? '50vh' : 300, overflowY: 'auto', overscrollBehavior: 'contain',
+              }}
+            >
+              {mcpServers === null ? (
+                <p style={{ margin: 0, padding: '8px 10px', fontSize: 11.5, color: 'var(--text-tertiary)' }}>
+                  {pt ? 'Lendo os servidores MCP…' : 'Reading the MCP servers…'}
+                </p>
+              ) : atLvl?.level === 'tool' ? (
+                // TOOL LEVEL — a `:` was typed after a server's name.
+                atTools === null ? null : atTools.kind !== 'tools' ? (
+                  <p style={{ margin: 0, padding: '8px 10px', fontSize: 11.5, lineHeight: 1.45, color: 'var(--text-tertiary)' }}>
+                    {atToolViewReason(atTools, atLvl.serverText, pt ? 'pt' : 'en')}
+                  </p>
+                ) : atTools.tools.length === 0 ? (
+                  <p style={{ margin: 0, padding: '8px 10px', fontSize: 11.5, lineHeight: 1.45, color: 'var(--text-tertiary)' }}>
+                    {emptyAtToolReason(
+                      atLvl.serverText, findAtServer(mcpServers, atLvl.serverText)?.tools?.length ?? 0,
+                      atLvl.toolText, pt ? 'pt' : 'en',
+                    )}
+                  </p>
+                ) : (
+                  <>
+                    {atTools.tools.map((t, i) => (
+                      <button
+                        key={t.name}
+                        role="option"
+                        aria-selected={i === Math.min(atIndex, atTools.tools.length - 1)}
+                        data-at-index={i}
+                        title={t.description}
+                        onMouseDown={e => e.preventDefault()}
+                        onMouseEnter={() => setAtIndex(i)}
+                        onClick={() => insertAtTool(atLvl.serverText, t.name)}
+                        style={{
+                          display: 'block', width: '100%', textAlign: 'left',
+                          minHeight: isMobile ? 44 : 34, padding: '6px 8px', borderRadius: 8,
+                          border: 'none',
+                          background: i === Math.min(atIndex, atTools.tools.length - 1) ? 'var(--bg-surface)' : 'transparent',
+                          color: 'var(--text-primary)', fontFamily: 'inherit', fontSize: 12.5,
+                          cursor: 'pointer', minWidth: 0,
+                        }}
+                      >
+                        <span style={{ display: 'block', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                          {t.name}
+                        </span>
+                        {t.description && (
+                          <span style={{
+                            display: 'block', fontSize: 10.5, lineHeight: 1.35, color: 'var(--text-tertiary)',
+                            overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+                          }}>
+                            {t.description}
+                          </span>
+                        )}
+                      </button>
+                    ))}
+                    <p style={{ margin: '4px 8px', fontSize: 10, lineHeight: 1.4, color: 'var(--text-tertiary)' }}>
+                      {pt
+                        ? '↑↓ escolhe · enter adiciona (dá para escolher mais de uma) · esc fecha. Não envia.'
+                        : '↑↓ to move · enter adds it (choose more than one) · esc closes. It does not send.'}
+                    </p>
+                  </>
+                )
+              ) : (
+                // SERVER LEVEL — no `:` typed yet.
+                atServers.length === 0 ? (
+                  <p style={{ margin: 0, padding: '8px 10px', fontSize: 11.5, lineHeight: 1.45, color: 'var(--text-tertiary)' }}>
+                    {emptyAtServerReason(mcpServers.length, atLvl?.serverText ?? '', pt ? 'pt' : 'en')}
+                  </p>
+                ) : (
+                  <>
+                    {atServers.map((s, i) => (
+                      <button
+                        key={s.name}
+                        role="option"
+                        aria-selected={i === Math.min(atIndex, atServers.length - 1)}
+                        data-at-index={i}
+                        onMouseDown={e => e.preventDefault()}
+                        onMouseEnter={() => setAtIndex(i)}
+                        onClick={() => insertAtServer(s.name)}
+                        style={{
+                          display: 'block', width: '100%', textAlign: 'left',
+                          minHeight: isMobile ? 44 : 34, padding: '6px 8px', borderRadius: 8,
+                          border: 'none',
+                          background: i === Math.min(atIndex, atServers.length - 1) ? 'var(--bg-surface)' : 'transparent',
+                          color: 'var(--text-primary)', fontFamily: 'inherit', fontSize: 12.5,
+                          cursor: s.status === 'unreachable' ? 'default' : 'pointer', minWidth: 0,
+                        }}
+                      >
+                        <span style={{ display: 'block', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                          @{s.name}
+                        </span>
+                        <span style={{
+                          display: 'block', fontSize: 10.5, lineHeight: 1.35,
+                          color: s.status === 'unreachable' ? 'var(--accent-red)' : 'var(--text-tertiary)',
+                          overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+                        }}>
+                          {atServerStatusText(s, pt ? 'pt' : 'en')}
+                        </span>
+                      </button>
+                    ))}
+                    <p style={{ margin: '4px 8px', fontSize: 10, lineHeight: 1.4, color: 'var(--text-tertiary)' }}>
+                      {pt
+                        ? '↑↓ escolhe · enter referencia · digite “:” para ver as ferramentas · esc fecha.'
+                        : '↑↓ to move · enter references it · type “:” to see its tools · esc closes.'}
+                    </p>
+                  </>
+                )
+              )}
+            </div>
+          )}
           {/* NO COMPOSER UNTIL THE CONVERSATION IS THERE. A field offered over a conversation still
               loading invites a message into a session whose state is not yet known — including one
               sitting in a dialog, where the text would go into the dialog's own filter. */}
@@ -1904,7 +2141,9 @@ export function SessionChat({ session, row, lang, act, onArtifacts }: SessionCha
                     setTyping(false)
                     // Leaving the field closes the picker — unless the focus went INTO it, which
                     // is what a keyboard user tabbing onto an entry does.
-                    if (!skillPickerRef.current?.contains(e.relatedTarget as Node | null)) setSlashDismissed(true)
+                    const into = e.relatedTarget as Node | null
+                    if (!skillPickerRef.current?.contains(into)) setSlashDismissed(true)
+                    if (!atPickerRef.current?.contains(into)) setAtDismissed(true)
                   }}
                   onPaste={onPaste}
                   onKeyDown={e => {
@@ -1924,6 +2163,27 @@ export function SessionChat({ session, row, lang, act, onArtifacts }: SessionCha
                     // Escape closes the picker BEFORE it reaches the stop verb: a person dismissing
                     // a list they opened by accident must not interrupt the session's turn.
                     if (e.key === 'Escape' && skillPickerOpen) { e.preventDefault(); setSlashDismissed(true); return }
+                    // THE `@` PICKER OWNS THE SAME KEYS, over whichever level is showing. At the
+                    // tool level Enter does NOT close it — `insertAtTool` reopens an empty
+                    // `@server:` trigger right after the token it writes, which is the whole
+                    // mechanism behind picking more than one before moving on.
+                    if (atOpen && atFlatLen > 0) {
+                      if (e.key === 'ArrowDown') { e.preventDefault(); setAtIndex(i => stepSkill(i, atFlatLen, 1)); return }
+                      if (e.key === 'ArrowUp') { e.preventDefault(); setAtIndex(i => stepSkill(i, atFlatLen, -1)); return }
+                      if (e.key === 'Enter' && !e.shiftKey && !isMobile) {
+                        e.preventDefault()
+                        const i = Math.min(atIndex, atFlatLen - 1)
+                        if (atLvl?.level === 'tool') {
+                          const picked = atTools?.kind === 'tools' ? atTools.tools[i] : undefined
+                          if (picked) insertAtTool(atLvl.serverText, picked.name)
+                        } else {
+                          const picked = atServers[i]
+                          if (picked) insertAtServer(picked.name)
+                        }
+                        return
+                      }
+                    }
+                    if (e.key === 'Escape' && atOpen) { e.preventDefault(); setAtDismissed(true); return }
                     // ON A PHONE, ENTER BREAKS THE LINE. Asked for directly, and it is the
                     // convention every messaging app on a touch keyboard follows: the return key is
                     // the only way to write a second line there, because `shift+enter` needs a

--- a/packages/web/src/components/sessions/SessionChat.tsx
+++ b/packages/web/src/components/sessions/SessionChat.tsx
@@ -28,7 +28,7 @@
  */
 
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
-import { ArrowDown, ChevronUp, CornerUpLeft, History, Loader, Mic, Paperclip, RotateCcw, Send, SlidersHorizontal, Square, X } from 'lucide-react'
+import { AlertTriangle, ArrowDown, ChevronUp, CornerUpLeft, History, Loader, Mic, Paperclip, RotateCcw, Send, SlidersHorizontal, Square, X } from 'lucide-react'
 import { hasSomethingToSend, stopShown as isStopShown } from '../../lib/composerAction'
 import type { ControlSession } from '@agentistics/tui/control/session-fleet'
 import type { FleetActionId, FleetRow } from '../../lib/fleet'
@@ -61,7 +61,9 @@ import { pendingEchoes } from '@agentistics/core'
 import {
   applyDraftRequest, consumeDraftRequest, getDraftRequest, useDraftRequest,
 } from '../../lib/composerStore'
-import { splitSlashLine } from '../../lib/slashLine'
+import { commandToken, knownCommands } from '../../lib/commandToken'
+import { draftSegments, needsMirror } from '../../lib/commandMirror'
+import { commandNotFoundNotice } from '../../lib/commandNotice'
 import { lastSentMessage, turnAnchorId } from '../../lib/lastSent'
 import { goToTurn } from '../../lib/turnScroll'
 import { attachmentName, isImageAttachment, splitMessage } from '../../lib/messageAttachments'
@@ -866,8 +868,12 @@ export function SessionChat({ session, row, lang, act, onArtifacts }: SessionCha
    * so a request can never land in another conversation's box. It APPENDS and never sends: what
    * reaches a session is what the person pressed enter on.
    */
-  /** The leading `/skill` of what is typed, for the field's own marker. See `slashLine.ts`. */
-  const slashDraft = useMemo(() => splitSlashLine(draft), [draft])
+  /**
+   * The leading `/command` of what is typed, for the field's own marker — see `commandToken.ts`.
+   * `knownCommands` carries `skills === null` through as `null` rather than an empty set, which is
+   * what keeps a session's first command from being painted `missing` before the list has answered.
+   */
+  const cmdToken = useMemo(() => commandToken(draft, knownCommands(skills)), [draft, skills])
   /**
    * A `/` typed where a command cannot be — see `slashMisplaced`.
    *
@@ -1838,18 +1844,30 @@ export function SessionChat({ session, row, lang, act, onArtifacts }: SessionCha
                   onChange={e => pick(e.target.files)}
                   style={{ display: 'none' }}
                 />
-                {/* THE INVOCATION IS MARKED IN THE FIELD ITSELF.
-                    A textarea cannot hold coloured spans, so this is the standard underlay: a div
-                    with the SAME typography and padding, behind the field, drawing the command as a
-                    highlighted block with transparent text. The field above keeps its own colour
-                    and its own caret — which is the reason it is a BACKGROUND and not a colour
-                    swap: `color: transparent` on the textarea would take the selection highlight
-                    and the caret with it, and a millimetre of metric drift would then be unreadable
-                    text rather than a marker sitting slightly off.
-                    It scrolls with the field, is `aria-hidden` (the text is already in the field,
-                    and a screen reader must not hear it twice) and takes no pointer events. */}
+                {/* THE INVOCATION IS PAINTED LIKE A BUTTON, IN THE FIELD ITSELF.
+                    A textarea cannot hold a coloured span, so a FOUND command is drawn by a mirror:
+                    a div with the SAME typography, padding and wrapping, behind the field, drawing
+                    the whole draft again with the command's run wrapped in an orange-on-white span
+                    — and the field's OWN text turned transparent so only the mirror is seen. That is
+                    a bigger step than colouring a background block behind the field's own opaque
+                    text (which is all a background-only marker can ever do): a BUTTON needs the
+                    glyphs themselves recoloured, and a plain textarea has no way to recolour one run
+                    of its own text. `caretColor` is set explicitly so hiding the text does not hide
+                    the caret with it (the caret otherwise follows `color`, which the transparency
+                    would carry off too) — the trade this makes, and it is a real one, is that a
+                    dragged SELECTION over the mirrored text highlights the right span (the browser
+                    measures the real, transparent characters) but shows no glyphs inside it, because
+                    those glyphs are exactly what was made invisible.
+                    `needsMirror`/`draftSegments` (`commandMirror.ts`) are the ONE place both
+                    decisions are made — whether to draw the mirror at all and which runs it paints —
+                    so the two can never drift into "a mirror with nothing painted" or "hidden text
+                    with no mirror to show it". Nothing here is state: both are re-derived from the
+                    draft and the token on every render, which is what makes deleting one character
+                    of the command turn it back into plain text with no flag to remember.
+                    The mirror scrolls with the field, is `aria-hidden` (the text is already in the
+                    field, and a screen reader must not hear it twice) and takes no pointer events. */}
                 <div style={{ position: 'relative' }}>
-                  {slashDraft.command !== '' && (
+                  {needsMirror(cmdToken) && (
                     <div
                       aria-hidden
                       ref={underlayRef}
@@ -1857,15 +1875,20 @@ export function SessionChat({ session, row, lang, act, onArtifacts }: SessionCha
                         position: 'absolute', inset: 0, overflow: 'hidden', pointerEvents: 'none',
                         boxSizing: 'border-box', padding: '6px 6px',
                         fontFamily: 'inherit', fontSize: 13.5, lineHeight: 1.5,
-                        whiteSpace: 'pre-wrap', overflowWrap: 'anywhere', color: 'transparent',
+                        whiteSpace: 'pre-wrap', overflowWrap: 'anywhere', color: 'var(--text-primary)',
                       }}
                     >
-                      <span style={{
-                        background: 'var(--anthropic-orange-dim)',
-                        boxShadow: '0 0 0 1px var(--anthropic-orange)',
-                        borderRadius: 4,
-                      }}>{slashDraft.command}</span>
-                      {slashDraft.rest}
+                      {draftSegments(draft, cmdToken).map((seg, i) => seg.button ? (
+                        <span key={i} style={{
+                          background: 'var(--anthropic-orange)', color: '#fff',
+                          borderRadius: 4,
+                          boxShadow: '0 0 0 2px var(--anthropic-orange)',
+                        }}>{seg.text}</span>
+                      ) : (
+                        // A plain run — key only, no wrapper style, so it never disagrees with the
+                        // textarea's own metrics for the text it is standing in for.
+                        <span key={i}>{seg.text}</span>
+                      ))}
                     </div>
                   )}
                 <textarea
@@ -1939,9 +1962,15 @@ export function SessionChat({ session, row, lang, act, onArtifacts }: SessionCha
                     // ROW and was left behind when it became a column.
                     width: '100%', display: 'block', boxSizing: 'border-box',
                     resize: 'none', border: 'none', outline: 'none', background: 'transparent',
-                    color: 'var(--text-primary)', fontFamily: 'inherit', fontSize: 13.5,
+                    // Transparent ONLY while the mirror is drawing the same text underneath — see
+                    // the note above the mirror div. `caretColor` is set unconditionally to the same
+                    // colour the text would otherwise be, so it never rides on `color` and vanishes
+                    // the moment `color` does.
+                    color: needsMirror(cmdToken) ? 'transparent' : 'var(--text-primary)',
+                    caretColor: 'var(--text-primary)',
+                    fontFamily: 'inherit', fontSize: 13.5,
                     lineHeight: 1.5, maxHeight: maxComposerH, overflowY: 'auto', padding: '6px 6px',
-                    // Above the underlay, and transparent so the mark shows through.
+                    // Above the mirror.
                     position: 'relative', zIndex: 1,
                   }}
                   onScroll={e => {
@@ -1959,6 +1988,21 @@ export function SessionChat({ session, row, lang, act, onArtifacts }: SessionCha
                     {pt
                       ? 'Uma skill só vale no começo da linha — apague o que está antes, ou quebre a linha.'
                       : 'A skill only counts at the start of a line — clear what is before it, or break the line.'}
+                  </p>
+                )}
+
+                {/* MISSING WARNS, IT NEVER BLOCKS. `commandToken.ts` already refuses to guess here:
+                    this only ever renders for `missing` (the session's own list does not have it),
+                    never for `unknown` (no list to check yet) — see its header for why those two
+                    are not the same fact. The send button below reads none of this. */}
+                {cmdToken?.state === 'missing' && (
+                  <p role="status" style={{
+                    display: 'flex', alignItems: 'center', gap: 5,
+                    margin: '2px 6px 0', fontSize: 10.5, lineHeight: 1.5,
+                    color: '#f59e0b',
+                  }}>
+                    <AlertTriangle size={11} style={{ flexShrink: 0 }} />
+                    {commandNotFoundNotice(cmdToken.text, pt)}
                   </p>
                 )}
 

--- a/packages/web/src/lib/atMenu.test.ts
+++ b/packages/web/src/lib/atMenu.test.ts
@@ -1,0 +1,213 @@
+import { test, expect } from 'bun:test'
+import {
+  applyAtServer, applyAtTool, atLevel, atQuery, atServerStatusText, atToolViewReason,
+  emptyAtServerReason, emptyAtToolReason, filterAtServers, filterAtTools, findAtServer,
+  resolveAtToolView, type MenuMcpServer, type MenuMcpTool,
+} from './atMenu'
+
+const tool = (name: string, description = ''): MenuMcpTool => ({ name, description })
+const server = (
+  name: string, status: MenuMcpServer['status'], extra: Partial<MenuMcpServer> = {},
+): MenuMcpServer => ({ name, status, ...extra })
+
+// ---------------------------------------------------------------------------------------------
+// atQuery — the trigger, and its word-boundary rule.
+// ---------------------------------------------------------------------------------------------
+
+test('a bare @ at the start of the message opens with an empty query', () => {
+  expect(atQuery('@')).toBe('')
+})
+
+test('typing after the @ is the query', () => {
+  expect(atQuery('@serena')).toBe('serena')
+  expect(atQuery('@serena:find')).toBe('serena:find')
+})
+
+test('an @ preceded by whitespace still triggers — it is a new word', () => {
+  expect(atQuery('hi @serena')).toBe('serena')
+  expect(atQuery('line one\n@serena')).toBe('serena')
+})
+
+test('an @ MID-WORD is not a trigger — an email address, a git ref', () => {
+  expect(atQuery('user@domain')).toBeNull()
+  expect(atQuery('HEAD@{1}')).toBeNull()
+})
+
+test('a trailing space ends the reference, same rule as the slash picker', () => {
+  expect(atQuery('@serena ')).toBeNull()
+  expect(atQuery('@serena: ')).toBeNull()
+})
+
+test('no @ at all is simply closed', () => {
+  expect(atQuery('')).toBeNull()
+  expect(atQuery('hello there')).toBeNull()
+})
+
+// ---------------------------------------------------------------------------------------------
+// atLevel — the two-level split on the FIRST colon.
+// ---------------------------------------------------------------------------------------------
+
+test('no colon is the server level, filtering by the whole query', () => {
+  expect(atLevel('')).toEqual({ level: 'server', serverText: '', toolText: '' })
+  expect(atLevel('ser')).toEqual({ level: 'server', serverText: 'ser', toolText: '' })
+})
+
+test('a colon switches to the tool level for the name typed before it', () => {
+  expect(atLevel('serena:')).toEqual({ level: 'tool', serverText: 'serena', toolText: '' })
+  expect(atLevel('serena:find')).toEqual({ level: 'tool', serverText: 'serena', toolText: 'find' })
+})
+
+test('a second colon is just more filter text, never a third level', () => {
+  expect(atLevel('serena:a:b')).toEqual({ level: 'tool', serverText: 'serena', toolText: 'a:b' })
+})
+
+// ---------------------------------------------------------------------------------------------
+// filterAtServers / findAtServer
+// ---------------------------------------------------------------------------------------------
+
+test('the server filter is case-insensitive substring, and blank means everything', () => {
+  const list = [server('serena', 'ready'), server('agentistics', 'ready')]
+  expect(filterAtServers(list, 'SER').map(s => s.name)).toEqual(['serena'])
+  expect(filterAtServers(list, '')).toHaveLength(2)
+})
+
+test('finding an exact server is case-insensitive too — the list is what taught the case', () => {
+  const list = [server('Serena', 'ready')]
+  expect(findAtServer(list, 'serena')?.name).toBe('Serena')
+  expect(findAtServer(list, 'nope')).toBeNull()
+})
+
+// ---------------------------------------------------------------------------------------------
+// filterAtTools / resolveAtToolView — never a confident zero.
+// ---------------------------------------------------------------------------------------------
+
+test('the tool filter reads name AND description', () => {
+  const tools = [tool('find_symbol', 'Locate a symbol'), tool('write_memory', 'Persist a note')]
+  expect(filterAtTools(tools, 'locate').map(t => t.name)).toEqual(['find_symbol'])
+  expect(filterAtTools(tools, '')).toHaveLength(2)
+})
+
+test('a pending server never resolves as zero tools — it resolves as PENDING', () => {
+  const list = [server('serena', 'pending')]
+  expect(resolveAtToolView(list, 'serena', '')).toEqual({ kind: 'pending' })
+})
+
+test('an unreachable server carries its reason and is never descended into', () => {
+  const list = [server('serena', 'unreachable', { outcome: 'not-found' })]
+  expect(resolveAtToolView(list, 'serena', '')).toEqual({ kind: 'unreachable', outcome: 'not-found' })
+})
+
+test('a typo in the server name is UNKNOWN, not an empty tool list', () => {
+  const list = [server('serena', 'ready', { tools: [] })]
+  expect(resolveAtToolView(list, 'serenaa', '')).toEqual({ kind: 'unknown-server' })
+})
+
+test('a ready server resolves its (filtered) tool list', () => {
+  const list = [server('serena', 'ready', { tools: [tool('find_symbol'), tool('write_memory')] })]
+  expect(resolveAtToolView(list, 'serena', 'find')).toEqual({ kind: 'tools', tools: [tool('find_symbol')] })
+  expect(resolveAtToolView(list, 'serena', '')).toEqual({
+    kind: 'tools', tools: [tool('find_symbol'), tool('write_memory')],
+  })
+})
+
+// ---------------------------------------------------------------------------------------------
+// atServerStatusText — the row subtitle, three states, three sentences.
+// ---------------------------------------------------------------------------------------------
+
+test('a ready server states its tool count, singular handled', () => {
+  expect(atServerStatusText(server('s', 'ready', { tools: [tool('a')] }), 'en')).toBe('1 tool')
+  expect(atServerStatusText(server('s', 'ready', { tools: [tool('a'), tool('b')] }), 'en')).toBe('2 tools')
+  expect(atServerStatusText(server('s', 'ready', { tools: [] }), 'pt')).toBe('0 ferramentas')
+})
+
+test('a pending server says it is still being asked, in both languages', () => {
+  expect(atServerStatusText(server('s', 'pending'), 'en')).toContain('asking')
+  expect(atServerStatusText(server('s', 'pending'), 'pt')).toContain('perguntando')
+})
+
+test('an unreachable server states its reason, reusing the six-outcome table', () => {
+  const text = atServerStatusText(server('s', 'unreachable', { outcome: 'not-found' }), 'en')
+  expect(text).toBe('The command is not on this machine.')
+})
+
+// ---------------------------------------------------------------------------------------------
+// atToolViewReason — the sentence for everything that is not a tool list.
+// ---------------------------------------------------------------------------------------------
+
+test('a tools view carries no reason — the caller draws the list', () => {
+  expect(atToolViewReason({ kind: 'tools', tools: [] }, 's', 'en')).toBeNull()
+})
+
+test('the other three shapes each get their own sentence', () => {
+  const un = atToolViewReason({ kind: 'unknown-server' }, 'serenaa', 'en')
+  const pe = atToolViewReason({ kind: 'pending' }, 'serena', 'en')
+  const nr = atToolViewReason({ kind: 'unreachable', outcome: 'timeout' }, 'serena', 'en')
+  expect(un).toContain('serenaa')
+  expect(pe).toContain('serena')
+  expect(nr).toContain('did not answer in time')
+  expect(new Set([un, pe, nr]).size).toBe(3)
+})
+
+// ---------------------------------------------------------------------------------------------
+// emptyAtServerReason / emptyAtToolReason
+// ---------------------------------------------------------------------------------------------
+
+test('no servers configured is a different sentence from none matching', () => {
+  expect(emptyAtServerReason(0, '', 'en')).toContain('No MCP server')
+  expect(emptyAtServerReason(3, 'zzz', 'en')).toContain('3')
+  expect(emptyAtServerReason(3, 'zzz', 'en')).toContain('zzz')
+})
+
+test('a server with genuinely zero tools reads differently from a filter matching nothing', () => {
+  expect(emptyAtToolReason('serena', 0, '', 'en')).toContain('reported no tools')
+  expect(emptyAtToolReason('serena', 5, 'zzz', 'en')).toContain('zzz')
+  expect(emptyAtToolReason('serena', 5, 'zzz', 'en')).toContain('serena')
+})
+
+// ---------------------------------------------------------------------------------------------
+// applyAtServer — rule 4: bare mention, closes.
+// ---------------------------------------------------------------------------------------------
+
+test('picking a server with no colon typed inserts the bare mention and closes', () => {
+  const out = applyAtServer('hi @ser', 7, 'serena')
+  expect(out.text).toBe('hi @serena ')
+  expect(out.caret).toBe(out.text.length)
+})
+
+test('picking a server keeps what comes after the caret', () => {
+  const out = applyAtServer('@ser tail', 4, 'serena')
+  expect(out.text).toBe('@serena  tail')
+})
+
+test('a vanished trigger falls back to appending, never throwing away the pick', () => {
+  const out = applyAtServer('already sent', 0, 'serena')
+  expect(out.text).toBe('already sent @serena ')
+})
+
+// ---------------------------------------------------------------------------------------------
+// applyAtTool — decision 4: fully-qualified token, and the reopened trigger.
+// ---------------------------------------------------------------------------------------------
+
+test('picking a tool writes the fully-qualified token, never a compressed form', () => {
+  const out = applyAtTool('@serena:find', 12, 'serena', 'find_symbol')
+  expect(out.text.startsWith('@serena:find_symbol @serena:')).toBe(true)
+})
+
+test('the trigger REOPENS for the same server — this is how "one or more" works', () => {
+  const first = applyAtTool('@serena:', 8, 'serena', 'find_symbol')
+  expect(atQuery(first.text.slice(0, first.caret))).toBe('serena:')
+  const level = atLevel(atQuery(first.text.slice(0, first.caret))!)
+  expect(level).toEqual({ level: 'tool', serverText: 'serena', toolText: '' })
+})
+
+test('a second pick on the reopened trigger appends its own token — never a,b compression', () => {
+  const first = applyAtTool('@serena:', 8, 'serena', 'find_symbol')
+  const second = applyAtTool(first.text, first.caret, 'serena', 'write_memory')
+  expect(second.text).toBe('@serena:find_symbol @serena:write_memory @serena:')
+  expect(second.text).not.toContain(',')
+})
+
+test('what comes after the caret survives a tool pick, exactly as a server pick preserves it', () => {
+  const out = applyAtTool('@serena: tail', 8, 'serena', 'find_symbol')
+  expect(out.text).toBe('@serena:find_symbol @serena: tail')
+})

--- a/packages/web/src/lib/atMenu.ts
+++ b/packages/web/src/lib/atMenu.ts
@@ -1,0 +1,289 @@
+/**
+ * atMenu.ts — PURE: referencing an MCP server (and its tools) by typing `@` in the composer.
+ *
+ * The counterpart to `skillMenu.ts`'s `/` picker, and it follows the same shape for the same
+ * reason: every decision that can be wrong here belongs in one tested module, not in JSX. It is a
+ * SEPARATE module rather than more exports on `skillMenu.ts` because the two triggers answer
+ * different questions — `/` is a command at the START OF A LINE; `@` is a reference at the START
+ * OF A WORD, anywhere in the line — and `@` has a SECOND LEVEL `/` does not: a server, then
+ * (optionally) one of its tools.
+ *
+ * FIVE DECISIONS live here:
+ *
+ * 1. WHEN THE PICKER IS OPEN, AT WHAT LEVEL. `@` triggers only at a word boundary — `user@domain`,
+ *    `HEAD@{1}` are not invocations, the same reasoning `slashMisplaced` documents for `/`. Once
+ *    open, a `:` in what was typed after the `@` switches the picker from listing SERVERS to
+ *    listing that server's TOOLS — driven by the raw text, exactly as the user asked for it
+ *    ("com : uma lista de ferramentas aparece").
+ *
+ * 2. THE SERVER LIST NEVER CLAIMS WHAT IT DOES NOT KNOW. `/api/mcp/tools` answers server NAMES
+ *    instantly and their TOOL LISTS later (`GET /api/mcp/tools`'s own header explains why), so a
+ *    server can be `ready` (its tool count is known), `pending` (asked, not yet answered — NEVER
+ *    drawn as zero tools) or `unreachable` (asked, and it could not be — reported with its reason,
+ *    never descended into).
+ *
+ * 3. THE FILTER, at both levels: substring, case-insensitive, on the name (and the tool's
+ *    description too, same reasoning `filterSkills` gives for skills whose name alone does not say
+ *    what they do).
+ *
+ * 4. WHAT A PICK WRITES. Selecting a SERVER with no `:` typed writes a bare `@name ` and closes —
+ *    a reference to the server itself, nothing more to choose. Selecting a TOOL writes the
+ *    fully-qualified `@server:tool ` and then REOPENS AN EMPTY TRIGGER FOR THE SAME SERVER
+ *    (`@server:`), which is what lets "one or more" fall out of the same text-driven design rather
+ *    than a second state machine: the reopened trigger is a perfectly ordinary `@server:` a person
+ *    could have typed by hand, so the picker naturally stays open on that server's tool list ready
+ *    for the next pick, and Escape (or moving on) leaves it exactly as typed — the same thing a
+ *    dismissed `/partial` command does in `skillMenu.ts`. Nothing here compresses several tools
+ *    into one token (`@serena:a,b`): each is its own reference, sent or not sent on its own.
+ *
+ * 5. INSERTION NEVER SENDS. Same rule `applySkill` states for the same reason: what reaches the
+ *    session is what the person chose to send, and most of these tokens sit inside a longer
+ *    message the person is still writing.
+ */
+
+import { mcpCheckText } from './mcpCheckText'
+
+/** One tool, as the composer needs it — see `McpToolInfo` on the server. */
+export interface MenuMcpTool {
+  name: string
+  description?: string
+}
+
+/** Mirrors `McpServerToolsView['status']` on the server — see its own header for why three. */
+export type MenuMcpServerStatus = 'ready' | 'unreachable' | 'pending'
+
+/**
+ * One configured MCP server, shaped for the picker. Deliberately narrower than the wire type
+ * (`McpServerToolsView`): the composer never needs `scope` or `transport` to reference a server by
+ * name, and importing server types into the web bundle is not this module's job.
+ */
+export interface MenuMcpServer {
+  name: string
+  status: MenuMcpServerStatus
+  /** Present only when `status === 'ready'`. */
+  tools?: MenuMcpTool[]
+  /** Present only when `status === 'unreachable'` — an `McpCheckOutcome`, read by `mcpCheckText`. */
+  outcome?: string
+  exitCode?: number
+}
+
+/**
+ * Is the caret inside an `@` reference, and what has been typed into it?
+ *
+ * `before` is the draft text UP TO THE CARET. The trigger is the trailing run of non-whitespace
+ * characters, and it counts ONLY when an `@` starts that run AND the character right before it is
+ * whitespace or the start of the text — a word boundary. That is what keeps `user@domain` and
+ * `HEAD@{1}` from opening a picker mid-word while `hi @serena` and a bare `@` at the start of the
+ * message still do. A trailing space ends it, exactly like `/` — the space starts an argument (or
+ * just more prose), and a picker still open there would take the arrow keys away from someone
+ * writing past it.
+ */
+export function atQuery(before: string): string | null {
+  const m = /(?:^|\s)@([^\s]*)$/.exec(before)
+  return m ? m[1]! : null
+}
+
+/** The `@` query split into its two levels — see the header, decision 1. */
+export interface AtQueryLevel {
+  level: 'server' | 'tool'
+  /** The server-name filter (level `server`) or the exact name typed (level `tool`). */
+  serverText: string
+  /** Only meaningful at level `tool`. */
+  toolText: string
+}
+
+/**
+ * Split an `@` query on its FIRST `:` — everything before names the server, everything after
+ * filters its tools. First and not last: a tool name is never expected to carry a colon of its
+ * own, but treating a second one as more filter text is a harmless miss rather than a crash.
+ */
+export function atLevel(query: string): AtQueryLevel {
+  const at = query.indexOf(':')
+  if (at < 0) return { level: 'server', serverText: query, toolText: '' }
+  return { level: 'tool', serverText: query.slice(0, at), toolText: query.slice(at + 1) }
+}
+
+/** Narrow the server list by name, case-insensitive. A blank query is "the picker just opened". */
+export function filterAtServers(servers: readonly MenuMcpServer[], query: string): MenuMcpServer[] {
+  const q = query.trim().toLowerCase()
+  if (q === '') return [...servers]
+  return servers.filter(s => s.name.toLowerCase().includes(q))
+}
+
+/**
+ * The exact server a typed `:` refers to, case-insensitive (the picker's own list is what taught
+ * the person the name; matching its exact case back would refuse a name it just showed them in a
+ * different one). `null` when nothing configured carries that name.
+ */
+export function findAtServer(servers: readonly MenuMcpServer[], name: string): MenuMcpServer | null {
+  const q = name.toLowerCase()
+  return servers.find(s => s.name.toLowerCase() === q) ?? null
+}
+
+/** Narrow a server's tool list by name AND description — half of these are named for a library. */
+export function filterAtTools(tools: readonly MenuMcpTool[], query: string): MenuMcpTool[] {
+  const q = query.trim().toLowerCase()
+  if (q === '') return [...tools]
+  return tools.filter(t =>
+    t.name.toLowerCase().includes(q) || (t.description ?? '').toLowerCase().includes(q))
+}
+
+/**
+ * What the tool level actually has to show, once a `:` names a server.
+ *
+ * FOUR SHAPES, because each sends a reader somewhere different — the same reasoning
+ * `McpCheckOutcome` gives for not collapsing its six into a boolean. `unknown-server` is its own
+ * case rather than falling through to an empty tool list: a typo in the name and a server with
+ * genuinely zero tools must not read as the same thing.
+ */
+export type AtToolView =
+  | { kind: 'unknown-server' }
+  | { kind: 'pending' }
+  | { kind: 'unreachable'; outcome?: string; exitCode?: number }
+  | { kind: 'tools'; tools: MenuMcpTool[] }
+
+export function resolveAtToolView(
+  servers: readonly MenuMcpServer[], serverName: string, toolQuery: string,
+): AtToolView {
+  const server = findAtServer(servers, serverName)
+  if (server === null) return { kind: 'unknown-server' }
+  if (server.status === 'pending') return { kind: 'pending' }
+  if (server.status === 'unreachable') {
+    return {
+      kind: 'unreachable',
+      ...(server.outcome !== undefined ? { outcome: server.outcome } : {}),
+      ...(server.exitCode !== undefined ? { exitCode: server.exitCode } : {}),
+    }
+  }
+  return { kind: 'tools', tools: filterAtTools(server.tools ?? [], toolQuery) }
+}
+
+/**
+ * The SERVER row's own subtitle — decision 2. Reuses `mcpCheckText` for the unreachable reason
+ * rather than re-stating the six-outcome table a second time: this file only decides which of the
+ * three states applies, never what a `McpCheckOutcome` means in words.
+ */
+export function atServerStatusText(server: MenuMcpServer, lang: 'pt' | 'en'): string {
+  if (server.status === 'pending') return lang === 'pt' ? 'perguntando…' : 'asking…'
+  if (server.status === 'ready') {
+    const n = server.tools?.length ?? 0
+    return lang === 'pt'
+      ? `${n} ferramenta${n === 1 ? '' : 's'}`
+      : `${n} tool${n === 1 ? '' : 's'}`
+  }
+  // Reuses `mcpCheckText`'s six-outcome table rather than re-stating it: this module only decides
+  // WHICH of the three states applies, never what an `McpCheckOutcome` means in words.
+  return mcpCheckText(
+    { outcome: server.outcome ?? 'uncheckable', ...(server.exitCode !== undefined ? { exitCode: server.exitCode } : {}) },
+    lang === 'pt',
+  ).text
+}
+
+/** What the SERVER level says when nothing matches — see `emptyPickerReason`'s own reasoning. */
+export function emptyAtServerReason(configured: number, query: string, lang: 'pt' | 'en'): string {
+  const pt = lang === 'pt'
+  if (configured === 0) {
+    return pt
+      ? 'Nenhum servidor MCP configurado para esta sessão.'
+      : 'No MCP server configured for this session.'
+  }
+  const q = query.trim()
+  if (q === '') {
+    return pt
+      ? `Nenhum dos ${configured} servidores.`
+      : `None of the ${configured} configured servers.`
+  }
+  return pt
+    ? `Nenhum dos ${configured} servidores tem "${q}" no nome.`
+    : `None of the ${configured} servers has "${q}" in its name.`
+}
+
+/** What the TOOL level says for a genuinely reachable server whose tool list matched nothing. */
+export function emptyAtToolReason(server: string, total: number, query: string, lang: 'pt' | 'en'): string {
+  const pt = lang === 'pt'
+  if (total === 0) {
+    return pt
+      ? `"${server}" não relatou nenhuma ferramenta.`
+      : `"${server}" reported no tools.`
+  }
+  const q = query.trim()
+  if (q === '') {
+    return pt ? `Nenhuma das ${total} ferramentas.` : `None of the ${total} tools.`
+  }
+  return pt
+    ? `Nenhuma das ${total} ferramentas de "${server}" tem "${q}" no nome ou na descrição.`
+    : `None of ${server}'s ${total} tools has "${q}" in its name or description.`
+}
+
+/**
+ * The sentence for the three non-`tools` shapes of `AtToolView` — `null` for `tools`, whose caller
+ * either draws the (possibly filtered-empty) list or falls to `emptyAtToolReason` itself.
+ */
+export function atToolViewReason(view: AtToolView, server: string, lang: 'pt' | 'en'): string | null {
+  const pt = lang === 'pt'
+  switch (view.kind) {
+    case 'unknown-server':
+      return pt ? `Nenhum servidor chamado "${server}".` : `No server named "${server}".`
+    case 'pending':
+      return pt
+        ? `Perguntando a "${server}" quais ferramentas ele tem…`
+        : `Asking "${server}" what tools it has…`
+    case 'unreachable':
+      return mcpCheckText(
+        { outcome: view.outcome ?? 'uncheckable', ...(view.exitCode !== undefined ? { exitCode: view.exitCode } : {}) },
+        pt,
+      ).text
+    case 'tools':
+      return null
+  }
+}
+
+/** The draft and caret after an insertion — same contract as `SkillInsertion`. */
+export interface AtInsertion {
+  text: string
+  caret: number
+}
+
+/**
+ * Rule 4: a bare server reference, no colon typed — closes the picker.
+ *
+ * Falls back to APPENDING when the trigger has already vanished (the same race `applySkill`
+ * guards against): a pick can only be dismissed between the click and this call by something the
+ * user did, and losing it to that race would be the worse of the two answers.
+ */
+export function applyAtServer(draft: string, caret: number, name: string): AtInsertion {
+  const at = Math.max(0, Math.min(caret, draft.length))
+  const before = draft.slice(0, at)
+  const after = draft.slice(at)
+  const query = atQuery(before)
+  const inserted = `@${name} `
+  if (query === null) {
+    const head = draft.replace(/\s+$/, '')
+    const text = head === '' ? inserted : `${head} ${inserted}`
+    return { text, caret: text.length }
+  }
+  const start = before.length - query.length - 1
+  return { text: draft.slice(0, start) + inserted + after, caret: start + inserted.length }
+}
+
+/**
+ * A tool picked at the tool level — decision 4. Writes the fully-qualified token and REOPENS an
+ * empty `@server:` trigger right after it, which is the whole mechanism behind "choose one or
+ * more": the reopened text is exactly what a person would have typed to keep browsing that same
+ * server's tools, so the picker stays open on it for free.
+ */
+export function applyAtTool(draft: string, caret: number, server: string, tool: string): AtInsertion {
+  const at = Math.max(0, Math.min(caret, draft.length))
+  const before = draft.slice(0, at)
+  const after = draft.slice(at)
+  const query = atQuery(before)
+  const inserted = `@${server}:${tool} @${server}:`
+  if (query === null) {
+    const head = draft.replace(/\s+$/, '')
+    const text = head === '' ? inserted : `${head} ${inserted}`
+    return { text, caret: text.length }
+  }
+  const start = before.length - query.length - 1
+  const text = draft.slice(0, start) + inserted + after
+  return { text, caret: start + inserted.length }
+}

--- a/packages/web/src/lib/commandMirror.test.ts
+++ b/packages/web/src/lib/commandMirror.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'bun:test'
+import { commandToken } from './commandToken'
+import { draftSegments, needsMirror } from './commandMirror'
+
+const known = new Set(['serena', 'update-docs'])
+
+describe('draftSegments', () => {
+  it('paints only the command run when the token is found', () => {
+    const token = commandToken('/serena find the symbol', known)
+    expect(draftSegments('/serena find the symbol', token)).toEqual([
+      { text: '/serena', button: true },
+      { text: ' find the symbol', button: false },
+    ])
+  })
+
+  it('paints nothing extra when the command fills the whole draft', () => {
+    const token = commandToken('/serena', known)
+    expect(draftSegments('/serena', token)).toEqual([{ text: '/serena', button: true }])
+  })
+
+  it('leaves a missing command as one plain run', () => {
+    const token = commandToken('/serana', known)
+    expect(draftSegments('/serana', token)).toEqual([{ text: '/serana', button: false }])
+  })
+
+  it('leaves an unknown command as one plain run', () => {
+    const token = commandToken('/serena', null)
+    expect(draftSegments('/serena', token)).toEqual([{ text: '/serena', button: false }])
+  })
+
+  it('leaves plain prose as one plain run', () => {
+    expect(draftSegments('hello there', null)).toEqual([{ text: 'hello there', button: false }])
+  })
+})
+
+describe('needsMirror', () => {
+  it('is true only for a found token', () => {
+    expect(needsMirror(commandToken('/serena', known))).toBe(true)
+    expect(needsMirror(commandToken('/serana', known))).toBe(false)
+    expect(needsMirror(commandToken('/serena', null))).toBe(false)
+    expect(needsMirror(null)).toBe(false)
+  })
+})

--- a/packages/web/src/lib/commandMirror.ts
+++ b/packages/web/src/lib/commandMirror.ts
@@ -1,0 +1,61 @@
+/**
+ * commandMirror.ts — PURE: what the composer's mirror layer draws.
+ *
+ * A textarea cannot hold a coloured span, so painting the `found` command as a button needs a
+ * second copy of the text sitting behind the field, with the field's OWN text made transparent so
+ * only the mirror is seen. That is a bigger trade than the old background-only underlay made (it
+ * kept the textarea's real, opaque text on top and only painted a highlight behind it, so the
+ * caret and the text selection stayed native) — but a background block cannot turn white-on-orange,
+ * because the textarea's characters are still drawn in the ordinary foreground colour over it. A
+ * BUTTON needs the glyphs themselves recoloured, and a plain textarea has no such per-run colour.
+ *
+ * So the mirror is drawn ONLY while there is something to recolour — a `found` token — and the
+ * textarea keeps its own opaque text everywhere else. `needsMirror` is the one predicate that
+ * decides which world a given render is in, and `draftSegments` is the one function that turns the
+ * draft into the runs the mirror paints. Nothing here is state: both are read straight off the
+ * draft and the token on every render, which is what makes "delete a character, it goes back to
+ * plain text" fall out for free rather than needing a flag someone has to remember to clear.
+ */
+
+import type { CommandToken } from './commandToken'
+
+export interface DraftSegment {
+  text: string
+  /** Paint this run as the command button — orange background, white text. */
+  button: boolean
+}
+
+/**
+ * The runs the mirror layer draws, in order.
+ *
+ * Only a `found` token is ever painted — `missing` and `unknown` claim nothing about the text (see
+ * `commandToken.ts`), so there is nothing to recolour and the textarea's own text already reads
+ * correctly. The whole draft comes back as one plain run in every other case, which is also the
+ * signal `needsMirror` uses to decide whether the mirror should be drawn at all.
+ *
+ * `token.start` is always 0 (`commandToken` only ever matches the head of the draft), but the slice
+ * is taken from it rather than hardcoded so this keeps working if that ever stops being true.
+ */
+export function draftSegments(draft: string, token: CommandToken | null): DraftSegment[] {
+  if (token === null || token.state !== 'found') return [{ text: draft, button: false }]
+  const before = draft.slice(0, token.start)
+  const head = draft.slice(token.start, token.end)
+  const rest = draft.slice(token.end)
+  const segments: DraftSegment[] = []
+  if (before !== '') segments.push({ text: before, button: false })
+  segments.push({ text: head, button: true })
+  if (rest !== '') segments.push({ text: rest, button: false })
+  return segments
+}
+
+/**
+ * Whether the mirror needs to be drawn at all, and the textarea's own text hidden.
+ *
+ * The same condition `draftSegments` uses to decide there is a coloured run — kept as its own
+ * function because the caller needs it TWICE (whether to render the mirror div, and whether to make
+ * the textarea's text transparent) and those two decisions must never drift apart: a mirror drawn
+ * without the text hidden doubles the command, and hidden text with no mirror is a blank field.
+ */
+export function needsMirror(token: CommandToken | null): boolean {
+  return token !== null && token.state === 'found'
+}

--- a/packages/web/src/lib/commandNotice.test.ts
+++ b/packages/web/src/lib/commandNotice.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'bun:test'
+import { commandNotFoundNotice } from './commandNotice'
+
+describe('commandNotFoundNotice', () => {
+  it('names the command and says the send is not blocked, in English', () => {
+    const msg = commandNotFoundNotice('/serana', false)
+    expect(msg).toContain('/serana')
+    expect(msg.toLowerCase()).toContain('can still be sent')
+  })
+
+  it('names the command and says the send is not blocked, in Portuguese', () => {
+    const msg = commandNotFoundNotice('/serana', true)
+    expect(msg).toContain('/serana')
+    expect(msg.toLowerCase()).toContain('ainda pode ser enviada')
+  })
+})

--- a/packages/web/src/lib/commandNotice.ts
+++ b/packages/web/src/lib/commandNotice.ts
@@ -1,0 +1,16 @@
+/**
+ * commandNotice.ts — PURE: the sentence for a `missing` command token.
+ *
+ * `commandToken.ts` draws the line between `missing` (the session's own list does not have it) and
+ * `unknown` (there is no list to check yet) — this module only ever speaks for the first of those.
+ * It WARNS, and nothing more: the list is what the harness reported, and a harness may still accept
+ * a command nobody enumerated, so the message never says the send will fail and the composer never
+ * disables it over this. See `commandToken.ts`'s header for why `unknown` gets no sentence at all.
+ */
+
+/** The sentence shown under the field when the leading command is `missing`. */
+export function commandNotFoundNotice(name: string, pt: boolean): string {
+  return pt
+    ? `“${name}” não é um comando desta sessão — a mensagem ainda pode ser enviada.`
+    : `“${name}” is not a command this session offers — the message can still be sent.`
+}

--- a/packages/web/src/lib/commandToken.test.ts
+++ b/packages/web/src/lib/commandToken.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'bun:test'
+import { commandToken, knownCommands } from './commandToken'
+
+const known = new Set(['serena', 'superpowers:brainstorming', 'update-docs'])
+
+describe('what the leading token is', () => {
+  it('finds a command the session offers', () => {
+    const t = commandToken('/serena', known)
+    expect(t).toEqual({ text: '/serena', start: 0, end: 7, state: 'found' })
+  })
+
+  it('finds a plugin command by its full package:skill name', () => {
+    expect(commandToken('/superpowers:brainstorming', known)?.state).toBe('found')
+  })
+
+  it('reports a command the list does not have as MISSING', () => {
+    expect(commandToken('/serana', known)?.state).toBe('missing')
+  })
+
+  it('keeps the token while an argument is being typed after it', () => {
+    const t = commandToken('/serena find the symbol', known)
+    expect(t?.text).toBe('/serena')
+    expect(t?.end).toBe(7)
+    expect(t?.state).toBe('found')
+  })
+})
+
+describe('what is NOT a command', () => {
+  it('ignores a slash that is not at the head of the draft', () => {
+    expect(commandToken('run /serena now', known)).toBeNull()
+  })
+
+  it('ignores a path, because the first segment is followed by another slash', () => {
+    expect(commandToken('/home/mithrandir/agentistics', known)).toBeNull()
+  })
+
+  it('ignores a bare slash and an empty draft', () => {
+    expect(commandToken('/', known)).toBeNull()
+    expect(commandToken('', known)).toBeNull()
+  })
+})
+
+describe('UNKNOWN is not MISSING', () => {
+  it('claims nothing when no list has been read', () => {
+    // The list is fetched when the picker first opens, so the first command of a session is typed
+    // before any answer has arrived. Calling it missing there would be a warning about nothing.
+    expect(commandToken('/serena', null)?.state).toBe('unknown')
+    expect(commandToken('/nonsense', null)?.state).toBe('unknown')
+  })
+
+  it('treats an EMPTY list as a real answer, not an absent one', () => {
+    // A session that offers nothing is a fact the server can report, and every command is missing.
+    expect(commandToken('/serena', new Set())?.state).toBe('missing')
+  })
+})
+
+describe('knownCommands', () => {
+  it('carries null through rather than inventing an empty set', () => {
+    expect(knownCommands(null)).toBeNull()
+  })
+
+  it('builds the set off the reported names', () => {
+    const set = knownCommands([{ name: 'serena' }, { name: 'update-docs' }])
+    expect(set?.has('serena')).toBe(true)
+    expect(set?.has('nope')).toBe(false)
+  })
+})

--- a/packages/web/src/lib/commandToken.ts
+++ b/packages/web/src/lib/commandToken.ts
@@ -1,0 +1,70 @@
+/**
+ * commandToken.ts — PURE: what the composer's leading `/command` IS, right now.
+ *
+ * `slashLine.ts` answers a different question and keeps answering it: given any message, which
+ * prefix LOOKS like an invocation. That is the right question for a sent message in a bubble,
+ * where the command may since have been uninstalled and re-colouring history would be a lie about
+ * the past. This one is about the DRAFT, where the useful question is whether the thing you are
+ * typing will actually do something.
+ *
+ * THREE STATES, and the third is the one that keeps this honest:
+ *
+ *  - `found`   — the session offers this command. The composer paints it like a button.
+ *  - `missing` — the session's command list was read, and this is not in it. A warning, never a
+ *                block: the list is what the harness reported, and a harness may accept a command
+ *                nobody enumerated. Refusing to send would turn an incomplete list into a wall.
+ *  - `unknown` — there is no list to check against yet, or the read failed. NOTHING is claimed.
+ *                No paint, no warning. "I could not check" and "it does not exist" are different
+ *                sentences, and only one of them is ever true here.
+ *
+ * The `unknown` case is not an edge: the list is fetched when the picker first opens, so the very
+ * first character of the very first command in a session is typed before any answer has arrived.
+ */
+
+/** The shape of a name a command can have: letters, digits, `-`, `_`, and the plugin `:` . */
+const COMMAND = /^\/([A-Za-z0-9][A-Za-z0-9_-]*(?::[A-Za-z0-9][A-Za-z0-9_-]*)?)(?=$|\s)/
+
+export type CommandState = 'found' | 'missing' | 'unknown'
+
+export interface CommandToken {
+  /** The `/name` as typed, without its trailing space. */
+  text: string
+  /** Where it sits in the draft, so a renderer can slice around it without re-matching. */
+  start: number
+  end: number
+  state: CommandState
+}
+
+/**
+ * The leading command token of a draft, or `null` when there is not one.
+ *
+ * `known` is the set of command names the session reported, WITHOUT their leading slash, or `null`
+ * when no list has been read. `null` is not an empty set — an empty set means "this session offers
+ * nothing", which is a real answer and makes every command `missing`.
+ *
+ * ONLY THE HEAD OF THE DRAFT. A slash mid-sentence is a path, a date or a fraction; painting those
+ * would light up half of what anybody types.
+ */
+export function commandToken(draft: string, known: ReadonlySet<string> | null): CommandToken | null {
+  const m = COMMAND.exec(draft)
+  if (!m) return null
+  const name = m[1]!
+  return {
+    text: `/${name}`,
+    start: 0,
+    end: name.length + 1,
+    state: known === null ? 'unknown' : known.has(name) ? 'found' : 'missing',
+  }
+}
+
+/**
+ * The set `commandToken` takes, from whatever the session reported.
+ *
+ * `null` in, `null` out: a list that has not arrived cannot be turned into an empty one without
+ * claiming the session offers nothing.
+ */
+export function knownCommands(
+  skills: readonly { name: string }[] | null,
+): ReadonlySet<string> | null {
+  return skills === null ? null : new Set(skills.map(s => s.name))
+}

--- a/packages/web/src/lib/fleet.ts
+++ b/packages/web/src/lib/fleet.ts
@@ -233,6 +233,31 @@ function emit(): void {
  */
 let pollCentral = false
 
+/**
+ * How long to wait before the follow-up read after an action.
+ *
+ * A verb that changes what the SCREEN says — cycling the harness's mode is the one this exists for
+ * — is answered by the server as soon as the keystroke is sent, but the row's words come from the
+ * next capture of the pane, and the harness has not redrawn its footer yet at that instant. One
+ * immediate read plus one a moment later covers both: the fast case where it already repainted,
+ * and the ordinary one where it needed a frame.
+ */
+const NUDGE_FOLLOWUP_MS = 450
+
+/**
+ * Read the fleet NOW instead of waiting out the interval.
+ *
+ * The poll is every `FLEET_POLL_MS`, which is right for watching and far too slow for a control
+ * somebody just pressed: cycling the mode left the chip showing the OLD mode for up to five
+ * seconds, so the button read as broken and people pressed it again. Nothing here invents the new
+ * state — it asks sooner. An optimistic label would be a guess about what the harness did with the
+ * keystroke, and this file does not guess.
+ */
+export function nudgeFleet(): void {
+  void pollOnce()
+  setTimeout(() => { void pollOnce() }, NUDGE_FOLLOWUP_MS)
+}
+
 export function setFleetSourceCentral(on: boolean): void {
   if (pollCentral === on) return
   pollCentral = on


### PR DESCRIPTION
## Summary

- A `/command` the session actually offers is painted like a button in the composer — orange, white text — and reverts to plain text the moment a character is deleted.
- A command it does not offer gets a warning that **does not block sending**.
- `@` references an MCP server and `:` opens that server's tools, with a new route that enumerates both.
- The mode chip changes on the click instead of on the next poll.
- (The Claude adapter test fix that was here was DROPPED on rebase: #449 landed the same fix in `dev` first, from another session. Theirs is kept.)

## Motivation

Three asks, verbatim: *"when the command does not exist a warning should appear saying the command was not found"*, *"when it is found I want the command to get an orange background and white text (almost like a button) but it is still text, and any character deleted makes it go back to being text (and if it is put back it becomes a button again)"*, and *"the @ references the mcp and with `:` a list of the tools appears and I can navigate to choose one of them (one or more)"*. Plus: the mode button took too long to move to the next option.

## Changes

**`commandToken.ts`** — three states, and the third is what keeps it honest: `found`, `missing`, and **`unknown`**. The command list is fetched when the picker first opens, so the first command of a session is typed before any answer has arrived; calling it missing there would be a warning about nothing. An empty list is a different thing — that is a session reporting it offers nothing.

**`commandMirror.ts` + `SessionChat.tsx`** — the paint is a mirror layer behind the textarea, re-derived from the draft on every render. The revert behaviour falls out of that rather than being a second piece of state somebody has to remember to invalidate.

**`mcp-tools.ts` + `GET /api/mcp/tools`** — `tools/list` on top of the `initialize` handshake `mcp-check.ts` already performs, so this is one more JSON-RPC call on a connection this product already opens. **The route never awaits a probe.** Measured across five configured servers: the one running from `bun` answered in 236ms with 19 tools; three spawned through `npx` and one HTTP/SSE endpoint did not answer inside three minutes between them. First call comes back in 6ms with everything `pending`, and five seconds later `agentistics` is ready(19) and `serena` ready(23). Three states, not two — `pending` is never drawn as "no tools", and a cached failure stays a failure with a shorter TTL than a real answer.

Deriving the tool list from past usage was measured and rejected: this machine's transcripts name **2** of serena's tools, and serena reports **23**.

**`atMenu.ts`** — the trigger, the two levels, the filtering, the empty reasons and what insertion writes. "One or more" is the insertion writing `@server:tool @server:`, so picking again is the next keystroke.

**`fleet.ts` `nudgeFleet`** — the mode chip's word comes from the next capture of the pane, so cycling left it showing the old mode for up to five seconds and the button read as broken. One read now, one 450ms later. No optimistic label: that would be a guess about what the harness did with the keystroke.

**The Claude adapter test fix is NOT in this branch any more.** I hit the same 113,7s-against-a-120s-limit failure and wrote the same fix — extract the invariant to a pure `tagClaude`, put the real scan behind a flag — and on rebase found #449 had landed an equivalent fix in `dev` first, from another session working in parallel. Mine was dropped; theirs is kept. The suite is now 16s.

## Test plan

- [x] `bun tsc --noEmit` clean; `bun test` **7546 pass / 0 fail** in 16s, after rebasing onto current `dev`.
- [x] **Verified in a real browser** on a build of this branch, against this machine's own fleet with the API proxied read-only (non-GET requests were never forwarded, so nothing could be sent):
  - a command that exists → `rgb(217, 119, 6)` background, white text, inside the field;
  - delete one character → the paint is gone;
  - type it back → painted again;
  - a command that does not exist → *"…is not a command this session offers — the message can still be sent"*, send button still enabled;
  - `@` → all four configured servers listed, with the pending ones said in words.
- [x] Same run at **390px**: identical results, `scrollWidth === innerWidth === 390`.
- [x] The MCP route measured end to end: 6ms first call all `pending`, then ready(19)/ready(23) with no wait.

**What reviewers should check**

- The `unknown` state is the load-bearing idea in the command half: a warning that fires before the list has arrived would be a warning about nothing.
- Picking exactly one tool leaves a trailing `@server:` in the draft — deliberate (it is the mechanism that makes "one or more" work), and it behaves like any half-typed token, but it is the one rough edge here and worth a second opinion.
- IME/composition text over the mirror layer was reasoned about, not eyeballed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019LT77q1YCgYQ6L8d1RRcM3