### PR TITLE
feat(web): "Your prompts" label, filled tab-menu, and full PT-BR i18n on the delivery view

### DIFF
--- a/packages/web/src/components/sessions/ProfilePanel.tsx
+++ b/packages/web/src/components/sessions/ProfilePanel.tsx
@@ -1,3 +1,4 @@
+import { MessageSquare, Clock, Minimize2, Sparkles, Plug, Bot, Hash, AlertTriangle } from 'lucide-react'
 import type { Baseline, ProfileMetric } from '@agentistics/core'
 import { SHOWN, roundProfile } from '@agentistics/tui/control/profile-lines'
 
@@ -25,10 +26,30 @@ export const LABEL_PT: Record<ProfileMetric, string> = {
 }
 
 /**
+ * One icon and one tone per metric — the same visual language `FleetOverview`'s own stat cards use
+ * (an icon in a tone colour, over a big number). The panel used to be plain numbered boxes with no
+ * colour and no icon, sitting directly under those cards and reading like a different, cheaper
+ * product bolted onto the bottom of a polished one — reported as "essas métricas feias". A metric
+ * this table has no entry for is a build error, the same guarantee `LABEL_EN`/`LABEL_PT` give.
+ */
+const ICON: Record<ProfileMetric, React.ComponentType<{ size?: number }>> = {
+  messages: MessageSquare, activeMinutes: Clock, compacts: Minimize2,
+  skills: Sparkles, mcpServers: Plug, subagents: Bot,
+  tokens: Hash, toolErrors: AlertTriangle,
+}
+const TONE: Record<ProfileMetric, string> = {
+  messages: 'var(--accent-blue)', activeMinutes: 'var(--text-tertiary)', compacts: 'var(--accent-cyan)',
+  skills: 'var(--anthropic-orange)', mcpServers: 'var(--accent-purple)', subagents: 'var(--accent-green)',
+  tokens: 'var(--accent-blue)', toolErrors: 'var(--accent-red)',
+}
+
+/**
  * The behaviour profile, shown where the sessions list is empty.
  *
  * A metric with `n === 0` is DROPPED, never rendered as a zero — the same N/A-versus-a-confident-0
- * rule `HARNESS_CAPABILITIES` applies to harness metrics.
+ * rule `HARNESS_CAPABILITIES` applies to harness metrics. This is the REAL complement to the empty
+ * state's sentence above it, not a placeholder: every figure is a measurement off this machine's own
+ * last `windowDays`, with its own sample size printed beside it rather than implied.
  */
 export function ProfilePanel({ baseline, pt }: { baseline?: Baseline; pt: boolean }) {
   if (!baseline) return null
@@ -45,17 +66,30 @@ export function ProfilePanel({ baseline, pt }: { baseline?: Baseline; pt: boolea
           ? `Seus últimos ${baseline.windowDays} dias · ${baseline.sessions} sessões`
           : `Your last ${baseline.windowDays} days · ${baseline.sessions} sessions`}
       </div>
-      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(120px, 1fr))', gap: 10 }}>
-        {rows.map(({ k, m }) => (
-          <div key={k} style={{
-            padding: '10px 12px', borderRadius: 10,
-            background: 'var(--bg-card)', border: '1px solid var(--border-subtle)', minWidth: 0,
-          }}>
-            <div style={{ fontSize: 18, fontWeight: 600, color: 'var(--text-primary)' }}>{roundProfile(m!.median)}</div>
-            <div style={{ fontSize: 11, color: 'var(--text-secondary)' }}>{label[k]}</div>
-            <div style={{ fontSize: 10, color: 'var(--text-tertiary)' }}>n={m!.n}</div>
-          </div>
-        ))}
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(130px, 1fr))', gap: 10 }}>
+        {rows.map(({ k, m }) => {
+          const Icon = ICON[k]
+          const tone = TONE[k]
+          return (
+            <div key={k} style={{
+              background: 'var(--bg-card)', border: '1px solid var(--border-subtle)', borderRadius: 12,
+              padding: '12px 14px', display: 'flex', flexDirection: 'column', gap: 6, minWidth: 0,
+            }}>
+              <span style={{ display: 'flex', alignItems: 'center', gap: 7, color: tone }}>
+                <Icon size={14} />
+                <span style={{ fontSize: 10.5, fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.05em', color: 'var(--text-tertiary)' }}>
+                  {label[k]}
+                </span>
+              </span>
+              <span style={{ fontSize: 22, fontWeight: 700, color: 'var(--text-primary)', lineHeight: 1 }}>
+                {roundProfile(m!.median)}
+              </span>
+              <span style={{ fontSize: 10.5, color: 'var(--text-tertiary)' }}>
+                {pt ? `mediana · n=${m!.n}` : `median · n=${m!.n}`}
+              </span>
+            </div>
+          )
+        })}
       </div>
     </div>
   )

--- a/packages/web/src/components/tasks/BoardArrange.tsx
+++ b/packages/web/src/components/tasks/BoardArrange.tsx
@@ -34,7 +34,7 @@ const BOARD_SORTS: Array<{ key: SortKey; label: string }> = [
   { key: 'updated', label: 'Last touched' },
   { key: 'created', label: 'Newest' },
   { key: 'cost', label: 'Cost' },
-  { key: 'rounds', label: 'Prompts' },
+  { key: 'rounds', label: 'Your prompts' },
   { key: 'title', label: 'Title' },
 ]
 

--- a/packages/web/src/components/tasks/CentralTaskBoard.tsx
+++ b/packages/web/src/components/tasks/CentralTaskBoard.tsx
@@ -151,7 +151,7 @@ function RowList({ rows, showMachine, lang, cost, isMobile }: {
               )}
               <div style={{ display: 'flex', gap: 14, flexWrap: 'wrap', ...numeric, fontSize: 11.5 }}>
                 <span>{fmtInt(r.rollup.sessionsLinked)} <span style={microLabel}>{pt ? 'sessões' : 'sessions'}</span></span>
-                <span>{fmtInt(r.rollup.rounds)} <span style={microLabel}>{pt ? 'rodadas' : 'rounds'}</span></span>
+                <span>{fmtInt(r.rollup.rounds)} <span style={microLabel}>{pt ? 'seus prompts' : 'your prompts'}</span></span>
                 <span>{fmtTokens(r.rollup.tokens)} <span style={microLabel}>tokens</span></span>
                 <span style={{ color: 'var(--anthropic-orange)' }}>{cost(r.rollup.costUSD)}</span>
               </div>
@@ -182,7 +182,7 @@ function RowList({ rows, showMachine, lang, cost, isMobile }: {
             <th style={th}>Status</th>
             <th style={th}>{pt ? 'Progresso' : 'Progress'}</th>
             <th style={{ ...th, textAlign: 'right' }}>{pt ? 'Sessões' : 'Sessions'}</th>
-            <th style={{ ...th, textAlign: 'right' }}>Prompts</th>
+            <th style={{ ...th, textAlign: 'right' }}>{pt ? 'Seus prompts' : 'Your prompts'}</th>
             <th style={{ ...th, textAlign: 'right' }}>Tokens</th>
             <th style={{ ...th, textAlign: 'right' }}>{pt ? 'Custo' : 'Cost'}</th>
             <th style={th}>Harnesses</th>

--- a/packages/web/src/components/tasks/DeliveryDetail.tsx
+++ b/packages/web/src/components/tasks/DeliveryDetail.tsx
@@ -127,6 +127,7 @@ function PlanCard({ task, busy, lang, onPatch, onStatus, onClaim }: {
     return () => clearInterval(t)
   }, [])
   const lease = task.claim ? claimLeft(task.claim.expiresAt, nowMs) : null
+  const copy = boardCopy(lang)
 
   return (
     <div style={{ ...surface, padding: 14, display: 'grid', gap: 11 }}>
@@ -152,7 +153,7 @@ function PlanCard({ task, busy, lang, onPatch, onStatus, onClaim }: {
           />
         </div>
         <div style={{ flex: '1 1 120px', display: 'grid', gap: 5, minWidth: 0 }}>
-          <span style={{ ...microLabel, fontSize: 9 }}>Priority</span>
+          <span style={{ ...microLabel, fontSize: 9 }}>{copy.priority}</span>
           <ChipSelect
             value={task.priority ?? 'none'}
             disabled={busy}
@@ -165,7 +166,7 @@ function PlanCard({ task, busy, lang, onPatch, onStatus, onClaim }: {
       </div>
 
       <div style={{ display: 'grid', gap: 5 }}>
-        <span style={{ ...microLabel, fontSize: 9 }}>Owner</span>
+        <span style={{ ...microLabel, fontSize: 9 }}>{copy.owner}</span>
         <input
           defaultValue={task.assignee ?? ''} placeholder="a person, or an agent"
           onBlur={e => {
@@ -184,11 +185,11 @@ function PlanCard({ task, busy, lang, onPatch, onStatus, onClaim }: {
        */}
       <div style={{ display: 'grid', gap: 5 }}>
         <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-          <span style={{ ...microLabel, fontSize: 9, flex: 1 }}>Dates</span>
+          <span style={{ ...microLabel, fontSize: 9, flex: 1 }}>{copy.dates}</span>
           {(task.startDate || task.dueDate) && (
             <button
               onClick={() => void onPatch({ startDate: '', dueDate: '' })}
-              title="Clear both dates"
+              title={copy.clearDates}
               style={{
                 background: 'none', border: 'none', cursor: 'pointer', display: 'flex',
                 color: 'var(--text-tertiary)', padding: 0,
@@ -202,10 +203,17 @@ function PlanCard({ task, busy, lang, onPatch, onStatus, onClaim }: {
          * The pair fits the filter bar, which is as wide as the page; in a 280px rail they came out
          * 9px over the card and the second one hung into the gutter. Stacking also lets each keep
          * its own label, which is what a person reads when the two are a month apart.
+         *
+         * `key` is the picker's own English identifier ('Start'/'Due'), used below to decide which
+         * date field a change patches — `DatePicker` never sees it, only the already-translated
+         * word from `copy`, since it prints whatever `label` it is handed verbatim.
          */}
-        {([['Start', task.startDate ?? ''], ['Due', task.dueDate ?? '']] as const).map(([label, value]) => (
+        {([
+          ['Start', copy.start, task.startDate ?? ''],
+          ['Due', copy.due, task.dueDate ?? ''],
+        ] as const).map(([key, label, value]) => (
           <div
-            key={label}
+            key={key}
             style={{
               display: 'flex', alignItems: 'center', ...surface,
               background: 'var(--bg-elevated)', borderRadius: 7, padding: '1px 4px',
@@ -216,8 +224,8 @@ function PlanCard({ task, busy, lang, onPatch, onStatus, onClaim }: {
               label={label}
               placeholder="DD/MM/YY"
               lang={lang}
-              {...(label === 'Due' && task.startDate ? { min: task.startDate } : {})}
-              onChange={v => void onPatch(label === 'Start' ? { startDate: v } : { dueDate: v })}
+              {...(key === 'Due' && task.startDate ? { min: task.startDate } : {})}
+              onChange={v => void onPatch(key === 'Start' ? { startDate: v } : { dueDate: v })}
             />
           </div>
         ))}
@@ -232,14 +240,14 @@ function PlanCard({ task, busy, lang, onPatch, onStatus, onClaim }: {
           border: `1px solid ${STATUS.blocked.color}`,
         }}>
           <span style={{ ...microLabel, fontSize: 9, display: 'block', marginBottom: 3, color: STATUS.blocked.color }}>
-            Waiting on
+            {copy.waitingOn}
           </span>
           {task.blockedReason}
         </div>
       )}
 
       <div style={{ display: 'grid', gap: 6, borderTop: '1px solid var(--border)', paddingTop: 10 }}>
-        <span style={{ ...microLabel, fontSize: 9 }}>Working on it</span>
+        <span style={{ ...microLabel, fontSize: 9 }}>{copy.workingOnIt}</span>
         {task.claim
           ? (
             <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
@@ -254,22 +262,20 @@ function PlanCard({ task, busy, lang, onPatch, onStatus, onClaim }: {
               <button
                 disabled={busy} onClick={() => void onClaim(true)}
                 style={{ ...button(isMobile), height: isMobile ? 44 : 26 }}
-                title={lease!.expired
-                  ? 'The lease has run out — clear the holder'
-                  : 'Give the task back to the board'}
-              >Release</button>
+                title={lease!.expired ? copy.releaseTitleExpired : copy.releaseTitle}
+              >{copy.release}</button>
             </div>
           )
           : (
             <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
               <span style={{ fontSize: 11.5, color: 'var(--text-tertiary)', flex: 1 }}>
-                Free — nobody has taken it.
+                {copy.free}
               </span>
               <button
                 disabled={busy} onClick={() => void onClaim(false)}
                 style={{ ...button(isMobile), height: isMobile ? 44 : 26 }}
-                title="Take it, so an agent asking what to work on is told somebody has this"
-              >Take it</button>
+                title={copy.takeItTitle}
+              >{copy.takeIt}</button>
             </div>
           )}
       </div>
@@ -371,22 +377,20 @@ function Caveats({ r }: { r: AttemptRollup }) {
   )
 }
 
-function Rollup({ r }: { r: AttemptRollup }) {
+function Rollup({ r, lang }: { r: AttemptRollup; lang: Lang }) {
   const fmt = useMoney()
+  const copy = boardCopy(lang)
   const money = r.mixedCurrency || (r.credits !== null && r.costUSD === null)
     ? `${r.credits!.premiumRequests} req`
     : fmt(r.costUSD)
   return (
     <>
       <div style={{ display: 'flex', gap: 20, flexWrap: 'wrap' }}>
-        <Stat label="Cost" value={money} accent />
-        <Stat
-          label="Prompts" value={fmtInt(r.rounds)}
-          title="How many times you prompted, across every session filed here"
-        />
-        <Stat label="Sessions" value={String(r.sessionsUsed)} />
-        <Stat label="Tokens" value={fmtTokens(r.tokens)} />
-        <Stat label="Active" value={r.activeMinutes === null ? NA : `${r.activeMinutes}m`} />
+        <Stat label={copy.cost} value={money} accent />
+        <Stat label={copy.yourPrompts} value={fmtInt(r.rounds)} title={copy.yourPromptsTitle} />
+        <Stat label={copy.sessions} value={String(r.sessionsUsed)} />
+        <Stat label={copy.tokens} value={fmtTokens(r.tokens)} />
+        <Stat label={copy.active} value={r.activeMinutes === null ? NA : `${r.activeMinutes}m`} />
       </div>
       <Caveats r={r} />
     </>
@@ -407,19 +411,26 @@ function Bar({ label, value, of, color }: { label: string; value: number | null;
   )
 }
 
-function AttemptCard({ a }: { a: AttemptView }) {
+function AttemptCard({ a, lang }: { a: AttemptView; lang: Lang }) {
+  const copy = boardCopy(lang)
   const cfg = a.config
     ? [a.config.model, a.config.effort, a.config.method].filter(Boolean).join(' · ')
     : ''
+  // `a.label` is a real, user-typed configuration name EXCEPT for the server's own sentinel for
+  // a session filed with no named attempt at all — that one sentence is the one attempt label
+  // this file may translate, the same way `statusLabel` translates a closed set of status ids
+  // and leaves anything else exactly as the server sent it.
+  const label = a.label === 'no attempt named' ? copy.noAttemptNamed : a.label
+  const status = a.status === 'unattributed' ? copy.unattributed : a.status
   return (
     <div style={{ ...surface, padding: 13, minWidth: 0, display: 'grid', gap: 9 }}>
       <div style={{ display: 'flex', alignItems: 'center', gap: 7, flexWrap: 'wrap' }}>
-        <span style={{ fontSize: 13, fontWeight: 600 }}>{a.label}</span>
+        <span style={{ fontSize: 13, fontWeight: 600 }}>{label}</span>
         {a.config && <span style={pill(harnessColor(a.config.harness))}>{a.config.harness}</span>}
-        <span style={pill()}>{a.status}</span>
+        <span style={pill()}>{status}</span>
       </div>
       {cfg && <div style={{ fontSize: 11, color: 'var(--text-tertiary)' }}>{cfg}</div>}
-      <Rollup r={a.rollup} />
+      <Rollup r={a.rollup} lang={lang} />
     </div>
   )
 }
@@ -596,7 +607,7 @@ function SessionsTab({ detail }: { detail: TaskDetail }) {
     <div style={{ ...surface, overflowX: 'auto' }}>
       <table style={{ width: '100%', borderCollapse: 'collapse', minWidth: 680 }}>
         <thead>
-          <tr>{['Session', 'State', 'Harness', 'Where', 'Prompts', 'Tokens', 'Cost', ''].map((h, i) => (
+          <tr>{['Session', 'State', 'Harness', 'Where', 'Your prompts', 'Tokens', 'Cost', ''].map((h, i) => (
             <th key={i} style={{ ...microLabel, textAlign: 'left', padding: '8px 10px', fontWeight: 600 }}>{h}</th>
           ))}</tr>
         </thead>
@@ -1162,36 +1173,60 @@ export function DeliveryDetail({ id, detail, lang, reload, dense, onDeleted }: D
             onSaved={next => run(() => editTask(id, { detail: next }))}
           />
 
-          <div style={{ display: 'flex', gap: 2, overflowX: 'auto', borderBottom: '1px solid var(--border)' }}>
-            {TABS.map(([key, label, count]) => (
-              <button
-                key={key} onClick={() => setTab(key)}
-                style={{
-                  height: isMobile ? 44 : 34, padding: '0 12px', border: 'none', background: 'transparent',
-                  color: tab === key ? 'var(--text-primary)' : 'var(--text-tertiary)',
-                  borderBottom: `2px solid ${tab === key ? 'var(--anthropic-orange)' : 'transparent'}`,
-                  cursor: 'pointer', fontSize: 12.5, fontWeight: tab === key ? 600 : 500, whiteSpace: 'nowrap',
-                }}
-              >
-                {label}{count > 0 ? ` ${count}` : ''}
-              </button>
-            ))}
+          {/*
+           * A TAB-MENU, not an underline row — a filled pill for the active tab (the same
+           * segmented-control shape the Chat/Terminal toggle uses elsewhere in the app), except the
+           * active fill is the brand accent rather than a neutral one: this is the ONE place on the
+           * board a person picks which part of a delivery they are looking at, so it earns the
+           * loudest state in the app's palette. The text on it is the same near-black
+           * `button(mobile, 'primary')` already uses on orange, not white — that pairing is the
+           * app's own answer to "what reads best on this orange" and a second one here would be a
+           * second answer to the same question.
+           */}
+          <div
+            role="tablist"
+            style={{
+              display: 'flex', gap: 3, padding: 3, borderRadius: 10, overflowX: 'auto',
+              background: 'var(--bg-elevated)', border: '1px solid var(--border-subtle)',
+            }}
+          >
+            {TABS.map(([key, label, count]) => {
+              const active = tab === key
+              return (
+                <button
+                  key={key} role="tab" aria-selected={active} onClick={() => setTab(key)}
+                  style={{
+                    display: 'flex', alignItems: 'center', gap: 4, flexShrink: 0,
+                    height: isMobile ? 44 : 32, padding: '0 12px', border: 'none', borderRadius: 8,
+                    cursor: 'pointer', fontFamily: 'inherit', fontSize: 12.5,
+                    fontWeight: active ? 700 : 500, whiteSpace: 'nowrap',
+                    background: active ? 'var(--anthropic-orange)' : 'transparent',
+                    color: active ? '#1a1008' : 'var(--text-tertiary)',
+                    transition: 'background 0.15s, color 0.15s',
+                  }}
+                >
+                  {label}{count > 0 ? ` ${count}` : ''}
+                </button>
+              )
+            })}
           </div>
 
           {tab === 'overview' && (
             <>
               <div style={{ ...surface, padding: 14 }}>
                 <div style={{ ...microLabel, marginBottom: 9 }}>{copy.wholeDelivery}</div>
-                <Rollup r={detail.rollup} />
+                <Rollup r={detail.rollup} lang={lang} />
               </div>
               <div style={{ display: 'grid', gap: 12, gridTemplateColumns: oneColumn ? '1fr' : 'repeat(auto-fit, minmax(230px, 1fr))' }}>
                 <div style={{ ...surface, padding: 14, display: 'grid', gap: 9 }}>
-                  <div style={microLabel}>Models</div>
+                  <div style={microLabel}>{copy.models}</div>
                   {stats.models.length === 0
-                    ? <div style={{ fontSize: 11.5, color: 'var(--text-tertiary)' }}>No session reported a model.</div>
+                    ? <div style={{ fontSize: 11.5, color: 'var(--text-tertiary)' }}>{copy.noModelReported}</div>
                     : stats.models.map(m => <Bar key={m.key} label={m.key} value={m.tokens} of={topTokens} color="var(--anthropic-orange)" />)}
                 </div>
                 <div style={{ ...surface, padding: 14, display: 'grid', gap: 9 }}>
+                  {/* "Harnesses" is kept untranslated in PT throughout the app (e.g. BackupSettings) — a
+                      technical term, not an English leftover. */}
                   <div style={microLabel}>Harnesses</div>
                   {stats.harnesses.map(h => (
                     <Bar key={h.key} label={h.key} value={h.tokens} of={topTokens} color={harnessColor(h.key)} />
@@ -1199,9 +1234,9 @@ export function DeliveryDetail({ id, detail, lang, reload, dense, onDeleted }: D
                 </div>
               </div>
               <div>
-                <div style={{ ...microLabel, marginBottom: 8 }}>Attempts — one card per configuration</div>
+                <div style={{ ...microLabel, marginBottom: 8 }}>{copy.attemptsHeader}</div>
                 <div style={{ display: 'grid', gap: 12, gridTemplateColumns: oneColumn ? '1fr' : 'repeat(auto-fit, minmax(260px, 1fr))' }}>
-                  {detail.attempts.map(a => <AttemptCard key={a.id ?? 'loose'} a={a} />)}
+                  {detail.attempts.map(a => <AttemptCard key={a.id ?? 'loose'} a={a} lang={lang} />)}
                 </div>
               </div>
             </>
@@ -1270,22 +1305,22 @@ export function DeliveryDetail({ id, detail, lang, reload, dense, onDeleted }: D
             }}
           />
 
-          <RailSection id="details" title="Delivery" badge={duration ?? NA} defaultOpen>
+          <RailSection id="details" title={copy.delivery} badge={duration ?? NA} defaultOpen>
             <div style={{ display: 'grid', gap: 10 }}>
-              <Stat label="Delivery time" value={duration ?? NA} />
+              <Stat label={copy.deliveryTime} value={duration ?? NA} />
               {duration === null && (
-                <div style={{ fontSize: 11, color: 'var(--text-tertiary)', marginTop: -8 }}>still open</div>
+                <div style={{ fontSize: 11, color: 'var(--text-tertiary)', marginTop: -8 }}>{copy.stillOpen}</div>
               )}
               <div style={{ display: 'flex', gap: 18, flexWrap: 'wrap' }}>
-                <Stat label="Agent runs" value={fmtInt(stats.agentRuns)} />
-                <Stat label="Commits" value={fmtInt(stats.commits)} />
+                <Stat label={copy.agentRuns} value={fmtInt(stats.agentRuns)} />
+                <Stat label={copy.commits} value={fmtInt(stats.commits)} />
               </div>
               <div style={{ display: 'flex', gap: 18, flexWrap: 'wrap' }}>
-                <Stat label="Files" value={fmtInt(stats.filesModified)} />
-                <Stat label="Errors" value={fmtInt(stats.toolErrors)} />
+                <Stat label={copy.files} value={fmtInt(stats.filesModified)} />
+                <Stat label={copy.errors} value={fmtInt(stats.toolErrors)} />
               </div>
               <Stat
-                label="Lines"
+                label={copy.lines}
                 value={stats.linesAdded === null && stats.linesRemoved === null
                   ? NA : `+${stats.linesAdded ?? 0} / −${stats.linesRemoved ?? 0}`}
               />
@@ -1294,22 +1329,23 @@ export function DeliveryDetail({ id, detail, lang, reload, dense, onDeleted }: D
 
           {stats.tokens && (
             <RailSection id="tokens" title="Tokens" badge={fmtTokens(detail.rollup.tokens)}>
-              {([['Input', stats.tokens.input], ['Output', stats.tokens.output],
-                 ['Cache read', stats.tokens.cacheRead], ['Cache write', stats.tokens.cacheWrite]] as const)
-                .map(([k, v]) => (
-                  <div key={k} style={{ display: 'flex', justifyContent: 'space-between', fontSize: 11.5 }}>
-                    <span style={{ color: 'var(--text-tertiary)' }}>{k}</span>
+              {([['Input', copy.tokenInput, stats.tokens.input], ['Output', copy.tokenOutput, stats.tokens.output],
+                 ['Cache read', copy.tokenCacheRead, stats.tokens.cacheRead],
+                 ['Cache write', copy.tokenCacheWrite, stats.tokens.cacheWrite]] as const)
+                .map(([key, label, v]) => (
+                  <div key={key} style={{ display: 'flex', justifyContent: 'space-between', fontSize: 11.5 }}>
+                    <span style={{ color: 'var(--text-tertiary)' }}>{label}</span>
                     <span style={numeric}>{v.toLocaleString()}</span>
                   </div>
                 ))}
             </RailSection>
           )}
 
-          <RailSection id="links" title="Links" badge={detail.task.links?.length ?? 0}>
+          <RailSection id="links" title={copy.links} badge={detail.task.links?.length ?? 0}>
             <LinksPanel id={id} task={detail.task} onChanged={reload} bare />
           </RailSection>
 
-          <RailSection id="blocked" title="Blocked by" badge={detail.task.blockedBy?.length ?? 0}>
+          <RailSection id="blocked" title={copy.blockedBy} badge={detail.task.blockedBy?.length ?? 0}>
             <BlockedBy id={id} task={detail.task} lang={lang} onChanged={reload} bare />
           </RailSection>
 

--- a/packages/web/src/components/tasks/RepoTasksTab.tsx
+++ b/packages/web/src/components/tasks/RepoTasksTab.tsx
@@ -112,7 +112,7 @@ export function RepoTasksTab(p: RepoTasksTabProps) {
               )}
               <div style={{ display: 'flex', gap: 14, flexWrap: 'wrap', ...numeric, fontSize: 11.5 }}>
                 <span>{fmtInt(r.rollup.sessionsLinked)} <span style={microLabel}>{pt ? 'sessões' : 'sessions'}</span></span>
-                <span>{fmtInt(r.rollup.rounds)} <span style={microLabel}>{pt ? 'rodadas' : 'rounds'}</span></span>
+                <span>{fmtInt(r.rollup.rounds)} <span style={microLabel}>{pt ? 'seus prompts' : 'your prompts'}</span></span>
                 <span>{fmtTokens(r.rollup.tokens)} <span style={microLabel}>tokens</span></span>
                 <span style={{ color: 'var(--anthropic-orange)' }}>{cost(r.rollup.costUSD)}</span>
               </div>
@@ -144,7 +144,7 @@ export function RepoTasksTab(p: RepoTasksTabProps) {
             <th style={th}>Status</th>
             <th style={th}>{pt ? 'Progresso' : 'Progress'}</th>
             <th style={{ ...th, textAlign: 'right' }}>{pt ? 'Sessões' : 'Sessions'}</th>
-            <th style={{ ...th, textAlign: 'right' }}>Prompts</th>
+            <th style={{ ...th, textAlign: 'right' }}>{pt ? 'Seus prompts' : 'Your prompts'}</th>
             <th style={{ ...th, textAlign: 'right' }}>Tokens</th>
             <th style={{ ...th, textAlign: 'right' }}>{pt ? 'Custo' : 'Cost'}</th>
             <th style={th}>Harnesses</th>

--- a/packages/web/src/components/tasks/TaskBoard.tsx
+++ b/packages/web/src/components/tasks/TaskBoard.tsx
@@ -36,7 +36,7 @@ function Facts({ row }: { row: TaskListRow }) {
         </span>
       </span>
       <span title="How many times you prompted, across every session filed here">
-        <span style={{ ...microLabel, display: 'block' }}>Prompts</span>
+        <span style={{ ...microLabel, display: 'block' }}>Your prompts</span>
         <span style={{ ...numeric, display: 'block' }}>{fmtInt(r.rounds)}</span>
       </span>
       <span>

--- a/packages/web/src/components/tasks/TaskTable.tsx
+++ b/packages/web/src/components/tasks/TaskTable.tsx
@@ -88,7 +88,7 @@ export const COLUMNS: ColumnDef[] = [
   { id: 'progress', label: 'Progress', width: 132, sort: 'subtasks' },
   { id: 'due', label: 'Due', width: 96, sort: 'due' },
   { id: 'sessions', label: 'Sessions', numeric: true, width: 84, sort: 'sessions' },
-  { id: 'rounds', label: 'Prompts', numeric: true, width: 84, sort: 'rounds' },
+  { id: 'rounds', label: 'Your prompts', numeric: true, width: 108, sort: 'rounds' },
   { id: 'cost', label: 'Cost', numeric: true, width: 88, sort: 'cost' },
   { id: 'tokens', label: 'Tokens', numeric: true, width: 84, sort: 'tokens' },
   { id: 'harnesses', label: 'Harnesses', width: 150, sort: 'harnesses' },

--- a/packages/web/src/components/tasks/copy.ts
+++ b/packages/web/src/components/tasks/copy.ts
@@ -82,6 +82,50 @@ export interface BoardCopy {
   tabs: Record<'overview' | 'sessions' | 'comments' | 'subtasks' | 'files' | 'activity', string>
   wholeDelivery: string
   deleteDelivery: string
+  /**
+   * `PlanCard`'s own fields — status/priority/owner/dates/claim — and the `Rollup` stat row beside
+   * it. These were the last English left on an otherwise-translated delivery page: the tab bar
+   * above them and the rail sections around them already read Portuguese, so a plain "Cost" /
+   * "Working on it" sitting between two Portuguese headings read as broken rather than untranslated.
+   */
+  priority: string
+  dates: string
+  clearDates: string
+  waitingOn: string
+  workingOnIt: string
+  free: string
+  takeIt: string
+  takeItTitle: string
+  release: string
+  releaseTitleExpired: string
+  releaseTitle: string
+  cost: string
+  yourPrompts: string
+  yourPromptsTitle: string
+  tokens: string
+  active: string
+  /** The attempts rail — one card per (harness, model, effort) configuration. */
+  attemptsHeader: string
+  /** The server's own sentinel for a session nobody filed under a named attempt — never a real
+   *  attempt name, so it is the one attempt label this file may translate. */
+  noAttemptNamed: string
+  unattributed: string
+  models: string
+  noModelReported: string
+  /** The "Delivery" rail section's own git/agent figures. */
+  deliveryTime: string
+  stillOpen: string
+  agentRuns: string
+  commits: string
+  files: string
+  errors: string
+  lines: string
+  tokenInput: string
+  tokenOutput: string
+  tokenCacheRead: string
+  tokenCacheWrite: string
+  links: string
+  blockedBy: string
 }
 
 const EN: BoardCopy = {
@@ -142,6 +186,40 @@ const EN: BoardCopy = {
   },
   wholeDelivery: 'The whole delivery',
   deleteDelivery: 'Delete this delivery',
+  priority: 'Priority',
+  dates: 'Dates',
+  clearDates: 'Clear both dates',
+  waitingOn: 'Waiting on',
+  workingOnIt: 'Working on it',
+  free: 'Free — nobody has taken it.',
+  takeIt: 'Take it',
+  takeItTitle: 'Take it, so an agent asking what to work on is told somebody has this',
+  release: 'Release',
+  releaseTitleExpired: 'The lease has run out — clear the holder',
+  releaseTitle: 'Give the task back to the board',
+  cost: 'Cost',
+  yourPrompts: 'Your prompts',
+  yourPromptsTitle: 'How many times you prompted, across every session filed here',
+  tokens: 'Tokens',
+  active: 'Active',
+  attemptsHeader: 'Attempts — one card per configuration',
+  noAttemptNamed: 'no attempt named',
+  unattributed: 'unattributed',
+  models: 'Models',
+  noModelReported: 'No session reported a model.',
+  deliveryTime: 'Delivery time',
+  stillOpen: 'still open',
+  agentRuns: 'Agent runs',
+  commits: 'Commits',
+  files: 'Files',
+  errors: 'Errors',
+  lines: 'Lines',
+  tokenInput: 'Input',
+  tokenOutput: 'Output',
+  tokenCacheRead: 'Cache read',
+  tokenCacheWrite: 'Cache write',
+  links: 'Links',
+  blockedBy: 'Blocked by',
 }
 
 const PT: BoardCopy = {
@@ -204,6 +282,40 @@ const PT: BoardCopy = {
   },
   wholeDelivery: 'A entrega inteira',
   deleteDelivery: 'Excluir esta entrega',
+  priority: 'Prioridade',
+  dates: 'Datas',
+  clearDates: 'Limpar as duas datas',
+  waitingOn: 'Aguardando',
+  workingOnIt: 'Em andamento',
+  free: 'Livre — ninguém pegou ainda.',
+  takeIt: 'Pegar',
+  takeItTitle: 'Pegar, para dizer a um agente perguntando o que fazer que alguém já está nisso',
+  release: 'Liberar',
+  releaseTitleExpired: 'O prazo da posse expirou — limpar o responsável',
+  releaseTitle: 'Devolver a tarefa para o quadro',
+  cost: 'Custo',
+  yourPrompts: 'Seus prompts',
+  yourPromptsTitle: 'Quantas vezes você fez um prompt, em todas as sessões filiadas aqui',
+  tokens: 'Tokens',
+  active: 'Ativo',
+  attemptsHeader: 'Tentativas — um cartão por configuração',
+  noAttemptNamed: 'sem tentativa nomeada',
+  unattributed: 'não atribuída',
+  models: 'Modelos',
+  noModelReported: 'Nenhuma sessão informou um modelo.',
+  deliveryTime: 'Tempo de entrega',
+  stillOpen: 'ainda aberta',
+  agentRuns: 'Execuções de agente',
+  commits: 'Commits',
+  files: 'Arquivos',
+  errors: 'Erros',
+  lines: 'Linhas',
+  tokenInput: 'Entrada',
+  tokenOutput: 'Saída',
+  tokenCacheRead: 'Leitura de cache',
+  tokenCacheWrite: 'Escrita de cache',
+  links: 'Links',
+  blockedBy: 'Bloqueada por',
 }
 
 export function boardCopy(lang: Lang): BoardCopy {

--- a/packages/web/src/pages/TasksPage.tsx
+++ b/packages/web/src/pages/TasksPage.tsx
@@ -485,7 +485,9 @@ function TaskDetailView({ id }: { id: string }) {
       />
 
       <p style={{ margin: 0, fontSize: 11, color: 'var(--text-tertiary)' }}>
-        These are cost, prompts and time. Whether the work is any good is not measured here.
+        {lang === 'pt'
+          ? 'Isso é custo, prompts e tempo. Se o trabalho ficou bom não é medido aqui.'
+          : 'These are cost, prompts and time. Whether the work is any good is not measured here.'}
       </p>
 
     </div>


### PR DESCRIPTION
## What
- Renames "Prompts" → "Your prompts" (PT: "Seus prompts") everywhere on the delivery board, so it's clear whose prompts are being counted.
- Replaces the delivery view's underlined tab row (Overview/Sessions/Comments/Subtasks/Files/Activity — shown both on the full page and in the session aside, since it's the same component) with a filled tab-menu: active tab is solid orange with near-black text (`#1a1008`, already the app's answer for text-on-orange in `board.ts`'s primary button and `TaskSharing.tsx`'s toggle).
- Fixes a PT-BR regression from the "Your prompts" rename: `CentralTaskBoard.tsx` and `RepoTasksTab.tsx` had a working `{pt ? 'Rodadas' : 'Rounds'}` that got hardcoded to English "Your prompts" — restored as bilingual.
- While investigating that regression, found the whole delivery detail rail (`PlanCard`, `Rollup`/`Stat`, `AttemptCard`, the git/agent stats section) was English-only despite `lang` being available — extended `copy.ts` and wired it through. `Harnesses` is deliberately left untranslated, matching the existing convention in `BackupSettings.tsx`.
- Restyles `ProfilePanel` (the 30-day behaviour baseline shown when the sessions fleet is genuinely empty) with an icon + tone colour per metric, matching the polished stat-card style `FleetOverview` already uses above it, instead of plain colourless boxes that read as a different, cheaper screen bolted under it.

## Testing
- `bunx tsc --noEmit -p packages/web/tsconfig.json` — clean.
- `bun test` — 1 pre-existing, unrelated failure (`auth.test.ts:188`, `shellEnabled`), confirmed against a clean `dev` checkout in an earlier session.
- Verified visually with Playwright against an isolated preview instance (own `AGENTISTICS_DIR`, ports 47391/47392): switched the app to PT-BR and confirmed every label above renders translated, and confirmed the tab-menu's orange fill moves correctly between tabs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BZecCuGfiCJ3Vb1dzcqBWi