### PR TITLE
feat(web): tab takes the highlighted entry, in both composer pickers

### DIFF
--- a/packages/web/src/components/sessions/SessionChat.tsx
+++ b/packages/web/src/components/sessions/SessionChat.tsx
@@ -46,6 +46,7 @@ import { liveTurnText, stripAnsi } from '../../lib/liveTurn'
 import { scratchKey, sessionScratch } from '../../lib/sessionScratch'
 import { chatReadAt, firstFrameStale, refreshChat, subscribeChat } from '../../lib/chatFeed'
 import { composerMaxHeight } from '../../lib/composerHeight'
+import { isPickerSelectKey } from '../../lib/pickerKeys'
 import { nudgeFleet } from '../../lib/fleet'
 import { artifactsFromTurns, hasUnlistedWrites, type Artifact } from '../../lib/sessionArtifacts'
 import type { LiveTurn } from '../../lib/artifactTabs'
@@ -1689,8 +1690,8 @@ export function SessionChat({ session, row, lang, act, onArtifacts }: SessionCha
                   ))}
                   <p style={{ margin: '4px 8px', fontSize: 10, lineHeight: 1.4, color: 'var(--text-tertiary)' }}>
                     {pt
-                      ? '↑↓ escolhe · enter escreve no campo · esc fecha. Não envia.'
-                      : '↑↓ to move · enter writes it into the field · esc closes. It does not send.'}
+                      ? '↑↓ escolhe · enter ou tab escreve no campo · esc fecha. Não envia.'
+                      : '↑↓ to move · enter or tab writes it into the field · esc closes. It does not send.'}
                   </p>
                 </>
               )}
@@ -1765,8 +1766,8 @@ export function SessionChat({ session, row, lang, act, onArtifacts }: SessionCha
                     ))}
                     <p style={{ margin: '4px 8px', fontSize: 10, lineHeight: 1.4, color: 'var(--text-tertiary)' }}>
                       {pt
-                        ? '↑↓ escolhe · enter adiciona (dá para escolher mais de uma) · esc fecha. Não envia.'
-                        : '↑↓ to move · enter adds it (choose more than one) · esc closes. It does not send.'}
+                        ? '↑↓ escolhe · enter ou tab adiciona (dá para escolher mais de uma) · esc fecha. Não envia.'
+                        : '↑↓ to move · enter or tab adds it (choose more than one) · esc closes. It does not send.'}
                     </p>
                   </>
                 )
@@ -1810,8 +1811,8 @@ export function SessionChat({ session, row, lang, act, onArtifacts }: SessionCha
                     ))}
                     <p style={{ margin: '4px 8px', fontSize: 10, lineHeight: 1.4, color: 'var(--text-tertiary)' }}>
                       {pt
-                        ? '↑↓ escolhe · enter referencia · digite “:” para ver as ferramentas · esc fecha.'
-                        : '↑↓ to move · enter references it · type “:” to see its tools · esc closes.'}
+                        ? '↑↓ escolhe · enter ou tab referencia · digite “:” para ver as ferramentas · esc fecha.'
+                        : '↑↓ to move · enter or tab references it · type “:” to see its tools · esc closes.'}
                     </p>
                   </>
                 )
