### PR TITLE
release: open a non-Claude session's own files (files tab, gallery, media)

### DIFF
--- a/packages/server/server/sessions/artifact-file.test.ts
+++ b/packages/server/server/sessions/artifact-file.test.ts
@@ -83,7 +83,7 @@ describe('planArtifactRead', () => {
 })
 
 describe('artifactPathsFromTurns', () => {
-  const turn = (tools: { name: string; detail?: string }[]) => ({ tools })
+  const turn = (tools: { name: string; canonical?: string; detail?: string }[]) => ({ tools })
 
   it('collects the paths of the file tools, deduped', () => {
     expect(artifactPathsFromTurns([
@@ -110,5 +110,26 @@ describe('artifactPathsFromTurns', () => {
     expect(artifactPathsFromTurns([turn([{ name: 'Write' }])])).toEqual([])
     expect(artifactPathsFromTurns([])).toEqual([])
     expect(artifactPathsFromTurns([{} as never])).toEqual([])
+  })
+
+  /**
+   * THE BUG THIS FILE EXISTS TO FIX. A non-Claude harness's own tool name (agy's `write_to_file`)
+   * never equals a Claude name, so a caller that only checked `call.name` refused every path a
+   * non-Claude session ever wrote — reported as the file panel LISTING a session's files (the
+   * browser's `sessionArtifacts.ts` already read `canonical ?? name`) and refusing to open a single
+   * one, "só funciona no claude". This must select on the SAME field the browser does.
+   */
+  it('selects by the CANONICAL name, not the harness\'s own — the cross-harness case', () => {
+    expect(artifactPathsFromTurns([
+      turn([{ name: 'write_to_file', canonical: 'Write', detail: '/p/a.ts' }]),
+      turn([{ name: 'replace_file_content', canonical: 'Edit', detail: '/p/b.ts' }]),
+    ])).toEqual(['/p/a.ts', '/p/b.ts'])
+  })
+
+  it('a canonical name that is not a file tool is still excluded, same as the raw-name case', () => {
+    // agy's `run_command` canonicalizes to `Bash` — never a path, whichever field named it.
+    expect(artifactPathsFromTurns([
+      turn([{ name: 'run_command', canonical: 'Bash', detail: 'rm -rf build/' }]),
+    ])).toEqual([])
   })
 })

--- a/packages/server/server/sessions/artifact-file.ts
+++ b/packages/server/server/sessions/artifact-file.ts
@@ -107,12 +107,21 @@ export function planArtifactRead({ path, cwd, allowed }: ArtifactReadRequest): A
  * names, kinds and counts, while the ALLOWLIST needs only the paths. This is the copy that guards
  * the disk, so it selects by the same tool NAMES and never by the shape of `detail` — `toolDetail`
  * reads `command` first, and a `Bash` line is not a path.
+ *
+ * These are the SHARED-VOCABULARY names (`canonicalTool`'s output), the same ones
+ * `sessionArtifacts.ts` matches on via `canonical ?? name` — never the harness's own name. A non-
+ * Claude harness's raw tool name (agy's `write_to_file`, say) never equals one of these, so a
+ * caller that checked `call.name` alone refused every file a non-Claude session ever wrote: the
+ * panel LISTED them (the browser reads `canonical ?? name` correctly) and then refused to open a
+ * single one (this allowlist did not), reported as "só funciona no claude".
  */
 export const ARTIFACT_TOOL_NAMES = ['Write', 'Edit', 'MultiEdit', 'NotebookEdit'] as const
 
 /** PURE: just the paths, for the server's allowlist. */
 export function artifactPathsFromTurns(
-  turns: readonly { tools?: { name: string; detail?: string; writes?: string[] }[] }[],
+  turns: readonly {
+    tools?: { name: string; canonical?: string; detail?: string; writes?: string[] }[]
+  }[],
 ): string[] {
   const out = new Set<string>()
   for (const t of turns) {
@@ -125,7 +134,9 @@ export function artifactPathsFromTurns(
         const t = w.trim()
         if (t !== '' && !t.endsWith('…')) out.add(t)
       }
-      if (!(ARTIFACT_TOOL_NAMES as readonly string[]).includes(call.name)) continue
+      // `canonical ?? name` — see the doc comment above. Selecting on the raw `name` alone is what
+      // made this allowlist Claude-only.
+      if (!(ARTIFACT_TOOL_NAMES as readonly string[]).includes(call.canonical ?? call.name)) continue
       const p = call.detail?.trim()
       // A truncated detail (`toolDetail` ellipsises past 200 chars) names no file. Admitting one
       // would put a path into the allowlist that resolves to nothing — or, worse, to something else.


### PR DESCRIPTION
## Release

- #490 — Bug 1 from the bugFinder list: a non-Claude session's files were listed but refused to open ("só funciona no claude"). The server-side allowlist selected tool calls by Claude's raw tool names; it now reads the shared canonical name, matching the browser's own listing rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BZecCuGfiCJ3Vb1dzcqBWi