### PR TITLE
feat(server): route around Windows-excluded ports on WSL2 startup

### DIFF
--- a/packages/server/bin/cli.ts
+++ b/packages/server/bin/cli.ts
@@ -754,6 +754,34 @@ if (command === 'start') {
 }
 
 if (command === 'server' || command === 'start' || !command) {
+  // WSL2 CAN HAVE OUR PORTS EXCLUDED BY WINDOWS BEFORE WE EVER BIND THEM. Windows' WinNAT reserves
+  // a port range for itself every time the Hyper-V/WSL network stack comes up (reboot, `wsl
+  // --shutdown`, Docker or a VPN reconnecting), and it is not the same range twice. When it lands
+  // on 47291/47292 the server binds fine INSIDE the VM — reachable over the LAN, over Tailscale —
+  // while `localhost` from Windows gets a bare connection refused, with nothing anywhere saying
+  // why. This runs BEFORE anything downstream reads PORT/WEB_PORT (the banner below, the MCP
+  // bridge, config.ts's own constants) so they all agree on where the server actually ends up; see
+  // wsl-ports-io.ts for the read-only detection and wsl-ports.ts for why the parser trusts no
+  // locale. A read-only query needs no elevation, so this runs unconditionally on every WSL2 boot
+  // — the actual fix (`net stop winnat && net start winnat`) needs an elevated PowerShell and stays
+  // a human's decision, never something this process does for them.
+  {
+    const { resolveWslPorts } = await import('../server/wsl-ports-io.ts')
+    const defaultPort = parseInt(process.env.PORT ?? '47291', 10)
+    const resolved = resolveWslPorts(defaultPort)
+    if (resolved.status === 'resolved') {
+      process.env.PORT = String(resolved.port)
+      process.env.WEB_PORT = String(resolved.webPort)
+      console.log(`\n  ⚠ Windows has excluded port ${defaultPort} (and ${defaultPort + 1}) from WSL2's`)
+      console.log(`    localhost forwarding — using ${resolved.port}/${resolved.webPort} instead.`)
+      console.log('    Fix on Windows (Admin PowerShell): net stop winnat && net start winnat\n')
+    } else if (resolved.status === 'unresolved') {
+      console.log(`\n  ⚠ Windows appears to exclude port ${defaultPort} from WSL2's localhost forwarding,`)
+      console.log('    and no free replacement turned up nearby — localhost may not reach this server.')
+      console.log('    Fix on Windows (Admin PowerShell): net stop winnat && net start winnat\n')
+    }
+  }
+
   // `--port` is already in the environment — see the note above the command dispatch. The index is
   // still needed here to forward the flag to a detached copy.
   const portIdx = args.indexOf('--port')

--- a/packages/server/server/wsl-ports-io.ts
+++ b/packages/server/server/wsl-ports-io.ts
@@ -1,0 +1,99 @@
+/**
+ * wsl-ports-io.ts — the IO boundary in front of the pure `wsl-ports.ts`.
+ *
+ * Two facts have to be read from the OS before the pure arithmetic can run: whether this process
+ * is even inside WSL2, and — only then — which port ranges Windows currently excludes. Both are
+ * READS, both are cheap, and both fail CLOSED: any error, timeout, or missing tool means "assume
+ * nothing is wrong" rather than risking a startup that hangs or a port picked on a guess. This is
+ * the same shape `repo-facts.ts` uses for "a directory that answers nothing is not a repository" —
+ * an absent answer is a fact about the moment, not license to invent one.
+ */
+import { readFileSync } from 'node:fs'
+import { findFreePortPair, parseExcludedRanges, portInAnyRange, type PortRange } from './wsl-ports'
+
+/** True only when `/proc/version` names Microsoft's WSL kernel build. False on any read error —
+ *  off Linux, in a container without `/proc`, or anywhere permission denies the read. */
+export function isWSL(): boolean {
+  try {
+    return /microsoft/i.test(readFileSync('/proc/version', 'utf8'))
+  } catch {
+    return false
+  }
+}
+
+/**
+ * `powershell.exe` by bare name, via a PATH lookup — works in an interactive login shell (WSL's
+ * `interop.appendWindowsPath` appends the Windows PATH there) and NOWHERE ELSE. Measured on a real
+ * machine: the same command that printed real output from an interactive bash session threw
+ * `ENOENT` from `Bun.spawnSync` and answered `sh: 1: powershell.exe: not found` from `sh -c` — the
+ * two contexts this feature actually runs in, `agentop-server.service` (systemd, no login shell)
+ * and this module's own spawn. The Windows PATH is a login-shell-only convenience, not a property
+ * of the process environment, so nothing here may depend on it.
+ */
+const POWERSHELL_PATHS = [
+  // The one location Windows PowerShell 5.1 ships at on every Windows install, confirmed present
+  // and working via Bun.spawnSync directly on the machine this was measured on. `/mnt/c` is the
+  // default WSL2 automount root; a machine with a customized one falls through to the PATH lookup.
+  '/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe',
+  'powershell.exe',
+]
+
+/**
+ * The Windows host's current TCP port exclusions, via WSL's interop with `powershell.exe` — or
+ * `null` when the answer could not be verified (no interop, `powershell.exe` missing everywhere
+ * tried, a non-zero exit, a hang past the timeout, or an exception). `null` must never be read as
+ * "no exclusions": it means this machine could not be asked, and the caller's job is to change
+ * NOTHING on that uncertainty, the same way an unreadable directory reports `missing` rather than
+ * "not a repo".
+ */
+export function readWindowsExcludedPortRanges(timeoutMs = 4000): PortRange[] | null {
+  for (const bin of POWERSHELL_PATHS) {
+    try {
+      const result = Bun.spawnSync(
+        [bin, '-NoProfile', '-NonInteractive', '-Command', 'netsh interface ipv4 show excludedportrange protocol=tcp'],
+        { stdout: 'pipe', stderr: 'ignore', timeout: timeoutMs },
+      )
+      if (result.exitCode === 0) return parseExcludedRanges(result.stdout.toString('utf8'))
+    } catch {
+      // Try the next candidate — ENOENT here is the ordinary case for whichever path is not this
+      // machine's, not a reason to give up on the other one.
+    }
+  }
+  return null
+}
+
+/** Why `resolveWslPorts` returned what it did — every branch is a sentence somewhere, never a
+ *  silent choice. See `wsl-ports.ts`'s header for the failure this exists to catch. */
+export type WslPortStatus =
+  | 'not-wsl' // not running under WSL2 — the whole feature does not apply
+  | 'unknown' // WSL2, but Windows' exclusion table could not be read — left untouched
+  | 'clear' // WSL2, checked, and the configured ports are not excluded
+  | 'resolved' // WSL2, the configured ports ARE excluded, and a free pair was found
+  | 'unresolved' // WSL2, excluded, and no free pair turned up within the search budget
+
+export interface WslPortResolution {
+  port: number
+  webPort: number
+  status: WslPortStatus
+}
+
+/**
+ * Resolve the port pair to actually bind, given the configured default — PORT/WEB_PORT unchanged
+ * unless WSL2 is detected AND the default pair is confirmed excluded AND a working pair exists.
+ * Every other case returns the untouched default, with `status` naming why nothing moved.
+ */
+export function resolveWslPorts(defaultPort: number): WslPortResolution {
+  const webPort = defaultPort + 1
+  if (!isWSL()) return { port: defaultPort, webPort, status: 'not-wsl' }
+
+  const ranges = readWindowsExcludedPortRanges()
+  if (ranges === null) return { port: defaultPort, webPort, status: 'unknown' }
+
+  if (!portInAnyRange(ranges, defaultPort) && !portInAnyRange(ranges, webPort)) {
+    return { port: defaultPort, webPort, status: 'clear' }
+  }
+
+  const found = findFreePortPair(ranges, defaultPort + 1)
+  if (!found) return { port: defaultPort, webPort, status: 'unresolved' }
+  return { port: found.port, webPort: found.webPort, status: 'resolved' }
+}

--- a/packages/server/server/wsl-ports.test.ts
+++ b/packages/server/server/wsl-ports.test.ts
@@ -1,0 +1,78 @@
+import { expect, test } from 'bun:test'
+import { findFreePortPair, parseExcludedRanges, portInAnyRange } from './wsl-ports'
+
+test('parses a real netsh excludedportrange table, Portuguese locale, asterisk and all', () => {
+  const output = `
+Protocolo tcp Intervalos de Exclusão de Porta
+
+Porta Inicial    Porta Final
+----------    --------
+      5357        5357
+      8883        8883
+     47277       47376
+     50000       50059     *
+     55245       55344
+
+* - Exclusões de porta administradas.
+`
+  expect(parseExcludedRanges(output)).toEqual([
+    { start: 5357, end: 5357 },
+    { start: 8883, end: 8883 },
+    { start: 47277, end: 47376 },
+    { start: 50000, end: 50059 },
+    { start: 55245, end: 55344 },
+  ])
+})
+
+test('parses the English-locale header the same way — the parser reads numbers, not labels', () => {
+  const output = `
+Protocol tcp Port Exclusion Ranges
+
+Start Port    End Port
+----------    --------
+     47291       47291
+`
+  expect(parseExcludedRanges(output)).toEqual([{ start: 47291, end: 47291 }])
+})
+
+test('an empty or garbage table yields no ranges rather than throwing', () => {
+  expect(parseExcludedRanges('')).toEqual([])
+  expect(parseExcludedRanges('access denied\nsomething went wrong')).toEqual([])
+})
+
+test('portInAnyRange is true only when the port falls inside a listed range, inclusive', () => {
+  const ranges = [{ start: 47277, end: 47376 }]
+  expect(portInAnyRange(ranges, 47276)).toBe(false)
+  expect(portInAnyRange(ranges, 47277)).toBe(true)
+  expect(portInAnyRange(ranges, 47320)).toBe(true)
+  expect(portInAnyRange(ranges, 47376)).toBe(true)
+  expect(portInAnyRange(ranges, 47377)).toBe(false)
+})
+
+test('findFreePortPair returns the default pair untouched when nothing conflicts', () => {
+  expect(findFreePortPair([], 47291)).toEqual({ port: 47291, webPort: 47292 })
+})
+
+test('findFreePortPair steps past an excluded range that covers the default pair', () => {
+  // This is the real machine's measured case: 47291/47292 both fall inside 47277-47376.
+  const ranges = [{ start: 47277, end: 47376 }]
+  const found = findFreePortPair(ranges, 47291)
+  expect(found).not.toBeNull()
+  expect(found!.port).toBeGreaterThan(47376)
+  expect(portInAnyRange(ranges, found!.port)).toBe(false)
+  expect(portInAnyRange(ranges, found!.webPort)).toBe(false)
+})
+
+test('findFreePortPair skips a pair only half-covered by a range', () => {
+  // 47292 (the would-be webPort) is excluded even though 47291 is not — a pair is only free when
+  // BOTH ports clear every range, or the dashboard would bind to a port Windows still won't relay.
+  const ranges = [{ start: 47292, end: 47292 }]
+  const found = findFreePortPair(ranges, 47291)
+  expect(found).toEqual({ port: 47293, webPort: 47294 })
+})
+
+test('findFreePortPair gives up honestly rather than searching forever', () => {
+  // A single range spanning the whole search budget leaves nothing to find.
+  const ranges = [{ start: 1, end: 100000 }]
+  expect(findFreePortPair(ranges, 47291, 50)).toBeNull()
+})

--- a/packages/server/server/wsl-ports.ts
+++ b/packages/server/server/wsl-ports.ts
@@ -1,0 +1,73 @@
+/**
+ * wsl-ports.ts — WSL2 finds its own ports excluded by Windows before it ever tries to bind them.
+ *
+ * WHY IT EXISTS. Windows' WinNAT reserves a contiguous block of TCP ports for its own use every
+ * time the Hyper-V / WSL network stack comes up, and it is NOT the same block twice — reboot,
+ * `wsl --shutdown`, Docker Desktop or a VPN reconnecting can all trigger a new reservation. When
+ * agentistics' fixed ports (47291/47292) land inside one, the server binds fine INSIDE the WSL2 VM
+ * (`0.0.0.0:47292`, confirmed reachable over the LAN and over Tailscale) while Windows silently
+ * refuses to relay `localhost:47292` to it at all — `ERR_CONNECTION_REFUSED`, with nothing in
+ * either the server's own log or the browser to say why. Measured on a real machine: the excluded
+ * range was `47277-47376`, covering both ports exactly.
+ *
+ * `netsh interface ipv4 show excludedportrange protocol=tcp` is a READ-ONLY query and needs no
+ * elevation, so this can run on every WSL2 boot without asking anything of the user — unlike the
+ * actual fix (`net stop winnat && net start winnat`), which needs an elevated PowerShell and is a
+ * decision for a person, never something this process does on its own.
+ *
+ * PARSING IS LOCALE-AGNOSTIC ON PURPOSE. The table's headers came back in Portuguese on the
+ * machine this was measured on ("Porta Inicial / Porta Final") and would read differently on an
+ * English or any other Windows install — the same trap `docs/harness-contract.md`'s pricing
+ * scrapers already avoid by reading cells positionally rather than by label. `parseExcludedRanges`
+ * therefore looks for lines that are exactly two integers (an optional trailing `*` for an
+ * "administered" range), and ignores everything else — the header row, the dashed separator, the
+ * legend line — because none of those match the shape.
+ */
+
+export interface PortRange {
+  start: number
+  end: number
+}
+
+const RANGE_LINE = /^\s*(\d+)\s+(\d+)\s*\*?\s*$/
+
+/** Every `start end` pair in a `netsh ... excludedportrange` table — PURE, and total: bad input
+ *  (empty, an error message, a locale nobody has seen) yields an empty list, never a throw. */
+export function parseExcludedRanges(output: string): PortRange[] {
+  const ranges: PortRange[] = []
+  for (const line of output.split(/\r?\n/)) {
+    const m = RANGE_LINE.exec(line)
+    if (!m) continue
+    const start = Number.parseInt(m[1]!, 10)
+    const end = Number.parseInt(m[2]!, 10)
+    if (Number.isFinite(start) && Number.isFinite(end)) ranges.push({ start, end })
+  }
+  return ranges
+}
+
+/** Whether `port` falls inside any of `ranges`, inclusive on both ends — PURE. */
+export function portInAnyRange(ranges: readonly PortRange[], port: number): boolean {
+  return ranges.some(r => port >= r.start && port <= r.end)
+}
+
+/**
+ * The next `{port, webPort}` pair (adjacent, `webPort = port + 1`) that clears every range in
+ * `ranges` on BOTH ports — PURE.
+ *
+ * Starts the search at `from` (never below it — a fallback that could land BELOW the configured
+ * port would be a second surprise on top of the first) and gives up after `maxAttempts`, returning
+ * `null` rather than searching forever: a range built to span the whole budget in a test, or a
+ * genuinely pathological exclusion table, must fail honestly instead of hanging the server start.
+ */
+export function findFreePortPair(
+  ranges: readonly PortRange[],
+  from: number,
+  maxAttempts = 2000,
+): { port: number; webPort: number } | null {
+  for (let i = 0; i < maxAttempts; i++) {
+    const port = from + i
+    const webPort = port + 1
+    if (!portInAnyRange(ranges, port) && !portInAnyRange(ranges, webPort)) return { port, webPort }
+  }
+  return null
+}


### PR DESCRIPTION
## What

On WSL2, detect when Windows' WinNAT has excluded agentistics' configured ports (47291/47292) from `localhost` forwarding, and route around it automatically before the server binds.

## Why

Windows' WinNAT reserves a TCP port range for itself every time the Hyper-V/WSL network stack comes up (reboot, `wsl --shutdown`, Docker or a VPN reconnecting), and it is not the same range twice. When it lands on our fixed ports, the server binds fine **inside** the WSL2 VM — reachable over the LAN, over Tailscale — while `localhost` from Windows silently refuses the connection (`ERR_CONNECTION_REFUSED`), with nothing anywhere saying why. Measured on a real machine: the excluded range was `47277-47376`, covering both ports exactly.

## How

- `wsl-ports.ts` (pure): parses `netsh interface ipv4 show excludedportrange protocol=tcp`'s table without depending on its locale (measured in Portuguese on the reporting machine — the parser reads two-integer lines positionally, the same anchoring principle the pricing scrapers already use), and finds the next free adjacent port pair.
- `wsl-ports-io.ts` (IO boundary): detects WSL2 via `/proc/version`, queries Windows through `powershell.exe` — read-only, needs no elevation.
- `cli.ts` resolves this **before** importing `server/index.ts`, so `PORT`/`WEB_PORT` are already corrected everywhere downstream reads them (the startup banner, the MCP bridge, `config.ts`'s own constants).

**A real finding along the way**: the `powershell.exe` lookup can't rely on a bare `PATH` search. Measured on this same machine, the identical command that worked from an interactive login shell (where WSL's `interop.appendWindowsPath` adds the Windows PATH) threw `ENOENT` from `Bun.spawnSync` and answered `not found` from `sh -c` — the two contexts this check actually runs in (a systemd service, this module's own spawn). Fixed by using the canonical absolute path with a bare-name fallback.

Any outcome other than a confirmed, resolvable conflict leaves the ports untouched and prints nothing, so the overwhelming majority of non-WSL2 machines pay zero cost.

## Testing

- `wsl-ports.test.ts` covers the pure parser/finder logic (locale variations, partial-range overlap, exhausted search budget).
- Verified end to end on a live WSL2 machine: real detection, a real forced conflict resolving to the correct next free pair, and the `powershell.exe` fix confirmed under a stripped non-login `PATH` matching what systemd provides.
- Full suite passes (7807+ tests, 0 fail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)