### PR TITLE
feat(sessions): the utility shell, phase 1 complete — opt-in, capped, and invisible to the fleet

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -453,6 +453,50 @@ packages/server/server/          — server-side modules (never bundled by Vite)
   │                          row and `SessionsPage` hides the chat tab. Its format WAS measured and
   │                          the finding is recorded in `harness-transcript.ts` so nobody spends it
   │                          twice: a patch log, not one message per line. See docs/session-manager.md
+  │                          **THE PER-SESSION UTILITY SHELL is not a session, and the separation
+  │                          is structural** (`shell-spec.ts` / `shell-gate.ts` / `shell-store.ts` /
+  │                          `shell-backend.ts` / `shell-web.ts`, phase 1). It is a PTY in a
+  │                          session's own directory, opened for the PERSON — `$SHELL` bare, no
+  │                          `-l`, because tmux already gives the pane a tty and a login flag would
+  │                          read a different set of rc files from the panes `agentop session`
+  │                          opens. It runs on its OWN tmux socket (`SHELL_SOCKET`,
+  │                          `agentop-shell`) and records itself in `~/.agentistics/shells.json`,
+  │                          never in the registry, and BOTH halves of that are load-bearing: on the
+  │                          fleet socket `idFromTmuxName` strips the `agentop-` prefix, so
+  │                          `parseTmuxList` KEEPS the session and `reconcileSessions` reports it as
+  │                          an `unregistered` row — "visible and inert", filed under
+  │                          `GONE_PROJECT_KEY`, beyond every verb — while in the registry each
+  │                          shell would join the ~200 ms pane walk `host.sessions()` runs every 5 s
+  │                          in four processes, be probed by `attention.ts` for dialog markers, take
+  │                          a `lastSeenMs` heartbeat, and count toward "N sessions waiting on you",
+  │                          so an `htop` would read as a session needing a person. A naming
+  │                          convention would have worked and been one refactor from breaking; a
+  │                          socket cannot break, and `shell-isolation.test.ts` asserts all of it
+  │                          over the module SOURCE (comments stripped first — these modules are
+  │                          REQUIRED to explain themselves in terms of the registry). **Two gates,
+  │                          and absent reads OFF**: `CAPS.localShell` decides the security answer
+  │                          and `preferences.shellEnabled` may only ever NARROW it — a raw shell is
+  │                          strictly more powerful than the chat `chat-gate.ts` already calls the
+  │                          most powerful thing this server does, because the chat at least runs a
+  │                          NAMED assistant CLI. Enforced in `index.ts` before the routes, not only
+  │                          in the UI, and a CENTRAL refuses outright. **Lifetime is a CEILING
+  │                          (`SHELL_CAP` = 8) and never a timer**: a TTL kills the `bun test` that
+  │                          finished at minute 61 at an hour nobody was watching and needs a timer
+  │                          running forever, while a ceiling is one check on open and only ever
+  │                          closes something at the instant somebody asks for a new one. Records go
+  │                          ONE WAY (`reconcileShells`): a pane that is gone is dropped — `exit` is
+  │                          the ordinary death — and a pane with no record is NOT adopted, the
+  │                          exact opposite of `session-adopt.ts`, because a shell carries no name,
+  │                          task or conversation worth recovering. The four refusals are CODES
+  │                          rendered by the route (`no-tmux` / `no-cwd` / `cwd-missing` /
+  │                          `at-cap`), ordered so the IMPOSSIBLE ones come before the merely FULL
+  │                          one: asking somebody to destroy work to make room for an open that
+  │                          could never have succeeded is worse than saying no. Verified end to
+  │                          end on 2026-09-09 — the switch refused before it was flipped, the
+  │                          shell opened in the row's own cwd, it appeared under `-L agentop-shell`
+  │                          and NOT under `-L agentop` nor anywhere in `/api/fleet`, the ninth open
+  │                          was refused in words, a pane killed outside agentop left no ghost, and
+  │                          `close` named an unknown id instead of counting it closed.
   ├── cli-start.ts         → the control center's HOST (`ControlHost`): service detection, start/stop/restart, connect/disconnect, boot service, archive consent, language — every action returns an already-localized `ActionResult` instead of printing
   ├── cli-stream.ts        → the control center's OUTPUT CHANNEL: subscribers + `streamCommand` (both pipes captured, never `inherit`) → lines via the pure `@agentistics/tui/control/stream`
   ├── cli-ui.ts            → dependency-free arrow-key select/confirm/input/pause + clearScreen (bundles clean into the binary; no node_modules to resolve)

--- a/docs/session-manager.md
+++ b/docs/session-manager.md
@@ -560,3 +560,81 @@ Four fixes that all come from the same place — a row must say what it IS, and 
   find, which is how two holders happen; a vanished lock now retries and an abandoned one is taken
   over by an atomic `rename`. Measured before and after over 600 concurrent writes: 31 losses in 150,
   then 0 in 600.
