### PR TITLE
feat(sessions): the broadcast becomes a two-step wizard, and reopens what it was told to reach

### DIFF
--- a/packages/server/server/cli-i18n.ts
+++ b/packages/server/server/cli-i18n.ts
@@ -184,7 +184,8 @@ export interface CliStrings {
   /** A broadcast that was refused before anything was typed. */
   sessBroadcastRefused: (reason: string, skipped: number) => string
   /** What a broadcast did, per outcome. Partial delivery is the NORMAL case. */
-  sessBroadcastDone: (sent: number, failed: number, skipped: number) => string
+  sessBroadcastDone: (sent: number, failed: number, skipped: number, reopened: number) => string
+  sessBroadcastReopenSlow: string
   /**
    * Refusing to open a conversation a live session already has, and NAMING that session.
    *
@@ -600,14 +601,19 @@ const EN: CliStrings = {
     }
     return `none of the ${skipped} session(s) picked can take a prompt right now — see the reason on each.`
   },
-  sessBroadcastDone: (sent: number, failed: number, skipped: number) => {
+  sessBroadcastDone: (sent: number, failed: number, skipped: number, reopened: number) => {
     const parts = [`sent to ${sent} session${sent === 1 ? '' : 's'}`]
+    // Said because it STARTED something: a reopen spawns an assistant, which is a bigger act than
+    // typing into one that was already running, and the person should read that it happened.
+    if (reopened > 0) parts.push(`${reopened} reopened first`)
     // Named separately: a REFUSAL at write time (the session was asking after all) and a row that
     // was never eligible are two different things to do something about.
     if (failed > 0) parts.push(`${failed} refused it`)
     if (skipped > 0) parts.push(`${skipped} could not be sent to`)
     return `${parts.join(', ')}.`
   },
+  sessBroadcastReopenSlow:
+    'it was reopened but had not come up in time to be written to — nothing was typed into it.',
   sessResumeInUse: (holder: string) =>
     `that conversation is already open in ${holder} — open it there instead of starting a second assistant in it.`,
   sessAdoptFailed: (holder: string) =>
@@ -937,6 +943,8 @@ const PT: CliStrings = {
     if (skipped > 0) parts.push(`${skipped} não pôde receber`)
     return `${parts.join(', ')}.`
   },
+  sessBroadcastReopenSlow:
+    'ela foi reaberta mas não subiu a tempo de receber a mensagem — nada foi digitado nela.',
   sessResumeInUse: (holder: string) =>
     `essa conversa já está aberta em ${holder} — abra ela por lá, em vez de colocar um segundo assistente dentro dela.`,
   sessAdoptFailed: (holder: string) =>

--- a/packages/server/server/cli-start.ts
+++ b/packages/server/server/cli-start.ts
@@ -142,6 +142,7 @@ import {
   broadcastReport, planBroadcast, type BroadcastOutcome,
 } from './sessions/broadcast-plan'
 import { sessionRunning } from '@agentistics/tui/control/session-dimensions'
+import { controlStrings } from '@agentistics/tui/control/i18n'
 import { loadHarnessSessions } from './sessions/harness-sessions'
 import { readProcessConversation } from './sessions/process-conversation'
 import { idleServers, isServerCommand } from './idle-servers'
@@ -1812,6 +1813,37 @@ async function restorableSessions(fell: readonly ManagedSession[]): Promise<Rest
  * of that would be a button that approves the highlighted row. Only `suspend`-requiring actions
  * (`central.sh init`) need a real terminal, and the web host is never asked for one.
  */
+/**
+ * Wait until a just-reopened session is actually LISTENING — or give up and say so.
+ *
+ * `resumeSession` returns when the session has been STARTED, which is not the same thing: the
+ * harness still has to come up, and a prompt typed into a pane that is mid-boot goes nowhere while
+ * looking exactly like a delivery. The broadcast needs the stronger fact, so it polls the fleet for
+ * the row and waits for `sessionRunning`.
+ *
+ * It returns the id it FOUND, because a reopen mints a new row for the same conversation: writing
+ * to the id that was ticked would write to the record that was just retired.
+ *
+ * Bounded, and a timeout is an honest failure for that one session rather than a silent skip — the
+ * whole point of reopening was that the person asked for the message to reach it.
+ */
+const REOPEN_WAIT_MS = 20_000
+const REOPEN_POLL_MS = 700
+
+async function waitRunning(
+  id: string,
+  read: () => Promise<ControlSessions | undefined> | undefined,
+): Promise<string | null> {
+  const until = Date.now() + REOPEN_WAIT_MS
+  for (;;) {
+    const fleet = await read()
+    const row = fleet?.sessions.find(r => r.id === id)
+    if (row && sessionRunning(row)) return row.id
+    if (Date.now() >= until) return null
+    await new Promise(r => setTimeout(r, REOPEN_POLL_MS))
+  }
+}
+
 export function createControlHost(initialLang: CliLang, altScreen: Suspendable): StartHost {
   let lang = initialLang
   const S = () => cliStrings(lang)
@@ -3270,12 +3302,59 @@ export function createControlHost(initialLang: CliLang, altScreen: Suspendable):
           // The row's own knowledge of an open dialog. The HOST still re-reads at write time; this
           // only keeps a doomed send out of the list before anything is typed.
           blocked: (r.approvalLines?.length ?? 0) > 0,
+          // Read off the row's own reopen target, never inferred: it is absent exactly when the
+          // harness cannot reopen by id, and promising to write to a row nothing can resurrect is
+          // the failure this flag exists to avoid.
+          reopenable: Boolean(r.resume),
         })),
       })
       if (!plan.ok) return { ok: false, message: s.sessBroadcastRefused(plan.reason, plan.skipped.length) }
 
       const outcomes: BroadcastOutcome[] = []
