### PR TITLE
feat(server): rollup por subtask + bucket direto (subtaskViews)

### DIFF
--- a/packages/server/server/sessions/task-model.ts
+++ b/packages/server/server/sessions/task-model.ts
@@ -274,11 +274,17 @@ export interface TaskComment {
  * the thing people actually break a task into is smaller pieces of the SAME kind of work, and a
  * checkbox cannot say "this half is blocked and that half shipped on Tuesday".
  *
- * What it deliberately does NOT carry is its own attempts or its own rollup. Cost, rounds and
- * tokens are measured per SESSION and roll up to the task; giving a subtask a second, smaller
- * rollup would either double-count the same sessions or invent a split nobody recorded. `done`
- * survives beside `status` because a tick is still the fastest way to close one, and it stays in
- * step with it: `done` is true exactly when `status` is `done`.
+ * It carries no columns of its own for cost, rounds or tokens — those still live only on
+ * `ManagedSession`/`SessionMeta`, never duplicated here — but it DOES have a rollup: `task-report.ts`'s
+ * `subtaskViews()` sums the sessions filed under this subtask's id, the same way `attemptViews()`
+ * already sums an attempt's. That is a READ over the existing rows, never a second source of truth —
+ * the task's own total (`TaskDetail.rollup`) is computed once, over every row `rowsOfTask` returns,
+ * and a subtask's rollup is only ever a partition of that same set, filtered by `subtaskId`. Nothing
+ * here double-counts a session or invents a split the data does not support: a subtask with no
+ * sessions filed yet gets an honest empty rollup (`sessionsUsed: 0`, every other metric `null`)
+ * rather than being left out or shown as a zero. `done` survives beside `status` because a tick is
+ * still the fastest way to close one, and it stays in step with it: `done` is true exactly when
+ * `status` is `done`. See docs/superpowers/specs/2026-09-10-task-session-hierarchy-design.md §4.2.
  */
 export interface Subtask {
   id: string

--- a/packages/server/server/sessions/task-report.test.ts
+++ b/packages/server/server/sessions/task-report.test.ts
@@ -9,12 +9,18 @@
 
 import { describe, expect, it } from 'bun:test'
 import type { SessionMeta } from '@agentistics/core'
-import { buildTaskDetail, buildTaskList, reposOfRows } from './task-report'
-import type { Task } from './task-model'
+import { buildTaskDetail, buildTaskList, reposOfRows, subtaskViews } from './task-report'
+import type { Subtask, Task } from './task-model'
 import type { ManagedSession } from './types'
 
 const task = (over: Partial<Task> = {}): Task => ({
   id: 't1', title: 'a delivery', status: 'in_progress',
+  createdAt: '2026-09-05T10:00:00.000Z', updatedAt: '2026-09-05T10:00:00.000Z',
+  ...over,
+})
+
+const subtask = (over: Partial<Subtask> = {}): Subtask => ({
+  id: 's1', taskId: 't1', title: 'a piece of work', done: false, status: 'todo',
   createdAt: '2026-09-05T10:00:00.000Z', updatedAt: '2026-09-05T10:00:00.000Z',
   ...over,
 })
@@ -201,5 +207,136 @@ describe('buildTaskDetail — one row per conversation', () => {
       row({ id: 'r2', conversationId: undefined }),
     ])
     expect(detail.sessions.map(s => s.id)).toEqual(['r1', 'r2'])
+  })
+})
+
+/**
+ * `subtaskViews` — a rollup per subtask, plus one `id: null` bucket for sessions filed directly on
+ * the delivery. See docs/superpowers/specs/2026-09-10-task-session-hierarchy-design.md §4.2.
+ *
+ * `rowsOfTask` never conditioned on `subtaskId`, so `TaskDetail.rollup` already summed both
+ * branches before this existed — these tests pin that the BREAKDOWN partitions the exact same rows
+ * exactly once each, across all three shapes the diagrams describe, rather than merely agreeing on
+ * a total two different bugs could still add up to.
+ */
+describe('subtaskViews — the three shapes, no session counted twice', () => {
+  // Distinct, deliberately non-round costs per conversation, so a duplication (double-counted row)
+  // or a drop (missing row) both move the sum away from the expected total instead of an accident
+  // of the numbers used cancelling it out.
+  const costs: Record<string, number> = { c1: 5, c2: 3, c3: 2, c4: 7, c5: 11 }
+  const costOf = (m: SessionMeta) => costs[m.session_id] ?? 0
+  const metasAll = metasOf(...Object.keys(costs).map(id => meta({ session_id: id })))
+
+  const detailOf = (rows: ManagedSession[], subtasks: Subtask[] = []) =>
+    buildTaskDetail({
+      task: task(), attempts: [], rows, metas: metasAll, costOf,
+      comments: [], subtasks, files: [],
+    })
+
+  it('shape #1 — two direct sessions, no subtasks: exactly one id:null bucket, equal to the total', () => {
+    const detail = detailOf([
+      row({ id: 'r1', conversationId: 'c1' }),
+      row({ id: 'r2', conversationId: 'c2' }),
+    ])
+    expect(detail.subtaskRollups).toHaveLength(1)
+    expect(detail.subtaskRollups[0]!.id).toBeNull()
+    // The whole rollup IS the direct bucket's rollup here — nothing else could have contributed.
+    expect(detail.subtaskRollups[0]!.rollup).toEqual(detail.rollup)
+    expect(detail.rollup.sessionsUsed).toBe(2)
+    expect(detail.rollup.costUSD).toBe(8)
+  })
+
+  it('shape #2 — three subtasks, each with a session, no direct ones: three buckets, no id:null', () => {
+    const subs = [subtask({ id: 's1' }), subtask({ id: 's2' }), subtask({ id: 's3' })]
+    const rows = [
+      row({ id: 'r1', conversationId: 'c1', subtaskId: 's1' }),
+      row({ id: 'r2', conversationId: 'c2', subtaskId: 's2' }),
+      row({ id: 'r3', conversationId: 'c3', subtaskId: 's3' }),
+    ]
+    const detail = detailOf(rows, subs)
+
+    expect(detail.subtaskRollups).toHaveLength(3)
+    expect(detail.subtaskRollups.map(v => v.id)).toEqual(['s1', 's2', 's3'])
+    expect(detail.subtaskRollups.some(v => v.id === null)).toBe(false)
+
+    // Each subtask's bucket carries exactly its own session — not zero, not more than one.
+    for (const v of detail.subtaskRollups) expect(v.rollup.sessionsUsed).toBe(1)
+
+    // The partition sums back to the task's own total, computed independently over ALL the rows —
+    // never by re-adding the partitions to derive the total (that would let a duplication that
+    // cancels out in the sum pass silently; checking counts per bucket rules that out here too).
+    const sumSessions = detail.subtaskRollups.reduce((a, v) => a + v.rollup.sessionsUsed, 0)
+    const sumCost = detail.subtaskRollups.reduce((a, v) => a + (v.rollup.costUSD ?? 0), 0)
+    expect(sumSessions).toBe(detail.rollup.sessionsUsed)
+    expect(detail.rollup.costUSD).toBe(sumCost)
+    expect(detail.rollup.costUSD).toBe(10) // 5 + 3 + 2
+  })
+
+  it('shape #3 — two direct + three subtasks with sessions: four buckets, union == the total, no overlap', () => {
+    const subs = [subtask({ id: 's1' }), subtask({ id: 's2' }), subtask({ id: 's3' })]
+    const rows = [
+      row({ id: 'r1', conversationId: 'c1' }), // direct
+      row({ id: 'r2', conversationId: 'c2' }), // direct
+      row({ id: 'r3', conversationId: 'c3', subtaskId: 's1' }),
+      row({ id: 'r4', conversationId: 'c4', subtaskId: 's2' }),
+      row({ id: 'r5', conversationId: 'c5', subtaskId: 's3' }),
+    ]
+    const detail = detailOf(rows, subs)
+
+    expect(detail.subtaskRollups).toHaveLength(4)
+    const byId = new Map(detail.subtaskRollups.map(v => [v.id, v]))
+    expect([...byId.keys()].sort()).toEqual([null, 's1', 's2', 's3'].sort())
+
+    // The direct bucket holds exactly the two direct rows — never the subtask ones, never zero.
+    expect(byId.get(null)!.rollup.sessionsUsed).toBe(2)
+    expect(byId.get(null)!.rollup.costUSD).toBe(8) // c1 + c2
+
+    // Each subtask bucket holds exactly its own row.
+    expect(byId.get('s1')!.rollup.sessionsUsed).toBe(1)
+    expect(byId.get('s1')!.rollup.costUSD).toBe(2) // c3
+    expect(byId.get('s2')!.rollup.sessionsUsed).toBe(1)
+    expect(byId.get('s2')!.rollup.costUSD).toBe(7) // c4
+    expect(byId.get('s3')!.rollup.sessionsUsed).toBe(1)
+    expect(byId.get('s3')!.rollup.costUSD).toBe(11) // c5
+
+    // No session counted in two buckets: the sum of per-bucket counts equals the total exactly —
+    // if a row leaked into two buckets this would read 6, not 5.
+    const sumSessions = [...byId.values()].reduce((a, v) => a + v.rollup.sessionsUsed, 0)
+    expect(sumSessions).toBe(5)
+    expect(sumSessions).toBe(detail.rollup.sessionsUsed)
+
+    const sumCost = [...byId.values()].reduce((a, v) => a + (v.rollup.costUSD ?? 0), 0)
+    expect(detail.rollup.costUSD).toBe(sumCost)
+    expect(detail.rollup.costUSD).toBe(28) // 5+3+2+7+11
+  })
+
+  it('gives a subtask with no sessions filed yet its own honest, empty bucket', () => {
+    // "Nothing filed here yet" is not a zero pretending to be a measurement — sessionsUsed is a
+    // real 0 (nothing IS filed), while cost/tokens/rounds stay null (nothing was MEASURED).
+    const subs = [subtask({ id: 's1' }), subtask({ id: 's2' })]
+    const rows = [row({ id: 'r1', conversationId: 'c1', subtaskId: 's1' })]
+    const detail = detailOf(rows, subs)
+
+    expect(detail.subtaskRollups).toHaveLength(2)
+    const empty = detail.subtaskRollups.find(v => v.id === 's2')!
+    expect(empty.rollup.sessionsUsed).toBe(0)
+    expect(empty.rollup.sessionsLinked).toBe(0)
+    expect(empty.rollup.costUSD).toBeNull()
+    expect(empty.rollup.tokens).toBeNull()
+    expect(empty.rollup.rounds).toBeNull()
+  })
+
+  it('is callable directly, on an already-scoped row set, matching attemptViews\'s own shape', () => {
+    // The exported function itself, not only through buildTaskDetail — it is meant to be composed
+    // the same way `attemptViews` is.
+    const subs = [subtask({ id: 's1' })]
+    const rows = [
+      row({ id: 'r1', conversationId: 'c1', subtaskId: 's1' }),
+      row({ id: 'r2', conversationId: 'c2' }),
+    ]
+    const views = subtaskViews(task(), subs, rows, metasAll, costOf)
+    expect(views).toHaveLength(2)
+    expect(views[0]).toEqual({ id: 's1', rollup: expect.objectContaining({ sessionsUsed: 1 }) })
+    expect(views[1]!.id).toBeNull()
   })
 })

