### PR TITLE
feat(backup): agenda com dias da semana, horário fixo e catch-up de 2h

### DIFF
--- a/docs/backup.md
+++ b/docs/backup.md
@@ -93,8 +93,9 @@ rule deleted in a refactor fails the build instead of shipping a leak, and
 ```bash
 agentop backup [--with-archive] [--with-raw] [--harness a,b] [--dest DIR]
                [--max-bundle MB] [--plan]
-agentop backup schedule <off|daily|weekly>
-agentop backup config [--layers a,b] [--schedule <off|daily|weekly>] [--schedule-layers a,b]
+agentop backup schedule <off|daily|weekly|custom [hours]> [--at HOUR] [--days mon,wed,fri]
+agentop backup config [--layers a,b] [--schedule <off|daily|weekly|custom>] [--schedule-layers a,b]
+               [--at HOUR] [--days mon,wed,fri]
 agentop backup status
 
 agentop restore <archive> [--repos] [--only <repo>]
@@ -113,13 +114,27 @@ partially fail, and a count of successes without the list of what did not come b
 
 ## The schedule
 
-`agentop backup schedule daily|weekly|off`, or `--schedule` on `backup config` (a `custom` interval
-exists with a floor of `MIN_CUSTOM_HOURS`; the raw value is carried unclamped into preferences and
-`intervalMs` is the ONE place that clamps it, so a hand-edited file cannot smuggle a five-minute
-backup past a validation living elsewhere).
+`agentop backup schedule daily|weekly|custom [hours]|off`, or `--schedule` on `backup config` (a
+`custom` interval exists with a floor of `MIN_CUSTOM_HOURS`; the raw value is carried unclamped into
+preferences and `intervalMs` is the ONE place that clamps it, so a hand-edited file cannot smuggle a
+five-minute backup past a validation living elsewhere).
 
 **Absent reads as OFF.** A machine must never start writing gigabytes because it was upgraded — the
 same rule `chat-gate.ts` applies to the local shell.
+
+**`custom` anchors to `--at HOUR` just like `daily`/`weekly` do — a fixed grid, not a rolling
+interval off the last run.** `every 8h from 09h` is 09/17/01, every day, forever: reconnecting late
+never slides the grid to the reconnect time, it only decides whether the ONE missed run is worth
+catching up on right now (see below). `--days mon,wed,fri` (or `0-6`, Sunday first) restricts
+`daily`/`custom` to those weekdays — absent or empty means every day; `weekly` ignores it, since it
+is already pinned to a single day (whichever `lastAt` fell on).
+
+**Catch-up after being off is bounded to ONE run, and only when it is actually worth it.** If the
+machine reconnects with the next normal slot still **more than 2h away**, the missed one runs
+immediately and the grid then continues exactly where it always was (09/17/01, unaffected by when
+the catch-up actually ran). If the next slot is **2h away or less**, nothing runs early — it just
+waits for that slot, so two backups never land within an hour of each other. However many slots
+were missed while the machine was off, at most one catch-up ever fires per reconnect.
 
 **A schedule never carries the `repos` layer.** Rebuilding the manifest means shelling out to git
 across every candidate directory; that is a thing a person asks for (`agentop backup`, or `b` in the

--- a/packages/server/server/backup-routes.ts
+++ b/packages/server/server/backup-routes.ts
@@ -68,9 +68,12 @@ export interface BackupStatusJson {
     scheduleActive: boolean
     /** Hours between runs when `schedule` is `'custom'`; null when it has never been set. */
     customHours: number | null
-    /** The local hour a daily/weekly run is anchored to; null when never chosen (reads as the
-     *  default in `schedule.ts`, which is the one place that decides it). */
+    /** The local hour a daily/weekly/custom run is anchored to; null when never chosen (reads as
+     *  the default in `schedule.ts`, which is the one place that decides it). */
     atHour: number | null
+    /** Which local weekdays (0=Sunday…6=Saturday) `daily`/`custom` may run on; null/empty means
+     *  every day. `weekly` ignores this — see `schedule.ts`'s `ScheduleInput.days`. */
+    days: number[] | null
     keep: number
     /** What EVERY retained backup occupies together, already formatted. */
     retainedLabel: string
@@ -107,8 +110,12 @@ export interface BackupConfigPatch {
   schedule?: ScheduleId
   /** Hours between runs, when `schedule` is `'custom'`. */
   customHours?: number
-  /** The local hour a daily/weekly run is anchored to. */
+  /** The local hour a daily/weekly/custom run is anchored to. */
   atHour?: number
+  /** Which local weekdays (0=Sunday…6=Saturday) `daily`/`custom` may run on. An EMPTY array is a
+   *  meaningful value — it clears a previous restriction back to every day — distinct from leaving
+   *  the field out entirely, which changes nothing. `weekly` ignores this. */
+  days?: number[]
 }
 
 /**
@@ -169,7 +176,7 @@ export async function readBackupStatus(): Promise<BackupStatusJson> {
   const lastAt = lastBackupRun(entries)?.at ?? null
   const st = scheduleStatus({
     schedule: prefs.schedule,
-    customHours: prefs.customHours, atHour: prefs.atHour,
+    customHours: prefs.customHours, atHour: prefs.atHour, days: prefs.days,
     tzOffsetMinutes: new Date().getTimezoneOffset(),
     lastAt,
     nowMs: Date.now(),
@@ -187,6 +194,7 @@ export async function readBackupStatus(): Promise<BackupStatusJson> {
       // number the user last chose rather than an empty field.
       customHours: prefs.customHours ?? null,
       atHour: prefs.atHour ?? null,
+      days: prefs.days?.length ? prefs.days : null,
       scheduleActive: st.kind === 'next',
       keep: prefs.keep,
       retainedLabel: formatBytes(retainedTotal(entries.filter(e => e.present))),
@@ -270,7 +278,12 @@ export async function updateBackupConfig(
     if (patch.atHour !== undefined && !Number.isFinite(patch.atHour)) {
       return { ok: false, reason: 'the hour of day must be a number' }
     }
-    await writeBackupSchedule(patch.schedule, patch.customHours, patch.atHour)
+    // Validated for MEMBERSHIP here — `dayAllowed` (schedule.ts) only ever tests membership, never
+    // the shape of the array it is given, so a bad value here would sail through silently otherwise.
+    if (patch.days !== undefined && patch.days.some(d => !Number.isInteger(d) || d < 0 || d > 6)) {
+      return { ok: false, reason: 'days must be 0-6 (0 = Sunday)' }
+    }
+    await writeBackupSchedule(patch.schedule, patch.customHours, patch.atHour, patch.days)
   }
   return { ok: true, status: await readBackupStatus() }
 }

--- a/packages/server/server/backup/cli-backup.test.ts
+++ b/packages/server/server/backup/cli-backup.test.ts
@@ -129,3 +129,53 @@ test('a stored schedule that names `raw` is honoured, but the default never does
     .toEqual(['metrics', 'raw'])
   expect(readBackupPrefs({}).scheduleLayers).toEqual(['metrics', 'repos'])
 })
+
+// -----------------------------------------------------------------------------
+// `--at` / `--days` — the grid anchor and the weekday filter, on `schedule` and `config`
+// -----------------------------------------------------------------------------
+
+test('`schedule custom` takes the hours right after it, and `--at`/`--days` anywhere after that', () => {
+  const a = parseBackupArgs(['schedule', 'custom', '8', '--at', '9', '--days', 'mon,wed,fri'])
+  if (a.kind !== 'schedule') throw new Error('expected schedule')
+  expect(a.schedule).toBe('custom')
+  expect(a.customHours).toBe(8)
+  expect(a.atHour).toBe(9)
+  expect(a.days).toEqual([1, 3, 5])
+})
+
+test('`schedule custom` with no hours still reads `--at`/`--days` (a flag never starts with a digit)', () => {
+  const a = parseBackupArgs(['schedule', 'custom', '--at', '9'])
+  if (a.kind !== 'schedule') throw new Error('expected schedule')
+  expect(a.customHours).toBeUndefined()
+  expect(a.atHour).toBe(9)
+})
+
+test('`--days` accepts weekday names, digits, or a mix, sorted and deduplicated', () => {
+  const a = parseBackupArgs(['schedule', 'daily', '--days', 'fri,1,mon,1'])
+  if (a.kind !== 'schedule') throw new Error('expected schedule')
+  expect(a.days).toEqual([1, 5])
+})
+
+test('`--days` refuses an unknown token, naming it', () => {
+  const a = parseBackupArgs(['schedule', 'daily', '--days', 'mon,someday'])
+  expect(a.kind).toBe('error')
+  if (a.kind !== 'error') return
+  expect(a.message).toContain('someday')
+})
+
+test('`--at` refuses an hour outside 0-23', () => {
+  expect(parseBackupArgs(['schedule', 'daily', '--at', '24']).kind).toBe('error')
+  expect(parseBackupArgs(['schedule', 'daily', '--at', 'noon']).kind).toBe('error')
+})
+
+test('`config --at`/`--days` parse the same way as `schedule`\'s', () => {
+  const a = parseBackupArgs(['config', '--at', '14', '--days', 'sat,sun'])
+  if (a.kind !== 'config') throw new Error('expected config')
+  expect(a.atHour).toBe(14)
+  expect(a.days).toEqual([0, 6])
+})
+
+test('`readBackupPrefs` filters `days` to valid 0-6 integers rather than trusting a hand-edited file', () => {
+  expect(readBackupPrefs({ backup: { days: [1, 3, 99, -1, 2.5] } } as never).days).toEqual([1, 3])
+  expect(readBackupPrefs({}).days).toBeUndefined()
+})

--- a/packages/server/server/backup/daemon.ts
+++ b/packages/server/server/backup/daemon.ts
@@ -37,7 +37,7 @@ export function startScheduledBackup(log: (line: string) => void = console.log):
       // serverRunning is true by construction: this code only runs inside the daemon.
       const verdict = isDue({
         schedule: prefs.schedule, customHours: prefs.customHours,
-        atHour: prefs.atHour, tzOffsetMinutes: new Date().getTimezoneOffset(),
+        atHour: prefs.atHour, days: prefs.days, tzOffsetMinutes: new Date().getTimezoneOffset(),
         lastAt: last?.at ?? null, nowMs: Date.now(), serverRunning: true,
       })
       if (!verdict.due) return

--- a/packages/server/server/backup/days-arg.ts
+++ b/packages/server/server/backup/days-arg.ts
@@ -1,0 +1,34 @@
+/**
+ * days-arg.ts — PURE. Parsing a `--days` flag's value into `schedule.ts`'s `days: number[]`
+ * (0=Sunday…6=Saturday), shared by every surface that reads it off a command line.
+ *
+ * Accepts either the digit or a three-letter English weekday name (`mon`, `tue`, …), case-
+ * insensitively, comma-separated — the CLI already spells out `SCHEDULE_IDS` and `HARNESS_ORDER`
+ * the same way, so a schedule day is typed the same way as everything else it sits beside on that
+ * line. Digits are accepted too because a hand-written preferences file or a script generating the
+ * flag has no reason to spell out a name for what `schedule.ts` itself always stores as a number.
+ */
+
+/** Index-matches `dayOfWeek`'s 0=Sunday…6=Saturday convention. */
+export const DAY_NAMES = ['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat'] as const
+
+/** `mon,wed,fri` or `1,3,5` (or a mix) -> `[1,3,5]`, sorted and deduplicated — or the bad token(s)
+ *  named so the CLI can refuse with a sentence rather than a silently-wrong schedule. An empty
+ *  string parses to `[]`, which reads as "every day" downstream — the same as never passing `--days`
+ *  at all, but explicit, which is what lets a picker CLEAR a previously-narrowed schedule. */
+export function parseDaysArg(raw: string): number[] | { error: string } {
+  const tokens = raw.split(',').map(s => s.trim().toLowerCase()).filter(Boolean)
+  const days = new Set<number>()
+  const bad: string[] = []
+  for (const token of tokens) {
+    const asNumber = Number(token)
+    if (Number.isInteger(asNumber) && asNumber >= 0 && asNumber <= 6) { days.add(asNumber); continue }
+    const named = DAY_NAMES.indexOf(token as (typeof DAY_NAMES)[number])
+    if (named !== -1) { days.add(named); continue }
+    bad.push(token)
+  }
+  if (bad.length) {
+    return { error: `unknown day: ${bad.join(', ')} (known: ${DAY_NAMES.join(', ')}, or 0-6)` }
+  }
+  return [...days].sort((a, b) => a - b)
+}

--- a/packages/server/server/backup/schedule.test.ts
+++ b/packages/server/server/backup/schedule.test.ts
@@ -2,11 +2,12 @@ import { describe, test, expect } from 'bun:test'
 import { readFileSync } from 'fs'
 import { join } from 'path'
 import {
-  MIN_CUSTOM_HOURS, DEFAULT_HOUR, intervalMs, isDue, scheduleStatus, SCHEDULE_IDS,
-  normalizeHour, hourAnchorOnLocalDay, nextRunMs,
+  MIN_CUSTOM_HOURS, DEFAULT_HOUR, CATCH_UP_LEAD_MS, intervalMs, isDue, scheduleStatus, SCHEDULE_IDS,
+  normalizeHour, hourAnchorOnLocalDay, nextRunMs, dayOfWeek, dayAllowed, gridSlotsInRange,
 } from './schedule'
 
 const DAY = 86_400_000
+const HOUR = 3_600_000
 const now = Date.parse('2026-09-04T12:00:00.000Z')
 
 test('a schedule that is off is never due', () => {
@@ -43,9 +44,6 @@ test('an unparseable lastAt is treated as never run, not as now', () => {
   expect(isDue({ schedule: 'daily', lastAt: 'garbage', nowMs: now, serverRunning: true }).due).toBe(true)
 })
 
-// The rule the spec commits the UI to. Nothing here runs without the daemon, so a "next at 03:00"
-// on a machine whose server is stopped is a promise the product cannot keep. Same N/A-versus-a-
-// confident-0 discipline HARNESS_CAPABILITIES applies to metrics.
 test('with the server stopped nothing is due and the status is `inactive`, with no next time', () => {
   const input = { schedule: 'daily' as const, lastAt: null, nowMs: now, serverRunning: false }
   expect(isDue(input).due).toBe(false)
@@ -54,15 +52,12 @@ test('with the server stopped nothing is due and the status is `inactive`, with 
   expect(s.nextAtMs).toBeNull()
 })
 
-// A daily run is now ANCHORED to an hour, so the next time is that hour on the next day rather
-// than one interval after whenever the last one happened to fire.
 test('with the server running the status names the next anchored time', () => {
   const s = scheduleStatus({
     schedule: 'daily', atHour: 10, tzOffsetMinutes: 0,
     lastAt: new Date(now - DAY / 2).toISOString(), nowMs: now, serverRunning: true,
   })
   expect(s.kind).toBe('next')
-  // last = 2026-09-04T00:00Z, so the next daily run is 2026-09-05T10:00Z.
   expect(s.nextAtMs).toBe(Date.parse('2026-09-05T10:00:00.000Z'))
 })
 
@@ -70,10 +65,6 @@ test('an off schedule reports off, not a missing next time', () => {
   expect(scheduleStatus({ schedule: 'off', lastAt: null, nowMs: now, serverRunning: true }).kind).toBe('off')
 })
 
-// `packages/tui` may not import from `packages/server` (server -> tui is the only allowed
-// direction), so `BackupScheduleId` is redeclared there. This is what stops the two drifting: a
-// value added here and not there would compile fine and simply never be offered by the cockpit —
-// the same guard `central-runtime.test.ts` runs for `CentralRuntimeId`.
 test('the control center\'s BackupScheduleId union matches SCHEDULE_IDS, member for member', () => {
   const source = readFileSync(join(import.meta.dir, '..', '..', '..', 'tui', 'src', 'control', 'types.ts'), 'utf8')
   const decl = source.match(/export type BackupScheduleId = ([^\n]+)/)?.[1]
@@ -83,12 +74,7 @@ test('the control center\'s BackupScheduleId union matches SCHEDULE_IDS, member 
 })
 
 describe('custom — an interval the user picks', () => {
-  const base = { lastAt: null as string | null, nowMs: 1_000_000, serverRunning: true }
-
   test('custom uses customHours, and off/daily/weekly ignore it', () => {
-    // In HOURS, which is the one unit that serves both ends of what people ask for: "every 6
-    // hours" and "every 3 days" are the same field. Days alone cannot express the first; minutes
-    // would invite a value that runs a 112 MB backup every five minutes.
     expect(intervalMs('custom', 6)).toBe(6 * 3_600_000)
     expect(intervalMs('custom', 72)).toBe(72 * 3_600_000)
     expect(intervalMs('daily', 6)).toBe(86_400_000)
@@ -96,37 +82,20 @@ describe('custom — an interval the user picks', () => {
   })
 
   test('a custom interval below the floor is CLAMPED, never honoured', () => {
-    // A backup here is 112 MB and its upload re-downloads the whole file to verify it. An hourly
-    // one is already a lot; anything under that is a machine spending its day backing itself up.
     expect(intervalMs('custom', 0)).toBe(MIN_CUSTOM_HOURS * 3_600_000)
     expect(intervalMs('custom', -5)).toBe(MIN_CUSTOM_HOURS * 3_600_000)
     expect(intervalMs('custom', 0.25)).toBe(MIN_CUSTOM_HOURS * 3_600_000)
   })
 
   test('a missing or unusable customHours falls back to daily, never to "never"', () => {
-    // A schedule the user switched ON must not silently become one that never fires. Falling back
-    // to daily keeps the promise; falling back to `null` breaks it in the direction where nobody
-    // notices until they need the backup.
     expect(intervalMs('custom', undefined)).toBe(86_400_000)
     expect(intervalMs('custom', Number.NaN)).toBe(86_400_000)
-  })
-
-  test('isDue and scheduleStatus both honour it', () => {
-    const six = { ...base, schedule: 'custom' as const, customHours: 6 }
-    expect(isDue({ ...six, lastAt: new Date(six.nowMs - 5 * 3_600_000).toISOString() }).due).toBe(false)
-    expect(isDue({ ...six, lastAt: new Date(six.nowMs - 7 * 3_600_000).toISOString() }).due).toBe(true)
-    const st = scheduleStatus({ ...six, lastAt: new Date(six.nowMs).toISOString() })
-    expect(st.kind).toBe('next')
-    if (st.kind !== 'next') return
-    expect(st.nextAtMs).toBe(six.nowMs + 6 * 3_600_000)
   })
 
   test('custom is in SCHEDULE_IDS, so every surface offering the list offers it', () => {
     expect(SCHEDULE_IDS).toContain('custom')
   })
 })
-
-// --- the hour of the day ----------------------------------------------------
 
 test('an hour outside the clock is clamped, never refused — a field is an intent', () => {
   expect(normalizeHour(undefined)).toBe(DEFAULT_HOUR)
@@ -137,15 +106,12 @@ test('an hour outside the clock is clamped, never refused — a field is an inte
 })
 
 test('the anchor lands on the local clock, not on UTC', () => {
-  // UTC-3: 10:00 local is 13:00Z.
   const at = hourAnchorOnLocalDay(Date.parse('2026-09-04T12:00:00Z'), 1, 10, 180)
   expect(new Date(at).toISOString()).toBe('2026-09-05T13:00:00.000Z')
 })
 
-// THE BUG THIS EXISTS FOR: "daily" fired every 15 minutes. It must fire once.
 test('a daily run already taken today is not due again today', () => {
   const base = { schedule: 'daily' as const, atHour: 10, tzOffsetMinutes: 0, serverRunning: true }
-  // Ran at 09:00, and it is now 11:00 — the anchor hour has passed, but the day already has a run.
   const v = isDue({ ...base, lastAt: '2026-09-04T09:00:00.000Z', nowMs: Date.parse('2026-09-04T11:00:00Z') })
   expect(v.due).toBe(false)
   if (v.due) return
@@ -158,12 +124,10 @@ test('a daily run is due at the anchor hour the next day, and not before', () =>
   expect(isDue({ ...base, nowMs: Date.parse('2026-09-05T10:00:00Z') }).due).toBe(true)
 })
 
-// The machine that was off through its hour: it comes back OWED, runs once, then waits.
 test('a missed window is owed on start, and the run after it is the next anchor', () => {
   const base = { schedule: 'daily' as const, atHour: 10, tzOffsetMinutes: 0, serverRunning: true }
   const bootedLate = Date.parse('2026-09-06T14:00:00Z')
   expect(isDue({ ...base, lastAt: '2026-09-04T10:00:00.000Z', nowMs: bootedLate }).due).toBe(true)
-  // Having run at 14:00, the next one is 10:00 the following day — not immediately, not a day late.
   const after = nextRunMs({ ...base, lastAt: null, nowMs: bootedLate }, bootedLate)
   expect(new Date(after!).toISOString()).toBe('2026-09-07T10:00:00.000Z')
 })
@@ -171,19 +135,9 @@ test('a missed window is owed on start, and the run after it is the next anchor'
 test('a weekly run is anchored a week on, at the same hour', () => {
   const after = nextRunMs(
     { schedule: 'weekly', atHour: 8, tzOffsetMinutes: 0, lastAt: null, nowMs: now, serverRunning: true },
-    Date.parse('2026-09-04T09:00:00Z'),
+    Date.parse('2026-09-04T09:00Z'),
   )
   expect(new Date(after!).toISOString()).toBe('2026-09-11T08:00:00.000Z')
-})
-
-// An interval cadence has no time of day, and forcing one on it would turn it into something else.
-test('a custom interval keeps interval semantics, unanchored', () => {
-  const last = Date.parse('2026-09-04T09:13:00Z')
-  const after = nextRunMs(
-    { schedule: 'custom', customHours: 6, atHour: 10, tzOffsetMinutes: 0, lastAt: null, nowMs: now, serverRunning: true },
-    last,
-  )
-  expect(after).toBe(last + 6 * 3_600_000)
 })
 
 test('an owed run is reported as now, never as a time already past', () => {
@@ -194,4 +148,140 @@ test('an owed run is reported as now, never as a time already past', () => {
   expect(s.kind).toBe('next')
   if (s.kind !== 'next') return
   expect(s.nextAtMs).toBe(now)
+})
+
+describe('custom now anchors to atHour — a fixed grid, never one that drifts to a late reconnect', () => {
+  const GRID_AT_HOUR = 9
+  const GRID_EVERY_HOURS = 8
+  const base = {
+    schedule: 'custom' as const, customHours: GRID_EVERY_HOURS, atHour: GRID_AT_HOUR,
+    tzOffsetMinutes: 0, serverRunning: true,
+  }
+
+  test('an 8-in-8h grid anchored at 09h reads 09 / 17 / 01, every day, forever', () => {
+    const slots = gridSlotsInRange(
+      GRID_AT_HOUR, GRID_EVERY_HOURS, 0, undefined,
+      Date.parse('2026-09-04T08:00:00.000Z'), Date.parse('2026-09-05T02:00:00.000Z'),
+    )
+    expect(slots.map(t => new Date(t).toISOString())).toEqual([
+      '2026-09-04T09:00:00.000Z',
+      '2026-09-04T17:00:00.000Z',
+      '2026-09-05T01:00:00.000Z',
+    ])
+  })
+
+  test('the grid does not reset phase at midnight — it keeps stepping across the day boundary', () => {
+    // 01:00 the next day is a real grid slot (09 - 8 = 01, wrapping past midnight), not just 09/17.
+    const slots = gridSlotsInRange(GRID_AT_HOUR, GRID_EVERY_HOURS, 0, undefined,
+      Date.parse('2026-09-04T00:30:00.000Z'), Date.parse('2026-09-04T01:30:00.000Z'))
+    expect(slots).toEqual([Date.parse('2026-09-04T01:00:00.000Z')])
+  })
+
+  test('nextRunMs never drifts: a `last` anywhere still lands on the fixed grid', () => {
+    // `last` recorded at an arbitrary, off-grid instant (a late catch-up run) — the NEXT slot the
+    // grid names is still 09/17/01, never "last + 8h" from the odd instant it actually ran.
+    const late = Date.parse('2026-09-04T06:00:00.000Z')
+    const next = nextRunMs({ ...base, lastAt: null, nowMs: late }, late)
+    expect(new Date(next!).toISOString()).toBe('2026-09-04T09:00:00.000Z')
+  })
+
+  test('reconnecting 2h+ before the next grid slot runs the missed backup now (confirmed example: 06h, next at 09h)', () => {
+    const v = isDue({
+      ...base, lastAt: '2026-09-01T09:00:00.000Z', nowMs: Date.parse('2026-09-04T06:00:00.000Z'),
+    })
+    expect(v.due).toBe(true)
+  })
+
+  test('reconnecting less than 2h before the next grid slot waits instead (confirmed example: 07h, next at 09h)', () => {
+    const v = isDue({
+      ...base, lastAt: '2026-09-01T09:00:00.000Z', nowMs: Date.parse('2026-09-04T07:00:00.000Z'),
+    })
+    expect(v.due).toBe(false)
+    if (v.due) return
+    expect(v.reason).toBe('too-close-to-next')
+  })
+
+  test('the boundary is exclusive: a gap of exactly 2h still waits, a gap just over 2h runs', () => {
+    expect(CATCH_UP_LEAD_MS).toBe(2 * HOUR)
+    const lastAt = '2026-09-01T09:00:00.000Z'
+    const exactlyTwoHours = isDue({ ...base, lastAt, nowMs: Date.parse('2026-09-04T09:00:00.000Z') - CATCH_UP_LEAD_MS })
+    expect(exactlyTwoHours.due).toBe(false)
+    const justOver = isDue({ ...base, lastAt, nowMs: Date.parse('2026-09-04T09:00:00.000Z') - CATCH_UP_LEAD_MS - 1 })
+    expect(justOver.due).toBe(true)
+  })
+
+  test('never more than one catch-up: several missed slots still only ever ask about the one nearest to now', () => {
+    // `last` is days behind — many grid slots were missed — but the verdict only ever depends on
+    // the gap from `now` to the single next future slot, never on how many were skipped.
+    const v = isDue({
+      ...base, lastAt: '2026-08-20T09:00:00.000Z', nowMs: Date.parse('2026-09-04T06:00:00.000Z'),
+    })
+    expect(v.due).toBe(true)
+  })
+
+  test('an ordinary, on-time tick always fires — the 2h buffer never suppresses the routine trigger', () => {
+    // Only ONE slot has elapsed since `last` (17h -> the very next slot, 01h) — this is the normal
+    // periodic tick, not a reconnect, so it must fire even though the FOLLOWING slot (09h) is less
+    // than 2h away from `now` at the moment it becomes due.
+    const v = isDue({
+      ...base, lastAt: '2026-09-03T17:00:00.000Z', nowMs: Date.parse('2026-09-04T01:00:00.000Z'),
+    })
+    expect(v.due).toBe(true)
+  })
+
+  test('a short custom interval (below the 2h buffer) still fires on its ordinary schedule', () => {
+    // An hourly grid never has more than an hour to its next slot, so if the routine tick required
+    // clearing the 2h buffer it could never fire at all. It must not.
+    const hourly = { schedule: 'custom' as const, customHours: 1, atHour: 0, tzOffsetMinutes: 0, serverRunning: true }
+    const v = isDue({ ...hourly, lastAt: '2026-09-04T03:00:00.000Z', nowMs: Date.parse('2026-09-04T04:05:00.000Z') })
+    expect(v.due).toBe(true)
+  })
+})
+
+describe('days — restricting a schedule to specific weekdays', () => {
+  test('absent or empty `days` means every day (no regression for configs saved before the field existed)', () => {
+    const at = Date.parse('2026-09-04T12:00:00.000Z')
+    expect(dayAllowed(at, 0, undefined)).toBe(true)
+    expect(dayAllowed(at, 0, [])).toBe(true)
+  })
+
+  test('a day outside the filter is skipped, even though the plain hour math lines up', () => {
+    const lastAt = '2026-09-07T10:00:00.000Z'
+    const allowedDay = dayOfWeek(Date.parse(lastAt), 0)
+    // Exactly 24h later, same hour — due under no filter, but that next calendar day is a
+    // DIFFERENT weekday, so restricting to `last`'s own weekday must push it out to next week.
+    const v = isDue({
+      schedule: 'daily', atHour: 10, tzOffsetMinutes: 0, days: [allowedDay],
+      lastAt, nowMs: Date.parse(lastAt) + DAY, serverRunning: true,
+    })
+    expect(v.due).toBe(false)
+    if (v.due) return
+    expect(v.reason).toBe('not-yet')
+    const next = nextRunMs({
+      schedule: 'daily', atHour: 10, tzOffsetMinutes: 0, days: [allowedDay],
+      lastAt, nowMs: Date.parse(lastAt) + DAY, serverRunning: true,
+    }, Date.parse(lastAt))
+    expect(next).toBe(Date.parse(lastAt) + 7 * DAY)
+  })
+
+  test('a matching weekday still fires normally', () => {
+    const lastAt = '2026-09-07T10:00:00.000Z'
+    const allowedDay = dayOfWeek(Date.parse(lastAt), 0)
+    const v = isDue({
+      schedule: 'daily', atHour: 10, tzOffsetMinutes: 0, days: [allowedDay],
+      lastAt, nowMs: Date.parse(lastAt) + 7 * DAY, serverRunning: true,
+    })
+    expect(v.due).toBe(true)
+  })
+
+  test('weekly ignores `days` — it is already pinned to a single weekday by `lastAt`', () => {
+    const after = nextRunMs(
+      {
+        schedule: 'weekly', atHour: 8, tzOffsetMinutes: 0, days: [1, 2, 3, 4, 5],
+        lastAt: null, nowMs: now, serverRunning: true,
+      },
+      Date.parse('2026-09-04T09:00Z'),
+    )
+    expect(new Date(after!).toISOString()).toBe('2026-09-11T08:00:00.000Z')
+  })
 })

--- a/packages/server/server/backup/schedule.ts
+++ b/packages/server/server/backup/schedule.ts
@@ -32,13 +32,27 @@ const HOUR_MS = 3_600_000
 export const MIN_CUSTOM_HOURS = 1
 
 /**
- * The hour of the local day a `daily` / `weekly` run is anchored to.
+ * The hour of the local day a `daily` / `weekly` / `custom` run is anchored to.
  *
  * A cadence with no time of day is a cadence anchored to whenever the machine last happened to run
  * one, which drifts and lands in the middle of the working day. Mid-morning is the default because
  * the machine is on by then and the run is not competing with a login.
  */
 export const DEFAULT_HOUR = 10
+
+/**
+ * How long the next scheduled slot must still be away for a missed one to be worth catching up on
+ * right now (`isDue`'s `'too-close-to-next'` reason).
+ *
+ * Confirmed with the user against a concrete pair: reconnecting at 06h with an 8-in-8h grid
+ * anchored at 09h (so the grid is 01/09/17) runs the missed backup immediately, because the next
+ * normal slot (09h) is still 3h away — but reconnecting at 07h, with that same 09h only 2h away,
+ * waits for it instead of running two backups within the hour of each other. The boundary is
+ * therefore EXCLUSIVE on the "run now" side: a gap of exactly two hours still waits, only a gap
+ * that exceeds two hours triggers the catch-up. Never reopen this — see the task's confirmed
+ * decision.
+ */
+export const CATCH_UP_LEAD_MS = 2 * HOUR_MS
 
 /** An hour outside 0–23 is not an hour. Clamped, never refused: a field is an intent. */
 export function normalizeHour(h: number | undefined): number {
@@ -94,15 +108,48 @@ export function intervalMs(schedule: ScheduleId, customHours?: number): number |
   return Math.max(MIN_CUSTOM_HOURS, customHours) * HOUR_MS
 }
 
+/**
+ * 0 = Sunday … 6 = Saturday, the local day-of-week `ms` falls on.
+ *
+ * 1970-01-01 (epoch day 0) was a Thursday (weekday 4), so an arbitrary day index is folded back to
+ * that reference rather than trusting `Date`'s own day-of-week reader — which would need a `Date`
+ * object per call for what is otherwise integer arithmetic identical to every other local-frame
+ * computation in this file.
+ */
+export function dayOfWeek(ms: number, tzOffsetMinutes: number): number {
+  const offset = tzOffsetMinutes * 60_000
+  const local = ms - offset
+  const dayIndex = Math.floor(local / DAY_MS)
+  return (((dayIndex + 4) % 7) + 7) % 7
+}
+
+/**
+ * Is `ms` on one of the allowed weekdays? Absent or empty `days` means every day — the same
+ * "absence is not a more restrictive value" convention the rest of the product follows (never
+ * invert this: a config saved before `days` existed must keep running every day it always did).
+ */
+export function dayAllowed(ms: number, tzOffsetMinutes: number, days: number[] | undefined): boolean {
+  if (!days || days.length === 0) return true
+  return days.includes(dayOfWeek(ms, tzOffsetMinutes))
+}
+
 export interface ScheduleInput {
   schedule: ScheduleId
   /** Only read when `schedule` is `'custom'`. See `intervalMs`. */
   customHours?: number
-  /** The local hour a daily/weekly run is anchored to. Absent reads as `DEFAULT_HOUR`.
-   *  Meaningless for `custom`, which is an interval and has no time of day. */
+  /** The local hour a daily/weekly/custom run is anchored to. Absent reads as `DEFAULT_HOUR`.
+   *  For `custom` this is the grid's own anchor (see `nextRunMs`), not a per-day time of day — the
+   *  grid steps by `customHours` from this hour indefinitely, never resetting phase at midnight. */
   atHour?: number
   /** `new Date().getTimezoneOffset()` from the caller — see `hourAnchorAfter`. */
   tzOffsetMinutes?: number
+  /** Which local weekdays (0=Sunday…6=Saturday) the schedule may run on. Absent or empty means
+   *  every day — this is the DEFAULT, never a more restrictive reading, so a config saved before
+   *  this field existed keeps running every day it always did. Applies to `daily` and `custom`;
+   *  `weekly` ignores it — it is already pinned to a single day of the week, the one `lastAt` fell
+   *  on, and a second day-of-week filter on top of that would just be a more confusing way to
+   *  express the same "one day a week" idea. */
+  days?: number[]
   /** ISO of the last run, or null. Unparseable reads as never — a corrupt timestamp must not
    *  suppress backups forever, which is what treating it as "now" would do. */
   lastAt: string | null
@@ -112,7 +159,7 @@ export interface ScheduleInput {
 
 export type ScheduleVerdict =
   | { due: true }
-  | { due: false; reason: 'off' | 'not-yet' | 'no-server' }
+  | { due: false; reason: 'off' | 'not-yet' | 'no-server' | 'too-close-to-next' }
 
 export type ScheduleStatus =
   | { kind: 'off'; nextAtMs: null }
@@ -126,22 +173,115 @@ function lastMs(lastAt: string | null): number | null {
 }
 
 /**
- * When the run AFTER `last` is owed.
+ * The smallest `daily` grid slot that is strictly after `ms`, honouring `days`.
  *
- * One rule for all three schedules, which is what makes the missed-window case fall out instead of
- * needing a branch of its own: `daily` is the anchor hour on the NEXT local day, `weekly` the
- * anchor hour a week on, and `custom` a plain interval — an "every 6 hours" cadence has no time of
- * day to anchor to, and forcing one on it would turn it into something else.
+ * `minOffsetDays` is what makes the SAME stepping function serve two different questions: called
+ * with `1` (from `last`) it enforces "never the same calendar day as `last`", which is the
+ * invariant that makes `daily` mean at most once a day rather than "an hour after whatever last
+ * happened to run". Called with `0` (from `now`, for the catch-up check below) it allows TODAY's
+ * slot if the anchor hour has not passed yet — a different question ("when does the grid next
+ * fire from here"), asked with no `last` in the picture at all.
  *
- * A machine that was off through its hour comes back with the run already OWED, runs it once on
- * start, and is then due again on the next anchored day — not immediately, and not a day late.
+ * Bounded at 7 days past the starting offset: `days` names at most 7 distinct weekdays, so an
+ * allowed one is always found within one full week of stepping, and the loop cannot run away on a
+ * config that (incorrectly) names no valid day at all.
+ */
+function dailyNextAllowed(
+  ms: number, atHour: number, tzOffsetMinutes: number, days: number[] | undefined, minOffsetDays: number,
+): number {
+  for (let offset = minOffsetDays; offset <= minOffsetDays + 7; offset++) {
+    const candidate = hourAnchorOnLocalDay(ms, offset, atHour, tzOffsetMinutes)
+    if (candidate > ms && dayAllowed(candidate, tzOffsetMinutes, days)) return candidate
+  }
+  // Unreachable while `days` names at least one valid weekday (the loop above always finds one
+  // within 7 days); kept as a total fallback rather than letting the function ever return undefined.
+  return hourAnchorOnLocalDay(ms, minOffsetDays + 8, atHour, tzOffsetMinutes)
+}
+
+/**
+ * The instant a `custom` grid is anchored to: `atHour` local, on the local day holding the epoch.
+ *
+ * Any instant at local-hour `atHour` works as the anchor — grid slots are this plus any whole
+ * multiple of the interval, forever in both directions — so the epoch is just a fixed, arbitrary
+ * reference that never moves. This is the fix for the bug the redesign exists to close: the OLD
+ * `custom` anchored to `last`, so a late reconnect slid the whole grid to the reconnect time
+ * instead of keeping it at the fixed 09/17/01 (or whatever hours) the user configured.
+ */
+function customGridAnchorMs(atHour: number, tzOffsetMinutes: number): number {
+  return hourAnchorOnLocalDay(0, 0, atHour, tzOffsetMinutes)
+}
+
+/**
+ * The smallest `custom` grid slot that is strictly after `ms`, honouring `days`.
+ *
+ * `everyMs` is the ALREADY-CLAMPED interval (`intervalMs`'s return value) — this function never
+ * re-derives the floor or the "unusable falls back to daily" rule, so there is exactly one place
+ * that decides what a custom interval means in milliseconds.
+ *
+ * Bounded the same way `dailyNextAllowed` is: at most 7 days' worth of slots need scanning before
+ * an allowed weekday repeats, however short the interval.
+ */
+function customNextAllowed(
+  ms: number, atHour: number, everyMs: number, tzOffsetMinutes: number, days: number[] | undefined,
+): number {
+  const anchor = customGridAnchorMs(atHour, tzOffsetMinutes)
+  let index = Math.floor((ms - anchor) / everyMs) + 1
+  const maxSteps = Math.ceil((7 * DAY_MS) / everyMs) + 1
+  for (let i = 0; i < maxSteps; i++) {
+    const candidate = anchor + index * everyMs
+    if (dayAllowed(candidate, tzOffsetMinutes, days)) return candidate
+    index++
+  }
+  // Same total-fallback rationale as `dailyNextAllowed`.
+  return anchor + index * everyMs
+}
+
+/**
+ * Every `custom` grid slot in `[fromMs, toMs)`, honouring `days`.
+ *
+ * Not read by `isDue`/`nextRunMs` — those only ever need ONE slot at a time — but exposed for a
+ * surface that wants to preview the grid a schedule describes (and for tests to pin the exact
+ * example the catch-up rule was confirmed against: an 8-hour grid anchored at 09h reads 09/17/01,
+ * every day, forever).
+ */
+export function gridSlotsInRange(
+  atHour: number, everyHours: number, tzOffsetMinutes: number,
+  days: number[] | undefined, fromMs: number, toMs: number,
+): number[] {
+  const anchor = customGridAnchorMs(normalizeHour(atHour), tzOffsetMinutes)
+  const everyMs = Math.max(MIN_CUSTOM_HOURS, everyHours) * HOUR_MS
+  const out: number[] = []
+  let index = Math.ceil((fromMs - anchor) / everyMs)
+  for (let t = anchor + index * everyMs; t < toMs; index++, t = anchor + index * everyMs) {
+    if (t >= fromMs && dayAllowed(t, tzOffsetMinutes, days)) out.push(t)
+  }
+  return out
+}
+
+/**
+ * When the run AFTER `last` is owed — the single "next scheduled slot" a status display shows.
+ *
+ * One rule per schedule kind: `weekly` keeps the exact anchor-a-week-on reading it always had
+ * (untouched by this file's redesign — see `ScheduleInput.days`); `daily` and `custom` both go
+ * through their own grid-stepping function, which is where the catch-up-related behaviour below
+ * (`isDue`) also gets its grid slots from, so the two can never disagree about what the next slot
+ * after any given instant is.
+ *
+ * A machine that was off through its hour comes back with the run already OWED; whether it is
+ * worth running THAT SPECIFIC missed run right now, or waiting for the grid's own next slot, is
+ * `isDue`'s job, not this function's — `nextRunMs` only ever answers "what slot comes after this
+ * one", which is exactly what a status display needs regardless of the catch-up question.
  */
 export function nextRunMs(input: ScheduleInput, last: number): number | null {
   const every = intervalMs(input.schedule, input.customHours)
   if (every === null) return null
-  if (input.schedule === 'custom') return last + every
   const tz = input.tzOffsetMinutes ?? 0
-  return hourAnchorOnLocalDay(last, input.schedule === 'weekly' ? 7 : 1, normalizeHour(input.atHour), tz)
+  if (input.schedule === 'weekly') {
+    return hourAnchorOnLocalDay(last, 7, normalizeHour(input.atHour), tz)
+  }
+  const atHour = normalizeHour(input.atHour)
+  if (input.schedule === 'daily') return dailyNextAllowed(last, atHour, tz, input.days, 1)
+  return customNextAllowed(last, atHour, every, tz, input.days)
 }
 
 export function isDue(input: ScheduleInput): ScheduleVerdict {
@@ -150,9 +290,39 @@ export function isDue(input: ScheduleInput): ScheduleVerdict {
   if (!input.serverRunning) return { due: false, reason: 'no-server' }
   const last = lastMs(input.lastAt)
   if (last === null) return { due: true }
-  const next = nextRunMs(input, last)
-  if (next === null) return { due: false, reason: 'off' }
-  return input.nowMs >= next ? { due: true } : { due: false, reason: 'not-yet' }
+
+  if (input.schedule === 'weekly') {
+    const next = nextRunMs(input, last)
+    if (next === null) return { due: false, reason: 'off' }
+    return input.nowMs >= next ? { due: true } : { due: false, reason: 'not-yet' }
+  }
+
+  const tz = input.tzOffsetMinutes ?? 0
+  const atHour = normalizeHour(input.atHour)
+  const isDaily = input.schedule === 'daily'
+  const slotAfter = (ms: number, minOffsetDays: number) => isDaily
+    ? dailyNextAllowed(ms, atHour, tz, input.days, minOffsetDays)
+    : customNextAllowed(ms, atHour, every, tz, input.days)
+
+  const nextAfterLast = slotAfter(last, 1)
+  if (input.nowMs < nextAfterLast) return { due: false, reason: 'not-yet' }
+
+  // More than one grid slot has passed since `last` only when the slot AFTER the owed one has
+  // also already gone by. That is the one thing distinguishing a genuine reconnect-after-being-off
+  // from the ordinary, on-time tick every schedule reaches once per interval — an ordinary tick
+  // always finds `nextAfterLast` still ahead of the FOLLOWING slot, so it fires unconditionally
+  // here, with no 2h consideration at all. Skipping this distinction would apply the 2h buffer to
+  // every trigger, which quietly disables any interval of 2h or under (its own gap to the next
+  // slot is never more than 2h even when firing exactly on schedule).
+  const followingSlot = slotAfter(nextAfterLast, 1)
+  if (input.nowMs < followingSlot) return { due: true }
+
+  // Genuine catch-up territory: at least one whole slot has been skipped. Whether to run the
+  // overdue one now or just wait for the grid's own next occurrence turns on how soon that next
+  // occurrence is — see `CATCH_UP_LEAD_MS`'s doc comment for the confirmed boundary.
+  const nextFutureSlot = slotAfter(input.nowMs, 0)
+  const gap = nextFutureSlot - input.nowMs
+  return gap > CATCH_UP_LEAD_MS ? { due: true } : { due: false, reason: 'too-close-to-next' }
 }
 
 export function scheduleStatus(input: ScheduleInput): ScheduleStatus {

--- a/packages/server/server/cli-backup.ts
+++ b/packages/server/server/cli-backup.ts
@@ -26,7 +26,8 @@ import { probeAll, candidatePaths, createBundle, capturePatch, listUntracked } f
 import { groupRepos, expandHome, assetRel, type RepoEntry } from './backup/repo-manifest'
 import { planRepos } from './backup/restore-plan'
 import { readManifestOf, restoreMetrics, restoreRepos, readRestoreState, restoreStateFile } from './backup/restore'
-import { MIN_CUSTOM_HOURS, SCHEDULE_IDS, scheduleStatus, type ScheduleId } from './backup/schedule'
+import { MIN_CUSTOM_HOURS, SCHEDULE_IDS, scheduleStatus, normalizeHour, type ScheduleId } from './backup/schedule'
+import { parseDaysArg, DAY_NAMES } from './backup/days-arg'
 import { loadConsolidated } from './consolidate'
 import { confirm, maskedInput } from './cli-ui'
 import { parseRepoUrl, repoUrlHost } from './backup/github-api'
@@ -50,9 +51,12 @@ export interface BackupPrefs {
   schedule: ScheduleId
   /** Hours between runs when `schedule` is `'custom'`. Undefined otherwise. */
   customHours?: number
-  /** The local hour a `daily`/`weekly` run is anchored to. Undefined reads as `DEFAULT_HOUR`
-   *  in `schedule.ts`, which is the one place that clamps and defaults it. */
+  /** The local hour a `daily`/`weekly`/`custom` run is anchored to. Undefined reads as
+   *  `DEFAULT_HOUR` in `schedule.ts`, which is the one place that clamps and defaults it. */
   atHour?: number
+  /** Which local weekdays (0=Sunday…6=Saturday) `daily`/`custom` may run on. Undefined or empty
+   *  means every day — see `schedule.ts`'s `ScheduleInput.days`. `weekly` ignores this. */
+  days?: number[]
   layers: BackupLayer[]
   scheduleLayers: BackupLayer[]
   harnesses: HarnessId[]
@@ -74,6 +78,11 @@ export function readBackupPrefs(p: Preferences): BackupPrefs {
     // Carried raw for the same reason as `customHours`: `normalizeHour` is the one place that
     // clamps it, so a hand-edited file cannot smuggle an hour past a validation living elsewhere.
     atHour: typeof b.atHour === 'number' ? b.atHour : undefined,
+    // Filtered rather than trusted whole: a hand-edited file could hold anything, and `schedule.ts`
+    // itself only ever validates membership (`dayAllowed`), never the shape of the array it is given.
+    days: Array.isArray(b.days)
+      ? b.days.filter((d): d is number => Number.isInteger(d) && d >= 0 && d <= 6)
+      : undefined,
     layers,
     scheduleLayers: (b.scheduleLayers as BackupLayer[] | undefined) ?? DEFAULT_LAYERS,
     harnesses: (b.harnesses as HarnessId[] | undefined)?.filter(h => HARNESS_ORDER.includes(h)) ?? [...HARNESS_ORDER],
@@ -163,11 +172,14 @@ export async function writeBackupScheduleLayers(layers: BackupLayer[]): Promise<
 }
 
 export async function writeBackupSchedule(
-  schedule: ScheduleId, customHours?: number, atHour?: number,
+  schedule: ScheduleId, customHours?: number, atHour?: number, days?: number[],
 ): Promise<void> {
   const p = await readPreferences()
-  // `customHours` and `atHour` are written only when given, so switching to `weekly` and back to
-  // `custom` returns to the number the user had chosen rather than to a default they never picked.
+  // `customHours`, `atHour` and `days` are written only when GIVEN, so switching to `weekly` and
+  // back to `custom` returns to the number/days the user had chosen rather than to a default they
+  // never picked. `days` is the one of the three that can be meaningfully "given" as an EMPTY
+  // array — that is how a picker clears a previous weekday restriction back to every day, and it
+  // must be distinguished from not touching the field at all (`undefined`).
   await writePreferences({
     ...p,
     backup: {
@@ -175,6 +187,7 @@ export async function writeBackupSchedule(
       schedule,
       ...(customHours === undefined ? null : { customHours }),
       ...(atHour === undefined ? null : { atHour }),
+      ...(days === undefined ? null : { days }),
     },
   })
 }
@@ -190,7 +203,7 @@ export type BackupArgs =
       maxBundleBytes?: number
       planOnly: boolean
     }
-  | { kind: 'schedule'; schedule: ScheduleId; customHours?: number }
+  | { kind: 'schedule'; schedule: ScheduleId; customHours?: number; atHour?: number; days?: number[] }
   | {
       kind: 'config'
       /** Each field present only when the matching flag was given. All absent means "print the
@@ -198,6 +211,8 @@ export type BackupArgs =
       layers?: BackupLayer[]
       schedule?: ScheduleId
       scheduleLayers?: BackupLayer[]
+      atHour?: number
+      days?: number[]
     }
   | { kind: 'status' }
   | { kind: 'github-status' }
@@ -242,22 +257,49 @@ export function parseBackupArgs(argv: string[]): BackupArgs {
     if (!id || !SCHEDULE_IDS.includes(id as ScheduleId)) {
       return { kind: 'error', message: `schedule takes one of: ${SCHEDULE_IDS.join(', ')}` }
     }
+
+    // `--at`/`--days` are read regardless of position, and apply to `daily`/`custom`/`weekly` alike
+    // (`weekly` simply ignores `days` — see `schedule.ts`). Neither is an error to omit: an absent
+    // `--at` reads as `DEFAULT_HOUR` and an absent `--days` as every day, exactly as a hand-edited
+    // preferences file would.
+    let atHour: number | undefined
+    const ai = rest.indexOf('--at')
+    if (ai !== -1) {
+      const hour = Number(rest[ai + 1])
+      if (!Number.isFinite(hour) || hour < 0 || hour > 23) {
+        return { kind: 'error', message: '--at takes an hour of the day, 0-23' }
+      }
+      atHour = hour
+    }
+    let days: number[] | undefined
+    const di = rest.indexOf('--days')
+    if (di !== -1) {
+      const parsed = parseDaysArg(rest[di + 1] ?? '')
+      if ('error' in parsed) return { kind: 'error', message: parsed.error }
+      days = parsed
+    }
+
     if (id === 'custom') {
       // `schedule custom` with no number is not an error — `intervalMs` defaults it to daily and
-      // says so. Refusing here would make the CLI stricter than the rule it is enforcing.
+      // says so. Refusing here would make the CLI stricter than the rule it is enforcing. The
+      // number, when given, is always the token right after `custom` — `--at`/`--days` never sit
+      // there, since a flag never starts with a digit.
       const raw = rest[1]
-      if (raw === undefined) return { kind: 'schedule', schedule: 'custom' }
+      if (raw === undefined || raw.startsWith('--')) return { kind: 'schedule', schedule: 'custom', atHour, days }
       const hours = Number(raw)
       if (!Number.isFinite(hours) || hours <= 0) {
         return { kind: 'error', message: 'schedule custom takes a number of hours, e.g. `schedule custom 6`' }
       }
-      return { kind: 'schedule', schedule: 'custom', customHours: hours }
+      return { kind: 'schedule', schedule: 'custom', customHours: hours, atHour, days }
     }
-    return { kind: 'schedule', schedule: id as ScheduleId }
+    return { kind: 'schedule', schedule: id as ScheduleId, atHour, days }
   }
 
   if (first === 'config') {
-    const out: { layers?: BackupLayer[]; schedule?: ScheduleId; scheduleLayers?: BackupLayer[] } = {}
+    const out: {
+      layers?: BackupLayer[]; schedule?: ScheduleId; scheduleLayers?: BackupLayer[]
+      atHour?: number; days?: number[]
+    } = {}
 
     const li = rest.indexOf('--layers')
     if (li !== -1) {
@@ -280,6 +322,22 @@ export function parseBackupArgs(argv: string[]): BackupArgs {
         return { kind: 'error', message: `--schedule takes one of: ${SCHEDULE_IDS.join(', ')}` }
       }
       out.schedule = id as ScheduleId
+    }
+
+    const ai = rest.indexOf('--at')
+    if (ai !== -1) {
+      const hour = Number(rest[ai + 1])
+      if (!Number.isFinite(hour) || hour < 0 || hour > 23) {
+        return { kind: 'error', message: '--at takes an hour of the day, 0-23' }
+      }
+      out.atHour = hour
+    }
+
+    const dwi = rest.indexOf('--days')
+    if (dwi !== -1) {
+      const parsed = parseDaysArg(rest[dwi + 1] ?? '')
+      if ('error' in parsed) return { kind: 'error', message: parsed.error }
+      out.days = parsed
     }
 
     return { kind: 'config', ...out }
@@ -328,8 +386,9 @@ export function parseBackupArgs(argv: string[]): BackupArgs {
 const USAGE = `Usage:
   agentop backup [--with-archive] [--with-raw] [--harness a,b] [--dest DIR]
                  [--max-bundle MB] [--plan]