+      let reopened = 0
       for (const t of plan.targets) {
+        /*
+         * A CLOSED SESSION IS BROUGHT BACK BEFORE ANYTHING IS TYPED, and the reopen is CONFIRMED.
+         *
+         * `resumeSession` returns once it has started the session, not once the assistant is
+         * listening, so writing immediately would type into a pane that is still coming up — and
+         * reporting that as a send is worse than the skip this replaced. `waitRunning` polls the
+         * fleet until the row is actually running, and a reopen that never becomes real is reported
+         * as a failure for THAT session rather than silently prompting nothing.
+         */
+        if (t.needsReopen) {
+          // The reopen target is read from the FLEET, never composed here: it names a conversation
+          // and a directory, and the `resume` route makes the same read for the same reason.
+          const row = rows.find(r => r.id === t.id)
+          if (!row?.resume) {
+            outcomes.push({ id: t.id, title: t.title, ok: false, message: controlStrings(lang).sessionsReopenNone })
+            continue
+          }
+          const back = await this.resumeSession!({
+            sessionId: row.resume.sessionId,
+            harness: row.harness,
+            cwd: row.cwd,
+            label: row.named ? row.title : row.resume.title,
+            // DETACHED, always. A broadcast is a message to several sessions at once; taking the
+            // terminal for one of them is not something this gesture can mean.
+            attach: false,
+            ...(row.actionable ? { replaces: row.id } : {}),
+          })
+          if (!back.ok) {
+            outcomes.push({ id: t.id, title: t.title, ok: false, message: back.message })
+            continue
+          }
+          const live = await waitRunning(back.id ?? t.id, () => this.sessions?.())
+          if (!live) {
+            outcomes.push({ id: t.id, title: t.title, ok: false, message: s.sessBroadcastReopenSlow })
+            continue
+          }
+          reopened++
+          // The reopen mints a NEW row for the same conversation, so the prompt goes to that one.
+          const out = await this.promptSession!(live, text)
+          outcomes.push({ id: live, title: t.title, ok: out.ok, message: out.message })
+          continue
+        }
         const out = await this.promptSession!(t.id, text)
         outcomes.push({ id: t.id, title: t.title, ok: out.ok, message: out.message })
       }
@@ -3285,7 +3364,7 @@ export function createControlHost(initialLang: CliLang, altScreen: Suspendable):
         // where four of five landed is not a failure, and reporting it as one would send somebody
         // to re-send to the four that already have it.
         ok: report.sent > 0,
-        message: s.sessBroadcastDone(report.sent, report.failed, report.skipped.length),
+        message: s.sessBroadcastDone(report.sent, report.failed, report.skipped.length, reopened),
       }
     },
 

--- a/packages/server/server/sessions/broadcast-plan.test.ts
+++ b/packages/server/server/sessions/broadcast-plan.test.ts
@@ -1,9 +1,9 @@
 import { test, expect } from 'bun:test'
-import { MAX_BROADCAST, broadcastReport, planBroadcast } from './broadcast-plan'
+import { MAX_BROADCAST, broadcastReport, planBroadcast , reopenCount } from './broadcast-plan'
 import type { BroadcastCandidate } from './broadcast-plan'
 
 const row = (id: string, o: Partial<BroadcastCandidate> = {}): BroadcastCandidate => ({
-  id, title: id.toUpperCase(), running: true, blocked: false, ...o,
+  id, title: id.toUpperCase(), running: true, blocked: false, reopenable: false, ...o,
 })
 
 test('sends to the running rows that were ticked', () => {
@@ -23,13 +23,14 @@ test('names what it will not send to, rather than dropping it', () => {
   const p = planBroadcast({
     text: 'go',
     ids: ['live', 'dead', 'asking'],
+    // `dead` cannot be brought back, so it is still named rather than sent to.
     rows: [row('live'), row('dead', { running: false }), row('asking', { blocked: true })],
   })
   expect(p.ok).toBe(true)
   if (!p.ok) throw new Error('expected ok')
   expect(p.targets.map(t => t.id)).toEqual(['live'])
   expect(p.skipped).toEqual([
-    { id: 'dead', title: 'DEAD', reason: 'not-running' },
+    { id: 'dead', title: 'DEAD', reason: 'not-reopenable' },
     { id: 'asking', title: 'ASKING', reason: 'dialog-open' },
   ])
 })
@@ -100,10 +101,59 @@ test('the report keeps every outcome, and counts both sides', () => {
       { id: 'a', title: 'A', ok: true, message: 'sent' },
       { id: 'b', title: 'B', ok: false, message: 'that session is not asking anything right now' },
     ],
-    [{ id: 'c', title: 'C', reason: 'not-running' }],
+    [{ id: 'c', title: 'C', reason: 'not-reopenable' }],
   )
   expect(r.sent).toBe(1)
   expect(r.failed).toBe(1)
   expect(r.skipped).toHaveLength(1)
   expect(r.outcomes.find(o => o.id === 'b')!.message).toContain('not asking')
+})
+
+/**
+ * A ticked session that is not running is BROUGHT BACK, when this machine knows how.
+ *
+ * Asked for directly: picking a closed session should reopen it and give it the prompt, rather than
+ * quietly dropping it from the send. The plan only says which ones need it — reopening, and waiting
+ * for the session to be real before anything is typed, is the host's job.
+ */
+test('a closed session that can be reopened becomes a target, marked as needing it', () => {
+  const p = planBroadcast({
+    text: 'go',
+    ids: ['live', 'closed'],
+    rows: [row('live'), row('closed', { running: false, reopenable: true })],
+  })
+  expect(p.ok).toBe(true)
+  if (!p.ok) throw new Error('expected ok')
+  expect(p.targets).toEqual([
+    { id: 'live', title: 'LIVE', needsReopen: false },
+    { id: 'closed', title: 'CLOSED', needsReopen: true },
+  ])
+  expect(p.skipped).toEqual([])
+  expect(reopenCount(p.targets)).toBe(1)
+})
+
+test('a closed session nothing can reopen is still named, with its own reason', () => {
+  // "It is not running" and "it is not running and nothing here knows how to bring it back" send a
+  // person to different places.
+  const p = planBroadcast({
+    text: 'go',
+    ids: ['gone'],
+    rows: [row('gone', { running: false, reopenable: false })],
+  })
+  expect(p.ok).toBe(false)
+  if (p.ok) throw new Error('expected refusal')
+  expect(p.skipped).toEqual([{ id: 'gone', title: 'GONE', reason: 'not-reopenable' }])
+})
+
+test('a stopped row is never skipped for a dialog its last frame happened to show', () => {
+  // A session that is not running has no dialog open; `blocked` there is whatever the frame before
+  // it died said, and reading it as a live dialog would refuse a reopen for no reason.
+  const p = planBroadcast({
+    text: 'go',
+    ids: ['stale'],
+    rows: [row('stale', { running: false, blocked: true, reopenable: true })],
+  })
+  expect(p.ok).toBe(true)
+  if (!p.ok) throw new Error('expected ok')
+  expect(p.targets).toEqual([{ id: 'stale', title: 'STALE', needsReopen: true }])
 })

