### PR TITLE
fix(web): cap the task board's harnesses column instead of letting it grow forever

### DIFF
--- a/packages/web/src/components/tasks/CentralTaskBoard.tsx
+++ b/packages/web/src/components/tasks/CentralTaskBoard.tsx
@@ -22,10 +22,11 @@ import { fmtCost } from '@agentistics/core'
 import { useIsMobile } from '../../hooks/useIsMobile'
 import type { CentralTaskMachine, CentralTaskRow } from '../../lib/tasks'
 import {
-  NA, STATUS, button, fmtInt, fmtTokens, harnessColor, microLabel, numeric, pill, surface,
+  NA, STATUS, button, fmtInt, fmtTokens, microLabel, numeric, pill, surface,
   type BoardStatus,
 } from './board'
 import { TaskProgressBar } from './TaskProgressBar'
+import { HarnessBadges } from './HarnessBadges'
 
 export interface CentralTaskBoardProps {
   machines: CentralTaskMachine[]
@@ -212,17 +213,7 @@ function RowList({ rows, showMachine, lang, cost, isMobile }: {
                 <td style={tdNum}>{fmtInt(r.rollup.rounds)}</td>
                 <td style={tdNum}>{fmtTokens(r.rollup.tokens)}</td>
                 <td style={{ ...tdNum, color: 'var(--anthropic-orange)' }}>{cost(r.rollup.costUSD)}</td>
-                <td style={td}>
-                  {r.harnesses.length === 0
-                    ? <span style={{ color: 'var(--text-tertiary)' }}>{NA}</span>
-                    : (
-                      <span style={{ display: 'inline-flex', gap: 4, flexWrap: 'wrap' }}>
-                        {r.harnesses.map(h => (
-                          <span key={h} style={{ ...pill(harnessColor(h)), fontSize: 10 }}>{h}</span>
-                        ))}
-                      </span>
-                    )}
-                </td>
+                <td style={td}><HarnessBadges harnesses={r.harnesses} fontSize={10} /></td>
               </tr>
             )
           })}

--- a/packages/web/src/components/tasks/HarnessBadges.tsx
+++ b/packages/web/src/components/tasks/HarnessBadges.tsx
@@ -1,0 +1,47 @@
+/**
+ * HarnessBadges — the harnesses a delivery's sessions ran on, as a bounded row of pills.
+ *
+ * One component instead of four near-identical inline renders (the main board table, a repo's
+ * Tasks tab table and its mobile card, the kanban card, the central board table) is what
+ * `TaskProgressBar` already does for the progress bar, and for the same reason: four copies of one
+ * rule is four chances for it to read differently on each screen.
+ *
+ * The rule it fixes: a task's harnesses list was rendered in full, `flexWrap`-ped, with no cap —
+ * every harness this product supports, every one a distinct pill, in a column that has to sit next
+ * to five or six other columns. A task whose sessions spanned most harnesses turned the column into
+ * a block of colour nobody could read at a glance ("acumula badges e fica ilegível"). `capList`
+ * (`board.ts`) caps it, and the remainder becomes a single `+N` pill — truthful (it names the exact
+ * count) rather than silently dropped, and its `title` still lists every hidden harness so nothing
+ * is actually lost, only deferred to a hover.
+ */
+
+import { capList, harnessColor, pill, NA } from './board'
+
+const DEFAULT_MAX = 4
+
+export function HarnessBadges({ harnesses, max = DEFAULT_MAX, fontSize }: {
+  harnesses: readonly string[]
+  /** How many pills to draw before folding the rest into `+N`. */
+  max?: number
+  /** Some callers (dense table cells) run the pill text smaller than the board default. */
+  fontSize?: number
+}) {
+  if (harnesses.length === 0) return <span style={{ color: 'var(--text-tertiary)' }}>{NA}</span>
+  const { shown, extra } = capList(harnesses, max)
+  const style = fontSize ? { fontSize } : undefined
+  return (
+    <span style={{ display: 'inline-flex', gap: 4, flexWrap: 'wrap', alignItems: 'center' }}>
+      {shown.map(h => (
+        <span key={h} style={{ ...pill(harnessColor(h)), ...style }}>{h}</span>
+      ))}
+      {extra > 0 && (
+        <span
+          title={harnesses.slice(max).join(', ')}
+          style={{ ...pill(), ...style, fontWeight: 600 }}
+        >
+          +{extra}
+        </span>
+      )}
+    </span>
+  )
+}

--- a/packages/web/src/components/tasks/RepoTasksTab.tsx
+++ b/packages/web/src/components/tasks/RepoTasksTab.tsx
@@ -19,10 +19,11 @@ import { fmtCost, sortRows, type SortSpec } from '@agentistics/core'
 import { useIsMobile } from '../../hooks/useIsMobile'
 import type { TaskListRow } from '../../lib/tasks'
 import {
-  NA, PRIORITY, STATUS, fmtInt, fmtTokens, harnessColor, microLabel, numeric, pill, surface,
+  NA, PRIORITY, STATUS, fmtInt, fmtTokens, microLabel, numeric, pill, surface,
   type BoardStatus,
 } from './board'
 import { TaskProgressBar } from './TaskProgressBar'