@@ -2182,7 +2183,10 @@ export function SessionChat({ session, row, lang, act, onArtifacts }: SessionCha
                     if (skillPickerOpen && slashFlat.length > 0) {
                       if (e.key === 'ArrowDown') { e.preventDefault(); setSlashIndex(i => stepSkill(i, slashFlat.length, 1)); return }
                       if (e.key === 'ArrowUp') { e.preventDefault(); setSlashIndex(i => stepSkill(i, slashFlat.length, -1)); return }
-                      if (e.key === 'Enter' && !e.shiftKey && !isMobile) {
+                      // Enter or Tab — one rule, shared with the `@` picker below. See
+                      // `pickerKeys.ts` for why shift is excluded and why Tab is not gated on
+                      // mobile the way Enter is.
+                      if (isPickerSelectKey({ key: e.key, shiftKey: e.shiftKey, isMobile })) {
                         e.preventDefault()
                         const picked = slashFlat[Math.min(slashIndex, slashFlat.length - 1)]
                         if (picked) insertSkill(picked.name)
@@ -2199,7 +2203,7 @@ export function SessionChat({ session, row, lang, act, onArtifacts }: SessionCha
                     if (atOpen && atFlatLen > 0) {
                       if (e.key === 'ArrowDown') { e.preventDefault(); setAtIndex(i => stepSkill(i, atFlatLen, 1)); return }
                       if (e.key === 'ArrowUp') { e.preventDefault(); setAtIndex(i => stepSkill(i, atFlatLen, -1)); return }
-                      if (e.key === 'Enter' && !e.shiftKey && !isMobile) {
+                      if (isPickerSelectKey({ key: e.key, shiftKey: e.shiftKey, isMobile })) {
                         e.preventDefault()
                         const i = Math.min(atIndex, atFlatLen - 1)
                         if (atLvl?.level === 'tool') {

--- a/packages/web/src/lib/pickerKeys.test.ts
+++ b/packages/web/src/lib/pickerKeys.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'bun:test'
+import { isPickerSelectKey } from './pickerKeys'
+
+const key = (over: Partial<Parameters<typeof isPickerSelectKey>[0]>) =>
+  isPickerSelectKey({ key: 'Enter', shiftKey: false, isMobile: false, ...over })
+
+describe('what takes the highlighted entry', () => {
+  it('takes it on Enter and on Tab', () => {
+    expect(key({ key: 'Enter' })).toBe(true)
+    expect(key({ key: 'Tab' })).toBe(true)
+  })
+
+  it('takes it on Tab even on a touch layout', () => {
+    // A soft keyboard rarely has Tab, and where it does it is not the line-break key.
+    expect(key({ key: 'Tab', isMobile: true })).toBe(true)
+  })
+
+  it('leaves Enter alone on a touch layout, where it breaks the line', () => {
+    expect(key({ key: 'Enter', isMobile: true })).toBe(false)
+  })
+})
+
+describe('shift is the way out', () => {
+  it('never selects with shift held, so focus can still leave the field', () => {
+    // Once Tab picks an entry there is no Tab left to leave with; shift+tab still moves focus.
+    expect(key({ key: 'Tab', shiftKey: true })).toBe(false)
+    expect(key({ key: 'Enter', shiftKey: true })).toBe(false)
+  })
+})
+
+describe('everything else is somebody typing', () => {
+  it('ignores the keys the picker does not own', () => {
+    for (const k of ['a', 'Escape', 'ArrowDown', 'ArrowUp', ' ', 'Backspace']) {
+      expect(key({ key: k })).toBe(false)
+    }
+  })
+})

--- a/packages/web/src/lib/pickerKeys.ts
+++ b/packages/web/src/lib/pickerKeys.ts
@@ -1,0 +1,33 @@
+/**
+ * pickerKeys.ts — PURE: which keypress takes the highlighted entry out of a composer picker.
+ *
+ * BOTH pickers answer it, so it is one rule rather than two. The `/` list and the `@` list are
+ * different menus over different things, and a key that worked in one and not the other would be
+ * discovered by trying — which is how the verbs in the cockpit ended up needing a reference card.
+ *
+ * ENTER AND TAB BOTH SELECT. Enter was the only one, and Tab is what a completion list has trained
+ * everybody's fingers to press — asked for directly. They are the same gesture here.
+ *
+ * SHIFT IS THE WAY OUT, and it is why `shiftKey` is checked rather than ignored. Once Tab picks an
+ * entry, a keyboard user has no Tab left to leave the field with; `shift+tab` still moves focus
+ * backwards, and Escape still closes the picker and gives every key back. A picker that could only
+ * be left with a mouse is one a keyboard cannot leave.
+ *
+ * ENTER ALONE IS GATED ON MOBILE, and Tab is not. On a touch keyboard the return key breaks the
+ * line — that is the convention every messaging app follows and this composer already keeps — so
+ * Enter must not be stolen there. A soft keyboard rarely has a Tab at all, and where it does it is
+ * not the line-break key, so nothing is taken from anybody by letting it select.
+ */
+
+export interface PickerKey {
+  key: string
+  shiftKey: boolean
+  /** Whether the composer is on a touch layout, where the return key breaks the line. */
+  isMobile: boolean
+}
+
+export function isPickerSelectKey(e: PickerKey): boolean {
+  if (e.shiftKey) return false
+  if (e.key === 'Tab') return true
+  return e.key === 'Enter' && !e.isMobile
+}


### PR DESCRIPTION
## Summary

Enter was the only key that took the highlighted entry out of a composer picker. Tab does it too now, in both the `/` list and the `@` list.

## Motivation

Asked for directly: *"both enter and tab should let the user select the item in the list"*. Tab is what a completion list has trained everybody's fingers to press.

## Changes

**`pickerKeys.ts`** (new, pure, 5 tests) — one predicate both branches read. The `/` list and the `@` list are different menus over different things, and a key that worked in one and not the other would be discovered by trying; that is how the cockpit's verbs ended up needing a reference card.

**Shift is excluded rather than ignored, and that is the point.** Once Tab picks an entry there is no Tab left to leave the field with. `shift+tab` still moves focus, and Escape still closes the picker and gives every key back. A picker that could only be left with a mouse is one a keyboard cannot leave.

**Enter alone stays gated on mobile.** There the return key breaks the line — the convention this composer already keeps. A soft keyboard rarely has Tab, and where it does it is not the line-break key, so letting it select takes nothing from anybody.

All six footer hints updated, EN and pt.

## Test plan

- [x] `bun tsc --noEmit` clean; `bun test` **7607 pass / 0 fail**.
- [x] **Verified in a real browser** on a build of this branch, against the machine's own fleet with the API proxied read-only:

```
@ + Tab        → "@agentistics "                      focus stays in the field
/ + Tab        → "/frontend-design:frontend-design "  focus stays in the field
@ + Shift+Tab  → "@" (nothing inserted)               focus moves to a button
```

**What reviewers should check**

- The Shift+Tab escape hatch is the accessibility half of this. If a future change makes Tab select regardless of modifiers, a keyboard user is trapped in the composer whenever a picker is open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019LT77q1YCgYQ6L8d1RRcM3