--- a/packages/server/server/sessions/task-report.ts
+++ b/packages/server/server/sessions/task-report.ts
@@ -91,6 +91,7 @@ export interface TaskDetail {
   comments: TaskComment[]
   subtasks: Subtask[]
   files: TaskFile[]
+  subtaskRollups: SubtaskView[]
 }
 
 /**
@@ -188,6 +189,49 @@ export function attemptViews(
       label: 'no attempt named',
       status: 'unattributed',
       rollup: rollupAttempt({ sessions: rollupSessionsFor(loose, metas, costOf) }),
+    })
+  }
+  return views
+}
+
+/** One rollup for a subtask, or for the direct branch (`id: null`) — sessions filed on the task
+ *  itself, under no subtask. Every row of a task falls into EXACTLY one of these buckets, because
+ *  `subtaskId` and "no subtaskId" partition `rowsOfTask(task, rows)` completely — the same
+ *  guarantee `filedUnder` already gives every session a single owner. */
+export interface SubtaskView {
+  id: string | null
+  rollup: AttemptRollup
+}
+
+/**
+ * A rollup per subtask, plus one `id: null` bucket for the sessions filed on the delivery directly
+ * — the same pattern `attemptViews` already applies to attempts, over the same partition.
+ *
+ * `rows` is expected already scoped to the task (`rowsOfTask(task, allRows)`), exactly like
+ * `attemptViews`'s own `rows` parameter — this never re-derives that scope, and never re-sums the
+ * partitions back into a total: `TaskDetail.rollup` is computed once, over the whole set, and this
+ * is only ever a breakdown of it. A subtask with no sessions filed under it yet still gets a row —
+ * "nothing filed here" is a real, empty measurement, not an omission.
+ */
+export function subtaskViews(
+  task: Task,
+  subtasks: readonly Subtask[],
+  rows: readonly ManagedSession[],
+  metas: ReadonlyMap<string, SessionMeta>,
+  costOf: (m: SessionMeta) => number,
+): SubtaskView[] {
+  const mine = subtasks.filter(s => s.taskId === task.id)
+  const views: SubtaskView[] = mine.map(s => ({
+    id: s.id,
+    rollup: rollupAttempt({
+      sessions: rollupSessionsFor(rows.filter(r => r.subtaskId === s.id), metas, costOf),
+    }),
+  }))
+  const direct = rows.filter(r => !r.subtaskId)
+  if (direct.length > 0) {
+    views.push({
+      id: null,
+      rollup: rollupAttempt({ sessions: rollupSessionsFor(direct, metas, costOf) }),
     })
   }
   return views
@@ -303,6 +347,7 @@ export function buildTaskDetail(o: {
     comments: [...(o.comments ?? [])].sort((a, b) => a.createdAt.localeCompare(b.createdAt)),
     subtasks: [...(o.subtasks ?? [])].sort((a, b) => a.createdAt.localeCompare(b.createdAt)),
     files: [...(o.files ?? [])].sort((a, b) => a.createdAt.localeCompare(b.createdAt)),
+    subtaskRollups: subtaskViews(o.task, o.subtasks ?? [], mine, o.metas, o.costOf),
   }
 }
 

--- a/packages/web/src/components/tasks/SubtaskSessions.tsx
+++ b/packages/web/src/components/tasks/SubtaskSessions.tsx
@@ -1,13 +1,15 @@
 /**
  * SubtaskSessions — the sessions filed under one subtask, wherever a subtask is drawn.
  *
- * **A subtask holds ANY NUMBER of sessions, and a delivery holds none directly.** Both halves are
- * new. The cell it replaces was `Subtask.sessionId` — ONE session, written straight onto the
- * subtask record — which could not express the ordinary case (a piece of work picked up again the
- * next morning is a second session on the same subtask) and was a second place the link lived: the
- * server's `task-attach.ts` decides where a session is filed, and a field on the other record was a
- * rule nothing enforced. So this reads the SESSIONS and asks which subtask each names, never the
- * other way round.
+ * **A subtask holds ANY NUMBER of sessions.** That is new — the cell it replaces was
+ * `Subtask.sessionId`, ONE session written straight onto the subtask record, which could not
+ * express the ordinary case (a piece of work picked up again the next morning is a second session
+ * on the same subtask) and was a second place the link lived: the server's `task-attach.ts` decides
+ * where a session is filed, and a field on the other record was a rule nothing enforced. So this
+ * reads the SESSIONS and asks which subtask each names, never the other way round. (A session may
+ * also be filed on the delivery directly, under no subtask at all — see `task-attach.ts` and
+ * docs/superpowers/specs/2026-09-10-task-session-hierarchy-design.md §4.1; that branch is drawn
+ * elsewhere, not by this component.)
  *
  * `Subtask.sessionId` still exists on records written before this and is deliberately NOT read
  * here. It is not evidence: `TaskSessionRow.subtaskId` is what every rollup, every filter and the

--- a/packages/web/src/components/tasks/SubtaskTable.tsx
+++ b/packages/web/src/components/tasks/SubtaskTable.tsx
@@ -5,10 +5,12 @@
  * and a checkbox on the detail page is two different records as far as the reader is concerned, and
  * the one with fewer columns teaches people the fields do not exist.
  *
- * What a subtask does NOT carry is cost, rounds or tokens. Those are measured per SESSION and roll
- * up to the task; a second, smaller rollup here would either count the same sessions twice or
- * invent a split nobody recorded. It carries a SESSION instead — which piece of work is being done
- * where — and that is the honest half.
+ * A subtask carries a SESSION — which piece of work is being done where — and now a ROLLUP of its
+ * own: cost, rounds and tokens are still measured per SESSION, never stored on the subtask itself,
+ * but the server's `subtaskViews()` (`task-report.ts`) sums a subtask's own sessions the same way
+ * `attemptViews()` sums an attempt's, as a partition of the task's rows rather than a second count
+ * of them — nothing here double-counts a session or invents a split the data does not record. See
+ * docs/superpowers/specs/2026-09-10-task-session-hierarchy-design.md §4.2.
  */
 
 import { useState } from 'react'

--- a/packages/web/src/lib/tasks.ts
+++ b/packages/web/src/lib/tasks.ts
@@ -207,6 +207,14 @@ export interface TaskFile {
   kind?: string; author?: string; createdAt: string
 }
 
+/** One rollup for a subtask, or for the direct branch (`id: null`) — sessions filed on the task
+ *  itself, under no subtask. Mirror of the server's `SubtaskView` (`task-report.ts`); see the
+ *  2026-09-10 task-session-hierarchy spec §4.2/§4.3. */
+export interface SubtaskView {
+  id: string | null
+  rollup: AttemptRollup
+}
+
 export interface TaskDetail {
   task: TaskRecord
   attempts: AttemptView[]
@@ -216,6 +224,7 @@ export interface TaskDetail {
   comments: TaskComment[]
   subtasks: Subtask[]
   files: TaskFile[]
+  subtaskRollups: SubtaskView[]
 }
 
 /**


### PR DESCRIPTION
## Resumo

Implementa o §4.2 da spec `docs/superpowers/specs/2026-09-10-task-session-hierarchy-design.md` (task `t-918cc82233`, subtasks `s-db765e0d03`, `s-ef6b3770de`, `s-843b0dd3cb`).

- **`packages/server/server/sessions/task-report.ts`**: novo export `SubtaskView` + `subtaskViews()`, reaproveitando `rollupAttempt`/`rollupSessionsFor` (mesmo padrão de `attemptViews`) — um rollup por subtask mais um bucket `id: null` para sessões filiadas direto na task, omitido quando vazio. Ligado em `buildTaskDetail` via `TaskDetail.subtaskRollups`.
- **`packages/web/src/lib/tasks.ts`**: espelho puro de `SubtaskView`/`TaskDetail.subtaskRollups` (tipo apenas, sem lógica). `GET /api/tasks/:id` já serializa o `TaskDetail` inteiro, então o campo chega ao browser/MCP sem mudança de rota.
- Correção de docblocks que afirmavam "subtask não tem custo próprio": `task-model.ts` (`Subtask`), `SubtaskTable.tsx` (cabeçalho), e a frase "a delivery holds none directly" em `SubtaskSessions.tsx` (que fica incorreta com a filiação direta sendo reaberta em paralelo por outra sessão/worktree — `task-attach.ts` e a ferramenta MCP não são tocados aqui).

## Testes

TDD — `task-report.test.ts` estendido cobrindo os 3 formatos do §7 da spec:
- tarefa só com sessões diretas → 1 bucket `id:null` == rollup total
- tarefa só com subtasks → N buckets, sem `id:null`, soma == total
- híbrida → N+1 buckets, nenhuma sessão duplicada (verificado por `sessionsUsed` por bucket, com custos distintos por conversa, não só pelos totais)
- edge case: subtask sem sessão filiada → bucket honesto (`sessionsUsed: 0`, métricas `null`)

`bun tsc --noEmit` limpo e `bun test` completo: 7846 pass / 0 fail / 1 skip (pré-existente).

🤖 Generated with [Claude Code](https://claude.com/claude-code)