### PR TITLE
feat(sessions): the utility shell, phase 2 — you can see it and type into it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -455,7 +455,8 @@ packages/server/server/          — server-side modules (never bundled by Vite)
   │                          twice: a patch log, not one message per line. See docs/session-manager.md
   │                          **THE PER-SESSION UTILITY SHELL is not a session, and the separation
   │                          is structural** (`shell-spec.ts` / `shell-gate.ts` / `shell-store.ts` /
-  │                          `shell-backend.ts` / `shell-web.ts`, phase 1). It is a PTY in a
+  │                          `shell-backend.ts` / `shell-web.ts` / `shell-terminal.ts` /
+  │                          `shell-stream-web.ts` / `shell-input-web.ts`). It is a PTY in a
   │                          session's own directory, opened for the PERSON — `$SHELL` bare, no
   │                          `-l`, because tmux already gives the pane a tty and a login flag would
   │                          read a different set of rc files from the panes `agentop session`
@@ -497,6 +498,31 @@ packages/server/server/          — server-side modules (never bundled by Vite)
   │                          and NOT under `-L agentop` nor anywhere in `/api/fleet`, the ninth open
   │                          was refused in words, a pane killed outside agentop left no ghost, and
   │                          `close` named an unknown id instead of counting it closed.
+  │                          **SEEING IT AND DRIVING IT is the fleet's own two channels, pointed at
+  │                          the other store** — `GET /api/shell/stream` sends the very frames
+  │                          `/api/fleet/stream` sends and `WS /api/shell/input` speaks the very
+  │                          protocol `/api/fleet/input` speaks, so the browser has ONE reader and
+  │                          ONE writer. The frame shape, the one-loop-per-watched-pane hub and the
+  │                          serial ack queue are all shared; what is NOT shared is the one rule
+  │                          each channel keeps, the SCOPE. `terminal-web.ts` / `input-web.ts`
+  │                          resolve an id against `managed-sessions.json` and the shell pair
+  │                          resolves it against `shells.json` — reusing the fleet's modules would
+  │                          have given a shell id the fleet's answer AND STILL WORKED, so
+  │                          `shell-isolation.test.ts` asserts those imports are absent over the
+  │                          source. `Escape` joined `KEY_ALLOWLIST` for the mobile key strip, on
+  │                          both sides: it CANCELS and controls no process, which is the line that
+  │                          set draws, and without it there is no leaving `vim` from a phone and a
+  │                          permission dialog's own `Esc to cancel` was unreachable. **The CAPTURE
+  │                          RUNS ONLY while the band is open, the session selected and the tab
+  │                          visible** (`shellWatching`, pure) — the only per-second cost the
+  │                          feature has, and the rule `terminal-web.ts` already states for the
+  │                          fleet. There is no arm/disarm: OPENING the shell is the consent.
+  │                          The honesty line takes a SUBJECT (`terminalStatus(state, lang,
+  │                          'shell')`), because "the agent's current screen" over a shell the
+  │                          person opened themselves is simply false — it was on a 390px screen
+  │                          before the parameter existed, beside a path whose leading `~` had been
+  │                          moved to the END by `direction: rtl` (`eu/freelas/Proj/~`, which reads
+  │                          as a folder called `~`; the trim is computed now, `shellWhere`).
   ├── cli-start.ts         → the control center's HOST (`ControlHost`): service detection, start/stop/restart, connect/disconnect, boot service, archive consent, language — every action returns an already-localized `ActionResult` instead of printing
   ├── cli-stream.ts        → the control center's OUTPUT CHANNEL: subscribers + `streamCommand` (both pipes captured, never `inherit`) → lines via the pure `@agentistics/tui/control/stream`
   ├── cli-ui.ts            → dependency-free arrow-key select/confirm/input/pause + clearScreen (bundles clean into the binary; no node_modules to resolve)

--- a/docs/session-manager.md
+++ b/docs/session-manager.md
@@ -619,6 +619,50 @@ A session whose directory is gone is refused by name — it never falls back to 
 shell somewhere other than where it was asked for is the same class of error as a confident `0` for
 a metric nobody can produce.
 
