### PR TITLE
fix(server): task status auto-advances out of backlog/todo when a session is filed

### DIFF
--- a/packages/server/server/sessions/task-model.test.ts
+++ b/packages/server/server/sessions/task-model.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'bun:test'
 import {
   TASK_STATUSES, isClosed, legacyTaskId, migrateLegacyTasks, migrateStatus, newAttemptId, newTaskId,
+  statusAfterAttach,
 } from './task-model'
 
 describe('legacyTaskId', () => {
@@ -78,5 +79,18 @@ describe('migrateStatus', () => {
 describe('isClosed', () => {
   it('is true only for the two that mean the work stopped', () => {
     expect(TASK_STATUSES.filter(isClosed)).toEqual(['done', 'abandoned'])
+  })
+})
+
+describe('statusAfterAttach', () => {
+  it('advances the two "nothing started" statuses to in_progress', () => {
+    expect(statusAfterAttach('backlog')).toBe('in_progress')
+    expect(statusAfterAttach('todo')).toBe('in_progress')
+  })
+
+  it('never overwrites a status that already means something more specific', () => {
+    for (const s of ['in_progress', 'blocked', 'in_review', 'done', 'abandoned'] as const) {
+      expect(statusAfterAttach(s)).toBeNull()
+    }
   })
 })

--- a/packages/server/server/sessions/task-model.ts
+++ b/packages/server/server/sessions/task-model.ts
@@ -56,6 +56,22 @@ export function isClosed(s: TaskStatus): boolean {
 }
 
 /**
+ * The status a task should move to the moment a session is actually filed under it, or `null` when
+ * this session changes nothing about where the work stands.
+ *
+ * A session `working`/`waiting` on a delivery still sitting in `backlog`/`todo` is exactly the
+ * confusion this exists to fix — reported as "não faz sentido ter sessão working ou waiting e
+ * status estarem em todo". It moves FORWARD ONLY, out of the two statuses that mean "nothing
+ * started" and into `in_progress`: `blocked`, `in_review`, `done` and `abandoned` all name
+ * something more specific than "somebody attached a session", and a session filing must never
+ * overwrite one of them — the same one-directional rule `isClosed` already protects elsewhere on
+ * this board (an overdue date is never red on a closed task; a claim is not a session).
+ */
+export function statusAfterAttach(current: TaskStatus): TaskStatus | null {
+  return current === 'backlog' || current === 'todo' ? 'in_progress' : null
+}
+
+/**
  * `abandoned` is first-class on purpose. An attempt that was given up on is the most informative
  * row in a comparison; treating it as merely "still open" quietly inflates every average.
  */

--- a/packages/server/server/sessions/task-web.ts
+++ b/packages/server/server/sessions/task-web.ts
@@ -15,7 +15,7 @@ import { getCommitsInWindow } from '../git'
 import { readPreferences, writePreferences } from '../preferences'
 import {
   legacyTaskId, migratePriority, newCommentId, newEventId, newFileId, newLinkId, newSubtaskId,
-  newTaskId, subtaskDone,
+  newTaskId, statusAfterAttach, subtaskDone,
   type Task, type TaskEvent, type TaskStatus,
 } from './task-model'
 import { boardProgress, DEFAULT_LEASE_MS, planNext } from './task-next'
@@ -618,6 +618,14 @@ export async function attachSession(
     subtaskId: plan.subtaskId,
   })
   if (!ok) return { ok: false, reason: 'no_such_session' }
+
+  // See `statusAfterAttach` — a session actually filed under this delivery is real progress, and a
+  // status still reading "backlog"/"todo" beside it is exactly the confusion this fixes ("não faz
+  // sentido ter sessão working ou waiting e status estarem em todo"). `task.status` here is read
+  // from the SAME `task` object resolved from `ref` above: attaching never renames or moves the
+  // task itself, so it is still that task's current status.
+  const advanced = statusAfterAttach(task.status)
+  if (advanced) await markTask(task.id, advanced, row.label || sessionId)
 
   // The record first, then LIVE git. Every row written before `ManagedSession.repo` existed carries
   // nothing, which is most of the fleet on a machine that has been running a while — and reading


### PR DESCRIPTION
## What
Cards stayed `todo` on the board while a live session filed under them was already `working`/`waiting` — status never moved on its own, and `attachSession` had no rule about what a session filing should do to it.

- `statusAfterAttach()` (`task-model.ts`, pure, tested) — the two "nothing started" statuses (`backlog`, `todo`) move to `in_progress` the moment a session is actually attached. Never touches `blocked`/`in_review`/`done`/`abandoned`, each of which names something more specific than "somebody filed a session".
- `attachSession()` (`task-web.ts`) calls it right after the session write succeeds, going through the existing `markTask()` rather than a raw patch — same activity-log event, `updatedAt` stamp, `blockedReason` handling as any other status change, attributed to the session that triggered it.
- `/api/tasks` is the one door the browser, the CLI and the MCP all come through, so `agentistics_task_session` picks this up for free.

`backlog` vs `todo` themselves are left as they are — they answer different questions ("recorded, not yet queued" vs "queued, nothing started") and are still meaningful once they stop lying about live work.

## Testing
- `bunx tsc --noEmit` — clean.
- `bun test` — full suite green (7781 pass, 1 skip, 0 fail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BZecCuGfiCJ3Vb1dzcqBWi