### PR TITLE
fix(web): a reopen stays ON the session, instead of dropping you on the fleet list

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2398,6 +2398,26 @@ harness must not break.
     the page body.
   - New pages need their nav entry in **both** the desktop `SideNav` `items` array **and** the
     `MobileBottomNav` `navTiles` array in `App.tsx` — adding only the first hides the page on a phone.
+- **A REOPEN LANDS SOMEWHERE, and the wait belongs to the ID.** Reopening retires the row it was
+  asked about and mints a new one, so the id in the URL stops naming anything the instant it
+  succeeds. `lib/sessionRoute.ts` is the ONE place both halves live — `reopenedSessionRoute` (the
+  path plus the state that says the row is coming) and `arrivalFor` / `stillArriving` (the budget),
+  all pure and tested. Two rules, each of which was a real defect:
+  **(a) EVERY surface that can reopen must follow the new id.** Four can: the row menu
+  (`SessionActions.onOpened`), the composer's own Reopen button (`SessionChat.onReopened`), the
+  aside's row handler, and the header's menu. Two of them kept only the message, on the written
+  belief that "the page follows it there" — nothing followed it, `collapseSupersededSessions`
+  dropped the retired row on the next poll, and the page fell through to the fleet OVERVIEW
+  permanently. Reported as "reabro uma sessão e ele me joga pra tela de sessions". `SessionChat`
+  still does not navigate — it reports the id and the PAGE decides, which is why the callback is
+  the same one the row menu already gets: two Reopen buttons on one screen must land in one place.
+  **(b) THE "IT IS ON ITS WAY" BUDGET MUST BE KEYED ON THE ID, NEVER ON THE MOUNT.** It was a
+  `useState(() => Date.now())` taken once, so it measured from when the PAGE was opened. Creating
+  from the overview remounts the page (`sessions` and `sessions/:sessionId` are different
+  `<Route>`s), which is why it always looked right; a reopen is `/sessions/A` -> `/sessions/B`, the
+  same route, no remount, the stamp long spent — so even a correctly-navigating reopen showed the
+  overview for the whole poll interval. `handedOver` had the same shape and the same bug: flipped
+  once per mount, only the FIRST arrival ever got its finish frame.
 - **A DATE FILTER IS ANSWERED BY `SessionMeta.daily`, AND AN UNBOUNDED RANGE IS ANSWERED FROM THE
   OTHER SIDE.** A session is a SPAN whose four counters are LIFETIME totals, so filing it on the day
   it STARTED empties "today" for anyone whose session has been open since Tuesday, and filing it on

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -101,7 +101,7 @@ import { CentralSessions } from './components/sessions/CentralSessions'
 // filter row in the strip and the body under it have to move together at every width.
 import { PAGE_INSET, PAGE_MAX_WIDTH } from './components/sessions/FleetOverview'
 import { setFleetSourceCentral } from './lib/fleet'