+
+## The per-session utility shell
+
+A real shell — a full PTY, so `vim`, `htop`, colours and `Ctrl+C` all work — opened in a session's
+own directory, for the person rather than for an assistant. Phase 1 is the server half: it can be
+opened, listed and closed through `/api/shell/*`, and it is verifiable with `curl` and `tmux` alone.
+
+### It is not a session, and that is structural
+
+A shell runs on its **own tmux socket** (`SHELL_SOCKET` = `agentop-shell`) and records itself in
+`~/.agentistics/shells.json` — never in `managed-sessions.json`. Both halves are load-bearing.
+
+On the fleet socket it would become a fleet row, silently: `idFromTmuxName` strips the `agentop-`
+prefix, so `parseTmuxList` keeps the session, and `reconcileSessions` then finds a running session
+the registry has no record of and calls it `unregistered` — the row `session-adopt.ts` describes as
+"visible and inert", filed under `GONE_PROJECT_KEY`, that no verb in the cockpit can act on.
+
+In the registry, each shell would join the pane walk `host.sessions()` performs every 5 s in four
+processes (~200 ms measured), be probed by `attention.ts` for dialog markers, take a `lastSeenMs`
+heartbeat, and count toward "N sessions waiting on you" — so an `htop` would read as a session
+needing a person.
+
+A naming convention would have worked and been one refactor away from breaking. A socket cannot
+break: `list-sessions -L agentop` cannot see another socket at all. `shell-isolation.test.ts`
+asserts it over the modules' own source, with comments stripped first — those modules are *required*
+to explain themselves in terms of the registry.
+
+### Two gates, and absent reads OFF
+
+- `CAPS.localShell` — the exposure profile's answer, already false outside `local`.
+- `preferences.shellEnabled` — the user's own switch, which may only ever NARROW.
+
+A raw shell is strictly more powerful than the chat, which `chat-gate.ts` already calls the most
+powerful thing this server does: the chat at least spawns a NAMED assistant CLI. So absent reads as
+OFF, it is a separate switch from `chatEnabled`, it is enforced in `index.ts` before the routes
+rather than only in the UI, and a central refuses outright.
+
+### A ceiling, never a timer
+
+`SHELL_CAP` is 8, stated once in `shell-spec.ts`. A TTL would kill the `bun test` that finished at
+minute 61 and whose output somebody wanted, at an hour nobody was watching, and it needs a timer
+running for the life of the process. A ceiling needs nothing running: one check, on open, and it
+only ever closes something at the instant somebody is asking for a new one.
+
+Records go one way (`reconcileShells`): a pane that is gone is dropped — typing `exit` is the
+ordinary death of a shell — and a pane with **no** record is not adopted, the exact opposite of
+`session-adopt.ts`, because a shell carries no name, task or conversation worth recovering.
+
+### The four refusals, and their order
+
+`no-tmux`, `no-cwd`, `cwd-missing`, `at-cap` — codes, rendered into sentences by the route so the
+deciding module stays language-free. The IMPOSSIBLE ones come before the merely FULL one: at the
+ceiling the caller asks the person to close a shell to make room, and asking somebody to destroy
+work to make room for an open that could never have succeeded is worse than saying no.
+
+A session whose directory is gone is refused by name — it never falls back to `$HOME`. Opening a
+shell somewhere other than where it was asked for is the same class of error as a confident `0` for
+a metric nobody can produce.
+
+### Verifying it
+
+```bash
+AGENTISTICS_DIR=/tmp/shell-check PORT=48291 WEB_PORT=48292 bun run packages/server/bin/cli.ts server
+
+curl -s -X POST localhost:48291/api/shell/open -d '{"sessionId":"<id>"}' \
+  -H 'Content-Type: application/json'      # {"error":"shell_disabled"} until the switch is on
+
+curl -s -X PUT localhost:48291/api/preferences -d '{"shellEnabled":true}' \
+  -H 'Content-Type: application/json'
+
+tmux -L agentop-shell ls    # the shell is here
+tmux -L agentop ls          # and never here
+```
+
+Measured on 2026-09-09: the switch refused before it was flipped; the shell opened in the row's own
+cwd; it appeared under `-L agentop-shell` and in neither `-L agentop` nor `/api/fleet`; the ninth
+open was refused in words; a pane killed outside agentop left no ghost record; and `close` named an
+unknown id instead of counting it closed.

--- a/packages/server/server/capability-guard.test.ts
+++ b/packages/server/server/capability-guard.test.ts
@@ -174,3 +174,25 @@ test('/api/live-sessions is deliberately NOT blanket-guarded, and the reason is 
   const helper = src.slice(src.indexOf('async function readLocalLiveSnapshot'))
   expect(helper.indexOf('CAPS.localProcesses')).toBeLessThan(helper.indexOf("import('./live-sessions')"))
 })
+
+test('THE UTILITY SHELL rides localShell, by prefix', () => {
+  // It spawns `$SHELL` on the host in a directory of the caller's session and types whatever
+  // arrives into it — more powerful than `/api/fleet` itself, which at least only ever runs a
+  // named assistant CLI.
+  expect(routeCapability('/api/shell/open')).toBe('localShell')
+  expect(routeCapability('/api/shell/list')).toBe('localShell')
+  expect(routeCapability('/api/shell/close')).toBe('localShell')
+})
+
+test('a shell route nobody has written yet is guarded by having been ADDED', () => {
+  // A prefix and not three names, for the reason the fleet entry gives: a route that is not
+  // registered here is assumed harmless, so the next one must be guarded by existing under the
+  // prefix, never by somebody remembering a second table.
+  expect(routeCapability('/api/shell/not-written-yet')).toBe('localShell')
+})
+
+test('the prefix does not swallow a neighbouring path', () => {
+  // `/api/shells-of-someone-else` is not under `/api/shell`, and a prefix that matched it would be
+  // guarding a route nobody registered — which reads as security and is an accident.
+  expect(routeCapability('/api/shellfish')).toBeNull()
+})

