### PR TITLE
fix(terminal): a faixa mostra a tela viva, não o fim da grade

### DIFF
--- a/packages/server/server/sessions/shell-terminal.test.ts
+++ b/packages/server/server/sessions/shell-terminal.test.ts
@@ -100,3 +100,43 @@ describe('the writes report what actually happened', () => {
     expect(t.calls[1]).not.toContain('-l')
   })
 })
+
+describe('clearing the scrollback is a NAMED keystroke, never a guess about pasted text', () => {
+  const cleared = (calls: string[][]) => calls.some(a => a.includes('clear-history'))
+
+  test('the C-l key clears it', async () => {
+    const t = fakeTmux()
+    await createShellTerminal(t.run).sendKey('s1', 'C-l')
+    expect(cleared(t.calls)).toBe(true)
+  })
+
+  test('a lone form feed — what a physical ctrl+l puts on the wire — clears it too', async () => {
+    // xterm emits ctrl+l as `\x0c` through `onData`, so it arrives as TEXT and not as a named key.
+    const t = fakeTmux()
+    await createShellTerminal(t.run).sendText('s1', '\x0c')
+    expect(cleared(t.calls)).toBe(true)
+  })
+
+  test('the WORD `clear` does not, however it is pasted', async () => {
+    // Typing goes one character at a time, so this can only ever be a PASTE — and a paste is
+    // matched BEFORE the shell has run anything, so acting on it throws away the history the user
+    // still has while changing nothing about what is on screen.
+    for (const text of ['clear', ' clear ', 'echo hi; clear\n', 'clear\r']) {
+      const t = fakeTmux()
+      await createShellTerminal(t.run).sendText('s1', text)
+      expect(cleared(t.calls), JSON.stringify(text)).toBe(false)
+    }
+  })
+
+  test('a paste that merely CONTAINS a form feed is left alone', async () => {
+    const t = fakeTmux()
+    await createShellTerminal(t.run).sendText('s1', 'printf "a\x0cb"')
+    expect(cleared(t.calls)).toBe(false)
+  })
+
+  test('a send that failed clears nothing', async () => {
+    const t = fakeTmux({ 'send-keys': { code: 1, out: '', err: 'no such session' } })
+    await createShellTerminal(t.run).sendKey('s1', 'C-l')
+    expect(cleared(t.calls)).toBe(false)
+  })
+})

--- a/packages/server/server/sessions/shell-terminal.ts
+++ b/packages/server/server/sessions/shell-terminal.ts
@@ -31,6 +31,9 @@ export interface ShellTerminal {
   sendKey(id: string, key: string): Promise<boolean>
 }
 