--- a/packages/server/server/sessions/broadcast-plan.ts
+++ b/packages/server/server/sessions/broadcast-plan.ts
@@ -20,9 +20,16 @@
  *
  * ## The rules
  *
- * - **A session that is not RUNNING is excluded, by name.** A prompt to a `lost` or `exited` row
- *   has nowhere to go. It is reported rather than dropped: a count that shrinks between what was
- *   ticked and what was sent is the thing that makes somebody re-send.
+ * - **A session that is not running is REOPENED FIRST, when it can be.** A prompt to a `lost` or
+ *   `exited` row used to have nowhere to go and was skipped; asked for directly, a ticked row that
+ *   the machine knows how to reopen is now brought back and then written to. The plan only SAYS
+ *   which ones need it (`needsReopen`) — the reopening, and waiting for it to be real, is the
+ *   host's job, exactly as the writing is.
+ * - **A row that cannot be reopened is still excluded, by name, and with its own reason.** "It is
+ *   not running" and "it is not running and nothing here knows how to bring it back" send a person
+ *   to different places, so `not-reopenable` is a separate code. It is reported rather than
+ *   dropped: a count that shrinks between what was ticked and what was sent is the thing that makes
+ *   somebody re-send.
  * - **A session with a DIALOG OPEN is excluded, by name.** The row already knows this — it is the
  *   same rule the composer keeps — and a sentence typed into a dialog goes into its filter, where
  *   the submit takes whatever is highlighted.
@@ -42,16 +49,34 @@ export interface BroadcastCandidate {
   running: boolean
   /** Is a dialog open on it? A prompt would go into the dialog's filter. */
   blocked: boolean
+  /**
+   * Can this machine bring it back? Read off the row's own `resume` target, never inferred here.
+   *
+   * The row is absent that field precisely when the harness cannot reopen by id, so a row that
+   * cannot be resurrected is one this plan must not promise to write to.
+   */
+  reopenable: boolean
 }
 
 /** A session this prompt will be offered to. */
-export interface BroadcastTarget { id: string; title: string }
+export interface BroadcastTarget {
+  id: string
+  title: string
+  /**
+   * It is not running, and has to be brought back before anything can be typed into it.
+   *
+   * The host reopens it and waits for it to actually be up — a prompt typed into a session that
+   * does not exist yet goes nowhere, and reporting that as a send would be worse than the skip this
+   * replaced.
+   */
+  needsReopen: boolean
+}
 
 /** A session it will not, and the reason in a code the caller renders. */
 export interface BroadcastSkip {
   id: string
   title: string
-  reason: 'not-running' | 'dialog-open' | 'unknown'
+  reason: 'not-reopenable' | 'dialog-open' | 'unknown'
 }
 
 export type BroadcastPlan =
@@ -66,6 +91,11 @@ export type BroadcastPlan =
  * before pressing. A caller that wants more sends twice, which is a decision made twice.
  */
 export const MAX_BROADCAST = 12