--- a/packages/server/server/capability-guard.ts
+++ b/packages/server/server/capability-guard.ts
@@ -62,6 +62,12 @@ const PREFIXES: ReadonlyArray<readonly [string, keyof Capabilities]> = [
   // next fleet route someone adds must be guarded by having been added AT ALL, never by having
   // remembered a second table.
   ['/api/fleet', 'localShell'],
+  // The per-session UTILITY SHELL. It spawns `$SHELL` on the host in a directory of the caller's
+  // session and types whatever arrives into it — the most powerful thing this server offers, more
+  // than `/api/fleet` itself, which at least only ever runs a NAMED assistant CLI. Same capability,
+  // and a PREFIX for the same reason: the next shell route must be guarded by having been added at
+  // all. The user's own opt-in switch is enforced separately, in index.ts — see shell-gate.ts.
+  ['/api/shell', 'localShell'],
   // The task board reads the session registry and the local store, and its DELIVER verb runs git in
   // the directories those sessions ran in. That is host power, so it rides the same capability as
   // the fleet — and a prefix for the same reason: the next task route must be guarded by having

--- a/packages/server/server/index.ts
+++ b/packages/server/server/index.ts
@@ -57,6 +57,7 @@ async function readLocalLiveSnapshot(sessions: SessionMeta[]): Promise<{
 import { AUTH_PUBLIC, isAdminPath, MFA_EXEMPT } from './index-routes'
 import { CAPS, PROFILE } from './exposure'
 import { chatAllowed } from './chat-gate'
+import { shellAllowed } from './sessions/shell-gate'
 import { limiter, RULES, rateRuleFor, tooManyRequests } from './rate-limit'
 import { resolveClientIp } from './client-ip'
 import { corsHeadersFor } from './cors'
@@ -2478,6 +2479,36 @@ async function handleRequestInner(req: Request, server: Server<WSData>): Promise
         status: 500,
         headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
       })
+    }
+
+    // THE PER-SESSION UTILITY SHELL. Two gates and a refusal, all of them enforced HERE and not
+    // only in the UI: a hidden button is not a closed door, and this endpoint is what actually
+    // spawns `$SHELL` on the host.
+    if (url.pathname === '/api/shell' || url.pathname.startsWith('/api/shell/')) {
+      // A CENTRAL NEVER OFFERS ONE. It aggregates other machines and has no host to serve — the
+      // same refusal, in the same shape, the `/api/fleet` block gives.
+      if (TEAM_CENTRAL) {
+        return new Response(JSON.stringify({ error: 'shell_central' }), {
+          status: 404,
+          headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
+        })
+      }
+      if (!shellAllowed(CAPS.localShell, (await readPreferences()).shellEnabled)) {
+        return new Response(JSON.stringify({ error: 'shell_disabled' }), {
+          status: 403,
+          headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
+        })
+      }
+      // Dynamic, following the `/api/fleet` handler's own pattern: the session machinery stays out
+      // of a cold start that never touches it.
+      const { hostForFleet, fleetLang } = await import('./sessions/fleet-web')
+      const { handleShellRoute } = await import('./sessions/shell-web')
+      const shellLang = fleetLang(url.searchParams.get('lang'))
+      const res = await handleShellRoute(req, url, await hostForFleet(shellLang), shellLang)
+      if (res) {
+        for (const [k, v] of Object.entries(CORS_HEADERS)) res.headers.set(k, v)
+        return res
+      }
     }
 
     // Chat is opt-in. `capability-guard.ts` has already refused these paths where the exposure