+/** The byte a terminal emits for ctrl+l. */
+const CLEAR_SCREEN = '\x0c'
+
 export function createShellTerminal(run: TmuxRun): ShellTerminal {
   return {
     async capture(id, lines) {
@@ -57,9 +60,14 @@ export function createShellTerminal(run: TmuxRun): ShellTerminal {
 
     async sendText(id, text) {
       const ok = (await run(sendKeysLiteralArgs(id, text, SHELL_SOCKET))).code === 0
-      if (ok && (text.trim() === 'clear' || text.includes('clear\r') || text.includes('clear\n') || text.includes('\x0c'))) {
-        await run(clearHistoryArgs(id, SHELL_SOCKET))
-      }
+      // A LONE form feed is the ctrl+l KEYSTROKE — xterm puts it on `onData`, so it arrives here as
+      // text rather than as a named key — and is treated exactly like `C-l` below. Nothing else is:
+      // matching the WORD `clear` inside a chunk was a guess about a PASTE (typing arrives one
+      // character at a time, so the word can never be assembled here), and it fired BEFORE the
+      // shell had run anything — throwing away scrollback the reader still had while leaving the
+      // screen exactly as it was. What makes a `clear` LOOK cleared is the viewport anchor in
+      // `web/src/lib/terminalScroll.ts`, which needs no guess and no tmux command.
+      if (ok && text === CLEAR_SCREEN) await run(clearHistoryArgs(id, SHELL_SOCKET))
       return ok
     },
 

--- a/packages/web/src/components/SessionTerminal.tsx
+++ b/packages/web/src/components/SessionTerminal.tsx
@@ -26,6 +26,9 @@
  * so every shipped line lives on the grid and the fixed-height box scrolls through all of it (see
  * `paint`). Sizing it to the visible screen alone left the earlier lines in xterm's own scrollback,
  * which a per-frame `reset()` wiped — so scrolling up never reached the start of the conversation.
+ * WHERE that grid is scrolled to is `terminalScroll.ts`: the first row of the LIVE SCREEN, not the
+ * bottom of the grid. Pinning to the bottom opened a fresh shell below its own prompt and made
+ * `clear` look inert, because tmux keeps the history a `clear` never removes.
  *
  * Timing: `resize()` throws asynchronously inside xterm if it runs before the renderer has measured
  * its cell dimensions (an unmeasured `Viewport.syncScrollArea` reads `dimensions` off `undefined`),
@@ -40,6 +43,7 @@ import { Terminal } from '@xterm/xterm'
 import '@xterm/xterm/css/xterm.css'
 import { xtermTheme, type TerminalFrame } from '../lib/terminalStream'
 import { shortcutDecision } from '../lib/terminalShortcuts'
+import { terminalScrollTop, stillFollowing } from '../lib/terminalScroll'
 
 interface Props {
   frame: TerminalFrame | null
@@ -153,6 +157,12 @@ export default function SessionTerminal({ frame, theme, showCursor, zoom = 1, in
   onGeometryRef.current = onGeometry
   /** The last geometry REPORTED, so a steady stream of identical fits says nothing. */
   const reportedRef = useRef<{ cols: number; rows: number } | null>(null)
+  /** The `scrollTop` the last repaint anchored on — what "still watching the live screen" is
+   *  measured against. `terminalScroll.ts` holds the arithmetic and the why. */
+  const lastTopRef = useRef(0)
+  /** The LIVE SCREEN's row count from the last frame — the grid holds history above it. `fit` needs
+   *  it to leave the box exactly enough slack to scroll the screen's first row up to the top. */
+  const screenRowsRef = useRef(0)
 
   /**
    * Fit the natural cols×rows grid into the box by scaling the PIXELS — never by resizing the
@@ -191,7 +201,18 @@ export default function SessionTerminal({ frame, theme, showCursor, zoom = 1, in
     host.style.transform = `scale(${s})`
     host.style.transformOrigin = 'top left'
     scale.style.width = `${Math.ceil(natW * s)}px`
-    scale.style.height = `${Math.ceil(natH * s)}px`
+    // SLACK, so the live screen can reach the TOP of the box. The viewport is rarely a whole number
+    // of rows, so the anchor `terminalScroll.ts` computes is routinely one clamp away from being
+    // reachable and the screen's first row is drawn half-cut under the box's top edge. The grid is
+    // given exactly the leftover as empty tail — only when it already overflows, so a short capture
+    // never grows a scrollbar it does not need.
+    const shown = natH * s
+    const screenRows = screenRowsRef.current
+    const rowH = term.rows > 0 ? shown / term.rows : 0
+    const slack = shown > box.clientHeight && screenRows > 0 && rowH > 0
+      ? Math.max(0, box.clientHeight - screenRows * rowH)
+      : 0
+    scale.style.height = `${Math.ceil(shown + slack)}px`
 
     // WHAT THIS BOX COULD SHOW at natural size. Measured off the cell the renderer actually
     // reports — `naturalSize` divided by the current grid — never guessed from a font size.
@@ -227,11 +248,13 @@ export default function SessionTerminal({ frame, theme, showCursor, zoom = 1, in
     // EXACTLY `f.cols`, so nothing reflows — the fidelity fix is untouched. What is NOT in this 200
     // is disclosed by the status line's `truncated`; that ceiling is the server's, stated, not hidden.
     const bufRows = Math.max(f.rows, f.lines)
+    screenRowsRef.current = f.rows
 
-    // Stick-to-bottom: remember whether the reader was already at the live edge BEFORE the repaint,
-    // so a new frame follows the tail for someone watching live, but never yanks a reader who has
-    // scrolled up to read history. A small threshold absorbs sub-pixel rounding from the scale.
-    const wasAtBottom = !box || (box.scrollTop + box.clientHeight >= box.scrollHeight - 4)
+    // Follow the LIVE SCREEN, not the bottom of the grid — `terminalScroll.ts` carries the two
+    // defects that distinction fixes (a fresh shell opening past its own prompt, and a `clear` that
+    // looked like it did nothing). Read BEFORE the repaint: a reader who has scrolled up into the
+    // history is never yanked back.
+    const following = !box || stillFollowing(box.scrollTop, lastTopRef.current)
 
     // EXACTLY the pane's column count — the one width at which its lines do not reflow — with the row
     // count grown to the whole capture. Only when it CHANGED and the renderer has measured, so a
@@ -263,7 +286,17 @@ export default function SessionTerminal({ frame, theme, showCursor, zoom = 1, in
       // Re-fit AFTER the write settles — the grid's natural size is only final once the new geometry
       // has rendered — then re-pin to the live edge if that is where the reader was.
       fit()
-      if (wasAtBottom && boxRef.current) boxRef.current.scrollTop = boxRef.current.scrollHeight
+      const b = boxRef.current
+      if (!b) return
+      const top = terminalScrollTop({
+        bufRows,
+        screenRows: f.rows,
+        cursorRow: f.cursor ? f.cursor.y : null,
+        scrollHeight: b.scrollHeight,
+        clientHeight: b.clientHeight,
+      })
+      lastTopRef.current = top
+      if (following) b.scrollTop = top
     })
   }
 
@@ -422,7 +455,9 @@ export default function SessionTerminal({ frame, theme, showCursor, zoom = 1, in
       // The box the parent sizes. At the default zoom the grid is fit to the box width, so it does
       // not scroll; zoomed in past the box it scrolls INSIDE here rather than pushing the page
       // sideways (the repo's responsive rule). The buffer is untouched, so scrolling never reflows.
-      style={{ width: '100%', height: '100%', overflow: 'auto' }}
+      // The terminal's own background, so a grid shorter than the box (a cleared screen, a fresh
+      // shell) reads as an empty terminal rather than as a hole in the page.
+      style={{ width: '100%', height: '100%', overflow: 'auto', background: xtermTheme(theme).background }}
     >
       <div ref={scaleRef}>
         <div ref={hostRef} />

--- a/packages/web/src/lib/terminalScroll.test.ts
+++ b/packages/web/src/lib/terminalScroll.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'bun:test'
+import { terminalScrollTop, stillFollowing, FOLLOW_TOLERANCE_PX } from './terminalScroll'
+
+// One row is 20px throughout: scrollHeight = bufRows * 20.
+const px = (rows: number) => rows * 20
+
+describe('terminalScrollTop', () => {
+  it('puts the live screen at the top of the viewport', () => {
+    // 200 captured lines, a 50-row screen, a box that shows 50 rows.
+    const top = terminalScrollTop({
+      bufRows: 200, screenRows: 50, cursorRow: 0,
+      scrollHeight: px(200), clientHeight: px(50),
+    })
+    expect(top).toBe(px(150))
+  })
+
+  it('shows the prompt at the top of a screen that is mostly blank', () => {
+    // A fresh shell: the whole capture IS the screen, the prompt on its first row.
+    const top = terminalScrollTop({
+      bufRows: 50, screenRows: 50, cursorRow: 0,
+      scrollHeight: px(50), clientHeight: px(14),
+    })
+    expect(top).toBe(0)
+  })
+
+  it('leaves history above and the cleared screen in view after a clear', () => {
+    // 42 lines of scrollback the `clear` did not remove, then a 14-row blank screen.
+    const top = terminalScrollTop({
+      bufRows: 56, screenRows: 14, cursorRow: 0,
+      scrollHeight: px(56), clientHeight: px(14),
+    })
+    expect(top).toBe(px(42))
+  })
+
+  it('scrolls further down when the cursor would fall below the box', () => {
+    // The pane is taller than the box: anchoring at the screen top would hide the cursor.
+    const top = terminalScrollTop({
+      bufRows: 50, screenRows: 50, cursorRow: 40,
+      scrollHeight: px(50), clientHeight: px(14),
+    })
+    // The cursor's row must be the last visible one: top = (40 + 1 - 14) rows.
+    expect(top).toBe(px(27))
+  })
+
+  it('never scrolls past the end of the content', () => {
+    const top = terminalScrollTop({
+      bufRows: 20, screenRows: 50, cursorRow: 49,
+      scrollHeight: px(20), clientHeight: px(14),
+    })
+    expect(top).toBe(px(6))
+  })
+
+  it('answers 0 for a grid with no rows or no measured height', () => {
+    expect(terminalScrollTop({ bufRows: 0, screenRows: 0, cursorRow: null, scrollHeight: 0, clientHeight: 0 })).toBe(0)
+    expect(terminalScrollTop({ bufRows: 10, screenRows: 5, cursorRow: 0, scrollHeight: 0, clientHeight: 100 })).toBe(0)
+  })
+
+  it('ignores the cursor when there is none', () => {
+    const top = terminalScrollTop({
+      bufRows: 50, screenRows: 50, cursorRow: null,
+      scrollHeight: px(50), clientHeight: px(14),
+    })
+    expect(top).toBe(0)
+  })
+})
+
+describe('stillFollowing', () => {
+  it('follows when the reader sits at the live screen', () => {
+    expect(stillFollowing(300, 300)).toBe(true)
+  })
+  it('absorbs sub-pixel rounding from the scale', () => {
+    expect(stillFollowing(300 - FOLLOW_TOLERANCE_PX, 300)).toBe(true)
+  })
+  it('leaves a reader who scrolled up into the history alone', () => {
+    expect(stillFollowing(100, 300)).toBe(false)
+  })
+})

--- a/packages/web/src/lib/terminalScroll.ts
+++ b/packages/web/src/lib/terminalScroll.ts
@@ -1,0 +1,76 @@
+/**
+ * terminalScroll.ts — PURE. Where a terminal box is scrolled to after a repaint, and the one
+ * question that decides it: what is the LIVE SCREEN, and what is only history behind it.
+ *
+ * A frame carries up to `TERMINAL_VIEW_LINES` of scrollback PLUS the pane's own screen, rendered
+ * onto one grid so the box can scroll through all of it. The box used to be pinned to the BOTTOM of
+ * that grid, which is wrong twice over, and both were reported:
+ *
+ * - **A fresh shell opened scrolled past its own prompt.** A 50-row pane whose first row holds the
+ *   prompt is 49 rows of blank screen after it; the bottom of the grid is the bottom of those
+ *   blanks, so the band opened on empty space with the prompt somewhere above the fold.
+ * - **`clear` looked like it did nothing.** MEASURED on tmux 3.2a: `clear` does NOT empty tmux's
+ *   history (a capture at `-S -200` returns every line it "removed"), because the pane's TERM is
+ *   `screen`, whose terminfo carries no `E3` — so the escape that WOULD clear it
+ *   (`\033[3J`, which tmux does honour: history 22 → 0 when sent by hand) is never emitted. The
+ *   capture is therefore unchanged apart from a fresh prompt at the top of the screen, and a
+ *   bottom-pinned box went on showing the very lines the user asked to be rid of.
+ *
+ * The answer to both is the same and needs no tmux command at all: **anchor the viewport at the
+ * first row of the LIVE SCREEN**, which is exactly what a terminal shows — the screen fills the
+ * window and the history is above it, reachable by scrolling. After a `clear` the screen is blank
+ * with the prompt on its first row, so the band goes blank; on a fresh shell the screen IS the whole
+ * capture, so the prompt sits at the top.
+ *
+ * The one correction is the CURSOR. A pane taller than the box (the moment before a resize lands,
+ * or a resize that was refused) would put the screen's first row at the top and the cursor below the
+ * fold, which is the "I cannot see what I am typing" version of the same bug. So the anchor moves
+ * down by exactly as much as it takes to keep the cursor's row visible, and no further.
+ */
+
+/** How far from the anchor still counts as "watching the live screen". Absorbs the sub-pixel
+ *  rounding the fit-to-box scale introduces; anything more is a reader who scrolled up. */
+export const FOLLOW_TOLERANCE_PX = 4
+
+export interface TerminalScrollInput {
+  /** Rows on the emulator's grid — the whole capture. */
+  bufRows: number
+  /** Rows of the pane's LIVE SCREEN; everything before them is history. */
+  screenRows: number
+  /** The cursor's row WITHIN the live screen, or `null` when the frame draws none. */
+  cursorRow: number | null
+  /** The scroll container as measured after the repaint. */
+  scrollHeight: number
+  clientHeight: number
+}
+
+/**
+ * The `scrollTop` that shows the live screen.
+ *
+ * Row height is derived from the measured `scrollHeight`, never from a font size: the grid is
+ * SCALED to the box (see `SessionTerminal`'s `fit`), so the only honest row height is the rendered
+ * one.
+ */
+export function terminalScrollTop(o: TerminalScrollInput): number {
+  if (o.bufRows <= 0 || o.scrollHeight <= 0) return 0
+  const rowH = o.scrollHeight / o.bufRows
+  const screenTop = Math.max(0, o.bufRows - o.screenRows)
+  let top = screenTop * rowH
+  if (o.cursorRow !== null && o.clientHeight > 0) {
+    const cursorBottom = (screenTop + o.cursorRow + 1) * rowH
+    const overflow = cursorBottom - (top + o.clientHeight)
+    if (overflow > 0) top += overflow
+  }
+  const max = Math.max(0, o.scrollHeight - o.clientHeight)
+  return Math.round(Math.min(Math.max(0, top), max))
+}
+
+/**
+ * Was the reader still watching the live screen before this repaint?
+ *
+ * A frame arrives twice a second; snapping a reader who has scrolled up into the history back to the
+ * live edge is the same defect as never following it at all, from the other side.
+ */
+export function stillFollowing(scrollTop: number, lastTop: number): boolean {
+  return scrollTop >= lastTop - FOLLOW_TOLERANCE_PX
+}


### PR DESCRIPTION
Os três defeitos reportados sobre a faixa do shell vêm todos do mesmo lugar: a caixa era presa no **fundo da grade**, e a grade carrega o histórico junto com a tela viva.

## O que foi medido (não deduzido)

- **`clear` não limpava.** No tmux 3.2a, `clear` **não** esvazia o histórico do tmux: a pane roda com `TERM=screen`, cujo terminfo não tem `E3`, então o escape que limparia (`\033[3J`) nunca é emitido. Verificado à mão: enviar `\033[3J` na pane leva `history_size` de 22 → 0; rodar `clear` deixa em 42. A captura em `-S -200` devolve tudo de novo e a faixa seguia mostrando exatamente o que o usuário pediu para sumir.
- **O terminal abria scrollado.** Uma pane de 50 linhas com o prompt na primeira linha é 49 linhas de tela em branco depois dele. O fundo da grade é o fundo desses brancos — a faixa abria em cima do vazio, com o prompt acima da dobra.
- **A largura não ia até o fim** enquanto a pane ainda não tinha sido redimensionada pela caixa.

## A correção

`packages/web/src/lib/terminalScroll.ts` (puro, testado) ancora a viewport na **primeira linha da TELA VIVA** — que é o que um terminal mostra: a tela preenche a janela e o histórico fica acima, alcançável rolando. Depois de um `clear` a tela é o prompt no topo, então a faixa fica limpa **sem comando nenhum no tmux**.

A única correção sobre isso é o **cursor**: uma pane mais alta que a caixa desce a âncora só o bastante para o cursor continuar visível, e nada além disso. E `fit()` dá à grade exatamente a sobra da viewport, senão a primeira linha da tela nasce cortada pela borda de cima (a caixa raramente é um número inteiro de linhas).

`clear-history` volta a ser uma **tecla**, nunca um palpite sobre texto colado: digitar chega caractere a caractere, então casar a palavra `clear` num chunk só podia pegar um *paste* — e disparava **antes** de o shell ter rodado qualquer coisa, jogando fora o histórico que o leitor ainda tinha sem mudar nada na tela. Um `\x0c` sozinho (o que o ctrl+l põe no fio) continua limpando, como `C-l`.

## Verificação no navegador

Preview isolado (porta 47492, `AGENTISTICS_DIR` próprio), Chromium:

- caixa de 1126px → pane redimensionada para **144x13** → `.xterm-screen` com **1123px**: a largura vai até o fim;
- depois de `clear`, **nenhuma** das 40 linhas anteriores fica na viewport; o prompt no topo, fundo de terminal abaixo;
- `scrollTop` 720 contra um máximo de 720 — a âncora é alcançável, sem linha cortada;
- aba Terminal (pane do assistente, 50 linhas numa caixa de 639px): a última linha visível é a caixa de entrada do Claude Code;
- 390px: `document.documentElement.scrollWidth === window.innerWidth`.

`bun tsc --noEmit` + `bun test` (7854 passando, 0 falhas).

🤖 Generated with [Claude Code](https://claude.com/claude-code)