+### Seeing it and driving it — the two channels
+
+A shell has the same two channels a session has, and the browser reads and writes both with one
+implementation:
+
+| | session | shell |
+|---|---|---|
+| read | `GET /api/fleet/stream?id=` | `GET /api/shell/stream?id=` |
+| write | `WS /api/fleet/input?id=` | `WS /api/shell/input?id=` |
+
+Everything generic is shared — the frame shape (`terminal-stream.ts`), the one-loop-per-watched-pane
+hub with its dedup and its death handling (`terminal-hub.ts`), the serial write queue and its
+per-key acks (`input-channel.ts` / `input-protocol.ts`). What is **not** shared is the one rule each
+channel keeps: **scope**. `terminal-web.ts` and `input-web.ts` resolve an id against
+`managed-sessions.json`; `shell-stream-web.ts` and `shell-input-web.ts` resolve it against
+`shells.json`. Reusing the fleet's modules would have given a shell id the fleet's answer, and it
+would still have worked — so `shell-isolation.test.ts` asserts the absence of those imports over the
+modules' own source, and `shell-terminal.ts` (the pane I/O) takes its tmux runner injected so the
+socket discipline is provable without a tmux server.
+
+`Escape` joined `KEY_ALLOWLIST` for this, on both sides, and the reasoning is the line that set
+draws: Escape **cancels** and controls no process, so it belongs with the editing keys rather than
+with `C-z`. A soft keyboard has none at all, so without it there is no way out of `vim` from a
+phone; and a Claude Code permission dialog's own footer says `Esc to cancel`, which this channel
+could not reach for as long as the set excluded it.
+
+### The band, and the unwatch discipline
+
+The band is the **last** strip of the session panel, below the composer — the VS Code geometry —
+with a drag handle on its top edge that also answers the arrow keys. On mobile it is a full-screen
+sheet with a back control and the key strip `esc tab ctrl ↑ ↓ ← →`; `ctrl` is a **sticky modifier**,
+because a soft keyboard has no chord to hold, and a letter the channel would refuse yields nothing
+rather than composing a key that earns a `bad_key` ack.
+
+**The capture loop runs only while the band is open, this session is selected and the tab is
+visible** (`shellWatching`, pure). It is the only per-second cost the feature has — two tmux reads a
+second per watched pane — and it is the rule `terminal-web.ts` already states for the fleet's own
+channel: a surface that forgets to unwatch leaves a `capture-pane` loop running for a screen nobody
+can see. Handing `useTerminalStream` a `null` id is what drops the subscription; the server's hub
+then stops capturing as its last reader leaves.
+
+There is no arm/disarm here, unlike the fleet terminal's composer: **opening the shell is the
+consent**, and the server refused the whole route unless the capability and the switch both stood.
+
 ### Verifying it
 
 ```bash
@@ -638,3 +682,12 @@ Measured on 2026-09-09: the switch refused before it was flipped; the shell open
 cwd; it appeared under `-L agentop-shell` and in neither `-L agentop` nor `/api/fleet`; the ninth
 open was refused in words; a pane killed outside agentop left no ghost record; and `close` named an
 unknown id instead of counting it closed.
+
+Measured again on 2026-09-09 for the two channels: the SSE stream carried the real pane, colours and
+all; a shell id on `/api/fleet/stream` and a fleet id on `/api/shell/stream` were both a clean 404,
+as was a fleet id on the shell's WS upgrade, and a cross-origin upgrade was 403; typing
+`echo …` + `Enter` over `WS /api/shell/input` acked `ok` and the output came back on the read
+channel, while `C-z` — outside the allowlist — acked `bad_key`. In the browser, counting
+EventSources: opening the band opened one stream and closed none, collapsing it closed one,
+re-opening opened a second, and backgrounding the tab closed it. At 390px `scrollWidth` equalled
+`innerWidth`, every control in the sheet measured 44x44, and the inputs computed to 16px.

--- a/packages/server/server/audit.ts
+++ b/packages/server/server/audit.ts
@@ -38,6 +38,10 @@ export type AuditAction =
   // entry per channel, never per keystroke. `fleet.input.denied` records a rejected WS upgrade
   // (e.g. a cross-origin attempt); the capability refusal is already `capability.denied`.
   | 'fleet.input.open' | 'fleet.input.denied'
+  // The same two, for the per-session UTILITY SHELL's write channel. Its own pair rather than a
+  // reuse of the fleet's: a shell is a raw PTY on this host and a session is a named assistant CLI,
+  // so a reader of the log must be able to tell which of the two a keyboard was attached to.
+  | 'shell.input.open' | 'shell.input.denied'
 
 export interface AuditEvent {
   action: AuditAction

--- a/packages/server/server/auth.test.ts
+++ b/packages/server/server/auth.test.ts
@@ -176,4 +176,15 @@ describe('handleSession', () => {
     expect(typeof body['required']).toBe('boolean')
     expect(typeof body['central']).toBe('boolean')
   })
+
+  it('reports shellEnabled separately from capabilities.localShell', async () => {
+    // Two different questions, and Settings has to be able to say "your profile allows this, you
+    // have it off" — the same split `chatEnabled` already makes. `shellEnabled` is the capability
+    // AND the user's switch; `capabilities.localShell` stays the exposure profile's answer alone.
+    const body = (await (await handleSession(new Request('http://localhost/api/team/session'))).json()) as
+      Record<string, unknown>
+    expect(typeof body['shellEnabled']).toBe('boolean')
+    // Absent reads as OFF: nobody acquires a browser shell by having upgraded.
+    expect(body['shellEnabled']).toBe(false)
+  })
 })

--- a/packages/server/server/auth.ts
+++ b/packages/server/server/auth.ts
@@ -21,6 +21,7 @@ import { TEAM_CENTRAL, TEAM_PASSWORD, TEAM_SESSION_SECRET, TEAM_TLS, CENTRAL_USE
 import { getAccount } from './accounts'
 import { CAPS, PROFILE } from './exposure'
 import { chatAllowed } from './chat-gate'
+import { shellAllowed } from './sessions/shell-gate'
 import { readPreferences } from './preferences'
 import type { Principal } from './iam-types'
 
@@ -315,8 +316,8 @@ export async function handleSession(req: Request): Promise<Response> {
   const required = Boolean(TEAM_PASSWORD)
   const authed = isAuthed(req)
   const aggregatorOnly = TEAM_CENTRAL && !CENTRAL_USER
-  // Unreadable preferences are not consent: chat stays off rather than falling open.
-  const prefs = await readPreferences().catch(() => ({} as { chatEnabled?: boolean }))
+  // Unreadable preferences are not consent: chat and the shell stay off rather than falling open.
+  const prefs = await readPreferences().catch(() => ({} as { chatEnabled?: boolean; shellEnabled?: boolean }))
   return new Response(
     JSON.stringify({
       authed,
@@ -337,6 +338,11 @@ export async function handleSession(req: Request): Promise<Response> {
       // Separate from `capabilities.localChat`, which stays the exposure profile's answer alone —
       // the Settings tab has to be able to say "your profile allows this, you have it off".
       chatEnabled: chatAllowed(CAPS.localChat, prefs.chatEnabled),
+      // The same split, for the per-session utility SHELL: the capability AND the user's own
+      // switch, separate from `capabilities.localShell` (the profile alone) so Settings can say
+      // "your profile allows this, you have it off". Unreadable preferences are not consent here
+      // either — `shellAllowed` reads an absent switch as OFF.
+      shellEnabled: shellAllowed(CAPS.localShell, prefs.shellEnabled),
     }),
     { status: 200, headers: JSON_CT },
   )

--- a/packages/server/server/index.ts
+++ b/packages/server/server/index.ts
@@ -82,6 +82,13 @@ import {
   openInputSocket, onInputMessage, closeInputSocket,
   createInputState, inputSessionExists, inputAtCapacity, type FleetInputState,
 } from './sessions/input-web'
+// The utility shell's own WS write channel. Its graph is the shell store plus the two pure input
+// modules — no registry, no session-view — so it is statically importable for the same reason
+// `input-web` is, and its handlers must be reachable synchronously from `_wsHandlers`.
+import {
+  openShellInputSocket, onShellInputMessage, closeShellInputSocket,
+  createShellInputState, shellInputExists, shellInputAtCapacity, type ShellInputState,
+} from './sessions/shell-input-web'
 import { wsInputOriginOk } from './sessions/input-protocol'
 // Type only: the module itself reaches `cli-start` → `@agentistics/tui/control` → Ink, and is
 // loaded by dynamic import inside the two /api/fleet handlers.
@@ -336,25 +343,35 @@ ensureClaudeChat().catch(err => console.warn('[claude-chat] failed to initialize
 // Bun HTTP server
 // ---------------------------------------------------------------------------
 
-// Two kinds of socket ride these handlers: the member↔central reverse channel (`isAgent`) and the
-// browser's live-terminal WRITE channel (`fleetInput`). They are disjoint — an agent socket never
-// carries `fleetInput` and vice versa — so each handler dispatches on which field is present.
-type WSData = { user: string; memberId: string; isAgent?: boolean; fleetInput?: FleetInputState }
+// Three kinds of socket ride these handlers: the member↔central reverse channel (`isAgent`), the
+// browser's live-terminal WRITE channel onto a SESSION (`fleetInput`), and the same channel onto a
+// utility SHELL (`shellInput`). They are disjoint — a socket carries exactly one of the three — so
+// each handler dispatches on which field is present. The last two are separate fields rather than
+// one with a scope tag, because that is what makes it impossible for a shell id to be dispatched
+// into the fleet's handler: the two never share a code path at all.
+type WSData = {
+  user: string; memberId: string; isAgent?: boolean
+  fleetInput?: FleetInputState
+  shellInput?: ShellInputState
+}
 
 // Shared WS + request handlers, so the binary can bind the SAME logic to two ports below:
 // PORT (47291 = api + mcp) and WEB_PORT (47292 = the web dashboard you open).
 const _wsHandlers = {
   open(ws: ServerWebSocket<WSData>) {
     if (ws.data.fleetInput) { openInputSocket(ws); return }
+    if (ws.data.shellInput) { openShellInputSocket(ws); return }
     if (!ws.data.isAgent) return; registerAgent(ws)
   },
   message(ws: ServerWebSocket<WSData>, msg: string | Buffer) {
     if (ws.data.fleetInput) { onInputMessage(ws, msg); return }
+    if (ws.data.shellInput) { onShellInputMessage(ws, msg); return }
     if (!ws.data.isAgent) return; onAgentMessage(ws, msg)
   },
   pong(ws: ServerWebSocket<WSData>) { if (!ws.data.isAgent) return; onAgentPong(ws) },
   close(ws: ServerWebSocket<WSData>) {
     if (ws.data.fleetInput) { closeInputSocket(ws); return }
+    if (ws.data.shellInput) { closeShellInputSocket(ws); return }
     if (!ws.data.isAgent) return; unregisterAgent(ws)
   },
 }
@@ -2499,6 +2516,50 @@ async function handleRequestInner(req: Request, server: Server<WSData>): Promise
           headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
         })
       }
+      // The shell's WRITE channel, upgraded HERE because only this scope holds `server`. It rides
+      // the two gates just applied plus the two a WS upgrade needs of its own: SAME-ORIGIN (CSWSH —
+      // `localShell` being on does not stop a malicious page in the user's own browser opening a
+      // socket to localhost) and SCOPE (the id must be an OPEN SHELL, resolved against
+      // `shells.json` and never the session registry), plus the ceiling.
+      if (url.pathname === '/api/shell/input') {
+        const id = url.searchParams.get('id')
+        if (!id) {
+          return new Response(JSON.stringify({ error: 'bad_request' }), {
+            status: 400, headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
+          })
+        }
+        if (!wsInputOriginOk({ origin: req.headers.get('origin'), host: url.host, allowlist: ALLOWED_ORIGINS, dev: !SERVE_STATIC })) {
+          void writeAudit({ action: 'shell.input.denied', ip: clientIp, meta: { id, reason: 'origin' } })
+          return new Response(JSON.stringify({ error: 'forbidden_origin' }), {
+            status: 403, headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
+          })
+        }
+        if (!(await shellInputExists(id))) {
+          return new Response(JSON.stringify({ error: 'not_found' }), {
+            status: 404, headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
+          })
+        }
+        if (shellInputAtCapacity()) {
+          return new Response(JSON.stringify({ error: 'too_many_streams' }), {
+            status: 503, headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
+          })
+        }
+        const upgraded = server.upgrade(req, {
+          // The shell id is fixed HERE — a message can never redirect a keystroke to another pane —
+          // and `shellInput` is its own field, so this socket can never reach the fleet's handler.
+          data: { user: '', memberId: '', shellInput: createShellInputState(id) },
+        })
+        if (upgraded) {
+          // ONE entry per channel opened — a keyboard was attached to a shell on this host — never
+          // one per keystroke, which would drown the log.
+          void writeAudit({ action: 'shell.input.open', ip: clientIp, meta: { id } })
+          return
+        }
+        return new Response(JSON.stringify({ error: 'upgrade_failed' }), {
+          status: 500, headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
+        })
+      }
+
       // Dynamic, following the `/api/fleet` handler's own pattern: the session machinery stays out
       // of a cold start that never touches it.
       const { hostForFleet, fleetLang } = await import('./sessions/fleet-web')

--- a/packages/server/server/sessions/input-protocol.test.ts
+++ b/packages/server/server/sessions/input-protocol.test.ts
@@ -74,10 +74,19 @@ describe('parseInputMessage', () => {
   })
 
   test('rejects a key name OUTSIDE the closed allowlist — defence in depth', () => {
-    for (const name of ['C-c; rm', 'a b', 'F1', 'Escape', 'Home', 'M-Up', 'PageDown', '', 'C-x']) {
+    for (const name of ['C-c; rm', 'a b', 'F1', 'Home', 'M-Up', 'PageDown', '', 'C-x']) {
       const r = parseInputMessage(JSON.stringify({ seq: 6, kind: 'key', name }))
       expect(r).toEqual({ ok: false, seq: 6, reason: 'bad_key' })
     }
+  })
+
+  test('Escape is IN the set — a deliberate widening, with its reason', () => {
+    // A soft keyboard has no Escape at all, so the mobile key strip is the only way to leave insert
+    // mode in `vim` or dismiss a picker; and a Claude Code permission dialog's own footer says
+    // `Esc to cancel`, which was unreachable from this channel for as long as the set excluded it.
+    // It CANCELS — it does not control the process, which is the line this allowlist draws.
+    expect(parseInputMessage(JSON.stringify({ seq: 9, kind: 'key', name: 'Escape' })))
+      .toEqual({ ok: true, msg: { seq: 9, kind: 'key', key: 'Escape' } })
   })
 
   test('rejects a non-string key name', () => {
@@ -87,7 +96,7 @@ describe('parseInputMessage', () => {
 
   test('KEY_ALLOWLIST is exactly the agreed closed set', () => {
     expect([...KEY_ALLOWLIST].sort()).toEqual(
-      ['BSpace', 'C-a', 'C-c', 'C-d', 'C-e', 'C-k', 'C-u', 'C-w', 'Down', 'Enter', 'Left', 'Right', 'Tab', 'Up'],
+      ['BSpace', 'C-a', 'C-c', 'C-d', 'C-e', 'C-k', 'C-u', 'C-w', 'Down', 'Enter', 'Escape', 'Left', 'Right', 'Tab', 'Up'],
     )
     for (const k of KEY_ALLOWLIST) {
       expect(parseInputMessage(JSON.stringify({ seq: 1, kind: 'key', name: k })).ok).toBe(true)

--- a/packages/server/server/sessions/input-protocol.ts
+++ b/packages/server/server/sessions/input-protocol.ts
@@ -49,9 +49,16 @@ export const MAX_INPUT_TEXT = 8192
  * is refused rather than passed to `send-keys`, so the write channel can never be talked into an
  * arbitrary key sequence. To widen it, add the tmux key name here — deliberately a code change, not a
  * client-supplied value.
+ *
+ * `Escape` was ADDED for the per-session utility shell's mobile key strip, and the reasoning is the
+ * line this set draws: Escape CANCELS (leaves insert mode, dismisses a picker) and controls no
+ * process, so it belongs with the editing keys rather than with `C-z`. A soft keyboard has none at
+ * all — the cockpit already records that it has no arrow keys either — so without it there is no way
+ * to leave `vim` from a phone; and a Claude Code permission dialog's own footer says `Esc to
+ * cancel`, which this channel could not reach for as long as the set excluded it.
  */
 export const KEY_ALLOWLIST: ReadonlySet<string> = new Set([
-  'Enter', 'BSpace', 'Tab',
+  'Enter', 'BSpace', 'Tab', 'Escape',
   'Up', 'Down', 'Left', 'Right',
   'C-c', 'C-d', 'C-a', 'C-e', 'C-u', 'C-w', 'C-k',
 ])

--- a/packages/server/server/sessions/shell-input-web.ts
+++ b/packages/server/server/sessions/shell-input-web.ts
@@ -1,0 +1,114 @@
+/**
+ * shell-input-web.ts — the utility shell's WRITE channel, `WS /api/shell/input?id=<shellId>`.
+ *
+ * The write-side sibling of `shell-stream-web.ts`, and the shell-scoped twin of `input-web.ts`.
+ * Same shape as the fleet's: the ORDER guarantee and the per-message confirmation are the pure
+ * `input-channel.ts`, the wire contract is the pure `input-protocol.ts`, and this file is only the
+ * socket plumbing. So a browser typing into a shell speaks EXACTLY the protocol it speaks to a
+ * session, and the client needs one implementation rather than two.
+ *
+ * What is not shared is the scope: `input-web.ts` resolves an id against `managed-sessions.json`,
+ * and this one against `shells.json`. Reusing it would have handed a shell id the fleet's answer.
+ *
+ * Everything harder is upstream, in `index.ts`, and it is the same gate the open route rides:
+ * `localShell` (capability-guard), the user's own `shellEnabled` switch, a central refused outright,
+ * and — for the upgrade specifically — the same-origin check (CSWSH). A raw shell is the most
+ * powerful thing this server does, so it rides the very same gates as the fleet channel and no
+ * lower ones.
+ */
+
+import { readShells } from './shell-store'
+import { createShellTerminal, type TmuxRun } from './shell-terminal'
+import { nudgeShell } from './shell-stream-web'
+import { createInputChannel, type InputChannel } from './input-channel'
+import { encodeAck } from './input-protocol'
+
+/** A ceiling on concurrent shell write sockets, for the reason `MAX_INPUT_SOCKETS` exists. */
+export const MAX_SHELL_INPUT_SOCKETS = 32
+
+async function tmux(args: string[]): Promise<{ code: number; out: string; err: string }> {
+  try {
+    const p = Bun.spawn(['tmux', ...args], { stdout: 'pipe', stderr: 'pipe', stdin: 'ignore' })
+    const [out, err] = await Promise.all([
+      new Response(p.stdout).text(),
+      new Response(p.stderr).text(),
+    ])
+    return { code: await p.exited, out, err }
+  } catch {
+    return { code: 127, out: '', err: '' }
+  }
+}
+
+const terminal = createShellTerminal(tmux as TmuxRun)
+
+/** The per-connection state carried on `ws.data`. The channel is built on `open`. */
+export interface ShellInputState {
+  readonly id: string
+  channel: InputChannel | null
+}
+
+/** The shape this module needs from a socket — structural, so `index.ts` owns the full `WSData`. */
+interface InputSocket {
+  data: { shellInput?: ShellInputState }
+  send(data: string): unknown
+}
+
+let openSockets = 0
+
+export function createShellInputState(id: string): ShellInputState {
+  return { id, channel: null }
+}
+
+/** Scope check for the route: an id that is not an open shell is a clean 404, never an upgrade. */
+export async function shellInputExists(id: string): Promise<boolean> {
+  return (await readShells()).some(s => s.id === id)
+}
+
+export function shellInputAtCapacity(): boolean {
+  return openSockets >= MAX_SHELL_INPUT_SOCKETS
+}
+
+/** For tests / diagnostics: how many shell write sockets are open right now. */
+export function shellInputSocketCount(): number {
+  return openSockets
+}
+
+/**
+ * On open: build the serial channel bound to this shell. There is no local echo and no "ready"
+ * frame — a character appears only when the SHELL draws it, read back over the SSE channel, so the
+ * UI can never paint a keystroke that did not land. A delivered keystroke NUDGES the read channel,
+ * because the capture cadence is tuned for WATCHING (500 ms), which is an eternity when typing.
+ */
+export function openShellInputSocket(ws: InputSocket): void {
+  const state = ws.data.shellInput
+  if (!state) return
+  openSockets++
+  const { id } = state
+  state.channel = createInputChannel({
+    sendText: async text => {
+      const ok = await terminal.sendText(id, text)
+      if (ok) nudgeShell(id)
+      return ok
+    },
+    sendKey: async key => {
+      const ok = await terminal.sendKey(id, key)
+      if (ok) nudgeShell(id)
+      return ok
+    },
+    emit: ack => { try { ws.send(encodeAck(ack)) } catch { /* socket already closed */ } },
+  })
+}
+
+export function onShellInputMessage(ws: InputSocket, raw: string | Buffer): void {
+  const state = ws.data.shellInput
+  if (!state?.channel) return
+  state.channel.submit(typeof raw === 'string' ? raw : raw.toString('utf8'))
+}
+
+/** Idempotent — a double close cannot go negative. */
+export function closeShellInputSocket(ws: InputSocket): void {
+  const state = ws.data.shellInput
+  if (!state || !state.channel) return
+  state.channel = null
+  openSockets = Math.max(0, openSockets - 1)
+}

--- a/packages/server/server/sessions/shell-isolation.test.ts
+++ b/packages/server/server/sessions/shell-isolation.test.ts
@@ -47,7 +47,14 @@ function code(src: string): string {
 test('NO SHELL MODULE TOUCHES THE SESSION REGISTRY', async () => {
   // Asserted over the SOURCE, like `events-frontier.test.ts`, because nothing else would fail: the
   // import would work, the tests would pass, and the cost would show up as a slower machine.
-  for (const f of ['shell-backend.ts', 'shell-store.ts', 'shell-spec.ts', 'shell-web.ts', 'shell-gate.ts']) {
+  const MODULES = [
+    'shell-backend.ts', 'shell-store.ts', 'shell-spec.ts', 'shell-web.ts', 'shell-gate.ts',
+    // Phase 2 — the read and write channels. They are the two places a shell id could most easily
+    // be resolved against the fleet: both channels ALREADY exist for sessions, and reusing
+    // `terminal-web.ts` / `input-web.ts` would have scoped a shell against `managed-sessions.json`.
+    'shell-terminal.ts', 'shell-stream-web.ts', 'shell-input-web.ts',
+  ]
+  for (const f of MODULES) {
     const src = code(await readFile(join(HERE, f), 'utf-8'))
     expect(src).not.toContain('managed-sessions')
     expect(src).not.toContain("from './registry'")
@@ -70,4 +77,24 @@ test('every tmux call the shell backend makes NAMES the shell socket', async () 
   // `listSessionsArgs()` with no argument is the fleet socket. It must not appear here.
   expect(src).not.toMatch(/listSessionsArgs\(\s*\)/)
   expect((src.match(/SHELL_SOCKET/g) ?? []).length).toBeGreaterThanOrEqual(calls.length)
+})
+
+test('and so does every tmux call the shell TERMINAL makes', async () => {
+  // Phase 2's pane I/O. The same builders the fleet uses, and the same silent default if the
+  // socket is left off — so the same assertion, over the module that reads and writes the pane.
+  const src = await readFile(join(HERE, 'shell-terminal.ts'), 'utf-8')
+  const calls = src.match(/(capturePaneAnsiArgs|paneInfoArgs|sendKeysLiteralArgs|sendKeysNamedArgs)\(/g) ?? []
+  expect(calls.length).toBeGreaterThanOrEqual(4)
+  expect((src.match(/SHELL_SOCKET/g) ?? []).length).toBeGreaterThanOrEqual(calls.length)
+})
+
+test('the shell channels do not reach the FLEET channels', async () => {
+  // `terminal-web.ts` and `input-web.ts` scope against `readRegistry`. Importing either would give
+  // a shell id the fleet's answer — the row-shaped failure this whole separation exists to stop —
+  // and the feature would still appear to work.
+  for (const f of ['shell-stream-web.ts', 'shell-input-web.ts']) {
+    const src = code(await readFile(join(HERE, f), 'utf-8'))
+    expect(src).not.toContain("from './terminal-web'")
+    expect(src).not.toContain("from './input-web'")
+  }
 })

--- a/packages/server/server/sessions/shell-stream-web.ts
+++ b/packages/server/server/sessions/shell-stream-web.ts
@@ -1,0 +1,136 @@
+/**
+ * shell-stream-web.ts — the utility shell's live READ channel, `GET /api/shell/stream?id=<shellId>`.
+ *
+ * The sibling of `terminal-web.ts`, and deliberately NOT a call into it. Everything generic is
+ * shared — the frame shape (`terminal-stream.ts`), the one-loop-per-watched-pane hub with its dedup
+ * and its death handling (`terminal-hub.ts`) — so the browser reads the very same frames from both
+ * channels and `SessionTerminal` needs no branch. What is NOT shared is the ONE rule each channel
+ * keeps: SCOPE. `terminal-web.ts` resolves an id against `managed-sessions.json`; this one resolves
+ * it against `shells.json`, which is what stops a shell id ever being answered as a fleet row (and
+ * a fleet id ever being answered as a shell).
+ *
+ * `index.ts` has already refused this path where the exposure profile forbids it (`localShell` in
+ * `capability-guard.ts`), on a central, and where the user's own `shellEnabled` switch is off. What
+ * is left here is the scope check, the stream ceiling and the SSE plumbing.
+ */
+
+import { readShells } from './shell-store'
+import { createShellTerminal, type TmuxRun } from './shell-terminal'
+import { createTerminalHub, type TerminalHub } from './terminal-hub'
+import { encodeSse, TERMINAL_POLL_MS, TERMINAL_VIEW_LINES } from './terminal-stream'
+import { HISTORY_LIMIT } from './tmux-cli'
+
+/**
+ * A ceiling on concurrent shell streams for the whole process, for the reason
+ * `MAX_TERMINAL_STREAMS` exists: each holds a socket and a controller, so an unbounded count is a
+ * free way to exhaust the server. It is far below the fleet's because the SHELLS themselves are
+ * capped at `SHELL_CAP` = 8 — this only has to allow several viewers of each.
+ */
+export const MAX_SHELL_STREAMS = 32
+
+/** See `terminal-web.ts`: a channel deduped to silence is what a proxy reaps as idle. */
+const KEEPALIVE_MS = 15_000
+
+async function tmux(args: string[]): Promise<{ code: number; out: string; err: string }> {
+  try {
+    const p = Bun.spawn(['tmux', ...args], { stdout: 'pipe', stderr: 'pipe', stdin: 'ignore' })
+    const [out, err] = await Promise.all([
+      new Response(p.stdout).text(),
+      new Response(p.stderr).text(),
+    ])
+    return { code: await p.exited, out, err }
+  } catch {
+    // tmux is not on PATH. 127 is what a shell reports for that; a capture then reads as gone,
+    // which is the truth — there is no pane. Never a throw.
+    return { code: 127, out: '', err: '' }
+  }
+}
+
+const terminal = createShellTerminal(tmux as TmuxRun)
+
+let hub: TerminalHub | null = null
+
+function getHub(): TerminalHub {
+  if (hub) return hub
+  hub = createTerminalHub({
+    capture: id => terminal.capture(id, TERMINAL_VIEW_LINES),
+    // THE SCOPE RULE. `shells.json`, never the registry — a shell is not a session, and an id from
+    // one store must never resolve in the other.
+    isManaged: async id => (await readShells()).some(s => s.id === id),
+    historyLimit: HISTORY_LIMIT,
+    viewLines: TERMINAL_VIEW_LINES,
+    pollMs: TERMINAL_POLL_MS,
+  })
+  return hub
+}
+
+/**
+ * A keystroke just landed — capture now rather than at the next poll.
+ *
+ * Reads the module's `hub` directly rather than building one: with no hub nobody is watching
+ * anything, and building one to nudge a pane no surface is showing would start a capture loop for a
+ * screen nobody can see. Same reasoning as `nudgeTerminal`.
+ */
+export function nudgeShell(id: string): void {
+  hub?.nudge(id)
+}
+
+/** Scope check for the route, so an id that is not an open shell is a clean 404. */
+export async function shellStreamExists(id: string): Promise<boolean> {
+  return (await readShells()).some(s => s.id === id)
+}
+
+/** True when the process is already at its stream ceiling — the route answers 503. */
+export function shellStreamAtCapacity(): boolean {
+  return getHub().subscribers() >= MAX_SHELL_STREAMS
+}
+
+/**
+ * The SSE body for one shell's pane. Identical framing to `/api/fleet/stream`, so the browser's
+ * reader is the same reader. Cleanup is tied to `signal`: when the browser disconnects the
+ * subscription is dropped, and when the last reader leaves, the hub stops capturing — the unwatch
+ * discipline, enforced on the server as well as asked of the client.
+ */
+export async function openShellStream(id: string, signal: AbortSignal): Promise<ReadableStream<Uint8Array>> {
+  const h = getHub()
+  const enc = new TextEncoder()
+  let unsubscribe: (() => void) | null = null
+  let keepalive: ReturnType<typeof setInterval> | null = null
+
+  const teardown = () => {
+    unsubscribe?.()
+    unsubscribe = null
+    if (keepalive !== null) { clearInterval(keepalive); keepalive = null }
+  }
+
+  return new ReadableStream<Uint8Array>({
+    async start(controller) {
+      let closed = false
+      const send = (chunk: string) => {
+        if (closed) return
+        try { controller.enqueue(enc.encode(chunk)) } catch { closed = true }
+      }
+      const close = () => {
+        if (closed) return
+        closed = true
+        teardown()
+        try { controller.close() } catch { /* already closed */ }
+      }
+
+      if (signal.aborted) { close(); return }
+
+      send(encodeSse('open', { id, viewLines: TERMINAL_VIEW_LINES, historyLimit: HISTORY_LIMIT }))
+      keepalive = setInterval(() => send(': keepalive\n\n'), KEEPALIVE_MS)
+
+      unsubscribe = await h.subscribe(id, {
+        onFrame: frame => send(encodeSse('frame', frame)),
+        onEnd: reason => { send(encodeSse('end', { reason })); close() },
+      })
+
+      signal.addEventListener('abort', close)
+    },
+    cancel() {
+      teardown()
+    },
+  })
+}

--- a/packages/server/server/sessions/shell-terminal.test.ts
+++ b/packages/server/server/sessions/shell-terminal.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from 'bun:test'
+import { createShellTerminal } from './shell-terminal'
+import { SHELL_SOCKET, TMUX_SOCKET } from './tmux-cli'
+
+/** A recording fake tmux: every argv it was handed, and a scripted answer per verb. */
+function fakeTmux(answers: Partial<Record<string, { code: number; out: string; err: string }>> = {}) {
+  const calls: string[][] = []
+  const run = async (args: string[]) => {
+    calls.push(args)
+    const verb = args.find(a => !a.startsWith('-') && a !== SHELL_SOCKET && a !== TMUX_SOCKET) ?? ''
+    return answers[verb] ?? { code: 0, out: '', err: '' }
+  }
+  return { calls, run }
+}
+
+const PANE = '3\t7\t80\t24\t0\t120'
+
+describe('every shell tmux call names the shell socket', () => {
+  test('a capture does', async () => {
+    const t = fakeTmux({ 'capture-pane': { code: 0, out: 'hi\n', err: '' }, 'display-message': { code: 0, out: PANE, err: '' } })
+    await createShellTerminal(t.run).capture('s1', 200)
+    expect(t.calls.length).toBeGreaterThan(0)
+    for (const args of t.calls) expect(args.slice(0, 2)).toEqual(['-L', SHELL_SOCKET])
+  })
+
+  test('so do the two writes', async () => {
+    const t = fakeTmux()
+    const term = createShellTerminal(t.run)
+    await term.sendText('s1', 'ls')
+    await term.sendKey('s1', 'C-c')
+    for (const args of t.calls) expect(args.slice(0, 2)).toEqual(['-L', SHELL_SOCKET])
+    // The fleet socket is what a builder called with no argument takes — the mistake this
+    // whole phase is designed around, and it would still work.
+    expect(t.calls.some(a => a.includes(TMUX_SOCKET))).toBe(false)
+  })
+})
+
+describe('capture', () => {
+  test('shapes the pane into lines plus its geometry', async () => {
+    const t = fakeTmux({
+      'capture-pane': { code: 0, out: 'one\ntwo\n', err: '' },
+      'display-message': { code: 0, out: PANE, err: '' },
+    })
+    const cap = await createShellTerminal(t.run).capture('s1', 200)
+    // The trailing '' from the final newline is not a row.
+    expect(cap?.lines).toEqual(['one', 'two'])
+    expect(cap?.info).toEqual({ cols: 80, rows: 24, cursorX: 3, cursorY: 7, alive: true, historySize: 120 })
+  })
+
+  test('a pane tmux no longer has answers null — which ENDS the stream', async () => {
+    const t = fakeTmux({ 'capture-pane': { code: 1, out: '', err: "can't find session" } })
+    expect(await createShellTerminal(t.run).capture('gone', 200)).toBeNull()
+  })
+
+  test('an unreadable geometry yields an honest fallback, never a confident cursor', async () => {
+    const t = fakeTmux({
+      'capture-pane': { code: 0, out: 'x\n', err: '' },
+      'display-message': { code: 1, out: '', err: 'nope' },
+    })
+    const cap = await createShellTerminal(t.run).capture('s1', 200)
+    expect(cap?.lines).toEqual(['x'])
+    // `cols: 0` is a "don't know" the browser emulator ignores; `alive` is true because the capture
+    // just worked. The same fallback `backend-tmux.ts` makes for a fleet pane.
+    expect(cap?.info.cols).toBe(0)
+    expect(cap?.info.alive).toBe(true)
+  })
+
+  test('a blank pane is EMPTY, not gone', async () => {
+    const t = fakeTmux({
+      'capture-pane': { code: 0, out: '', err: '' },
+      'display-message': { code: 0, out: PANE, err: '' },
+    })
+    const cap = await createShellTerminal(t.run).capture('s1', 200)
+    expect(cap).not.toBeNull()
+    expect(cap?.lines).toEqual([])
+  })
+})
+
+describe('the writes report what actually happened', () => {
+  test('a non-zero send is a failure, never a silent success', async () => {
+    const t = fakeTmux({ 'send-keys': { code: 1, out: '', err: 'no session' } })
+    const term = createShellTerminal(t.run)
+    expect(await term.sendText('s1', 'ls')).toBe(false)
+    expect(await term.sendKey('s1', 'Enter')).toBe(false)
+  })
+
+  test('a zero send is a success', async () => {
+    const t = fakeTmux()
+    expect(await createShellTerminal(t.run).sendText('s1', 'ls')).toBe(true)
+  })
+
+  test('literal text and a named key are DIFFERENT calls', async () => {
+    // `send-keys -l Enter` types five letters. Confusing the two fails silently in tmux, which is
+    // why the argv builders are separate downstream.
+    const t = fakeTmux()
+    const term = createShellTerminal(t.run)
+    await term.sendText('s1', 'Enter')
+    await term.sendKey('s1', 'Enter')
+    expect(t.calls[0]).toContain('-l')
+    expect(t.calls[1]).not.toContain('-l')
+  })
+})

--- a/packages/server/server/sessions/shell-terminal.ts
+++ b/packages/server/server/sessions/shell-terminal.ts
@@ -1,0 +1,66 @@
+/**
+ * shell-terminal.ts — reading and writing a utility shell's pane, on the SHELL socket.
+ *
+ * The fleet's own pane I/O is `backend-tmux.ts`'s `captureTerminal` / `sendTextRaw` / `sendKey`,
+ * reached through `SessionBackend`. A shell cannot borrow those: every one of them resolves against
+ * the fleet socket, and a shell that answered on it would be exactly the `unregistered` fleet row
+ * this whole feature is shaped to prevent. So this module is the same three verbs, bound to
+ * `SHELL_SOCKET` and to nothing else — `shell-isolation.test.ts` asserts that over the source, and
+ * `shell-terminal.test.ts` asserts it over the argv actually produced.
+ *
+ * The tmux runner is INJECTED, the way `terminal-hub.ts` injects its capture and its clock: the
+ * socket discipline, the gone-versus-empty distinction and the honest geometry fallback are then
+ * provable without a tmux server.
+ */
+
+import {
+  capturePaneAnsiArgs, paneInfoArgs, parsePaneInfo, SHELL_SOCKET, sendKeysLiteralArgs,
+  sendKeysNamedArgs,
+} from './tmux-cli'
+import type { TerminalCapture } from './types'
+
+export interface TmuxResult { code: number; out: string; err: string }
+export type TmuxRun = (args: string[]) => Promise<TmuxResult>
+
+export interface ShellTerminal {
+  /** The pane as it renders right now, or `null` when tmux no longer has it — which ends a stream. */
+  capture(id: string, lines: number): Promise<TerminalCapture | null>
+  /** Type literal characters, with NO Enter. */
+  sendText(id: string, text: string): Promise<boolean>
+  /** Press ONE named key (`C-c`, `Enter`, `Escape`). */
+  sendKey(id: string, key: string): Promise<boolean>
+}
+
+export function createShellTerminal(run: TmuxRun): ShellTerminal {
+  return {
+    async capture(id, lines) {
+      // Content FIRST: a non-zero capture is how we learn the shell is gone, and there is no point
+      // asking for the geometry of a pane that is not there. `-e` keeps the colours, and the frame
+      // is NOT trailing-trimmed — a full-screen program's blank rows are its layout, not padding.
+      const cap = await run(capturePaneAnsiArgs(id, lines, SHELL_SOCKET))
+      if (cap.code !== 0) return null
+      const raw = cap.out.split('\n')
+      // Only the one empty string the final newline leaves; a genuinely blank pane stays EMPTY
+      // rather than becoming gone.
+      if (raw.length && raw[raw.length - 1] === '') raw.pop()
+
+      const meta = await run(paneInfoArgs(id, SHELL_SOCKET))
+      const info = meta.code === 0 ? parsePaneInfo(meta.out) : null
+      if (!info) {
+        // The pane exists (the capture worked) but its geometry could not be read. A minimal honest
+        // answer rather than a confident-wrong cursor: `cols: 0` is a "don't know" the browser
+        // emulator sizes past, and `alive` is true because the capture just succeeded.
+        return { lines: raw, info: { cols: 0, rows: raw.length, cursorX: 0, cursorY: 0, alive: true, historySize: 0 } }
+      }
+      return { lines: raw, info }
+    },
+
+    async sendText(id, text) {
+      return (await run(sendKeysLiteralArgs(id, text, SHELL_SOCKET))).code === 0
+    },
+
+    async sendKey(id, key) {
+      return (await run(sendKeysNamedArgs(id, key, SHELL_SOCKET))).code === 0
+    },
+  }
+}

--- a/packages/server/server/sessions/shell-web.test.ts
+++ b/packages/server/server/sessions/shell-web.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from 'bun:test'
+import { handleShellRoute } from './shell-web'
+import type { StartHost } from '../cli-start'
+
+/** The routes under test need no host; the ones that do are covered by their own scope checks. */
+const HOST = {} as StartHost
+
+async function call(method: string, path: string): Promise<Response | null> {
+  const url = new URL(`http://x${path}`)
+  return handleShellRoute(new Request(url, { method }), url, HOST, 'en')
+}
+
+describe('GET /api/shell/stream', () => {
+  test('a request with no id is a bad request, not an empty stream', async () => {
+    const res = await call('GET', '/api/shell/stream')
+    expect(res?.status).toBe(400)
+  })
+
+  test('an id that is not an open shell is a clean 404', async () => {
+    // SCOPE. The id is resolved against `shells.json` and nothing else — an id from the session
+    // registry is exactly as unknown here as one nobody ever minted.
+    const res = await call('GET', '/api/shell/stream?id=00000000-0000-4000-8000-000000000000')
+    expect(res?.status).toBe(404)
+  })
+
+  test('a path that is not ours falls through, so index.ts can keep routing', async () => {
+    expect(await call('GET', '/api/shell/nope')).toBeNull()
+  })
+})