-import { sessionPath } from './lib/sessionRoute'
+import { reopenedSessionRoute, sessionPath } from './lib/sessionRoute'
 import { SessionStatsMenu } from './components/sessions/SessionStatsMenu'
 
 /**
@@ -3247,8 +3247,16 @@ export default function AppLayout() {
           lang={lang === 'pt' ? 'pt' : 'en'}
           act={headerFleetAct}
           onGone={() => navigate('/sessions')}
-          // A reopen mints a NEW session; going to it is what makes the verb visibly do something.
-          onOpened={id => navigate(sessionPath(id))}
+          // A reopen mints a NEW session; going to it is what makes the verb visibly do something
+          // — WITH the state that says it is on its way, or the page shows the fleet overview
+          // until the next poll carries the new row. See `reopenedSessionRoute`.
+          onOpened={id => {
+            const r = reopenedSessionRoute(id, {
+              harness: selectedSessionRow.harness,
+              title: selectedSessionRow.title,
+            })
+            navigate(r.path, r.options)
+          }}
         />
       )}
     </div>

--- a/packages/web/src/components/nav/SessionsAside.tsx
+++ b/packages/web/src/components/nav/SessionsAside.tsx
@@ -33,7 +33,7 @@ import { SessionFiling } from '../tasks/SessionFiling'
 import { boardCopy } from '../tasks/copy'
 import { attachSession, detachSession } from '../../lib/tasks'
 import { SessionFacts } from '../sessions/SessionFacts'
-import { sessionPath } from '../../lib/sessionRoute'
+import { reopenedSessionRoute, sessionPath } from '../../lib/sessionRoute'
 import {
   MAX_PINNED, getPinnedIds, movePinnedSession, pinnedServerSnapshot, resolvePinnedRows,
   subscribePinnedSessions, togglePinnedSession,
@@ -244,7 +244,17 @@ export function SessionsAside({
       return
     }
     if (!act) return
-    void act({ id, action }).then(out => setNotice(out.message))
+    void act({ id, action }).then(out => {
+      setNotice(out.message)
+      // A REOPEN LANDS SOMEWHERE, here too. It retires the row it was asked about, so a reader
+      // sitting on that row is left on an id the next poll drops — and this handler kept only the
+      // message. The row it came FROM names the wait; see `reopenedSessionRoute`.
+      if (out.ok && action === 'resume' && out.id) {
+        const from = rows.find(r => r.id === id)
+        const r = reopenedSessionRoute(out.id, from ? { harness: from.harness, title: from.title } : undefined)
+        navigate(r.path, r.options)
+      }
+    })
   }
 
   // The top bar's magnifier focuses this field. An event rather than a prop because the button and

--- a/packages/web/src/components/sessions/SessionChat.tsx
+++ b/packages/web/src/components/sessions/SessionChat.tsx
@@ -109,6 +109,20 @@ export interface SessionChatProps {
    * the very turns this one already polls. Fetching the conversation a second time to build the
    * same list would be two pollers disagreeing about one session — so it is handed over instead.
    */
