### PR TITLE
release: reabre filiação direta de sessão na task + rollup por subtask

### DIFF
--- a/packages/mcp/agentistics-mcp.ts
+++ b/packages/mcp/agentistics-mcp.ts
@@ -359,7 +359,7 @@ const TOOLS: Tool[] = [
   {
     name: "agentistics_task_session",
     description:
-      "BETA — the task board is new and still changing; its shapes may move between releases. File a SESSION under a SUBTASK of a task, which is what makes the task measurable: its cost, tokens, rounds and harness all come from the sessions filed under its parts. **A session is NEVER filed under a task directly — always name a `subtaskId`.** A task is the unit of DELIVERY and a subtask is the unit of WORK; filing at both levels made 'does this cost include the subtasks' unanswerable, so the server refuses it. Use agentistics_task to read the subtasks, or agentistics_task_subtask to create one, then pass `ref` + `sessionId` (a managed session id or conversation id) + `subtaskId`. Pass `detach` with a session id to unfile one. The task inherits the session's repository when it has none.",
+      "BETA — the task board is new and still changing; its shapes may move between releases. File a SESSION under a task, which is what makes the task measurable: its cost, tokens, rounds and harness all come from the sessions filed under it. Pass `subtaskId` to file it under one of the task's subtasks (the unit of WORK, for a task broken into steps); omit it to file the session directly on the task itself (the unit of DELIVERY, for a task simple enough not to need subtasks). Both can be used on the same task — some sessions direct, some under subtasks — and each subtask's own rollup plus the directly-filed sessions' own rollup are both readable via agentistics_task's `subtaskRollups` (keyed by subtask id, with `id: null` for the direct ones), so the breakdown never disappears. Use agentistics_task to read the subtasks, or agentistics_task_subtask to create one, then pass `ref` + `sessionId` (a managed session id or conversation id) + optionally `subtaskId`. Pass `detach` with a session id to unfile one. The task inherits the session's repository when it has none.",
     inputSchema: {
       type: "object",
       properties: {
@@ -368,7 +368,7 @@ const TOOLS: Tool[] = [
         subtaskId: {
           type: "string",
           description:
-            "The subtask to file it under. REQUIRED to file — a task does not take sessions itself.",
+            "The subtask to file it under. Optional — omit to file the session directly on the task itself.",
         },
         detach: { type: "string" },
       },
@@ -730,24 +730,13 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
           return { content: [{ type: "text", text: JSON.stringify(body, null, 2) }] };
         }
         const ref = encodeURIComponent(String(a?.ref ?? ""));
-        // REFUSED HERE, in a sentence, rather than by the server's bare `{ok:false}`. The rule is
-        // the server's (`task-attach.ts`) and this is not a second copy of it — it is the same
-        // refusal said in words the caller can act on, naming the two calls that get it unstuck.
-        // A tool that answers "false" to a reasonable request teaches a retry loop.
-        if (!a?.subtaskId) {
-          return {
-            content: [{
-              type: "text",
-              text: "A session is filed under a SUBTASK, never under the delivery itself — a task is the "
-                + "unit of delivery, a subtask the unit of work. Read the parts with agentistics_task, or "
-                + "create one with agentistics_task_subtask, then call this again with `subtaskId`.",
-            }],
-            isError: true,
-          };
-        }
+        // `subtaskId` is optional: omitted, the server (`task-attach.ts`) files the session
+        // directly on the task; named, it files under that subtask. Either way the server decides
+        // and refuses what it must (unknown task/subtask, a still-blocked subtask) — this is not a
+        // second copy of that rule, just the pass-through.
         const body = await apiSend("POST", `/api/tasks/${ref}/sessions`, {
           sessionId: a?.sessionId,
-          subtaskId: a.subtaskId,
+          ...(a?.subtaskId ? { subtaskId: a.subtaskId } : {}),
         });
         return { content: [{ type: "text", text: JSON.stringify(body, null, 2) }] };
       }

--- a/packages/server/server/cli-start.ts
+++ b/packages/server/server/cli-start.ts
@@ -152,6 +152,7 @@ import { readMemory, readRss } from './sessions/memory-probe'
 // The lock on the door: one conversation, one live session. See `conversation-claim.ts` for the
 // measurement that made it necessary, and `live-claims.ts` for the evidence it is allowed to use.
 import { conversationHeldBy } from './sessions/conversation-claim'
+import { withResumeLock } from './sessions/resume-lock'
 import { liveConversationHolders } from './sessions/live-claims'
 import type { ManagedSession, SpawnPlanError } from './sessions/types'
 import {
@@ -2180,6 +2181,112 @@ export function createControlHost(initialLang: CliLang, altScreen: Suspendable):
     : mode === 'central' ? s.configCentral
     : s.configSolo
 
+  /**
+   * The actual body of `ControlHost.resumeSession`, run inside `withResumeLock` by its caller.
+   *
+   * Pulled out to a plain closure function (not a `StartHost` method) so the lock can wrap it
+   * without adding an undeclared property to the object literal below, which `StartHost` would
+   * reject as an excess property.
+   */
+  async function resumeSessionLocked(req: ResumeSessionRequest): Promise<SpawnSessionResult> {
+    const s = S()
+    // What the old row knew about this work — its task and its note — comes with it. A reopen
+    // that dropped them would file the recovered session nowhere and lose what someone wrote
+    // about it, which is most of the reason the row was worth keeping across the reboot.
+    const previous = req.replaces
+      ? (await readRegistry()).find(m => m.id === req.replaces)
+      : undefined
+    // THE LOCK ON THE DOOR — and, for one kind of holder, the door opening instead.
+    //
+    // Two assistants in one transcript and one working tree is the worst thing this feature has
+    // done, so nothing is spawned before asking who holds the conversation. But WHO holds it
+    // decides what the answer means:
+    //
+    //  - a MANAGED row is somewhere to go. It has a pane, `o` attaches to it, and "open it there"
+    //    is an instruction the user can follow. Still refused, unchanged.
+    //  - a PROCESS is not somewhere to go. An assistant started by hand has no pane to attach to,
+    //    and the refusal named its DIRECTORY — which is not a place. There was no verb that could
+    //    do anything with it either, so the row was a dead end: visible, and inert. Reported.
+    //
+    // For that second case the conversation is on DISK, so ending the process and reopening the
+    // same id under tmux costs the turn in flight and nothing else — and puts the work back under
+    // every verb this screen has. That is a takeover, and it is what `resume` now does rather
+    // than a verb of its own: the user already pressed the key that means "put this conversation
+    // in front of me".
+    // THE DECISION IS `planTakeover`, which already existed and which this code did not use.
+    //
+    // `cli-session.ts` had been taking a conversation over since the CLI gained the verb, through
+    // that pure planner. This method grew its own copy of the same gesture — the exact drift
+    // `task-reopen.ts` was extracted to end — and the copy was WORSE in a way that costs work: it
+    // killed the holder and then tried to resume, so a harness that cannot reopen by id would
+    // have had its assistant closed for nothing. The planner refuses `resume-unsupported` BEFORE
+    // anything is signalled, which is the whole reason it is a plan rather than an action.
+    const holder = conversationHeldBy(
+      await liveConversationHolders(await resolveBackend()),
+      req.sessionId,
+      req.replaces,
+    )
+    // A managed row is somewhere to go: it has a pane and `o` attaches to it, so "open it there"
+    // is an instruction the user can follow. It never becomes a takeover.
+    if (holder?.kind === 'managed') return { ok: false, message: s.sessResumeInUse(holder.label) }
+
+    const harness = req.harness as HarnessId
+    const plan = planTakeover({
+      conversationId: req.sessionId,
+      harness,
+      resumable: planSpawn({ harness, cwd: req.cwd, resumeId: req.sessionId }).ok,
+      ...(holder?.kind === 'process'
+        ? { holder: { ...(holder.pid !== undefined ? { pid: holder.pid } : {}), label: holder.label, cwd: req.cwd } }
+        : {}),
+      cwd: req.cwd,
+    })
+    if (plan.kind === 'refuse') return { ok: false, message: s.sessTakeoverRefused(plan.reason) }
+    if (plan.kind === 'takeover') {
+      // A pid is not an identity — see `isAssistantPid`. Confirmed against the live scan in the
+      // moment before signalling, or the takeover is abandoned: the cost of being wrong here is
+      // SIGKILL on somebody else's process. The planner cannot do this: it is pure, and this is a
+      // question only the machine can answer, in the instant before the signal.
+      if (plan.holder.pid === undefined || !await isAssistantPid(plan.holder.pid)) {
+        return { ok: false, message: s.sessResumeInUse(plan.holder.label ?? req.sessionId) }
+      }
+      const ended = await endProcess(plan.holder.pid)
+      if (!ended) return { ok: false, message: s.sessAdoptFailed(plan.holder.label ?? req.sessionId) }
+    }
+    const spawned = await spawnManaged({
+      harness: req.harness as HarnessId,
+      cwd: req.cwd,
+      resumeId: req.sessionId,
+      label: req.label,
+      attach: req.attach,
+      ...(previous?.task ? { task: previous.task } : {}),
+    }, s)
+    if (spawned.ok) {
+      // We handed this id to the CLI, so the new row KNOWS which conversation it drives — there
+      // is no guessing left for the next reopen. Without it the fallback matches on directory
+      // alone, and every session in one repository resolves to the same conversation.
+      if (spawned.id) await patchSession(spawned.id, { conversationId: req.sessionId })
+      if (previous?.note && spawned.id) await patchSession(spawned.id, { note: previous.note })
+      // The old row is RETIRED rather than deleted: it is still a thing that happened, and it
+      // stops standing beside its own continuation with the same name on it.
+      if (previous) await patchSession(previous.id, { endedAt: new Date().toISOString() })
+
+      const liveBackend = await (await resolveBackend()).list().catch(() => [])
+      const backendIds = new Set(liveBackend.map(b => b.id))
+      await retireFallenSessions({
+        newSessionId: spawned.id,
+        conversationId: req.sessionId,
+        cwd: req.cwd,
+        harness: req.harness,
+        backendIds,
+      })
+
+      // The store's view of what is running just changed, and the next poll must see it rather
+      // than waiting out the cache and showing the conversation as still closed.
+      forgetConversations()
+    }
+    return spawned
+  }
+
   return {
     get lang() { return lang },
 
@@ -3133,102 +3240,15 @@ export function createControlHost(initialLang: CliLang, altScreen: Suspendable):
      * inherits the conversation's NAME, so the row keeps reading the same after the swap.
      */
     async resumeSession(req: ResumeSessionRequest): Promise<SpawnSessionResult> {
-      const s = S()
-      // What the old row knew about this work — its task and its note — comes with it. A reopen
-      // that dropped them would file the recovered session nowhere and lose what someone wrote
-      // about it, which is most of the reason the row was worth keeping across the reboot.
-      const previous = req.replaces
-        ? (await readRegistry()).find(m => m.id === req.replaces)
-        : undefined
-      // THE LOCK ON THE DOOR — and, for one kind of holder, the door opening instead.
-      //
-      // Two assistants in one transcript and one working tree is the worst thing this feature has
-      // done, so nothing is spawned before asking who holds the conversation. But WHO holds it
-      // decides what the answer means:
-      //
-      //  - a MANAGED row is somewhere to go. It has a pane, `o` attaches to it, and "open it there"
-      //    is an instruction the user can follow. Still refused, unchanged.
-      //  - a PROCESS is not somewhere to go. An assistant started by hand has no pane to attach to,
-      //    and the refusal named its DIRECTORY — which is not a place. There was no verb that could
-      //    do anything with it either, so the row was a dead end: visible, and inert. Reported.
-      //
-      // For that second case the conversation is on DISK, so ending the process and reopening the
-      // same id under tmux costs the turn in flight and nothing else — and puts the work back under
-      // every verb this screen has. That is a takeover, and it is what `resume` now does rather
-      // than a verb of its own: the user already pressed the key that means "put this conversation
-      // in front of me".
-      // THE DECISION IS `planTakeover`, which already existed and which this code did not use.
-      //
-      // `cli-session.ts` had been taking a conversation over since the CLI gained the verb, through
-      // that pure planner. This method grew its own copy of the same gesture — the exact drift
-      // `task-reopen.ts` was extracted to end — and the copy was WORSE in a way that costs work: it
-      // killed the holder and then tried to resume, so a harness that cannot reopen by id would
-      // have had its assistant closed for nothing. The planner refuses `resume-unsupported` BEFORE
-      // anything is signalled, which is the whole reason it is a plan rather than an action.
-      const holder = conversationHeldBy(
-        await liveConversationHolders(await resolveBackend()),
-        req.sessionId,
-        req.replaces,
-      )
-      // A managed row is somewhere to go: it has a pane and `o` attaches to it, so "open it there"
-      // is an instruction the user can follow. It never becomes a takeover.
-      if (holder?.kind === 'managed') return { ok: false, message: s.sessResumeInUse(holder.label) }
-
-      const harness = req.harness as HarnessId
-      const plan = planTakeover({
-        conversationId: req.sessionId,
-        harness,
-        resumable: planSpawn({ harness, cwd: req.cwd, resumeId: req.sessionId }).ok,
-        ...(holder?.kind === 'process'
-          ? { holder: { ...(holder.pid !== undefined ? { pid: holder.pid } : {}), label: holder.label, cwd: req.cwd } }
-          : {}),
-        cwd: req.cwd,
-      })
-      if (plan.kind === 'refuse') return { ok: false, message: s.sessTakeoverRefused(plan.reason) }
-      if (plan.kind === 'takeover') {
-        // A pid is not an identity — see `isAssistantPid`. Confirmed against the live scan in the
-        // moment before signalling, or the takeover is abandoned: the cost of being wrong here is
-        // SIGKILL on somebody else's process. The planner cannot do this: it is pure, and this is a
-        // question only the machine can answer, in the instant before the signal.
-        if (plan.holder.pid === undefined || !await isAssistantPid(plan.holder.pid)) {
-          return { ok: false, message: s.sessResumeInUse(plan.holder.label ?? req.sessionId) }
-        }
-        const ended = await endProcess(plan.holder.pid)
-        if (!ended) return { ok: false, message: s.sessAdoptFailed(plan.holder.label ?? req.sessionId) }
-      }
-      const spawned = await spawnManaged({
-        harness: req.harness as HarnessId,
-        cwd: req.cwd,
-        resumeId: req.sessionId,
-        label: req.label,
-        attach: req.attach,
-        ...(previous?.task ? { task: previous.task } : {}),
-      }, s)
-      if (spawned.ok) {
-        // We handed this id to the CLI, so the new row KNOWS which conversation it drives — there
-        // is no guessing left for the next reopen. Without it the fallback matches on directory
-        // alone, and every session in one repository resolves to the same conversation.
-        if (spawned.id) await patchSession(spawned.id, { conversationId: req.sessionId })
-        if (previous?.note && spawned.id) await patchSession(spawned.id, { note: previous.note })
-        // The old row is RETIRED rather than deleted: it is still a thing that happened, and it
-        // stops standing beside its own continuation with the same name on it.
-        if (previous) await patchSession(previous.id, { endedAt: new Date().toISOString() })
-
-        const liveBackend = await (await resolveBackend()).list().catch(() => [])
-        const backendIds = new Set(liveBackend.map(b => b.id))
-        await retireFallenSessions({
-          newSessionId: spawned.id,
-          conversationId: req.sessionId,
-          cwd: req.cwd,
-          harness: req.harness,
-          backendIds,
-        })
-
-        // The store's view of what is running just changed, and the next poll must see it rather
-        // than waiting out the cache and showing the conversation as still closed.
-        forgetConversations()
-      }
-      return spawned
+      // ONE RESUME AT A TIME PER CONVERSATION — see resume-lock.ts. The check inside
+      // `resumeSessionLocked` is a fresh live read, but a fresh read is not an exclusive one: two
+      // `resume` requests for the SAME conversation arriving within milliseconds of each other
+      // (two tabs, a phone and a desktop both reacting to a session that looked stuck at the same
+      // instant) could both read "nobody holds this" before either had spawned, and both would
+      // spawn. Measured on a real machine: two `claude --resume <same-id>` processes, 62ms apart,
+      // both writing into one transcript. The lock serialises the whole check-and-spawn sequence
+      // per conversation id, so the second caller's check only runs once the first has settled.
+      return withResumeLock(req.sessionId, () => resumeSessionLocked(req))
     },
 
     /*

--- a/packages/server/server/sessions/resume-lock.test.ts
+++ b/packages/server/server/sessions/resume-lock.test.ts
@@ -1,0 +1,54 @@
+import { beforeEach, expect, test } from 'bun:test'
+import { resetResumeLocks, withResumeLock } from './resume-lock'
+
+beforeEach(() => { resetResumeLocks() })
+
+const defer = () => {
+  let resolve!: () => void
+  const promise = new Promise<void>(r => { resolve = r })
+  return { promise, resolve }
+}
+
+test('a second resume for the same conversation waits for the first to finish', async () => {
+  const order: string[] = []
+  const gate = defer()
+
+  const first = withResumeLock('conv-1', async () => {
+    order.push('first:start')
+    await gate.promise
+    order.push('first:end')
+  })
+  const second = withResumeLock('conv-1', async () => { order.push('second') })
+
+  // The chain runs on a microtask, so let the first one actually start before looking.
+  await Promise.resolve()
+  // The second must not run while the first is still checking-and-spawning — that overlap is
+  // exactly what let two `claude --resume` processes land for the same conversation.
+  expect(order).toEqual(['first:start'])
+  gate.resolve()
+  await Promise.all([first, second])
+  expect(order).toEqual(['first:start', 'first:end', 'second'])
+})
+
+test('two different conversations do not wait on each other', async () => {
+  const order: string[] = []
+  const gate = defer()
+
+  const a = withResumeLock('conv-a', async () => { await gate.promise; order.push('a') })
+  const b = withResumeLock('conv-b', async () => { order.push('b') })
+
+  await b
+  expect(order).toEqual(['b'])
+  gate.resolve()
+  await a
+})
+
+test('a failed resume does not wedge the lock forever', async () => {
+  await expect(withResumeLock('conv-1', async () => { throw new Error('spawn failed') })).rejects.toThrow('spawn failed')
+  expect(await withResumeLock('conv-1', async () => 'through')).toBe('through')
+})
+
+test('the caller still sees a rejection, it is only the chain that is protected', async () => {
+  const boom = withResumeLock('conv-2', async () => { throw new Error('nope') })
+  await expect(boom).rejects.toThrow('nope')
+})

--- a/packages/server/server/sessions/resume-lock.ts
+++ b/packages/server/server/sessions/resume-lock.ts
@@ -1,0 +1,49 @@
+/**
+ * resume-lock.ts — one resume attempt at a time, per conversation.
+ *
+ * WHY IT EXISTS. `resumeSession` (cli-start.ts) checks who holds a conversation
+ * (`conversationHeldBy`, a fresh live read) and, if nobody does, spawns a new
+ * `claude --resume <id>`. That check is live but not EXCLUSIVE: nothing stopped a second call for
+ * the SAME conversation from running its own check before the first call's spawn had registered a
+ * holder. Two `resume` requests arriving within milliseconds of each other — two browser tabs, or
+ * a phone and a desktop both reacting to a session that looked stuck at the same instant — both
+ * read "nobody holds this" and both spawned. Measured on a real machine: two `claude --resume
+ * <same-id>` processes, 62ms apart, each with its own tmux pane, both writing into one transcript.
+ *
+ * This is a CONVERSATION lock, not a pane lock (see `pane-writer.ts`, which this mirrors) — the key
+ * is the conversation id being resumed, not a session or pane id, because the race is between two
+ * REQUESTS that have not yet created a pane at all.
+ *
+ * FIFO by construction: each call links onto the chain for its own conversation id, so the second
+ * caller's check-and-spawn only runs after the first's has fully settled — by which point the first
+ * has either registered a holder (so the second correctly refuses) or failed outright (so the
+ * second gets a clean attempt).
+ *
+ * A REJECTION NEVER BREAKS THE CHAIN. A failed resume must not wedge every later resume attempt for
+ * that conversation.
+ */
+
+const chains = new Map<string, Promise<unknown>>()
+
+/**
+ * Run `fn` once every resume already queued for `conversationId` has finished.
+ *
+ * The returned promise settles exactly as `fn` does — a throw is still a throw for the caller.
+ */
+export function withResumeLock<T>(conversationId: string, fn: () => Promise<T>): Promise<T> {
+  const prior = chains.get(conversationId) ?? Promise.resolve()
+  const run = prior.then(fn, fn)
+  // The stored link never rejects, so a failure cannot wedge the chain. The CALLER still sees it.
+  chains.set(conversationId, run.then(() => undefined, () => undefined))
+  return run
+}
+
+/** How many conversations currently hold a chain — for a test, and for nothing else. */
+export function conversationsWithPendingResumes(): number {
+  return chains.size
+}
+
+/** Test seam: the map is process-wide, so a test that writes must be able to reset it. */
+export function resetResumeLocks(): void {
+  chains.clear()
+}

--- a/packages/server/server/sessions/task-attach.test.ts
+++ b/packages/server/server/sessions/task-attach.test.ts
@@ -9,16 +9,27 @@ const SUBS = [
 const TASKS = ['t1', 't2']
 
 describe('planAttach', () => {
-  it('REFUSES a delivery as a target — a delivery does not take sessions', () => {
-    // The delivery is the container; the subtask is the work. Allowing both left "does this cost
-    // include the subtasks" without an answer.
+  it('files directly under a delivery — the "not broken out" branch has its own bucket now', () => {
+    // See docs/superpowers/specs/2026-09-10-task-session-hierarchy-design.md §4.1/§4.2: the
+    // task-level total already summed direct rows regardless of subtaskId, and the per-subtask
+    // rollup gives the un-broken-out part its own answerable bucket (subtaskId: null) instead of
+    // an unaccounted-for gap.
     expect(planAttach({ target: { kind: 'task', id: 't1' }, taskIds: TASKS, subtasks: SUBS }))
-      .toEqual({ ok: false, reason: 'needs_subtask' })
+      .toEqual({ ok: true, taskId: 't1', subtaskId: null })
   })
 
   it('still refuses a delivery that does not exist, before anything else', () => {
     expect(planAttach({ target: { kind: 'task', id: 'gone' }, taskIds: TASKS, subtasks: SUBS }))
       .toEqual({ ok: false, reason: 'no_such_task' })
+  })
+
+  it('files directly under a delivery that ALREADY has subtasks — the two branches coexist (#3)', () => {
+    // A task is never forced into one shape: direct sessions and subtask-filed ones can both
+    // exist on the same delivery, and neither blocks the other.
+    expect(planAttach({ target: { kind: 'task', id: 't1' }, taskIds: TASKS, subtasks: SUBS }))
+      .toEqual({ ok: true, taskId: 't1', subtaskId: null })
+    expect(planAttach({ target: { kind: 'subtask', id: 's1' }, taskIds: TASKS, subtasks: SUBS }))
+      .toEqual({ ok: true, taskId: 't1', subtaskId: 's1' })
   })
 
   it('files under a subtask, and takes the parent FROM the subtask', () => {

--- a/packages/server/server/sessions/task-attach.ts
+++ b/packages/server/server/sessions/task-attach.ts
@@ -9,20 +9,28 @@
  * (the blocking subtask was deleted) is not a live block — the same reconciliation `filedUnder`
  * already applies to a missing subtask.
  *
- * **A session is filed under a SUBTASK. Never a delivery directly, never two, never both.**
+ * **A session may be filed on the delivery directly, or on one of its subtasks, or both — see the
+ * 2026-09-10 spec for why holding both is safe** (`docs/superpowers/specs/
+ * 2026-09-10-task-session-hierarchy-design.md`). A delivery is the unit of DELIVERY; a subtask is
+ * the unit of WORK. The two are not mutually exclusive: a simple task can hold its sessions
+ * directly (no subtasks at all), a task broken into steps can file each session under the subtask
+ * it belongs to, and a task can do both at once — direct sessions for the part that was never
+ * broken out, plus subtasks for the part that was.
  *
- * A delivery is the unit of DELIVERY; a subtask is the unit of WORK, and work is what a session
- * does. Allowing both meant the same delivery could hold sessions at two levels with no rule for
- * reading them together — "did this cost include the subtasks or not" had no answer. So the
- * delivery is now a container: its cost is its subtasks' cost, and nothing else.
+ * This used to be refused outright ("a delivery does not take sessions, the caller must name a
+ * subtask"), on the reasoning that allowing both left "did this cost include the subtasks or not"
+ * without an answer. That reasoning stopped holding once `rowsOfTask` (`task-report.ts`) turned out
+ * to already sum every row by `taskId` regardless of `subtaskId` — the task-level total was never
+ * actually ambiguous. What had no answer was one level down: how much a given SUBTASK cost, because
+ * a subtask carried no rollup of its own. `task-report.ts`'s per-subtask views close that gap and
+ * give the un-broken-out, directly-filed part of a task its own answerable bucket
+ * (`subtaskId: null`) instead of a silent, unaccounted-for gap — which is what makes reopening
+ * direct filing safe rather than a regression back to the original ambiguity.
  *
- * Rows filed directly under a delivery before this rule existed are NOT migrated: inventing a
- * subtask to hold them would be inventing the one thing this module refuses to invent. They keep
- * their `taskId`, `filedUnder` still answers `task` for them, and the delivery's screen lists them
- * as work still to be PLACED — visible, countable, and one click from a subtask.
- * That is the whole point of this module: the exclusivity is one rule in one place, so a second
- * surface cannot invent a session that appears in the delivery's own list AND in a subtask's, where
- * a reader would count it twice and neither list would be the truth.
+ * That is still the whole point of this module: the exclusivity that matters is at the STORAGE
+ * level — a session's `subtaskId`/`taskId` pair names exactly one owner, decided in exactly one
+ * place — so a second surface cannot invent a session that appears in two lists at once, where a
+ * reader would count it twice and neither list would be the truth.
  *
  * The parent id is still STORED beside the subtask id, and that is not a contradiction — it is the
  * derived half of the same fact. A subtask belongs to a task, so a session filed under the subtask
@@ -62,10 +70,9 @@ export type AttachPlan =
   | {
     ok: false
     /**
-     * `needs_subtask`: the target was a delivery, and a delivery does not take sessions.
      * `blocked`: the target subtask is still waiting on work named in its own `blockedBy`.
      */
-    reason: 'no_such_task' | 'no_such_subtask' | 'needs_subtask' | 'blocked'
+    reason: 'no_such_task' | 'no_such_subtask' | 'blocked'
     /** Set only for `blocked` — the still-open blocker ids, so the caller can name them. */
     blockedBy?: readonly string[]
   }
@@ -80,10 +87,12 @@ export function planAttach(o: {
 
   if (o.target.kind === 'task') {
     if (!o.taskIds.includes(o.target.id)) return { ok: false, reason: 'no_such_task' }
-    // A DELIVERY DOES NOT TAKE SESSIONS. The caller has to name a subtask of it — creating one is
-    // a gesture the surfaces offer, and refusing here is what keeps "the delivery's cost is its
-    // subtasks' cost" true rather than aspirational.
-    return { ok: false, reason: 'needs_subtask' }
+    // A session may be filed straight on the delivery — see §2.2/§4.2 of
+    // docs/superpowers/specs/2026-09-10-task-session-hierarchy-design.md for why this is safe: the
+    // task's own rollup already sums every row by taskId regardless of subtaskId, and the
+    // subtask-rollup work (task-report.ts's per-subtask views) gives the "not broken out" part of a
+    // task its own answerable bucket instead of an unaccounted-for gap.
+    return { ok: true, taskId: o.target.id, subtaskId: null }
   }
 
   const wanted = o.target.id

--- a/packages/server/server/sessions/task-model.ts
+++ b/packages/server/server/sessions/task-model.ts
@@ -274,11 +274,17 @@ export interface TaskComment {
  * the thing people actually break a task into is smaller pieces of the SAME kind of work, and a
  * checkbox cannot say "this half is blocked and that half shipped on Tuesday".
  *
- * What it deliberately does NOT carry is its own attempts or its own rollup. Cost, rounds and
- * tokens are measured per SESSION and roll up to the task; giving a subtask a second, smaller
- * rollup would either double-count the same sessions or invent a split nobody recorded. `done`
- * survives beside `status` because a tick is still the fastest way to close one, and it stays in
- * step with it: `done` is true exactly when `status` is `done`.
+ * It carries no columns of its own for cost, rounds or tokens — those still live only on
+ * `ManagedSession`/`SessionMeta`, never duplicated here — but it DOES have a rollup: `task-report.ts`'s
+ * `subtaskViews()` sums the sessions filed under this subtask's id, the same way `attemptViews()`
+ * already sums an attempt's. That is a READ over the existing rows, never a second source of truth —
+ * the task's own total (`TaskDetail.rollup`) is computed once, over every row `rowsOfTask` returns,
+ * and a subtask's rollup is only ever a partition of that same set, filtered by `subtaskId`. Nothing
+ * here double-counts a session or invents a split the data does not support: a subtask with no
+ * sessions filed yet gets an honest empty rollup (`sessionsUsed: 0`, every other metric `null`)
+ * rather than being left out or shown as a zero. `done` survives beside `status` because a tick is
+ * still the fastest way to close one, and it stays in step with it: `done` is true exactly when
+ * `status` is `done`. See docs/superpowers/specs/2026-09-10-task-session-hierarchy-design.md §4.2.
  */
 export interface Subtask {
   id: string

--- a/packages/server/server/sessions/task-report.test.ts
+++ b/packages/server/server/sessions/task-report.test.ts
@@ -9,12 +9,18 @@
 
 import { describe, expect, it } from 'bun:test'
 import type { SessionMeta } from '@agentistics/core'
-import { buildTaskDetail, buildTaskList, reposOfRows } from './task-report'
-import type { Task } from './task-model'
+import { buildTaskDetail, buildTaskList, reposOfRows, subtaskViews } from './task-report'
+import type { Subtask, Task } from './task-model'
 import type { ManagedSession } from './types'
 
 const task = (over: Partial<Task> = {}): Task => ({
   id: 't1', title: 'a delivery', status: 'in_progress',
+  createdAt: '2026-09-05T10:00:00.000Z', updatedAt: '2026-09-05T10:00:00.000Z',
+  ...over,
+})
+
+const subtask = (over: Partial<Subtask> = {}): Subtask => ({
+  id: 's1', taskId: 't1', title: 'a piece of work', done: false, status: 'todo',
   createdAt: '2026-09-05T10:00:00.000Z', updatedAt: '2026-09-05T10:00:00.000Z',
   ...over,
 })
@@ -201,5 +207,136 @@ describe('buildTaskDetail — one row per conversation', () => {
       row({ id: 'r2', conversationId: undefined }),
     ])
     expect(detail.sessions.map(s => s.id)).toEqual(['r1', 'r2'])
+  })
+})
+
+/**
+ * `subtaskViews` — a rollup per subtask, plus one `id: null` bucket for sessions filed directly on
+ * the delivery. See docs/superpowers/specs/2026-09-10-task-session-hierarchy-design.md §4.2.
+ *
+ * `rowsOfTask` never conditioned on `subtaskId`, so `TaskDetail.rollup` already summed both
+ * branches before this existed — these tests pin that the BREAKDOWN partitions the exact same rows
+ * exactly once each, across all three shapes the diagrams describe, rather than merely agreeing on
+ * a total two different bugs could still add up to.
+ */
+describe('subtaskViews — the three shapes, no session counted twice', () => {
+  // Distinct, deliberately non-round costs per conversation, so a duplication (double-counted row)
+  // or a drop (missing row) both move the sum away from the expected total instead of an accident
+  // of the numbers used cancelling it out.
+  const costs: Record<string, number> = { c1: 5, c2: 3, c3: 2, c4: 7, c5: 11 }
+  const costOf = (m: SessionMeta) => costs[m.session_id] ?? 0
+  const metasAll = metasOf(...Object.keys(costs).map(id => meta({ session_id: id })))
+
+  const detailOf = (rows: ManagedSession[], subtasks: Subtask[] = []) =>
+    buildTaskDetail({
+      task: task(), attempts: [], rows, metas: metasAll, costOf,
+      comments: [], subtasks, files: [],
+    })
+
+  it('shape #1 — two direct sessions, no subtasks: exactly one id:null bucket, equal to the total', () => {
+    const detail = detailOf([
+      row({ id: 'r1', conversationId: 'c1' }),
+      row({ id: 'r2', conversationId: 'c2' }),
+    ])
+    expect(detail.subtaskRollups).toHaveLength(1)
+    expect(detail.subtaskRollups[0]!.id).toBeNull()
+    // The whole rollup IS the direct bucket's rollup here — nothing else could have contributed.
+    expect(detail.subtaskRollups[0]!.rollup).toEqual(detail.rollup)
+    expect(detail.rollup.sessionsUsed).toBe(2)
+    expect(detail.rollup.costUSD).toBe(8)
+  })
+
+  it('shape #2 — three subtasks, each with a session, no direct ones: three buckets, no id:null', () => {
+    const subs = [subtask({ id: 's1' }), subtask({ id: 's2' }), subtask({ id: 's3' })]
+    const rows = [
+      row({ id: 'r1', conversationId: 'c1', subtaskId: 's1' }),
+      row({ id: 'r2', conversationId: 'c2', subtaskId: 's2' }),
+      row({ id: 'r3', conversationId: 'c3', subtaskId: 's3' }),
+    ]
+    const detail = detailOf(rows, subs)
+
+    expect(detail.subtaskRollups).toHaveLength(3)
+    expect(detail.subtaskRollups.map(v => v.id)).toEqual(['s1', 's2', 's3'])
+    expect(detail.subtaskRollups.some(v => v.id === null)).toBe(false)
+
+    // Each subtask's bucket carries exactly its own session — not zero, not more than one.
+    for (const v of detail.subtaskRollups) expect(v.rollup.sessionsUsed).toBe(1)
+
+    // The partition sums back to the task's own total, computed independently over ALL the rows —
+    // never by re-adding the partitions to derive the total (that would let a duplication that
+    // cancels out in the sum pass silently; checking counts per bucket rules that out here too).
+    const sumSessions = detail.subtaskRollups.reduce((a, v) => a + v.rollup.sessionsUsed, 0)
+    const sumCost = detail.subtaskRollups.reduce((a, v) => a + (v.rollup.costUSD ?? 0), 0)
+    expect(sumSessions).toBe(detail.rollup.sessionsUsed)
+    expect(detail.rollup.costUSD).toBe(sumCost)
+    expect(detail.rollup.costUSD).toBe(10) // 5 + 3 + 2
+  })
+
+  it('shape #3 — two direct + three subtasks with sessions: four buckets, union == the total, no overlap', () => {
+    const subs = [subtask({ id: 's1' }), subtask({ id: 's2' }), subtask({ id: 's3' })]
+    const rows = [
+      row({ id: 'r1', conversationId: 'c1' }), // direct
+      row({ id: 'r2', conversationId: 'c2' }), // direct
+      row({ id: 'r3', conversationId: 'c3', subtaskId: 's1' }),
+      row({ id: 'r4', conversationId: 'c4', subtaskId: 's2' }),
+      row({ id: 'r5', conversationId: 'c5', subtaskId: 's3' }),
+    ]
+    const detail = detailOf(rows, subs)
+
+    expect(detail.subtaskRollups).toHaveLength(4)
+    const byId = new Map(detail.subtaskRollups.map(v => [v.id, v]))
+    expect([...byId.keys()].sort()).toEqual([null, 's1', 's2', 's3'].sort())
+
+    // The direct bucket holds exactly the two direct rows — never the subtask ones, never zero.
+    expect(byId.get(null)!.rollup.sessionsUsed).toBe(2)
+    expect(byId.get(null)!.rollup.costUSD).toBe(8) // c1 + c2
+
+    // Each subtask bucket holds exactly its own row.
+    expect(byId.get('s1')!.rollup.sessionsUsed).toBe(1)
+    expect(byId.get('s1')!.rollup.costUSD).toBe(2) // c3
+    expect(byId.get('s2')!.rollup.sessionsUsed).toBe(1)
+    expect(byId.get('s2')!.rollup.costUSD).toBe(7) // c4
+    expect(byId.get('s3')!.rollup.sessionsUsed).toBe(1)
+    expect(byId.get('s3')!.rollup.costUSD).toBe(11) // c5
+
+    // No session counted in two buckets: the sum of per-bucket counts equals the total exactly —
+    // if a row leaked into two buckets this would read 6, not 5.
+    const sumSessions = [...byId.values()].reduce((a, v) => a + v.rollup.sessionsUsed, 0)
+    expect(sumSessions).toBe(5)
+    expect(sumSessions).toBe(detail.rollup.sessionsUsed)
+
+    const sumCost = [...byId.values()].reduce((a, v) => a + (v.rollup.costUSD ?? 0), 0)
+    expect(detail.rollup.costUSD).toBe(sumCost)
+    expect(detail.rollup.costUSD).toBe(28) // 5+3+2+7+11
+  })
+
+  it('gives a subtask with no sessions filed yet its own honest, empty bucket', () => {
+    // "Nothing filed here yet" is not a zero pretending to be a measurement — sessionsUsed is a
+    // real 0 (nothing IS filed), while cost/tokens/rounds stay null (nothing was MEASURED).
+    const subs = [subtask({ id: 's1' }), subtask({ id: 's2' })]
+    const rows = [row({ id: 'r1', conversationId: 'c1', subtaskId: 's1' })]
+    const detail = detailOf(rows, subs)
+
+    expect(detail.subtaskRollups).toHaveLength(2)
+    const empty = detail.subtaskRollups.find(v => v.id === 's2')!
+    expect(empty.rollup.sessionsUsed).toBe(0)
+    expect(empty.rollup.sessionsLinked).toBe(0)
+    expect(empty.rollup.costUSD).toBeNull()
+    expect(empty.rollup.tokens).toBeNull()
+    expect(empty.rollup.rounds).toBeNull()
+  })
+
+  it('is callable directly, on an already-scoped row set, matching attemptViews\'s own shape', () => {
+    // The exported function itself, not only through buildTaskDetail — it is meant to be composed
+    // the same way `attemptViews` is.
+    const subs = [subtask({ id: 's1' })]
+    const rows = [
+      row({ id: 'r1', conversationId: 'c1', subtaskId: 's1' }),
+      row({ id: 'r2', conversationId: 'c2' }),
+    ]
+    const views = subtaskViews(task(), subs, rows, metasAll, costOf)
+    expect(views).toHaveLength(2)
+    expect(views[0]).toEqual({ id: 's1', rollup: expect.objectContaining({ sessionsUsed: 1 }) })
+    expect(views[1]!.id).toBeNull()
   })
 })

--- a/packages/server/server/sessions/task-report.ts
+++ b/packages/server/server/sessions/task-report.ts
@@ -91,6 +91,7 @@ export interface TaskDetail {
   comments: TaskComment[]
   subtasks: Subtask[]
   files: TaskFile[]
+  subtaskRollups: SubtaskView[]
 }
 
 /**
@@ -188,6 +189,49 @@ export function attemptViews(
       label: 'no attempt named',
       status: 'unattributed',
       rollup: rollupAttempt({ sessions: rollupSessionsFor(loose, metas, costOf) }),
+    })
+  }
+  return views
+}
+
+/** One rollup for a subtask, or for the direct branch (`id: null`) — sessions filed on the task
+ *  itself, under no subtask. Every row of a task falls into EXACTLY one of these buckets, because
+ *  `subtaskId` and "no subtaskId" partition `rowsOfTask(task, rows)` completely — the same
+ *  guarantee `filedUnder` already gives every session a single owner. */
+export interface SubtaskView {
+  id: string | null
+  rollup: AttemptRollup
+}
+
+/**
+ * A rollup per subtask, plus one `id: null` bucket for the sessions filed on the delivery directly
+ * — the same pattern `attemptViews` already applies to attempts, over the same partition.
+ *
+ * `rows` is expected already scoped to the task (`rowsOfTask(task, allRows)`), exactly like
+ * `attemptViews`'s own `rows` parameter — this never re-derives that scope, and never re-sums the
+ * partitions back into a total: `TaskDetail.rollup` is computed once, over the whole set, and this
+ * is only ever a breakdown of it. A subtask with no sessions filed under it yet still gets a row —
+ * "nothing filed here" is a real, empty measurement, not an omission.
+ */
+export function subtaskViews(
+  task: Task,
+  subtasks: readonly Subtask[],
+  rows: readonly ManagedSession[],
+  metas: ReadonlyMap<string, SessionMeta>,
+  costOf: (m: SessionMeta) => number,
+): SubtaskView[] {
+  const mine = subtasks.filter(s => s.taskId === task.id)
+  const views: SubtaskView[] = mine.map(s => ({
+    id: s.id,
+    rollup: rollupAttempt({
+      sessions: rollupSessionsFor(rows.filter(r => r.subtaskId === s.id), metas, costOf),
+    }),
+  }))
+  const direct = rows.filter(r => !r.subtaskId)
+  if (direct.length > 0) {
+    views.push({
+      id: null,
+      rollup: rollupAttempt({ sessions: rollupSessionsFor(direct, metas, costOf) }),
     })
   }
   return views
@@ -303,6 +347,7 @@ export function buildTaskDetail(o: {
     comments: [...(o.comments ?? [])].sort((a, b) => a.createdAt.localeCompare(b.createdAt)),
     subtasks: [...(o.subtasks ?? [])].sort((a, b) => a.createdAt.localeCompare(b.createdAt)),
     files: [...(o.files ?? [])].sort((a, b) => a.createdAt.localeCompare(b.createdAt)),
+    subtaskRollups: subtaskViews(o.task, o.subtasks ?? [], mine, o.metas, o.costOf),
   }
 }
 

--- a/packages/web/src/components/tasks/SubtaskSessions.tsx
+++ b/packages/web/src/components/tasks/SubtaskSessions.tsx
@@ -1,13 +1,15 @@
 /**
  * SubtaskSessions — the sessions filed under one subtask, wherever a subtask is drawn.
  *
- * **A subtask holds ANY NUMBER of sessions, and a delivery holds none directly.** Both halves are
- * new. The cell it replaces was `Subtask.sessionId` — ONE session, written straight onto the
- * subtask record — which could not express the ordinary case (a piece of work picked up again the
- * next morning is a second session on the same subtask) and was a second place the link lived: the
- * server's `task-attach.ts` decides where a session is filed, and a field on the other record was a
- * rule nothing enforced. So this reads the SESSIONS and asks which subtask each names, never the
- * other way round.
+ * **A subtask holds ANY NUMBER of sessions.** That is new — the cell it replaces was
+ * `Subtask.sessionId`, ONE session written straight onto the subtask record, which could not
+ * express the ordinary case (a piece of work picked up again the next morning is a second session
+ * on the same subtask) and was a second place the link lived: the server's `task-attach.ts` decides
+ * where a session is filed, and a field on the other record was a rule nothing enforced. So this
+ * reads the SESSIONS and asks which subtask each names, never the other way round. (A session may
+ * also be filed on the delivery directly, under no subtask at all — see `task-attach.ts` and
+ * docs/superpowers/specs/2026-09-10-task-session-hierarchy-design.md §4.1; that branch is drawn
+ * elsewhere, not by this component.)
  *
  * `Subtask.sessionId` still exists on records written before this and is deliberately NOT read
  * here. It is not evidence: `TaskSessionRow.subtaskId` is what every rollup, every filter and the

--- a/packages/web/src/components/tasks/SubtaskTable.tsx
+++ b/packages/web/src/components/tasks/SubtaskTable.tsx
@@ -5,10 +5,12 @@
  * and a checkbox on the detail page is two different records as far as the reader is concerned, and
  * the one with fewer columns teaches people the fields do not exist.
  *
- * What a subtask does NOT carry is cost, rounds or tokens. Those are measured per SESSION and roll
- * up to the task; a second, smaller rollup here would either count the same sessions twice or
- * invent a split nobody recorded. It carries a SESSION instead — which piece of work is being done
- * where — and that is the honest half.
+ * A subtask carries a SESSION — which piece of work is being done where — and now a ROLLUP of its
+ * own: cost, rounds and tokens are still measured per SESSION, never stored on the subtask itself,
+ * but the server's `subtaskViews()` (`task-report.ts`) sums a subtask's own sessions the same way
+ * `attemptViews()` sums an attempt's, as a partition of the task's rows rather than a second count
+ * of them — nothing here double-counts a session or invents a split the data does not record. See
+ * docs/superpowers/specs/2026-09-10-task-session-hierarchy-design.md §4.2.
  */
 
 import { useState } from 'react'

--- a/packages/web/src/lib/tasks.ts
+++ b/packages/web/src/lib/tasks.ts
@@ -207,6 +207,14 @@ export interface TaskFile {
   kind?: string; author?: string; createdAt: string
 }
 
+/** One rollup for a subtask, or for the direct branch (`id: null`) — sessions filed on the task
+ *  itself, under no subtask. Mirror of the server's `SubtaskView` (`task-report.ts`); see the
+ *  2026-09-10 task-session-hierarchy spec §4.2/§4.3. */
+export interface SubtaskView {
+  id: string | null
+  rollup: AttemptRollup
+}
+
 export interface TaskDetail {
   task: TaskRecord
   attempts: AttemptView[]
@@ -216,6 +224,7 @@ export interface TaskDetail {
   comments: TaskComment[]
   subtasks: Subtask[]
   files: TaskFile[]
+  subtaskRollups: SubtaskView[]
 }
 
 /**


### PR DESCRIPTION
## Release

- #494 — rollup por subtask (`subtaskViews`, com o bucket `id: null` pras sessões filiadas direto na task) — parte da remodelagem da hierarquia task/subtask/sessão (spec `docs/superpowers/specs/2026-09-10-task-session-hierarchy-design.md`).
- #495 — `planAttach` para de recusar sessão filiada direto na task (`needs_subtask` removido); MCP `agentistics_task_session` documenta `subtaskId` como opcional.
- #496 — serializa tentativas concorrentes de resume por conversa (`resume-lock.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)