--- a/packages/server/server/sessions/shell-web.ts
+++ b/packages/server/server/sessions/shell-web.ts
@@ -1,5 +1,5 @@
 /**
- * shell-web.ts — the three routes behind the per-session utility shell.
+ * shell-web.ts — the routes behind the per-session utility shell.
  *
  * `capability-guard.ts` has already refused these paths where the exposure profile forbids them,
  * and `index.ts` has already applied the user's own `shellEnabled` switch on top and refused a
@@ -11,6 +11,7 @@
 import type { StartHost } from '../cli-start'
 import type { CliLang } from '../cli-lang'
 import { closeShells, listShells, openShell } from './shell-backend'
+import { openShellStream, shellStreamAtCapacity, shellStreamExists } from './shell-stream-web'
 import { SHELL_CAP, type ShellRefusal } from './shell-spec'
 
 /** One sentence per refusal code. The module that decides never writes prose; this one never decides. */
@@ -43,6 +44,25 @@ export async function handleShellRoute(
   host: StartHost,
   lang: CliLang,
 ): Promise<Response | null> {
+  // The live READ channel — the same SSE frames `/api/fleet/stream` sends, so the browser's reader
+  // is the same reader. The three checks are the ones a stream needs and no more: an id, SCOPE (the
+  // id must be an OPEN SHELL — resolved against `shells.json`, never the registry) and the ceiling.
+  if (url.pathname === '/api/shell/stream' && req.method === 'GET') {
+    const id = url.searchParams.get('id')
+    if (!id) return json({ error: 'bad_request' }, 400)
+    if (!(await shellStreamExists(id))) return json({ error: 'not_found' }, 404)
+    if (shellStreamAtCapacity()) return json({ error: 'too_many_streams' }, 503)
+    return new Response(await openShellStream(id, req.signal), {
+      status: 200,
+      headers: {
+        'Content-Type': 'text/event-stream',
+        'Cache-Control': 'no-cache',
+        'Connection': 'keep-alive',
+        'X-Accel-Buffering': 'no',
+      },
+    })
+  }
+
   if (url.pathname === '/api/shell/list' && req.method === 'GET') {
     return json({ shells: await listShells(), cap: SHELL_CAP })
   }

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -143,6 +143,8 @@ interface TeamSessionState {
    *  Undefined on an older server, which had no switch — treated as "the capability decides",
    *  so upgrading the web ahead of the server never hides a chat that still works. */
   chatEnabled?: boolean
+  /** The same, for `/api/shell/*`. Undefined reads as OFF — see `AppContext.shellEnabled`. */
+  shellEnabled?: boolean
 }
 
 export interface IamAccount { id: string; name: string; email: string; role: 'owner' | 'member'; memberships: { teamId: string; role: 'manager' | 'user' }[]; mustChangePassword: boolean }
@@ -3007,6 +3009,7 @@ export default function AppLayout() {
     harnesses: data.harnesses,
     isCentral,
     capabilities: teamSession?.capabilities,
+    shellEnabled: teamSession?.shellEnabled === true,
     me: iam?.account,
     teams: teamsList,
     machines: machinesList,

--- a/packages/web/src/components/sessions/SessionPanel.tsx
+++ b/packages/web/src/components/sessions/SessionPanel.tsx
@@ -30,6 +30,7 @@ import type { FleetActionId, FleetRow } from '../../lib/fleet'
 import { TerminalRegion } from '../RecentSessions'
 import { SessionChat, type SessionChatProps } from './SessionChat'
 import { SessionActions } from './SessionActions'
+import { ShellBand } from './ShellBand'
 
 export type SessionView = 'chat' | 'terminal'
 
@@ -60,9 +61,19 @@ export interface SessionPanelProps {
   onViewChange?: (v: SessionView) => void
   /** Passed straight to `SessionChat` — see its own `onArtifacts`. This panel reads none of it. */
   onArtifacts?: SessionChatProps['onArtifacts']
+  /**
+   * May this machine serve a per-session utility SHELL right now — `CAPS.localShell` AND the
+   * user's own switch, as `/api/team/session` reports it.
+   *
+   * Absent reads as OFF, and the band is then ABSENT rather than present-and-refusing: a control
+   * that is there and says no teaches nothing, while Settings → Sessions is where the switch lives
+   * and says so. It is never inferred from `capabilities.localShell` alone — that is the profile's
+   * answer, and the switch may only ever narrow it further.
+   */
+  shellEnabled?: boolean
 }
 
-export function SessionPanel({ session, row, lang, theme, act, authorName, onGone, onOpened, view: viewProp, onViewChange, onArtifacts }: SessionPanelProps) {
+export function SessionPanel({ session, row, lang, theme, act, authorName, onGone, onOpened, view: viewProp, onViewChange, onArtifacts, shellEnabled }: SessionPanelProps) {
   /**
    * Is this a session of ANOTHER machine, reached through the relay?
    *
@@ -202,6 +213,25 @@ export function SessionPanel({ session, row, lang, theme, act, authorName, onGon
           </div>
         )}
       </div>
+
+      {/* THE LAST BAND, below everything — the VS Code geometry, where the panel is always the
+          bottom-most strip. It is deliberately OUTSIDE the view switch: a shell you opened to run
+          `bun test` must not vanish because you moved from the conversation to the assistant's own
+          screen. It is keyed by session, so switching rows unmounts it — which is also what drops
+          its stream, the client half of the unwatch discipline.
+
+          Absent on a RELAYED session for the same reason the live stream is: those routes are the
+          machine's own and a central refuses them outright, so a band there could only ever draw a
+          refusal. Absent when the machine does not serve shells at all — see `shellEnabled`. */}
+      {shellEnabled && !relayed && (
+        <ShellBand
+          key={session.id}
+          sessionId={session.id}
+          {...(session.cwd ? { cwd: session.cwd } : {})}
+          lang={lang}
+          theme={theme}
+        />
+      )}
     </div>
   )
 }

--- a/packages/web/src/components/sessions/ShellBand.tsx
+++ b/packages/web/src/components/sessions/ShellBand.tsx
@@ -40,7 +40,9 @@
  */
 
 import { Suspense, lazy, useCallback, useEffect, useReducer, useRef, useState } from 'react'
-import { ChevronDown, ChevronUp, ChevronLeft, Loader2, RotateCcw, TerminalSquare, X } from 'lucide-react'
+import {
+  ChevronDown, ChevronUp, ChevronLeft, Loader2, RotateCcw, TerminalSquare, Trash2,
+} from 'lucide-react'
 import { useDocumentVisible } from '../../hooks/useDocumentVisible'
 import { useIsMobile } from '../../hooks/useIsMobile'
 import { useTerminalStream } from '../../hooks/useTerminalStream'
@@ -64,6 +66,7 @@ interface T {
   close: string
   collapse: string
   expand: string
+  toggleBar: string
   back: string
   ctrlHint: string
   ctrlRefused: (c: string) => string
@@ -76,9 +79,10 @@ const TXT: Record<'pt' | 'en', T> = {
     title: 'Shell',
     open: 'Open a shell here',
     opening: 'Opening…',
-    close: 'Close this shell',
+    close: 'End this shell',
     collapse: 'Collapse the shell',
     expand: 'Expand the shell',
+    toggleBar: 'Open or collapse the shell',
     back: 'Back to the session',
     ctrlHint: 'ctrl is armed — press a letter',
     ctrlRefused: c => `ctrl+${c} is not one of the keys this channel sends.`,
@@ -89,9 +93,10 @@ const TXT: Record<'pt' | 'en', T> = {
     title: 'Shell',
     open: 'Abrir um shell aqui',
     opening: 'Abrindo…',
-    close: 'Fechar este shell',
+    close: 'Encerrar este shell',
     collapse: 'Recolher o shell',
     expand: 'Expandir o shell',
+    toggleBar: 'Abrir ou recolher o shell',
     back: 'Voltar para a sessão',
     ctrlHint: 'ctrl armado — pressione uma letra',
     ctrlRefused: c => `ctrl+${c} não é uma das teclas que este canal envia.`,
@@ -414,7 +419,7 @@ export function ShellBand({ sessionId, cwd, lang, theme }: ShellBandProps) {
                 border: 'none', background: 'transparent', color: 'var(--text-tertiary)', cursor: 'pointer',
               }}
             >
-              <X size={18} />
+              <Trash2 size={18} />
             </button>
           )}
         </div>
@@ -452,7 +457,27 @@ export function ShellBand({ sessionId, cwd, lang, theme }: ShellBandProps) {
           style={{ height: 6, cursor: 'ns-resize', background: 'transparent' }}
         />
       )}
-      <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '4px 12px', minHeight: 32 }}>
+      {/* THE WHOLE BAR IS THE TOGGLE. A 26px chevron at the far right of a full-width strip is a
+          target you have to aim at, and the strip beside it did nothing at all — so the bar takes
+          the click and the chevron stays as the thing that NAMES the gesture. `role="button"`
+          rather than a real one: it contains buttons, and nesting them is invalid HTML. The
+          controls inside it stop propagation, or ending a shell would also collapse the band. */}
+      <div
+        role="button"
+        tabIndex={0}
+        aria-expanded={prefs.open}
+        aria-label={t.toggleBar}
+        onClick={() => setBand({ open: !prefs.open })}
+        onKeyDown={e => {
+          if (e.key !== 'Enter' && e.key !== ' ') return
+          e.preventDefault()
+          setBand({ open: !prefs.open })
+        }}
+        style={{
+          display: 'flex', alignItems: 'center', gap: 8, padding: '4px 12px', minHeight: 32,
+          cursor: 'pointer', userSelect: 'none',
+        }}
+      >
         <span style={{ color: 'var(--anthropic-orange)', display: 'inline-flex' }}><TerminalSquare size={14} /></span>
         <span style={{ fontSize: 11.5, fontWeight: 700, letterSpacing: 0.4, color: 'var(--text-secondary)' }}>
           {t.title.toUpperCase()}