+import { HarnessBadges } from './HarnessBadges'
 
 /**
  * Most recently touched first.
@@ -56,17 +57,6 @@ function fmtDay(iso: string | undefined, lang: 'pt' | 'en'): string | null {
 function StatusPill({ status }: { status: string }) {
   const s = STATUS[status as BoardStatus] ?? STATUS.backlog
   return <span style={{ ...pill(s.color), background: s.dim }}>{s.label}</span>
-}
-
-function Harnesses({ harnesses }: { harnesses: string[] }) {
-  if (harnesses.length === 0) return <span style={{ color: 'var(--text-tertiary)' }}>{NA}</span>
-  return (
-    <span style={{ display: 'inline-flex', gap: 4, flexWrap: 'wrap' }}>
-      {harnesses.map(h => (
-        <span key={h} style={{ ...pill(harnessColor(h)), fontSize: 10 }}>{h}</span>
-      ))}
-    </span>
-  )
 }
 
 export function RepoTasksTab(p: RepoTasksTabProps) {
@@ -116,7 +106,7 @@ export function RepoTasksTab(p: RepoTasksTabProps) {
                 <span>{fmtTokens(r.rollup.tokens)} <span style={microLabel}>tokens</span></span>
                 <span style={{ color: 'var(--anthropic-orange)' }}>{cost(r.rollup.costUSD)}</span>
               </div>
-              <Harnesses harnesses={r.harnesses} />
+              <HarnessBadges harnesses={r.harnesses} max={3} fontSize={10} />
             </button>
           )
         })}
@@ -186,7 +176,7 @@ export function RepoTasksTab(p: RepoTasksTabProps) {
                 <td style={tdNum}>{fmtInt(r.rollup.rounds)}</td>
                 <td style={tdNum}>{fmtTokens(r.rollup.tokens)}</td>
                 <td style={{ ...tdNum, color: 'var(--anthropic-orange)' }}>{cost(r.rollup.costUSD)}</td>
-                <td style={td}><Harnesses harnesses={r.harnesses} /></td>
+                <td style={td}><HarnessBadges harnesses={r.harnesses} fontSize={10} /></td>
                 {/* An open task has no delivery date — "still running" is not a date, and a
                     duration "so far" beside a delivered one reads as the same measurement. */}
                 <td style={{ ...td, color: 'var(--text-secondary)', whiteSpace: 'nowrap' }}>

--- a/packages/web/src/components/tasks/TaskBoard.tsx
+++ b/packages/web/src/components/tasks/TaskBoard.tsx
@@ -13,10 +13,11 @@ import { Bot, CalendarClock, MessageSquare, Paperclip, Terminal } from 'lucide-r
 import { sortRows, type SortSpec } from '@agentistics/core'
 import {
   COLUMN_ORDER, PRIORITY, SESSION_STATE, STATUS, cardStyle, claimLeft, fmtInt, fmtTokens,
-  harnessColor, microLabel, numeric, pill, surface, type BoardStatus,
+  microLabel, numeric, pill, surface, type BoardStatus,
 } from './board'
 import type { LaneKey } from './boardPrefs'
 import { TaskProgressBar } from './TaskProgressBar'
+import { HarnessBadges } from './HarnessBadges'
 import { statusLabel } from './copy'
 import { useMoney } from './money'
 import type { TaskListRow } from '../../lib/tasks'