--- a/packages/server/server/preferences.ts
+++ b/packages/server/server/preferences.ts
@@ -89,6 +89,10 @@ export interface Preferences {
    *  CLI on the host, and until it was made opt-in every machine installed for its metrics also
    *  shipped a shell nobody had chosen. It can only ever narrow `CAPS.localChat`; see chat-gate.ts. */
   chatEnabled?: boolean
+  /** Opt-in for the per-session utility SHELL (`/api/shell/*`). Absent reads as OFF, and it can
+   *  only ever narrow `CAPS.localShell`; see sessions/shell-gate.ts. Separate from `chatEnabled`
+   *  because they are different powers: the chat runs a named assistant CLI, this runs anything. */
+  shellEnabled?: boolean
   /** true once the user dismissed the install prompt with "don't show again".
    *  Persisted server-side (not localStorage) so it survives incognito windows. */
   installDismissed?: boolean

--- a/packages/server/server/sessions/shell-backend.test.ts
+++ b/packages/server/server/sessions/shell-backend.test.ts
@@ -1,0 +1,32 @@
+import { expect, test } from 'bun:test'
+import { reconcileShells } from './shell-backend'
+import type { ShellRecord } from './shell-store'
+
+const rec = (id: string): ShellRecord => ({
+  id, sessionId: 's1', cwd: '/home/u/proj', createdMs: 1, lastViewedMs: 2,
+})
+
+test('a shell whose tmux session is gone is DROPPED — `exit` is the ordinary death', () => {
+  expect(reconcileShells([rec('a'), rec('b')], ['a']).map(r => r.id)).toEqual(['a'])
+})
+
+test('a tmux session with no record is NOT adopted', () => {
+  // The exact opposite of `session-adopt.ts`, and deliberately. A session there carries a name, a
+  // task and a conversation worth recovering; a shell carries none of that, and this store's whole
+  // job is to be the small exact list the ceiling counts.
+  expect(reconcileShells([rec('a')], ['a', 'stray']).map(r => r.id)).toEqual(['a'])
+})
+
+test('nothing running empties the store rather than keeping ghosts', () => {
+  // Ghost records would make the ceiling refuse an open with every shell already dead — a cap you
+  // cannot get under by closing things.
+  expect(reconcileShells([rec('a'), rec('b')], [])).toEqual([])
+})
+
+test('order is preserved — the store is read in the order it was written', () => {
+  expect(reconcileShells([rec('b'), rec('a')], ['a', 'b']).map(r => r.id)).toEqual(['b', 'a'])
+})
+
+test('an empty store stays empty whatever tmux is running', () => {
+  expect(reconcileShells([], ['a', 'b'])).toEqual([])
+})

--- a/packages/server/server/sessions/shell-backend.ts
+++ b/packages/server/server/sessions/shell-backend.ts
@@ -1,0 +1,128 @@
+/**
+ * shell-backend.ts — opening, listing and closing utility shells against tmux.
+ *
+ * The DECISIONS are `shell-spec.ts`'s and the RECORD is `shell-store.ts`'s; what is here is the
+ * tmux and filesystem work between them, plus the one rule that needs its own test —
+ * `reconcileShells`.
+ *
+ * Everything runs on `SHELL_SOCKET`, never the fleet's. That is structural and not a naming
+ * convention: on the fleet socket `parseTmuxList` would keep these sessions and `reconcileSessions`
+ * would report each as an `unregistered` fleet row. See `tmux-cli.ts`'s note on `SHELL_SOCKET`.
+ */
+
+import { randomUUID } from 'node:crypto'
+import { stat } from 'node:fs/promises'
+import {
+  killSessionArgs, listSessionsArgs, newSessionArgs, parseTmuxList, SHELL_SOCKET,
+  tmuxListIsEmptyState,
+} from './tmux-cli'
+import { planShellOpen, type ShellRefusal } from './shell-spec'
+import { readShells, writeShells, type ShellRecord } from './shell-store'
+
+async function tmux(args: string[]): Promise<{ code: number; out: string; err: string }> {
+  try {
+    const p = Bun.spawn(['tmux', ...args], { stdout: 'pipe', stderr: 'pipe', stdin: 'ignore' })
+    const [out, err] = await Promise.all([
+      new Response(p.stdout).text(),
+      new Response(p.stderr).text(),
+    ])
+    return { code: await p.exited, out, err }
+  } catch {
+    // tmux is not on PATH. 127 is what a shell reports for that, and callers consult
+    // `tmuxAvailable` — no throw, so a missing tmux never crashes one.
+    return { code: 127, out: '', err: '' }
+  }
+}
+
+async function tmuxAvailable(): Promise<boolean> {
+  return (await tmux(['-V'])).code === 0
+}
+
+async function dirExists(path: string): Promise<boolean> {
+  try { return (await stat(path)).isDirectory() } catch { return false }
+}
+
+/** Which shell ids tmux is actually running on our socket. */
+async function runningIds(): Promise<string[]> {
+  const r = await tmux(listSessionsArgs(SHELL_SOCKET))
+  if (r.code !== 0) {
+    // Either "no server running on that socket" — the ordinary state before the day's first shell —
+    // or a real failure. Both mean no shells; `tmuxListIsEmptyState` is consulted so the two can be
+    // told apart in a log, and so this reads as a decision rather than a swallowed error.
+    if (!tmuxListIsEmptyState(r.code, r.out, r.err)) {
+      console.error(`[shell] tmux list-sessions on ${SHELL_SOCKET} failed: ${r.err.trim()}`)
+    }
+    return []
+  }
+  return parseTmuxList(r.out).map(s => s.id)
+}
+
+/**
+ * PURE: the store, narrowed to what is really running.
+ *
+ * Records go ONE WAY only. A record whose pane is gone is DROPPED — typing `exit` is the ordinary
+ * death of a shell, and a ghost record would make the ceiling refuse an open with nothing actually
+ * running. A pane with NO record is not adopted, which is the exact opposite of `session-adopt.ts`
+ * and is deliberate: a session there carries a name, a task and a conversation worth recovering,
+ * while a shell carries none of that, and this store's whole job is to be the small exact list the
+ * ceiling counts.
+ */
+export function reconcileShells(stored: ShellRecord[], running: string[]): ShellRecord[] {
+  const live = new Set(running)
+  return stored.filter(r => live.has(r.id))
+}
+
+export async function listShells(): Promise<ShellRecord[]> {
+  const stored = await readShells()
+  const live = reconcileShells(stored, await runningIds())
+  if (live.length !== stored.length) await writeShells(live)
+  return live
+}
+
+export async function openShell(o: {
+  sessionId: string
+  cwd: string | undefined
+  now?: number
+}): Promise<{ ok: true; shell: ShellRecord } | { ok: false; reason: ShellRefusal }> {
+  const now = o.now ?? Date.now()
+  const open = await listShells()
+  const plan = planShellOpen({
+    cwd: o.cwd,
+    cwdExists: o.cwd ? await dirExists(o.cwd) : false,
+    tmuxAvailable: await tmuxAvailable(),
+    openCount: open.length,
+    shell: process.env.SHELL,
+  })
+  if (!plan.ok) return plan
+
+  const id = randomUUID()
+  const r = await tmux(newSessionArgs({ id, cwd: plan.cwd, argv: plan.argv, socket: SHELL_SOCKET }))
+  // tmux would not start it. `no-tmux` is the honest code: nothing the caller named went wrong with
+  // the request, and the alternative is inventing a reason for a failure we cannot attribute.
+  if (r.code !== 0) {
+    console.error(`[shell] tmux new-session failed: ${r.err.trim()}`)
+    return { ok: false, reason: 'no-tmux' }
+  }
+
+  const shell: ShellRecord = {
+    id, sessionId: o.sessionId, cwd: plan.cwd, createdMs: now, lastViewedMs: now,
+  }
+  await writeShells([...open, shell])
+  return { ok: true, shell }
+}
+
+export async function closeShells(ids: string[]): Promise<{ closed: string[]; unknown: string[] }> {
+  const open = await listShells()
+  const known = new Set(open.map(r => r.id))
+  const closed: string[] = []
+  const unknown: string[] = []
+  for (const id of ids) {
+    if (!known.has(id)) { unknown.push(id); continue }
+    await tmux(killSessionArgs(id, SHELL_SOCKET))
+    closed.push(id)
+  }
+  // An id nobody knows is REPORTED rather than silently counted as closed: a caller that asked to
+  // close four and hears "four closed" must not be told that about three.
+  if (closed.length > 0) await writeShells(open.filter(r => !closed.includes(r.id)))
+  return { closed, unknown }
+}

--- a/packages/server/server/sessions/shell-gate.test.ts
+++ b/packages/server/server/sessions/shell-gate.test.ts
@@ -1,0 +1,29 @@
+import { expect, test } from 'bun:test'
+import { shellAllowed } from './shell-gate'
+
+/**
+ * A raw shell is strictly more powerful than the chat, which `chat-gate.ts` already calls the most
+ * powerful thing this server does — the chat at least spawns a NAMED assistant CLI, while this
+ * spawns whatever the person types. So it takes the same two gates, and the strict reading of an
+ * absent preference matters more here, not less.
+ */
+
+test('ABSENT READS AS OFF — nobody acquires a browser shell by having upgraded', () => {
+  expect(shellAllowed(true, undefined)).toBe(false)
+})
+
+test('an explicit no is a no', () => {
+  expect(shellAllowed(true, false)).toBe(false)
+})
+
+test('both together, and only both together', () => {
+  expect(shellAllowed(true, true)).toBe(true)
+})
+
+test('the preference may only ever NARROW the profile, never re-open it', () => {
+  // A preference that could re-enable what `public` denied would be the opt-in restoring host power
+  // on an exposed instance, which `exposure.ts` exists to make impossible.
+  expect(shellAllowed(false, true)).toBe(false)
+  expect(shellAllowed(false, undefined)).toBe(false)
+  expect(shellAllowed(false, false)).toBe(false)
+})

--- a/packages/server/server/sessions/shell-gate.ts
+++ b/packages/server/server/sessions/shell-gate.ts
@@ -1,0 +1,23 @@
+/** PURE: may this machine serve a per-session utility shell?
+ *
+ *  A raw shell is strictly more powerful than the chat, which `chat-gate.ts` already calls the most
+ *  powerful thing this server does — the chat at least spawns a NAMED assistant CLI, while this
+ *  spawns whatever the person types into it. So it takes the same two gates, in the same order:
+ *
+ *  - `capable` is `CAPS.localShell`, decided by the exposure profile in `exposure.ts`. It is the
+ *    SECURITY answer.
+ *  - `preference` is the user's own switch, and it may only ever NARROW. A preference that could
+ *    re-enable what `public` denied would be an opt-in restoring host power on an exposed instance,
+ *    which `exposure.ts` exists to make impossible.
+ *
+ *  Absent reads as OFF, for the reason `chatAllowed` gives and with more force: treating absence as
+ *  ON would leave a shell open in the browser of every machine nobody has touched since the
+ *  upgrade. The cost of the strict reading is a switch to flip in Settings; the cost of the lenient
+ *  one is a shell nobody chose.
+ *
+ *  It is a SEPARATE switch from `chatEnabled`, not a reuse of it: they are different powers, and
+ *  somebody who wants to talk to an assistant through the dashboard has not thereby asked for a
+ *  shell on the host. */
+export function shellAllowed(capable: boolean, preference: boolean | undefined): boolean {
+  return capable && preference === true
+}

--- a/packages/server/server/sessions/shell-isolation.test.ts
+++ b/packages/server/server/sessions/shell-isolation.test.ts
@@ -1,0 +1,73 @@
+import { expect, test } from 'bun:test'
+import { readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { listSessionsArgs, SHELL_SOCKET, TMUX_SOCKET } from './tmux-cli'
+import { shellsPath } from './shell-store'
+import { routeCapability } from '../capability-guard'
+
+/**
+ * A SHELL IS NOT A SESSION, and the cost of getting that wrong is invisible.
+ *
+ * The feature would work perfectly and quietly add a pane capture to the ~200 ms walk
+ * `host.sessions()` runs every 5 s in four processes, put a row per shell in every fleet surface,
+ * hand each one to `attention.ts` to be probed for dialog markers, and count an `htop` toward
+ * "N sessions waiting on you". So the separation is asserted here rather than left to be noticed.
+ */
+
+const HERE = import.meta.dir
+
+test('the fleet lists ONE socket and it is not the shells’', () => {
+  // `parseTmuxList` keeps any session whose name starts with `agentop-`, and `reconcileSessions`
+  // turns a running session with no registry record into an `unregistered` row. On one socket a
+  // shell would therefore be a fleet row nobody can act on. This is the assertion that stops it.
+  expect(listSessionsArgs().slice(0, 2)).toEqual(['-L', TMUX_SOCKET])
+  expect(SHELL_SOCKET).not.toBe(TMUX_SOCKET)
+})
+
+test('the shell store is not the session registry', () => {
+  expect(shellsPath('/x')).not.toContain('managed-sessions')
+})
+
+test('the routes are guarded, including ones nobody has written', () => {
+  expect(routeCapability('/api/shell/open')).toBe('localShell')
+  expect(routeCapability('/api/shell/whatever-comes-next')).toBe('localShell')
+})
+
+/**
+ * COMMENTS ARE STRIPPED FIRST, and that is not a loophole.
+ *
+ * These modules are REQUIRED to explain themselves in terms of the registry — the whole reason they
+ * exist is that a shell must not be in it, and the first version of this test failed on
+ * `shell-store.ts`'s own header for saying so. What must not appear is a reference in CODE.
+ */
+function code(src: string): string {
+  return src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1')
+}
+
+test('NO SHELL MODULE TOUCHES THE SESSION REGISTRY', async () => {
+  // Asserted over the SOURCE, like `events-frontier.test.ts`, because nothing else would fail: the
+  // import would work, the tests would pass, and the cost would show up as a slower machine.
+  for (const f of ['shell-backend.ts', 'shell-store.ts', 'shell-spec.ts', 'shell-web.ts', 'shell-gate.ts']) {
+    const src = code(await readFile(join(HERE, f), 'utf-8'))
+    expect(src).not.toContain('managed-sessions')
+    expect(src).not.toContain("from './registry'")
+    expect(src).not.toContain("from './session-view'")
+  }
+})
+
+test('the stripper does not hide a real reference behind a comment', () => {
+  // The guard above is only worth having if it still sees code. This is the test of the test.
+  expect(code("/* managed-sessions */\nimport x from './registry'")).toContain("from './registry'")
+  expect(code('// managed-sessions.json\nconst a = 1')).not.toContain('managed-sessions')
+})
+
+test('every tmux call the shell backend makes NAMES the shell socket', async () => {
+  // A builder called without a socket silently takes the fleet's, which is precisely the mistake
+  // this phase is designed around — and it would still work, which is why a test says it.
+  const src = await readFile(join(HERE, 'shell-backend.ts'), 'utf-8')
+  const calls = src.match(/(newSessionArgs|killSessionArgs|listSessionsArgs)\(/g) ?? []
+  expect(calls.length).toBeGreaterThanOrEqual(3)
+  // `listSessionsArgs()` with no argument is the fleet socket. It must not appear here.
+  expect(src).not.toMatch(/listSessionsArgs\(\s*\)/)
+  expect((src.match(/SHELL_SOCKET/g) ?? []).length).toBeGreaterThanOrEqual(calls.length)
+})

--- a/packages/server/server/sessions/shell-store.test.ts
+++ b/packages/server/server/sessions/shell-store.test.ts
@@ -1,0 +1,65 @@
+import { expect, test } from 'bun:test'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { readShells, shellsPath, writeShells, type ShellRecord } from './shell-store'
+
+const rec = (id: string): ShellRecord => ({
+  id, sessionId: 's1', cwd: '/home/u/proj', createdMs: 1, lastViewedMs: 2,
+})
+
+const tmp = () => mkdtemp(join(tmpdir(), 'agentistics-shells-'))
+
+test('IT IS NOT THE SESSION REGISTRY — a different file, so a different writer', () => {
+  // The whole isolation argument rests on this. `host.sessions()` walks every row in
+  // managed-sessions.json and captures its pane — ~200 ms, every 5 s, in four processes — and a
+  // shell in there would join that loop AND become a fleet row besides.
+  expect(shellsPath('/x')).toBe('/x/shells.json')
+  expect(shellsPath('/x')).not.toContain('managed-sessions')
+})
+
+test('a missing store is an empty list, never a throw', async () => {
+  const dir = await tmp()
+  expect(await readShells(dir)).toEqual([])
+  await rm(dir, { recursive: true, force: true })
+})
+
+test('what is written is what is read, in order', async () => {
+  const dir = await tmp()
+  await writeShells([rec('a'), rec('b')], dir)
+  expect((await readShells(dir)).map(r => r.id)).toEqual(['a', 'b'])
+  await rm(dir, { recursive: true, force: true })
+})
+
+test('an unreadable store is an empty list, never a throw', async () => {
+  // A truncated write or a hand edit must cost the person a new shell, never the dashboard.
+  const dir = await tmp()
+  await writeFile(join(dir, 'shells.json'), '{ not json')
+  expect(await readShells(dir)).toEqual([])
+  await rm(dir, { recursive: true, force: true })
+})
+
+test('a store that is not an array is an empty list', async () => {
+  const dir = await tmp()
+  await writeFile(join(dir, 'shells.json'), '{"id":"a"}')
+  expect(await readShells(dir)).toEqual([])
+  await rm(dir, { recursive: true, force: true })
+})
+
+test('a row missing a field it cannot do without is DROPPED, not kept half-built', async () => {
+  // A record with no cwd names no directory, and the ceiling counts rows: a half-read one would be
+  // counted against the cap while being useless to every verb.
+  const dir = await tmp()
+  await writeFile(join(dir, 'shells.json'), JSON.stringify([rec('a'), { id: 'b' }]))
+  expect((await readShells(dir)).map(r => r.id)).toEqual(['a'])
+  await rm(dir, { recursive: true, force: true })
+})
+
+test('a row whose timestamps are not numbers is dropped too', async () => {
+  const dir = await tmp()
+  await writeFile(join(dir, 'shells.json'), JSON.stringify([
+    { id: 'a', sessionId: 's', cwd: '/w', createdMs: 'yesterday', lastViewedMs: 2 },
+  ]))
+  expect(await readShells(dir)).toEqual([])
+  await rm(dir, { recursive: true, force: true })
+})

--- a/packages/server/server/sessions/shell-store.ts
+++ b/packages/server/server/sessions/shell-store.ts
@@ -1,0 +1,74 @@
+/**
+ * shell-store.ts — where the open utility shells are recorded, and why it is not the registry.
+ *
+ * `~/.agentistics/shells.json`, a separate file with a separate writer from
+ * `managed-sessions.json`, and that separation is the whole performance argument of this feature.
+ * `host.sessions()` "walks every session and captures its pane: ~200 ms measured here"
+ * (`fleet-web.ts`) and runs every 5 s in the cockpit, in the web fleet poll, in the VS Code
+ * extension and on every `/api/fleet` call. A shell in the registry would join that loop — and
+ * would also become a fleet row, be probed by `attention.ts` for dialog markers, take a
+ * `lastSeenMs` heartbeat, and count toward "N sessions waiting on you", so an `htop` would read as
+ * a session needing a person.
+ *
+ * Reads are TOTAL: a missing, unreadable, non-array or half-written store yields `[]`. A shell is a
+ * convenience, and a corrupt store must cost the person a new shell, never the dashboard.
+ */
+
+import { join } from 'node:path'
+import { AGENTISTICS_DATA_DIR } from '../config'
+
+/** One open shell. There is no `tmuxName` field: it is `tmuxName(id)`, on `SHELL_SOCKET`. */
+export interface ShellRecord {
+  /** This shell's own id — also its tmux session name, through `tmuxName`. */
+  id: string
+  /** The fleet row it was opened for. Not a foreign key anything enforces: the row can go away. */
+  sessionId: string
+  /** Where it was opened. Recorded at open, the one moment the directory is provably there. */
+  cwd: string
+  createdMs: number
+  /** When a viewer last had it on screen — the tiebreak the ceiling's recommendation will use. */
+  lastViewedMs: number
+}
+
+export function shellsPath(dir: string = AGENTISTICS_DATA_DIR): string {
+  return join(dir, 'shells.json')
+}
+
+/**
+ * A record, or `null` for anything that does not read as one.
+ *
+ * DROPPED rather than repaired: the ceiling counts these rows, so a half-read one would be charged
+ * against the cap while being useless to every verb — a shell you cannot reach and cannot close.
+ */
+function asRecord(v: unknown): ShellRecord | null {
+  if (typeof v !== 'object' || v === null) return null
+  const r = v as Record<string, unknown>
+  if (typeof r.id !== 'string' || !r.id) return null
+  if (typeof r.sessionId !== 'string') return null
+  if (typeof r.cwd !== 'string' || !r.cwd) return null
+  if (typeof r.createdMs !== 'number' || !Number.isFinite(r.createdMs)) return null
+  if (typeof r.lastViewedMs !== 'number' || !Number.isFinite(r.lastViewedMs)) return null
+  return {
+    id: r.id,
+    sessionId: r.sessionId,
+    cwd: r.cwd,
+    createdMs: r.createdMs,
+    lastViewedMs: r.lastViewedMs,
+  }
+}
+
+export async function readShells(dir?: string): Promise<ShellRecord[]> {
+  try {
+    const file = Bun.file(shellsPath(dir))
+    if (!(await file.exists())) return []
+    const parsed = JSON.parse(await file.text()) as unknown
+    if (!Array.isArray(parsed)) return []
+    return parsed.map(asRecord).filter((r): r is ShellRecord => r !== null)
+  } catch {
+    return []
+  }
+}
+
+export async function writeShells(list: ShellRecord[], dir?: string): Promise<void> {
+  await Bun.write(shellsPath(dir), JSON.stringify(list, null, 2))
+}

--- a/packages/server/server/sessions/shell-web.ts
+++ b/packages/server/server/sessions/shell-web.ts
@@ -1,0 +1,80 @@
+/**
+ * shell-web.ts — the three routes behind the per-session utility shell.
+ *
+ * `capability-guard.ts` has already refused these paths where the exposure profile forbids them,
+ * and `index.ts` has already applied the user's own `shellEnabled` switch on top and refused a
+ * central outright. What is left here is resolving the session and turning a `ShellRefusal` code
+ * into a localized sentence — the modules below stay language-free, like `central-runtime.ts`'s
+ * reason codes.
+ */
+
+import type { StartHost } from '../cli-start'
+import type { CliLang } from '../cli-lang'
+import { closeShells, listShells, openShell } from './shell-backend'
+import { SHELL_CAP, type ShellRefusal } from './shell-spec'
+
+/** One sentence per refusal code. The module that decides never writes prose; this one never decides. */
+const REFUSAL: Record<ShellRefusal, { en: string; pt: string }> = {
+  'no-tmux': {
+    en: 'This machine has no tmux, so there is no terminal to open. On Windows, run agentop under WSL.',
+    pt: 'Esta máquina não tem tmux, então não há terminal para abrir. No Windows, rode o agentop pelo WSL.',
+  },
+  'no-cwd': {
+    en: 'The registry records no directory for this session, so there is nowhere to open a shell.',
+    pt: 'O registro não guarda um diretório para esta sessão, então não há onde abrir um shell.',
+  },
+  'cwd-missing': {
+    en: 'This session’s directory no longer exists, so its shell cannot be opened there.',
+    pt: 'O diretório desta sessão não existe mais, então o shell dele não pode ser aberto ali.',
+  },
+  'at-cap': {
+    en: `${SHELL_CAP} terminals are already open. Close one to open another.`,
+    pt: `Já há ${SHELL_CAP} terminais abertos. Feche um para abrir outro.`,
+  },
+}
+
+const json = (body: unknown, status = 200): Response =>
+  new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } })
+
+/** `null` when the path is not ours, so `index.ts` falls through to its next route. */
+export async function handleShellRoute(
+  req: Request,
+  url: URL,
+  host: StartHost,
+  lang: CliLang,
+): Promise<Response | null> {
+  if (url.pathname === '/api/shell/list' && req.method === 'GET') {
+    return json({ shells: await listShells(), cap: SHELL_CAP })
+  }
+
+  if (url.pathname === '/api/shell/open' && req.method === 'POST') {
+    const body = await req.json().catch(() => ({})) as { sessionId?: string }
+    if (!body.sessionId) return json({ error: 'sessionId required' }, 400)
+    if (!host.sessions) return json({ error: 'no_host' }, 503)
+
+    // SCOPE IS CHECKED HERE, like `readAttachTicket` and `readFleetSkills`: the directory comes
+    // from the ROW, never from the caller, so an unknown id is refused rather than answered with a
+    // shell somewhere. `/api/fleet/new` is the one route that takes a directory from a body, and it
+    // says why.
+    const fleet = await host.sessions()
+    const row = fleet.sessions.find(r => r.id === body.sessionId || r.conversationId === body.sessionId)
+    if (!row) return json({ error: 'unknown_session' }, 404)
+
+    const out = await openShell({ sessionId: row.id, cwd: row.cwd })
+    if (!out.ok) {
+      // A REFUSAL IS A 200 CARRYING A SENTENCE, not an error status. The request was well formed
+      // and the answer is "no, and here is why" — a 4xx would make the browser draw its generic
+      // failure instead of the one sentence that says what to do about it.
+      return json({ ok: false, reason: out.reason, message: REFUSAL[out.reason][lang] })
+    }
+    return json({ ok: true, shell: out.shell })
+  }
+
+  if (url.pathname === '/api/shell/close' && req.method === 'POST') {
+    const body = await req.json().catch(() => ({})) as { ids?: unknown }
+    if (!Array.isArray(body.ids)) return json({ error: 'ids required' }, 400)
+    return json(await closeShells(body.ids.filter((i): i is string => typeof i === 'string')))
+  }
+
+  return null
+}