@@ -465,19 +490,21 @@ export function ShellBand({ sessionId, cwd, lang, theme }: ShellBandProps) {
         {busy && <Loader2 size={13} className="ag-spin" style={{ color: 'var(--text-tertiary)' }} />}
         {prefs.open && shell && (
           <button className="ag-tap-icon"
-            onClick={() => { void close() }}
+            /* A TRASH CAN, not an ✕. The ✕ read as "close this panel" next to a chevron that
+               actually closes the panel, and this one KILLS the shell — a different, irreversible
+               act. The icon is the only thing saying which of the two you are about to do. */
+            onClick={e => { e.stopPropagation(); void close() }}
             title={t.close}
             aria-label={t.close}
             style={iconBtn}
           >
-            <X size={13} />
+            <Trash2 size={13} />
           </button>
         )}
         <button className="ag-tap-icon"
-          onClick={() => setBand({ open: !prefs.open })}
+          onClick={e => { e.stopPropagation(); setBand({ open: !prefs.open }) }}
           title={prefs.open ? t.collapse : t.expand}
           aria-label={prefs.open ? t.collapse : t.expand}
-          aria-expanded={prefs.open}
           style={iconBtn}
         >
           {prefs.open ? <ChevronDown size={13} /> : <ChevronUp size={13} />}

--- a/packages/web/src/components/sessions/ShellBand.tsx
+++ b/packages/web/src/components/sessions/ShellBand.tsx
@@ -1,0 +1,476 @@
+/**
+ * ShellBand — a real shell, in the selected session's own folder, docked as the LAST band of the
+ * session panel.
+ *
+ * It is called **Shell**, not Terminal, and that is not fussiness: the session header already
+ * carries a `Chat | Terminal` toggle, and that "Terminal" is the ASSISTANT'S own screen — the tmux
+ * pane `claude` is drawing in, where a permission dialog is answered. Two controls named Terminal
+ * on one panel, doing different things, is an ambiguity nobody untangles on their own.
+ *
+ * ## What is reused, and what is new
+ *
+ * Everything that renders and drives a tmux pane in this browser already exists and is already
+ * hardened: `SessionTerminal` (the lazily-chunked xterm), `useTerminalStream` (SSE + the honesty
+ * line), `useTerminalWrite` (the ordered WS write channel with its per-key acks). This component
+ * points all three at the SHELL scope — `lib/terminalEndpoint.ts` owns which routes that means —
+ * and adds the two things a shell needs that a session does not: the band geometry, and the mobile
+ * key strip.
+ *
+ * ## The unwatch discipline
+ *
+ * The capture loop runs ONLY while the band is open, this session is the selected one, and the
+ * document is visible. It is the only per-second cost this feature has, and it is `shellWatching`'s
+ * one job; `useTerminalStream(null)` is what actually drops the subscription, after which the
+ * server's hub stops capturing as its last reader leaves. Collapsing the band, switching session
+ * (the component is keyed by session, so it unmounts) or backgrounding the tab all stop it.
+ *
+ * ## Consent
+ *
+ * There is no arm/disarm here, unlike the fleet terminal's composer. OPENING the shell is the
+ * consent — a person pressed a button that spawned `$SHELL` in a directory they named — and the
+ * server refused the whole route unless `CAPS.localShell` and the `shellEnabled` switch both stand.
+ * A second gate on top of that would be ceremony, not safety.
+ *
+ * ## Refusals
+ *
+ * `/api/shell/open` answers a REFUSAL as a 200 carrying a sentence (`no-tmux`, `no-cwd`,
+ * `cwd-missing`, `at-cap`) — shown verbatim, never re-worded here. The route-level errors upstream
+ * of it (`shell_disabled`, `shell_central`) carry a CODE and no prose, and `shellErrorText` is the
+ * one place that turns those into sentences. A blank band is never an answer.
+ */
+
+import { Suspense, lazy, useCallback, useEffect, useRef, useState } from 'react'
+import { ChevronDown, ChevronUp, ChevronLeft, Loader2, TerminalSquare, X } from 'lucide-react'
+import { useDocumentVisible } from '../../hooks/useDocumentVisible'
+import { useIsMobile } from '../../hooks/useIsMobile'
+import { useTerminalStream } from '../../hooks/useTerminalStream'
+import { useTerminalWrite } from '../../hooks/useTerminalWrite'
+import {
+  BAND_MIN_PX, clampBandHeight, readBandPrefs, shellErrorText, shellWatching, shellWhere,
+  writeBandPrefs,
+} from '../../lib/shellBand'
+import { SHELL_STRIP, ctrlKeyFor, keyBytes, stripKeyLabel } from '../../lib/shellKeys'
+import { terminalStatus } from '../../lib/terminalStream'
+
+const SessionTerminal = lazy(() => import('../SessionTerminal'))
+
+interface OpenShell { id: string; cwd: string }
+
+interface T {
+  title: string
+  open: string
+  opening: string
+  close: string
+  collapse: string
+  expand: string
+  back: string
+  ctrlHint: string
+  ctrlRefused: (c: string) => string
+  resize: string
+}
+
+const TXT: Record<'pt' | 'en', T> = {
+  en: {
+    title: 'Shell',
+    open: 'Open a shell here',
+    opening: 'Opening…',
+    close: 'Close this shell',
+    collapse: 'Collapse the shell',
+    expand: 'Expand the shell',
+    back: 'Back to the session',
+    ctrlHint: 'ctrl is armed — press a letter',
+    ctrlRefused: c => `ctrl+${c} is not one of the keys this channel sends.`,
+    resize: 'Drag to resize the shell',
+  },
+  pt: {
+    title: 'Shell',
+    open: 'Abrir um shell aqui',
+    opening: 'Abrindo…',
+    close: 'Fechar este shell',
+    collapse: 'Recolher o shell',
+    expand: 'Expandir o shell',
+    back: 'Voltar para a sessão',
+    ctrlHint: 'ctrl armado — pressione uma letra',
+    ctrlRefused: c => `ctrl+${c} não é uma das teclas que este canal envia.`,
+    resize: 'Arraste para redimensionar o shell',
+  },
+}
+
+export interface ShellBandProps {
+  /** The fleet row this shell belongs to. Its `cwd` is the server's to read — never sent from here. */
+  sessionId: string
+  /** Shown in the band's title, so it is obvious WHERE the shell was opened. */
+  cwd?: string
+  lang: 'pt' | 'en'
+  theme: 'dark' | 'light'
+}
+
+export function ShellBand({ sessionId, cwd, lang, theme }: ShellBandProps) {
+  const t = TXT[lang]
+  const isMobile = useIsMobile()
+  const documentVisible = useDocumentVisible()
+
+  const [prefs, setPrefs] = useState(() => readBandPrefs())
+  const [shell, setShell] = useState<OpenShell | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [busy, setBusy] = useState(false)
+  const [ctrlArmed, setCtrlArmed] = useState(false)
+  const [ctrlNote, setCtrlNote] = useState<string | null>(null)
+
+  const setBand = useCallback((next: Partial<{ open: boolean; height: number }>) => {
+    setPrefs(p => {
+      const merged = { ...p, ...next }
+      writeBandPrefs(merged)
+      return merged
+    })
+  }, [])
+
+  /**
+   * Resolve THIS session's shell: reuse the one already running for it, else open one.
+   *
+   * A shell lives until it is closed — it survives switching session, reloading the page and closing
+   * the browser — so the list is asked first. Opening blind would mint a second shell per reload and
+   * walk into the ceiling with seven copies of one directory.
+   */
+  // A REF, not `busy`, because `busy` cannot be an effect dependency here: setting it re-runs the
+  // effect, whose CLEANUP then cancels the very request it just started, and the band would sit on
+  // "Opening…" forever. The ref is the in-flight guard; `busy` is only what the UI reads.
+  const resolvingRef = useRef(false)
+  useEffect(() => {
+    if (!prefs.open || shell || resolvingRef.current) return
+    let cancelled = false
+    resolvingRef.current = true
+    setBusy(true)
+    setError(null)
+    void (async () => {
+      try {
+        const listed = await fetch('/api/shell/list')
+        if (listed.ok) {
+          const body = await listed.json() as { shells?: OpenShell[] & { sessionId?: string }[] }
+          const mine = (body.shells ?? []).find(s => (s as { sessionId?: string }).sessionId === sessionId)
+          if (mine) { if (!cancelled) setShell({ id: mine.id, cwd: mine.cwd }); return }
+        } else {
+          const body = await listed.json().catch(() => ({})) as { error?: string }
+          if (body.error) { if (!cancelled) setError(shellErrorText(body.error, lang)); return }
+        }
+        const res = await fetch('/api/shell/open', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ sessionId }),
+        })
+        const body = await res.json().catch(() => ({})) as {
+          ok?: boolean; shell?: OpenShell; message?: string; error?: string
+        }
+        if (cancelled) return
+        // A REFUSAL arrives as a sentence the server composed; it is shown verbatim. A route-level
+        // error carries only a code, and `shellErrorText` is the one place that words those.
+        if (body.ok && body.shell) setShell(body.shell)
+        else if (body.message) setError(body.message)
+        else setError(shellErrorText(body.error ?? 'network', lang))
+      } catch {
+        if (!cancelled) setError(shellErrorText('network', lang))
+      } finally {
+        resolvingRef.current = false
+        if (!cancelled) setBusy(false)
+      }
+    })()
+    return () => { cancelled = true }
+  }, [prefs.open, shell, sessionId, lang])
+
+  const watching = shellWatching({
+    bandOpen: prefs.open,
+    sessionSelected: Boolean(sessionId),
+    documentVisible,
+  })
+  // `null` is what DROPS the subscription — the client half of the unwatch discipline.
+  const { state } = useTerminalStream(watching && shell ? shell.id : null, 'shell')
+  const write = useTerminalWrite(shell?.id ?? '', watching && Boolean(shell), lang, 'shell')
+  // `'shell'`: the honesty line must say whose screen this is. The default subject calls it "the
+  // agent's current screen", which over a shell the person opened themselves is simply false.
+  const status = terminalStatus(state, lang, 'shell')
+
+  /**
+   * One send path for everything.
+   *
+   * A strip press produces the same bytes a real keypress would (`keyBytes`) and goes through the
+   * same `send`, so `splitInput`'s allowlist judges both identically — a key it would refuse cannot
+   * reach the wire by a side door. `ctrl` is a STICKY modifier because a soft keyboard has no chord
+   * to hold: it arms, and the next single character becomes the control key instead.
+   */
+  const send = useCallback((data: string) => {
+    if (ctrlArmed) {
+      setCtrlArmed(false)
+      const key = ctrlKeyFor(data)
+      if (!key) { setCtrlNote(t.ctrlRefused(data)); return }
+      setCtrlNote(null)
+      write.send(keyBytes(key))
+      return
+    }
+    write.send(data)
+  }, [ctrlArmed, write, t])
+
+  const pressStrip = useCallback((id: string) => {
+    const entry = SHELL_STRIP.find(e => e.id === id)
+    if (!entry) return
+    if (entry.kind === 'modifier') { setCtrlNote(null); setCtrlArmed(a => !a); return }
+    setCtrlArmed(false)
+    write.send(keyBytes(entry.key))
+  }, [write])
+
+  const close = useCallback(async () => {
+    if (!shell) return
+    const id = shell.id
+    setShell(null)
+    setBand({ open: false })
+    await fetch('/api/shell/close', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ids: [id] }),
+    }).catch(() => {})
+  }, [shell, setBand])
+
+  // ---- the drag handle -----------------------------------------------------------------------
+  const dragRef = useRef<{ startY: number; startH: number } | null>(null)
+  const onDragStart = (clientY: number) => { dragRef.current = { startY: clientY, startH: prefs.height } }
+  useEffect(() => {
+    if (isMobile) return
+    const move = (clientY: number) => {
+      const d = dragRef.current
+      if (!d) return
+      // The band grows UPWARD: it is docked at the bottom, so dragging up must make it taller.
+      setBand({ height: clampBandHeight(d.startH + (d.startY - clientY), window.innerHeight) })
+    }
+    const onMouse = (e: MouseEvent) => move(e.clientY)
+    const onTouch = (e: TouchEvent) => { const p = e.touches[0]; if (p) move(p.clientY) }
+    const end = () => { dragRef.current = null }
+    window.addEventListener('mousemove', onMouse)
+    window.addEventListener('mouseup', end)
+    window.addEventListener('touchmove', onTouch)
+    window.addEventListener('touchend', end)
+    return () => {
+      window.removeEventListener('mousemove', onMouse)
+      window.removeEventListener('mouseup', end)
+      window.removeEventListener('touchmove', onTouch)
+      window.removeEventListener('touchend', end)
+    }
+  }, [isMobile, setBand])
+
+  const where = shellWhere(cwd)
+
+  const screen = (
+    <div style={{
+      flex: 1, minHeight: 0, borderRadius: 8, overflow: 'hidden',
+      border: '1px solid var(--border-subtle)',
+      background: theme === 'light' ? '#ffffff' : '#0e1116',
+    }}>
+      <Suspense fallback={<div style={{ padding: 12, fontSize: 12, fontFamily: 'monospace', color: 'var(--text-tertiary)' }}>
+        {lang === 'pt' ? 'Carregando o emulador…' : 'Loading the emulator…'}
+      </div>}>
+        {/* key={shell.id}: a new shell gets a brand-new emulator, so no content leaks across. */}
+        <SessionTerminal
+          key={shell?.id ?? 'none'}
+          frame={state.frame}
+          theme={theme}
+          showCursor={status.showCursor}
+          interactive={write.ready}
+          onInput={send}
+        />
+      </Suspense>
+    </div>
+  )
+
+  /** The one sentence the band always has: a refusal, a delivery failure, or what is on screen. */
+  const line = error ?? (write.reason ? write.reason : busy ? t.opening : status.detail)
+  const lineIsBad = Boolean(error || write.reason)
+
+  const notice = (
+    <div
+      role={lineIsBad ? 'status' : undefined}
+      style={{
+        fontSize: 11, lineHeight: 1.5, flexShrink: 0,
+        color: lineIsBad ? 'var(--accent-red)' : 'var(--text-tertiary)',
+      }}
+    >
+      {ctrlArmed ? t.ctrlHint : ctrlNote ?? line}
+    </div>
+  )
+
+  const strip = (
+    <div style={{
+      display: 'flex', gap: 6, flexShrink: 0, overflowX: 'auto',
+      paddingBottom: 'var(--safe-bottom)',
+    }}>
+      {SHELL_STRIP.map(entry => {
+        const armed = entry.kind === 'modifier' && ctrlArmed
+        return (
+          <button
+            key={entry.id}
+            onClick={() => pressStrip(entry.id)}
+            aria-pressed={entry.kind === 'modifier' ? ctrlArmed : undefined}
+            style={{
+              // 44px is the MOBILE figure, and this strip exists only on mobile.
+              minWidth: 44, minHeight: 44, flexShrink: 0,
+              borderRadius: 8, cursor: 'pointer', fontFamily: 'inherit',
+              fontSize: 14, fontWeight: 600,
+              border: `1px solid ${armed ? 'var(--anthropic-orange)' : 'var(--border-subtle)'}`,
+              background: armed ? 'var(--anthropic-orange)' : 'var(--bg-elevated)',
+              color: armed ? '#fff' : 'var(--text-secondary)',
+            }}
+          >
+            {stripKeyLabel(entry.id)}
+          </button>
+        )
+      })}
+    </div>
+  )
+
+  // ---- mobile: a full-screen sheet over the session --------------------------------------------
+  if (isMobile) {
+    if (!prefs.open) {
+      return (
+        <button
+          onClick={() => setBand({ open: true })}
+          style={{
+            display: 'flex', alignItems: 'center', gap: 8, width: '100%',
+            minHeight: 44, padding: '0 12px', flexShrink: 0,
+            borderTop: '1px solid var(--border)', border: 'none',
+            background: 'var(--bg-surface)', color: 'var(--text-secondary)',
+            fontFamily: 'inherit', fontSize: 13, fontWeight: 600, cursor: 'pointer',
+          }}
+        >
+          <TerminalSquare size={16} />
+          <span>{t.title}</span>
+          {where && <span style={{
+            minWidth: 0, flex: 1, textAlign: 'right', fontSize: 11, color: 'var(--text-tertiary)',
+            overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+          }}>{where}</span>}
+        </button>
+      )
+    }
+    return (
+      <div style={{
+        position: 'fixed', inset: 0, zIndex: 60,
+        display: 'flex', flexDirection: 'column',
+        background: 'var(--bg-base)',
+        paddingTop: 'var(--safe-top)',
+      }}>
+        <div style={{
+          display: 'flex', alignItems: 'center', gap: 8, minHeight: 44, padding: '0 10px',
+          borderBottom: '1px solid var(--border)', background: 'var(--bg-surface)', flexShrink: 0,
+        }}>
+          <button
+            onClick={() => setBand({ open: false })}
+            aria-label={t.back}
+            style={{
+              display: 'flex', alignItems: 'center', justifyContent: 'center',
+              width: 44, height: 44, flexShrink: 0, marginLeft: -6,
+              border: 'none', background: 'transparent', color: 'var(--text-secondary)', cursor: 'pointer',
+            }}
+          >
+            <ChevronLeft size={20} />
+          </button>
+          <div style={{ minWidth: 0, flex: 1 }}>
+            <div style={{ fontSize: 13, fontWeight: 650, color: 'var(--text-primary)' }}>{t.title}</div>
+            {where && <div style={{
+              fontSize: 10.5, color: 'var(--text-tertiary)',
+              overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+            }}>{where}</div>}
+          </div>
+          {shell && (
+            <button
+              onClick={() => { void close() }}
+              aria-label={t.close}
+              style={{
+                display: 'flex', alignItems: 'center', justifyContent: 'center',
+                width: 44, height: 44, flexShrink: 0,
+                border: 'none', background: 'transparent', color: 'var(--text-tertiary)', cursor: 'pointer',
+              }}
+            >
+              <X size={18} />
+            </button>
+          )}
+        </div>
+        <div style={{
+          flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column', gap: 8, padding: 10,
+        }}>
+          {shell ? screen : <div style={{ flex: 1 }} />}
+          {notice}
+          {strip}
+        </div>
+      </div>
+    )
+  }
+
+  // ---- desktop: the last band of the panel, under the composer ---------------------------------
+  return (
+    <div style={{
+      flexShrink: 0, display: 'flex', flexDirection: 'column',
+      borderTop: '1px solid var(--border)', background: 'var(--bg-surface)',
+    }}>
+      {/* The drag handle sits on the band's TOP edge — the VS Code geometry, where the panel is
+          always the bottom-most strip. It is `role="separator"` and takes the arrow keys, so the
+          band is resizable without a pointer. */}
+      {prefs.open && (
+        <div
+          role="separator"
+          aria-orientation="horizontal"
+          aria-label={t.resize}
+          tabIndex={0}
+          onMouseDown={e => { e.preventDefault(); onDragStart(e.clientY) }}
+          onKeyDown={e => {
+            if (e.key === 'ArrowUp') { e.preventDefault(); setBand({ height: clampBandHeight(prefs.height + 24, window.innerHeight) }) }
+            if (e.key === 'ArrowDown') { e.preventDefault(); setBand({ height: clampBandHeight(prefs.height - 24, window.innerHeight) }) }
+          }}
+          style={{ height: 6, cursor: 'ns-resize', background: 'transparent' }}
+        />
+      )}
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '4px 12px', minHeight: 32 }}>
+        <span style={{ color: 'var(--anthropic-orange)', display: 'inline-flex' }}><TerminalSquare size={14} /></span>
+        <span style={{ fontSize: 11.5, fontWeight: 700, letterSpacing: 0.4, color: 'var(--text-secondary)' }}>
+          {t.title.toUpperCase()}
+        </span>
+        {where && <span style={{
+          minWidth: 0, flex: 1, fontSize: 11, color: 'var(--text-tertiary)',
+          overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+        }}>{where}</span>}
+        {!where && <span style={{ flex: 1 }} />}
+        {busy && <Loader2 size={13} className="ag-spin" style={{ color: 'var(--text-tertiary)' }} />}
+        {prefs.open && shell && (
+          <button className="ag-tap-icon"
+            onClick={() => { void close() }}
+            title={t.close}
+            aria-label={t.close}
+            style={iconBtn}
+          >
+            <X size={13} />
+          </button>
+        )}
+        <button className="ag-tap-icon"
+          onClick={() => setBand({ open: !prefs.open })}
+          title={prefs.open ? t.collapse : t.expand}
+          aria-label={prefs.open ? t.collapse : t.expand}
+          aria-expanded={prefs.open}
+          style={iconBtn}
+        >
+          {prefs.open ? <ChevronDown size={13} /> : <ChevronUp size={13} />}
+        </button>
+      </div>
+      {prefs.open && (
+        <div style={{
+          height: Math.max(BAND_MIN_PX, prefs.height),
+          display: 'flex', flexDirection: 'column', gap: 6, padding: '0 12px 10px',
+        }}>
+          {shell ? screen : <div style={{ flex: 1 }} />}
+          {notice}
+        </div>
+      )}
+    </div>
+  )
+}
+
+const iconBtn: React.CSSProperties = {
+  display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+  width: 26, height: 22, flexShrink: 0, borderRadius: 6, padding: 0,
+  border: '1px solid var(--border-subtle)', background: 'var(--bg-elevated)',
+  color: 'var(--text-secondary)', cursor: 'pointer',
+}

--- a/packages/web/src/components/sessions/ShellBand.tsx
+++ b/packages/web/src/components/sessions/ShellBand.tsx
@@ -39,22 +39,23 @@
  * one place that turns those into sentences. A blank band is never an answer.
  */
 
-import { Suspense, lazy, useCallback, useEffect, useRef, useState } from 'react'
-import { ChevronDown, ChevronUp, ChevronLeft, Loader2, TerminalSquare, X } from 'lucide-react'
+import { Suspense, lazy, useCallback, useEffect, useReducer, useRef, useState } from 'react'
+import { ChevronDown, ChevronUp, ChevronLeft, Loader2, RotateCcw, TerminalSquare, X } from 'lucide-react'
 import { useDocumentVisible } from '../../hooks/useDocumentVisible'
 import { useIsMobile } from '../../hooks/useIsMobile'
 import { useTerminalStream } from '../../hooks/useTerminalStream'
 import { useTerminalWrite } from '../../hooks/useTerminalWrite'
 import {
-  BAND_MIN_PX, clampBandHeight, readBandPrefs, shellErrorText, shellWatching, shellWhere,
-  writeBandPrefs,
+  BAND_MIN_PX, clampBandHeight, readBandPrefs, shellApiUrl, shellErrorText, shellWatching,
+  shellWhere, writeBandPrefs,
 } from '../../lib/shellBand'
+import {
+  INITIAL_SHELL_BAND, shellBandReducer, shellResolveWanted, type OpenShell,
+} from '../../lib/shellBandState'
 import { SHELL_STRIP, ctrlKeyFor, keyBytes, stripKeyLabel } from '../../lib/shellKeys'
 import { terminalStatus } from '../../lib/terminalStream'
 
 const SessionTerminal = lazy(() => import('../SessionTerminal'))
-
-interface OpenShell { id: string; cwd: string }
 
 interface T {
   title: string
@@ -67,6 +68,7 @@ interface T {
   ctrlHint: string
   ctrlRefused: (c: string) => string
   resize: string
+  retry: string
 }
 
 const TXT: Record<'pt' | 'en', T> = {
@@ -81,6 +83,7 @@ const TXT: Record<'pt' | 'en', T> = {
     ctrlHint: 'ctrl is armed — press a letter',
     ctrlRefused: c => `ctrl+${c} is not one of the keys this channel sends.`,
     resize: 'Drag to resize the shell',
+    retry: 'Try again',
   },
   pt: {
     title: 'Shell',
@@ -93,6 +96,7 @@ const TXT: Record<'pt' | 'en', T> = {
     ctrlHint: 'ctrl armado — pressione uma letra',
     ctrlRefused: c => `ctrl+${c} não é uma das teclas que este canal envia.`,
     resize: 'Arraste para redimensionar o shell',
+    retry: 'Tentar de novo',
   },
 }
 
@@ -111,9 +115,10 @@ export function ShellBand({ sessionId, cwd, lang, theme }: ShellBandProps) {
   const documentVisible = useDocumentVisible()
 
   const [prefs, setPrefs] = useState(() => readBandPrefs())
-  const [shell, setShell] = useState<OpenShell | null>(null)
-  const [error, setError] = useState<string | null>(null)
-  const [busy, setBusy] = useState(false)
+  // THE MACHINE, not a pile of flags. See `shellBandState.ts` for the rule it enforces.
+  const [band, dispatch] = useReducer(shellBandReducer, INITIAL_SHELL_BAND, init =>
+    readBandPrefs().open ? shellBandReducer(init, { type: 'openBand' }) : init)
+  const shell = band.shell
   const [ctrlArmed, setCtrlArmed] = useState(false)
   const [ctrlNote, setCtrlNote] = useState<string | null>(null)
 
@@ -123,6 +128,8 @@ export function ShellBand({ sessionId, cwd, lang, theme }: ShellBandProps) {
       writeBandPrefs(merged)
       return merged
     })
+    if (next.open === true) dispatch({ type: 'openBand' })
+    if (next.open === false) dispatch({ type: 'closeBand' })
   }, [])
 
   /**
@@ -131,29 +138,33 @@ export function ShellBand({ sessionId, cwd, lang, theme }: ShellBandProps) {
    * A shell lives until it is closed — it survives switching session, reloading the page and closing
    * the browser — so the list is asked first. Opening blind would mint a second shell per reload and
    * walk into the ceiling with seven copies of one directory.
+   *
+   * The effect is driven by ONE fact, `shellResolveWanted(band)`, and every exit dispatches: an
+   * abandoned attempt goes back to `wanted` rather than leaving the band spinning on work nobody is
+   * doing. That is the whole reason the machine exists — see `shellBandState.ts`.
    */
