### PR TITLE
release: a entrega no card de métricas, e a contagem de sessões de uma entrega

### DIFF
--- a/packages/server/server/auth.test.ts
+++ b/packages/server/server/auth.test.ts
@@ -184,7 +184,11 @@ describe('handleSession', () => {
     const body = (await (await handleSession(new Request('http://localhost/api/team/session'))).json()) as
       Record<string, unknown>
     expect(typeof body['shellEnabled']).toBe('boolean')
-    // Absent reads as OFF: nobody acquires a browser shell by having upgraded.
-    expect(body['shellEnabled']).toBe(false)
+    // The VALUE is deliberately not asserted: it is this machine's own switch, so a test that
+    // pinned it passed on a machine with the shell off and FAILED on one with it on — which is
+    // what happened here the day the switch was flipped. What this route owes is the FIELD, as a
+    // boolean, separate from the capability. The rule it carries ("absent reads as OFF") is a
+    // property of `shellAllowed` and is pinned in `sessions/shell-gate.test.ts`, where it depends
+    // on nothing but its arguments.
   })
 })

--- a/packages/server/server/sessions/task-report.test.ts
+++ b/packages/server/server/sessions/task-report.test.ts
@@ -9,7 +9,7 @@
 
 import { describe, expect, it } from 'bun:test'
 import type { SessionMeta } from '@agentistics/core'
-import { buildTaskList, reposOfRows } from './task-report'
+import { buildTaskDetail, buildTaskList, reposOfRows } from './task-report'
 import type { Task } from './task-model'
 import type { ManagedSession } from './types'
 
@@ -138,5 +138,68 @@ describe('distinctConversations', () => {
       row({ id: 'r5', conversationId: undefined }),
     ]
     expect(distinctConversations(rows).map(r => r.id)).toEqual(['r1', 'r3', 'r4', 'r5'])
+  })
+})
+
+/**
+ * THE LIST MUST COUNT A CONVERSATION ONCE, exactly as the ROLLUP beside it already does.
+ *
+ * `rollupSessionsFor` was taught this on 2026-09-08, after the "ALM board" delivery reported
+ * 13.072.988.605 tokens and $7.477,50 against a true 2.456.546.185 and $1.402,92 — five times over
+ * on the headline figure of the whole feature. The fix went into the numbers and NOT into the list
+ * beside them, which kept mapping over every registry row.
+ *
+ * Reported with a screenshot on 2026-09-09: a delivery whose rollup correctly said `2 sessions`
+ * drew FIVE rows under its "Sessions" tab — one conversation repeated four times, each row carrying
+ * that conversation's full R$384,89, three marked `finished` and one `working`. That is the exact
+ * signature of the retired predecessors every attach/reopen/restart mints, and the same cost read
+ * four times is the most expensive thing this screen can say wrongly, because reading cost is what
+ * the screen is for.
+ */
+describe('buildTaskDetail — one row per conversation', () => {
+  const detailOf = (rows: ManagedSession[]) =>
+    buildTaskDetail({
+      task: task(), attempts: [], rows, metas: metasOf(meta()), costOf: () => 1,
+      comments: [], subtasks: [], files: [],
+    })
+
+  it('collapses the reopenings of ONE conversation into one row', () => {
+    const detail = detailOf([
+      row({ id: 'r1', conversationId: 'c1', endedAt: '2026-09-05T11:00:00.000Z' }),
+      row({ id: 'r2', conversationId: 'c1', endedAt: '2026-09-05T12:00:00.000Z' }),
+      row({ id: 'r3', conversationId: 'c1' }),
+    ])
+    expect(detail.sessions.length).toBe(1)
+    // FIRST-SEEN order, the same rule `distinctConversations` states for every other surface.
+    expect(detail.sessions[0]!.id).toBe('r1')
+  })
+
+  it('agrees with the rollup drawn beside it', () => {
+    const rows = [
+      row({ id: 'r1', conversationId: 'c1' }),
+      row({ id: 'r2', conversationId: 'c1' }),
+    ]
+    const detail = detailOf(rows)
+    // The tab's own count is `sessions.length`, so a list that disagrees with the rollup makes the
+    // TAB LABEL lie too — "Sessions 5" over a delivery that used two.
+    expect(detail.sessions.length).toBe(detail.rollup.sessionsUsed)
+  })
+
+  it('keeps DISTINCT conversations apart', () => {
+    const detail = detailOf([
+      row({ id: 'r1', conversationId: 'c1' }),
+      row({ id: 'r2', conversationId: 'c2' }),
+    ])
+    expect(detail.sessions.map(s => s.id)).toEqual(['r1', 'r2'])
+  })
+
+  it('keeps every row that carries NO conversation link', () => {
+    // It cannot be shown to be a duplicate of anything, and it contributes no numbers anyway —
+    // the same rule `usage-dedupe.ts` applies to a usage record with no message id.
+    const detail = detailOf([
+      row({ id: 'r1', conversationId: undefined }),
+      row({ id: 'r2', conversationId: undefined }),
+    ])
+    expect(detail.sessions.map(s => s.id)).toEqual(['r1', 'r2'])
   })
 })

