### PR TITLE
release: merge dev to main

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentistics",
-  "version": "2.17.0",
+  "version": "2.21.0",
   "description": "Local analytics dashboard for AI coding assistants — tracks tokens, cost, sessions, and activity from ~/.claude/",
   "keywords": [
     "claude",

--- a/packages/agentop/package.json
+++ b/packages/agentop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentistics/agentop",
-  "version": "2.17.0",
+  "version": "2.21.0",
   "description": "agentop CLI — npm install for the same native binary distributed via install.sh (Linux x86_64 only)",
   "type": "commonjs",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentistics/core",
-  "version": "2.17.0",
+  "version": "2.21.0",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentistics/mcp",
-  "version": "2.17.0",
+  "version": "2.21.0",
   "description": "Agentistics MCP server — Claude Code analytics for Claude Desktop and Claude Code",
   "type": "module",
   "main": "./dist/agentistics-mcp.js",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentistics/server",
-  "version": "2.17.0",
+  "version": "2.21.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentistics/tui",
-  "version": "2.17.0",
+  "version": "2.21.0",
   "private": true,
   "type": "module",
   "main": "src/control/index.ts",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentistics/web",
-  "version": "2.17.0",
+  "version": "2.21.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/web/src/components/tasks/money.ts
+++ b/packages/web/src/components/tasks/money.ts
@@ -1,5 +1,5 @@
 /**
- * money.ts — the board prices in the reader's OWN currency, like every other screen.
+ * money.ts — the board prices in the reader's OWN currency AND basis, like every other screen.
  *
  * `fmtUSD` was the board's own formatter and it hardcoded a dollar sign, so a dashboard set to BRL
  * — the header, the cost page, the session cards, all of it in `R$` — answered `$12.07` on the one
@@ -11,14 +11,25 @@
  * cached for the rest of the app, read off the page's own `AppContext`. Neither is re-derived here:
  * a second rate is a second answer, and the board would then disagree with the header above it.
  *
+ * **The header's API/Plan switch used to do nothing here** — every figure on the board stayed in
+ * API terms no matter which basis was selected, because this hook never read `costBasis` at all.
+ * `viewCost` (`../../lib/costBasis`) is what every other screen applies before formatting, and the
+ * factor is `planAllocation(...).aggregateFactor` — the CROSS-HARNESS one, never a single harness's
+ * `byHarness[h]` — because a board row (a delivery, an attempt) sums sessions that can span several
+ * harnesses, exactly the case `aggregateFactor` exists for (see `CostsPage`/`HomePage`/
+ * `TopUsagePage`, which already apply it the same way). `viewCost` REFUSES rather than invents: a
+ * plan basis with no usable factor comes back as the API figure, so a board with no registered plan
+ * reads exactly as it did before this fix.
+ *
  * `null` stays `N/A`. A delivery nobody could price is not a delivery that cost nothing, and the
  * conversion must not turn one into `R$0,00`.
  */
 
 import { useCallback } from 'react'
 import { useOutletContext } from 'react-router-dom'
-import { fmtCost } from '@agentistics/core'
+import { fmtCost, planAllocation } from '@agentistics/core'
 import { NA } from './board'
+import { viewCost } from '../../lib/costBasis'
 import type { AppContext } from '../../lib/app-context'
 
 export type Money = (usd: number | null | undefined) => string
@@ -37,8 +48,15 @@ export function useMoney(): Money {
   const ctx = useOutletContext<AppContext | null>()
   const currency = ctx?.currency ?? 'USD'
   const rate = ctx?.brlRate ?? 1
+  const costBasis = ctx?.costBasis ?? 'api'
+  const planBasis = ctx?.planBasis?.basis ?? null
+  const factor = costBasis === 'plan' && planBasis ? planAllocation(planBasis).aggregateFactor : null
   return useCallback(
-    n => (n === null || n === undefined ? NA : fmtCost(n, currency, rate)),
-    [currency, rate],
+    n => {
+      if (n === null || n === undefined) return NA
+      const view = viewCost(n, { basis: costBasis, factor, allocated: true })
+      return fmtCost(view.usd, currency, rate)
+    },
+    [currency, rate, costBasis, factor],
   )
 }

--- a/packages/web/src/pages/TagDetailPage.tsx
+++ b/packages/web/src/pages/TagDetailPage.tsx
@@ -6,7 +6,7 @@ import {
 import { format, parseISO } from 'date-fns'
 import { ArrowLeft, Pencil, Trash2, CalendarRange } from 'lucide-react'
 import {
-  fmt, fmtCost, formatModel, formatProjectName, repoShortName,
+  fmt, fmtCost, formatModel, formatProjectName, planAllocation, repoShortName,
   totalTokens as totalTokensOf, totalTokensExplained,
 } from '@agentistics/core'
 import { TokenBreakdownLine } from '../components/TokenBreakdownLine'
@@ -130,11 +130,17 @@ const OVERLAY_COLORS: Record<Metric, string> = {
 }
 
 export default function TagDetailPage() {
-  const { lang, currency, brlRate, me, isCentral } = useOutletContext<AppContext>()
+  const { lang, currency, brlRate, me, isCentral, costBasis, planBasis } = useOutletContext<AppContext>()
   const { id } = useParams()
   const navigate = useNavigate()
   const pt = lang === 'pt'
   const isMobile = useIsMobile()
+
+  // Same fix as TagsPage: a tag's sources are not per-harness, so the AGGREGATE factor applies —
+  // toggling the header's API/Plan switch used to change nothing here at all.
+  const planFactor = (costBasis === 'plan' && planBasis.basis
+    ? planAllocation(planBasis.basis).aggregateFactor
+    : null) ?? 1
 
   const [detail, setDetail] = useState<TagDetail | null>(null)
   const [err, setErr] = useState<string | null>(null)
@@ -331,7 +337,7 @@ export default function TagDetailPage() {
     tokens: 'Tokens',
   }
   const metricValue = (v: number) =>
-    metric === 'costUSD' ? fmtCost(v, currency, brlRate) : metric === 'sessions' ? v.toLocaleString() : fmt(v)
+    metric === 'costUSD' ? fmtCost(v * planFactor, currency, brlRate) : metric === 'sessions' ? v.toLocaleString() : fmt(v)
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 18, minWidth: 0 }}>
@@ -406,7 +412,7 @@ export default function TagDetailPage() {
             the overlap is explained, which is the only place it can surprise anyone. */}
         <SectionHeader label={pt ? 'Total' : 'Total'} />
         <div style={{ display: 'grid', gridTemplateColumns: STAT_TILE_GRID, gap: 10 }}>
-          <StatTile label={pt ? 'Custo' : 'Cost'} value={fmtCost(tag.aggregate.costUSD, currency, brlRate)} accent />
+          <StatTile label={pt ? 'Custo' : 'Cost'} value={fmtCost(tag.aggregate.costUSD * planFactor, currency, brlRate)} accent />
           <StatTile label={pt ? 'Sessões' : 'Sessions'} value={tag.aggregate.sessions.toLocaleString()} />
           {/* ONE tokens tile, with the four counters on the line below the strip. It was the total
               plus input and output as three tiles, under a note explaining why two of them did not
@@ -513,7 +519,7 @@ export default function TagDetailPage() {
               />
               <YAxis hide />
               <Tooltip
-                content={<DayTooltip currency={currency} brlRate={brlRate} pt={pt} />}
+                content={<DayTooltip currency={currency} brlRate={brlRate} planFactor={planFactor} pt={pt} />}
                 cursor={{ stroke: 'var(--border)' }}
               />
               {overlay ? (
@@ -562,13 +568,13 @@ export default function TagDetailPage() {
       {/* Bare `.ag-grid` is the 2-column utility, collapsing to one column below 420px. */}
       <div className="ag-grid">
         <Ranked title={pt ? 'Projetos' : 'Projects'} buckets={stats.projects} color={color} pt={pt}
-          currency={currency} brlRate={brlRate} otherLabel={otherLabel}
+          currency={currency} brlRate={brlRate} planFactor={planFactor} otherLabel={otherLabel}
           labelOf={b => formatProjectName(b.key)} />
         <Ranked title={pt ? 'Repositórios' : 'Repositories'} buckets={stats.repos} color={color} pt={pt}
-          currency={currency} brlRate={brlRate} otherLabel={otherLabel}
+          currency={currency} brlRate={brlRate} planFactor={planFactor} otherLabel={otherLabel}
           labelOf={b => repoShortName(b.key) || b.key} />
         <Ranked title={pt ? 'Modelos' : 'Models'} buckets={stats.models} color={color} pt={pt}
-          currency={currency} brlRate={brlRate} otherLabel={otherLabel}
+          currency={currency} brlRate={brlRate} planFactor={planFactor} otherLabel={otherLabel}
           labelOf={b => formatModel(b.key)}
           footnote={stats.sessionsWithoutModel > 0
             ? (pt
@@ -576,15 +582,15 @@ export default function TagDetailPage() {
               : `${stats.sessionsWithoutModel} session(s) carry no model id — they count in the total but not here.`)
             : undefined} />
         <Ranked title="Harnesses" buckets={stats.harnesses} color={color} pt={pt}
-          currency={currency} brlRate={brlRate} otherLabel={otherLabel}
+          currency={currency} brlRate={brlRate} planFactor={planFactor} otherLabel={otherLabel}
           labelOf={b => HARNESS_LABELS[b.key as keyof typeof HARNESS_LABELS] ?? b.key} />
         {/* People first, then the machines they used: "who worked on this" is the question a
             reader asks before "from where". A person on two machines is one row here and two below. */}
         <Ranked title={pt ? 'Membros' : 'Members'} buckets={stats.users} color={color} pt={pt}
-          currency={currency} brlRate={brlRate} otherLabel={otherLabel}
+          currency={currency} brlRate={brlRate} planFactor={planFactor} otherLabel={otherLabel}
           labelOf={b => b.key} />
         <Ranked title={pt ? 'Máquinas' : 'Machines'} buckets={stats.members} color={color} pt={pt}
-          currency={currency} brlRate={brlRate} otherLabel={otherLabel}
+          currency={currency} brlRate={brlRate} planFactor={planFactor} otherLabel={otherLabel}
           labelOf={b => b.label ?? b.key} />
       </div>
 
@@ -660,7 +666,7 @@ export default function TagDetailPage() {
                     {sourceValueLabel(b.source)}
                   </span>
                   <span style={{ textAlign: 'right', color: 'var(--anthropic-orange)', fontWeight: 600, fontVariantNumeric: 'tabular-nums' }}>
-                    {fmtCost(b.aggregate.costUSD, currency, brlRate)}
+                    {fmtCost(b.aggregate.costUSD * planFactor, currency, brlRate)}
                   </span>
                   <span style={{ textAlign: 'right', color: 'var(--text-secondary)', fontVariantNumeric: 'tabular-nums' }}>
                     {b.aggregate.sessions.toLocaleString()}
@@ -823,13 +829,15 @@ function AccessChip({ text, muted }: { text: string; muted?: boolean }) {
 /** One ranked distribution: name, share-of-total bar, then sessions / cost / tokens.
  *  The share is computed on cost, falling back to sessions when nothing in the list cost anything
  *  (Gemini/Copilot sessions carry no token data, so a cost-only bar would render flat at zero). */
-function Ranked({ title, buckets, color, pt, currency, brlRate, otherLabel, labelOf, footnote }: {
+function Ranked({ title, buckets, color, pt, currency, brlRate, planFactor, otherLabel, labelOf, footnote }: {
   title: string
   buckets: Bucket[]
   color: string
   pt: boolean
   currency: 'USD' | 'BRL'
   brlRate: number
+  /** `1` when the API basis is selected or no plan is registered — see the page-level comment. */
+  planFactor: number
   otherLabel: string
   labelOf: (b: Bucket) => string
   footnote?: string
@@ -870,7 +878,7 @@ function Ranked({ title, buckets, color, pt, currency, brlRate, otherLabel, labe
                   <span style={{
                     fontSize: 12, fontWeight: 700, color: 'var(--anthropic-orange)',
                     fontVariantNumeric: 'tabular-nums', flexShrink: 0,
-                  }}>{fmtCost(b.costUSD, currency, brlRate)}</span>
+                  }}>{fmtCost(b.costUSD * planFactor, currency, brlRate)}</span>
                 </div>
                 <div style={{ height: 4, borderRadius: 2, background: 'var(--bg-elevated)', margin: '5px 0 4px', overflow: 'hidden' }}>
                   <div style={{
@@ -910,12 +918,14 @@ function Ranked({ title, buckets, color, pt, currency, brlRate, otherLabel, labe
 }
 
 /** Recharts tooltip for the daily series — all three metrics at once, same chrome as ActivityChart. */
-function DayTooltip({ active, payload, label, currency, brlRate, pt }: {
+function DayTooltip({ active, payload, label, currency, brlRate, planFactor, pt }: {
   active?: boolean
   payload?: { payload?: DayPoint }[]
   label?: string | number
   currency: 'USD' | 'BRL'
   brlRate: number
+  /** `1` when the API basis is selected or no plan is registered — see the page-level comment. */
+  planFactor: number
   pt: boolean
 }) {
   const point = active ? payload?.[0]?.payload : undefined
@@ -928,7 +938,7 @@ function DayTooltip({ active, payload, label, currency, brlRate, pt }: {
       <div style={{ fontWeight: 600, color: 'var(--text-primary)', marginBottom: 6 }}>
         {niceDate(String(label ?? point.date))}
       </div>
-      <Row label={pt ? 'Custo' : 'Cost'} value={fmtCost(point.costUSD, currency, brlRate)} />
+      <Row label={pt ? 'Custo' : 'Cost'} value={fmtCost(point.costUSD * planFactor, currency, brlRate)} />
       <Row label={pt ? 'Sessões' : 'Sessions'} value={point.sessions.toLocaleString()} />
       <Row label="Tokens" value={fmt(point.tokens)} />
     </div>

--- a/packages/web/src/pages/TagsPage.tsx
+++ b/packages/web/src/pages/TagsPage.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { useLocation, useNavigate, useOutletContext } from 'react-router-dom'
 import { Plus, Trash2, X, CalendarRange } from 'lucide-react'
-import { fmt, fmtCost, formatProjectName, canonicalProjectPath, totalTokens, totalTokensExplained } from '@agentistics/core'
+import { fmt, fmtCost, formatProjectName, canonicalProjectPath, planAllocation, totalTokens, totalTokensExplained } from '@agentistics/core'
 import type { AppContext } from '../lib/app-context'
 import type { TokenBreakdown } from '@agentistics/core'
 import { HARNESS_LABELS } from '../lib/harness'
@@ -172,11 +172,19 @@ function Field({ label, children }: { label: string; children: React.ReactNode }
 }
 
 export default function TagsPage() {
-  const { lang, currency, brlRate, data, me, isCentral } = useOutletContext<AppContext>()
+  const { lang, currency, brlRate, data, me, isCentral, costBasis, planBasis } = useOutletContext<AppContext>()
   const pt = lang === 'pt'
   const isMobile = useIsMobile()
   const navigate = useNavigate()
   const location = useLocation()
+
+  // Tag cards are not per-harness — a tag's sources can span several — so the AGGREGATE factor is
+  // the right one here, the same one CostsPage/HomePage/TopUsagePage apply to a cross-harness
+  // total. Toggling the header's API/Plan switch used to change nothing on this page at all: every
+  // card kept reading `fmtCost(costUSD, …)` straight off the API figure regardless of the basis.
+  const planFactor = (costBasis === 'plan' && planBasis.basis
+    ? planAllocation(planBasis.basis).aggregateFactor
+    : null) ?? 1
 
   const [tags, setTags] = useState<Tag[]>([])
   const [err, setErr] = useState<string | null>(null)
@@ -597,7 +605,7 @@ export default function TagsPage() {
                 </span>
               )}
               <div style={{ fontSize: 20, fontWeight: 700, color: 'var(--anthropic-orange)', wordBreak: 'break-word' }}>
-                {fmtCost(t.aggregate.costUSD, currency, brlRate)}
+                {fmtCost(t.aggregate.costUSD * planFactor, currency, brlRate)}
               </div>
               <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '6px 10px' }}>
                 <MiniStat label={pt ? 'Sessões' : 'Sessions'} value={t.aggregate.sessions.toLocaleString()} />
@@ -649,7 +657,7 @@ export default function TagsPage() {
                   </span>
                 )}
               </span>
-              <Cell label={pt ? 'Custo' : 'Cost'} value={fmtCost(t.aggregate.costUSD, currency, brlRate)} accent />
+              <Cell label={pt ? 'Custo' : 'Cost'} value={fmtCost(t.aggregate.costUSD * planFactor, currency, brlRate)} accent />
               <Cell label={pt ? 'Sessões' : 'Sessions'} value={t.aggregate.sessions.toLocaleString()} />
               <Cell label={pt ? 'Entrada' : 'Input'} value={fmt(t.aggregate.inputTokens)} />
               <Cell label={pt ? 'Saída' : 'Output'} value={fmt(t.aggregate.outputTokens)} />


### PR DESCRIPTION
## Summary

Release: merges `dev` into `main`, one commit ahead —

- #476 — API/Plan basis toggle now recalculates cost on the Deliveries board and both Tags pages (was silently a no-op on both).

## Test plan

- [x] CI green on #476 before it merged into `dev`.
- [x] This diff against `dev` should contain only that squashed commit — no unrelated file resurrections.