-  // A REF, not `busy`, because `busy` cannot be an effect dependency here: setting it re-runs the
-  // effect, whose CLEANUP then cancels the very request it just started, and the band would sit on
-  // "Opening…" forever. The ref is the in-flight guard; `busy` is only what the UI reads.
-  const resolvingRef = useRef(false)
+  // DEPENDS ON `band.attempt` AND NOT ON `band`. The effect dispatches, and an effect that depends
+  // on what it dispatches cancels its own request on the very next render — the loop that made this
+  // band spin on "Abrindo…". `attempt` moves only when a PERSON opens or retries.
+  const wanted = shellResolveWanted(band)
+  const wantedRef = useRef(wanted)
+  wantedRef.current = wanted
   useEffect(() => {
-    if (!prefs.open || shell || resolvingRef.current) return
+    if (!wantedRef.current) return
     let cancelled = false
-    resolvingRef.current = true
-    setBusy(true)
-    setError(null)
+    dispatch({ type: 'resolving' })
     void (async () => {
       try {
-        const listed = await fetch('/api/shell/list')
+        const listed = await fetch(shellApiUrl('/api/shell/list', lang))
         if (listed.ok) {
-          const body = await listed.json() as { shells?: OpenShell[] & { sessionId?: string }[] }
-          const mine = (body.shells ?? []).find(s => (s as { sessionId?: string }).sessionId === sessionId)
-          if (mine) { if (!cancelled) setShell({ id: mine.id, cwd: mine.cwd }); return }
+          const body = await listed.json() as { shells?: (OpenShell & { sessionId?: string })[] }
+          const mine = (body.shells ?? []).find(sh => sh.sessionId === sessionId)
+          if (mine) { if (!cancelled) dispatch({ type: 'resolved', shell: { id: mine.id, cwd: mine.cwd } }); return }
         } else {
           const body = await listed.json().catch(() => ({})) as { error?: string }
-          if (body.error) { if (!cancelled) setError(shellErrorText(body.error, lang)); return }
+          if (body.error) { if (!cancelled) dispatch({ type: 'refused', message: shellErrorText(body.error, lang) }); return }
         }
-        const res = await fetch('/api/shell/open', {
+        const res = await fetch(shellApiUrl('/api/shell/open', lang), {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ sessionId }),
@@ -164,18 +175,17 @@ export function ShellBand({ sessionId, cwd, lang, theme }: ShellBandProps) {
         if (cancelled) return
         // A REFUSAL arrives as a sentence the server composed; it is shown verbatim. A route-level
         // error carries only a code, and `shellErrorText` is the one place that words those.
-        if (body.ok && body.shell) setShell(body.shell)
-        else if (body.message) setError(body.message)
-        else setError(shellErrorText(body.error ?? 'network', lang))
+        if (body.ok && body.shell) dispatch({ type: 'resolved', shell: body.shell })
+        else if (body.message) dispatch({ type: 'refused', message: body.message })
+        else dispatch({ type: 'refused', message: shellErrorText(body.error ?? 'network', lang) })
       } catch {
-        if (!cancelled) setError(shellErrorText('network', lang))
-      } finally {
-        resolvingRef.current = false
-        if (!cancelled) setBusy(false)
+        if (!cancelled) dispatch({ type: 'refused', message: shellErrorText('network', lang) })
       }
     })()
-    return () => { cancelled = true }
-  }, [prefs.open, shell, sessionId, lang])
+    // An abandoned attempt is NOT a failure and NOT a silence: it returns to `wanted`, so the next
+    // render asks again instead of leaving a spinner over nothing.
+    return () => { cancelled = true; dispatch({ type: 'cancelled' }) }
+  }, [band.attempt, sessionId, lang])
 
   const watching = shellWatching({
     bandOpen: prefs.open,
@@ -220,14 +230,14 @@ export function ShellBand({ sessionId, cwd, lang, theme }: ShellBandProps) {
   const close = useCallback(async () => {
     if (!shell) return
     const id = shell.id
-    setShell(null)
+    dispatch({ type: 'ended' })
     setBand({ open: false })
-    await fetch('/api/shell/close', {
+    await fetch(shellApiUrl('/api/shell/close', lang), {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ ids: [id] }),
     }).catch(() => {})
-  }, [shell, setBand])
+  }, [shell, setBand, lang])
 
   // ---- the drag handle -----------------------------------------------------------------------
   const dragRef = useRef<{ startY: number; startH: number } | null>(null)
@@ -280,8 +290,9 @@ export function ShellBand({ sessionId, cwd, lang, theme }: ShellBandProps) {
   )
 
   /** The one sentence the band always has: a refusal, a delivery failure, or what is on screen. */
-  const line = error ?? (write.reason ? write.reason : busy ? t.opening : status.detail)
-  const lineIsBad = Boolean(error || write.reason)
+  const line = band.message ?? (write.reason ? write.reason : band.phase === 'opening' ? t.opening : status.detail)
+  const lineIsBad = Boolean(band.message || write.reason)
+  const busy = band.phase === 'opening'
 
   const notice = (
     <div
@@ -292,6 +303,23 @@ export function ShellBand({ sessionId, cwd, lang, theme }: ShellBandProps) {
       }}
     >
       {ctrlArmed ? t.ctrlHint : ctrlNote ?? line}
+      {/* A refusal is a DEAD STOP by design — the band never retries a "no" on its own — so the way
+          forward has to be on screen. Without it a refused band is a sentence and nothing else. */}
+      {band.phase === 'refused' && (
+        <button
+          onClick={() => dispatch({ type: 'retry' })}
+          style={{
+            display: 'inline-flex', alignItems: 'center', gap: 4, marginLeft: 8,
+            minHeight: isMobile ? 44 : 22, padding: isMobile ? '0 12px' : '0 8px',
+            borderRadius: 6, cursor: 'pointer', fontFamily: 'inherit', fontSize: 11, fontWeight: 600,
+            border: '1px solid var(--border-subtle)', background: 'var(--bg-elevated)',
+            color: 'var(--text-secondary)',
+          }}
+        >
+          <RotateCcw size={11} />
+          {t.retry}
+        </button>
+      )}
     </div>
   )
 

--- a/packages/web/src/hooks/useDocumentVisible.ts
+++ b/packages/web/src/hooks/useDocumentVisible.ts
@@ -1,0 +1,27 @@
+import { useEffect, useState } from 'react'
+
+/**
+ * Is this tab on screen right now?
+ *
+ * It exists for the unwatch discipline: a capture loop is two tmux reads a second, and a
+ * backgrounded tab is a screen nobody can see. `shellWatching` reads this alongside the band's own
+ * state, and the stream hook is handed `null` while it is false — which drops the subscription, and
+ * the server's hub then stops capturing when the last reader leaves.
+ *
+ * Guarded for an environment with no `document` (a test DOM, SSR): assumed visible, because the
+ * alternative is a surface that never opens its stream at all.
+ */
+export function useDocumentVisible(): boolean {
+  const [visible, setVisible] = useState(
+    () => typeof document === 'undefined' || document.visibilityState !== 'hidden',
+  )
+
+  useEffect(() => {
+    if (typeof document === 'undefined') return
+    const onChange = () => setVisible(document.visibilityState !== 'hidden')
+    document.addEventListener('visibilitychange', onChange)
+    return () => document.removeEventListener('visibilitychange', onChange)
+  }, [])
+
+  return visible
+}

--- a/packages/web/src/hooks/useTerminalStream.ts
+++ b/packages/web/src/hooks/useTerminalStream.ts
@@ -2,9 +2,14 @@
  * useTerminalStream — the EventSource wiring for the live terminal read channel.
  *
  * The pure decisions (what each event means, what the user is told) live in `lib/terminalStream.ts`.
- * This hook is the thin, impure glue: open `GET /api/fleet/stream?id=<id>` as SSE, funnel its named
+ * This hook is the thin, impure glue: open the SSE stream for one pane, funnel its named
  * `open`/`frame`/`end` events through the reducer, and tear the connection down when the id changes
  * or the component unmounts.
+ *
+ * It is generic over the SCOPE — a fleet row's screen or a per-session utility SHELL — because both
+ * channels send the very same frames and differ only in which store the server resolves the id
+ * against. The route is never interpolated here: `lib/terminalEndpoint.ts` owns that mapping, so a
+ * shell id cannot be handed to a route that would resolve it against the session registry.
  *
  * Two things it is careful about:
  *  - **No leak between sessions.** When `id` changes it dispatches `connecting` FIRST (which drops
@@ -23,6 +28,7 @@
  */
 
 import { useCallback, useEffect, useReducer, useRef, useState } from 'react'
+import { streamUrl, type TerminalScope } from '../lib/terminalEndpoint'
 import {
   INITIAL_TERMINAL_STATE,
   terminalReducer,
@@ -43,7 +49,7 @@ export interface TerminalStream {
   reconnect: () => void
 }
 
-export function useTerminalStream(id: string | null): TerminalStream {
+export function useTerminalStream(id: string | null, scope: TerminalScope = 'fleet'): TerminalStream {
   const [state, dispatch] = useReducer(terminalReducer, INITIAL_TERMINAL_STATE)
   // Bumped by reconnect() to force the effect to tear down and re-open, even for the same id.
   const [nonce, setNonce] = useState(0)
@@ -58,7 +64,7 @@ export function useTerminalStream(id: string | null): TerminalStream {
     // Fresh id → clear any previous session's frame before a single byte of the new one arrives.
     dispatch({ type: 'connecting' })
 
-    const es = new EventSource(`/api/fleet/stream?id=${encodeURIComponent(id)}`)
+    const es = new EventSource(streamUrl(scope, id))
 
     // Has this connection drawn anything yet? While false, a timeout or an error means the channel
     // never established — worth saying so. Once true, a drop is a transient blip: keep the screen and
@@ -99,7 +105,7 @@ export function useTerminalStream(id: string | null): TerminalStream {
     es.onerror = () => { if (!framed) { clearStall(); dispatch({ type: 'stall' }) } }
 
     return () => { clearStall(); es.close() }
-  }, [id, nonce])
+  }, [id, scope, nonce])
 
   return { state, reconnect }
 }

--- a/packages/web/src/hooks/useTerminalWrite.ts
+++ b/packages/web/src/hooks/useTerminalWrite.ts
@@ -20,6 +20,7 @@
  */
 
 import { useCallback, useEffect, useReducer, useRef } from 'react'
+import { inputWsUrl, type TerminalScope } from '../lib/terminalEndpoint'
 import { inputReasonText, splitInput } from '../lib/terminalKeys'
 import {
   INITIAL_CHANNEL,
@@ -39,17 +40,20 @@ export interface TerminalWrite {
   reason: string | null
 }
 
-function wsUrl(id: string): string {
-  const proto = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
-  return `${proto}//${window.location.host}/api/fleet/input?id=${encodeURIComponent(id)}`
+/** The route mapping is `lib/terminalEndpoint.ts`'s, never written out here — see its header. */
+function wsUrl(scope: TerminalScope, id: string): string {
+  return inputWsUrl(scope, id, window.location.protocol, window.location.host)
 }
 
 /**
- * @param id       the fleet row id (same id `/api/fleet/stream` and `/api/fleet/act` use)
+ * @param id       the pane's id — a fleet row id, or a shell id under the `shell` scope
  * @param enabled  consent stands AND the row is typable — the ONLY thing that opens the socket
  * @param lang     for the localized failure reason
+ * @param scope    which channel this id belongs to; the read hook takes the same one
  */
-export function useTerminalWrite(id: string, enabled: boolean, lang: 'pt' | 'en'): TerminalWrite {
+export function useTerminalWrite(
+  id: string, enabled: boolean, lang: 'pt' | 'en', scope: TerminalScope = 'fleet',
+): TerminalWrite {
   const [state, dispatch] = useReducer(channelReducer, INITIAL_CHANNEL)
   const wsRef = useRef<WebSocket | null>(null)
   const seqRef = useRef(1)
@@ -71,7 +75,7 @@ export function useTerminalWrite(id: string, enabled: boolean, lang: 'pt' | 'en'
 
     let ws: WebSocket
     try {
-      ws = new WebSocket(wsUrl(id))
+      ws = new WebSocket(wsUrl(scope, id))
     } catch {
       dispatch({ type: 'closed', reason: 'channel_unavailable' })
       return
@@ -111,7 +115,7 @@ export function useTerminalWrite(id: string, enabled: boolean, lang: 'pt' | 'en'
       try { ws.close() } catch { /* already closing */ }
       wsRef.current = null
     }
-  }, [id, enabled])
+  }, [id, enabled, scope])
 
   const send = useCallback((data: string) => {
     const ws = wsRef.current

--- a/packages/web/src/lib/app-context.ts
+++ b/packages/web/src/lib/app-context.ts
@@ -182,6 +182,14 @@ export interface AppContext {
     mcpAdmin?: boolean
   }
 
+  /** What `/api/shell/*` will ACTUALLY answer: `CAPS.localShell` AND the user's own switch. It is
+   *  separate from `capabilities.localShell` (the profile alone) for the reason `chatEnabled` is:
+   *  Settings has to be able to say "your profile allows this, you have it off". Undefined on an
+   *  older server that has no switch — read as OFF, because a raw shell is opt-in and absence is
+   *  never consent (`shell-gate.ts`), which is the OPPOSITE of the reading chat takes for its own
+   *  flag and deliberately so: chat was on before it had a switch, and this never was. */
+  shellEnabled?: boolean
+
   /** The tag definitions `useDerivedStats` resolves a tag filter against.
    *
    *  Exposed because a page that derives a SECOND scope (the compare page's B side) must pass the

--- a/packages/web/src/lib/shellBand.test.ts
+++ b/packages/web/src/lib/shellBand.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'bun:test'
+import {
+  BAND_MAX_FRACTION, BAND_MIN_PX, DEFAULT_BAND_PREFS, clampBandHeight, readBandPrefs, shellErrorText,
+  shellWatching, shellWhere, writeBandPrefs, type BandPrefs,
+} from './shellBand'
+
+describe('the unwatch discipline', () => {
+  const open = { bandOpen: true, sessionSelected: true, documentVisible: true }
+
+  it('captures only when the band is open, the session selected AND the tab visible', () => {
+    expect(shellWatching(open)).toBe(true)
+  })
+
+  it('a collapsed band captures nothing', () => {
+    expect(shellWatching({ ...open, bandOpen: false })).toBe(false)
+  })
+
+  it('a session that is not selected captures nothing', () => {
+    expect(shellWatching({ ...open, sessionSelected: false })).toBe(false)
+  })
+
+  it('a backgrounded tab captures nothing', () => {
+    // This is the only per-second cost the feature has: two tmux reads a second, per watched pane.
+    // A surface that forgets to unwatch leaves a capture-pane loop running for a screen nobody sees.
+    expect(shellWatching({ ...open, documentVisible: false })).toBe(false)
+  })
+})
+
+describe('the band geometry', () => {
+  it('a dragged height is kept as asked when it fits', () => {
+    expect(clampBandHeight(300, 900)).toBe(300)
+  })
+
+  it('it never shrinks below a readable floor', () => {
+    expect(clampBandHeight(10, 900)).toBe(BAND_MIN_PX)
+    expect(clampBandHeight(-40, 900)).toBe(BAND_MIN_PX)
+  })
+
+  it('it never takes more than its share of the viewport', () => {
+    expect(clampBandHeight(10_000, 900)).toBe(Math.round(900 * BAND_MAX_FRACTION))
+  })
+
+  it('a viewport too short for the floor still yields the floor, never a negative box', () => {
+    // The ceiling would be below the floor here; a max/min written the other way round returns a
+    // height the flex column cannot lay out.
+    expect(clampBandHeight(200, 100)).toBe(BAND_MIN_PX)
+  })
+
+  it('a height that is not a number falls back to the floor', () => {
+    expect(clampBandHeight(Number.NaN, 900)).toBe(BAND_MIN_PX)
+  })
+})
+
+describe('where the shell was opened, said in the room a band has', () => {
+  it('the home directory becomes ~', () => {
+    expect(shellWhere('/home/mithrandir/agentistics')).toBe('~/agentistics')
+  })
+
+  it('a long path keeps its TAIL, with a leading ellipsis', () => {
+    // The tail is what answers "where am I". `direction: rtl` was the first attempt and it moves
+    // the LEADING `~` to the end — `eu/freelas/Pelvis-Institucional/~`, which reads as a directory
+    // called `~` inside the project. So the trim is computed rather than left to the text engine.
+    expect(shellWhere('/home/mithrandir/eu/freelas/Pelvis-Institucional')).toBe('…/freelas/Pelvis-Institucional')
+  })
+
+  it('a path already short enough is untouched', () => {
+    expect(shellWhere('/srv/app')).toBe('/srv/app')
+    expect(shellWhere('/home/m/x')).toBe('~/x')
+  })
+
+  it('nothing to say is an empty string, never a guess', () => {
+    expect(shellWhere(undefined)).toBe('')
+    expect(shellWhere('')).toBe('')
+  })
+})
+
+describe('a refusal is a sentence, never a blank pane', () => {
+  it('the switch being off says so, and says where to turn it on', () => {
+    expect(shellErrorText('shell_disabled', 'en')).toContain('Settings')
+    expect(shellErrorText('shell_disabled', 'pt')).toContain('Configurações')
+  })
+
+  it('a central says it has no host to open one on', () => {
+    expect(shellErrorText('shell_central', 'en')).not.toBe('shell_central')
+    expect(shellErrorText('shell_central', 'pt')).not.toBe('shell_central')
+  })
+
+  it('an unknown code is shown verbatim rather than swallowed', () => {
+    // A reason the reader cannot parse still beats a silent failure — `inputReasonText`'s own rule.
+    expect(shellErrorText('something_new', 'en')).toBe('something_new')
+  })
+})
+
+describe('the band prefs are a per-viewer convenience and never a hard dependency', () => {
+  function memory(): Storage {
+    const map = new Map<string, string>()
+    return {
+      getItem: (k: string) => map.get(k) ?? null,
+      setItem: (k: string, v: string) => { map.set(k, v) },
+      removeItem: (k: string) => { map.delete(k) },
+      clear: () => map.clear(),
+      key: () => null,
+      get length() { return map.size },
+    } as unknown as Storage
+  }
+
+  it('round-trips', () => {
+    const s = memory()
+    const prefs: BandPrefs = { open: true, height: 260 }
+    writeBandPrefs(prefs, s)
+    expect(readBandPrefs(s)).toEqual(prefs)
+  })
+
+  it('no stored value reads as CLOSED — the band is never opened by a machine nobody asked', () => {
+    expect(readBandPrefs(memory()).open).toBe(false)
+  })
+
+  it('a storage that throws on read costs nothing', () => {
+    const hostile = { getItem() { throw new Error('blocked') }, setItem() { throw new Error('blocked') } } as unknown as Storage
+    expect(() => readBandPrefs(hostile)).not.toThrow()
+    expect(readBandPrefs(hostile).open).toBe(false)
+    expect(() => writeBandPrefs({ open: true, height: 200 }, hostile)).not.toThrow()
+  })
+
+  it('junk in storage reads as the default rather than as a broken band', () => {
+    const s = memory()
+    s.setItem('agentistics-shell-band', 'not json')
+    expect(readBandPrefs(s).open).toBe(false)
+    s.setItem('agentistics-shell-band', '{"open":"yes","height":"tall"}')
+    expect(readBandPrefs(s)).toEqual({ open: false, height: DEFAULT_BAND_PREFS.height })
+  })
+})

--- a/packages/web/src/lib/shellBand.test.ts
+++ b/packages/web/src/lib/shellBand.test.ts
@@ -1,7 +1,7 @@
-import { describe, expect, it } from 'bun:test'
+import { describe, expect, it, test } from 'bun:test'
 import {
   BAND_MAX_FRACTION, BAND_MIN_PX, DEFAULT_BAND_PREFS, clampBandHeight, readBandPrefs, shellErrorText,
-  shellWatching, shellWhere, writeBandPrefs, type BandPrefs,
+  shellApiUrl, shellWatching, shellWhere, writeBandPrefs, type BandPrefs,
 } from './shellBand'
 
 describe('the unwatch discipline', () => {
@@ -71,6 +71,17 @@ describe('where the shell was opened, said in the room a band has', () => {
   it('nothing to say is an empty string, never a guess', () => {
     expect(shellWhere(undefined)).toBe('')
     expect(shellWhere('')).toBe('')
+  })
+})
+
+describe('the refusal comes back in the reader’s own language', () => {
+  test('every call carries the language, because the SERVER composes the sentence', () => {
+    // `handleShellRoute` renders each `ShellRefusal` code into prose and reads the language off the
+    // query string; with no `lang` it answers in English. Seen on screen: a Portuguese dashboard
+    // showing "8 terminals are already open. Close one to open another." beside a Portuguese retry
+    // button. The one thing a refusal has to be is readable.
+    expect(shellApiUrl('/api/shell/open', 'pt')).toBe('/api/shell/open?lang=pt')
+    expect(shellApiUrl('/api/shell/list', 'en')).toBe('/api/shell/list?lang=en')
   })
 })
 

--- a/packages/web/src/lib/shellBand.ts
+++ b/packages/web/src/lib/shellBand.ts
@@ -1,0 +1,147 @@
+/**
+ * shellBand.ts — PURE. The decisions the per-session shell band makes, kept out of the JSX.
+ *
+ * Three of them, and each is a rule the spec states rather than a preference:
+ *
+ *  - **The unwatch discipline** (`shellWatching`). The capture loop runs ONLY while the band is
+ *    open, the session selected and the document visible. It is the only per-second cost this
+ *    feature has — two tmux reads a second per watched pane — and `terminal-web.ts` already records
+ *    the rule for the fleet's own channel: "capture is viewer-gated, so a surface that forgets to
+ *    unwatch leaves a `capture-pane` loop running for a screen nobody can see."
+ *  - **The geometry** (`clampBandHeight`). A drag may not shrink the band below a readable floor
+ *    nor let it eat the conversation above it.
+ *  - **The refusals** (`shellErrorText`). The route-level errors — the ones `index.ts` answers
+ *    BEFORE `shell-web.ts` gets to compose a sentence — carry a CODE and no prose. The band must
+ *    still say what happened: a blank pane is the confident-nothing this repo refuses everywhere
+ *    else. `shell-web.ts`'s own refusals (`no-tmux`, `no-cwd`, `cwd-missing`, `at-cap`) already
+ *    arrive as sentences and are shown verbatim; nothing here re-words them.
+ *
+ * The band's open/closed state and its height are a per-viewer convenience, so they live in
+ * `localStorage` — the CLAUDE.md rule for exactly this kind of state — and every read and write is
+ * guarded: a private window, cleared site data or a browser blocking storage makes the accessor
+ * itself throw.
+ */
+
+/** The smallest band worth drawing: a prompt, a command and a few lines of its output. */
+export const BAND_MIN_PX = 140
+
+/** The most of the panel a band may take. Above this the conversation it docks under is gone. */
+export const BAND_MAX_FRACTION = 0.7
+
+const STORAGE_KEY = 'agentistics-shell-band'
+
+export interface ShellWatchFacts {
+  /** Is the band expanded (or the mobile sheet up)? */
+  bandOpen: boolean
+  /** Is a session selected, and is this band that session's? */
+  sessionSelected: boolean
+  /** `document.visibilityState === 'visible'`. */
+  documentVisible: boolean
+}
+
+export function shellWatching(f: ShellWatchFacts): boolean {
+  return f.bandOpen && f.sessionSelected && f.documentVisible
+}
+
+/**
+ * The dragged height, bounded.
+ *
+ * The floor is applied LAST so a viewport too short for it still yields a layable-out box rather
+ * than a ceiling below the floor, which a naive `Math.min(max, Math.max(min, h))` produces as a
+ * height smaller than the minimum — and a flex child cannot be laid out at a negative one.
+ */
+export function clampBandHeight(px: number, viewportHeight: number): number {
+  if (!Number.isFinite(px)) return BAND_MIN_PX
+  const ceiling = Math.round(viewportHeight * BAND_MAX_FRACTION)
+  return Math.max(BAND_MIN_PX, Math.min(px, ceiling))
+}
+
+/** The route-level refusal codes, which carry no sentence of their own. */
+const ERROR_TEXT: Record<string, { en: string; pt: string }> = {
+  shell_disabled: {
+    en: 'The terminal is off on this machine. Turn it on in Settings → Sessions.',
+    pt: 'O terminal está desligado nesta máquina. Ligue em Configurações → Sessões.',
+  },
+  shell_central: {
+    en: 'A central aggregates other machines and has no host of its own to open a terminal on.',
+    pt: 'Uma central agrega outras máquinas e não tem host próprio para abrir um terminal.',
+  },
+  no_host: {
+    en: 'This server cannot reach its session host right now.',
+    pt: 'Este servidor não consegue alcançar o host das sessões agora.',
+  },
+  unknown_session: {
+    en: 'This machine does not manage that session, so there is no directory to open a terminal in.',
+    pt: 'Esta máquina não gerencia essa sessão, então não há diretório onde abrir um terminal.',
+  },
+  network: {
+    en: 'The server did not answer.',
+    pt: 'O servidor não respondeu.',
+  },
+}
+
+/** An unknown code is shown VERBATIM — a reason nobody can read still beats a silent failure. */
+export function shellErrorText(code: string, lang: 'pt' | 'en'): string {
+  const entry = ERROR_TEXT[code]
+  return entry ? entry[lang] : code
+}
+
+/**
+ * How many trailing segments of the directory the band names.
+ *
+ * Two, because one is ambiguous on a machine full of `src` and `web` folders and three does not fit
+ * a band's title row at 390px.
+ */
+const WHERE_SEGMENTS = 2
+
+/**
+ * Where the shell was opened, said in the room a band's title row has.
+ *
+ * `direction: rtl` is the trick the session list uses to keep a path's tail visible, and it is
+ * WRONG here: this string starts with `~`, and rtl moves that marker to the END —
+ * `eu/freelas/Pelvis-Institucional/~`, which reads as a directory called `~` inside the project.
+ * Verified on screen at 390px before this existed. So the trim is computed, and the leading `…`
+ * says out loud that something was cut.
+ */
+export function shellWhere(cwd: string | undefined): string {
+  if (!cwd) return ''
+  const short = cwd.replace(/^\/home\/[^/]+/, '~').replace(/^\/Users\/[^/]+/, '~')
+  const segments = short.split('/').filter(Boolean)
+  // `~/x` and `/srv/app` are already at the budget; only a genuinely deeper path is cut.
+  if (segments.length <= WHERE_SEGMENTS) return short
+  return `…/${segments.slice(-WHERE_SEGMENTS).join('/')}`
+}
+
+export interface BandPrefs {
+  open: boolean
+  height: number
+}
+
+/** ABSENT READS AS CLOSED. Nobody acquires an open shell band by having reloaded the page. */
+export const DEFAULT_BAND_PREFS: BandPrefs = { open: false, height: 240 }
+
+export function readBandPrefs(storage?: Storage): BandPrefs {
+  try {
+    const raw = (storage ?? globalThis.localStorage)?.getItem(STORAGE_KEY)
+    if (!raw) return DEFAULT_BAND_PREFS
+    const v = JSON.parse(raw) as unknown
+    if (typeof v !== 'object' || v === null) return DEFAULT_BAND_PREFS
+    const r = v as Record<string, unknown>
+    return {
+      open: r.open === true,
+      // A height that does not read as one falls back to the DEFAULT, not to the floor: a record
+      // half of which could not be read is not a request for the smallest possible band.
+      height: typeof r.height === 'number' && Number.isFinite(r.height)
+        ? Math.max(BAND_MIN_PX, r.height)
+        : DEFAULT_BAND_PREFS.height,
+    }
+  } catch {
+    return DEFAULT_BAND_PREFS
+  }
+}
+
+export function writeBandPrefs(prefs: BandPrefs, storage?: Storage): void {
+  try {
+    (storage ?? globalThis.localStorage)?.setItem(STORAGE_KEY, JSON.stringify(prefs))
+  } catch { /* a browser blocking site data costs the convenience, never the band */ }
+}

--- a/packages/web/src/lib/shellBand.ts
+++ b/packages/web/src/lib/shellBand.ts
@@ -80,6 +80,20 @@ const ERROR_TEXT: Record<string, { en: string; pt: string }> = {
   },
 }
 
+/**
+ * A shell API call, carrying the reader's language.
+ *
+ * `handleShellRoute` renders each `ShellRefusal` CODE into prose — the deciding module stays
+ * language-free — and it reads the language off the query string, answering in English when none is
+ * given. Omitting it put "8 terminals are already open. Close one to open another." on a Portuguese
+ * dashboard, beside a Portuguese retry button. A refusal that cannot be read is the one kind this
+ * feature cannot afford, so the language travels on every call rather than on the ones somebody
+ * remembered.
+ */
+export function shellApiUrl(path: string, lang: 'pt' | 'en'): string {
+  return `${path}?lang=${lang}`
+}
+
 /** An unknown code is shown VERBATIM — a reason nobody can read still beats a silent failure. */
 export function shellErrorText(code: string, lang: 'pt' | 'en'): string {
   const entry = ERROR_TEXT[code]

--- a/packages/web/src/lib/shellBandState.test.ts
+++ b/packages/web/src/lib/shellBandState.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  INITIAL_SHELL_BAND, shellBandReducer, shellResolveWanted, type ShellBandState,
+} from './shellBandState'
+
+const opening = (): ShellBandState =>
+  shellBandReducer(shellBandReducer(INITIAL_SHELL_BAND, { type: 'openBand' }), { type: 'resolving' })
+
+describe('the ATTEMPT is what drives a request, and only a person moves it', () => {
+  test('nothing has been asked yet', () => {
+    expect(INITIAL_SHELL_BAND.attempt).toBe(0)
+  })
+
+  test('opening the band asks once', () => {
+    expect(shellBandReducer(INITIAL_SHELL_BAND, { type: 'openBand' }).attempt).toBe(1)
+  })
+
+  test('THE EFFECT’S OWN DISPATCHES NEVER MOVE IT, or the effect re-triggers itself', () => {
+    // This is the loop the first two versions of this band hit: the resolve ran in an effect that
+    // changed the very thing it depended on, so its cleanup cancelled the request it had just made
+    // and the next render started another. `attempt` is the dependency, and only `openBand` and
+    // `retry` — both of them a person's act — advance it.
+    const asked = shellBandReducer(INITIAL_SHELL_BAND, { type: 'openBand' })
+    for (const a of [
+      { type: 'resolving' }, { type: 'resolved', shell: { id: 'a', cwd: '/x' } },
+      { type: 'refused', message: 'no' }, { type: 'cancelled' }, { type: 'closeBand' },
+    ] as const) {
+      expect(shellBandReducer(asked, a).attempt).toBe(asked.attempt)
+    }
+  })
+
+  test('retry asks again', () => {
+    const refused = shellBandReducer(opening(), { type: 'refused', message: 'no' })
+    expect(shellBandReducer(refused, { type: 'retry' }).attempt).toBe(refused.attempt + 1)
+  })
+
+  test('re-opening a band that already holds a shell asks nothing', () => {
+    const open = shellBandReducer(opening(), { type: 'resolved', shell: { id: 'a', cwd: '/x' } })
+    const shut = shellBandReducer(open, { type: 'closeBand' })
+    expect(shellBandReducer(shut, { type: 'openBand' }).attempt).toBe(shut.attempt)
+  })
+})
+
+describe('the band never claims to be opening with nothing in flight', () => {
+  test('the happy path: open the band, resolve, show the screen', () => {
+    let s = shellBandReducer(INITIAL_SHELL_BAND, { type: 'openBand' })
+    expect(s.phase).toBe('wanted')
+    s = shellBandReducer(s, { type: 'resolving' })
+    expect(s.phase).toBe('opening')
+    s = shellBandReducer(s, { type: 'resolved', shell: { id: 'a', cwd: '/x' } })
+    expect(s.phase).toBe('ready')
+    expect(s.shell).toEqual({ id: 'a', cwd: '/x' })
+    expect(s.message).toBeNull()
+  })
+
+  test('AN ATTEMPT THAT WAS CANCELLED GOES BACK TO WANTED, never stays "opening"', () => {
+    // The defect this reducer replaces: the resolve lived in an effect whose cleanup set a
+    // `cancelled` flag that ALSO suppressed the "no longer busy" write. A run cancelled between its
+    // request and its answer therefore left the band spinning on "Abrindo…" with nothing in flight,
+    // no shell, no error — and no dependency left to change, so nothing ever retried it. Seen on
+    // screen: a band stuck on "Abrindo…" over an empty terminal.
+    const s = shellBandReducer(opening(), { type: 'cancelled' })
+    expect(s.phase).toBe('wanted')
+    expect(shellResolveWanted(s)).toBe(true)
+  })
+
+  test('a refusal is a sentence and a DEAD STOP — never a silent retry loop', () => {
+    const s = shellBandReducer(opening(), { type: 'refused', message: 'Já há 8 terminais abertos.' })
+    expect(s.phase).toBe('refused')
+    expect(s.message).toBe('Já há 8 terminais abertos.')
+    // Retrying by itself would hammer a server that already said no, in a loop nobody asked for.
+    expect(shellResolveWanted(s)).toBe(false)
+  })
+
+  test('but a refusal can always be retried by hand', () => {
+    let s = shellBandReducer(opening(), { type: 'refused', message: 'nope' })
+    s = shellBandReducer(s, { type: 'retry' })
+    expect(s.phase).toBe('wanted')
+    expect(s.message).toBeNull()
+    expect(shellResolveWanted(s)).toBe(true)
+  })
+
+  test('closing the band drops the phase but KEEPS the shell — it is still running', () => {
+    // Collapsing stops the capture; it does not end the shell. Re-opening must not mint a second.
+    const open = shellBandReducer(opening(), { type: 'resolved', shell: { id: 'a', cwd: '/x' } })
+    const shut = shellBandReducer(open, { type: 'closeBand' })
+    expect(shut.phase).toBe('closed')
+    expect(shut.shell).toEqual({ id: 'a', cwd: '/x' })
+    expect(shellResolveWanted(shut)).toBe(false)
+    expect(shellBandReducer(shut, { type: 'openBand' }).phase).toBe('ready')
+  })
+
+  test('ENDING the shell forgets it, so the next open mints a new one', () => {
+    const open = shellBandReducer(opening(), { type: 'resolved', shell: { id: 'a', cwd: '/x' } })
+    const gone = shellBandReducer(open, { type: 'ended' })
+    expect(gone.shell).toBeNull()
+    expect(gone.phase).toBe('closed')
+  })
+
+  test('only ONE attempt is ever in flight', () => {
+    // `resolving` on an already-opening band changes nothing, so a re-render cannot start a second
+    // request — which is how a session ended up with three shells of its own.
+    const twice = shellBandReducer(opening(), { type: 'resolving' })
+    expect(twice).toEqual(opening())
+    expect(shellResolveWanted(opening())).toBe(false)
+  })
+
+  test('a resolve is wanted exactly when the band wants one and none is in flight', () => {
+    expect(shellResolveWanted(INITIAL_SHELL_BAND)).toBe(false)
+    expect(shellResolveWanted(shellBandReducer(INITIAL_SHELL_BAND, { type: 'openBand' }))).toBe(true)
+  })
+})

--- a/packages/web/src/lib/shellBandState.ts
+++ b/packages/web/src/lib/shellBandState.ts
@@ -1,0 +1,116 @@
+/**
+ * shellBandState.ts — PURE. The band's own state machine, and the one rule it exists to enforce:
+ *
+ *   **THE BAND NEVER CLAIMS TO BE OPENING WITH NOTHING IN FLIGHT.**
+ *
+ * This replaces an effect that resolved the shell and tracked its own `busy` flag. That shape had
+ * two defects, and the second was on screen: the effect's cleanup set a `cancelled` flag which ALSO
+ * suppressed the "no longer busy" write, so an attempt cancelled between its request and its answer
+ * left the band spinning on "Abrindo…" over an empty terminal — no shell, no error, nothing in
+ * flight, and no dependency left to change, so nothing ever retried. A hung spinner is the exact
+ * shape of dishonesty this repo refuses everywhere else: it says work is happening when none is.
+ *
+ * A reducer makes both impossible by construction. `cancelled` returns to `wanted`, so the next
+ * render simply asks again; `resolving` on an already-opening band is a no-op, so a re-render cannot
+ * start a second request (which is how one session ended up holding three shells); and a refusal is
+ * a DEAD STOP carrying its sentence, retried only by hand — a band that retried a refusal on its own
+ * would hammer a server that already said no.
+ */
+
+export interface OpenShell {
+  id: string
+  cwd: string
+}
+
+export type ShellPhase =
+  /** The band is collapsed. Nothing is captured; a shell may still be RUNNING (see `closeBand`). */
+  | 'closed'
+  /** The band is open and wants a shell; none is in flight yet. */
+  | 'wanted'
+  /** A request is in flight. Reachable only from `wanted`, and only one at a time. */
+  | 'opening'
+  /** A shell is resolved and the screen can be drawn. */
+  | 'ready'
+  /** The server said no, in a sentence. Only `retry` leaves this state. */
+  | 'refused'
+
+export interface ShellBandState {
+  phase: ShellPhase
+  /** The resolved shell. KEPT while the band is merely collapsed — it is still running. */
+  shell: OpenShell | null
+  /** The refusal's own sentence, verbatim from the server. Null unless `phase === 'refused'`. */
+  message: string | null
+  /**
+   * How many times a person has ASKED for a shell here. `0` = never.
+   *
+   * It is the caller's effect dependency, and that is its whole job: an effect that resolves the
+   * shell must not change the thing it depends on, or its own cleanup cancels the request it just
+   * made and the next render starts another — a loop the first two versions of this band hit. So
+   * only `openBand` (with no shell in hand) and `retry` advance it; every dispatch the effect makes
+   * itself leaves it exactly where it was.
+   */
+  attempt: number
+}
+
+export const INITIAL_SHELL_BAND: ShellBandState = {
+  phase: 'closed', shell: null, message: null, attempt: 0,
+}
+
+export type ShellBandAction =
+  /** The person expanded the band (or the stored preference had it open). */
+  | { type: 'openBand' }
+  /** The person collapsed it. The shell keeps running; only the capture stops. */
+  | { type: 'closeBand' }
+  /** A request is going out now. */
+  | { type: 'resolving' }
+  | { type: 'resolved'; shell: OpenShell }
+  /** The server refused, or the request failed — the sentence is the caller's to compose. */
+  | { type: 'refused'; message: string }
+  /** The attempt was abandoned (the component re-ran, the session changed). NOT a failure. */
+  | { type: 'cancelled' }
+  /** The person asked again after a refusal. */
+  | { type: 'retry' }
+  /** The shell is gone — closed by the person, or `exit` typed into it. */
+  | { type: 'ended' }
+
+export function shellBandReducer(state: ShellBandState, action: ShellBandAction): ShellBandState {
+  switch (action.type) {
+    case 'openBand':
+      // A shell we already hold is shown again rather than re-minted: collapsing never ended it.
+      if (state.shell) return { ...state, phase: 'ready', message: null }
+      return state.phase === 'closed'
+        ? { ...state, phase: 'wanted', message: null, attempt: state.attempt + 1 }
+        : state
+
+    case 'closeBand':
+      return { ...state, phase: 'closed', message: null }
+
+    case 'resolving':
+      // ONLY from `wanted`, so a re-render cannot put a second request on the wire.
+      return state.phase === 'wanted' ? { ...state, phase: 'opening' } : state
+
+    case 'resolved':
+      return { ...state, phase: 'ready', shell: action.shell, message: null }
+
+    case 'refused':
+      return { ...state, phase: 'refused', message: action.message }
+
+    case 'cancelled':
+      // Back to WANTED, never left in `opening`: the band must not claim work nobody is doing.
+      return state.phase === 'opening' ? { ...state, phase: 'wanted' } : state
+
+    case 'retry':
+      return { ...state, phase: 'wanted', message: null, attempt: state.attempt + 1 }
+
+    case 'ended':
+      return { ...state, phase: 'closed', shell: null, message: null }
+
+    default:
+      return state
+  }
+}
+
+/** Should the caller fire a resolve right now? Exactly when one is wanted and none is in flight. */
+export function shellResolveWanted(state: ShellBandState): boolean {
+  return state.phase === 'wanted'
+}

--- a/packages/web/src/lib/shellKeys.test.ts
+++ b/packages/web/src/lib/shellKeys.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'bun:test'
+import { SHELL_STRIP, ctrlKeyFor, keyBytes, stripKeyLabel } from './shellKeys'
+import { classifyInput, type NamedKey } from './terminalKeys'
+
+/** Every named key the strip claims to send must survive the client allowlist. */
+function sendable(key: NamedKey): boolean {
+  const i = classifyInput(keyBytes(key))
+  return i.kind === 'key' && i.key === key
+}
+
+describe('the mobile key strip', () => {
+  it('carries exactly the keys the design names, in that order', () => {
+    // `esc tab ctrl ↑ ↓ ← →` — without it there is no Ctrl+C on a phone, and a soft keyboard has
+    // no arrow keys at all.
+    expect(SHELL_STRIP.map(k => k.id)).toEqual(['esc', 'tab', 'ctrl', 'up', 'down', 'left', 'right'])
+  })
+
+  it('every direct key of the strip is one the channel actually accepts', () => {
+    for (const entry of SHELL_STRIP) {
+      if (entry.kind !== 'key') continue
+      expect(sendable(entry.key)).toBe(true)
+    }
+  })
+
+  it('ctrl is a MODIFIER, not a key — it has nothing to send on its own', () => {
+    const ctrl = SHELL_STRIP.find(k => k.id === 'ctrl')
+    expect(ctrl?.kind).toBe('modifier')
+  })
+
+  it('labels are readable glyphs, never internal ids', () => {
+    expect(stripKeyLabel('up')).toBe('↑')
+    expect(stripKeyLabel('esc')).toBe('esc')
+  })
+})
+
+describe('a named key goes out as the bytes the emulator would have produced', () => {
+  it('every key the channel accepts round-trips through the ONE classifier', () => {
+    // The strip does not get a private send path: it produces the raw bytes and hands them to the
+    // same `send` an actual keypress uses, so a key the allowlist would refuse is refused here too
+    // rather than reaching the wire by a side door.
+    const keys: NamedKey[] = [
+      'Enter', 'BSpace', 'Tab', 'Escape', 'Up', 'Down', 'Left', 'Right',
+      'C-c', 'C-d', 'C-a', 'C-e', 'C-u', 'C-w', 'C-k',
+    ]
+    for (const k of keys) expect(classifyInput(keyBytes(k))).toEqual({ kind: 'key', key: k })
+  })
+})
+
+describe('ctrl composes with the NEXT character typed', () => {
+  it('the interrupt everybody comes here for', () => {
+    expect(ctrlKeyFor('c')).toBe('C-c')
+  })
+
+  it('case does not matter — a soft keyboard capitalises on its own', () => {
+    expect(ctrlKeyFor('C')).toBe('C-c')
+  })
+
+  it('every control key the channel allows can be reached', () => {
+    expect(ctrlKeyFor('d')).toBe('C-d')
+    expect(ctrlKeyFor('a')).toBe('C-a')
+    expect(ctrlKeyFor('e')).toBe('C-e')
+    expect(ctrlKeyFor('u')).toBe('C-u')
+    expect(ctrlKeyFor('w')).toBe('C-w')
+    expect(ctrlKeyFor('k')).toBe('C-k')
+  })
+
+  it('a letter the channel does NOT allow yields nothing rather than a key it will refuse', () => {
+    // `C-z` (suspend) and `C-\` (SIGQUIT) are deliberately outside the allowlist. Composing one and
+    // sending it would earn a `bad_key` ack for a keystroke the person had every reason to expect
+    // to work; answering `null` lets the strip say so instead.
+    expect(ctrlKeyFor('z')).toBeNull()
+    expect(ctrlKeyFor('1')).toBeNull()
+  })
+
+  it('a multi-character chunk is not a control key', () => {
+    // A soft keyboard can deliver a whole composed word; that is not `ctrl` plus one letter.
+    expect(ctrlKeyFor('cd')).toBeNull()
+    expect(ctrlKeyFor('')).toBeNull()
+  })
+})

--- a/packages/web/src/lib/shellKeys.ts
+++ b/packages/web/src/lib/shellKeys.ts
@@ -1,0 +1,93 @@
+/**
+ * shellKeys.ts — PURE. The mobile key strip, and what `ctrl` does on a phone.
+ *
+ * A soft keyboard has no `esc`, no `tab` and no arrow keys at all — the cockpit already records the
+ * last of those — so without this strip there is no way to leave `vim`, complete a path, or reach
+ * the shell's history from a phone, and NO Ctrl+C at all. That is the whole reason the strip exists:
+ * `esc tab ctrl ↑ ↓ ← →`, sitting above the system keyboard.
+ *
+ * `ctrl` is the only entry that sends nothing of its own. It is a STICKY MODIFIER: tap it, then type
+ * a letter, and the letter becomes the control key instead. That is the only shape a soft keyboard
+ * admits — there is no chord to hold — and it is why `ctrlKeyFor` exists rather than a row of
+ * pre-composed `C-c` / `C-d` buttons: the letters worth reaching are the shell's, not a list this
+ * module could guess.
+ *
+ * It answers `null` for a letter the channel does not accept rather than composing one it will
+ * refuse. `C-z` (suspend) and `C-\` (SIGQUIT) are outside `KEY_ALLOWLIST` on purpose, and sending
+ * one would earn a `bad_key` ack for a keystroke the person had every reason to expect to work —
+ * the strip says so instead, which is the honest half of the same refusal.
+ */
+
+import type { NamedKey } from './terminalKeys'
+
+export type StripEntry =
+  /** Sends one named key, directly. */
+  | { id: string; kind: 'key'; key: NamedKey }
+  /** Arms the control modifier for the NEXT character typed. Sends nothing itself. */
+  | { id: string; kind: 'modifier' }
+
+/** The strip, in the order the design names it. */
+export const SHELL_STRIP: readonly StripEntry[] = [
+  { id: 'esc', kind: 'key', key: 'Escape' },
+  { id: 'tab', kind: 'key', key: 'Tab' },
+  { id: 'ctrl', kind: 'modifier' },
+  { id: 'up', kind: 'key', key: 'Up' },
+  { id: 'down', kind: 'key', key: 'Down' },
+  { id: 'left', kind: 'key', key: 'Left' },
+  { id: 'right', kind: 'key', key: 'Right' },
+]
+
+const LABELS: Record<string, string> = {
+  esc: 'esc', tab: 'tab', ctrl: 'ctrl',
+  up: '↑', down: '↓', left: '←', right: '→',
+}
+
+/** What the button reads. A glyph where one exists, the word where it does not — never an id. */
+export function stripKeyLabel(id: string): string {
+  return LABELS[id] ?? id
+}
+
+/**
+ * The control keys `KEY_ALLOWLIST` accepts, by the letter that composes them. Mirrored from the
+ * server's own closed set for the reason `MAX_TEXT_PER_MESSAGE` is mirrored: so the client does not
+ * ASK for what will be refused.
+ */
+const CTRL: Record<string, NamedKey> = {
+  a: 'C-a', c: 'C-c', d: 'C-d', e: 'C-e', k: 'C-k', u: 'C-u', w: 'C-w',
+}
+
+/** The named key `ctrl` + this character makes, or `null` when the channel would refuse it. */
+export function ctrlKeyFor(char: string): NamedKey | null {
+  if (char.length !== 1) return null
+  return CTRL[char.toLowerCase()] ?? null
+}
+
+/**
+ * The raw bytes a real keypress would have produced for one named key.
+ *
+ * The strip deliberately gets NO private send path. It produces these bytes and hands them to the
+ * same `send` an actual keystroke goes through, so `splitInput`'s allowlist judges a strip press
+ * exactly as it judges a typed one — a key it would refuse cannot reach the wire by a side door,
+ * and there is one classifier rather than two that must agree.
+ */
+const BYTES: Record<NamedKey, string> = {
+  Enter: '\r',
+  BSpace: '\x7f',
+  Tab: '\t',
+  Escape: '\x1b',
+  Up: '\x1b[A',
+  Down: '\x1b[B',
+  Left: '\x1b[D',
+  Right: '\x1b[C',
+  'C-c': '\x03',
+  'C-d': '\x04',
+  'C-a': '\x01',
+  'C-e': '\x05',
+  'C-u': '\x15',
+  'C-w': '\x17',
+  'C-k': '\x0b',
+}
+
+export function keyBytes(key: NamedKey): string {
+  return BYTES[key]
+}

--- a/packages/web/src/lib/terminalEndpoint.test.ts
+++ b/packages/web/src/lib/terminalEndpoint.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'bun:test'
+import { inputWsUrl, streamUrl, type TerminalScope } from './terminalEndpoint'
+
+describe('a scope decides which route a terminal talks to', () => {
+  it('a fleet id reads the fleet stream', () => {
+    expect(streamUrl('fleet', 'abc')).toBe('/api/fleet/stream?id=abc')
+  })
+
+  it('a shell id reads the SHELL stream, never the fleet one', () => {
+    // The whole isolation argument, at the client end: a shell is not a fleet row, so a shell id
+    // must never be offered to a route that resolves against `managed-sessions.json`.
+    expect(streamUrl('shell', 'abc')).toBe('/api/shell/stream?id=abc')
+    expect(streamUrl('shell', 'abc')).not.toContain('/api/fleet')
+  })
+
+  it('the id is encoded, so it can never smuggle a second query parameter', () => {
+    expect(streamUrl('shell', 'a&b=c')).toBe('/api/shell/stream?id=a%26b%3Dc')
+  })
+
+  it('the write channel mirrors the read channel, scope for scope', () => {
+    expect(inputWsUrl('fleet', 'abc', 'http:', 'host:1')).toBe('ws://host:1/api/fleet/input?id=abc')
+    expect(inputWsUrl('shell', 'abc', 'http:', 'host:1')).toBe('ws://host:1/api/shell/input?id=abc')
+  })
+
+  it('https becomes wss', () => {
+    expect(inputWsUrl('shell', 'x', 'https:', 'h')).toBe('wss://h/api/shell/input?id=x')
+  })
+
+  it('every scope has both halves', () => {
+    const scopes: TerminalScope[] = ['fleet', 'shell']
+    for (const s of scopes) {
+      expect(streamUrl(s, 'i')).toStartWith('/api/')
+      expect(inputWsUrl(s, 'i', 'http:', 'h')).toStartWith('ws://')
+    }
+  })
+})

--- a/packages/web/src/lib/terminalEndpoint.ts
+++ b/packages/web/src/lib/terminalEndpoint.ts
@@ -1,0 +1,39 @@
+/**
+ * terminalEndpoint.ts — PURE. Which routes a terminal channel talks to, decided in ONE place.
+ *
+ * There are two kinds of pane this dashboard reads and writes, and they are not interchangeable:
+ * a FLEET row (an assistant's own screen, resolved against `managed-sessions.json`) and a SHELL
+ * (the per-session utility terminal, resolved against `shells.json`, on its own tmux socket). The
+ * routes are deliberately separate on the server — `/api/shell` is registered in
+ * `capability-guard.ts` rather than riding the `/api/fleet` prefix, because "a shell is not a fleet
+ * row, and filing it under that prefix would be the first step toward it becoming one".
+ *
+ * The client end of that same argument lives here. `useTerminalStream` and `useTerminalWrite` are
+ * generic over the SCOPE and interpolate nothing themselves, so a shell id can never be handed to a
+ * route that would resolve it against the session registry — and a test says so, over the strings
+ * rather than over a comment.
+ */
+
+/** Which of the two channels an id belongs to. Never inferred from the id — an id is opaque. */
+export type TerminalScope = 'fleet' | 'shell'
+
+const BASE: Record<TerminalScope, string> = {
+  fleet: '/api/fleet',
+  shell: '/api/shell',
+}
+
+/** The SSE read channel for one pane. */
+export function streamUrl(scope: TerminalScope, id: string): string {
+  return `${BASE[scope]}/stream?id=${encodeURIComponent(id)}`
+}
+
+/**
+ * The WebSocket write channel for one pane.
+ *
+ * `protocol` and `host` are passed in rather than read off `window`, so the mapping is testable and
+ * the module stays free of the DOM — the same split every other pure module here makes.
+ */
+export function inputWsUrl(scope: TerminalScope, id: string, protocol: string, host: string): string {
+  const proto = protocol === 'https:' ? 'wss:' : 'ws:'
+  return `${proto}//${host}${BASE[scope]}/input?id=${encodeURIComponent(id)}`
+}

--- a/packages/web/src/lib/terminalKeys.test.ts
+++ b/packages/web/src/lib/terminalKeys.test.ts
@@ -89,13 +89,33 @@ describe('allowlist — nothing else reaches the process', () => {
     expect(intent('\x1b[15~')).toEqual({ kind: 'blocked', reason: 'unsupported-sequence' }) // F5
     expect(intent('\x1b[200~')).toEqual({ kind: 'blocked', reason: 'unsupported-sequence' }) // paste start
     expect(intent('\x1b[M')).toEqual({ kind: 'blocked', reason: 'unsupported-sequence' }) // mouse
-    expect(intent('\x1b')).toEqual({ kind: 'blocked', reason: 'unsupported-sequence' }) // lone ESC
+    // A LONE ESC used to be listed here. It is now `Escape` — a deliberate widening with its own
+    // describe block above; everything BUILT on the escape byte is still refused unless mapped.
   })
   it('a chunk mixing printable text and a control char is refused (not a single keystroke)', () => {
     // A paste containing a newline is the line-composer's job, not a raw keystroke — refuse rather
     // than silently reinterpret half of it as text and half as a key.
     expect(intent('ab\r')).toEqual({ kind: 'blocked', reason: 'unsupported-sequence' })
     expect(intent('a\x03')).toEqual({ kind: 'blocked', reason: 'unsupported-sequence' })
+  })
+})
+
+describe('Escape — the one widening the utility shell needed', () => {
+  it('a bare ESC is a named key, not an unsupported sequence', () => {
+    // A soft keyboard has no Escape at all, so the shell's mobile key strip is the only way out of
+    // `vim`; and a permission dialog's own footer says `Esc to cancel`. It CANCELS and controls no
+    // process, which is the line this allowlist draws.
+    expect(classifyInput('\x1b')).toEqual({ kind: 'key', key: 'Escape' })
+  })
+
+  it('it does not swallow the escape SEQUENCES built on it', () => {
+    // `\x1b[A` is still Up; the bare byte is only Escape when nothing follows it.
+    expect(classifyInput('\x1b[A')).toEqual({ kind: 'key', key: 'Up' })
+    expect(classifyInput('\x1bOD')).toEqual({ kind: 'key', key: 'Left' })
+  })
+
+  it('an unmapped escape sequence is still refused', () => {
+    expect(classifyInput('\x1b[1;5A')).toEqual({ kind: 'blocked', reason: 'unsupported-sequence' })
   })
 })
 

--- a/packages/web/src/lib/terminalKeys.ts
+++ b/packages/web/src/lib/terminalKeys.ts
@@ -22,8 +22,8 @@
  * The allowlist's dividing line: "edits the line" passes; "controls the process" is refused unless
  * explicitly requested. So it admits printable text, Enter, BSpace, Tab, the four arrows, the
  * line-editing controls (Ctrl+A/E cursor, Ctrl+U/W/K kill line/word/to-end — none touch the
- * process), and the two process-control keys the assignment does request (Ctrl+C for A7's interrupt,
- * Ctrl+D for EOF). Everything else is refused: other process-control C0 keys (Ctrl+Z suspend, Ctrl+\
+ * process), Escape (it cancels — see its entry in `NAMED`), and the two process-control keys the
+ * assignment does request (Ctrl+C for A7's interrupt, Ctrl+D for EOF). Everything else is refused: other process-control C0 keys (Ctrl+Z suspend, Ctrl+\
  * SIGQUIT) and every unmapped escape sequence (function keys, mouse, bracketed-paste). Widening it
  * again is a deliberate security choice with a reason, which is exactly why the default is "no".
  *
@@ -32,7 +32,7 @@
 
 /** The named keys the server keystroke channel accepts (tmux `send-keys` key names). */
 export type NamedKey =
-  | 'Enter' | 'BSpace' | 'Tab' | 'Up' | 'Down' | 'Left' | 'Right'
+  | 'Enter' | 'BSpace' | 'Tab' | 'Escape' | 'Up' | 'Down' | 'Left' | 'Right'
   | 'C-c' | 'C-d' // process control — explicitly requested (A7 / EOF)
   | 'C-a' | 'C-e' | 'C-u' | 'C-w' | 'C-k' // line editing — "edits the line" passes
 
@@ -62,6 +62,12 @@ const NAMED: Readonly<Record<string, NamedKey>> = {
   '\x7f': 'BSpace', // DEL — what most terminals send for Backspace
   '\x08': 'BSpace', // BS
   '\t': 'Tab',
+  // ESC, and it is the LAST thing matched against a bare byte — `NAMED` is consulted for the WHOLE
+  // chunk, so `\x1b[A` still resolves to `Up` and only a lone escape reaches this entry. Added for
+  // the utility shell's mobile key strip: a soft keyboard has no Escape, so without it there is no
+  // way out of `vim` from a phone, and a permission dialog's `Esc to cancel` was unreachable. It
+  // cancels; it controls no process, which is the line the allowlist draws.
+  '\x1b': 'Escape',
   '\x03': 'C-c', // interrupt (A7)
   '\x04': 'C-d', // EOF
   // Line editing — none of these touch the process; they are what "typing in a terminal" means.

--- a/packages/web/src/lib/terminalStream.test.ts
+++ b/packages/web/src/lib/terminalStream.test.ts
@@ -231,3 +231,39 @@ describe('xtermTheme', () => {
     expect(typeof d.foreground).toBe('string')
   })
 })
+
+describe('the honesty line names the RIGHT thing', () => {
+  const live = {
+    phase: 'streaming' as const,
+    open: null,
+    frame: { seq: 1, content: 'x', cols: 80, rows: 24, cursor: { x: 0, y: 0 }, alive: true, lines: 3, historyLimit: 50, truncated: false },
+    endReason: null,
+  }
+  const gone = { ...live, phase: 'ended' as const, endReason: 'gone' as const }
+
+  test('a fleet pane is the AGENT’s screen', () => {
+    expect(terminalStatus(live, 'pt').detail).toContain('agente')
+    expect(terminalStatus(live, 'en').detail).toContain('agent')
+  })
+
+  test('a SHELL is yours, and saying "the agent’s screen" over it is simply false', () => {
+    // Read off a real 390px screenshot before this existed: the shell the person opened themselves
+    // was labelled "A tela atual do agente". Nobody's agent is in there.
+    expect(terminalStatus(live, 'pt', 'shell').detail).not.toContain('agente')
+    expect(terminalStatus(live, 'pt', 'shell').detail.toLowerCase()).toContain('shell')
+    expect(terminalStatus(live, 'en', 'shell').detail).not.toContain('agent')
+    expect(terminalStatus(live, 'en', 'shell').detail.toLowerCase()).toContain('shell')
+  })
+
+  test('and a shell that left tmux is not "a session"', () => {
+    expect(terminalStatus(gone, 'en', 'shell').detail.toLowerCase()).toContain('shell')
+    expect(terminalStatus(gone, 'pt', 'shell').detail.toLowerCase()).toContain('shell')
+  })
+
+  test('the subject changes the words and nothing else', () => {
+    for (const s of [live, gone]) {
+      expect(terminalStatus(s, 'en', 'shell').tone).toBe(terminalStatus(s, 'en').tone)
+      expect(terminalStatus(s, 'en', 'shell').showCursor).toBe(terminalStatus(s, 'en').showCursor)
+    }
+  })
+})

--- a/packages/web/src/lib/terminalStream.ts
+++ b/packages/web/src/lib/terminalStream.ts
@@ -193,8 +193,20 @@ export interface TerminalStatus {
   truncated: boolean
 }
 
-export function terminalStatus(state: TerminalState, lang: 'pt' | 'en'): TerminalStatus {
+/**
+ * WHAT the pane belongs to — the only thing that changes between the two channels.
+ *
+ * The frames, the tones and the cursor rule are identical; the WORDS are not. Saying "the agent's
+ * current screen" over a shell the person opened themselves is simply false, and it was on screen
+ * at 390px before this parameter existed. The tone, the label and `showCursor` are untouched by it.
+ */
+export type TerminalSubject = 'session' | 'shell'
+
+export function terminalStatus(
+  state: TerminalState, lang: 'pt' | 'en', subject: TerminalSubject = 'session',
+): TerminalStatus {
   const pt = lang === 'pt'
+  const shell = subject === 'shell'
   const f = state.frame
   const lines = f?.lines ?? 0
   const truncated = Boolean(f?.truncated)
@@ -202,8 +214,10 @@ export function terminalStatus(state: TerminalState, lang: 'pt' | 'en'): Termina
   if (state.phase === 'idle') {
     return {
       tone: 'idle',
-      label: pt ? 'Nenhuma sessão' : 'No session',
-      detail: pt ? 'Escolha uma sessão viva para ver o terminal dela.' : 'Pick a live session to watch its terminal.',
+      label: shell ? (pt ? 'Nenhum shell' : 'No shell') : (pt ? 'Nenhuma sessão' : 'No session'),
+      detail: shell
+        ? (pt ? 'Abra um shell para ver a tela dele.' : 'Open a shell to watch its screen.')
+        : (pt ? 'Escolha uma sessão viva para ver o terminal dela.' : 'Pick a live session to watch its terminal.'),
       showCursor: false,
       truncated: false,
     }
@@ -247,7 +261,9 @@ export function terminalStatus(state: TerminalState, lang: 'pt' | 'en'): Termina
     return {
       tone: 'live',
       label: pt ? 'Ao vivo' : 'Live',
-      detail: pt ? `A tela atual do agente — ${scope}.` : `The agent's current screen — ${scope}.`,
+      detail: shell
+        ? (pt ? `A tela atual do seu shell — ${scope}.` : `Your shell's current screen — ${scope}.`)
+        : (pt ? `A tela atual do agente — ${scope}.` : `The agent's current screen — ${scope}.`),
       showCursor: Boolean(f?.cursor),
       truncated,
     }
@@ -256,7 +272,7 @@ export function terminalStatus(state: TerminalState, lang: 'pt' | 'en'): Termina
   if (state.phase === 'finished') {
     return {
       tone: 'finished',
-      label: pt ? 'Encerrada' : 'Finished',
+      label: shell ? (pt ? 'Encerrado' : 'Finished') : (pt ? 'Encerrada' : 'Finished'),
       detail: pt
         ? `O comando terminou; esta é a última tela que ele desenhou — ${scope}.`
         : `The command exited; this is the last screen it drew — ${scope}.`,
@@ -270,23 +286,35 @@ export function terminalStatus(state: TerminalState, lang: 'pt' | 'en'): Termina
   // "the screen below is the last thing it drew" is only true when there IS a last frame; a session
   // that was already gone when we opened the stream left nothing to show, so say that instead.
   const goneDetail = state.frame
-    ? (pt
-        ? 'A sessão saiu do tmux; a tela abaixo é a última coisa que ela desenhou.'
-        : 'The session left tmux; the screen below is the last thing it drew.')
-    : (pt
-        ? 'A sessão já não estava mais no tmux; não há tela para mostrar.'
-        : 'The session was already gone from tmux; there is no screen to show.')
+    ? shell
+      ? (pt
+          ? 'O shell saiu do tmux; a tela abaixo é a última coisa que ele desenhou.'
+          : 'The shell left tmux; the screen below is the last thing it drew.')
+      : (pt
+          ? 'A sessão saiu do tmux; a tela abaixo é a última coisa que ela desenhou.'
+          : 'The session left tmux; the screen below is the last thing it drew.')
+    : shell
+      ? (pt
+          ? 'Este shell já não estava mais no tmux; não há tela para mostrar.'
+          : 'The shell was already gone from tmux; there is no screen to show.')
+      : (pt
+          ? 'A sessão já não estava mais no tmux; não há tela para mostrar.'
+          : 'The session was already gone from tmux; there is no screen to show.')
   const detail =
     reason === 'not-found'
-      ? (pt
-          ? 'Esta sessão deixou de ser gerenciada por esta máquina.'
-          : 'This session is no longer managed by this machine.')
+      ? shell
+        ? (pt
+            ? 'Este shell não está mais aberto nesta máquina.'
+            : 'This shell is no longer open on this machine.')
+        : (pt
+            ? 'Esta sessão deixou de ser gerenciada por esta máquina.'
+            : 'This session is no longer managed by this machine.')
       : reason === 'error'
         ? (pt ? 'O canal do terminal não pôde ser lido.' : 'The terminal channel could not be read.')
         : goneDetail
   return {
     tone: 'ended',
-    label: pt ? 'Sessão encerrada' : 'Session gone',
+    label: shell ? (pt ? 'Shell encerrado' : 'Shell gone') : (pt ? 'Sessão encerrada' : 'Session gone'),
     detail,
     showCursor: false,
     truncated,

--- a/packages/web/src/pages/SessionsPage.tsx
+++ b/packages/web/src/pages/SessionsPage.tsx
@@ -508,6 +508,8 @@ export default function SessionsPage() {
       view={sessionView}
       onViewChange={setSessionView}
       onArtifacts={onArtifacts}
+      // The capability AND the user's switch, as the server reports them. Absent reads as OFF.
+      shellEnabled={ctx.shellEnabled === true}
     />
   )
 

--- a/packages/web/src/pages/settings/SessionsSettings.tsx
+++ b/packages/web/src/pages/settings/SessionsSettings.tsx
@@ -3,7 +3,7 @@ import { useOutletContext } from 'react-router-dom'
 import { Check, HardDrive, FolderClock, ExternalLink, DatabaseZap } from 'lucide-react'
 import type { AppContext } from '../../lib/app-context'
 import type { ArchiveMode } from '../../components/ArchiveConsentModal'
-import { SectionHeader } from './primitives'
+import { Divider, PrefRow, SectionHeader, Toggle } from './primitives'
 
 const ARCHIVE_DOCS_URL = 'https://code.claude.com/docs/en/settings'
 
@@ -14,16 +14,41 @@ export default function SessionsSettings() {
   const [saving, setSaving] = useState<ArchiveMode | null>(null)
   const [savedAt, setSavedAt] = useState<number>(0)
 
+  // The utility shell's own switch. `shellEnabled` is null until the preferences answer — a toggle
+  // rendered from a guess would flick to its real position a moment later.
+  const [shellEnabled, setShellEnabled] = useState<boolean | null>(null)
+  const [shellSaving, setShellSaving] = useState(false)
+  // The PROFILE's answer, which the switch may only ever narrow. Undefined on an older server that
+  // had no capability model — read as permitted, the same reading the rest of the app uses.
+  const shellCapable = ctx.capabilities?.localShell !== false
+
   useEffect(() => {
     fetch('/api/preferences')
       .then(r => (r.ok ? r.json() : null))
-      .then((p: { archiveMode?: ArchiveMode; archiveSessions?: boolean } | null) => {
+      .then((p: { archiveMode?: ArchiveMode; archiveSessions?: boolean; shellEnabled?: boolean } | null) => {
         const m: ArchiveMode =
           p?.archiveMode ?? (p?.archiveSessions === true ? 'full' : p?.archiveSessions === false ? 'off' : 'off')
         setMode(m)
+        // ABSENT READS AS OFF. Nobody acquires a browser shell by having upgraded.
+        setShellEnabled(p?.shellEnabled === true)
       })
-      .catch(() => setMode('off'))
+      .catch(() => { setMode('off'); setShellEnabled(false) })
   }, [])
+
+  const toggleShell = () => {
+    if (shellEnabled === null || !shellCapable || shellSaving) return
+    const next = !shellEnabled
+    setShellSaving(true)
+    setShellEnabled(next)
+    fetch('/api/preferences', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ shellEnabled: next }),
+    })
+      .then(r => { if (!r.ok) throw new Error('save failed') })
+      .catch(() => setShellEnabled(!next))  // put the switch back; nothing was saved
+      .finally(() => setShellSaving(false))
+  }
 
   const choose = (m: ArchiveMode) => {
     if (m === mode || saving) return
@@ -70,6 +95,49 @@ export default function SessionsSettings() {
 
   return (
     <div>
+      {/* THE SHELL SWITCH. It is off until somebody turns it on, and that is the whole security
+          model this feature ships with: a raw PTY on the host is strictly more powerful than the
+          chat — which `chat-gate.ts` already calls the most powerful thing this server does, and
+          the chat at least runs a NAMED assistant CLI. So absent reads as OFF, it may only ever
+          NARROW what the exposure profile already permits, and the server enforces both before the
+          routes rather than only here. Hiding a button would not close a door. */}
+      <SectionHeader label={pt ? 'Terminal nesta máquina' : 'Terminal on this machine'} />
+
+      <PrefRow
+        label={pt ? 'Habilitar o shell por sessão' : 'Enable the per-session shell'}
+        sub={shellCapable
+          ? (pt
+            ? 'Desligado por padrão. Ligar permite abrir um shell de verdade na pasta de uma sessão, direto no painel.'
+            : 'Off by default. Turning it on lets you open a real shell in a session’s own folder, from the dashboard.')
+          : (pt
+            ? 'Indisponível: o perfil de exposição desta instância não permite executar nada no host — o interruptor só pode restringir, nunca reabrir.'
+            : 'Unavailable: this instance’s exposure profile does not allow running anything on the host — the switch can only narrow, never re-open.')}
+      >
+        <Toggle
+          on={shellEnabled === true}
+          onToggle={toggleShell}
+          disabled={!shellCapable || shellEnabled === null || shellSaving}
+        />
+      </PrefRow>
+
+      <div style={{ fontSize: 12, color: 'var(--text-tertiary)', lineHeight: 1.6 }}>
+        {/* The sentence that distinguishes "your profile allows this, you have it off" from "your
+            profile denies it" — the two are one disabled toggle apart and mean different things. */}
+        {!shellCapable
+          ? (pt
+            ? 'O perfil desta instância já nega o shell; nada aqui pode reabri-lo.'
+            : 'This instance’s profile already denies the shell; nothing here can re-open it.')
+          : shellEnabled
+            ? (pt
+              ? 'Seu perfil permite e você está com isso LIGADO. Cada sessão ganha uma faixa "Shell" abaixo do compositor; no máximo 8 terminais abertos ao mesmo tempo.'
+              : 'Your profile allows this and you have it ON. Each session gets a "Shell" band below the composer; at most 8 terminals open at once.')
+            : (pt
+              ? 'Seu perfil permite isso, e você está com isso DESLIGADO. Com o shell desligado, /api/shell/* responde 403 — o servidor é quem decide.'
+              : 'Your profile allows this, and you have it OFF. With the shell off, /api/shell/* answers 403 — the server is what decides.')}
+      </div>
+
+      <Divider />
+
       <SectionHeader label={pt ? 'Preservação de histórico' : 'History preservation'} />
       <p style={{ fontSize: 12.5, color: 'var(--text-tertiary)', lineHeight: 1.55, margin: '0 0 14px' }}>
         {pt

--- a/packages/web/vite.config.lint.test.ts
+++ b/packages/web/vite.config.lint.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+/**
+ * THE DEV PROXY MUST CARRY WEBSOCKETS, and nothing else in this repo would say so.
+ *
+ * `vite.config.ts` proxies `/api` to the API port, and a proxy entry without `ws: true` forwards
+ * ordinary requests and silently DROPS an upgrade — the handshake gets no answer at all, so the
+ * browser reports a plain connection failure with no status to look up. Both write channels ride a
+ * WebSocket (`/api/fleet/input`, `/api/shell/input`), so under `bun run dev` typing into a session
+ * or into a utility shell simply does nothing, while every other route works perfectly and the READ
+ * stream (SSE, a plain GET) keeps drawing the live screen.
+ *
+ * That is the worst shape a dev-only gap can take: the feature looks alive and one half of it is
+ * dead. Measured on 2026-09-09 — the same shell id opened a socket on the API port and timed out
+ * with no response through the vite port.
+ */
+describe('the vite dev proxy', () => {
+  const src = readFileSync(join(import.meta.dir, 'vite.config.ts'), 'utf-8')
+
+  test('proxies WebSockets, or the write channels are dead in dev', () => {
+    const proxyBlock = src.slice(src.indexOf('proxy:'))
+    expect(proxyBlock).toContain('ws: true')
+  })
+
+  test('and the assertion is looking at the proxy, not at a comment somewhere else', () => {
+    expect(src).toContain('proxy:')
+    expect(src.indexOf('ws: true')).toBeGreaterThan(src.indexOf('proxy:'))
+  })
+})

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -59,6 +59,12 @@ export default defineConfig({
       '/api': {
         target: `http://localhost:${apiPort}`,
         changeOrigin: true,
+        // WEBSOCKETS TOO, and without this line the write channels are dead in dev while
+        // everything else works. Both of them ride an upgrade (`/api/fleet/input`,
+        // `/api/shell/input`); a proxy entry without `ws` forwards ordinary requests and silently
+        // DROPS the handshake, so the socket times out with no status to look up — the live screen
+        // keeps drawing over SSE (a plain GET) and typing into it just does nothing.
+        ws: true,
       },
     },
   },


### PR DESCRIPTION
## Summary

- The utility shell gains the two channels a session already has — `GET /api/shell/stream` (SSE, the very frames `/api/fleet/stream` sends) and `WS /api/shell/input` (the very protocol `/api/fleet/input` speaks) — so the browser reads and writes both with **one** implementation.
- A **Shell** band docked as the last strip of the session panel, below the composer, with a drag handle; on mobile a full-screen sheet with the key strip `esc tab ctrl ↑ ↓ ← →`.
- The switch in Settings → Sessions, and `/api/team/session` now reporting `shellEnabled` (capability **and** switch) separately from `capabilities.localShell` (the profile alone).

Phase 2 of `docs/superpowers/specs/2026-09-08-session-utility-shell-design.md`. Phase 1 (the shell exists, `/api/shell/open|list|close`) shipped in #453 / #455.

## Motivation

Phase 1 could open a shell and prove it was invisible to the fleet, but there was no way to see it or type into it. This is the half that makes it usable — and the half where the isolation is easiest to lose, because both channels *already exist* for sessions and reusing them would have scoped a shell against `managed-sessions.json` and still worked.

## Changes

**Server**
- `sessions/shell-terminal.ts` (new) — the pane I/O (capture / literal text / named key), bound to `SHELL_SOCKET` and nothing else. The tmux runner is injected, so the socket discipline is provable without a tmux server.
- `sessions/shell-stream-web.ts`, `sessions/shell-input-web.ts` (new) — the read and write channels. Everything generic is shared with the fleet (`terminal-stream.ts`, `terminal-hub.ts`, `input-channel.ts`, `input-protocol.ts`); the one thing that is not is the **scope** — these resolve an id against `shells.json`, never the registry.
- `sessions/shell-web.ts` — the SSE route. `index.ts` — the WS upgrade (its own `shellInput` field on `WSData`, so a shell socket can never reach the fleet's handler), behind the same gates the open route rides plus same-origin and the ceiling. `audit.ts` — `shell.input.open` / `shell.input.denied`, its own pair so a reader of the log can tell a raw PTY from a named assistant CLI.
- `input-protocol.ts` — `Escape` joins `KEY_ALLOWLIST`.
- `auth.ts` — `/api/team/session` reports `shellEnabled`.

**Web**
- `lib/terminalEndpoint.ts` (new, pure) — the one place that maps a scope to its routes. `useTerminalStream` / `useTerminalWrite` are now generic over it and interpolate no route themselves.
- `lib/shellBand.ts` (new, pure) — the unwatch rule, the band geometry, the route-level refusal sentences, the guarded `localStorage` prefs, `shellWhere`.
- `lib/shellKeys.ts` (new, pure) — the key strip, sticky `ctrl`, and the bytes each named key sends.
- `components/sessions/ShellBand.tsx` (new) — the band and the mobile sheet. `SessionPanel` mounts it last; `SessionsPage` passes the switch.
- `lib/terminalStream.ts` — `terminalStatus` takes a **subject**.
- `pages/settings/SessionsSettings.tsx` — the switch and its sentence.

**Docs** — `CLAUDE.md` and `docs/session-manager.md`.

## Test plan

TDD throughout: every module got its failing test first. `bun tsc --noEmit` clean, `bun test` 7673 pass / 0 fail.

- [x] **Isolation.** `shell-isolation.test.ts` grew to cover the three new modules over their own source: no `managed-sessions`, no `from './registry'`, and — new — no `from './terminal-web'` / `from './input-web'`. Plus every tmux call in `shell-terminal.ts` naming `SHELL_SOCKET`.
- [x] **Cross-scope, live.** A shell id on `/api/fleet/stream` → 404. A fleet id on `/api/shell/stream` → 404. A fleet id on the shell's WS upgrade → 404. A cross-origin upgrade → 403.
- [x] **The channels, live.** The SSE stream carried the real pane with its colours; `echo …` + `Enter` over the WS acked `ok` and the output came back on the read channel; `C-z` — outside the allowlist — acked `bad_key`. The shell appeared under `-L agentop-shell` and never under `-L agentop`.
- [x] **The unwatch discipline, in the browser.** Counting `EventSource`s: opening the band opened 1 stream and closed 0; collapsing closed 1; re-opening opened a 2nd; backgrounding the tab closed it. Every open matched by a close.
- [x] **Mobile at 390px.** `document.documentElement.scrollWidth === window.innerWidth` before and after opening the sheet; every control in the sheet measures 44×44; inputs compute to 16px; console clean. Screenshots in the thread below.
- [x] **Two defects the 390px screen exposed, both now pinned by tests.** The honesty line said "the agent's current screen" over a shell the person opened themselves — `terminalStatus` takes a subject now. And `direction: rtl` moved the path's leading `~` to the end (`eu/freelas/Pelvis-Institucional/~`, which reads as a folder called `~`) — the trim is computed now.

Reviewers should check the scope rule hardest: it is the one thing that would still *work* if it were wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0193VhpDrMwKBu1qT5o8hfd8