--- a/packages/server/server/sessions/task-report.ts
+++ b/packages/server/server/sessions/task-report.ts
@@ -271,7 +271,18 @@ export function buildTaskDetail(o: {
       createdAt: o.task.createdAt,
       ...(o.task.deliveredAt ? { deliveredAt: o.task.deliveredAt } : {}),
     }),
-    sessions: mine.map(r => {
+    // ONE ROW PER CONVERSATION, the same rule the rollup two lines above already applies.
+    //
+    // This mapped over every registry row while `rollupSessionsFor` deduped, so the LIST and the
+    // NUMBERS beside it disagreed: a delivery whose rollup correctly said `2 sessions` drew five
+    // rows, one conversation repeated four times, each carrying that conversation's full cost —
+    // three `finished` predecessors and the live one. Every attach, reopen and restart mints a new
+    // managedId for the same conversation, so the repetition is ordinary rather than exotic, and
+    // the tab's own label (`sessions.length`) lied with it.
+    //
+    // It is the twin of the 2026-09-08 defect recorded on `rollupSessionsFor`, which was fixed in
+    // the figures and left in the list standing next to them.
+    sessions: distinctConversations(mine).map(r => {
       const meta = r.conversationId ? o.metas.get(r.conversationId) ?? null : null
       return {
         id: r.id,

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -3212,6 +3212,11 @@ export default function AppLayout() {
           {...(headerSessionMeta ? { onOpenFull: () => openArtifacts('metrics') } : {})}
           {...(selectedFleetSession.model ? { startedModel: selectedFleetSession.model } : {})}
           {...(selectedFleetSession.effort ? { startedEffort: selectedFleetSession.effort } : {})}
+          /* THE DELIVERY this session is filed under, one click from the figures it spent. The
+             fleet row carries the NAME, and the name is a ref the board resolves — see
+             `lib/sessionTaskLink.ts`, which is why this costs no id lookup. */
+          {...(selectedFleetSession.task ? { task: selectedFleetSession.task } : {})}
+          onOpenTask={ref => navigate(`/tasks/${encodeURIComponent(ref)}`)}
         />
       )}
 

--- a/packages/web/src/components/sessions/SessionStatsMenu.tsx
+++ b/packages/web/src/components/sessions/SessionStatsMenu.tsx
@@ -17,11 +17,12 @@
 import { useEffect, useRef, useState } from 'react'
 import { sessionTime } from '../../lib/sessionTime'
 import { asideCache, asideKey } from '../../lib/asideCache'
-import { BarChart3, ChevronRight, PanelRight, X } from 'lucide-react'
+import { BarChart3, ChevronRight, ListChecks, PanelRight, X } from 'lucide-react'
 import { fmt, fmtCost, type CostBasis, type HarnessId, type SessionMeta } from '@agentistics/core'
 import { HARNESS_LABELS } from '../../lib/harness'
 import { sessionStats, statReason } from '../../lib/sessionStats'
 import { costBasisLabel, viewCost } from '../../lib/costBasis'
+import { sessionTaskLink } from '../../lib/sessionTaskLink'
 
 /**
  * The trigger button's own percentage colour — a THREE-tier ramp, deliberately not the same as the
@@ -94,11 +95,26 @@ export interface SessionStatsMenuProps {
    * which is the same fact that decides whether the tab exists at all.
    */
   onOpenFull?: () => void
+  /**
+   * The DELIVERY this session is filed under — its NAME, straight off the fleet row.
+   *
+   * A name and not an id because that is what the row carries: the id lives on the session record
+   * the server holds and never reaches the wire. `findTask` resolves a ref by title, so the name IS
+   * a ref the board accepts — see `lib/sessionTaskLink.ts`. Absent when the session is filed under
+   * nothing, and then NOTHING is drawn: no dash, no empty row.
+   */
+  task?: string
+  /**
+   * Open that delivery. A CALLBACK for the same reason `onOpenFull` is one — this card does not
+   * know how the surface around it navigates. Absent where there is nowhere to go, and then the
+   * delivery is NAMED rather than offered as a control that does nothing.
+   */
+  onOpenTask?: (ref: string) => void
 }
 
 export function SessionStatsMenu({
   harness, sessionId, meta, lang, currency, brlRate, startedModel, startedEffort, touch = false,
-  costBasis = 'api', planFactor = null, onOpenFull,
+  costBasis = 'api', planFactor = null, onOpenFull, task, onOpenTask,
 }: SessionStatsMenuProps) {
   const pt = lang === 'pt'
   const [open, setOpen] = useState(false)
@@ -233,6 +249,48 @@ export function SessionStatsMenu({
               }}
             ><X size={13} /></button>
           </div>
+
+          {/* WHICH DELIVERY THIS SESSION BELONGS TO — first, because it is the only line here that
+              is about the WORK rather than about the spend, and it is the one you follow out of
+              this card. Absent entirely for a session filed under nothing: the alternative is a row
+              saying "—", which is the confident zero in another costume. */}
+          {(() => {
+            const link = sessionTaskLink(task, Boolean(onOpenTask))
+            if (link.kind === 'none') return null
+            return (
+              <Block title={pt ? 'Entrega' : 'Delivery'}>
+                {link.kind === 'link' ? (
+                  <button
+                    onClick={() => { onOpenTask?.(link.title); setOpen(false) }}
+                    style={{
+                      display: 'flex', alignItems: 'center', gap: 6, width: '100%',
+                      // 44px is the MOBILE number, and this is a control, not a read-only line.
+                      minHeight: touch ? 44 : 0, padding: 0,
+                      border: 'none', background: 'transparent', color: 'var(--anthropic-orange)',
+                      fontFamily: 'inherit', fontSize: 11.5, fontWeight: 600,
+                      cursor: 'pointer', textAlign: 'left',
+                    }}
+                  >
+                    <ListChecks size={12} style={{ flexShrink: 0 }} />
+                    <span style={{
+                      minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+                    }}>{link.title}</span>
+                    <ChevronRight size={12} style={{ marginLeft: 'auto', flexShrink: 0 }} />
+                  </button>
+                ) : (
+                  <div style={{
+                    display: 'flex', alignItems: 'center', gap: 6,
+                    fontSize: 11.5, lineHeight: 1.7, color: 'var(--text-primary)', fontWeight: 600,
+                  }}>
+                    <ListChecks size={12} style={{ flexShrink: 0, color: 'var(--text-tertiary)' }} />
+                    <span style={{
+                      minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+                    }}>{link.title}</span>
+                  </div>
+                )}
+              </Block>
+            )
+          })()}
 
           {/* HOW THIS SESSION IS RUNNING — before the numbers, because it is what the numbers are
               OF. `model` has two sources and they are not the same claim: what agentop was asked to

--- a/packages/web/src/lib/sessionTaskLink.test.ts
+++ b/packages/web/src/lib/sessionTaskLink.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from 'bun:test'
+import { sessionTaskLink, taskPath } from './sessionTaskLink'
+
+describe('the parent delivery, on the session metrics card', () => {
+  test('a filed session with somewhere to go is a LINK', () => {
+    expect(sessionTaskLink('O terminal na sessão', true)).toEqual({
+      kind: 'link', title: 'O terminal na sessão', path: '/tasks/O%20terminal%20na%20sess%C3%A3o',
+    })
+  })
+
+  test('a filed session with nowhere to go is NAMED, not offered', () => {
+    // The same rule `onOpenFull` keeps in this card: on a surface with nothing to open, the link is
+    // ABSENT rather than inert. But the NAME is still worth saying — knowing which delivery this
+    // session belongs to is the answer even where you cannot navigate to it.
+    expect(sessionTaskLink('ALM board', false)).toEqual({ kind: 'label', title: 'ALM board' })
+  })
+
+  test('a session filed under nothing draws NOTHING — never a dash, never an empty row', () => {
+    expect(sessionTaskLink(undefined, true)).toEqual({ kind: 'none' })
+    expect(sessionTaskLink('', true)).toEqual({ kind: 'none' })
+    expect(sessionTaskLink('   ', true)).toEqual({ kind: 'none' })
+  })
+})
+
+describe('the path is built from a TITLE, and a title is not a path', () => {
+  test('a title carrying a slash does not become two segments', () => {
+    // `feat/x` would route to `/tasks/feat/x`, which matches nothing — the board's route is one
+    // segment. Every other caller in this app already encodes; this is the same rule, tested.
+    expect(taskPath('feat/session-shell')).toBe('/tasks/feat%2Fsession-shell')
+  })
+
+  test('and neither do the other characters a person types into a title', () => {
+    expect(taskPath('50% & rising')).toBe('/tasks/50%25%20%26%20rising')
+    expect(taskPath('a?b#c')).toBe('/tasks/a%3Fb%23c')
+  })
+
+  test('the title is passed through as the REF, which the server resolves by name', () => {
+    // `findTask` tries id, then exact title, then case-insensitively — so the title the fleet row
+    // carries is a ref the board accepts. That is why no id lookup is needed to build this link.
+    expect(taskPath('t-a68ee45199')).toBe('/tasks/t-a68ee45199')
+  })
+})

--- a/packages/web/src/lib/sessionTaskLink.ts
+++ b/packages/web/src/lib/sessionTaskLink.ts
@@ -1,0 +1,50 @@
+/**
+ * sessionTaskLink.ts — PURE. Which DELIVERY a session belongs to, on the session's metrics card.
+ *
+ * The card answers "what has this conversation spent"; this is the one line of identity beside it,
+ * asked for so the delivery is one click away instead of a search on the board.
+ *
+ * **The ref is the TITLE, and that is deliberate rather than lazy.** A fleet row carries
+ * `task?: string` — the delivery's NAME — because the id lives on the session record the server
+ * holds and never reaches the wire. `findTask` (server, `task-report.ts`) resolves a ref by id,
+ * then by exact title, then case-insensitively, so the name the row already has IS a ref the board
+ * accepts. That is what makes this link cost NO extra request: no id lookup, no task list fetched
+ * to open a card. `SessionTasksTab` makes the same join for the same reason and records it as "the
+ * honest join the browser can make"; two places matching by name is one rule, not two.
+ *
+ * The cost of that rule, stated: two deliveries sharing a title would resolve to whichever the
+ * server finds first. Creating a title that already exists returns the existing delivery rather
+ * than a duplicate, so a collision takes a deliberate rename to produce.
+ */
+
+/** What the card should draw for the delivery — three outcomes, and `none` is one of them. */
+export type SessionTaskLink =
+  /** Filed, and there is somewhere to go. */
+  | { kind: 'link'; title: string; path: string }
+  /** Filed, but this surface cannot navigate — say the name, offer no control. */
+  | { kind: 'label'; title: string }
+  /** Filed under nothing. Draw NOTHING: no dash, no empty row. */
+  | { kind: 'none' }
+
+/**
+ * The board's own route for one delivery, from a ref.
+ *
+ * ENCODED, because a title is not a path: `feat/x` would otherwise become `/tasks/feat/x`, two
+ * segments against a one-segment route, and match nothing. Every other caller in this app already
+ * encodes; this is that same rule with a test on it.
+ */
+export function taskPath(ref: string): string {
+  return `/tasks/${encodeURIComponent(ref)}`
+}
+
+/**
+ * @param task    the delivery's name, off the fleet row — absent when the session is filed under
+ *                nothing
+ * @param canOpen does this surface have anywhere to navigate? A card on a screen with no router
+ *                names the delivery and offers no control, the same rule `onOpenFull` keeps.
+ */
+export function sessionTaskLink(task: string | undefined, canOpen: boolean): SessionTaskLink {
+  const title = task?.trim() ?? ''
+  if (!title) return { kind: 'none' }
+  return canOpen ? { kind: 'link', title, path: taskPath(title) } : { kind: 'label', title }
+}

--- a/packages/web/src/pages/SessionsPage.tsx
+++ b/packages/web/src/pages/SessionsPage.tsx
@@ -755,6 +755,10 @@ export default function SessionsPage() {
                 costBasis={ctx.costBasis}
                 planFactor={sessionPlanFactor(ctx.planBasis.basis, selected.harness)}
                 touch
+                // THE DELIVERY, one tap away. The name IS the ref the board resolves, so this
+                // costs no id lookup — see `lib/sessionTaskLink.ts`.
+                {...(selected.task ? { task: selected.task } : {})}
+                onOpenTask={ref => navigate(`/tasks/${encodeURIComponent(ref)}`)}
                 // The full reading is a TAB in the aside, not a second dialog over the session —
                 // withheld when there is no record, exactly as the tab is.
                 {...(sessionMetrics ? { onOpenFull: () => openArtifacts('metrics') } : {})}


### PR DESCRIPTION
## Summary

Uma entrega desde a v2.22.0.

- **A entrega de uma sessão, no card de métricas dela** — primeira linha, com seta para `/tasks/…`, sem custar requisição (o título já é um ref que `findTask` resolve).
- **A aba "Sessões" de uma entrega para de contar a mesma conversa cinco vezes** — o rollup dizia `2 sessões` e a lista ao lado desenhava cinco, quatro delas a mesma conversa com o custo inteiro repetido.
- Um teste que media o estado da máquina em vez do código.

## Motivation

Release de `dev` para `main`. O defeito da lista é o que vale a pena ler: `rollupSessionsFor` aprendeu a contar uma conversa uma vez em 2026-09-08, depois de uma entrega reportar $7.477,50 contra $1.402,92 verdadeiros — cinco vezes no número de manchete. A correção entrou nos NÚMEROS e não na LISTA ao lado deles, então as duas metades da mesma tela discordavam e a etiqueta da aba mentia junto. Numa tela cujo propósito é ler custo, o mesmo custo repetido quatro vezes é a coisa mais cara que ela pode dizer errado.

## Changes

`sessions/task-report.ts` · `web/src/lib/sessionTaskLink.ts` (novo, puro) · `SessionStatsMenu.tsx` · `SessionsPage.tsx` · `App.tsx` · `auth.test.ts`

## Test plan

- [x] `bun tsc --noEmit` limpo e `bun test` verde na origem (#478), CI verde nos dois checks.
- [x] `task-report.test.ts` — as reaberturas de uma conversa colapsam em uma linha; a lista concorda com o rollup ao lado (é o que também conserta a etiqueta da aba); conversas distintas seguem separadas; toda linha sem vínculo de conversa é mantida.
- [x] `sessionTaskLink.test.ts` — as três saídas (`link` / `label` / `none`), e um título com barra não vira dois segmentos de rota.

Ressalva registrada na #478 e mantida: a linha `Entrega` **não foi vista na tela** — o preview isolado não reconcilia registry com as sessões tmux do servidor principal. O que existe são os testes unitários e a tipagem nos dois call sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FUJpqNsYWMfQPaGATN577f
