### PR TITLE
fix(server): serialize concurrent resume attempts per conversation

### DIFF
--- a/packages/server/server/cli-start.ts
+++ b/packages/server/server/cli-start.ts
@@ -152,6 +152,7 @@ import { readMemory, readRss } from './sessions/memory-probe'
 // The lock on the door: one conversation, one live session. See `conversation-claim.ts` for the
 // measurement that made it necessary, and `live-claims.ts` for the evidence it is allowed to use.
 import { conversationHeldBy } from './sessions/conversation-claim'
+import { withResumeLock } from './sessions/resume-lock'
 import { liveConversationHolders } from './sessions/live-claims'
 import type { ManagedSession, SpawnPlanError } from './sessions/types'
 import {
@@ -2180,6 +2181,112 @@ export function createControlHost(initialLang: CliLang, altScreen: Suspendable):
     : mode === 'central' ? s.configCentral
     : s.configSolo
 
+  /**
+   * The actual body of `ControlHost.resumeSession`, run inside `withResumeLock` by its caller.
+   *
+   * Pulled out to a plain closure function (not a `StartHost` method) so the lock can wrap it
+   * without adding an undeclared property to the object literal below, which `StartHost` would
+   * reject as an excess property.
+   */
+  async function resumeSessionLocked(req: ResumeSessionRequest): Promise<SpawnSessionResult> {
+    const s = S()
+    // What the old row knew about this work — its task and its note — comes with it. A reopen
+    // that dropped them would file the recovered session nowhere and lose what someone wrote
+    // about it, which is most of the reason the row was worth keeping across the reboot.
+    const previous = req.replaces
+      ? (await readRegistry()).find(m => m.id === req.replaces)
+      : undefined
+    // THE LOCK ON THE DOOR — and, for one kind of holder, the door opening instead.
+    //
+    // Two assistants in one transcript and one working tree is the worst thing this feature has
+    // done, so nothing is spawned before asking who holds the conversation. But WHO holds it
+    // decides what the answer means:
+    //
+    //  - a MANAGED row is somewhere to go. It has a pane, `o` attaches to it, and "open it there"
+    //    is an instruction the user can follow. Still refused, unchanged.
+    //  - a PROCESS is not somewhere to go. An assistant started by hand has no pane to attach to,
+    //    and the refusal named its DIRECTORY — which is not a place. There was no verb that could
+    //    do anything with it either, so the row was a dead end: visible, and inert. Reported.
+    //
+    // For that second case the conversation is on DISK, so ending the process and reopening the
+    // same id under tmux costs the turn in flight and nothing else — and puts the work back under
+    // every verb this screen has. That is a takeover, and it is what `resume` now does rather
+    // than a verb of its own: the user already pressed the key that means "put this conversation
+    // in front of me".
+    // THE DECISION IS `planTakeover`, which already existed and which this code did not use.
+    //
+    // `cli-session.ts` had been taking a conversation over since the CLI gained the verb, through
+    // that pure planner. This method grew its own copy of the same gesture — the exact drift
+    // `task-reopen.ts` was extracted to end — and the copy was WORSE in a way that costs work: it
+    // killed the holder and then tried to resume, so a harness that cannot reopen by id would
+    // have had its assistant closed for nothing. The planner refuses `resume-unsupported` BEFORE
+    // anything is signalled, which is the whole reason it is a plan rather than an action.
+    const holder = conversationHeldBy(
+      await liveConversationHolders(await resolveBackend()),
+      req.sessionId,
+      req.replaces,
+    )
+    // A managed row is somewhere to go: it has a pane and `o` attaches to it, so "open it there"
+    // is an instruction the user can follow. It never becomes a takeover.
+    if (holder?.kind === 'managed') return { ok: false, message: s.sessResumeInUse(holder.label) }
+
+    const harness = req.harness as HarnessId
+    const plan = planTakeover({
+      conversationId: req.sessionId,
+      harness,
+      resumable: planSpawn({ harness, cwd: req.cwd, resumeId: req.sessionId }).ok,
+      ...(holder?.kind === 'process'
+        ? { holder: { ...(holder.pid !== undefined ? { pid: holder.pid } : {}), label: holder.label, cwd: req.cwd } }
+        : {}),
+      cwd: req.cwd,
+    })
+    if (plan.kind === 'refuse') return { ok: false, message: s.sessTakeoverRefused(plan.reason) }
+    if (plan.kind === 'takeover') {
+      // A pid is not an identity — see `isAssistantPid`. Confirmed against the live scan in the
+      // moment before signalling, or the takeover is abandoned: the cost of being wrong here is
+      // SIGKILL on somebody else's process. The planner cannot do this: it is pure, and this is a
+      // question only the machine can answer, in the instant before the signal.
+      if (plan.holder.pid === undefined || !await isAssistantPid(plan.holder.pid)) {
+        return { ok: false, message: s.sessResumeInUse(plan.holder.label ?? req.sessionId) }
+      }
+      const ended = await endProcess(plan.holder.pid)
+      if (!ended) return { ok: false, message: s.sessAdoptFailed(plan.holder.label ?? req.sessionId) }
+    }
+    const spawned = await spawnManaged({
+      harness: req.harness as HarnessId,
+      cwd: req.cwd,
+      resumeId: req.sessionId,
+      label: req.label,
+      attach: req.attach,
+      ...(previous?.task ? { task: previous.task } : {}),
+    }, s)
+    if (spawned.ok) {
+      // We handed this id to the CLI, so the new row KNOWS which conversation it drives — there
+      // is no guessing left for the next reopen. Without it the fallback matches on directory
+      // alone, and every session in one repository resolves to the same conversation.
+      if (spawned.id) await patchSession(spawned.id, { conversationId: req.sessionId })
+      if (previous?.note && spawned.id) await patchSession(spawned.id, { note: previous.note })
+      // The old row is RETIRED rather than deleted: it is still a thing that happened, and it
+      // stops standing beside its own continuation with the same name on it.
+      if (previous) await patchSession(previous.id, { endedAt: new Date().toISOString() })
+
+      const liveBackend = await (await resolveBackend()).list().catch(() => [])
+      const backendIds = new Set(liveBackend.map(b => b.id))
+      await retireFallenSessions({
+        newSessionId: spawned.id,
+        conversationId: req.sessionId,
+        cwd: req.cwd,
+        harness: req.harness,
+        backendIds,
+      })
+
+      // The store's view of what is running just changed, and the next poll must see it rather
+      // than waiting out the cache and showing the conversation as still closed.
+      forgetConversations()
+    }
+    return spawned
+  }
+
   return {
     get lang() { return lang },
 
@@ -3133,102 +3240,15 @@ export function createControlHost(initialLang: CliLang, altScreen: Suspendable):
      * inherits the conversation's NAME, so the row keeps reading the same after the swap.
      */
     async resumeSession(req: ResumeSessionRequest): Promise<SpawnSessionResult> {
-      const s = S()
-      // What the old row knew about this work — its task and its note — comes with it. A reopen
-      // that dropped them would file the recovered session nowhere and lose what someone wrote
-      // about it, which is most of the reason the row was worth keeping across the reboot.
-      const previous = req.replaces
-        ? (await readRegistry()).find(m => m.id === req.replaces)
-        : undefined
-      // THE LOCK ON THE DOOR — and, for one kind of holder, the door opening instead.
-      //
-      // Two assistants in one transcript and one working tree is the worst thing this feature has
-      // done, so nothing is spawned before asking who holds the conversation. But WHO holds it
-      // decides what the answer means:
-      //
-      //  - a MANAGED row is somewhere to go. It has a pane, `o` attaches to it, and "open it there"
-      //    is an instruction the user can follow. Still refused, unchanged.
-      //  - a PROCESS is not somewhere to go. An assistant started by hand has no pane to attach to,
-      //    and the refusal named its DIRECTORY — which is not a place. There was no verb that could
-      //    do anything with it either, so the row was a dead end: visible, and inert. Reported.
-      //
-      // For that second case the conversation is on DISK, so ending the process and reopening the
-      // same id under tmux costs the turn in flight and nothing else — and puts the work back under
-      // every verb this screen has. That is a takeover, and it is what `resume` now does rather
-      // than a verb of its own: the user already pressed the key that means "put this conversation
-      // in front of me".
-      // THE DECISION IS `planTakeover`, which already existed and which this code did not use.
-      //
-      // `cli-session.ts` had been taking a conversation over since the CLI gained the verb, through
-      // that pure planner. This method grew its own copy of the same gesture — the exact drift
-      // `task-reopen.ts` was extracted to end — and the copy was WORSE in a way that costs work: it
-      // killed the holder and then tried to resume, so a harness that cannot reopen by id would
-      // have had its assistant closed for nothing. The planner refuses `resume-unsupported` BEFORE
-      // anything is signalled, which is the whole reason it is a plan rather than an action.
-      const holder = conversationHeldBy(
-        await liveConversationHolders(await resolveBackend()),
-        req.sessionId,
-        req.replaces,
-      )
-      // A managed row is somewhere to go: it has a pane and `o` attaches to it, so "open it there"
-      // is an instruction the user can follow. It never becomes a takeover.
-      if (holder?.kind === 'managed') return { ok: false, message: s.sessResumeInUse(holder.label) }
-
-      const harness = req.harness as HarnessId
-      const plan = planTakeover({
-        conversationId: req.sessionId,
-        harness,
-        resumable: planSpawn({ harness, cwd: req.cwd, resumeId: req.sessionId }).ok,
-        ...(holder?.kind === 'process'
-          ? { holder: { ...(holder.pid !== undefined ? { pid: holder.pid } : {}), label: holder.label, cwd: req.cwd } }
-          : {}),
-        cwd: req.cwd,
-      })
-      if (plan.kind === 'refuse') return { ok: false, message: s.sessTakeoverRefused(plan.reason) }
-      if (plan.kind === 'takeover') {
-        // A pid is not an identity — see `isAssistantPid`. Confirmed against the live scan in the
-        // moment before signalling, or the takeover is abandoned: the cost of being wrong here is
-        // SIGKILL on somebody else's process. The planner cannot do this: it is pure, and this is a
-        // question only the machine can answer, in the instant before the signal.
-        if (plan.holder.pid === undefined || !await isAssistantPid(plan.holder.pid)) {
-          return { ok: false, message: s.sessResumeInUse(plan.holder.label ?? req.sessionId) }
-        }
-        const ended = await endProcess(plan.holder.pid)
-        if (!ended) return { ok: false, message: s.sessAdoptFailed(plan.holder.label ?? req.sessionId) }
-      }
-      const spawned = await spawnManaged({
-        harness: req.harness as HarnessId,
-        cwd: req.cwd,
-        resumeId: req.sessionId,
-        label: req.label,
-        attach: req.attach,
-        ...(previous?.task ? { task: previous.task } : {}),
-      }, s)
-      if (spawned.ok) {
-        // We handed this id to the CLI, so the new row KNOWS which conversation it drives — there
-        // is no guessing left for the next reopen. Without it the fallback matches on directory
-        // alone, and every session in one repository resolves to the same conversation.
-        if (spawned.id) await patchSession(spawned.id, { conversationId: req.sessionId })
-        if (previous?.note && spawned.id) await patchSession(spawned.id, { note: previous.note })
-        // The old row is RETIRED rather than deleted: it is still a thing that happened, and it
-        // stops standing beside its own continuation with the same name on it.
-        if (previous) await patchSession(previous.id, { endedAt: new Date().toISOString() })
-
-        const liveBackend = await (await resolveBackend()).list().catch(() => [])
-        const backendIds = new Set(liveBackend.map(b => b.id))
-        await retireFallenSessions({
-          newSessionId: spawned.id,
-          conversationId: req.sessionId,
-          cwd: req.cwd,
-          harness: req.harness,
-          backendIds,
-        })
-
-        // The store's view of what is running just changed, and the next poll must see it rather
-        // than waiting out the cache and showing the conversation as still closed.
-        forgetConversations()
-      }
-      return spawned
+      // ONE RESUME AT A TIME PER CONVERSATION — see resume-lock.ts. The check inside
+      // `resumeSessionLocked` is a fresh live read, but a fresh read is not an exclusive one: two
+      // `resume` requests for the SAME conversation arriving within milliseconds of each other
+      // (two tabs, a phone and a desktop both reacting to a session that looked stuck at the same
+      // instant) could both read "nobody holds this" before either had spawned, and both would
+      // spawn. Measured on a real machine: two `claude --resume <same-id>` processes, 62ms apart,
+      // both writing into one transcript. The lock serialises the whole check-and-spawn sequence
+      // per conversation id, so the second caller's check only runs once the first has settled.
+      return withResumeLock(req.sessionId, () => resumeSessionLocked(req))
     },
 
     /*

--- a/packages/server/server/sessions/resume-lock.test.ts
+++ b/packages/server/server/sessions/resume-lock.test.ts
@@ -1,0 +1,54 @@
+import { beforeEach, expect, test } from 'bun:test'
+import { resetResumeLocks, withResumeLock } from './resume-lock'
+
+beforeEach(() => { resetResumeLocks() })
+
+const defer = () => {
+  let resolve!: () => void
+  const promise = new Promise<void>(r => { resolve = r })
+  return { promise, resolve }
+}
+
+test('a second resume for the same conversation waits for the first to finish', async () => {
+  const order: string[] = []
+  const gate = defer()
+
+  const first = withResumeLock('conv-1', async () => {
+    order.push('first:start')
+    await gate.promise
+    order.push('first:end')
+  })
+  const second = withResumeLock('conv-1', async () => { order.push('second') })
+
+  // The chain runs on a microtask, so let the first one actually start before looking.
+  await Promise.resolve()
+  // The second must not run while the first is still checking-and-spawning — that overlap is
+  // exactly what let two `claude --resume` processes land for the same conversation.
+  expect(order).toEqual(['first:start'])
+  gate.resolve()
+  await Promise.all([first, second])
+  expect(order).toEqual(['first:start', 'first:end', 'second'])
+})
+
+test('two different conversations do not wait on each other', async () => {
+  const order: string[] = []
+  const gate = defer()
+
+  const a = withResumeLock('conv-a', async () => { await gate.promise; order.push('a') })
+  const b = withResumeLock('conv-b', async () => { order.push('b') })
+
+  await b
+  expect(order).toEqual(['b'])
+  gate.resolve()
+  await a
+})
+
+test('a failed resume does not wedge the lock forever', async () => {
+  await expect(withResumeLock('conv-1', async () => { throw new Error('spawn failed') })).rejects.toThrow('spawn failed')
+  expect(await withResumeLock('conv-1', async () => 'through')).toBe('through')
+})
+
+test('the caller still sees a rejection, it is only the chain that is protected', async () => {
+  const boom = withResumeLock('conv-2', async () => { throw new Error('nope') })
+  await expect(boom).rejects.toThrow('nope')
+})

--- a/packages/server/server/sessions/resume-lock.ts
+++ b/packages/server/server/sessions/resume-lock.ts
@@ -1,0 +1,49 @@
+/**
+ * resume-lock.ts — one resume attempt at a time, per conversation.
+ *
+ * WHY IT EXISTS. `resumeSession` (cli-start.ts) checks who holds a conversation
+ * (`conversationHeldBy`, a fresh live read) and, if nobody does, spawns a new
+ * `claude --resume <id>`. That check is live but not EXCLUSIVE: nothing stopped a second call for
+ * the SAME conversation from running its own check before the first call's spawn had registered a
+ * holder. Two `resume` requests arriving within milliseconds of each other — two browser tabs, or
+ * a phone and a desktop both reacting to a session that looked stuck at the same instant — both
+ * read "nobody holds this" and both spawned. Measured on a real machine: two `claude --resume
+ * <same-id>` processes, 62ms apart, each with its own tmux pane, both writing into one transcript.
+ *
+ * This is a CONVERSATION lock, not a pane lock (see `pane-writer.ts`, which this mirrors) — the key
+ * is the conversation id being resumed, not a session or pane id, because the race is between two
+ * REQUESTS that have not yet created a pane at all.
+ *
+ * FIFO by construction: each call links onto the chain for its own conversation id, so the second
+ * caller's check-and-spawn only runs after the first's has fully settled — by which point the first
+ * has either registered a holder (so the second correctly refuses) or failed outright (so the
+ * second gets a clean attempt).
+ *
+ * A REJECTION NEVER BREAKS THE CHAIN. A failed resume must not wedge every later resume attempt for
+ * that conversation.
+ */
+
+const chains = new Map<string, Promise<unknown>>()
+
+/**
+ * Run `fn` once every resume already queued for `conversationId` has finished.
+ *
+ * The returned promise settles exactly as `fn` does — a throw is still a throw for the caller.
+ */
+export function withResumeLock<T>(conversationId: string, fn: () => Promise<T>): Promise<T> {
+  const prior = chains.get(conversationId) ?? Promise.resolve()
+  const run = prior.then(fn, fn)
+  // The stored link never rejects, so a failure cannot wedge the chain. The CALLER still sees it.
+  chains.set(conversationId, run.then(() => undefined, () => undefined))
+  return run
+}
+
+/** How many conversations currently hold a chain — for a test, and for nothing else. */
+export function conversationsWithPendingResumes(): number {
+  return chains.size
+}
+
+/** Test seam: the map is process-wide, so a test that writes must be able to reset it. */
+export function resetResumeLocks(): void {
+  chains.clear()
+}


### PR DESCRIPTION
## What

Two near-simultaneous `resume` requests for the same conversation could both pass the live `conversationHeldBy()` check before either had finished spawning, so both spawned a `claude --resume` process for the same conversation id.

## Why

Measured on a real machine: two `claude --resume <same-id>` processes, 62ms apart, both writing into one transcript — right after a reboot brought two clients (phone via Tailscale, desktop via localhost) back online at nearly the same instant.

## How

`resume-lock.ts` mirrors `pane-writer.ts`'s per-key async chain, keyed by `conversationId` instead of pane id. `resumeSession` now runs its whole check-and-spawn body through `withResumeLock()`, so a second concurrent call only proceeds once the first has fully settled and correctly sees the new holder.

## Testing

- New `resume-lock.test.ts` reproduces the race against the lock primitive directly (RED before the module existed, GREEN after).
- Full suite passes (7807+ tests, 0 fail) both before and after rebasing onto latest `dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)