### PR TITLE
fix(web): show 'compacting' instead of generic 'working', and colour the context %

### DIFF
--- a/packages/web/src/components/sessions/SessionChat.tsx
+++ b/packages/web/src/components/sessions/SessionChat.tsx
@@ -42,7 +42,7 @@ import { promptCountLabel } from '../../lib/promptCount'
 import { splitImageAttachments } from '../../lib/attachmentPreview'
 import { attachmentUrl } from '../../lib/attachmentUrl'
 import { AttachmentLightbox } from './AttachmentLightbox'
-import { liveTurnText, stripAnsi } from '../../lib/liveTurn'
+import { detectCompacting, liveTurnText, stripAnsi } from '../../lib/liveTurn'
 import { scratchKey, sessionScratch } from '../../lib/sessionScratch'
 import { chatReadAt, firstFrameStale, refreshChat, subscribeChat } from '../../lib/chatFeed'
 import { composerMaxHeight } from '../../lib/composerHeight'
@@ -971,6 +971,17 @@ export function SessionChat({ session, row, lang, act, onArtifacts, onReopened }
     })
   }, [term.frame, lastAssistant, working])
 
+  /**
+   * Whether the frame is showing Claude Code's OWN compaction screen right now — see
+   * `detectCompacting`. Read over the RAW frame lines rather than `live`'s filtered text: the
+   * progress bar is exactly the kind of line `liveTurnText` strips out as chrome, and compaction
+   * writes nothing to the transcript while it runs, so this is the only signal there is.
+   */
+  const compacting = useMemo(() => {
+    if (!working || !term.frame) return null
+    return detectCompacting(stripAnsi(term.frame.content).split('\n'))
+  }, [term.frame, working])
+
   const toTail = useCallback((smooth = true) => {
     const el = scrollRef.current
     if (!el) return
@@ -1550,6 +1561,7 @@ export function SessionChat({ session, row, lang, act, onArtifacts, onReopened }
               lang={lang}
               {...(newestAssistant?.tools ? { tools: newestAssistant.tools } : {})}
               thinking={Boolean(newestAssistant?.thinking)}
+              {...(compacting ? { compacting } : {})}
             />
           )}
 

--- a/packages/web/src/components/sessions/SessionStatsMenu.tsx
+++ b/packages/web/src/components/sessions/SessionStatsMenu.tsx
@@ -23,6 +23,19 @@ import { HARNESS_LABELS } from '../../lib/harness'
 import { sessionStats, statReason } from '../../lib/sessionStats'
 import { costBasisLabel, viewCost } from '../../lib/costBasis'
 
+/**
+ * The trigger button's own percentage colour — a THREE-tier ramp, deliberately not the same as the
+ * expanded bar's two (see the bar's own comment for why they may not share one). The button sat
+ * fixed and neutral at 96% no matter what, which is the one figure on this whole panel that says
+ * what to do next (finish up, rather than keep extending a conversation about to be compacted) —
+ * reported as "a % não muda de cor de acordo com quanto de contexto já foi consumido". `>= 0.85`
+ * matches the bar's own red threshold; `>= 0.6` gives the badge a step before the window is
+ * actually a problem, since it is read constantly rather than only once the menu is opened.
+ */
+function contextTone(fraction: number): string {
+  return fraction >= 0.85 ? 'var(--accent-red)' : fraction >= 0.6 ? 'var(--anthropic-orange)' : 'var(--text-secondary)'
+}
+
 export interface SessionStatsMenuProps {
   harness: string
   sessionId: string
@@ -177,11 +190,21 @@ export function SessionStatsMenu({
           fontFamily: 'inherit', fontSize: 12,
         }}
       >
-        <BarChart3 size={touch ? 18 : 14} />
+        <BarChart3
+          size={touch ? 18 : 14}
+          {...(s.context && !open ? { color: contextTone(s.context.fraction) } : {})}
+        />
         {/* The context percentage rides the BUTTON, because it is the one figure that changes what
             you do next — a conversation near its window is one to finish rather than extend. It is
-            absent, not zero, when it cannot be known. */}
-        {s.context && <span style={{ fontWeight: 650 }}>{Math.floor(s.context.fraction * 100)}%</span>}
+            absent, not zero, when it cannot be known. Its OWN colour follows how full the window
+            is (`contextTone`, the same ramp the bar inside uses) rather than the button's open/
+            closed state — that state still wins while the menu is open, where the accent border
+            already says "this is active" and a red 96% fighting it for attention reads as a fault. */}
+        {s.context && (
+          <span style={{ fontWeight: 650, ...(open ? {} : { color: contextTone(s.context.fraction) }) }}>
+            {Math.floor(s.context.fraction * 100)}%
+          </span>
+        )}
       </button>
 
       {open && (
@@ -247,6 +270,11 @@ export function SessionStatsMenu({
                 }}>
                   <div style={{
                     height: '100%', width: `${Math.min(100, s.context.fraction * 100)}%`,
+                    // Deliberately its OWN two-tier rule, not `contextTone`: a FILLED bar reads fine
+                    // starting orange at any size (that is just "how much is used"), while the badge
+                    // above stays neutral until there is something worth noticing — sharing one scale
+                    // would either paint this bar grey at low usage (looks broken) or paint the badge
+                    // orange from the first token (a colour that means nothing once it never changes).
                     background: s.context.fraction >= 0.85 ? 'var(--accent-red)' : 'var(--anthropic-orange)',
                     transition: 'width 0.3s',
                   }} />

--- a/packages/web/src/components/sessions/WorkingNote.tsx
+++ b/packages/web/src/components/sessions/WorkingNote.tsx
@@ -19,13 +19,25 @@ export interface WorkingNoteProps {
   tools?: Array<{ name: string; detail?: string }>
   /** True when the assistant recorded reasoning but no text on the newest turn. */
   thinking?: boolean
+  /**
+   * Claude Code is running its OWN compaction right now — read off the live terminal frame (see
+   * `detectCompacting`), because nothing about it reaches the transcript until it finishes. It
+   * outranks `tools`/`thinking`: those describe the newest COMMITTED turn, which is necessarily the
+   * one before compaction started, so a caller that also has tools from that stale turn must not
+   * have them win. `percent` is `null` when the frame shows the caption but not yet a number.
+   */
+  compacting?: { percent: number | null } | null
 }
 
-export function WorkingNote({ lang, tools, thinking }: WorkingNoteProps) {
+export function WorkingNote({ lang, tools, thinking, compacting }: WorkingNoteProps) {
   const pt = lang === 'pt'
   const names = (tools ?? []).map(t => t.name)
 
-  const what = names.length > 0
+  const what = compacting
+    ? (compacting.percent === null
+        ? (pt ? 'compactando a conversa' : 'compacting the conversation')
+        : (pt ? `compactando a conversa · ${compacting.percent}%` : `compacting the conversation · ${compacting.percent}%`))
+    : names.length > 0
     // Named, but only up to two: a turn can invoke eight tools and the line is not a manifest.
     ? (names.length <= 2
         ? names.join(', ')
@@ -49,8 +61,10 @@ export function WorkingNote({ lang, tools, thinking }: WorkingNoteProps) {
         {what}
       </span>
       {/* The first tool's own detail, when there is one and there is room. The line stays one line:
-          a command is routinely longer than the pane and this is a status, not content. */}
-      {tools?.[0]?.detail && (
+          a command is routinely longer than the pane and this is a status, not content. Withheld
+          while compacting: `tools` here is still the PREVIOUS turn's, and a stale command sitting
+          next to "compacting the conversation" reads as something happening right now. */}
+      {!compacting && tools?.[0]?.detail && (
         <code style={{
           minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
           fontFamily: "'JetBrains Mono', 'Fira Code', Menlo, Consolas, monospace",

--- a/packages/web/src/lib/liveTurn.test.ts
+++ b/packages/web/src/lib/liveTurn.test.ts
@@ -1,5 +1,5 @@
 import { expect, test, describe } from 'bun:test'
-import { liveTurnText, stripAnsi } from './liveTurn'
+import { detectCompacting, liveTurnText, stripAnsi } from './liveTurn'
 
 describe('stripAnsi', () => {
   test('strips a CSI sequence, ESC byte included', () => {
@@ -103,5 +103,27 @@ describe('liveTurnText', () => {
       working: true,
       lines: ['Entering the directory now.'],
     })).toBe('Entering the directory now.')
+  })
+})
+
+describe('detectCompacting', () => {
+  test('reads the caption and the percent off the bar line below it', () => {
+    expect(detectCompacting([
+      '· Compacting conversation… (3m 43s)',
+      '  ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓░░░ 92%',
+      '  └ Tip: Run /ultrareview for a cloud-based multi-agent review',
+    ])).toEqual({ percent: 92 })
+  })
+
+  test('an ordinary working frame is not compaction', () => {
+    expect(detectCompacting(['Let me check the config first.', 'Reading package.json…'])).toBeNull()
+  })
+
+  test('the caption with no percent found nearby reports it absent, never a fake 0', () => {
+    expect(detectCompacting(['Compacting conversation…'])).toEqual({ percent: null })
+  })
+
+  test('is case-insensitive, since a harness could capitalise it differently', () => {
+    expect(detectCompacting(['COMPACTING CONVERSATION… (1s)', '0%'])).toEqual({ percent: 0 })
   })
 })

--- a/packages/web/src/lib/liveTurn.ts
+++ b/packages/web/src/lib/liveTurn.ts
@@ -111,3 +111,33 @@ export function liveTurnText(input: LiveTurnInput): string | null {
 function collapse(s: string): string {
   return s.replace(/\s+/g, ' ').trim()
 }
+
+/** Matches Claude Code's own compaction line — "Compacting conversation… (3m 43s)". */
+const COMPACTING_LINE = /compacting conversation/i
+/** The progress figure on the bar line just under it — "▓▓▓░░░ 92%". */
+const COMPACTING_PERCENT = /(\d{1,3})\s*%/
+
+/**
+ * Whether the frame is showing Claude Code's OWN compaction screen right now, and how far along it
+ * is — read off the raw terminal frame, because compaction is not a turn: nothing is written to the
+ * transcript while it runs (the `compact_boundary` line lands only once it FINISHES), so the chat
+ * transcript has no signal for it at all and `WorkingNote` fell back to its generic "working",
+ * reported as "o compacting fica sendo mostrado como working invés de mostrar o compacting mesmo".
+ *
+ * Deliberately over the UNFILTERED lines, not `liveTurnText`'s kept text: the progress bar is drawn
+ * with block-drawing characters that `NOTHING`/`CHROME` exist to strip out of ordinary speech, which
+ * is exactly the line this needs to read. `null` when the frame is not on this screen at all — never
+ * a `percent: 0`, which would claim a reading this function has not made.
+ */
+export function detectCompacting(lines: readonly string[]): { percent: number | null } | null {
+  const at = lines.findIndex(l => COMPACTING_LINE.test(l))
+  if (at === -1) return null
+  // The percent sits on the bar line just below the caption, not on the caption's own line — but
+  // read a few lines forward rather than exactly one, so a frame wrapped differently by a narrower
+  // pane still finds it.
+  for (const line of lines.slice(at, at + 4)) {
+    const m = COMPACTING_PERCENT.exec(line)
+    if (m) return { percent: Math.min(100, Number(m[1])) }
+  }
+  return { percent: null }
+}


### PR DESCRIPTION
## What
- `WorkingNote` (the quiet status line under the last message while a session is busy) showed a generic "working" while Claude Code was running its own conversation compaction, because compaction writes nothing to the transcript while it's in progress — the only evidence is the raw terminal screen ("Compacting conversation… (3m 43s)" + a progress bar). Added `detectCompacting()` (pure, tested) to `liveTurn.ts`, which reads that off the RAW frame lines rather than `liveTurnText`'s filtered text (the progress bar is exactly the kind of line that filter strips as chrome). `SessionChat` computes it and `WorkingNote` now shows "compacting the conversation · N%", taking priority over the stale `tools`/`thinking` from the turn before compaction started.
- The context badge (icon + `%`) in `SessionStatsMenu` stayed a fixed neutral colour no matter how full the window was — only the bar inside the expanded menu changed colour. Added a 3-tier `contextTone()` for the badge (neutral / orange from 60% / red from 85%, same red threshold the bar already used) — deliberately NOT shared with the bar's own 2-tier rule (see the comment in the file: a filled bar reads fine starting orange at any size, while a badge that's always on screen needs to stay neutral until there's something worth noticing).

## Testing
- `bunx tsc --noEmit -p packages/web/tsconfig.json` — clean.
- `bun test packages/web/src/lib/liveTurn.test.ts` — new `detectCompacting` cases pass, including the exact caption+bar shape from the report.
- `bun test` overall — 1 pre-existing, unrelated failure (`auth.test.ts:188`, `shellEnabled`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BZecCuGfiCJ3Vb1dzcqBWi