### PR TITLE
fix(web): the @ picker stops leaving its scaffolding in the draft

### DIFF
--- a/packages/web/src/components/sessions/SessionChat.tsx
+++ b/packages/web/src/components/sessions/SessionChat.tsx
@@ -59,7 +59,7 @@ import {
 import {
   applyAtServer, applyAtTool, atLevel, atQuery, atServerStatusText, atToolViewReason,
   emptyAtServerReason, emptyAtToolReason, filterAtServers, findAtServer, resolveAtToolView,
-  type MenuMcpServer,
+  type MenuMcpServer, dropEmptyAtTrigger,
 } from '../../lib/atMenu'
 import { composeReply, markExcerpt, quoteFor, replyAuthor, replyPreview, type ReplyTarget } from '../../lib/replyQuote'
 import { pendingEchoes } from '@agentistics/core'
@@ -1305,7 +1305,8 @@ export function SessionChat({ session, row, lang, act, onArtifacts }: SessionCha
   }
 
   async function send() {
-    const text = draft.trim()
+    // A trailing `@server:` is the picker's scaffolding and was never typed — it must not be sent.
+    const text = dropEmptyAtTrigger(draft).trim()
     // A message that is ONLY attachments is still a message: the paths are the content.
     // `canPrompt` is checked HERE now rather than only on the field's `disabled`, which no longer
     // follows it — see the note on the textarea. This is where it belonged anyway: the rule is
@@ -2143,7 +2144,10 @@ export function SessionChat({ session, row, lang, act, onArtifacts }: SessionCha
                     // is what a keyboard user tabbing onto an entry does.
                     const into = e.relatedTarget as Node | null
                     if (!skillPickerRef.current?.contains(into)) setSlashDismissed(true)
-                    if (!atPickerRef.current?.contains(into)) setAtDismissed(true)
+                    if (!atPickerRef.current?.contains(into)) {
+                      setAtDismissed(true)
+                      setDraft(d => dropEmptyAtTrigger(d))
+                    }
                   }}
                   onPaste={onPaste}
                   onKeyDown={e => {
@@ -2183,7 +2187,14 @@ export function SessionChat({ session, row, lang, act, onArtifacts }: SessionCha
                         return
                       }
                     }
-                    if (e.key === 'Escape' && atOpen) { e.preventDefault(); setAtDismissed(true); return }
+                    if (e.key === 'Escape' && atOpen) {
+                      e.preventDefault()
+                      setAtDismissed(true)
+                      // Closing the picker ends the pick, so the open `@server:` it left for the
+                      // NEXT one is scaffolding now — see `dropEmptyAtTrigger`.
+                      setDraft(d => dropEmptyAtTrigger(d))
+                      return
+                    }
                     // ON A PHONE, ENTER BREAKS THE LINE. Asked for directly, and it is the
                     // convention every messaging app on a touch keyboard follows: the return key is
                     // the only way to write a second line there, because `shift+enter` needs a

--- a/packages/web/src/lib/atMenu.test.ts
+++ b/packages/web/src/lib/atMenu.test.ts
@@ -2,7 +2,7 @@ import { test, expect } from 'bun:test'
 import {
   applyAtServer, applyAtTool, atLevel, atQuery, atServerStatusText, atToolViewReason,
   emptyAtServerReason, emptyAtToolReason, filterAtServers, filterAtTools, findAtServer,
-  resolveAtToolView, type MenuMcpServer, type MenuMcpTool,
+  resolveAtToolView, dropEmptyAtTrigger, type MenuMcpServer, type MenuMcpTool,
 } from './atMenu'
 
 const tool = (name: string, description = ''): MenuMcpTool => ({ name, description })
@@ -210,4 +210,27 @@ test('a second pick on the reopened trigger appends its own token — never a,b 
 test('what comes after the caret survives a tool pick, exactly as a server pick preserves it', () => {
   const out = applyAtTool('@serena: tail', 8, 'serena', 'find_symbol')
   expect(out.text).toBe('@serena:find_symbol @serena: tail')
+})
+
+test('a trailing empty @server: is the picker\'s scaffolding, and is dropped', () => {
+  // What picking exactly one tool leaves behind: the token, plus the trigger that would have let
+  // you pick another. Nobody typed the tail and nobody wants to send it.
+  expect(dropEmptyAtTrigger('@serena:find_symbol @serena:')).toBe('@serena:find_symbol')
+  expect(dropEmptyAtTrigger('olha @serena:')).toBe('olha')
+  expect(dropEmptyAtTrigger('@serena:')).toBe('')
+})
+
+test('it never touches a reference that names a tool', () => {
+  expect(dropEmptyAtTrigger('@serena:find_symbol')).toBe('@serena:find_symbol')
+  expect(dropEmptyAtTrigger('@serena:a @serena:b')).toBe('@serena:a @serena:b')
+})
+
+test('it only ever takes the TAIL, never a word inside the message', () => {
+  // Somebody writing about the syntax must keep what they wrote.
+  expect(dropEmptyAtTrigger('use @serena: para isso')).toBe('use @serena: para isso')
+})
+
+test('a half-typed server name is the person still writing', () => {
+  expect(dropEmptyAtTrigger('@ser')).toBe('@ser')
+  expect(dropEmptyAtTrigger('')).toBe('')
 })

--- a/packages/web/src/lib/atMenu.ts
+++ b/packages/web/src/lib/atMenu.ts
@@ -287,3 +287,28 @@ export function applyAtTool(draft: string, caret: number, server: string, tool: 
   const text = draft.slice(0, start) + inserted + after
   return { text, caret: start + inserted.length }
 }
+
+/**
+ * DROP A TRIGGER THAT NEVER BECAME A REFERENCE — PURE.
+ *
+ * `applyAtTool` writes `@server:tool @server:` on every pick: the token you chose, plus a fresh open
+ * trigger on the same server so choosing another is the next keystroke rather than a new gesture.
+ * That is what makes "one or more" work, and it leaves a tail behind for anyone who wanted exactly
+ * one — `@serena:find_symbol @serena:` sitting in the draft, ready to be sent as literal text.
+ *
+ * An `@server:` with nothing after the colon is not a reference to anything. It is the picker's own
+ * scaffolding, and once the picker is closed or the message is going out, it is noise the person
+ * never typed. So it is removed at exactly those two moments, and nowhere else: while the picker is
+ * OPEN the trigger is doing its job, and a half-typed `@ser` is the person still writing.
+ *
+ * Only ever the TAIL, and only when it is empty. `@serena:find_symbol` keeps its tool, and an
+ * `@server:` in the middle of a sentence is left exactly as typed — this cannot reach in and edit
+ * words somebody wrote.
+ */
+const TRAILING_EMPTY_TRIGGER = /(?:^|\s)@[A-Za-z0-9][A-Za-z0-9_./-]*:\s*$/
+
+export function dropEmptyAtTrigger(draft: string): string {
+  const m = TRAILING_EMPTY_TRIGGER.exec(draft)
+  if (!m) return draft
+  return draft.slice(0, m.index).replace(/\s+$/, '')
+}


### PR DESCRIPTION
## Summary

Picking exactly one MCP tool left `@serena:` behind in the composer, ready to be sent as literal text. It is dropped when the pick is over.

## Motivation

Every pick writes `@server:tool @server:` — the token you chose plus a fresh open trigger on the same server, so choosing another is the next keystroke rather than a new gesture. That mechanism is what makes "one or more" work, and it was shipped in #452 with this rough edge named in the PR body as the one point worth a second opinion. This is that fix.

An `@server:` with nothing after the colon is not a reference to anything — it is the picker's own scaffolding, and once the pick is over it is text the person never typed.

## Changes

**`atMenu.ts`** — `dropEmptyAtTrigger`, pure and tested. Only ever the TAIL, and only when it is empty.

**`SessionChat.tsx`** — called at the two moments the pick ends (Escape, and leaving the field) and again on send, so the tail cannot reach the session even if some other path closes the picker.

**Nowhere else, deliberately.** While the picker is open the trigger is doing its job; a half-typed `@ser` is somebody still writing; and an `@server:` in the middle of a sentence is left exactly as typed. This may take the tail and never a word anyone wrote.

## Test plan

- [x] `bun tsc --noEmit` clean; `bun test` **7563 pass / 0 fail**.
- [x] Four new unit tests: the tail is dropped, a reference naming a tool survives, two real references survive, and mid-sentence text is untouched.
- [x] **Verified in a real browser** on a build of this branch, against the machine's own fleet with the API proxied read-only:

```
antes do Escape : "@serena:find_symbol @serena:"
depois do Escape: "@serena:find_symbol"
referencia real : "@serena:find_symbol"
no meio da frase: "use @serena: para isso"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019LT77q1YCgYQ6L8d1RRcM3