-  agentop backup schedule <off|daily|weekly>
-  agentop backup config [--layers a,b] [--schedule <off|daily|weekly>] [--schedule-layers a,b]
+  agentop backup schedule <off|daily|weekly|custom [hours]> [--at HOUR] [--days mon,wed,fri]
+  agentop backup config [--layers a,b] [--schedule <off|daily|weekly|custom>] [--schedule-layers a,b]
+                 [--at HOUR] [--days mon,wed,fri]
   agentop backup status
   agentop backup github setup <url>
   agentop backup github status
@@ -347,6 +406,14 @@ Carry this machine's whole agentistics history to another one.
   Layers are metrics,repos,archive,raw — metrics is always included even if you leave it out.
   A schedule never carries the repos layer; \`agentop backup\` (or the cockpit's \`b\`) is what
   rebuilds the repository manifest.
+
+  \`--at HOUR\` anchors a \`daily\`/\`custom\` (also \`weekly\`) run to a fixed local hour — for
+  \`custom\` this is the GRID's anchor, e.g. \`schedule custom 8 --at 9\` runs every 8h at
+  09/17/01, forever, never drifting to whatever time the machine happens to reconnect at.
+  \`--days mon,wed,fri\` (or \`0-6\`, Sunday first) restricts \`daily\`/\`custom\` to those weekdays;
+  absent or empty means every day. If the machine was off through a scheduled time, it catches up
+  immediately when the NEXT normal slot is still more than 2h away, and otherwise just waits for it
+  — never more than one catch-up run, however many slots were missed while it was off.
 
   Live credentials are NEVER included. \`restore\` prints each one and the command that
   re-establishes it.
@@ -546,10 +613,16 @@ export async function runBackupCli(argv: string[]): Promise<number> {
   const prefs = readBackupPrefs(await readPreferences())
 
   if (parsed.kind === 'schedule') {
-    await writeBackupSchedule(parsed.schedule, parsed.customHours)
+    await writeBackupSchedule(parsed.schedule, parsed.customHours, parsed.atHour, parsed.days)
     log(parsed.schedule === 'custom'
       ? `schedule: every ${Math.max(MIN_CUSTOM_HOURS, parsed.customHours ?? 24)}h`
       : `schedule: ${parsed.schedule}`)
+    if (parsed.schedule === 'daily' || parsed.schedule === 'custom') {
+      if (parsed.atHour !== undefined) log(`  anchored at ${parsed.atHour}:00`)
+      log(parsed.days?.length
+        ? `  days: ${parsed.days.map(d => DAY_NAMES[d]).join(', ')}`
+        : '  days: every day')
+    }
     if (parsed.schedule !== 'off') {
       log('Scheduled backups run inside `agentop server`. With the server stopped, none run.')
     }
@@ -621,6 +694,10 @@ export async function runBackupCli(argv: string[]): Promise<number> {
       log(`layers:          ${prefs.layers.join(', ')}`)
       for (const l of BACKUP_LAYERS) log(`  ${l.padEnd(9)} ${prefs.layers.includes(l) ? 'on ' : 'off'}  ${sizeLabel(l)}`)
       log(`schedule:        ${prefs.schedule}`)
+      if (prefs.schedule === 'daily' || prefs.schedule === 'custom') {
+        log(`  anchored at:   ${normalizeHour(prefs.atHour)}:00`)
+        log(`  days:          ${prefs.days?.length ? prefs.days.map(d => DAY_NAMES[d]).join(', ') : 'every day'}`)
+      }
       log(`schedule-layers: ${prefs.scheduleLayers.join(', ')}`)
       if (prefs.schedule !== 'off' && prefs.scheduleLayers.includes('repos')) {
         log('  note: a scheduled run never carries the repos layer — `agentop backup` builds it, not a schedule.')
@@ -641,9 +718,13 @@ export async function runBackupCli(argv: string[]): Promise<number> {
         log('  note: a scheduled run never carries the repos layer — `agentop backup` builds it, not a schedule.')
       }
     }
-    if (parsed.schedule) {
-      await writeBackupSchedule(parsed.schedule)
-      log(`schedule: ${parsed.schedule}`)
+    if (parsed.schedule || parsed.atHour !== undefined || parsed.days !== undefined) {
+      await writeBackupSchedule(parsed.schedule ?? prefs.schedule, undefined, parsed.atHour, parsed.days)
+      if (parsed.schedule) log(`schedule: ${parsed.schedule}`)
+      if (parsed.atHour !== undefined) log(`  anchored at ${parsed.atHour}:00`)
+      if (parsed.days !== undefined) {
+        log(`  days: ${parsed.days.length ? parsed.days.map(d => DAY_NAMES[d]).join(', ') : 'every day'}`)
+      }
     }
     return 0
   }
@@ -667,6 +748,7 @@ export async function runBackupCli(argv: string[]): Promise<number> {
     // pruned backup still answers that. See `lastBackupRun`.
     const st = scheduleStatus({
       schedule: prefs.schedule, customHours: prefs.customHours,
+      atHour: prefs.atHour, days: prefs.days, tzOffsetMinutes: new Date().getTimezoneOffset(),
       lastAt: lastBackupRun(entries)?.at ?? null, nowMs: Date.now(),
       serverRunning: existsSync(join(AGENTISTICS_DATA_DIR, 'events-producer.json')),
     })

--- a/packages/server/server/cli-start.ts
+++ b/packages/server/server/cli-start.ts
@@ -2633,7 +2633,7 @@ export function createControlHost(initialLang: CliLang, altScreen: Suspendable):
       // The SCHEDULE asks when one last RAN, which a pruned file still answers — see `lastBackupRun`.
       const st = scheduleStatus({
         schedule: prefs.schedule, customHours: prefs.customHours,
-        atHour: prefs.atHour, tzOffsetMinutes: new Date().getTimezoneOffset(),
+        atHour: prefs.atHour, days: prefs.days, tzOffsetMinutes: new Date().getTimezoneOffset(),
         lastAt: lastBackupRun(entries)?.at ?? null, nowMs: Date.now(),
         serverRunning: existsSync(join(AGENTISTICS_DATA_DIR, 'events-producer.json')),
       })

--- a/packages/server/server/preferences.ts
+++ b/packages/server/server/preferences.ts
@@ -155,8 +155,11 @@ export interface Preferences {
     /** Hours between runs when `schedule` is `'custom'`. Clamped and defaulted by `intervalMs`
      *  (backup/schedule.ts), never here — a preferences file is hand-editable. */
     customHours?: number
-    /** Local hour (0–23) a daily/weekly run is anchored to. */
+    /** Local hour (0–23) a daily/weekly/custom run is anchored to. */
     atHour?: number
+    /** Which local weekdays (0=Sunday…6=Saturday) `daily`/`custom` may run on. Absent or empty
+     *  means every day — see backup/schedule.ts's `ScheduleInput.days`. `weekly` ignores this. */
+    days?: number[]
     /** Layers a MANUAL run writes when no `--with-*` flag is given. An explicit flag wins. */
     layers?: ('metrics' | 'repos' | 'archive' | 'raw')[]
     /** Layers a SCHEDULED run writes. Deliberately separate: `raw` is 2.4 GB a copy, so a daily

--- a/packages/web/src/pages/settings/BackupSettings.tsx
+++ b/packages/web/src/pages/settings/BackupSettings.tsx
@@ -76,8 +76,11 @@ interface BackupStatusJson {
     scheduleActive: boolean
     /** Hours between runs when `schedule` is `'custom'`; null when never set. */
     customHours: number | null
-    /** The local hour a daily/weekly run is anchored to; null when never chosen. */
+    /** The local hour a daily/weekly/custom run is anchored to; null when never chosen. */
     atHour: number | null
+    /** Which local weekdays (0=Sunday…6=Saturday) `daily`/`custom` may run on; null/empty means
+     *  every day. `weekly` ignores this. */
+    days: number[] | null
     keep: number
     retainedLabel: string
     secretsCount: number
@@ -105,8 +108,12 @@ interface BackupConfigPatch {
   schedule?: BackupScheduleId
   /** Hours between runs, when `schedule` is `'custom'`. */
   customHours?: number
-  /** The local hour a daily/weekly run is anchored to. */
+  /** The local hour a daily/weekly/custom run is anchored to. */
   atHour?: number
+  /** Which local weekdays (0=Sunday…6=Saturday) `daily`/`custom` may run on. An EMPTY array is a
+   *  meaningful value (clears a restriction back to every day) distinct from leaving the field out
+   *  (changes nothing). `weekly` ignores this. */
+  days?: number[]
 }
 
 type RunOutcome = { ok: true; bytesLabel: string; skipped?: number } | { ok: false; reason: string }
@@ -296,6 +303,13 @@ const SCHEDULE_WORD: Record<string, { en: string; pt: string }> = {
   weekly: { en: 'weekly', pt: 'semanal' },
   custom: { en: 'custom', pt: 'personalizado' },
 }
+
+/** 0=Sunday…6=Saturday — matches `schedule.ts`'s `dayOfWeek` convention exactly, so a day picked
+ *  here is the same day the engine reads back. */
+const DAY_WORD: { en: string; pt: string }[] = [
+  { en: 'Sun', pt: 'Dom' }, { en: 'Mon', pt: 'Seg' }, { en: 'Tue', pt: 'Ter' },
+  { en: 'Wed', pt: 'Qua' }, { en: 'Thu', pt: 'Qui' }, { en: 'Fri', pt: 'Sex' }, { en: 'Sat', pt: 'Sáb' },
+]
 
 /** The floor the server clamps to (`MIN_CUSTOM_HOURS`). Mirrored, never imported — the web bundle
  *  may not import from `packages/server`. */
@@ -1192,7 +1206,8 @@ export default function BackupSettings() {
             disabled={savingConfig}
             customHours={status.config.customHours ?? null}
             atHour={status.config.atHour ?? null}
-            onChange={(schedule, customHours, atHour) => void patchConfig({ schedule, customHours, atHour })}
+            days={status.config.days ?? null}
+            onChange={(schedule, customHours, atHour, days) => void patchConfig({ schedule, customHours, atHour, days })}
           />
           <p style={{ fontSize: 12, fontWeight: 600, color: 'var(--text-secondary)', margin: '18px 0 4px' }}>
             {pt ? 'O que uma execução agendada grava' : 'What a scheduled run carries'}
@@ -1556,7 +1571,7 @@ function LayerPicker({ layers, sizes, archiveMode, pt, disabled, onToggle }: {
  */
 const DEFAULT_BACKUP_HOUR = 10
 
-function SchedulePicker({ value, active, pt, disabled, customHours, atHour, onChange }: {
+function SchedulePicker({ value, active, pt, disabled, customHours, atHour, days, onChange }: {
   value: BackupScheduleId
   active: boolean
   pt: boolean
@@ -1565,7 +1580,9 @@ function SchedulePicker({ value, active, pt, disabled, customHours, atHour, onCh
   customHours: number | null
   /** The local hour chosen, or null when never chosen — rendered as the default, not as blank. */
   atHour: number | null
-  onChange: (schedule: BackupScheduleId, customHours?: number, atHour?: number) => void
+  /** Which weekdays `daily`/`custom` may run on, or null/empty for every day. Ignored for `weekly`. */
+  days: number[] | null
+  onChange: (schedule: BackupScheduleId, customHours?: number, atHour?: number, days?: number[]) => void
 }) {
   const isMobile = useIsMobile()
   // Local, so typing a two-digit number does not fire a save on the first digit — `6` would be a
@@ -1574,6 +1591,14 @@ function SchedulePicker({ value, active, pt, disabled, customHours, atHour, onCh
   const parsed = Number(draft)
   const canSave = Number.isFinite(parsed) && parsed >= MIN_CUSTOM_HOURS
     && parsed !== customHours && !disabled
+  const daySet = new Set(days ?? [])
+  const toggleDay = (d: number) => {
+    const next = new Set(daySet)
+    if (next.has(d)) next.delete(d); else next.add(d)
+    // An empty selection is sent as `[]`, not omitted — that is what CLEARS a restriction back to
+    // every day rather than leaving the previous one untouched. See `BackupConfigPatch.days`.
+    onChange(value, undefined, undefined, [...next].sort((a, b) => a - b))
+  }
   return (
     <div>
       <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
@@ -1602,17 +1627,18 @@ function SchedulePicker({ value, active, pt, disabled, customHours, atHour, onCh
         })}
       </div>
       {/* A cadence with no time of day is anchored to whenever the machine last happened to run
-          one, which drifts across the day. `custom` is deliberately excluded: "every 6 hours" has
-          no single time of day, and forcing one on it would turn it into a different schedule. */}
-      {(value === 'daily' || value === 'weekly') && (
+          one, which drifts across the day. `custom` anchors to it too — every N hours FROM this
+          time, on a fixed grid that never resets, so `8` from `09:00` always reads 09/17/01, never
+          whatever hour a late reconnect happens to land on. */}
+      {(value === 'daily' || value === 'weekly' || value === 'custom') && (
         <div style={{ marginTop: 10 }}>
           <div style={{ fontSize: 12, fontWeight: 600, color: 'var(--text-secondary)', marginBottom: 2 }}>
             {pt ? 'A que horas' : 'At what time'}
           </div>
           <p style={{ fontSize: 11, color: 'var(--text-tertiary)', lineHeight: 1.45, margin: '0 0 6px' }}>
             {pt
-              ? 'No relógio desta máquina. Se ela estiver desligada nesse horário, o backup roda assim que você ligar e o próximo volta a ser no horário marcado.'
-              : 'On this machine’s clock. If it is off at that time the backup runs as soon as you turn it on, and the next one goes back to the chosen time.'}
+              ? 'No relógio desta máquina. Se ela estava desligada num horário perdido: com 2h ou mais até o próximo horário normal, o backup roda assim que você ligar; com menos de 2h, ele só espera o próximo horário — nunca dois backups colados.'
+              : 'On this machine’s clock. If it was off through a scheduled time: with 2h or more until the next normal time, the backup runs as soon as you turn it on; with less than 2h, it just waits for that next time instead — never two backups back to back.'}
           </p>
           <select
             value={String(atHour ?? DEFAULT_BACKUP_HOUR)}
@@ -1632,6 +1658,47 @@ function SchedulePicker({ value, active, pt, disabled, customHours, atHour, onCh
               <option key={h} value={String(h)}>{`${String(h).padStart(2, '0')}:00`}</option>
             ))}
           </select>
+        </div>
+      )}
+      {/* Weekdays — `weekly` is already pinned to a single day (whichever `lastAt` fell on), so a
+          second day-of-week filter on top of that would just be a more confusing way to say the
+          same thing. Empty (no chip pressed) means every day — the same default as never touching
+          this at all. */}
+      {(value === 'daily' || value === 'custom') && (
+        <div style={{ marginTop: 10 }}>
+          <div style={{ fontSize: 12, fontWeight: 600, color: 'var(--text-secondary)', marginBottom: 2 }}>
+            {pt ? 'Em quais dias' : 'On which days'}
+          </div>
+          <p style={{ fontSize: 11, color: 'var(--text-tertiary)', lineHeight: 1.45, margin: '0 0 6px' }}>
+            {pt ? 'Nenhum selecionado = todo dia.' : 'None selected = every day.'}
+          </p>
+          <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+            {DAY_WORD.map((word, d) => {
+              const on = daySet.has(d)
+              return (
+                <button
+                  key={d}
+                  type="button"
+                  onClick={() => toggleDay(d)}
+                  disabled={disabled}
+                  style={{
+                    display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+                    padding: isMobile ? '0 14px' : '6px 12px', minHeight: isMobile ? 44 : undefined,
+                    // Not a 44x44 painted square (`touchTarget.lint.test.ts`) — the 44px comes from
+                    // height alone; width grows with the label instead of being forced to match it.
+                    flex: isMobile ? '1 1 auto' : undefined, minWidth: isMobile ? 0 : 48,
+                    borderRadius: 7, border: `1px solid ${on ? 'var(--anthropic-orange)' : 'var(--border)'}`,
+                    background: on ? 'var(--anthropic-orange-dim)' : 'transparent',
+                    color: on ? 'var(--anthropic-orange)' : 'var(--text-secondary)',
+                    fontSize: 12, fontWeight: on ? 700 : 500, fontFamily: 'inherit',
+                    cursor: disabled ? 'not-allowed' : 'pointer', opacity: disabled ? 0.6 : 1,
+                  }}
+                >
+                  {pt ? word.pt : word.en}
+                </button>
+              )
+            })}
+          </div>
         </div>
       )}
       {value === 'custom' && (


### PR DESCRIPTION
## O que muda

Fecha o gap descrito na tarefa `t-354cb171b0`: um agendamento de backup com dias da semana + horário fixo + repetição, com a regra de catch-up de 2h já confirmada com o usuário.

### Motor puro (`packages/server/server/backup/schedule.ts`)

- **`custom` agora ancora em `atHour`** (grade fixa: `atHour, atHour+everyHours, atHour+2*everyHours, ...`, sem resetar de fase à meia-noite) em vez de `last + every`. Reconectar tarde não desliza mais o grid inteiro — `8 em 8h a partir das 09h` continua sendo 09/17/01 pra sempre.
- **Novo campo opcional `days?: number[]`** (0=domingo…6=sábado) em `ScheduleInput`, aplicado a `daily`/`custom`. Ausente ou vazio = todo dia (nunca uma leitura mais restritiva — mesma convenção do resto do produto). `weekly` ignora, já que está preso a um único dia da semana (o de `lastAt`).
- **Regra de catch-up (2h), confirmada com o usuário:** ao reconectar com um horário perdido, roda o backup avulso na hora só se faltar **mais de 2h** pro próximo horário normal da grade; se faltar 2h ou menos, só espera o horário normal — nunca dois backups colados. Nunca mais de um catch-up por reconexão, não importa quantos horários tenham sido perdidos enquanto a máquina estava off. A distinção entre o tick ordinário (um único intervalo decorrido) e um catch-up de verdade (mais de um intervalo decorrido) é o que garante que um intervalo curto (ex.: 1h) continue disparando no horário normal em vez de nunca superar o buffer de 2h.

`schedule.test.ts` cobre: a grade 09/17/01, os dois exemplos de reconexão confirmados (06h roda / 07h espera), o limite exato de 2h (exclusivo — 2h00m ainda espera), o filtro por dia da semana, `days` ausente = todo dia, e a garantia de que o tick ordinário nunca é suprimido pelo buffer de 2h.

### Threading (`cli-backup.ts` + `daemon.ts` + `backup-routes.ts` + `cli-start.ts` + `preferences.ts`)

- `BackupPrefs`/`Preferences.backup` ganham `days?: number[]`.
- Novo `packages/server/server/backup/days-arg.ts` (puro): parse de `--days mon,wed,fri` (ou `0-6`) compartilhado pelo CLI.
- `agentop backup schedule <...> [--at HOUR] [--days mon,wed,fri]` e `agentop backup config [--at HOUR] [--days ...]`.
- `daemon.ts` só passou a incluir `prefs.days` na chamada de `isDue` — a lógica de "no máximo 1 por tick" não mudou.
- `backup-routes.ts`/`cli-start.ts` passam `days`/`atHour` pro `scheduleStatus`, mantendo as três leituras (CLI, cockpit, web) consistentes — inclusive corrigindo um `scheduleStatus` que já vinha sem `atHour`/`tzOffsetMinutes` no `agentop backup status`.

### Web Settings (`BackupSettings.tsx`)

`SchedulePicker` ganha chips de dia da semana (para `daily`/`custom`) e agora mostra o seletor de horário também para `custom` (antes só `daily`/`weekly`), no mesmo estilo visual que já existia — PT e EN.

### Fora desta PR

**Paridade no cockpit TUI (`packages/tui/src/control/backup.ts`) não foi feita** — o tipo `ControlBackupConfig` já não expõe `atHour`/`customHours` hoje (só `schedule`), então adicionar `days` lá seria abrir uma tela nova, não só um campo. Comentei isso na tarefa do board.

## Verificação

- `bun tsc --noEmit` — limpo.
- `bun test` — 7786 passam, 1 skip, **1 falha pré-existente e não relacionada** em `auth.test.ts` (`handleSession` lê o `preferences.json` real da máquina, que já tem o shell habilitado — reproduzi o mesmo resultado num clone limpo de `origin/dev`, então não é deste diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WdG7uLRnLd1vvuFbgHYJ71