### PR DESCRIPTION
Tasks 3–8 of phase 1. A real shell (full PTY) can now be opened, listed and closed in a session's own directory through `/api/shell/*` — verifiable with `curl` and `tmux`, no UI yet.

## It is not a session, and the separation is structural

The shell runs on its OWN tmux socket (`agentop-shell`) and records itself in `~/.agentistics/shells.json`, never in the registry. Both halves are load-bearing:

- On the fleet socket `idFromTmuxName` strips the `agentop-` prefix, so `parseTmuxList` KEEPS the session and `reconcileSessions` reports it as an `unregistered` row — *"visible and inert"*, filed under `GONE_PROJECT_KEY`, beyond every verb in the cockpit.
- In the registry each shell would join the ~200 ms pane walk `host.sessions()` runs every 5 s in four processes, be probed by `attention.ts` for dialog markers, take a `lastSeenMs` heartbeat, and count toward "N sessions waiting on you" — an `htop` reading as a session that needs a person.

`shell-isolation.test.ts` asserts it over the modules' own SOURCE, comments stripped first — those modules are *required* to explain themselves in terms of the registry, and the first version of the test failed on `shell-store.ts`'s own header for doing so. There is a test of the test.

## Two gates, absent reads OFF

`CAPS.localShell` decides the security answer; `preferences.shellEnabled` may only ever NARROW it. A raw shell is strictly more powerful than the chat `chat-gate.ts` already calls the most powerful thing this server does — the chat at least runs a NAMED assistant CLI. Enforced in `index.ts` before the routes, not only in the UI; a central refuses outright.