+
+/** How many of a plan's targets have to be brought back before they can be written to. */
+export function reopenCount(targets: readonly BroadcastTarget[]): number {
+  return targets.filter(t => t.needsReopen).length
+}
 
 export function planBroadcast(o: {
   text: string
@@ -88,9 +118,13 @@ export function planBroadcast(o: {
     seen.add(id)
     const row = known.get(id)
     if (!row) { skipped.push({ id, title: id, reason: 'unknown' }); continue }
-    if (!row.running) { skipped.push({ id, title: row.title, reason: 'not-running' }); continue }
-    if (row.blocked) { skipped.push({ id, title: row.title, reason: 'dialog-open' }); continue }
-    targets.push({ id, title: row.title })
+    // A dialog is checked FIRST and on running rows only: a stopped session has no dialog open,
+    // and its `blocked` is whatever the last frame before it died happened to say.
+    if (row.running && row.blocked) { skipped.push({ id, title: row.title, reason: 'dialog-open' }); continue }
+    if (!row.running && !row.reopenable) {
+      skipped.push({ id, title: row.title, reason: 'not-reopenable' }); continue
+    }
+    targets.push({ id, title: row.title, needsReopen: !row.running })
   }
 
   // Counted over the TARGETS, not the selection: rows that were going to be skipped anyway cost

--- a/packages/web/src/components/sessions/SessionPickModal.tsx
+++ b/packages/web/src/components/sessions/SessionPickModal.tsx
@@ -7,16 +7,30 @@
  * empty state to drift, and this is a screen that starts assistants or writes into them: the
  * number on the button is the last thing anybody checks.
  *
+ * `send` is a TWO-STEP WIZARD — pick WHO, then write WHAT — because the prompt grew a composer of
+ * its own (paste-to-attach, an attach button, a preview strip) and a session list plus a composer
+ * do not both fit a 390px screen. `reopen` has no prompt and stays exactly one step; `lib/
+ * sendWizard.ts` holds which steps a kind has, whether the second is reachable, and what the primary
+ * button says on each — the same reasoning `sessionPick.ts` applies to the two FEATURES applies here
+ * to the two STEPS of one of them. The step lives in this component's own state (never remounted
+ * between steps), which is what lets the ticks, the search and the typed text all survive going
+ * back and forth.
+ *
  * It is built from `formBits` and wears the new-session wizard's own shell, tab strip and field.
  * A dialog that invents its own chrome reads as a different product from the one beside it.
  */
-import React, { useEffect, useMemo, useState } from 'react'
-import { RotateCcw, Search, Send, X } from 'lucide-react'
+import React, { useEffect, useMemo, useRef, useState } from 'react'
+import { ArrowLeft, Loader, Paperclip, RotateCcw, Search, Send, X } from 'lucide-react'
 import {
-  PICK_TABS, filterPickRows, initialPick, pickAllState, pickConfirmLabel, pickEmpty, pickTabHint,
+  PICK_TABS, filterPickRows, initialPick, pickAllState, pickEmpty, pickTabHint,
   pickTabLabel, pickedRows, togglePick, togglePickAll,
   type PickRow, type PickTab,
 } from '../../lib/sessionPick'
+import { composeBroadcastText, wizardPrimaryLabel, type WizardStep } from '../../lib/sendWizard'
+import { hasSomethingToSend } from '../../lib/composerAction'
+import { MAX_ATTACHMENTS, attachmentRoom, planPaste } from '../../lib/pastePlan'
+import { isImagePath } from '../../lib/attachmentPreview'
+import { attachmentUrl } from '../../lib/attachmentUrl'
 import { useIsMobile } from '../../hooks/useIsMobile'
 import { overlayPadding } from '../../lib/mobileOverlay'
 import { Field, Muted, TabStrip, inputStyle } from './formBits'
@@ -40,6 +54,9 @@ interface Props {
   onConfirm: (ids: string[], text: string) => void
 }
 
+/** One uploaded file, as the composer holds it — the same shape `SessionChat`'s own composer uses. */
+interface Attachment { name: string; path: string }
+
 export function SessionPickModal({ kind, rows, lang, busy, onClose, onConfirm }: Props) {
   const pt = lang === 'pt'
   const isMobile = useIsMobile()
@@ -50,6 +67,14 @@ export function SessionPickModal({ kind, rows, lang, busy, onClose, onConfirm }:
   // Reopen has no tabs: every row in it fell, so none of them is running and "Active" would always
   // be empty. A tab that can only ever be empty is a control that teaches the wrong thing.
   const [tab, setTab] = useState<PickTab>('active')
+  // `reopen` never leaves 'pick' — `wizardSteps('reopen')` is a single entry, so nothing here ever
+  // asks it to advance. Kept in ONE piece of state (not remounted between screens) so the ticks, the
+  // search and the typed text all survive going back and forth.
+  const [step, setStep] = useState<WizardStep>('pick')
+  const [attached, setAttached] = useState<Attachment[]>([])
+  const [uploading, setUploading] = useState(false)
+  const [notice, setNotice] = useState<string | null>(null)
+  const fileRef = useRef<HTMLInputElement>(null)
 
   // The fleet polls every five seconds. A row that ended while this was open must not stay ticked,
   // and one that arrived must not be silently ticked into a verb the user never saw.
@@ -62,6 +87,9 @@ export function SessionPickModal({ kind, rows, lang, busy, onClose, onConfirm }:
   }, [rows])
 
   useEffect(() => {
+    // Escape ALWAYS closes the whole wizard, on either step — it is the modal's own exit, not the
+    // step's. Going back one screen is a separate gesture (the Back button), because a person who
+    // has half-written a prompt and presses Escape expects to leave, not to lose the page.
     const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape' && !busy) onClose() }
     window.addEventListener('keydown', onKey)
     return () => window.removeEventListener('keydown', onKey)
@@ -76,8 +104,78 @@ export function SessionPickModal({ kind, rows, lang, busy, onClose, onConfirm }:
   const allState = pickAllState(shown, picked)
   const chosen = useMemo(() => pickedRows(rows, picked), [rows, picked])
   const overCap = needsText && chosen.length > MAX_BROADCAST
-  const confirm = pickConfirmLabel(chosen.length, kind, pt)
-  const ready = confirm.enabled && !busy && !overCap && (!needsText || text.trim().length > 0)
+  const primary = wizardPrimaryLabel(step, kind, chosen.length, pt)
+  // On the PICK step, `send` only turns the page — busy/cap/text have nothing to do with that yet.
+  // On the one step `reopen` has, and on `send`'s COMPOSE step, the button actually PERFORMS the
+  // verb, so it inherits every guard the single-screen modal always had.
+  const ready = step === 'pick' && kind === 'send'
+    ? primary.enabled && !busy
+    : primary.enabled && !busy && !overCap
+      && (!needsText || hasSomethingToSend({ draft: text, attachments: attached.length }))
+
+  async function upload(files: readonly File[]): Promise<void> {
+    if (files.length === 0) return
+    setUploading(true)
+    for (const file of files) {
+      const body = new FormData()
+      body.append('file', file)
+      /*
+       * `session` IS OPTIONAL ON THE WIRE (see `/api/fleet/attach` in `server/index.ts`: "Absent is
+       * fine — the attachment still works, it just cannot be drawn as a thumbnail in that case").
+       * Its only job is letting a later `[Image #N]` marker find its file again FOR ONE SESSION —
+       * `recordAttachmentSend` files it under exactly the id given. A broadcast has no single
+       * session to name honestly: naming one of the N picked would make marker resolution work for
+       * that one recipient and silently not for the rest, which is a worse lie than naming none. So
+       * this is left BLANK on purpose — the path still reaches every session exactly as typed, it
+       * just never grows a `[Image #N]` thumbnail anywhere, the same outcome as attaching from a
+       * session `SessionChat` cannot link to a transcript at all.
+       */
+      body.append('session', '')
+      try {
+        const res = await fetch(`/api/fleet/attach?lang=${lang}`, { method: 'POST', body })
+        const json = await res.json() as { ok: boolean; path?: string; name?: string; message?: string }
+        if (json.ok && json.path && json.name) {
+          setAttached(a => [...a, { name: json.name!, path: json.path! }])
+        } else {
+          setNotice(json.message ?? (pt ? 'O anexo falhou.' : 'The attachment failed.'))
+        }
+      } catch {
+        setNotice(pt ? 'Erro de rede ao enviar o anexo.' : 'Network error uploading the attachment.')
+      }
+    }
+    setUploading(false)
+    if (fileRef.current) fileRef.current.value = ''
+  }
+
+  function pickFiles(list: FileList | null): void {
+    if (!list) return
+    const room = attachmentRoom(attached.length)
+    const files = Array.from(list).slice(0, room)
+    if (files.length < list.length) {
+      setNotice(pt
+        ? `No máximo ${MAX_ATTACHMENTS} anexos por mensagem.`
+        : `At most ${MAX_ATTACHMENTS} attachments per message.`)
+    }
+    void upload(files)
+  }
+
+  /** Same rule the live composer uses — `planPaste.ts` decides which of the three a paste is. */
+  function onPaste(e: React.ClipboardEvent<HTMLTextAreaElement>): void {
+    const plan = planPaste({
+      files: Array.from(e.clipboardData.files),
+      text: e.clipboardData.getData('text/plain'),
+      existing: attached.length,
+    })
+    if (plan.kind === 'text') return
+    e.preventDefault()
+    if (plan.kind === 'files') { void upload(plan.files); return }
+    if (plan.kind === 'textFile') {
+      void upload([new File([plan.text], plan.name, { type: 'text/plain' })])
+      setNotice(pt
+        ? 'O texto colado era grande demais para digitar na sessão, então foi anexado como arquivo.'
+        : 'The pasted text was too large to type into the session, so it was attached as a file.')
+    }
+  }
 
   const t = {
     title: kind === 'reopen'
@@ -88,8 +186,15 @@ export function SessionPickModal({ kind, rows, lang, busy, onClose, onConfirm }:
         ? 'Estas sessões estavam abertas quando a máquina parou. Vêm todas marcadas — desmarque as que não quiser de volta.'
         : 'These sessions were open when the machine stopped. They all start ticked — untick any you do not want back.')
       : (pt
-        ? 'O mesmo prompt vai para cada sessão marcada, uma de cada vez. Nenhuma vem marcada: escolha uma a uma.'
-        : 'The same prompt goes to each ticked session, one at a time. None start ticked: pick them yourself.'),
+        ? 'Escolha as sessões que vão receber o mesmo prompt. Nenhuma vem marcada: escolha uma a uma.'
+        : 'Pick the sessions that will receive the same prompt. None start ticked: pick them yourself.'),
+    composeLead: pt
+      ? (chosen.length === 1
+        ? 'O prompt vai para 1 sessão.'
+        : `O prompt vai para ${chosen.length} sessões, uma de cada vez.`)
+      : (chosen.length === 1
+        ? 'The prompt goes to 1 session.'
+        : `The prompt goes to ${chosen.length} sessions, one at a time.`),
     sessions: pt ? 'Sessões' : 'Sessions',
     prompt: pt ? 'Prompt' : 'Prompt',
     all: pt ? 'Marcar todas' : 'Tick all',
@@ -97,6 +202,11 @@ export function SessionPickModal({ kind, rows, lang, busy, onClose, onConfirm }:
     searchSessions: pt ? 'Buscar por título ou pasta…' : 'Search by title or folder…',
     placeholder: pt ? 'O prompt que cada sessão vai receber…' : 'The prompt each session will receive…',
     cancel: pt ? 'Cancelar' : 'Cancel',
+    back: pt ? 'Voltar' : 'Back',
+    attach: pt ? 'Anexar arquivo' : 'Attach file',
+    attachNote: pt
+      ? 'gravados nesta máquina; o caminho vai na mensagem'
+      : 'stored on this machine; the path goes in the message',
     cap: pt
       ? `No máximo ${MAX_BROADCAST} de uma vez — ${chosen.length} marcadas.`
       : `At most ${MAX_BROADCAST} at a time — ${chosen.length} ticked.`,
@@ -136,6 +246,21 @@ export function SessionPickModal({ kind, rows, lang, busy, onClose, onConfirm }:
           display: 'flex', alignItems: 'center', gap: 10,
           padding: '16px 20px', borderBottom: '1px solid var(--border)',
         }}>
+          {/* Only on the compose step — the pick step's own way out is the X, exactly as before. */}
+          {step === 'compose' && (
+            <button
+              onClick={() => !busy && setStep('pick')}
+              aria-label={t.back}
+              title={t.back}
+              style={{
+                display: 'flex', width: tap, height: tap, alignItems: 'center', justifyContent: 'center',
+                borderRadius: 8, border: 'none', background: 'transparent', flexShrink: 0,
+                color: 'var(--text-tertiary)', cursor: busy ? 'default' : 'pointer',
+              }}
+            >
+              <ArrowLeft size={16} />
+            </button>
+          )}
           <h2 style={{ margin: 0, fontSize: 15, fontWeight: 700, color: 'var(--text-primary)', flex: 1 }}>
             {t.title}
           </h2>
@@ -157,9 +282,10 @@ export function SessionPickModal({ kind, rows, lang, busy, onClose, onConfirm }:
           display: 'flex', flexDirection: 'column', gap: 16, padding: '16px 20px',
         }}>
           <p style={{ margin: 0, fontSize: 12.5, lineHeight: 1.55, color: 'var(--text-secondary)' }}>
-            {t.lead}
+            {step === 'compose' ? t.composeLead : t.lead}
           </p>
 
+          {step === 'pick' && (
           <Field label={t.sessions}>
             <div style={{ position: 'relative' }}>
               <Search size={13} style={{
@@ -275,23 +401,129 @@ export function SessionPickModal({ kind, rows, lang, busy, onClose, onConfirm }:
               })}
             </div>
           </Field>
+          )}
 
-          {needsText && (
-            <Field label={t.prompt}>
-              <textarea
-                value={text}
-                onChange={e => setText(e.target.value)}
-                placeholder={t.placeholder}
-                rows={3}
-                style={{
-                  ...inputStyle, paddingLeft: 12, resize: 'vertical', lineHeight: 1.5,
-                  ...(isMobile ? { fontSize: 16 } : {}),
-                }}
-              />
-              {overCap && (
-                <span role="status" style={{ fontSize: 11.5, color: 'var(--accent-red)' }}>{t.cap}</span>
-              )}
-            </Field>
+          {step === 'compose' && (
+            <>
+              {/* WHO it is going to — read-only here, on purpose: changing the list is Back's job,
+                  and a second way to edit the same set from this screen is a second place for the
+                  two to disagree about what "chosen" means. */}
+              <Field label={t.sessions}>
+                <div style={{
+                  maxHeight: 96, overflowY: 'auto', display: 'flex', flexDirection: 'column', gap: 2,
+                  border: '1px solid var(--border-subtle)', borderRadius: 10, padding: '6px 10px',
+                }}>
+                  {chosen.map(row => (
+                    <span key={row.id} style={{
+                      fontSize: 12, color: 'var(--text-secondary)',
+                      overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+                    }}>
+                      {row.title}
+                    </span>
+                  ))}
+                </div>
+              </Field>
+
+              <Field label={t.prompt}>
+                <textarea
+                  value={text}
+                  onChange={e => setText(e.target.value)}
+                  onPaste={onPaste}
+                  placeholder={t.placeholder}
+                  rows={3}
+                  style={{
+                    ...inputStyle, paddingLeft: 12, resize: 'vertical', lineHeight: 1.5,
+                    ...(isMobile ? { fontSize: 16 } : {}),
+                  }}
+                />
+
+                <input
+                  ref={fileRef}
+                  type="file"
+                  multiple
+                  onChange={e => pickFiles(e.target.files)}
+                  style={{ display: 'none' }}
+                />
+                <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+                  <button
+                    type="button"
+                    onClick={() => fileRef.current?.click()}
+                    disabled={uploading}
+                    aria-label={t.attach}
+                    title={t.attach}
+                    style={{
+                      display: 'flex', alignItems: 'center', justifyContent: 'center',
+                      width: tap, height: tap, borderRadius: 9, border: 'none', flexShrink: 0,
+                      background: 'transparent', color: 'var(--text-tertiary)',
+                      cursor: uploading ? 'default' : 'pointer',
+                    }}
+                  >
+                    {uploading ? <Loader size={15} className="ag-working-spin" /> : <Paperclip size={15} />}
+                  </button>
+                </div>
+
+                {attached.length > 0 && (
+                  <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+                    {attached.map(a => isImagePath(a.path) ? (
+                      <span key={a.path} title={a.name} style={{
+                        position: 'relative', display: 'block', width: 48, height: 48,
+                        borderRadius: 8, overflow: 'hidden', flexShrink: 0,
+                        border: '1px solid var(--border-subtle)', background: 'var(--bg-elevated)',
+                      }}>
+                        <img
+                          src={attachmentUrl(a.path)} alt=""
+                          style={{ width: '100%', height: '100%', objectFit: 'cover', display: 'block' }}
+                        />
+                        <button
+                          onClick={() => setAttached(list => list.filter(x => x.path !== a.path))}
+                          aria-label={pt ? `Remover ${a.name}` : `Remove ${a.name}`}
+                          style={{
+                            position: 'absolute', top: 2, right: 2,
+                            display: 'flex', alignItems: 'center', justifyContent: 'center',
+                            width: 16, height: 16, borderRadius: '50%', border: 'none', padding: 0,
+                            background: 'rgba(0,0,0,0.55)', color: '#fff', cursor: 'pointer',
+                          }}
+                        >
+                          <X size={10} />
+                        </button>
+                      </span>
+                    ) : (
+                      <span key={a.path} title={a.path} style={{
+                        display: 'inline-flex', alignItems: 'center', gap: 6, maxWidth: '100%',
+                        padding: '5px 8px', borderRadius: 8, minWidth: 0,
+                        background: 'var(--bg-elevated)', border: '1px solid var(--border-subtle)',
+                        fontSize: 11.5, color: 'var(--text-secondary)',
+                      }}>
+                        <Paperclip size={11} style={{ flexShrink: 0 }} />
+                        <span style={{ minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                          {a.name}
+                        </span>
+                        <button
+                          onClick={() => setAttached(list => list.filter(x => x.path !== a.path))}
+                          aria-label={pt ? `Remover ${a.name}` : `Remove ${a.name}`}
+                          style={{
+                            display: 'flex', border: 'none', background: 'transparent', padding: 0,
+                            color: 'var(--text-tertiary)', cursor: 'pointer', flexShrink: 0,
+                          }}
+                        >
+                          <X size={11} />
+                        </button>
+                      </span>
+                    ))}
+                    <span style={{ fontSize: 10.5, color: 'var(--text-tertiary)', alignSelf: 'center' }}>
+                      {t.attachNote}
+                    </span>
+                  </div>
+                )}
+
+                {notice && (
+                  <span role="status" style={{ fontSize: 11.5, color: 'var(--anthropic-orange)' }}>{notice}</span>
+                )}
+                {overCap && (
+                  <span role="status" style={{ fontSize: 11.5, color: 'var(--accent-red)' }}>{t.cap}</span>
+                )}
+              </Field>
+            </>
           )}
         </div>
 
@@ -300,17 +532,28 @@ export function SessionPickModal({ kind, rows, lang, busy, onClose, onConfirm }:
           padding: '14px 20px', borderTop: '1px solid var(--border)',
         }}>
           <button
-            onClick={onClose}
+            onClick={() => (step === 'compose' ? setStep('pick') : onClose())}
+            disabled={busy}
             style={{
-              minHeight: isMobile ? 44 : 34, padding: '0 14px', borderRadius: 9, cursor: 'pointer',
+              minHeight: isMobile ? 44 : 34, padding: '0 14px', borderRadius: 9,
+              cursor: busy ? 'default' : 'pointer',
               border: '1px solid var(--border)', background: 'transparent',
               color: 'var(--text-secondary)', fontFamily: 'inherit', fontSize: 12.5,
             }}
           >
-            {t.cancel}
+            {step === 'compose' ? t.back : t.cancel}
           </button>
           <button
-            onClick={() => ready && onConfirm(chosen.map(r => r.id), text.trim())}
+            onClick={() => {
+              if (!ready) return
+              // `send`'s pick step only turns the page — the verb has not happened yet, so it must
+              // not call `onConfirm`, which is what actually starts writing into live sessions.
+              if (kind === 'send' && step === 'pick') { setStep('compose'); return }
+              onConfirm(
+                chosen.map(r => r.id),
+                kind === 'send' ? composeBroadcastText(attached.map(a => a.path), text.trim()) : '',
+              )
+            }}
             disabled={!ready}
             style={{
               display: 'flex', alignItems: 'center', gap: 7,
@@ -322,8 +565,8 @@ export function SessionPickModal({ kind, rows, lang, busy, onClose, onConfirm }:
               fontFamily: 'inherit', fontSize: 12.5, fontWeight: 650,
             }}
           >
-            {kind === 'reopen' ? <RotateCcw size={13} /> : <Send size={13} />}
-            {confirm.label}
+            {kind === 'reopen' ? <RotateCcw size={13} /> : (step === 'compose' ? <Send size={13} /> : null)}
+            {primary.label}
           </button>
         </footer>
       </div>

--- a/packages/web/src/lib/sendWizard.test.ts
+++ b/packages/web/src/lib/sendWizard.test.ts
@@ -1,0 +1,50 @@
+import { expect, test } from 'bun:test'
+import { canAdvanceToCompose, composeBroadcastText, wizardPrimaryLabel, wizardSteps } from './sendWizard'
+
+test('reopen stays one step; send grows a compose step', () => {
+  expect(wizardSteps('reopen')).toEqual(['pick'])
+  expect(wizardSteps('send')).toEqual(['pick', 'compose'])
+})
+
+test('the compose step is reachable only once something is ticked', () => {
+  expect(canAdvanceToCompose(0)).toBe(false)
+  expect(canAdvanceToCompose(1)).toBe(true)
+  expect(canAdvanceToCompose(5)).toBe(true)
+})
+
+/**
+ * `send`'s pick step must not borrow the sending verb's wording — pressing it only turns the page.
+ */
+test('send/pick says "Next" and never claims delivery', () => {
+  const zero = wizardPrimaryLabel('pick', 'send', 0, false)
+  expect(zero.enabled).toBe(false)
+  expect(zero.label).toBe('None picked')
+
+  const one = wizardPrimaryLabel('pick', 'send', 1, false)
+  expect(one.enabled).toBe(true)
+  expect(one.label).toBe('Next · 1 session')
+  expect(one.label).not.toContain('Send')
+
+  const many = wizardPrimaryLabel('pick', 'send', 4, true)
+  expect(many.label).toBe('Avançar · 4 sessões')
+})
+
+/**
+ * `send`'s compose step and `reopen`'s only step are the two places that actually PERFORM the verb,
+ * so both go through `pickConfirmLabel`'s own arithmetic — this is a cross-check, not a re-decision.
+ */
+test('send/compose and reopen share pickConfirmLabel wording exactly', () => {
+  expect(wizardPrimaryLabel('compose', 'send', 3, false)).toEqual({ enabled: true, label: 'Send to 3 sessions' })
+  expect(wizardPrimaryLabel('compose', 'send', 0, false)).toEqual({ enabled: false, label: 'None picked' })
+  expect(wizardPrimaryLabel('pick', 'reopen', 2, false)).toEqual({ enabled: true, label: 'Reopen 2 sessions' })
+  expect(wizardPrimaryLabel('pick', 'reopen', 0, true)).toEqual({ enabled: false, label: 'Nenhuma escolhida' })
+})
+
+test('composing puts paths on their own lines above what was typed', () => {
+  expect(composeBroadcastText([], 'hello')).toBe('hello')
+  expect(composeBroadcastText(['/tmp/a.png'], 'hello'))
+    .toBe('/tmp/a.png\n\nhello')
+  expect(composeBroadcastText(['/tmp/a.png', '/tmp/b.png'], ''))
+    .toBe('/tmp/a.png\n/tmp/b.png')
+  expect(composeBroadcastText([], '')).toBe('')
+})

--- a/packages/web/src/lib/sendWizard.ts
+++ b/packages/web/src/lib/sendWizard.ts
@@ -1,0 +1,75 @@
+/**
+ * sendWizard.ts — PURE: the two-step "send a prompt to several sessions" wizard.
+ *
+ * `SessionPickModal` used to be one screen for BOTH `SessionPickModal` kinds — tick some sessions,
+ * then (for `send`) write a prompt underneath the very same list. Once the prompt needed a composer
+ * of its own (paste-to-attach, an attach button, a preview strip) that one screen ran out of room —
+ * a 390px modal cannot hold a session list AND a composer AND stay usable. So `send` is now two
+ * steps: pick WHO, then write WHAT. `reopen` stays exactly one step — it has no prompt, so a second
+ * step would be a step with nothing on it.
+ *
+ * Every decision the wizard needs at more than one place in the DOM lives here, tested apart from
+ * any DOM — the last three bugs in this area were rules that existed twice and drifted (see
+ * `sessionPick.ts`'s own header).
+ */
+
+import { pickConfirmLabel } from './sessionPick'
+import { composeReply } from './replyQuote'
+
+export type WizardStep = 'pick' | 'compose'
+
+/** The screens THIS kind has, in order. `reopen` never grows a second one. */
+export function wizardSteps(kind: 'reopen' | 'send'): readonly WizardStep[] {
+  return kind === 'send' ? ['pick', 'compose'] : ['pick']
+}
+
+/**
+ * May the wizard move from picking sessions to writing the prompt?
+ *
+ * Nothing ticked means there is nothing to write TO — the same reasoning `pickConfirmLabel` already
+ * applies to the final button, asked one step earlier so a person cannot land on an empty compose
+ * screen with no way to know why the list behind it is empty.
+ */
+export function canAdvanceToCompose(pickedCount: number): boolean {
+  return pickedCount > 0
+}
+
+/**
+ * What the primary button says on THIS step, and whether pressing it does anything.
+ *
+ * `reopen` (one step) and `send`'s COMPOSE step share one wording, because pressing either
+ * PERFORMS the verb — both go through `pickConfirmLabel`'s exact arithmetic ("Reopen N sessions" /
+ * "Send to N sessions"), so the count is never computed twice.
+ *
+ * `send`'s PICK step is the one new case, and it may not borrow that wording: pressing it does not
+ * send anything yet, only turns the page, so "Send to 3 sessions" pressed here would claim a
+ * delivery that has not happened. "Nothing may claim what it does not know" applies here exactly as
+ * it does to `pickConfirmLabel`'s own "None picked" — an empty pick reads that word, not "Next".
+ */
+export function wizardPrimaryLabel(
+  step: WizardStep, kind: 'reopen' | 'send', pickedCount: number, pt: boolean,
+): { label: string; enabled: boolean } {
+  if (kind === 'reopen' || step === 'compose') return pickConfirmLabel(pickedCount, kind, pt)
+  if (!canAdvanceToCompose(pickedCount)) {
+    return { enabled: false, label: pt ? 'Nenhuma escolhida' : 'None picked' }
+  }
+  const one = pickedCount === 1
+  return {
+    enabled: true,
+    label: pt
+      ? (one ? 'Avançar · 1 sessão' : `Avançar · ${pickedCount} sessões`)
+      : (one ? 'Next · 1 session' : `Next · ${pickedCount} sessions`),
+  }
+}
+
+/**
+ * The message that actually goes out: the uploaded attachments' paths, then what was typed.
+ *
+ * A broadcast answers nobody's turn, so there is no quote — this is `composeReply` with that block
+ * left empty, kept under its own name so the wizard's one real decision (what travels, and in what
+ * order) is findable beside the rest of it rather than a bare call into a module about a different
+ * feature (replying to one message inside one conversation).
+ */
+export function composeBroadcastText(paths: readonly string[], text: string): string {
+  return composeReply({ quote: '', paths, text })
+}


### PR DESCRIPTION
## Summary

- "Send a prompt to several sessions" is now **two steps**: pick the sessions, then write the prompt.
- Step 2 takes **pasted images (ctrl+v)** and has an **attach button**.
- A **closed session that was ticked is reopened** and then written to, instead of being dropped from the send.

## Motivation

Asked for directly, with a screenshot of the old one-screen modal: make it a wizard, accept attachments, and let closed sessions receive the prompt.

## Changes

**The wizard** (`sendWizard.ts`, pure, 5 tests + `SessionPickModal.tsx`). Step 1 keeps its ticks, search and tab when you go forward and come back. The `reopen` kind of this same modal is untouched — it has no prompt and stays one step.

**Attachments reuse the composer's mechanism exactly**: each file is `POST`ed to `/api/fleet/attach`, and the returned PATHS are composed into the text above what was typed. The wire carries no attachment field, so the server needed nothing for this. The upload's `session` field is sent empty and the code says why: naming one of the N picked would make marker resolution work for that one and lie for the others.

**Reopening** (`broadcast-plan.ts` + `cli-start.ts`). `reopenable` is read off the row's own `resume` target, never inferred — it is absent exactly when the harness cannot reopen by id.

**The reopen is confirmed before anything is typed.** `resumeSession` returns once a session has been STARTED, which is not the same as listening; writing immediately types into a pane still coming up, and reporting that as a send is worse than the skip it replaced. `waitRunning` polls until the row actually reports running, and a reopen that never becomes real is a failure for that session with its own sentence. The prompt then goes to the id the reopen minted, because a reopen retires the row that was ticked.

**A row nothing can reopen is still named**, as `not-reopenable` rather than `not-running`: "it is stopped" and "it is stopped and nothing here knows how to bring it back" send a person to different places.

**The dialog check now applies to running rows only.** A stopped session has no dialog open; its `blocked` is whatever the frame before it died happened to show, and reading that as a live dialog refused a reopen for no reason.

**The report says how many were reopened**, because a reopen STARTS an assistant — a bigger act than typing into one already running.

## Test plan

- [x] `bun tsc --noEmit` clean; `bun test` **7610 pass / 0 fail**.
- [x] `broadcast-plan.test.ts` grew from 9 to 12: a closed-but-reopenable row becomes a target marked `needsReopen`, a row nothing can reopen is refused by name, and a stopped row is not skipped for a dialog its last frame happened to show.
- [x] **Verified in a real browser** on a build of this branch, at 1440px and 390px, against the machine's own fleet with the API proxied read-only:

```
step 1 → 6 checkboxes, 0 textareas   [Cancel] [None picked]
step 2 → 0 checkboxes, 1 textarea    [Back]   [Send to 1 session]
no page errors, no horizontal overflow at either width
```

Step 2 shows the picked session by name, the prompt field and the attach clip.

**What reviewers should check**

- `MAX_BROADCAST` is unchanged at 12. Its own comment calls that a blast radius rather than a performance limit, and this change makes the radius larger — 12 reopens spawn 12 assistants. The count is now in the confirmation sentence, but whether 12 is still the right number with reopening in the picture is a product call I did not make alone.
- The paste path and the attach button were verified as present, not exercised with a real image file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019LT77q1YCgYQ6L8d1RRcM3