@@ -113,9 +114,7 @@ function Card({ row, onOpen, live, nowMs }: {
         <Facts row={row} />
 
         <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap', alignItems: 'center' }}>
-          {row.harnesses.map(h => (
-            <span key={h} style={pill(harnessColor(h))}>{h}</span>
-          ))}
+          {row.harnesses.length > 0 && <HarnessBadges harnesses={row.harnesses} max={3} />}
           {row.attempts > 0 && (
             <span style={pill()}>{row.attempts} attempt{row.attempts === 1 ? '' : 's'}</span>
           )}

--- a/packages/web/src/components/tasks/TaskTable.tsx
+++ b/packages/web/src/components/tasks/TaskTable.tsx
@@ -47,6 +47,7 @@ import { boardCopy, statusLabel, type Lang } from './copy'
 import { subtaskSessions } from './SubtaskSessions'
 import { PickerMenu } from './PickerMenu'
 import { TaskProgressBar } from './TaskProgressBar'
+import { HarnessBadges } from './HarnessBadges'
 import type {
   Subtask, TaskClaim, TaskDetail, TaskListRow, TaskSessionRow, TaskStatus,
 } from '../../lib/tasks'
@@ -229,13 +230,7 @@ function cellFor(
       ? <span style={{ ...numeric, fontSize: 12 }}>{r.credits!.premiumRequests} req</span>
       : <span style={{ ...numeric, fontSize: 12, color: r.costUSD === null ? 'var(--text-tertiary)' : 'var(--anthropic-orange)' }}>{money(r.costUSD)}</span>
     case 'tokens': return <span style={{ ...numeric, fontSize: 12, color: r.tokens === null ? 'var(--text-tertiary)' : undefined }}>{fmtTokens(r.tokens)}</span>
-    case 'harnesses': return (
-      <span style={{ display: 'inline-flex', gap: 4, flexWrap: 'wrap' }}>
-        {row.harnesses.length === 0
-          ? <span style={{ fontSize: 11, color: 'var(--text-tertiary)' }}>{NA}</span>
-          : row.harnesses.map(h => <span key={h} style={pill(harnessColor(h))}>{h}</span>)}
-      </span>
-    )
+    case 'harnesses': return <HarnessBadges harnesses={row.harnesses} />
     case 'subtasks': return row.counts.subtasks === 0
       ? <span style={{ fontSize: 11, color: 'var(--text-tertiary)' }}>—</span>
       : <span style={{ ...numeric, fontSize: 12 }}>{row.counts.subtasksDone}/{row.counts.subtasks}</span>

--- a/packages/web/src/components/tasks/board.test.ts
+++ b/packages/web/src/components/tasks/board.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'bun:test'
+import { capList } from './board'
+
+describe('capList', () => {
+  it('shows everything and reports no extra when the list already fits', () => {
+    expect(capList(['claude', 'codex'], 4)).toEqual({ shown: ['claude', 'codex'], extra: 0 })
+  })
+
+  it('caps at max and reports the truthful remainder — this is the Repositories bug', () => {
+    // Six harnesses, capped at 4: the column must draw 4 pills plus a "+2", never all six.
+    const all = ['claude', 'codex', 'gemini', 'copilot', 'antigravity', 'kimi']
+    expect(capList(all, 4)).toEqual({ shown: ['claude', 'codex', 'gemini', 'copilot'], extra: 2 })
+  })
+
+  it('an empty list stays empty with no extra', () => {
+    expect(capList([], 4)).toEqual({ shown: [], extra: 0 })
+  })
+
+  it('never returns fewer than 1 slot even if max is given as 0 or negative', () => {
+    expect(capList(['a', 'b'], 0)).toEqual({ shown: ['a'], extra: 1 })
+    expect(capList(['a', 'b'], -3)).toEqual({ shown: ['a'], extra: 1 })
+  })
+
+  it('does not mutate the input array', () => {
+    const input = ['a', 'b', 'c']
+    const { shown } = capList(input, 2)
+    shown.push('z')
+    expect(input).toEqual(['a', 'b', 'c'])
+  })
+})

--- a/packages/web/src/components/tasks/board.ts
+++ b/packages/web/src/components/tasks/board.ts
@@ -203,6 +203,18 @@ export const fmtInt = (n: number | null | undefined): string =>
 export const fmtBytes = (n: number): string =>
   (n < 1024 ? `${n} B` : n < 1048576 ? `${(n / 1024).toFixed(1)} KB` : `${(n / 1048576).toFixed(1)} MB`)
 
+/**
+ * Cap a list for display, truthfully: `shown` is what fits, `extra` is what does not — never
+ * silently dropped. A row filed under many harnesses (or any other unbounded per-row list) grows
+ * without limit otherwise, one badge at a time, and a table column stops being a column.
+ */
+export function capList<T>(items: readonly T[], max: number): { shown: T[]; extra: number } {
+  const limit = Math.max(1, Math.floor(max))
+  if (items.length <= limit) return { shown: [...items], extra: 0 }
+  const shown = items.slice(0, limit)
+  return { shown, extra: items.length - shown.length }
+}
+
 /** Compact token counts, because these reach the billions and a full number breaks every column. */
 export function fmtTokens(n: number | null): string {
   if (n === null) return NA


### PR DESCRIPTION
## Bug 4 from bugFinder

"Repositories: coluna de harnesses acumula badges e fica ilegível — repensar exibição."

A task's harnesses list was rendered in full, one pill per harness, `flexWrap`-ped with **no cap** — duplicated near-identically in four places: the main board table (`TaskTable.tsx`), a repository's Tasks tab table + mobile card (`RepoTasksTab.tsx`), the kanban card (`TaskBoard.tsx`), and the central board table (`CentralTaskBoard.tsx`). A delivery whose sessions spanned most of the harnesses this product supports turned the column into an unreadable block of colour.

## Fix

New shared `HarnessBadges` component (+ a pure, tested `capList` helper in `board.ts`) caps the row at a sensible max (4 in a table cell, 3 in the tighter kanban card / mobile card) and folds the remainder into one truthful `+N` pill — its `title` still lists every hidden harness, so nothing is actually lost, only deferred to a hover.

Replaces the four duplicated inline renders with one component — the same pattern `TaskProgressBar` already established (one shared visual rule instead of N copies that can each drift).

## Tests

- New `board.test.ts`: 5 cases for `capList` (fits under max, caps with truthful remainder — the exact bug scenario with 6 harnesses, empty list, degenerate max, no mutation).
- `bunx tsc --noEmit` clean.
- Full suite: 7846 pass / 0 fail.
- `bun run build` succeeds.

Closes out subtask 4 of the "Bug Fixer" board task (`t-379f04a7e2`) — the last remaining item from the original bugFinder list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)