## A ceiling, never a timer

`SHELL_CAP` = 8, stated once. A TTL kills the `bun test` that finished at minute 61 at an hour nobody was watching, and needs a timer running forever; a ceiling is one check on open and only ever closes something at the instant somebody asks for a new one.

Records go ONE WAY (`reconcileShells`): a pane that is gone is dropped — `exit` is the ordinary death — and a pane with no record is NOT adopted, the exact opposite of `session-adopt.ts`, because a shell carries no name, task or conversation worth recovering.

## Verified end to end (2026-09-09)

On an isolated port and data directory:

| | |
|---|---|
| switch off | `403 shell_disabled` |
| open | shell created in the ROW's own cwd |
| `tmux -L agentop-shell ls` | the shell is there |
| `tmux -L agentop ls` | 5 sessions, none of them the shell |
| grep the shell id in `/api/fleet` | 0 |
| ninth open | `at-cap :: 8 terminals are already open. Close one to open another.` |
| pane killed outside agentop | list went 8 → 7, no ghost |
| `close` with an invented id | 7 closed, the unknown id NAMED |

The `no-cwd` refusal proved itself on the way: with the isolated registry empty, every row came from `/proc` with no recorded directory, and the route answered with the sentence instead of opening a shell somewhere plausible.

## Test plan

- `bun tsc --noEmit` — clean.
- `bun test` — 0 fail on every commit (pre-commit hook ran both).
- `shell-gate.test.ts`, `shell-store.test.ts`, `shell-backend.test.ts`, `shell-isolation.test.ts`, plus the `capability-guard.test.ts` additions.

Phases 2–4 (the docked band and the mobile sheet, the ceiling modal, the floating window) follow in their own PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVZTKeH2GD6bxgR2EP4mns