### PR TITLE
release: merge dev to main

### DIFF
--- a/packages/web/src/components/tasks/BoardArrange.tsx
+++ b/packages/web/src/components/tasks/BoardArrange.tsx
@@ -34,7 +34,7 @@ const BOARD_SORTS: Array<{ key: SortKey; label: string }> = [
   { key: 'updated', label: 'Last touched' },
   { key: 'created', label: 'Newest' },
   { key: 'cost', label: 'Cost' },
-  { key: 'rounds', label: 'Rounds' },
+  { key: 'rounds', label: 'Prompts' },
   { key: 'title', label: 'Title' },
 ]
 

--- a/packages/web/src/components/tasks/CentralTaskBoard.tsx
+++ b/packages/web/src/components/tasks/CentralTaskBoard.tsx
@@ -182,7 +182,7 @@ function RowList({ rows, showMachine, lang, cost, isMobile }: {
             <th style={th}>Status</th>
             <th style={th}>{pt ? 'Progresso' : 'Progress'}</th>
             <th style={{ ...th, textAlign: 'right' }}>{pt ? 'Sessões' : 'Sessions'}</th>
-            <th style={{ ...th, textAlign: 'right' }}>{pt ? 'Rodadas' : 'Rounds'}</th>
+            <th style={{ ...th, textAlign: 'right' }}>Prompts</th>
             <th style={{ ...th, textAlign: 'right' }}>Tokens</th>
             <th style={{ ...th, textAlign: 'right' }}>{pt ? 'Custo' : 'Cost'}</th>
             <th style={th}>Harnesses</th>

--- a/packages/web/src/components/tasks/DeliveryDetail.tsx
+++ b/packages/web/src/components/tasks/DeliveryDetail.tsx
@@ -341,10 +341,10 @@ function ChipSelect({ value, options, disabled, onPick }: {
   )
 }
 
-function Stat({ label, value, accent }: { label: string; value: string; accent?: boolean }) {
+function Stat({ label, value, accent, title }: { label: string; value: string; accent?: boolean; title?: string }) {
   const absent = value === NA
   return (
-    <div style={{ minWidth: 76 }}>
+    <div style={{ minWidth: 76 }} title={title}>
       <div style={microLabel}>{label}</div>
       <div style={{
         fontSize: 17, fontWeight: 650, fontVariantNumeric: 'tabular-nums',
@@ -380,7 +380,10 @@ function Rollup({ r }: { r: AttemptRollup }) {
     <>
       <div style={{ display: 'flex', gap: 20, flexWrap: 'wrap' }}>
         <Stat label="Cost" value={money} accent />
-        <Stat label="Rounds" value={fmtInt(r.rounds)} />
+        <Stat
+          label="Prompts" value={fmtInt(r.rounds)}
+          title="How many times you prompted, across every session filed here"
+        />
         <Stat label="Sessions" value={String(r.sessionsUsed)} />
         <Stat label="Tokens" value={fmtTokens(r.tokens)} />
         <Stat label="Active" value={r.activeMinutes === null ? NA : `${r.activeMinutes}m`} />
@@ -593,7 +596,7 @@ function SessionsTab({ detail }: { detail: TaskDetail }) {
     <div style={{ ...surface, overflowX: 'auto' }}>
       <table style={{ width: '100%', borderCollapse: 'collapse', minWidth: 680 }}>
         <thead>
-          <tr>{['Session', 'State', 'Harness', 'Where', 'Rounds', 'Tokens', 'Cost', ''].map((h, i) => (
+          <tr>{['Session', 'State', 'Harness', 'Where', 'Prompts', 'Tokens', 'Cost', ''].map((h, i) => (
             <th key={i} style={{ ...microLabel, textAlign: 'left', padding: '8px 10px', fontWeight: 600 }}>{h}</th>
           ))}</tr>
         </thead>

--- a/packages/web/src/components/tasks/RepoTasksTab.tsx
+++ b/packages/web/src/components/tasks/RepoTasksTab.tsx
@@ -144,7 +144,7 @@ export function RepoTasksTab(p: RepoTasksTabProps) {
             <th style={th}>Status</th>
             <th style={th}>{pt ? 'Progresso' : 'Progress'}</th>
             <th style={{ ...th, textAlign: 'right' }}>{pt ? 'Sessões' : 'Sessions'}</th>
-            <th style={{ ...th, textAlign: 'right' }}>{pt ? 'Rodadas' : 'Rounds'}</th>
+            <th style={{ ...th, textAlign: 'right' }}>Prompts</th>
             <th style={{ ...th, textAlign: 'right' }}>Tokens</th>
             <th style={{ ...th, textAlign: 'right' }}>{pt ? 'Custo' : 'Cost'}</th>
             <th style={th}>Harnesses</th>

--- a/packages/web/src/components/tasks/TaskBoard.tsx
+++ b/packages/web/src/components/tasks/TaskBoard.tsx
@@ -35,8 +35,8 @@ function Facts({ row }: { row: TaskListRow }) {
           {money}
         </span>
       </span>
-      <span>
-        <span style={{ ...microLabel, display: 'block' }}>Rounds</span>
+      <span title="How many times you prompted, across every session filed here">
+        <span style={{ ...microLabel, display: 'block' }}>Prompts</span>
         <span style={{ ...numeric, display: 'block' }}>{fmtInt(r.rounds)}</span>
       </span>
       <span>

--- a/packages/web/src/components/tasks/TaskTable.tsx
+++ b/packages/web/src/components/tasks/TaskTable.tsx
@@ -88,7 +88,7 @@ export const COLUMNS: ColumnDef[] = [
   { id: 'progress', label: 'Progress', width: 132, sort: 'subtasks' },
   { id: 'due', label: 'Due', width: 96, sort: 'due' },
   { id: 'sessions', label: 'Sessions', numeric: true, width: 84, sort: 'sessions' },
-  { id: 'rounds', label: 'Rounds', numeric: true, width: 76, sort: 'rounds' },
+  { id: 'rounds', label: 'Prompts', numeric: true, width: 84, sort: 'rounds' },
   { id: 'cost', label: 'Cost', numeric: true, width: 88, sort: 'cost' },
   { id: 'tokens', label: 'Tokens', numeric: true, width: 84, sort: 'tokens' },
   { id: 'harnesses', label: 'Harnesses', width: 150, sort: 'harnesses' },

--- a/packages/web/src/pages/TasksPage.tsx
+++ b/packages/web/src/pages/TasksPage.tsx
@@ -485,7 +485,7 @@ function TaskDetailView({ id }: { id: string }) {
       />
 
       <p style={{ margin: 0, fontSize: 11, color: 'var(--text-tertiary)' }}>
-        These are cost, rounds and time. Whether the work is any good is not measured here.
+        These are cost, prompts and time. Whether the work is any good is not measured here.
       </p>
 
     </div>


### PR DESCRIPTION
## Summary

Release: merges `dev` into `main`, one commit ahead —

- #479 — renames the delivery/task board's "Rounds" stat (and its Portuguese "Rodadas" counterpart) to "Prompts" everywhere it appears, plus a tooltip on the two headline stat cards. Label-only, no data change.

## Test plan

- [x] CI green on #479 before it merged into `dev`.
- [x] This diff against `dev` should contain only that squashed commit — no unrelated file resurrections.