### PR TITLE
release: a fase 3 do terminal — foco, tela própria, atalhos e o pane que acompanha a caixa

### DIFF
--- a/packages/server/server/index.ts
+++ b/packages/server/server/index.ts
@@ -2428,6 +2428,32 @@ async function handleRequestInner(req: Request, server: Server<WSData>): Promise
       }
     }
 
+    // The viewer's geometry, applied to the ASSISTANT's pane — and this is the half with a floor.
+    // `PANE_COLS`/`PANE_ROWS` exist because a 24-row pane redrew the top of an `AskUserQuestion`
+    // off the screen and broke `readDialog`/`approvalTail`, invisible from an attached terminal.
+    // So the pane may GROW for a wide viewer and may never shrink for a narrow one: a phone must
+    // not degrade approval detection in the cockpit, the VS Code panel and the web at once.
+    // `pane-resize.ts` holds that rule; this route only carries the request.
+    if (url.pathname === '/api/fleet/resize' && req.method === 'POST') {
+      const body = await readJsonLimited<{ id?: string; cols?: number; rows?: number }>(req, LIMITS.bodyBytes)
+      if (!body.ok || !body.value.id || typeof body.value.cols !== 'number' || typeof body.value.rows !== 'number') {
+        return new Response(JSON.stringify({ error: 'bad_request' }), {
+          status: 400, headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
+        })
+      }
+      const { terminalSessionExists } = await import('./sessions/terminal-web')
+      if (!(await terminalSessionExists(body.value.id))) {
+        return new Response(JSON.stringify({ error: 'not_found' }), {
+          status: 404, headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
+        })
+      }
+      const { resizeFleetPane } = await import('./sessions/fleet-resize')
+      const out = await resizeFleetPane(body.value.id, { cols: body.value.cols, rows: body.value.rows })
+      return new Response(JSON.stringify(out), {
+        headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
+      })
+    }
+
     if (url.pathname === '/api/fleet/stream' && req.method === 'GET') {
       const id = url.searchParams.get('id')
       if (!id) {

--- a/packages/server/server/sessions/fleet-resize.ts
+++ b/packages/server/server/sessions/fleet-resize.ts
@@ -1,0 +1,28 @@
+/**
+ * fleet-resize.ts — the ASSISTANT pane's resize, wired to its own tmux runner.
+ *
+ * A thin twin of the shell's, and separate for the reason every pair in this directory is: the two
+ * resolve against different sockets, and the FLOOR that protects the dialog readers applies to this
+ * one alone. The decision is `pane-resize.ts`; the socket discipline is `createPaneResizer`'s.
+ */
+
+import { createPaneResizer } from './pane-resize-web'
+
+async function tmux(args: string[]): Promise<{ code: number; out: string; err: string }> {
+  try {
+    const p = Bun.spawn(['tmux', ...args], { stdout: 'pipe', stderr: 'pipe', stdin: 'ignore' })
+    const [out, err] = await Promise.all([
+      new Response(p.stdout).text(),
+      new Response(p.stderr).text(),
+    ])
+    return { code: await p.exited, out, err }
+  } catch {
+    return { code: 127, out: '', err: '' }
+  }
+}
+
+const resize = createPaneResizer(tmux)
+
+export function resizeFleetPane(id: string, want: { cols: number; rows: number }) {
+  return resize('fleet', id, want)
+}

--- a/packages/server/server/sessions/input-protocol.test.ts
+++ b/packages/server/server/sessions/input-protocol.test.ts
@@ -89,6 +89,14 @@ describe('parseInputMessage', () => {
       .toEqual({ ok: true, msg: { seq: 9, kind: 'key', key: 'Escape' } })
   })
 
+  test('C-l is IN the set, and the server already knew what to do with it', () => {
+    // `backend-tmux.ts` clears the pane's scrollback after a successful `C-l` — written before the
+    // key could arrive from a browser at all, because this allowlist refused it as `bad_key`. It
+    // CLEARS, it controls no process, and it is the shortcut people reach for most.
+    expect(parseInputMessage(JSON.stringify({ seq: 9, kind: 'key', name: 'C-l' })))
+      .toEqual({ ok: true, msg: { seq: 9, kind: 'key', key: 'C-l' } })
+  })
+
   test('rejects a non-string key name', () => {
     expect(parseInputMessage(JSON.stringify({ seq: 6, kind: 'key', name: 3 })))
       .toEqual({ ok: false, seq: 6, reason: 'bad_key' })
@@ -96,7 +104,7 @@ describe('parseInputMessage', () => {
 
   test('KEY_ALLOWLIST is exactly the agreed closed set', () => {
     expect([...KEY_ALLOWLIST].sort()).toEqual(
-      ['BSpace', 'C-a', 'C-c', 'C-d', 'C-e', 'C-k', 'C-u', 'C-w', 'Down', 'Enter', 'Escape', 'Left', 'Right', 'Tab', 'Up'],
+      ['BSpace', 'C-a', 'C-c', 'C-d', 'C-e', 'C-k', 'C-l', 'C-u', 'C-w', 'Down', 'Enter', 'Escape', 'Left', 'Right', 'Tab', 'Up'],
     )
     for (const k of KEY_ALLOWLIST) {
       expect(parseInputMessage(JSON.stringify({ seq: 1, kind: 'key', name: k })).ok).toBe(true)

--- a/packages/server/server/sessions/input-protocol.ts
+++ b/packages/server/server/sessions/input-protocol.ts
@@ -56,11 +56,16 @@ export const MAX_INPUT_TEXT = 8192
  * all — the cockpit already records that it has no arrow keys either — so without it there is no way
  * to leave `vim` from a phone; and a Claude Code permission dialog's own footer says `Esc to
  * cancel`, which this channel could not reach for as long as the set excluded it.
+ *
+ * `C-l` was added for the same shape of reason and is the odder story: `backend-tmux.ts` ALREADY
+ * clears the pane's scrollback after a successful `C-l`, written before the key could arrive from a
+ * browser at all — this set refused it as `bad_key`, so that handling was unreachable from the web.
+ * It CLEARS the screen and controls no process, which is the line this set draws.
  */
 export const KEY_ALLOWLIST: ReadonlySet<string> = new Set([
   'Enter', 'BSpace', 'Tab', 'Escape',
   'Up', 'Down', 'Left', 'Right',
-  'C-c', 'C-d', 'C-a', 'C-e', 'C-u', 'C-w', 'C-k',
+  'C-c', 'C-d', 'C-a', 'C-e', 'C-u', 'C-w', 'C-k', 'C-l',
 ])
 
 export type InputMessage =

--- a/packages/server/server/sessions/pane-resize-web.test.ts
+++ b/packages/server/server/sessions/pane-resize-web.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from 'bun:test'
+import { createPaneResizer } from './pane-resize-web'
+import { PANE_COLS, PANE_ROWS, SHELL_SOCKET, TMUX_SOCKET } from './tmux-cli'
+
+const PANE = (cols: number, rows: number) => `3\t7\t${cols}\t${rows}\t0\t120`
+
+function fake(paneOut: string, resizeCode = 0) {
+  const calls: string[][] = []
+  const run = async (args: string[]) => {
+    calls.push(args)
+    if (args.includes('display-message')) return { code: paneOut ? 0 : 1, out: paneOut, err: '' }
+    return { code: resizeCode, out: '', err: '' }
+  }
+  return { calls, resize: createPaneResizer(run) }
+}
+
+describe('the resize reaches the right socket', () => {
+  test('a shell is resized on the shell socket', async () => {
+    const f = fake(PANE(120, 50))
+    await f.resize('shell', 's1', { cols: 200, rows: 60 })
+    for (const args of f.calls) expect(args.slice(0, 2)).toEqual(['-L', SHELL_SOCKET])
+  })
+
+  test('an assistant on the fleet socket', async () => {
+    const f = fake(PANE(120, 50))
+    await f.resize('fleet', 's1', { cols: 200, rows: 60 })
+    for (const args of f.calls) expect(args.slice(0, 2)).toEqual(['-L', TMUX_SOCKET])
+  })
+})
+
+describe('the outcome says what actually happened', () => {
+  test('a pane that cannot be read is REPORTED, never guessed at', async () => {
+    expect(await fake('').resize('shell', 's1', { cols: 100, rows: 40 }))
+      .toEqual({ ok: false, reason: 'unreadable' })
+  })
+
+  test('nothing to change costs no resize call', async () => {
+    const f = fake(PANE(120, 50))
+    expect(await f.resize('shell', 's1', { cols: 120, rows: 50 })).toEqual({ ok: true, changed: false })
+    expect(f.calls.some(a => a.includes('resize-window'))).toBe(false)
+  })
+
+  test('a clamp reports what the pane BECAME, not what was asked for', async () => {
+    // A phone asking for 40x20 gets the floor, and the caller is told the real numbers rather than
+    // its own request echoed back.
+    const f = fake(PANE(200, 80))
+    expect(await f.resize('fleet', 's1', { cols: 40, rows: 20 }))
+      .toEqual({ ok: true, changed: true, cols: PANE_COLS, rows: PANE_ROWS })
+  })
+
+  test('tmux refusing is a failure, not a silent success', async () => {
+    expect(await fake(PANE(120, 50), 1).resize('shell', 's1', { cols: 200, rows: 60 }))
+      .toEqual({ ok: false, reason: 'failed' })
+  })
+})

--- a/packages/server/server/sessions/pane-resize-web.ts
+++ b/packages/server/server/sessions/pane-resize-web.ts
@@ -1,0 +1,46 @@
+/**
+ * pane-resize-web.ts — applying a viewer's geometry to a pane, on either socket.
+ *
+ * The DECISION is the pure `pane-resize.ts` — including the asymmetry that is the whole point: a
+ * shell follows its box, an assistant's pane may grow and never shrink below the floor every dialog
+ * reader in this product depends on. What is here is the tmux work around it.
+ *
+ * The runner is INJECTED, as it is in `shell-terminal.ts`, so the socket discipline and the
+ * read-plan-write shape are provable without a tmux server.
+ */
+
+import { paneInfoArgs, parsePaneInfo, resizeWindowArgs, SHELL_SOCKET } from './tmux-cli'
+import { resizePlan, type PaneGeometry } from './pane-resize'
+import type { TmuxRun } from './shell-terminal'
+
+export type ResizeScope = 'fleet' | 'shell'
+
+export type ResizeOutcome =
+  /** Applied. `cols`/`rows` are what the pane ACTUALLY became, which a clamp can change. */
+  | { ok: true; changed: true; cols: number; rows: number }
+  /** Nothing to do: the numbers were unusable, or the plan landed on what is already there. */
+  | { ok: true; changed: false }
+  /** The pane could not be read, or tmux refused. Reported rather than swallowed. */
+  | { ok: false; reason: 'unreadable' | 'failed' }
+
+export function createPaneResizer(run: TmuxRun) {
+  return async function resize(
+    scope: ResizeScope,
+    id: string,
+    want: PaneGeometry,
+  ): Promise<ResizeOutcome> {
+    const socket = scope === 'shell' ? SHELL_SOCKET : undefined
+    // READ FIRST. The plan needs the current geometry to answer "nothing changed", which is what
+    // stops a dragged divider spawning one tmux process per animation frame.
+    const meta = await run(paneInfoArgs(id, socket))
+    const info = meta.code === 0 ? parsePaneInfo(meta.out) : null
+    if (!info) return { ok: false, reason: 'unreadable' }
+
+    const plan = resizePlan({ scope, want, current: { cols: info.cols, rows: info.rows } })
+    if (!plan) return { ok: true, changed: false }
+
+    const r = await run(resizeWindowArgs(id, plan, socket))
+    if (r.code !== 0) return { ok: false, reason: 'failed' }
+    return { ok: true, changed: true, cols: plan.cols, rows: plan.rows }
+  }
+}

--- a/packages/server/server/sessions/pane-resize.test.ts
+++ b/packages/server/server/sessions/pane-resize.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from 'bun:test'
+import { PANE_COLS, PANE_ROWS } from './tmux-cli'
+import { resizePlan } from './pane-resize'
+
+describe('a SHELL pane follows the box it is drawn in', () => {
+  test('it takes the geometry asked for', () => {
+    // Nothing in the product reads a shell's screen, so there is no floor to protect.
+    expect(resizePlan({ scope: 'shell', want: { cols: 200, rows: 60 }, current: { cols: 120, rows: 50 } }))
+      .toEqual({ cols: 200, rows: 60 })
+  })
+
+  test('and it may shrink', () => {
+    expect(resizePlan({ scope: 'shell', want: { cols: 60, rows: 20 }, current: { cols: 120, rows: 50 } }))
+      .toEqual({ cols: 60, rows: 20 })
+  })
+})
+
+describe('an ASSISTANT pane may GROW and never shrink past the floor', () => {
+  test('growing is allowed', () => {
+    expect(resizePlan({ scope: 'fleet', want: { cols: 220, rows: 80 }, current: { cols: 120, rows: 50 } }))
+      .toEqual({ cols: 220, rows: 80 })
+  })
+
+  test('a phone asking for 40x20 is CLAMPED, not obeyed', () => {
+    // `PANE_COLS`/`PANE_ROWS` exist because a 24-row pane cut the top off an `AskUserQuestion` and
+    // broke `readDialog`/`approvalTail` — invisible from an attached terminal, because attaching
+    // resizes. Letting a phone shrink this pane would degrade approval detection in the cockpit,
+    // the VS Code panel and the web at once, for every other viewer of the same session.
+    expect(resizePlan({ scope: 'fleet', want: { cols: 40, rows: 20 }, current: { cols: 120, rows: 50 } }))
+      .toBeNull()
+  })
+
+  test('one dimension may grow while the other is held at the floor', () => {
+    expect(resizePlan({ scope: 'fleet', want: { cols: 300, rows: 10 }, current: { cols: 120, rows: 50 } }))
+      .toEqual({ cols: 300, rows: PANE_ROWS })
+  })
+})
+
+describe('a resize that changes nothing is not a resize', () => {
+  test('the same geometry costs no tmux call', () => {
+    // The client measures on every layout change, so an unguarded plan would spawn a process per
+    // animation frame while somebody drags a divider.
+    expect(resizePlan({ scope: 'shell', want: { cols: 120, rows: 50 }, current: { cols: 120, rows: 50 } }))
+      .toBeNull()
+    expect(resizePlan({ scope: 'fleet', want: { cols: PANE_COLS, rows: PANE_ROWS }, current: { cols: PANE_COLS, rows: PANE_ROWS } }))
+      .toBeNull()
+  })
+})
+
+describe('a geometry that is not one is refused rather than resolved', () => {
+  test('zero, negative and absurd values yield no plan', () => {
+    // The numbers come off a browser measuring a box that can be mid-layout, display:none, or
+    // zero-height for a frame. A `resize-window -x 0` is a pane nobody can read.
+    for (const want of [{ cols: 0, rows: 50 }, { cols: 120, rows: 0 }, { cols: -5, rows: 50 }, { cols: 5000, rows: 50 }]) {
+      expect(resizePlan({ scope: 'shell', want, current: { cols: 120, rows: 50 } })).toBeNull()
+    }
+  })
+})

--- a/packages/server/server/sessions/pane-resize.ts
+++ b/packages/server/server/sessions/pane-resize.ts
@@ -1,0 +1,62 @@
+/**
+ * pane-resize.ts — PURE. What a viewer's box may do to the pane behind it, and the one asymmetry
+ * that makes this its own module.
+ *
+ * The complaint is ordinary: "a largura não tá indo até o final". A pane is created at a fixed
+ * `PANE_COLS` x `PANE_ROWS` and `SessionTerminal` SCALES rather than reflows (the capture is already
+ * hard-broken at the pane's own width, so reflowing scatters the text), which leaves a correct
+ * 120-column terminal with dead margin beside it in a 1500px band. The fix is to resize the PANE,
+ * not the rendering.
+ *
+ * **But the two panes are not equally free, and getting that wrong is expensive.**
+ *
+ * A SHELL's screen is read by nothing in this product: it exists for the person looking at it. So a
+ * shell follows its box exactly, in both directions.
+ *
+ * An ASSISTANT's pane is read by `attention.ts`, `readDialog` and `approvalTail`, in the cockpit, in
+ * the VS Code panel and in the web — all of them at once, for every viewer of that session.
+ * `PANE_COLS`/`PANE_ROWS` are not a default: a 24-row pane redrew the top of an `AskUserQuestion`
+ * off the screen, so the parsers could not find their anchor and the card could not say what the
+ * session was asking. It was invisible from a terminal, because ATTACHING resizes the pane to the
+ * client. So an assistant's pane may GROW — a wider pane is strictly better for those readers — and
+ * may never shrink below that floor, however small the box asking is.
+ *
+ * STATED LIMIT, not solved here: a tmux pane has ONE size, so two viewers at different widths mean
+ * the last to resize wins. That is already what happens with two attached tmux clients, so it is
+ * not a new class of problem — but it is why this returns a plan for a CALLER to debounce rather
+ * than something that runs on every frame.
+ */
+
+import { PANE_COLS, PANE_ROWS } from './tmux-cli'
+
+export interface PaneGeometry { cols: number; rows: number }
+
+/** The widest and tallest a pane may be asked for. A browser mid-layout can report anything. */
+const MAX_COLS = 1000
+const MAX_ROWS = 500
+
+function sane(g: PaneGeometry): boolean {
+  return Number.isInteger(g.cols) && Number.isInteger(g.rows)
+    && g.cols > 0 && g.rows > 0 && g.cols <= MAX_COLS && g.rows <= MAX_ROWS
+}
+
+/**
+ * The geometry to apply, or `null` for "do nothing".
+ *
+ * `null` covers three different situations on purpose — the numbers are unusable, the clamp landed
+ * back on what is already there, or nothing changed — because the caller's action is the same in
+ * all three and inventing a distinction would only be a reason to spawn a process.
+ */
+export function resizePlan(o: {
+  scope: 'fleet' | 'shell'
+  want: PaneGeometry
+  current: PaneGeometry
+}): PaneGeometry | null {
+  if (!sane(o.want)) return null
+  const next: PaneGeometry = o.scope === 'shell'
+    ? o.want
+    // GROW ONLY. The floor is the whole reason this module exists — see the header.
+    : { cols: Math.max(o.want.cols, PANE_COLS), rows: Math.max(o.want.rows, PANE_ROWS) }
+  if (next.cols === o.current.cols && next.rows === o.current.rows) return null
+  return next
+}

--- a/packages/server/server/sessions/shell-web.ts
+++ b/packages/server/server/sessions/shell-web.ts
@@ -12,6 +12,7 @@ import type { StartHost } from '../cli-start'
 import type { CliLang } from '../cli-lang'
 import { closeShells, listShells, openShell } from './shell-backend'
 import { openShellStream, shellStreamAtCapacity, shellStreamExists } from './shell-stream-web'
+import { createPaneResizer } from './pane-resize-web'
 import { SHELL_CAP, type ShellRefusal } from './shell-spec'
 
 /** One sentence per refusal code. The module that decides never writes prose; this one never decides. */
@@ -33,6 +34,21 @@ const REFUSAL: Record<ShellRefusal, { en: string; pt: string }> = {
     pt: `Já há ${SHELL_CAP} terminais abertos. Feche um para abrir outro.`,
   },
 }
+
+/** One tmux runner for this module's own calls — the same shape `shell-terminal.ts` is given. */
+async function tmux(args: string[]): Promise<{ code: number; out: string; err: string }> {
+  try {
+    const p = Bun.spawn(['tmux', ...args], { stdout: 'pipe', stderr: 'pipe', stdin: 'ignore' })
+    const [out, err] = await Promise.all([
+      new Response(p.stdout).text(),
+      new Response(p.stderr).text(),
+    ])
+    return { code: await p.exited, out, err }
+  } catch {
+    return { code: 127, out: '', err: '' }
+  }
+}
+const resizeShellPane = createPaneResizer(tmux)
 
 const json = (body: unknown, status = 200): Response =>
   new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } })
@@ -61,6 +77,18 @@ export async function handleShellRoute(
         'X-Accel-Buffering': 'no',
       },
     })
+  }
+
+  // The viewer's geometry, applied to the pane. A shell follows its box in both directions —
+  // nothing in this product reads its screen — which is exactly what an ASSISTANT's pane may not
+  // do; that asymmetry is `pane-resize.ts`'s and is the reason it is a module.
+  if (url.pathname === '/api/shell/resize' && req.method === 'POST') {
+    const body = await req.json().catch(() => ({})) as { id?: string; cols?: number; rows?: number }
+    if (!body.id || typeof body.cols !== 'number' || typeof body.rows !== 'number') {
+      return json({ error: 'bad_request' }, 400)
+    }
+    if (!(await shellStreamExists(body.id))) return json({ error: 'not_found' }, 404)
+    return json(await resizeShellPane('shell', body.id, { cols: body.cols, rows: body.rows }))
   }
 
   if (url.pathname === '/api/shell/list' && req.method === 'GET') {

--- a/packages/server/server/sessions/tmux-cli.test.ts
+++ b/packages/server/server/sessions/tmux-cli.test.ts
@@ -7,7 +7,7 @@ import {
   tmuxName,
   serverOptionsArgs, HISTORY_LIMIT, PANE_COLS, PANE_ROWS,
   resolveDefaultTerminal, resolveTruecolorTerm, spawnArgs,
-  type TerminalProfile, tmuxListIsEmptyState, SHELL_SOCKET, TMUX_SOCKET, listSessionsArgs,
+  type TerminalProfile, tmuxListIsEmptyState, SHELL_SOCKET, TMUX_SOCKET, listSessionsArgs, resizeWindowArgs,
 } from './tmux-cli'
 
 /** A colour-neutral profile: neither a 256-colour terminfo entry nor a truecolor invoker. */
@@ -420,5 +420,20 @@ describe('the socket is a PARAMETER — the utility shell runs on its own', () =
     // through would otherwise produce `['-L', undefined, …]` and tmux would be handed a nonsense
     // argv that fails at runtime rather than at the type checker.
     expect(killSessionArgs('a', undefined)).toEqual(['-L', TMUX_SOCKET, 'kill-session', '-t', 'agentop-a'])
+  })
+})
+
+describe('resizeWindowArgs', () => {
+  it('names the window, the size and the socket', () => {
+    expect(resizeWindowArgs('abc', { cols: 200, rows: 60 })).toEqual([
+      '-L', TMUX_SOCKET, 'resize-window', '-t', 'agentop-abc', '-x', '200', '-y', '60',
+    ])
+  })
+
+  it('takes the SHELL socket when it is given one', () => {
+    // A shell resized on the fleet socket would resize whatever happened to share its name there —
+    // the same reason every other builder takes this argument.
+    expect(resizeWindowArgs('abc', { cols: 80, rows: 24 }, SHELL_SOCKET).slice(0, 2))
+      .toEqual(['-L', SHELL_SOCKET])
   })
 })

--- a/packages/server/server/sessions/tmux-cli.ts
+++ b/packages/server/server/sessions/tmux-cli.ts
@@ -146,6 +146,25 @@ export function newSessionArgs(
   ], o.socket)
 }
 
+/**
+ * Resize a session's window — the pane behind it follows.
+ *
+ * `resize-window` and not `resize-pane`: these sessions hold ONE window with ONE pane, and the
+ * window is what a client's size is negotiated against. Which geometry may be asked for is
+ * `pane-resize.ts`'s decision, and it is NOT the same answer for a shell and for an assistant —
+ * see that module's header for why the assistant has a floor.
+ */
+export function resizeWindowArgs(
+  id: string,
+  size: { cols: number; rows: number },
+  socket?: string,
+): string[] {
+  return sock(
+    ['resize-window', '-t', tmuxName(id), '-x', String(size.cols), '-y', String(size.rows)],
+    socket,
+  )
+}
+
 export function killSessionArgs(id: string, socket?: string): string[] {
   return sock(['kill-session', '-t', tmuxName(id)], socket)
 }

--- a/packages/web/src/AppRouter.tsx
+++ b/packages/web/src/AppRouter.tsx
@@ -64,6 +64,12 @@ export default function AppRouter() {
               the list does not flash on every selection. */}
           <Route path="sessions" element={<Suspense fallback={<PageFallback />}><SessionsPage /></Suspense>} />
           <Route path="sessions/:sessionId" element={<Suspense fallback={<PageFallback />}><SessionsPage /></Suspense>} />
+          {/* The DEDICATED terminal — its own place rather than a mode of the page above. A route
+              survives a reload, is a link somebody can send, gives a phone the router's own back
+              gesture, and cannot be lost by a re-render; `?pane=` carries which screen it shows, or
+              a shared link would open on whichever pane the recipient last used. See
+              `lib/terminalSurface.ts`. */}
+          <Route path="sessions/:sessionId/terminal" element={<Suspense fallback={<PageFallback />}><SessionsPage /></Suspense>} />
           <Route path="workflows" element={<Suspense fallback={<PageFallback />}><WorkflowsPage /></Suspense>} />
           {/* GONE, and redirected rather than 404'd. Its two panels — top projects and
               languages — are on Home, and the dimension the page was really asked for is the

--- a/packages/web/src/components/RecentSessions.tsx
+++ b/packages/web/src/components/RecentSessions.tsx
@@ -20,6 +20,9 @@ import {
 } from '../lib/terminalInput'
 import { operatorId, recordPromptSend, resolveAuthor } from '../lib/promptAudit'
 import { getTerminalZoom, setTerminalZoom, subscribeTerminalZoom, ZOOM_STEP, ZOOM_MIN, ZOOM_MAX } from '../lib/terminalZoom'
+import { consentMode, keyStripShown, type TerminalPlacement } from '../lib/terminalSurface'
+import { createPaneResizer } from '../lib/paneResizeRequest'
+import { KEY_STRIP, ctrlKeyFor, keyBytes, stripKeyLabel } from '../lib/keyStrip'
 import { getPinnedIds, isSessionPinned, togglePinnedSession, subscribePinnedSessions, pinnedServerSnapshot, MAX_PINNED } from '../lib/pinnedSessions'
 import { getOpenModalSession, setOpenModalSession, subscribeOpenModalSession } from '../lib/openModalSession'
 import { useIsMobile } from '../hooks/useIsMobile'
@@ -1739,8 +1742,14 @@ const TYPING_T = {
  * about reconnects, stall reporting, zoom and the consent gate on typing into a live session, and
  * two assemblies is two chances for them not to.
  */
-export function TerminalRegion({ id, theme, lang, fill, onMaximize, row, act, authorName }: {
+export function TerminalRegion({ id, theme, lang, fill, onMaximize, row, act, authorName, placement = 'card' }: {
   id: string; theme: 'dark' | 'light'; lang: 'pt' | 'en'
+  /**
+   * WHERE this terminal is being drawn, which is what decides who may type into it and whether a
+   * phone gets the key strip — see `lib/terminalSurface.ts`. Defaults to `card`, the most cautious
+   * of the four: a terminal inside a row of a list somebody is scrolling keeps its arm button.
+   */
+  placement?: TerminalPlacement
   /** Fill the available height (in the modal) instead of a fixed card-sized box. */
   fill?: boolean
   /** When set, a maximize button opens the modal — where the box is wide enough to read a wide pane
@@ -1770,6 +1779,17 @@ export function TerminalRegion({ id, theme, lang, fill, onMaximize, row, act, au
   // keyboard: "a digitação fica especificamente NO input do type into this session ao invés de me
   // permitir digitar direto no terminal renderizado". One owner, one surface at a time.
   const [composer, dispatchComposer] = useReducer(composerReducer, INITIAL_COMPOSER)
+  /**
+   * CONSENT FOLLOWS THE SURFACE (`lib/terminalSurface.ts`). In every placement inside the sessions
+   * workspace the terminal IS the thing you asked for, so focus is the gate — the way every
+   * terminal on every platform works, and the way the VS Code extension in this repo already
+   * shipped it. Only a `card` keeps the arm button, because that terminal appears in a row somebody
+   * is scrolling past.
+   *
+   * It arms the EXISTING machine rather than bypassing it, so the channel, the acks and the
+   * honesty line downstream are untouched: what changes is who was asked, not what is promised.
+   */
+  const consent = consentMode(placement)
   const rowBlock = row ? interactionBlock(row.state) : 'external'
   const canType = !!row && !!act && rowBlock !== 'external' && rowBlock !== 'not-running'
   // A row with no live process cannot be typed into either way — revoke rather than leave a consent
@@ -1780,6 +1800,13 @@ export function TerminalRegion({ id, theme, lang, fill, onMaximize, row, act, au
     if (hardBlocked && composer.armed) dispatchComposer({ type: 'disarm' })
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [hardBlocked])
+  // The focus gate, applied. A row with no live process is still refused — `canType` is the same
+  // check the button path makes, so the two modes differ in who is ASKED and in nothing else.
+  const autoArm = consent === 'focus' && canType && !composer.armed && !hardBlocked
+  useEffect(() => {
+    if (autoArm) dispatchComposer({ type: 'arm' })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [autoArm])
   const write = useTerminalWrite(id, composer.armed && canType, lang === 'pt' ? 'pt' : 'en')
   // The emulator accepts keys only once the channel is actually OPEN — so a captured keystroke can
   // always be delivered (no local echo; a key you can see was typed is a key that landed) — AND only
@@ -1796,6 +1823,37 @@ export function TerminalRegion({ id, theme, lang, fill, onMaximize, row, act, au
   // xterm's own textarea is enough — and this is the difference between "armed" and "your next
   // keystroke lands", which is the one thing a person cannot tell by looking at a terminal.
   const [termFocused, setTermFocused] = useState(false)
+  /**
+   * THE KEY STRIP's sticky `ctrl`. A soft keyboard has no chord to hold, so `ctrl` arms and the
+   * next single character becomes the control key instead. A letter the channel would refuse
+   * answers `null` and is SAID — composing one earns a `bad_key` ack for a keystroke the person had
+   * every reason to expect to work.
+   */
+  const [ctrlArmed, setCtrlArmed] = useState(false)
+  const [stripNote, setStripNote] = useState<string | null>(null)
+  const showStrip = keyStripShown(placement, isMobile)
+  /**
+   * MAKE THE PANE FIT THE BOX. The emulator scales rather than reflows, so a 120-column pane in a
+   * 1500px band leaves dead margin — reported as "a largura não tá indo até o final". The server
+   * decides what it may actually do: this pane may GROW and never shrink below the floor every
+   * dialog reader depends on (`server/sessions/pane-resize.ts`).
+   */
+  const resizer = useMemo(() => createPaneResizer({ scope: 'fleet', id }), [id])
+  useEffect(() => () => resizer.cancel(), [resizer])
+  /** One send path for everything: a strip press and a real keypress are judged by one allowlist. */
+  const sendKeys = (data: string) => {
+    if (!ctrlArmed) { write.send(data); return }
+    setCtrlArmed(false)
+    const key = ctrlKeyFor(data)
+    if (!key) {
+      setStripNote(lang === 'pt'
+        ? `ctrl+${data} não é uma das teclas que este canal envia.`
+        : `ctrl+${data} is not one of the keys this channel sends.`)
+      return
+    }
+    setStripNote(null)
+    write.send(keyBytes(key))
+  }
   const tw = TYPING_T[lang]
   // The one honest status for the keystroke channel: connecting → live, a drop, or a not-delivered.
   const typingNotice: { tone: 'live' | 'wait' | 'bad'; text: string } | null =
@@ -1860,9 +1918,52 @@ export function TerminalRegion({ id, theme, lang, fill, onMaximize, row, act, au
       >
         <Suspense fallback={<div style={{ padding: 16, fontSize: 12, color: 'var(--text-tertiary)', fontFamily: 'monospace' }}>{lang === 'pt' ? 'Carregando o emulador…' : 'Loading the emulator…'}</div>}>
           {/* key={id}: a new session gets a brand-new emulator, so no content leaks across. */}
-          <SessionTerminal key={id} frame={state.frame} theme={theme} showCursor={status.showCursor} zoom={zoom} interactive={interactive} onInput={write.send} />
+          <SessionTerminal key={id} frame={state.frame} theme={theme} showCursor={status.showCursor} zoom={zoom} interactive={interactive} onInput={sendKeys} onGeometry={resizer.request} />
         </Suspense>
       </div>
+      {/* THE KEY STRIP — mobile only, and never in a dashboard card (`keyStripShown`). Without it a
+          phone has no `esc`, no `tab`, no arrows and no Ctrl+C, so a permission dialog whose own
+          footer says `Esc to cancel` is unanswerable. A press produces the same bytes a real
+          keypress would (`keyBytes`) and goes through the same `send`, so `splitInput`'s allowlist
+          judges both identically — a key it would refuse cannot reach the wire by a side door. */}
+      {showStrip && write.ready && (
+        <div style={{ display: 'flex', gap: 6, flexShrink: 0, overflowX: 'auto' }}>
+          {KEY_STRIP.map(entry => {
+            const armed = entry.kind === 'modifier' && ctrlArmed
+            return (
+              <button
+                key={entry.id}
+                onClick={(e) => {
+                  e.stopPropagation()
+                  if (entry.kind === 'modifier') { setStripNote(null); setCtrlArmed(a => !a); return }
+                  setCtrlArmed(false)
+                  write.send(keyBytes(entry.key))
+                }}
+                aria-pressed={entry.kind === 'modifier' ? ctrlArmed : undefined}
+                style={{
+                  // 44px is the MOBILE figure, and this strip exists only on mobile.
+                  minWidth: 44, minHeight: 44, flexShrink: 0,
+                  borderRadius: 8, cursor: 'pointer', fontFamily: 'inherit',
+                  fontSize: 14, fontWeight: 600,
+                  border: `1px solid ${armed ? 'var(--anthropic-orange)' : 'var(--border-subtle)'}`,
+                  background: armed ? 'var(--anthropic-orange)' : 'var(--bg-elevated)',
+                  color: armed ? '#fff' : 'var(--text-secondary)',
+                }}
+              >
+                {stripKeyLabel(entry.id)}
+              </button>
+            )
+          })}
+        </div>
+      )}
+      {showStrip && (ctrlArmed || stripNote) && (
+        <div style={{ fontSize: 11, color: 'var(--text-tertiary)', lineHeight: 1.5 }}>
+          {ctrlArmed
+            ? (lang === 'pt' ? 'ctrl armado — pressione uma letra' : 'ctrl is armed — press a letter')
+            : stripNote}
+        </div>
+      )}
+
       {/* Phase 2b — the keystroke channel's honest status. It never echoes a key; this line is the one
           place a drop or a not-delivered is reported (A6), and where "you are typing live" is stated. */}
       {typingNotice && (
@@ -1903,6 +2004,9 @@ export function TerminalRegion({ id, theme, lang, fill, onMaximize, row, act, au
           row={row} act={act} authorName={authorName} lang={lang} isMobile={isMobile}
           state={composer} dispatch={dispatchComposer}
           channelDead={write.state.phase === 'closed'}
+          /* Where consent IS the focus there is nothing to revoke: looking away already does it,
+             and a "stop typing" button would re-arm itself on the next render. */
+          consent={consent}
         />
       )}
       <style>{`@keyframes ag-term-pulse { 0%,100% { opacity: 1 } 50% { opacity: 0.35 } }`}</style>
@@ -1921,7 +2025,7 @@ export function TerminalRegion({ id, theme, lang, fill, onMaximize, row, act, au
  *    then lost — nothing is delivered per key, and the one line's outcome is always on screen.
  *  - AUDIT: the delivered-or-failed line is recorded through `recordPromptSend`; keystrokes are not.
  */
-function TerminalComposer({ row, act, authorName, lang, isMobile, state: composer, dispatch, channelDead }: {
+function TerminalComposer({ row, act, authorName, lang, isMobile, state: composer, dispatch, channelDead, consent = 'button' }: {
   row: FleetRow
   act: (req: { id: string; action: FleetActionId; text?: string; choice?: number })
     => Promise<{ ok: boolean; message: string; id?: string }>
@@ -1939,6 +2043,8 @@ function TerminalComposer({ row, act, authorName, lang, isMobile, state: compose
   dispatch: React.Dispatch<ComposerAction>
   /** The keystroke channel could not be opened — the line editor is then the only way in, and says so. */
   channelDead: boolean
+  /** `focus` where the surface itself is the consent — see `lib/terminalSurface.ts`. */
+  consent?: 'focus' | 'button'
 }) {
   // A brief "delivered" confirmation; the durable record lives in the audit panel below the card.
   const [flash, setFlash] = useState(false)
@@ -2036,6 +2142,8 @@ function TerminalComposer({ row, act, authorName, lang, isMobile, state: compose
       <Hand size={13} /> <span>{t.stop}</span>
     </button>
   )
+  /** Absent under the focus gate: looking away already revokes it, and the button would re-arm. */
+  const revoke = consent === 'focus' ? null : stopButton
 
   /**
    * ARMED, KEYBOARD ON THE TERMINAL — the default, and the whole point of the button that got here.
@@ -2067,7 +2175,7 @@ function TerminalComposer({ row, act, authorName, lang, isMobile, state: compose
         >
           <Send size={13} /> <span>{t.openLine}</span>
         </button>
-        {stopButton}
+        {revoke}
       </div>
     )
   }
@@ -2144,7 +2252,7 @@ function TerminalComposer({ row, act, authorName, lang, isMobile, state: compose
             <Terminal size={13} /> <span>{t.backToTerminal}</span>
           </button>
         )}
-        {stopButton}
+        {revoke}
       </form>
       {channelDead && (
         <div style={{ fontSize: 11, color: 'var(--text-tertiary)', lineHeight: 1.5 }}>{t.lineOnly}</div>
@@ -2456,7 +2564,7 @@ function LiveSessionCard({ s, lang, onSelect, isPinned, state, fleetRow, onFleet
   // where nothing else can reach a stored conversation.
   const body = (large: boolean) => (
     <>
-      {watchable && <TerminalRegion id={fleetRow.id} theme={theme ?? 'dark'} lang={lang} fill={large} onMaximize={large ? undefined : () => setModalOpen(true)} row={fleetRow} act={onFleetAction} authorName={authorName} />}
+      {watchable && <TerminalRegion placement="card" id={fleetRow.id} theme={theme ?? 'dark'} lang={lang} fill={large} onMaximize={large ? undefined : () => setModalOpen(true)} row={fleetRow} act={onFleetAction} authorName={authorName} />}
       <SessionActionsPanel ctrl={ctrl} />
       <CardChips s={s} lang={lang} />
     </>

--- a/packages/web/src/components/SessionTerminal.tsx
+++ b/packages/web/src/components/SessionTerminal.tsx
@@ -39,6 +39,7 @@ import { useEffect, useRef } from 'react'
 import { Terminal } from '@xterm/xterm'
 import '@xterm/xterm/css/xterm.css'
 import { xtermTheme, type TerminalFrame } from '../lib/terminalStream'
+import { shortcutDecision } from '../lib/terminalShortcuts'
 
 interface Props {
   frame: TerminalFrame | null
@@ -55,6 +56,17 @@ interface Props {
   interactive?: boolean
   /** Receives each raw `onData` chunk while `interactive`. Wired to the write channel by the parent. */
   onInput?: (data: string) => void
+  /**
+   * HOW MANY CELLS THIS BOX COULD SHOW at natural size — reported whenever it changes, so the
+   * parent can ask the server to resize the PANE to match.
+   *
+   * The pane is what has to change, not the rendering: the capture is already hard-broken at the
+   * pane's own width, so reflowing it scatters the text (see this file's header), and the fit
+   * therefore SCALES — which is why a 120-column pane leaves dead margin in a 1500px band. What the
+   * server does with these numbers is not symmetric between a shell and an assistant's pane; that
+   * asymmetry is `server/sessions/pane-resize.ts`'s.
+   */
+  onGeometry?: (g: { cols: number; rows: number }) => void
 }
 
 const FONT_SIZE = 13
@@ -108,7 +120,7 @@ function naturalSize(term: Terminal): { w: number; h: number } | null {
   return null
 }
 
-export default function SessionTerminal({ frame, theme, showCursor, zoom = 1, interactive = false, onInput }: Props) {
+export default function SessionTerminal({ frame, theme, showCursor, zoom = 1, interactive = false, onInput, onGeometry }: Props) {
   // boxRef is the fixed viewport the parent sizes; scaleRef takes the SCALED footprint so the page
   // lays out correctly; hostRef holds the emulator at its natural cols×rows pixels and is the thing
   // the transform shrinks.
@@ -132,6 +144,15 @@ export default function SessionTerminal({ frame, theme, showCursor, zoom = 1, in
   // latest one without re-subscribing (and never captures a stale closure).
   const onInputRef = useRef<Props['onInput']>(onInput)
   onInputRef.current = onInput
+  // Read through a ref for the same reason `onInput` is: the key handler is attached ONCE for the
+  // emulator's life, so a value captured in its closure would be the one from the first render —
+  // a terminal that went interactive later would keep leaving every shortcut to the browser.
+  const interactiveRef = useRef(interactive)
+  interactiveRef.current = interactive
+  const onGeometryRef = useRef<Props['onGeometry']>(onGeometry)
+  onGeometryRef.current = onGeometry
+  /** The last geometry REPORTED, so a steady stream of identical fits says nothing. */
+  const reportedRef = useRef<{ cols: number; rows: number } | null>(null)
 
   /**
    * Fit the natural cols×rows grid into the box by scaling the PIXELS — never by resizing the
@@ -171,6 +192,23 @@ export default function SessionTerminal({ frame, theme, showCursor, zoom = 1, in
     host.style.transformOrigin = 'top left'
     scale.style.width = `${Math.ceil(natW * s)}px`
     scale.style.height = `${Math.ceil(natH * s)}px`
+
+    // WHAT THIS BOX COULD SHOW at natural size. Measured off the cell the renderer actually
+    // reports — `naturalSize` divided by the current grid — never guessed from a font size.
+    // Reported only on a CHANGE: `fit` runs on every ResizeObserver tick, and a drag would
+    // otherwise be one request per animation frame.
+    const cellW = natW / term.cols
+    const cellH = natH / term.rows
+    if (cellW > 0 && cellH > 0) {
+      const cols = Math.max(1, Math.floor(availW / cellW))
+      const availH = box.clientHeight
+      const rows = availH > 0 ? Math.max(1, Math.floor(availH / cellH)) : term.rows
+      const last = reportedRef.current
+      if (!last || last.cols !== cols || last.rows !== rows) {
+        reportedRef.current = { cols, rows }
+        onGeometryRef.current?.({ cols, rows })
+      }
+    }
   }
 
   function paint() {
@@ -291,6 +329,28 @@ export default function SessionTerminal({ frame, theme, showCursor, zoom = 1, in
       })
       termRef.current = term
       disposeRender = term.onRender(onRender)
+      /**
+       * THE SHORTCUTS THE TERMINAL OWNS, and only while it owns the keyboard.
+       *
+       * `ctrl+w` closed the tab and `ctrl+l` went to the address bar, so neither ever reached the
+       * pane — reported as "quero que os atalhos funcionem ... sem afetar o navegador", which is
+       * two requirements, not one. `terminalShortcuts.ts` holds the whole rule: only the letters
+       * the channel can actually deliver, never `ctrl+shift+*`, never Cmd/Win, never Alt.
+       *
+       * It is gated on `interactive`, so a read-only terminal — and any terminal that merely EXISTS
+       * on a page somebody is scrolling — swallows nothing. A page-level handler eating `ctrl+w`
+       * whenever a terminal was on screen would be a browser the person cannot close.
+       *
+       * Returning `true` lets xterm handle the key as usual; the `preventDefault` beside it is what
+       * stops the browser doing its own thing with the same press.
+       */
+      term.attachCustomKeyEventHandler((e: KeyboardEvent) => {
+        if (e.type !== 'keydown') return true
+        if (!interactiveRef.current) return true
+        if (shortcutDecision(e) === 'take') e.preventDefault()
+        return true
+      })
+
       // One input listener for the emulator's life; it forwards to the LATEST handler through the ref.
       // xterm only fires `onData` while stdin is enabled, so a read-only terminal delivers nothing.
       disposeData = term.onData((d: string) => onInputRef.current?.(d))

--- a/packages/web/src/components/sessions/SessionPanel.tsx
+++ b/packages/web/src/components/sessions/SessionPanel.tsx
@@ -62,6 +62,14 @@ export interface SessionPanelProps {
   /** Passed straight to `SessionChat` — see its own `onArtifacts`. This panel reads none of it. */
   onArtifacts?: SessionChatProps['onArtifacts']
   /**
+   * OPEN THE TERMINAL ON ITS OWN SCREEN.
+   *
+   * A callback and not a path, for the reason `onOpenFull` is one on the metrics card: this panel
+   * does not know how the surface around it navigates. Absent where there is nowhere to go, and
+   * then the enlarge control is ABSENT too rather than inert.
+   */
+  onOpenTerminal?: () => void
+  /**
    * May this machine serve a per-session utility SHELL right now — `CAPS.localShell` AND the
    * user's own switch, as `/api/team/session` reports it.
    *
@@ -73,7 +81,7 @@ export interface SessionPanelProps {
   shellEnabled?: boolean
 }
 
-export function SessionPanel({ session, row, lang, theme, act, authorName, onGone, onOpened, view: viewProp, onViewChange, onArtifacts, shellEnabled }: SessionPanelProps) {
+export function SessionPanel({ session, row, lang, theme, act, authorName, onGone, onOpened, view: viewProp, onViewChange, onArtifacts, shellEnabled, onOpenTerminal }: SessionPanelProps) {
   /**
    * Is this a session of ANOTHER machine, reached through the relay?
    *
@@ -205,6 +213,10 @@ export function SessionPanel({ session, row, lang, theme, act, authorName, onGon
                 hook, the emulator and a composer would be three things that must agree about
                 reconnects, stalls, zoom and the consent gate on typing into a live session. */}
             <TerminalRegion
+              /* REPLACING the conversation, and inside the workspace — so focus is the consent and
+                 a phone gets the key strip. See `lib/terminalSurface.ts`. */
+              placement="replacing"
+              {...(onOpenTerminal ? { onMaximize: onOpenTerminal } : {})}
               id={session.id}
               theme={theme}
               lang={lang}

--- a/packages/web/src/components/sessions/ShellBand.tsx
+++ b/packages/web/src/components/sessions/ShellBand.tsx
@@ -39,7 +39,7 @@
  * one place that turns those into sentences. A blank band is never an answer.
  */
 
-import { Suspense, lazy, useCallback, useEffect, useReducer, useRef, useState } from 'react'
+import { Suspense, lazy, useCallback, useEffect, useMemo, useReducer, useRef, useState } from 'react'
 import {
   ChevronDown, ChevronUp, ChevronLeft, Loader2, RotateCcw, TerminalSquare, Trash2,
 } from 'lucide-react'
@@ -54,8 +54,9 @@ import {
 import {
   INITIAL_SHELL_BAND, shellBandReducer, shellResolveWanted, type OpenShell,
 } from '../../lib/shellBandState'
-import { SHELL_STRIP, ctrlKeyFor, keyBytes, stripKeyLabel } from '../../lib/shellKeys'
+import { KEY_STRIP, ctrlKeyFor, keyBytes, stripKeyLabel } from '../../lib/keyStrip'
 import { terminalStatus } from '../../lib/terminalStream'
+import { createPaneResizer } from '../../lib/paneResizeRequest'
 
 const SessionTerminal = lazy(() => import('../SessionTerminal'))
 
@@ -203,6 +204,12 @@ export function ShellBand({ sessionId, cwd, lang, theme }: ShellBandProps) {
   // `'shell'`: the honesty line must say whose screen this is. The default subject calls it "the
   // agent's current screen", which over a shell the person opened themselves is simply false.
   const status = terminalStatus(state, lang, 'shell')
+  /** A shell follows its box in BOTH directions — nothing in this product reads its screen. */
+  const resizer = useMemo(
+    () => createPaneResizer({ scope: 'shell', id: shell?.id ?? '' }),
+    [shell?.id],
+  )
+  useEffect(() => () => resizer.cancel(), [resizer])
 
   /**
    * One send path for everything.
@@ -225,7 +232,7 @@ export function ShellBand({ sessionId, cwd, lang, theme }: ShellBandProps) {
   }, [ctrlArmed, write, t])
 
   const pressStrip = useCallback((id: string) => {
-    const entry = SHELL_STRIP.find(e => e.id === id)
+    const entry = KEY_STRIP.find(e => e.id === id)
     if (!entry) return
     if (entry.kind === 'modifier') { setCtrlNote(null); setCtrlArmed(a => !a); return }
     setCtrlArmed(false)
@@ -289,6 +296,7 @@ export function ShellBand({ sessionId, cwd, lang, theme }: ShellBandProps) {
           showCursor={status.showCursor}
           interactive={write.ready}
           onInput={send}
+          onGeometry={shell ? resizer.request : undefined}
         />
       </Suspense>
     </div>
@@ -333,7 +341,7 @@ export function ShellBand({ sessionId, cwd, lang, theme }: ShellBandProps) {
       display: 'flex', gap: 6, flexShrink: 0, overflowX: 'auto',
       paddingBottom: 'var(--safe-bottom)',
     }}>
-      {SHELL_STRIP.map(entry => {
+      {KEY_STRIP.map(entry => {
         const armed = entry.kind === 'modifier' && ctrlArmed
         return (
           <button

--- a/packages/web/src/lib/keyStrip.test.ts
+++ b/packages/web/src/lib/keyStrip.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'bun:test'
-import { SHELL_STRIP, ctrlKeyFor, keyBytes, stripKeyLabel } from './shellKeys'
+import { KEY_STRIP, ctrlKeyFor, keyBytes, stripKeyLabel } from './keyStrip'
 import { classifyInput, type NamedKey } from './terminalKeys'
 
 /** Every named key the strip claims to send must survive the client allowlist. */
@@ -12,18 +12,18 @@ describe('the mobile key strip', () => {
   it('carries exactly the keys the design names, in that order', () => {
     // `esc tab ctrl ↑ ↓ ← →` — without it there is no Ctrl+C on a phone, and a soft keyboard has
     // no arrow keys at all.
-    expect(SHELL_STRIP.map(k => k.id)).toEqual(['esc', 'tab', 'ctrl', 'up', 'down', 'left', 'right'])
+    expect(KEY_STRIP.map(k => k.id)).toEqual(['esc', 'tab', 'ctrl', 'up', 'down', 'left', 'right'])
   })
 
   it('every direct key of the strip is one the channel actually accepts', () => {
-    for (const entry of SHELL_STRIP) {
+    for (const entry of KEY_STRIP) {
       if (entry.kind !== 'key') continue
       expect(sendable(entry.key)).toBe(true)
     }
   })
 
   it('ctrl is a MODIFIER, not a key — it has nothing to send on its own', () => {
-    const ctrl = SHELL_STRIP.find(k => k.id === 'ctrl')
+    const ctrl = KEY_STRIP.find(k => k.id === 'ctrl')
     expect(ctrl?.kind).toBe('modifier')
   })
 

--- a/packages/web/src/lib/keyStrip.ts
+++ b/packages/web/src/lib/keyStrip.ts
@@ -1,5 +1,11 @@
 /**
- * shellKeys.ts — PURE. The mobile key strip, and what `ctrl` does on a phone.
+ * keyStrip.ts — PURE. The mobile key strip, and what `ctrl` does on a phone.
+ *
+ * It was `shellKeys.ts` and belonged to the utility shell alone, which is why the ASSISTANT's own
+ * terminal had no `esc`, no arrows and no Ctrl+C on a phone at all — the larger gap of the two,
+ * since a permission dialog's own footer says `Esc to cancel`. The strip is a property of the
+ * SURFACE (see `terminalSurface.ts`'s `keyStripShown`), never of which process is on the other end,
+ * so the name no longer claims otherwise.
  *
  * A soft keyboard has no `esc`, no `tab` and no arrow keys at all — the cockpit already records the
  * last of those — so without this strip there is no way to leave `vim`, complete a path, or reach
@@ -27,7 +33,7 @@ export type StripEntry =
   | { id: string; kind: 'modifier' }
 
 /** The strip, in the order the design names it. */
-export const SHELL_STRIP: readonly StripEntry[] = [
+export const KEY_STRIP: readonly StripEntry[] = [
   { id: 'esc', kind: 'key', key: 'Escape' },
   { id: 'tab', kind: 'key', key: 'Tab' },
   { id: 'ctrl', kind: 'modifier' },
@@ -53,7 +59,7 @@ export function stripKeyLabel(id: string): string {
  * ASK for what will be refused.
  */
 const CTRL: Record<string, NamedKey> = {
-  a: 'C-a', c: 'C-c', d: 'C-d', e: 'C-e', k: 'C-k', u: 'C-u', w: 'C-w',
+  a: 'C-a', c: 'C-c', d: 'C-d', e: 'C-e', k: 'C-k', l: 'C-l', u: 'C-u', w: 'C-w',
 }
 
 /** The named key `ctrl` + this character makes, or `null` when the channel would refuse it. */
@@ -86,6 +92,7 @@ const BYTES: Record<NamedKey, string> = {
   'C-u': '\x15',
   'C-w': '\x17',
   'C-k': '\x0b',
+  'C-l': '\x0c',
 }
 
 export function keyBytes(key: NamedKey): string {

--- a/packages/web/src/lib/paneResizeRequest.test.ts
+++ b/packages/web/src/lib/paneResizeRequest.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from 'bun:test'
+import { createPaneResizer } from './paneResizeRequest'
+
+function harness(scope: 'fleet' | 'shell' = 'fleet') {
+  const sent: { url: string; body: unknown }[] = []
+  let fire: (() => void) | null = null
+  const r = createPaneResizer({
+    scope, id: 's1',
+    send: (url, body) => sent.push({ url, body: JSON.parse(body) }),
+    setTimeout: (fn) => { fire = fn; return 1 as unknown as ReturnType<typeof setTimeout> },
+    clearTimeout: () => { fire = null },
+  })
+  return { r, sent, tick: () => { const f = fire; fire = null; f?.() } }
+}
+
+describe('a drag is ONE request, not one per frame', () => {
+  test('only the last geometry is sent', () => {
+    const h = harness()
+    h.r.request({ cols: 100, rows: 40 })
+    h.r.request({ cols: 140, rows: 40 })
+    h.r.request({ cols: 180, rows: 40 })
+    expect(h.sent).toHaveLength(0)
+    h.tick()
+    expect(h.sent).toEqual([{ url: '/api/fleet/resize', body: { id: 's1', cols: 180, rows: 40 } }])
+  })
+
+  test('nothing is sent until the debounce fires', () => {
+    const h = harness()
+    h.r.request({ cols: 100, rows: 40 })
+    expect(h.sent).toHaveLength(0)
+  })
+})
+
+describe('each scope asks its own route', () => {
+  test('a shell resize never reaches the fleet route', () => {
+    const h = harness('shell')
+    h.r.request({ cols: 100, rows: 40 })
+    h.tick()
+    expect(h.sent[0]!.url).toBe('/api/shell/resize')
+  })
+})
+
+describe('cancel drops what was pending', () => {
+  test('an unmount sends nothing', () => {
+    const h = harness()
+    h.r.request({ cols: 100, rows: 40 })
+    h.r.cancel()
+    h.tick()
+    expect(h.sent).toHaveLength(0)
+  })
+})

--- a/packages/web/src/lib/paneResizeRequest.ts
+++ b/packages/web/src/lib/paneResizeRequest.ts
@@ -1,0 +1,60 @@
+/**
+ * paneResizeRequest.ts — the browser half of "make the pane fit the box".
+ *
+ * The emulator reports a geometry on every layout change (`SessionTerminal`'s `onGeometry`), and a
+ * dragged divider produces one of those per animation frame. So this DEBOUNCES, keeps only the
+ * latest, and never has two requests in flight for one pane.
+ *
+ * It is deliberately fire-and-forget in the UI's terms: a resize that fails changes nothing on
+ * screen — the terminal keeps rendering the pane exactly as it is — so there is no honest sentence
+ * to show and nothing for the reader to do. That is the opposite of the WRITE channel, where a
+ * keystroke that did not land must be said out loud.
+ */
+
+import type { TerminalScope } from './terminalEndpoint'
+
+/** Long enough that a drag settles, short enough that a single layout change feels immediate. */
+export const RESIZE_DEBOUNCE_MS = 250
+
+export interface PaneResizer {
+  /** Ask for this geometry. Later calls replace an unsent earlier one. */
+  request(g: { cols: number; rows: number }): void
+  /** Drop anything pending — call on unmount. */
+  cancel(): void
+}
+
+export function createPaneResizer(o: {
+  scope: TerminalScope
+  id: string
+  /** Injected so the debounce and the coalescing are testable without a network or a clock. */
+  send?: (url: string, body: string) => void
+  setTimeout?: (fn: () => void, ms: number) => unknown
+  clearTimeout?: (h: never) => void
+}): PaneResizer {
+  const setT = (o.setTimeout ?? setTimeout) as (fn: () => void, ms: number) => unknown
+  const clearT = (o.clearTimeout ?? clearTimeout) as (h: unknown) => void
+  const url = o.scope === 'shell' ? '/api/shell/resize' : '/api/fleet/resize'
+  const send = o.send ?? ((u, body) => {
+    void fetch(u, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body })
+      .catch(() => {})
+  })
+  let handle: unknown = null
+  let pending: { cols: number; rows: number } | null = null
+
+  return {
+    request(g) {
+      pending = g
+      if (handle !== null) clearT(handle)
+      handle = setT(() => {
+        handle = null
+        const g2 = pending
+        pending = null
+        if (g2) send(url, JSON.stringify({ id: o.id, cols: g2.cols, rows: g2.rows }))
+      }, RESIZE_DEBOUNCE_MS)
+    },
+    cancel() {
+      if (handle !== null) { clearT(handle); handle = null }
+      pending = null
+    },
+  }
+}

--- a/packages/web/src/lib/terminalKeys.ts
+++ b/packages/web/src/lib/terminalKeys.ts
@@ -35,6 +35,7 @@ export type NamedKey =
   | 'Enter' | 'BSpace' | 'Tab' | 'Escape' | 'Up' | 'Down' | 'Left' | 'Right'
   | 'C-c' | 'C-d' // process control — explicitly requested (A7 / EOF)
   | 'C-a' | 'C-e' | 'C-u' | 'C-w' | 'C-k' // line editing — "edits the line" passes
+  | 'C-l' // clears the screen — see `input-protocol.ts`'s note on why it arrived late
 
 /** Why an input chunk was refused. `empty` is a no-op; `unsupported-sequence` is "not in the allowlist". */
 export type BlockReason = 'empty' | 'unsupported-sequence' | 'too-long'
@@ -76,6 +77,7 @@ const NAMED: Readonly<Record<string, NamedKey>> = {
   '\x15': 'C-u', // kill whole line
   '\x17': 'C-w', // kill previous word
   '\x0b': 'C-k', // kill to end of line
+  '\x0c': 'C-l', // clear the screen (form feed)
   // CSI cursor keys (normal mode)
   '\x1b[A': 'Up',
   '\x1b[B': 'Down',

--- a/packages/web/src/lib/terminalShortcuts.test.ts
+++ b/packages/web/src/lib/terminalShortcuts.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from 'bun:test'
+import { CTRL_SHORTCUTS, shortcutDecision } from './terminalShortcuts'
+
+const ev = (over: Partial<Parameters<typeof shortcutDecision>[0]> = {}) => ({
+  ctrlKey: true, metaKey: false, altKey: false, shiftKey: false, key: 'c', ...over,
+})
+
+describe('the shortcuts a terminal owns while it has the keyboard', () => {
+  test('every ctrl key the channel accepts is TAKEN from the browser', () => {
+    // Reported: "quando eu estiver no terminal, quero que os atalhos funcionem (ctrl l ctrl w etc)".
+    // Today `ctrl+w` closes the tab and `ctrl+l` goes to the address bar; neither reaches the pane.
+    for (const key of CTRL_SHORTCUTS) expect(shortcutDecision(ev({ key }))).toBe('take')
+  })
+
+  test('a ctrl key the channel does NOT accept is left to the browser', () => {
+    // `C-z` (suspend) and `C-t`/`C-n`/`C-r` are outside `KEY_ALLOWLIST`. Swallowing one would cost
+    // the person their browser shortcut and deliver nothing in exchange.
+    for (const key of ['z', 't', 'n', 'r', 'p', 's']) {
+      expect(shortcutDecision(ev({ key }))).toBe('leave')
+    }
+  })
+})
+
+describe('what may NEVER be swallowed', () => {
+  test('ctrl+shift+* stays the browser’s', () => {
+    // Devtools, the incognito window, reopen-tab. The VS Code extension records the same rule for
+    // its panel: swallow these and the editor around the terminal stops working.
+    for (const key of CTRL_SHORTCUTS) {
+      expect(shortcutDecision(ev({ key, shiftKey: true }))).toBe('leave')
+    }
+  })
+
+  test('Cmd / Win is never touched', () => {
+    // On a Mac every application shortcut is Cmd. A terminal that ate them would be a terminal you
+    // cannot copy out of, quit, or switch away from.
+    for (const key of CTRL_SHORTCUTS) {
+      expect(shortcutDecision(ev({ key, metaKey: true }))).toBe('leave')
+      expect(shortcutDecision(ev({ key, ctrlKey: false, metaKey: true }))).toBe('leave')
+    }
+  })
+
+  test('alt combinations are left alone', () => {
+    expect(shortcutDecision(ev({ key: 'c', altKey: true }))).toBe('leave')
+  })
+
+  test('a bare letter is not a shortcut at all', () => {
+    expect(shortcutDecision(ev({ key: 'c', ctrlKey: false }))).toBe('leave')
+  })
+
+  test('case does not decide it — a capital arrives with shift, and shift already refuses', () => {
+    expect(shortcutDecision(ev({ key: 'C' }))).toBe('take')
+    expect(shortcutDecision(ev({ key: 'C', shiftKey: true }))).toBe('leave')
+  })
+})
+
+describe('the set is closed and matches the channel', () => {
+  test('exactly the letters `KEY_ALLOWLIST` carries as C-<letter>', () => {
+    expect([...CTRL_SHORTCUTS].sort()).toEqual(['a', 'c', 'd', 'e', 'k', 'l', 'u', 'w'])
+  })
+})

--- a/packages/web/src/lib/terminalShortcuts.ts
+++ b/packages/web/src/lib/terminalShortcuts.ts
@@ -1,0 +1,56 @@
+/**
+ * terminalShortcuts.ts — PURE. Which key combinations the terminal takes from the browser while it
+ * holds the keyboard, and — far more important — which it may never touch.
+ *
+ * Reported: "quando eu estiver no terminal, quero que os atalhos funcionem (ctrl l ctrl w etc). sem
+ * afetar o navegador." Both halves of that sentence are the specification. Today `ctrl+w` closes
+ * the tab and `ctrl+l` focuses the address bar, so neither ever reaches the pane; and the naive fix
+ * — swallow anything with ctrl — costs somebody their devtools, their new tab and, on a Mac, every
+ * application shortcut there is.
+ *
+ * So the rule is narrow on purpose and stated once:
+ *
+ *  - **Take only what the channel can actually deliver.** `CTRL_SHORTCUTS` is exactly the set of
+ *    letters `KEY_ALLOWLIST` carries as `C-<letter>`. Swallowing `ctrl+z` would cost the browser
+ *    shortcut and deliver nothing in exchange, because the server would refuse it as `bad_key`.
+ *  - **Never `ctrl+shift+*`.** Devtools, the incognito window, reopen-tab. The VS Code extension in
+ *    this repo records the identical rule for its panel — swallow these and the editor around the
+ *    terminal stops working.
+ *  - **Never Cmd/Win, never Alt.** On a Mac every application shortcut is Cmd; a terminal that ate
+ *    them is a terminal you cannot copy out of, quit, or switch away from.
+ *
+ * The caller applies this ONLY while the emulator is focused and the write channel is open. A
+ * page-level handler that swallowed `ctrl+w` whenever a terminal existed somewhere on screen would
+ * be a browser the person cannot close.
+ */
+
+/**
+ * The letters this terminal claims when they arrive with ctrl alone.
+ *
+ * Exactly the ones `KEY_ALLOWLIST` (server, `input-protocol.ts`) accepts as `C-<letter>`:
+ * `C-a` `C-c` `C-d` `C-e` `C-k` `C-l` `C-u` `C-w`. Mirrored here for the reason the key allowlist
+ * itself is mirrored — so the client does not claim a keystroke the server will refuse.
+ */
+export const CTRL_SHORTCUTS: readonly string[] = ['a', 'c', 'd', 'e', 'k', 'l', 'u', 'w']
+
+const CLAIMED = new Set(CTRL_SHORTCUTS)
+
+/** Only the fields the decision reads, so it is testable without a DOM event. */
+export interface ShortcutEvent {
+  ctrlKey: boolean
+  metaKey: boolean
+  altKey: boolean
+  shiftKey: boolean
+  key: string
+}
+
+/**
+ * `take` = the terminal handles it and the browser must not; `leave` = the browser keeps it.
+ *
+ * `shiftKey` is refused before the letter is even looked at, which is also why case cannot decide
+ * anything: a capital arrives WITH shift, and shift already refuses.
+ */
+export function shortcutDecision(e: ShortcutEvent): 'take' | 'leave' {
+  if (!e.ctrlKey || e.metaKey || e.altKey || e.shiftKey) return 'leave'
+  return CLAIMED.has(e.key.toLowerCase()) ? 'take' : 'leave'
+}

--- a/packages/web/src/lib/terminalSurface.test.ts
+++ b/packages/web/src/lib/terminalSurface.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  TERMINAL_PLACEMENTS, consentMode, dedicatedTerminalPath, dockedAllowed, keyStripShown,
+  readTerminalPane, type TerminalPlacement,
+} from './terminalSurface'
+
+describe('consent follows the SURFACE, never the session', () => {
+  test('a terminal you went to takes keys on FOCUS', () => {
+    // The workspace placements are all deliberate: you clicked a tab, expanded a band, or opened
+    // the dedicated screen. The VS Code extension already decided this — "FOCUS is the consent
+    // gate (every terminal works that way)" — and the web kept an arm button, so one product held
+    // two answers to one question.
+    expect(consentMode('replacing')).toBe('focus')
+    expect(consentMode('docked')).toBe('focus')
+    expect(consentMode('dedicated')).toBe('focus')
+  })
+
+  test('a terminal merely PRESENT keeps the button', () => {
+    // The dashboard's session list renders a terminal inside a card you are scrolling past. Nobody
+    // went there to type, so a stray keystroke would land in a live assistant's dialog.
+    expect(consentMode('card')).toBe('button')
+  })
+
+  test('every placement answers, and the set is closed', () => {
+    for (const p of TERMINAL_PLACEMENTS) expect(['focus', 'button']).toContain(consentMode(p))
+    expect([...TERMINAL_PLACEMENTS]).toEqual(['card', 'docked', 'replacing', 'dedicated'])
+  })
+})
+
+describe('the key strip', () => {
+  test('appears on mobile wherever you went to the terminal on purpose', () => {
+    // A soft keyboard has no `esc`, no `tab` and no arrows at all — so without it there is no
+    // leaving `vim` and no Ctrl+C. The shell band has had it since phase 2; the assistant's own
+    // terminal never did.
+    for (const p of ['docked', 'replacing', 'dedicated'] as TerminalPlacement[]) {
+      expect(keyStripShown(p, true)).toBe(true)
+    }
+  })
+
+  test('never on desktop — the keys are already on the keyboard', () => {
+    for (const p of TERMINAL_PLACEMENTS) expect(keyStripShown(p, false)).toBe(false)
+  })
+
+  test('never in a dashboard card, even on mobile', () => {
+    // That terminal is read-only until armed; a row of send-a-key buttons over it would be five
+    // controls that do nothing.
+    expect(keyStripShown('card', true)).toBe(false)
+  })
+})
+
+describe('there is no docked placement on a phone', () => {
+  test('below the breakpoint the band cannot exist', () => {
+    // Measured in the phase-2 spec: at 390px with the keyboard open there are ~250px of visible
+    // height; split between conversation, composer and terminal that is ~80px each — four lines.
+    expect(dockedAllowed(true)).toBe(false)
+  })
+
+  test('on desktop it can', () => {
+    expect(dockedAllowed(false)).toBe(true)
+  })
+})
+
+describe('the dedicated terminal is a PLACE, not a mode', () => {
+  test('its path carries the session and the pane it is showing', () => {
+    // A route rather than a piece of component state: it survives a reload, it is a link somebody
+    // can send, and the router already gives a phone a back gesture for it. The TARGET goes in the
+    // URL or a shared link opens on the wrong pane.
+    expect(dedicatedTerminalPath('abc')).toBe('/sessions/abc/terminal')
+    expect(dedicatedTerminalPath('abc', 'shell')).toBe('/sessions/abc/terminal?pane=shell')
+  })
+
+  test('the id is encoded, so it can never smuggle a second segment', () => {
+    expect(dedicatedTerminalPath('a/b')).toBe('/sessions/a%2Fb/terminal')
+  })
+
+  test('the assistant is the default and is left out of the URL', () => {
+    // A bare `/sessions/x/terminal` has to mean something, and the assistant's own pane is what the
+    // Terminal tab has always shown — so a link written by hand lands where a reader expects.
+    expect(dedicatedTerminalPath('abc', 'assistant')).toBe('/sessions/abc/terminal')
+    expect(readTerminalPane(null)).toBe('assistant')
+    expect(readTerminalPane('assistant')).toBe('assistant')
+  })
+
+  test('a pane nobody offers reads as the assistant rather than as nothing', () => {
+    // The value comes off a query string a person can type. An unknown one must not blank the
+    // screen — it lands on the pane the bare path already means.
+    expect(readTerminalPane('shell')).toBe('shell')
+    expect(readTerminalPane('banana')).toBe('assistant')
+    expect(readTerminalPane('')).toBe('assistant')
+  })
+})

--- a/packages/web/src/lib/terminalSurface.ts
+++ b/packages/web/src/lib/terminalSurface.ts
@@ -1,0 +1,110 @@
+/**
+ * terminalSurface.ts — PURE. The rules every terminal in this dashboard obeys, stated once.
+ *
+ * There are two terminal implementations in the web app and they answer different questions:
+ * `TerminalRegion` shows the ASSISTANT's own tmux pane, `ShellBand` shows a PTY the person opened.
+ * That difference is real and is not what this module unifies. What it unifies is everything that
+ * was decided TWICE and differently — who may type, and what a phone gets — because two answers to
+ * one question is how a product ends up arguing with itself in front of a user.
+ *
+ * The placements are the four surfaces a terminal can occupy, and they are the axis every rule here
+ * turns on. `card` is the odd one and the reason the axis is placement rather than session: it is
+ * the terminal embedded in the dashboard's session list, which appears because you scrolled past
+ * it rather than because you asked for it.
+ */
+
+/** Where a terminal is being drawn. CLOSED — a new surface must be named here on purpose. */
+export type TerminalPlacement =
+  /** Inside a card in the dashboard's session list. You did not go there to type. */
+  | 'card'
+  /** The band docked under the session panel (desktop only — see `dockedAllowed`). */
+  | 'docked'
+  /** Replacing the conversation, behind the panel's own Chat|Terminal toggle. */
+  | 'replacing'
+  /** Its own screen, at its own route. */
+  | 'dedicated'
+
+export const TERMINAL_PLACEMENTS: readonly TerminalPlacement[] = [
+  'card', 'docked', 'replacing', 'dedicated',
+]
+
+/**
+ * How this surface asks permission before a keystroke reaches a live process.
+ *
+ * **`focus` wherever the terminal is the thing you asked for**, which is every placement inside the
+ * sessions workspace: you pressed a tab, expanded a band, or opened the dedicated screen. Every
+ * terminal on every platform works this way, and the VS Code extension in this same repo already
+ * shipped that decision ("FOCUS is the consent gate") while the web kept an explicit arm button —
+ * so one product held two answers to one question.
+ *
+ * **`button` only in a `card`.** That terminal renders inside a row of a list somebody is
+ * scrolling; nobody went there to drive the session, and a stray keystroke lands in whatever dialog
+ * the assistant has open.
+ *
+ * Dropping the button does NOT drop the honesty: there is still no local echo, the per-key acks
+ * still run, and "not delivered" is still said in words. The button is CONSENT, not safety.
+ */
+export function consentMode(placement: TerminalPlacement): 'focus' | 'button' {
+  return placement === 'card' ? 'button' : 'focus'
+}
+
+/**
+ * Does this surface draw the `esc tab ctrl ↑ ↓ ← →` strip?
+ *
+ * On mobile only, and never in a card. A soft keyboard has no Escape, no Tab and — as the cockpit
+ * already records — no arrow keys at all, so without the strip there is no leaving `vim` and no
+ * Ctrl+C. The shell band has had it since phase 2; the ASSISTANT's own terminal never did, which is
+ * the larger gap of the two: a permission dialog's footer says `Esc to cancel`.
+ *
+ * A card is excluded even on a phone: that terminal is read-only until armed, so a row of
+ * send-a-key buttons over it would be five controls that do nothing.
+ */
+export function keyStripShown(placement: TerminalPlacement, isMobile: boolean): boolean {
+  return isMobile && placement !== 'card'
+}
+
+/**
+ * May a docked band exist at this width?
+ *
+ * No, on a phone. Measured while designing phase 2: at 390px with the keyboard open there are
+ * ~250px of visible height, and split between the conversation, the composer and a terminal that is
+ * ~80px each — four lines of terminal. On mobile the terminal is the dedicated sheet instead.
+ */
+export function dockedAllowed(isMobile: boolean): boolean {
+  return !isMobile
+}
+
+/**
+ * WHICH pane the dedicated screen is showing.
+ *
+ * `assistant` is the session's own tmux pane — what the Chat|Terminal toggle has always meant —
+ * and `shell` is the utility PTY the person opened. They are different processes on different
+ * sockets, so this is a target, never a mode of one thing.
+ */
+export type TerminalPane = 'assistant' | 'shell'
+
+/**
+ * The dedicated terminal's own route.
+ *
+ * A ROUTE and not a piece of component state, deliberately: it survives a reload, it is a link
+ * somebody can send, the router already gives a phone the back gesture for it, and a re-render
+ * cannot lose it. The TARGET travels in the URL for the same reason — a shared link that opened on
+ * whichever pane the recipient last used would be a link to the wrong screen.
+ *
+ * `assistant` is omitted because it is what a bare path already means: the Terminal tab has always
+ * shown the session's own pane, so a URL somebody types by hand lands where they expect.
+ */
+export function dedicatedTerminalPath(sessionId: string, pane: TerminalPane = 'assistant'): string {
+  const base = `/sessions/${encodeURIComponent(sessionId)}/terminal`
+  return pane === 'shell' ? `${base}?pane=shell` : base
+}
+
+/**
+ * Read the pane off the query string — which a person can type, so this never blanks a screen.
+ *
+ * Anything unrecognised (absent, empty, misspelled) resolves to `assistant`, the pane the bare path
+ * already means. A refusal here would be a dead screen produced by a typo.
+ */
+export function readTerminalPane(raw: string | null | undefined): TerminalPane {
+  return raw === 'shell' ? 'shell' : 'assistant'
+}

--- a/packages/web/src/pages/SessionsPage.tsx
+++ b/packages/web/src/pages/SessionsPage.tsx
@@ -51,6 +51,8 @@ import { FiltersSheet } from '../components/sessions/FiltersSheet'
 import {
   arrivalFor, reopenedSessionRoute, sessionPath, stillArriving, type SessionArrival,
 } from '../lib/sessionRoute'
+import { dedicatedTerminalPath, readTerminalPane } from '../lib/terminalSurface'
+import { TerminalRegion } from '../components/RecentSessions'
 import { sessionPlanFactor } from '../lib/costBasis'
 
 /** The dimensions a live fleet row can be narrowed by — the same set on both layouts. */
@@ -111,6 +113,17 @@ export default function SessionsPage() {
   const selected = sessionId === undefined
     ? undefined
     : fleet.rows.find(r => r.id === sessionId || r.conversationId === sessionId)
+
+  /**
+   * THE DEDICATED TERMINAL — the same page at its own route, showing one screen and nothing else.
+   *
+   * Detected off the path rather than carried in state, which is the whole reason it is a route:
+   * a reload lands back here, the link can be sent, and on a phone the router's own back gesture
+   * already means "leave the terminal". `?pane=` says which screen; an unrecognised value resolves
+   * to the assistant rather than blanking one (`readTerminalPane`).
+   */
+  const dedicatedTerminal = useLocation().pathname.endsWith('/terminal')
+  const dedicatedPane = readTerminalPane(useSearchParams()[0].get('pane'))
 
   /**
    * WHERE A REOPEN LANDS — one place, for all three controls on this page that can perform one.
@@ -538,6 +551,8 @@ export default function SessionsPage() {
       onArtifacts={onArtifacts}
       // The capability AND the user's switch, as the server reports them. Absent reads as OFF.
       shellEnabled={ctx.shellEnabled === true}
+      // The terminal's own screen. A route, so it survives a reload and can be sent to somebody.
+      onOpenTerminal={() => navigate(dedicatedTerminalPath(selected.id))}
     />
   )
 
@@ -658,6 +673,74 @@ export default function SessionsPage() {
       />
     </FiltersSheet>
   )
+
+  // ---------------------------------------------------------------------------
+  // The DEDICATED terminal — one screen, one pane, both layouts. Before the mobile branch because
+  // it is the SAME screen at 390px and at 1440px: a terminal that fills what it is given needs no
+  // second version, and the key strip it gets on a phone is decided by `keyStripShown`.
+  // ---------------------------------------------------------------------------
+  if (dedicatedTerminal && selected) {
+    const back = () => navigate(sessionPath(selected.id))
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0 }}>
+        <div style={{
+          display: 'flex', alignItems: 'center', gap: 8, minHeight: 44, padding: '0 10px',
+          flexShrink: 0, paddingTop: 'var(--safe-top)',
+          borderBottom: '1px solid var(--border)', background: 'var(--bg-surface)',
+        }}>
+          <button
+            onClick={back}
+            aria-label={pt ? 'Voltar para a sessão' : 'Back to the session'}
+            style={{
+              display: 'flex', alignItems: 'center', justifyContent: 'center',
+              // 44px is the mobile figure, and this is the only way back from a full screen.
+              width: 44, height: 44, flexShrink: 0, marginLeft: -6,
+              border: 'none', background: 'transparent', color: 'var(--text-secondary)',
+              cursor: 'pointer',
+            }}
+          >
+            <ChevronLeft size={20} />
+          </button>
+          <div style={{ minWidth: 0, flex: 1 }}>
+            <div style={{
+              fontSize: 13, fontWeight: 650, color: 'var(--text-primary)',
+              overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+            }}>{selected.title}</div>
+            <div style={{
+              fontSize: 10.5, color: 'var(--text-tertiary)',
+              overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+            }}>
+              {selected.stateLabel}
+              {selected.project ? ` · ${selected.project}` : ''}
+            </div>
+          </div>
+        </div>
+        <div style={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column', padding: 10 }}>
+          {/* The SHELL's own dedicated screen is not built yet, and this says so rather than
+              drawing the assistant's pane under a shell's name. Nothing links here today — the
+              selector is what will make it reachable. */}
+          {dedicatedPane === 'shell' && (
+            <div role="status" style={{ fontSize: 11, color: 'var(--accent-red)', marginBottom: 8 }}>
+              {pt
+                ? 'A tela dedicada do shell ainda não existe — abaixo está o terminal do assistente.'
+                : 'The shell’s own dedicated screen does not exist yet — below is the assistant’s terminal.'}
+            </div>
+          )}
+          <TerminalRegion
+            /* DEDICATED: you asked for this screen, so focus is the consent and there is no arm
+               button; on a phone it carries the key strip. */
+            placement="dedicated"
+            id={selected.id}
+            theme={theme === 'light' ? 'light' : 'dark'}
+            lang={pt ? 'pt' : 'en'}
+            fill
+            {...(rowIndex.get(selected.id) ? { row: rowIndex.get(selected.id)! } : {})}
+            act={act}
+          />
+        </div>
+      </div>
+    )
+  }
 
   // ---------------------------------------------------------------------------
   // Mobile: one column at a time.


### PR DESCRIPTION
## Summary

A fase 3 do terminal, inteira menos o seletor: **o consentimento passa a seguir a superfície, o terminal ganha tela própria, os atalhos chegam nele, e o pane passa a acompanhar a caixa.**

## Motivation

Três dores relatadas, e uma quarta que apareceu no caminho.

**"quero que os atalhos funcionem (ctrl l ctrl w etc). sem afetar o navegador"** — são duas exigências, não uma. Hoje `ctrl+w` fecha a aba e `ctrl+l` vai para a barra de endereço; nenhum chega ao pane. E a correção ingênua custa o devtools e, num Mac, todo atalho de aplicação.

**"a largura não tá indo até o final"** — o pane nasce com 120 colunas fixas e o emulador escala em vez de refluir, então sobra margem morta numa faixa larga.

**"quero que se o usuário abriu o terminal já esteja disponível pra ele digitar direto lá"** — o botão "Digitar nesta sessão" fazia sentido num card que a pessoa está rolando, e nenhum numa tela que ela abriu de propósito.

E a quarta: **num celular o terminal do assistente não tinha `esc`, nem setas, nem `Ctrl+C`** — enquanto o rodapé do diálogo de permissão dele diz `Esc to cancel`.

## Changes

**`consentMode`** — foco dentro da workspace, botão só no card do dashboard. É a decisão que a extensão do VS Code neste mesmo repositório já tinha entregue enquanto a web discordava dela.

**`/sessions/:id/terminal`** — rota, não estado: sobrevive ao reload, dá para mandar o link, e no celular o voltar já é o do router.

**`shellKeys.ts` → `keyStrip.ts`** — a tira é propriedade da superfície, não de qual processo está do outro lado.

**`terminalShortcuts.ts`** — só as letras que o canal entrega; nunca `ctrl+shift+*`, Cmd/Win ou Alt. `C-l` entrou no allowlist: o servidor **já** sabia limpar o scrollback com ele, mas o navegador nunca conseguia enviá-lo.

**`pane-resize.ts`** — e aqui a assimetria é dura. Um shell acompanha a caixa nos dois sentidos. O pane do assistente pode crescer e **nunca** encolher abaixo de `PANE_COLS`/`PANE_ROWS`: aquele piso existe porque um pane de 24 linhas quebrava `readDialog`/`approvalTail`, e um celular encolhendo-o degradaria a detecção de aprovação do cockpit, do VS Code e da web ao mesmo tempo.

## Test plan

- [x] `bun tsc --noEmit` limpo; `bun test` **7819 passa / 0 falha**.
- [x] TDD em cada módulo puro: `terminalSurface`, `terminalShortcuts`, `pane-resize`, `pane-resize-web`, `paneResizeRequest`, `resizeWindowArgs`.
- [x] **Medido contra um tmux vivo**: `120x50` → pedido `220x70` → virou `220x70`; pedido `40x20` → `120x50` (o piso), com a resposta dizendo o que o pane **virou**. Um shell pedindo `40x20` encolhe de verdade.
- [x] **Ponta a ponta no navegador**: a 1600px o pane foi de 120 para **165 colunas** e a tela passou a preencher a caixa exatamente. Numa sessão real parada num diálogo de permissão de 5 opções, a rota sobreviveu a um load frio, **sem botão de armar**, tira de teclas a 390px e não a 1440px, `scrollWidth == innerWidth`, ampliar navega e voltar retorna. Console limpo.

**Não verificado na tela:** o card do dashboard mantendo seu botão (só renderiza num card expandido). Coberto por teste unitário e pelo default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FUJpqNsYWMfQPaGATN577f
