### PR TITLE
feat(web): a mention looks like a mention, not like loose text

### DIFF
--- a/packages/web/src/components/sessions/SessionChat.tsx
+++ b/packages/web/src/components/sessions/SessionChat.tsx
@@ -68,6 +68,7 @@ import {
 } from '../../lib/composerStore'
 import { commandToken, knownCommands } from '../../lib/commandToken'
 import { draftSegments, needsMirror } from '../../lib/commandMirror'
+import { knownServers, mentionTokens } from '../../lib/mentionTokens'
 import { commandNotFoundNotice } from '../../lib/commandNotice'
 import { lastSentMessage, turnAnchorId } from '../../lib/lastSent'
 import { goToTurn } from '../../lib/turnScroll'
@@ -475,6 +476,18 @@ export function SessionChat({ session, row, lang, act, onArtifacts }: SessionCha
    * POLLING (below) for as long as the picker could still be showing one.
    */
   const [mcpServers, setMcpServers] = useState<MenuMcpServer[] | null>(null)
+  /**
+   * The references in the draft that point at a server this machine actually has.
+   *
+   * Derived on every render from the draft and the server list, exactly like `cmdToken` — which is
+   * what makes deleting a character un-mark a reference with nothing to invalidate. Empty while the
+   * list has not arrived: a mark is read at a glance and believed, so it may never stand over
+   * something unverified. See `mentionTokens.ts`.
+   */
+  const mentions = useMemo(
+    () => mentionTokens(draft, knownServers(mcpServers)),
+    [draft, mcpServers],
+  )
   /** Escape closes the picker while the `@word` it was triggered by is still on screen — see `slashDismissed`. */
   const [atDismissed, setAtDismissed] = useState(false)
   const [atIndex, setAtIndex] = useState(0)
@@ -2105,7 +2118,7 @@ export function SessionChat({ session, row, lang, act, onArtifacts }: SessionCha
                     The mirror scrolls with the field, is `aria-hidden` (the text is already in the
                     field, and a screen reader must not hear it twice) and takes no pointer events. */}
                 <div style={{ position: 'relative' }}>
-                  {needsMirror(cmdToken) && (
+                  {needsMirror(cmdToken, mentions) && (
                     <div
                       aria-hidden
                       ref={underlayRef}
@@ -2116,17 +2129,29 @@ export function SessionChat({ session, row, lang, act, onArtifacts }: SessionCha
                         whiteSpace: 'pre-wrap', overflowWrap: 'anywhere', color: 'var(--text-primary)',
                       }}
                     >
-                      {draftSegments(draft, cmdToken).map((seg, i) => seg.button ? (
-                        <span key={i} style={{
-                          background: 'var(--anthropic-orange)', color: '#fff',
-                          borderRadius: 4,
-                          boxShadow: '0 0 0 2px var(--anthropic-orange)',
-                        }}>{seg.text}</span>
-                      ) : (
-                        // A plain run — key only, no wrapper style, so it never disagrees with the
-                        // textarea's own metrics for the text it is standing in for.
-                        <span key={i}>{seg.text}</span>
-                      ))}
+                      {draftSegments(draft, cmdToken, mentions).map((seg, i) => {
+                        // A plain run gets a key and nothing else, so it can never disagree with
+                        // the textarea's own metrics for the text it is standing in for.
+                        if (seg.kind === 'plain') return <span key={i}>{seg.text}</span>
+                        // TWO MARKS, because they are two different things. A command is an ACTION
+                        // the message performs and is painted as the button it effectively is; a
+                        // mention is a REFERENCE to something on this machine and is marked as a
+                        // chip. Giving both the same paint would say they do the same thing.
+                        const command = seg.kind === 'command'
+                        return (
+                          <span key={i} style={{
+                            background: command ? 'var(--anthropic-orange)' : 'var(--accent-blue-dim)',
+                            color: command ? '#fff' : 'var(--accent-blue)',
+                            borderRadius: 4,
+                            // The ring is what gives the run its padding WITHOUT taking any width:
+                            // the mirror has to lay out character-for-character with the field
+                            // behind it, so nothing here may change the text's metrics.
+                            boxShadow: command
+                              ? '0 0 0 2px var(--anthropic-orange)'
+                              : '0 0 0 2px var(--accent-blue-dim)',
+                          }}>{seg.text}</span>
+                        )
+                      })}
                     </div>
                   )}
                 <textarea
@@ -2237,7 +2262,7 @@ export function SessionChat({ session, row, lang, act, onArtifacts }: SessionCha
                     // the note above the mirror div. `caretColor` is set unconditionally to the same
                     // colour the text would otherwise be, so it never rides on `color` and vanishes
                     // the moment `color` does.
-                    color: needsMirror(cmdToken) ? 'transparent' : 'var(--text-primary)',
+                    color: needsMirror(cmdToken, mentions) ? 'transparent' : 'var(--text-primary)',
                     caretColor: 'var(--text-primary)',
                     fontFamily: 'inherit', fontSize: 13.5,
                     lineHeight: 1.5, maxHeight: maxComposerH, overflowY: 'auto', padding: '6px 6px',

--- a/packages/web/src/lib/commandMirror.test.ts
+++ b/packages/web/src/lib/commandMirror.test.ts
@@ -8,28 +8,28 @@ describe('draftSegments', () => {
   it('paints only the command run when the token is found', () => {
     const token = commandToken('/serena find the symbol', known)
     expect(draftSegments('/serena find the symbol', token)).toEqual([
-      { text: '/serena', button: true },
-      { text: ' find the symbol', button: false },
+      { text: '/serena', kind: 'command' },
+      { text: ' find the symbol', kind: 'plain' },
     ])
   })
 
   it('paints nothing extra when the command fills the whole draft', () => {
     const token = commandToken('/serena', known)
-    expect(draftSegments('/serena', token)).toEqual([{ text: '/serena', button: true }])
+    expect(draftSegments('/serena', token)).toEqual([{ text: '/serena', kind: 'command' }])
   })
 
   it('leaves a missing command as one plain run', () => {
     const token = commandToken('/serana', known)
-    expect(draftSegments('/serana', token)).toEqual([{ text: '/serana', button: false }])
+    expect(draftSegments('/serana', token)).toEqual([{ text: '/serana', kind: 'plain' }])
   })
 
   it('leaves an unknown command as one plain run', () => {
     const token = commandToken('/serena', null)
-    expect(draftSegments('/serena', token)).toEqual([{ text: '/serena', button: false }])
+    expect(draftSegments('/serena', token)).toEqual([{ text: '/serena', kind: 'plain' }])
   })
 
   it('leaves plain prose as one plain run', () => {
-    expect(draftSegments('hello there', null)).toEqual([{ text: 'hello there', button: false }])
+    expect(draftSegments('hello there', null)).toEqual([{ text: 'hello there', kind: 'plain' }])
   })
 })
 
@@ -39,5 +39,42 @@ describe('needsMirror', () => {
     expect(needsMirror(commandToken('/serana', known))).toBe(false)
     expect(needsMirror(commandToken('/serena', null))).toBe(false)
     expect(needsMirror(null)).toBe(false)
+  })
+})
+
+describe('mentions are marked too, and differently', () => {
+  it('marks a mention as a reference, not as the command button', () => {
+  // Two different things: a command is an action the message performs, a mention points at
+  // something on this machine. They must not read as the same mark.
+  const out = draftSegments('olha @serena:find_symbol', null, [{ start: 5, end: 24 }])
+  expect(out).toEqual([
+    { text: 'olha ', kind: 'plain' },
+    { text: '@serena:find_symbol', kind: 'mention' },
+  ])
+  })
+
+  it('paints a command and its mentions in the same draft, in order', () => {
+  const draft = '/review @serena e @agentistics'
+  const out = draftSegments(
+    draft,
+    { text: '/review', start: 0, end: 7, state: 'found' },
+    [{ start: 8, end: 15 }, { start: 18, end: 30 }],
+  )
+  expect(out.map(s => s.kind)).toEqual(['command', 'plain', 'mention', 'plain', 'mention'])
+  expect(out.map(s => s.text).join('')).toBe(draft)
+  })
+
+  it('the mirror is drawn for a mention alone, with no command at all', () => {
+  expect(needsMirror(null, [{ start: 0, end: 8 }])).toBe(true)
+  expect(needsMirror(null, [])).toBe(false)
+  })
+
+  it('every segmentation reproduces the draft exactly', () => {
+  // The mirror sits behind the field: a run lost or duplicated here misaligns every character
+  // after it.
+  const draft = 'a @serena b /x c'
+  for (const mentions of [[], [{ start: 2, end: 9 }]]) {
+    expect(draftSegments(draft, null, mentions).map(s => s.text).join('')).toBe(draft)
+  }
   })
 })

--- a/packages/web/src/lib/commandMirror.ts
+++ b/packages/web/src/lib/commandMirror.ts
@@ -18,34 +18,56 @@
  */
 
 import type { CommandToken } from './commandToken'
+import type { MentionToken } from './mentionTokens'
+
+/** How a run is painted. `plain` is the ordinary text the field would have drawn anyway. */
+export type SegmentKind = 'plain' | 'command' | 'mention'
 
 export interface DraftSegment {
   text: string
-  /** Paint this run as the command button — orange background, white text. */
-  button: boolean
+  kind: SegmentKind
 }
 
 /**
  * The runs the mirror layer draws, in order.
  *
- * Only a `found` token is ever painted — `missing` and `unknown` claim nothing about the text (see
- * `commandToken.ts`), so there is nothing to recolour and the textarea's own text already reads
- * correctly. The whole draft comes back as one plain run in every other case, which is also the
- * signal `needsMirror` uses to decide whether the mirror should be drawn at all.
+ * TWO KINDS, and they are not the same thing. A `found` command is an ACTION the message performs,
+ * and it is painted as the button it effectively is. A mention is a REFERENCE to something on this
+ * machine, and it is marked as a chip — enough to say "this was picked from a real list", which is
+ * what it was missing when it read as loose text.
  *
- * `token.start` is always 0 (`commandToken` only ever matches the head of the draft), but the slice
- * is taken from it rather than hardcoded so this keeps working if that ever stops being true.
+ * Only what can be vouched for is painted: a `missing` or `unknown` command claims nothing (see
+ * `commandToken.ts`), and a mention whose server this machine does not have is left plain (see
+ * `mentionTokens.ts`). Everything else comes back as plain runs, which is also the signal
+ * `needsMirror` uses to decide whether to draw the mirror at all.
+ *
+ * The command is only ever at the head and a mention can be anywhere, so the ranges are collected,
+ * sorted and walked once. They cannot overlap — a command's range ends before any whitespace, and
+ * a mention must start after whitespace — but the walk skips anything that would, rather than
+ * trusting that.
  */
-export function draftSegments(draft: string, token: CommandToken | null): DraftSegment[] {
-  if (token === null || token.state !== 'found') return [{ text: draft, button: false }]
-  const before = draft.slice(0, token.start)
-  const head = draft.slice(token.start, token.end)
-  const rest = draft.slice(token.end)
-  const segments: DraftSegment[] = []
-  if (before !== '') segments.push({ text: before, button: false })
-  segments.push({ text: head, button: true })
-  if (rest !== '') segments.push({ text: rest, button: false })
-  return segments
+export function draftSegments(
+  draft: string,
+  token: CommandToken | null,
+  mentions: readonly MentionToken[] = [],
+): DraftSegment[] {
+  const marks: { start: number; end: number; kind: SegmentKind }[] = []
+  if (token !== null && token.state === 'found') {
+    marks.push({ start: token.start, end: token.end, kind: 'command' })
+  }
+  for (const m of mentions) marks.push({ start: m.start, end: m.end, kind: 'mention' })
+  marks.sort((a, b) => a.start - b.start)
+
+  const out: DraftSegment[] = []
+  let at = 0
+  for (const mark of marks) {
+    if (mark.start < at) continue
+    if (mark.start > at) out.push({ text: draft.slice(at, mark.start), kind: 'plain' })
+    out.push({ text: draft.slice(mark.start, mark.end), kind: mark.kind })
+    at = mark.end
+  }
+  if (at < draft.length) out.push({ text: draft.slice(at), kind: 'plain' })
+  return out.length > 0 ? out : [{ text: draft, kind: 'plain' }]
 }
 
 /**
@@ -56,6 +78,9 @@ export function draftSegments(draft: string, token: CommandToken | null): DraftS
  * the textarea's text transparent) and those two decisions must never drift apart: a mirror drawn
  * without the text hidden doubles the command, and hidden text with no mirror is a blank field.
  */
-export function needsMirror(token: CommandToken | null): boolean {
-  return token !== null && token.state === 'found'
+export function needsMirror(
+  token: CommandToken | null,
+  mentions: readonly MentionToken[] = [],
+): boolean {
+  return (token !== null && token.state === 'found') || mentions.length > 0
 }

--- a/packages/web/src/lib/mentionTokens.test.ts
+++ b/packages/web/src/lib/mentionTokens.test.ts
@@ -1,0 +1,54 @@
+import { test, expect } from 'bun:test'
+import { knownServers, mentionTokens } from './mentionTokens'
+
+const known = new Set(['serena', 'agentistics', 'makenotion/notion-mcp-server', 'computer-use-mcp'])
+const slice = (d: string, s: ReadonlySet<string> | null = known) =>
+  mentionTokens(d, s).map(t => d.slice(t.start, t.end))
+
+test('marks a bare server reference', () => {
+  expect(slice('@agentistics')).toEqual(['@agentistics'])
+})
+
+test('marks a server:tool reference', () => {
+  expect(slice('@serena:find_symbol')).toEqual(['@serena:find_symbol'])
+})
+
+test('marks several in one message, wherever they are', () => {
+  // A mention is one word inside a message, not the whole message.
+  expect(slice('usa @serena:find_symbol e depois @agentistics ok')).toEqual([
+    '@serena:find_symbol', '@agentistics',
+  ])
+})
+
+test('marks a server whose name carries a slash or a dash', () => {
+  expect(slice('@makenotion/notion-mcp-server')).toEqual(['@makenotion/notion-mcp-server'])
+  expect(slice('@computer-use-mcp')).toEqual(['@computer-use-mcp'])
+})
+
+test('leaves a server this machine does not have as plain text', () => {
+  // The mark is read at a glance and believed, so it may never appear over something unverified.
+  expect(slice('@naoexiste e @nada:coisa')).toEqual([])
+})
+
+test('an email address is not a mention', () => {
+  expect(slice('me@agentistics escreve')).toEqual([])
+})
+
+test('marks nothing at all while the server list has not arrived', () => {
+  // "I could not check" is not "this is real".
+  expect(slice('@serena:find_symbol', null)).toEqual([])
+})
+
+test('an empty list is a real answer: this machine has no servers', () => {
+  expect(slice('@serena', new Set())).toEqual([])
+})
+
+test('the trailing empty trigger is not a reference', () => {
+  // `@serena:` with nothing after the colon is the picker's scaffolding — see dropEmptyAtTrigger.
+  expect(slice('@serena:')).toEqual(['@serena'])
+})
+
+test('knownServers carries null through rather than inventing an empty set', () => {
+  expect(knownServers(null)).toBeNull()
+  expect(knownServers([{ name: 'serena' }])?.has('serena')).toBe(true)
+})

--- a/packages/web/src/lib/mentionTokens.ts
+++ b/packages/web/src/lib/mentionTokens.ts
@@ -1,0 +1,66 @@
+/**
+ * mentionTokens.ts — PURE: the `@server` and `@server:tool` references inside a draft.
+ *
+ * A mention that is not marked reads as loose text — reported with a screenshot of `@agentistics`
+ * sitting in the composer looking exactly like the words around it, with nothing to say it had been
+ * picked from a list of real servers.
+ *
+ * IT PAINTS ONLY WHAT IT CAN VOUCH FOR. A mention is marked when its SERVER is one the machine
+ * actually has; an `@someone` in prose, or a server that is not configured, is left as the plain
+ * text it is. This is the same rule `commandToken.ts` follows and for the same reason: the mark is
+ * read at a glance and believed, so it may never appear over something unverified. When the server
+ * list has not arrived yet (`null`), nothing is marked at all — "I could not check" is not "this is
+ * real".
+ *
+ * The TOOL half is deliberately not checked. A server's tools are probed lazily and are `pending`
+ * for the first few seconds (see `mcp-tools.ts`), so gating the mark on them would make a mention
+ * flicker into existence some seconds after it was inserted — and the thing being vouched for here
+ * is the reference's shape and its server, both of which are known immediately.
+ *
+ * UNLIKE a command, a mention can appear anywhere and any number of times: it is one word inside a
+ * message, not the whole message. So this scans the draft rather than only its head.
+ */
+
+/** One reference found in the draft, as a half-open range over it. */
+export interface MentionToken {
+  start: number
+  end: number
+}
+
+/**
+ * `@name` or `@name:tool`.
+ *
+ * The server part allows the characters a configured name really uses — this machine has
+ * `makenotion/notion-mcp-server` and `computer-use-mcp`, so `/`, `-` and `.` all have to be in.
+ * A preceding character, when there is one, must be whitespace: `me@host` is an address and
+ * `a@b:c` is not a reference, which is the same word-boundary rule the picker's own trigger uses.
+ */
+const MENTION = /(^|\s)@([A-Za-z0-9][A-Za-z0-9_./-]*)(:([A-Za-z0-9][A-Za-z0-9_.-]*))?/g
+
+export function mentionTokens(
+  draft: string,
+  knownServers: ReadonlySet<string> | null,
+): MentionToken[] {
+  if (knownServers === null || knownServers.size === 0) return []
+  const out: MentionToken[] = []
+  for (const m of draft.matchAll(MENTION)) {
+    const lead = m[1] ?? ''
+    const server = m[2] ?? ''
+    if (!knownServers.has(server)) continue
+    const start = (m.index ?? 0) + lead.length
+    out.push({ start, end: start + m[0].length - lead.length })
+  }
+  return out
+}
+
+/**
+ * The set `mentionTokens` takes, from whatever the machine reported.
+ *
+ * `null` in, `null` out — a list that has not arrived cannot be turned into an empty one without
+ * claiming this machine has no MCP servers.
+ */
+export function knownServers(
+  servers: readonly { name: string }[] | null,
+): ReadonlySet<string> | null {
+  return servers === null ? null : new Set(servers.map(s => s.name))
+}


### PR DESCRIPTION
## Summary

`@agentistics` sat in the composer reading exactly like the words around it — nothing said it had been picked from a list of real servers. Mentions are now marked.

## Motivation

Reported with a screenshot: the picker works, the reference is inserted, and then it is indistinguishable from prose. Fixes the one thing #452 shipped without.

## Changes

**Two marks, because they are two different things.** A `/command` is an ACTION the message performs and keeps the solid orange button it already had. A mention is a REFERENCE to something on this machine and is marked as a chip in the blue accent. Giving both the same paint would say they do the same thing.

**`mentionTokens.ts`** (new, pure, 10 tests) — the references in a draft that point at a server this machine actually has. `@someone` in prose, an email address, and a server that is not configured stay plain text. While the server list has not arrived, nothing is marked: *"I could not check" is not "this is real"* — the same rule `commandToken.ts` follows.

The **tool** half is deliberately not checked: tools are probed lazily and are `pending` for the first seconds, so gating on them would make a mention flicker into existence some seconds after it was inserted. What is vouched for is the reference's shape and its server, both known immediately.

**`commandMirror.ts`** — the mirror now walks both kinds of range together. Unlike a command, a mention can appear anywhere and any number of times, so the draft is scanned rather than only its head. A test pins that every segmentation reproduces the draft exactly: a run lost or duplicated there misaligns every character after it.

## Test plan

- [x] `bun tsc --noEmit` clean; `bun test` **7577 pass / 0 fail**.
- [x] **Verified in a real browser** on a build of this branch, against the machine's own fleet with the API proxied read-only, at **1440px and 390px**, identical at both:

```
/agentop-parallel-sessions  bg rgb(217, 119, 6)          (command, solid orange)
@agentistics                bg rgba(99, 102, 241, 0.15)  (mention, blue chip)
@serena:find_symbol         bg rgba(99, 102, 241, 0.15)
@naoexiste                  not marked
```

**What reviewers should check**

- The two marks must stay visually distinct. If a future palette change makes them read alike, the distinction between "this message runs a command" and "this message points at a server" is lost.
- Nothing in the mirror may change the text's metrics — the ring is drawn with `box-shadow` precisely so it takes no width. A padding here would misalign every character after it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019LT77q1YCgYQ6L8d1RRcM3