+  /**
+   * A REOPEN LANDED, and its NEW id.
+   *
+   * The composer's Reopen button used to keep only the message, on the belief that "the page
+   * follows it there". Nothing followed it: a reopen retires the row it was asked about, so the id
+   * in the URL stopped naming anything and the page fell through to the fleet overview — reported
+   * as "reabro uma sessão e ele me joga pra tela de sessions".
+   *
+   * A CALLBACK and not a `navigate()` here, for the reason the old comment gave and was right
+   * about: navigating from inside the composer would be this component deciding where the app
+   * goes. It reports the id; the page decides. The same callback the row's own menu already gets
+   * (`SessionActions.onOpened`), so the two Reopen buttons on one screen cannot land differently.
+   */
+  onReopened?: (id: string) => void
   onArtifacts?: (a: {
     artifacts: Artifact[]
     loading: boolean
@@ -150,7 +164,7 @@ const TAIL_SLACK = 24
 
 interface Attachment { name: string; path: string }
 
-export function SessionChat({ session, row, lang, act, onArtifacts }: SessionChatProps) {
+export function SessionChat({ session, row, lang, act, onArtifacts, onReopened }: SessionChatProps) {
   const pt = lang === 'pt'
   /** Touch targets grow on a phone and nowhere else — 44px on a desktop is a row of buttons. */
   const isMobile = useIsMobile()
@@ -1223,9 +1237,10 @@ export function SessionChat({ session, row, lang, act, onArtifacts }: SessionCha
     const out = await act({ id: session.id, action: 'resume' })
     setReopening(false)
     setNotice(out.message)
-    // The new row arrives on the next fleet poll under a NEW id; the page follows it there. Nothing
-    // to do here but say what happened — navigating from inside the composer would be this
-    // component deciding where the app goes.
+    // THE NEW ID IS REPORTED UP. The server hands it back precisely so a caller does not stay on
+    // the row it just retired; see `onReopened` for what used to happen instead. Navigating is
+    // still not this component's decision — it says what happened and hands over the id.
+    if (out.ok && out.id) onReopened?.(out.id)
   }
 
   /**

--- a/packages/web/src/components/sessions/SessionPanel.tsx
+++ b/packages/web/src/components/sessions/SessionPanel.tsx
@@ -178,6 +178,9 @@ export function SessionPanel({ session, row, lang, theme, act, authorName, onGon
             key={session.id}
             session={session} {...(row ? { row } : {})} lang={lang} act={act}
             {...(onArtifacts ? { onArtifacts } : {})}
+            /* THE SAME callback the row's menu gets. There are two Reopen buttons on this
+               screen — the menu's verb and the composer's — and they must land in one place. */
+            {...(onOpened ? { onReopened: onOpened } : {})}
           />
         ) : relayed ? (
           /* ANOTHER MACHINE's session. The live stream is the machine's own SSE route, refused on a

--- a/packages/web/src/lib/sessionRoute.test.ts
+++ b/packages/web/src/lib/sessionRoute.test.ts
@@ -1,5 +1,7 @@
-import { expect, test } from 'bun:test'
-import { sessionPath } from './sessionRoute'
+import { describe, expect, test } from 'bun:test'
+import {
+  ARRIVAL_WAIT_MS, arrivalFor, reopenedSessionRoute, sessionPath, stillArriving,
+} from './sessionRoute'
 
 test('an external id keeps its directory inside ONE path segment', () => {
   // Raw interpolation made this three segments and matched no route — a blank page.
@@ -21,4 +23,63 @@ test('a plain managed id is unchanged in practice', () => {
 test('a windows-shaped cwd survives as well', () => {
   const id = 'external:claude:C:\\Users\\u\\proj:12'
   expect(decodeURIComponent(sessionPath(id).slice('/sessions/'.length))).toBe(id)
+})
+
+describe('arrivalFor — the budget belongs to the ID, not to the mount', () => {
+  test('an announced id starts the wait', () => {
+    expect(arrivalFor(null, 'b', true, 1000)).toEqual({ id: 'b', since: 1000 })
+  })
+
+  test('the same id is NOT re-stamped — an unrelated re-render must not extend the budget', () => {
+    const prev = { id: 'b', since: 1000 }
+    expect(arrivalFor(prev, 'b', true, 9000)).toBe(prev)
+  })
+
+  test('a DIFFERENT id is a new arrival — the reopen case the mount-scoped budget missed', () => {
+    // `/sessions/A` -> `/sessions/B` is the SAME <Route>, so the page never remounts and the stamp
+    // taken when it was opened was still in force. A reopen minutes in got no wait at all, and the
+    // fleet overview showed for the whole poll interval — reported as "me joga pra tela de
+    // sessions".
+    expect(arrivalFor({ id: 'a', since: 1000 }, 'b', true, 500_000))
+      .toEqual({ id: 'b', since: 500_000 })
+  })
+
+  test('nothing announced is not a wait — navigating to a session that already exists', () => {
+    expect(arrivalFor({ id: 'a', since: 1000 }, 'a', false, 2000)).toBeNull()
+    expect(arrivalFor(null, undefined, true, 2000)).toBeNull()
+  })
+})
+
+describe('stillArriving — bounded, because an endless loader cannot be told from a dead id', () => {
+  test('inside the budget, for the id it was stamped for', () => {
+    expect(stillArriving({ id: 'b', since: 1000 }, 'b', 1000 + ARRIVAL_WAIT_MS - 1)).toBe(true)
+  })
+
+  test('past the budget it stops claiming', () => {
+    expect(stillArriving({ id: 'b', since: 1000 }, 'b', 1000 + ARRIVAL_WAIT_MS)).toBe(false)
+  })
+
+  test('never for a different id, and never with no record', () => {
+    expect(stillArriving({ id: 'b', since: 1000 }, 'c', 1200)).toBe(false)
+    expect(stillArriving(null, 'b', 1200)).toBe(false)
+  })
+})
+
+describe('reopenedSessionRoute — the landing carries the wait', () => {
+  test('the path is the session path, and the state announces the arrival', () => {
+    const r = reopenedSessionRoute('new-1', { harness: 'claude', title: 'FILTRO TODAY' })
+    expect(r.path).toBe('/sessions/new-1')
+    expect(r.options.state.creating).toEqual({ harness: 'claude', label: 'FILTRO TODAY' })
+  })
+
+  test('with no row to name it the state still EXISTS — its presence is what says "coming"', () => {
+    const r = reopenedSessionRoute('new-1')
+    expect(r.options.state.creating).toEqual({})
+    expect(stillArriving(arrivalFor(null, 'new-1', true, 0), 'new-1', 0)).toBe(true)
+  })
+
+  test('an id with slashes is still one path segment', () => {
+    expect(reopenedSessionRoute('external:agy:/home/x:1').path)
+      .toBe(sessionPath('external:agy:/home/x:1'))
+  })
 })

--- a/packages/web/src/lib/sessionRoute.ts
+++ b/packages/web/src/lib/sessionRoute.ts
@@ -24,3 +24,102 @@
 export function sessionPath(id: string): string {
   return `/sessions/${encodeURIComponent(id)}`
 }
+
+// ---------------------------------------------------------------------------
+// WHERE A REOPEN LANDS, and how long the page may say a session is on its way.
+//
+// A reopen mints a NEW managed row and retires the one it was asked about, so the id in the URL
+// stops naming anything the moment it succeeds. Two separate things went wrong there, and only
+// together do they produce what was reported — "reabro uma sessão e ele me joga pra tela de
+// sessions":
+//
+//   1. THE NEW ID WAS THROWN AWAY on two of the four surfaces that can reopen. The composer's own
+//      Reopen button (`SessionChat`) and the aside's row menu both called the action and kept only
+//      its message, on the stated belief that "the page follows it there". Nothing followed it: the
+//      URL still held the retired id, `collapseSupersededSessions` dropped that row on the next
+//      poll, and the page fell through to its "nothing selected" branch — the fleet overview —
+//      permanently.
+//
+//   2. THE "IT IS ON ITS WAY" GUARD WAS SCOPED TO THE MOUNT. `creatingSince` was a `useState`
+//      initialised once and never reset, so the budget it measured against started when the page
+//      was OPENED. Creating a session from the overview remounts the page (a different `<Route>`),
+//      which is why it always looked right; reopening from inside a session is `/sessions/A` ->
+//      `/sessions/B`, the SAME route, no remount — so on any page open longer than the budget the
+//      guard was already spent and the overview showed anyway, for the whole poll interval.
+//
+// Both halves live here so the four call sites cannot each answer differently — the same reason
+// `sessionPath` exists rather than five hand-built URLs.
+
+/**
+ * How long the page may claim a session is coming before it says the id names nothing here.
+ *
+ * BOUNDED on purpose: a loader with no end cannot be told from a session that never started.
+ */
+// `NewSessionModal.waitForRow` already gives the SERVER 6s to hold a new row; this covers the poll
+// that brings it to THIS browser afterwards, and covers a reopen the same way.
+export const ARRIVAL_WAIT_MS = 20_000
+
+/** A session the page has been told to expect, and when it was told. */
+export interface SessionArrival {
+  id: string
+  since: number
+}
+
+/**
+ * The arrival record for the id now in the URL — PURE, and keyed on the ID rather than the mount.
+ *
+ * Returns `prev` unchanged while the same id is still arriving, so the budget is not restarted by
+ * an unrelated re-render; a DIFFERENT id announced is a new arrival and gets a fresh stamp. An id
+ * nobody announced clears the record: navigating to a session that already exists is not a wait.
+ */
+export function arrivalFor(
+  prev: SessionArrival | null,
+  sessionId: string | undefined,
+  announced: boolean,
+  now: number,
+): SessionArrival | null {
+  if (sessionId === undefined || !announced) return null
+  if (prev !== null && prev.id === sessionId) return prev
+  return { id: sessionId, since: now }
+}
+
+/** Whether the page is still entitled to say that session is on its way. PURE. */
+export function stillArriving(
+  arrival: SessionArrival | null,
+  sessionId: string | undefined,
+  now: number,
+): boolean {
+  if (arrival === null || sessionId === undefined) return false
+  return arrival.id === sessionId && now - arrival.since < ARRIVAL_WAIT_MS
+}
+
+/** What a caller hands `navigate()` to land on a session it has just been given the id of. */
+export interface SessionRoute {
+  path: string
+  options: { state: { creating: { harness?: string; label?: string } } }
+}
+
+/**
+ * Where a REOPEN lands.
+ *
+ * The row it came FROM is what names the wait — the reopened conversation keeps its harness and
+ * its title, and a wait that names neither is a bare spinner. Both are optional because two of the
+ * callers have the id and nothing else; the state is still carried, because its presence is what
+ * tells the page "this is coming" rather than "this id names nothing".
+ */
+export function reopenedSessionRoute(
+  id: string,
+  from?: { harness?: string; title?: string },
+): SessionRoute {
+  return {
+    path: sessionPath(id),
+    options: {
+      state: {
+        creating: {
+          ...(from?.harness ? { harness: from.harness } : {}),
+          ...(from?.title ? { label: from.title } : {}),
+        },
+      },
+    },
+  }
+}

--- a/packages/web/src/pages/SessionsPage.tsx
+++ b/packages/web/src/pages/SessionsPage.tsx
@@ -26,15 +26,10 @@ import { useIsMobile } from '../hooks/useIsMobile'
 import { FleetOverview } from '../components/sessions/FleetOverview'
 import { SessionCreating } from '../components/sessions/SessionCreating'
 
-/**
- * How long a navigation may keep claiming its session is still coming.
- *
- * `NewSessionModal.waitForRow` already gave the SERVER 6s to hold the row; this covers the poll
- * that brings it to THIS browser afterwards. Past it the page stops asserting and says the id
- * names nothing here, which is the honest answer and the one that can be acted on — a loader with
- * no end cannot be told from a session that never started.
- */
-const CREATE_WAIT_MS = 20_000
+// How long a navigation may keep claiming its session is still coming is `ARRIVAL_WAIT_MS` in
+// `lib/sessionRoute.ts`, beside the rest of the arrival rule. It lived here as `CREATE_WAIT_MS`
+// while creating was the only thing that could announce a session; a reopen announces one too, and
+// two constants for one budget is two answers.
 import { SessionStatsMenu } from '../components/sessions/SessionStatsMenu'
 import { MagnifierButton } from '../components/a11y/MagnifierButton'
 import { HideLensesButton } from '../components/a11y/HideLensesButton'
@@ -53,7 +48,9 @@ import { SessionsAside } from '../components/nav/SessionsAside'
 import { SessionActions } from '../components/sessions/SessionActions'
 import { filterFleet } from '../lib/fleetFilter'
 import { FiltersSheet } from '../components/sessions/FiltersSheet'
-import { sessionPath } from '../lib/sessionRoute'
+import {
+  arrivalFor, reopenedSessionRoute, sessionPath, stillArriving, type SessionArrival,
+} from '../lib/sessionRoute'
 import { sessionPlanFactor } from '../lib/costBasis'
 
 /** The dimensions a live fleet row can be narrowed by — the same set on both layouts. */
@@ -116,6 +113,20 @@ export default function SessionsPage() {
     : fleet.rows.find(r => r.id === sessionId || r.conversationId === sessionId)
 
   /**
+   * WHERE A REOPEN LANDS — one place, for all three controls on this page that can perform one.
+   *
+   * A reopen mints a new managed row and RETIRES the one it was asked about, so staying on the id
+   * in the URL leaves the reader on a session the next poll drops. The state it carries is what
+   * makes the wait a wait instead of the fleet overview; the row it came FROM is what names it.
+   */
+  const goToReopened = (id: string) => {
+    const r = reopenedSessionRoute(id, selected
+      ? { harness: selected.harness, title: selected.title }
+      : undefined)
+    navigate(r.path, r.options)
+  }
+
+  /**
    * THE STORE'S RECORD for the open conversation — read ONCE, for the two surfaces that show it.
    *
    * The metrics card in the bar and the aside's METRICS tab are the small reading and the full one
@@ -155,11 +166,25 @@ export default function SessionsPage() {
    * nothing here. A loader with no end is the worse failure, because it cannot be told from a
    * session that simply never started.
    */
+  /**
+   * THE BUDGET BELONGS TO THE ID, NOT TO THE MOUNT — `sessionRoute.ts` carries the whole account.
+   *
+   * `creatingSince` was a `useState` taken once and never reset, so it measured from the moment the
+   * PAGE was opened. Creating from the overview remounts this page (`sessions` and
+   * `sessions/:sessionId` are different `<Route>`s), which is why it always looked right. A REOPEN
+   * is `/sessions/A` -> `/sessions/B`: the same route, no remount, the stamp long spent — so the
+   * guard did nothing and the fleet overview showed for the whole poll interval.
+   *
+   * Set during RENDER rather than in an effect: this is state derived from the URL, and an effect
+   * would paint the overview for one frame before correcting itself, which is the flash being
+   * fixed. `arrivalFor` returns the previous record unchanged for the same id, so it settles at
+   * once instead of looping.
+   */
   const creatingState = (useLocation().state as { creating?: { harness?: string; label?: string } } | null)?.creating
-  const [creatingSince] = useState(() => Date.now())
-  const arriving = creatingState !== undefined
-    && sessionId !== undefined
-    && Date.now() - creatingSince < CREATE_WAIT_MS
+  const [arrival, setArrival] = useState<SessionArrival | null>(null)
+  const nextArrival = arrivalFor(arrival, sessionId, creatingState !== undefined, Date.now())
+  if (nextArrival !== arrival) setArrival(nextArrival)
+  const arriving = stillArriving(nextArrival, sessionId, Date.now())
   const creating = arriving && selected === undefined
   /**
    * ONE FRAME, and only so the finish is real.
@@ -169,13 +194,16 @@ export default function SessionsPage() {
    * frame lets that state be painted instead of existing only in the types. It is a frame, not a
    * beat: nothing here is watched to the end, and showing the session fast is the whole point.
    */
-  const [handedOver, setHandedOver] = useState(false)
-  const finishing = arriving && selected !== undefined && !handedOver
+  // Keyed on the ARRIVAL, for the reason the budget is: a `useState(false)` flipped once per mount
+  // stayed true for every later arrival on the same page, so only the first one got a finish frame.
+  const [handedOver, setHandedOver] = useState<string | null>(null)
+  const finishing = arriving && selected !== undefined && handedOver !== nextArrival?.id
+  const arrivingId = nextArrival?.id
   useEffect(() => {
     if (!finishing) return
-    const raf = requestAnimationFrame(() => setHandedOver(true))
+    const raf = requestAnimationFrame(() => setHandedOver(arrivingId ?? null))
     return () => cancelAnimationFrame(raf)
-  }, [finishing])
+  }, [finishing, arrivingId])
 
   // The Chat/Terminal choice, in the URL — the SAME `?view=` the shared header in `App.tsx` reads
   // and writes on desktop. Independent `useSearchParams()` calls on the one search string, not a
@@ -501,7 +529,7 @@ export default function SessionsPage() {
       onGone={() => navigate('/sessions')}
       // Follow a reopen to the row it created. Without it the panel keeps an id the fleet no longer
       // carries — see `SessionPanel`'s own `onOpened`.
-      onOpened={id => navigate(sessionPath(id))}
+      onOpened={goToReopened}
       // CONTROLLED on both layouts now. Passing `onViewChange` is what suppresses SessionPanel's
       // own header, and mobile draws the same three things in the row that already holds the back
       // button — one bar instead of two stacked ones saying overlapping things.
@@ -739,7 +767,7 @@ export default function SessionsPage() {
                 lang={pt ? 'pt' : 'en'}
                 act={act}
                 onGone={() => navigate('/sessions')}
-                onOpened={id => navigate(sessionPath(id))}
+                onOpened={goToReopened}
                 /* THE VIEW SWITCH, AS THE SWITCH IT IS. It came off the bar and was briefly two
                    rows in this list, which is a different statement: two rows read as two things
                    you could pick, while a segmented control says they are ALTERNATIVES and which


### PR DESCRIPTION
Closes #463

## Summary

A reopen retires the row it was asked about and mints a new one, so the id in the URL stops naming anything the instant it succeeds. Two separate defects, and only together do they produce what was reported — *"reabro uma sessao com reopen e ele me joga pra tela de sessions"*.

**1 — the new id was thrown away on two of the four surfaces that can reopen.** The composer's own Reopen button (`SessionChat`) and the aside's row handler both called the action and kept only its message, on the belief — written in a comment — that "the page follows it there". Nothing followed it: `collapseSupersededSessions` drops the retired row on the next poll and the page falls through to the fleet overview, permanently.

`SessionChat` still does not navigate. The old comment was right that navigating from inside the composer would be that component deciding where the app goes; it reports the id and the PAGE decides. The callback is the **same one the row menu already gets**, because there are two Reopen buttons on that screen and they must land in one place.

**2 — the "it is on its way" budget was scoped to the MOUNT.** `creatingSince` was a `useState(() => Date.now())` taken once and never reset, so it measured from when the *page* was opened. Creating from the overview is `/sessions` → `/sessions/:id`, two different `<Route>`s, so the page remounts and the stamp is fresh — which is why this never showed up for creating. A reopen is `/sessions/A` → `/sessions/B`: same route, no remount, stamp long spent. So even the two sites that *did* navigate showed the fleet overview for the whole poll interval. `handedOver` had the same shape and the same bug: flipped once per mount, only the first arrival ever got its finish frame.

Both halves now live in `lib/sessionRoute.ts` — `reopenedSessionRoute`, `arrivalFor`, `stillArriving`, all pure — for the reason `sessionPath` is already there: four call sites cannot each answer differently.

## Motivation

The server has returned the new id since it was written, with a comment saying why (*"THE NEW ID TRAVELS … a caller that stays on the id it asked about is looking at a dead session — which is exactly how 'reopen does nothing' was reported"*). Half the clients ignored it, and the guard that should have covered the gap had been quietly dead for every reopen since it was written.

## Test plan

`bun tsc --noEmit` clean; **7625 pass, 0 fail** — 10 new, over `arrivalFor` / `stillArriving` / `reopenedSessionRoute`, including the case the mount-scoped budget missed (a *different* id is a new arrival even 500s in) and the two it must not confuse (the same id is never re-stamped; nothing announced is not a wait).

Driven in a real browser against a live server, reopening a throwaway session from the composer's own Reopen button:

| t | URL | fleet overview? | composer? |
|---|---|---|---|
| 0.7s | `/sessions/f67e74cf1d` (the NEW id) | no | — the wait |
| 6.3s | `/sessions/f67e74cf1d` | no | yes — the reopened conversation |

The URL changes on the same tick as the click, the wait is what shows until the poll carries the new row, and the session lands. Before the change the URL never moved and the page sat on the fleet overview. The session created for the test was killed and its scratch directory removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FenRDmhbdYZW6jGC5mZHbm