### PR TITLE
fix(server): force live GitHub release check during manual upgrade

### DIFF
--- a/packages/server/server/upgrade.ts
+++ b/packages/server/server/upgrade.ts
@@ -712,7 +712,7 @@ export async function runUpgrade(lang: CliLang = 'en'): Promise<number> {
 
   let info
   try {
-    info = await getVersionInfo()
+    info = await getVersionInfo({ force: true })
   } catch {
     console.error('Failed to check for updates. Check your internet connection.')
     return 1


### PR DESCRIPTION
Ensure agentop upgrade bypasses negative version cache and fetches latest releases directly from GitHub.