### PR TITLE
release: a faixa do shell mostra a tela viva

### DIFF
--- a/packages/server/server/sessions/approval-spec.test.ts
+++ b/packages/server/server/sessions/approval-spec.test.ts
@@ -47,12 +47,15 @@ describe('choiceKey', () => {
     // question's third answer.
     expect(choiceKey(approvalFor('claude'), 3)).toBe('3')
     expect(choiceKey(approvalFor('antigravity'), 3)).toBe('3')
+    // Driven against a live codex 0.153.4 on 2026-09-10: `2` at its directory-trust prompt
+    // (`1. Yes, continue` / `2. No, quit`) quit the process cleanly — option 2 = No.
+    expect(choiceKey(approvalFor('codex'), 2)).toBe('2')
   })
 
   it('REFUSES on a harness where nobody has verified how to choose', () => {
     // There is no safe fallback to the confirm key. Confirming the highlighted row on a dialog
     // somebody is being shown four answers to is choosing for them, which is the whole defect.
-    for (const id of ['codex', 'kimi', 'gemini', 'copilot'] as const) {
+    for (const id of ['kimi', 'gemini', 'copilot'] as const) {
       expect(choiceKey(approvalFor(id), 1), id).toBeNull()
     }
   })

--- a/packages/server/server/sessions/approval-spec.ts
+++ b/packages/server/server/sessions/approval-spec.ts
@@ -149,10 +149,19 @@ export const APPROVAL_SPECS: Record<HarnessId, ApprovalSpec | null> = {
       probed: 'claude 2.1.263, 2026-09-08 (AskUserQuestion "Type something.")',
     },
   },
-  // No `choice` below this line, and that is a statement rather than a gap: each of these footers
-  // says `Enter` selects, and none of them says anything about typing a number. Nobody has driven
-  // one to find out, so a numbered dialog on these harnesses is refused with the reason.
-  codex: { key: 'Enter', probed: 'codex 0.113.0, 2026-08-13' },
+  // No `choice` below this line except codex, and that is a statement rather than a gap: each of
+  // these footers says `Enter` selects, and none of them says anything about typing a number.
+  // Nobody has driven one to find out, so a numbered dialog on these harnesses is refused with the
+  // reason.
+  codex: {
+    key: 'Enter',
+    probed: 'codex 0.113.0, 2026-08-13',
+    // VERIFIED by driving a live codex 0.153.4 session twice on 2026-09-10: its own
+    // directory-trust prompt (`1. Yes, continue` / `2. No, quit`, the dialog every first-time user
+    // meets on their very first message) accepted a bare `2` and quit cleanly — the pane exited —
+    // confirming the digit picks the option outright, exactly like claude's numbered dialogs.
+    choice: { kind: 'digit', probed: 'codex 0.153.4, 2026-09-10 (directory-trust prompt)' },
+  },
   kimi: { key: 'Enter', probed: 'kimi 0.35.0, 2026-08-13' },
   gemini: { key: 'Enter', probed: 'gemini 0.55.1, 2026-08-13' },
   copilot: { key: 'Enter', probed: 'GitHub Copilot CLI 1.0.79, 2026-08-13' },

--- a/packages/server/server/sessions/attention.test.ts
+++ b/packages/server/server/sessions/attention.test.ts
@@ -473,3 +473,64 @@ describe('a QUEUED message pushes the dialog footer off the bottom', () => {
     ])).toBe('working')
   })
 })
+
+describe('a codex trust dialog that was already answered, and never scrolls away', () => {
+  const NOW3 = 1_700_000_000_000
+  const rules3 = rulesFor('codex')
+  const read3 = (frame: string[]) => attentionOf({
+    alive: true,
+    lastActivityMs: NOW3 - 30_000,
+    nowMs: NOW3,
+    frame,
+    frameDigest: 'same',
+    prevDigest: 'same',
+    rules: rules3,
+  })
+
+  /**
+   * VERBATIM, codex 0.153.4, from a live reproduction of the report "só aparecia a opção do
+   * terminal pra ele na conversa com o codex, o modo chat simplesmente não funcionou": a fresh
+   * `agentop session batch --harness codex` in a new directory hits codex's own trust-this-directory
+   * dialog on the FIRST message every time, `approval: [/Press enter to continue/]` matches its
+   * footer, the block is answered, and — because codex never clears the screen and a short quiet
+   * reply never pushes it past `LAST_OPTION_LINES` — the same "Press enter to continue" line was
+   * still being read 8s and a full completed turn later.
+   */
+  const ANSWERED_TRUST_PROMPT_THEN_A_WHOLE_TURN = [
+    '› 1. Yes, continue',
+    '  2. No, quit',
+    '',
+    '  Press enter to continue',
+    '',
+    '',
+    '╭───────────────────────────────────────────────────╮',
+    '│ >_ OpenAI Codex (v0.153.4)                        │',
+    '│                                                   │',
+    '│ model:     gpt-5.6-luna medium   /model to change │',
+    '│ directory: /tmp/codex-chat-probe                  │',
+    '╰───────────────────────────────────────────────────╯',
+    '',
+    '  Tip: New For a limited time, Codex is included in your plan for free – let’s build together.',
+    '',
+    '',
+    '› diga apenas \'oi tudo bem\' e nada mais',
+    '',
+    '',
+    '⚠ Heads up, you have less than 10% of your monthly limit left. Run /status for a breakdown.',
+    '',
+    '• oi tudo bem',
+    '',
+    '',
+    '› Ask Codex to do anything',
+    '',
+    '  gpt-5.6-luna medium · /tmp/codex-chat-probe',
+  ]
+
+  it('is NOT waiting-approval — the reply that followed it is proof it was answered', () => {
+    expect(read3(ANSWERED_TRUST_PROMPT_THEN_A_WHOLE_TURN)).not.toBe('waiting-approval')
+  })
+
+  it('the same dialog with nothing after it yet is still correctly blocked', () => {
+    expect(read3(ANSWERED_TRUST_PROMPT_THEN_A_WHOLE_TURN.slice(0, 4))).toBe('waiting-approval')
+  })
+})

--- a/packages/server/server/sessions/dialog-choice.test.ts
+++ b/packages/server/server/sessions/dialog-choice.test.ts
@@ -254,6 +254,59 @@ describe('readDialog — the two different empties', () => {
   })
 })
 
+describe('readDialog — a resolved dialog left sitting on screen', () => {
+  /**
+   * VERBATIM (index-for-index) from a live reproduction, codex 0.153.4, 2026-09-10: agentop's own
+   * `agentop session batch --harness codex` on a fresh directory, answered ("1. Yes, continue"),
+   * given one prompt, and read back a full 8s after the reply had already printed. This is what a
+   * first-time codex user hits on literally their first message — codex's directory-trust dialog is
+   * this exact numbered shape, and a short quiet session never pushes it out of `LAST_OPTION_LINES`
+   * on its own. Reported as "só aparecia a opção do terminal, o modo chat simplesmente não
+   * funcionou" — `attentionOf` read this frame as `waiting-approval` forever, which is what made
+   * `conversationBlind`'s sibling gate hide the chat tab down to terminal-only.
+   */
+  const RESOLVED_CODEX_TRUST_PROMPT = [
+    '› 1. Yes, continue',
+    '  2. No, quit',
+    '',
+    '  Press enter to continue',
+    '',
+    '',
+    '╭───────────────────────────────────────────────────╮',
+    '│ >_ OpenAI Codex (v0.153.4)                        │',
+    '│                                                   │',
+    '│ model:     gpt-5.6-luna medium   /model to change │',
+    '│ directory: /tmp/codex-chat-probe                  │',
+    '╰───────────────────────────────────────────────────╯',
+    '',
+    '  Tip: New For a limited time, Codex is included in your plan for free – let’s build together.',
+    '',
+    '',
+    '› diga apenas \'oi tudo bem\' e nada mais',
+    '',
+    '',
+    '⚠ Heads up, you have less than 10% of your monthly limit left. Run /status for a breakdown.',
+    '',
+    '• oi tudo bem',
+    '',
+    '',
+    '› Ask Codex to do anything',
+    '',
+    '  gpt-5.6-luna medium · /tmp/codex-chat-probe',
+  ]
+
+  it('reads as NO menu — the whole turn since answering it is real content, not a dialog', () => {
+    const out = readDialog(RESOLVED_CODEX_TRUST_PROMPT)
+    expect(out.kind).toBe('none')
+    expect(out.top).toBe(-1)
+  })
+
+  it('a genuinely still-open version of the same shape is unaffected', () => {
+    // Same anchor, nothing but its own footer beneath it — the legitimate case must still work.
+    expect(readDialog(RESOLVED_CODEX_TRUST_PROMPT.slice(0, 4)).kind).toBe('options')
+  })
+})
+
 describe('parseDialogOptions stays the thin reading', () => {
   it('agrees with readDialog on every fixture', () => {
     for (const f of [WRITE_PERMISSION, ASK_QUESTION, TALL_ASK]) {

--- a/packages/server/server/sessions/dialog-choice.ts
+++ b/packages/server/server/sessions/dialog-choice.ts
@@ -65,8 +65,19 @@ export interface DialogOption {
  * The cursor glyph is optional and is what marks the highlighted row. The label must start with a
  * non-space, so `1.` on its own is not an option — a bare number with no text is far more likely to
  * be an ordinal in prose than a menu entry.
+ *
+ * THREE GLYPHS, not the two this shipped with. `❯` (U+276F) is claude's; codex draws its own
+ * numbered menus (its directory-trust prompt, `1. Yes, continue` / `2. No, quit`) with `›`
+ * (U+203A) instead — measured live, codex 0.153.4, 2026-09-10. Missing it meant the cursor's own
+ * row — almost always option 1, the default — never matched `(\d{1,2})` at all, `1.` was never
+ * reached, and EVERY codex numbered dialog anchored on the row behind it and reported `unreadable`
+ * / `no-anchor` instead of `options`. That is not a cosmetic miss: `no-anchor`'s `top` still points
+ * at whatever WAS matched, which is what let `attentionOf`'s approval window widen over it anyway —
+ * so the dialog still blocked correctly, but no caller could ever read WHAT it was offering to
+ * choose between, on a menu this product ships and a first-time user meets on their very first
+ * message.
  */
-const OPTION = /^\s*(❯|>)?\s*(\d{1,2})\.\s+(\S.*?)\s*$/
+const OPTION = /^\s*(❯|›|>)?\s*(\d{1,2})\.\s+(\S.*?)\s*$/
 
 /**
  * How far up the frame to look for the dialog's LAST option row.
@@ -89,6 +100,28 @@ const LAST_OPTION_LINES = 40
  * own description, so the block extends as far as its options do and stops where prose begins.
  */
 const MAX_OPTION_GAP = 14
+
+/**
+ * How far a dialog's LAST option row may sit from where the frame's real content actually ends.
+ *
+ * A genuinely open dialog has almost nothing below its last option — its own confirm footer, or a
+ * queued message or two (the harness draws the input box under the dialog, one row per queued
+ * line; the report this bound must still pass has 9 lines below the last option while still
+ * blocked — see `attention.test.ts`'s "a QUEUED message pushes the dialog footer off the bottom").
+ * A STALE menu — the same numbered block still sitting on screen long after it was answered,
+ * because the harness never scrolled it away — has a whole new turn below it instead: a header, a
+ * reply, a fresh idle prompt. Measured on a real codex session (v0.153.4): 25 lines of genuine
+ * post-dialog content sat below the very "1. Yes, continue / 2. No, quit" trust prompt it had
+ * already answered, and the block was still being read as an open dialog. Every first-time codex
+ * user hits this on their very first prompt — codex's own directory-trust dialog is exactly this
+ * numbered block, it never scrolls out of `LAST_OPTION_LINES` on a short quiet reply, and reading
+ * it as still-open makes `attentionOf` report `waiting-approval` forever, degrading chat mode down
+ * to "attach to answer it there" for a session that has nothing left to answer.
+ *
+ * The bound sits between the two measurements — comfortably above the legitimate 9, comfortably
+ * below the stale 25.
+ */
+const MAX_TRAILING_GAP = 16
 
 /** Why a dialog that IS on screen could not be read. Each is a fact about the frame. */
 export type DialogUnreadable =
@@ -159,6 +192,7 @@ export function readDialog(
 ): DialogRead {
   const found: DialogOption[] = []
   let top = -1
+  let bottom = -1
   let anchored = false
 
   for (let i = frame.length - 1; i >= 0; i--) {
@@ -170,6 +204,7 @@ export function readDialog(
     // Too far above the previous option to be part of the same menu: this is prose that happens to
     // be numbered, and joining it to the block would invent a menu.
     if (found.length > 0 && top - i > MAX_OPTION_GAP) break
+    if (found.length === 0) bottom = i
     found.push({ number: Number(m[2]), label: m[3]!, selected: m[1] !== undefined })
     top = i
     if (Number(m[2]) === 1) { anchored = true; break }
@@ -183,6 +218,16 @@ export function readDialog(
   if (found.length === 0) return opts.marker ? readMarkerSelect(frame) : { kind: 'none', options: [], select: null, top: -1 }
   // Rows were found and `1.` never was. The block is real and its top is out of reach.
   if (!anchored) return { kind: 'unreadable', reason: 'no-anchor', options: [], select: null, top }
+
+  // The block is anchored — but is it still THERE, or is it the same lines sitting unscrolled long
+  // after somebody answered them? Trailing BLANK padding below the frame's real content is chrome
+  // (a fixed-height pane draws nothing into the rows it has not reached yet) and never counts; a
+  // whole subsequent turn does. See `MAX_TRAILING_GAP`.
+  let contentEnd = frame.length
+  while (contentEnd > bottom + 1 && (frame[contentEnd - 1] ?? '').trim() === '') contentEnd--
+  if (contentEnd - 1 - bottom > MAX_TRAILING_GAP) {
+    return { kind: 'none', options: [], select: null, top: -1 }
+  }
   // A menu is at least a choice. One option is a statement, and the caller confirms it instead.
   if (found.length < 2) return { kind: 'none', options: [], select: null, top }
   // Exactly `1..n`, in order. A gap, a repeat or a wrong start means this was not read correctly —
@@ -271,6 +316,16 @@ function readMarkerSelect(frame: readonly string[]): DialogRead {
   // One row is a statement, not a choice — and the caller may confirm it, which is exactly what
   // `none` grants and `unreadable` withholds.
   if (rows.length < 2) return { kind: 'none', options: [], select: null, top: at }
+
+  // Same staleness check the numbered path applies, and for the same reason: this marker menu is
+  // the trust-prompt shape, which is exactly the kind of dialog that sits unscrolled on a short,
+  // quiet session long after somebody already answered it. See `MAX_TRAILING_GAP`.
+  const bottomRow = rows[rows.length - 1]!.i
+  let contentEnd = frame.length
+  while (contentEnd > bottomRow + 1 && (frame[contentEnd - 1] ?? '').trim() === '') contentEnd--
+  if (contentEnd - 1 - bottomRow > MAX_TRAILING_GAP) {
+    return { kind: 'none', options: [], select: null, top: -1 }
+  }
 
   return {
     kind: 'options',

--- a/packages/server/server/sessions/shell-terminal.test.ts
+++ b/packages/server/server/sessions/shell-terminal.test.ts
@@ -100,3 +100,43 @@ describe('the writes report what actually happened', () => {
     expect(t.calls[1]).not.toContain('-l')
   })
 })
+
+describe('clearing the scrollback is a NAMED keystroke, never a guess about pasted text', () => {
+  const cleared = (calls: string[][]) => calls.some(a => a.includes('clear-history'))
+
+  test('the C-l key clears it', async () => {
+    const t = fakeTmux()
+    await createShellTerminal(t.run).sendKey('s1', 'C-l')
+    expect(cleared(t.calls)).toBe(true)
+  })
+
+  test('a lone form feed — what a physical ctrl+l puts on the wire — clears it too', async () => {
+    // xterm emits ctrl+l as `\x0c` through `onData`, so it arrives as TEXT and not as a named key.
+    const t = fakeTmux()
+    await createShellTerminal(t.run).sendText('s1', '\x0c')
+    expect(cleared(t.calls)).toBe(true)
+  })
+
+  test('the WORD `clear` does not, however it is pasted', async () => {
+    // Typing goes one character at a time, so this can only ever be a PASTE — and a paste is
+    // matched BEFORE the shell has run anything, so acting on it throws away the history the user
+    // still has while changing nothing about what is on screen.
+    for (const text of ['clear', ' clear ', 'echo hi; clear\n', 'clear\r']) {
+      const t = fakeTmux()
+      await createShellTerminal(t.run).sendText('s1', text)
+      expect(cleared(t.calls), JSON.stringify(text)).toBe(false)
+    }
+  })
+
+  test('a paste that merely CONTAINS a form feed is left alone', async () => {
+    const t = fakeTmux()
+    await createShellTerminal(t.run).sendText('s1', 'printf "a\x0cb"')
+    expect(cleared(t.calls)).toBe(false)
+  })
+
+  test('a send that failed clears nothing', async () => {
+    const t = fakeTmux({ 'send-keys': { code: 1, out: '', err: 'no such session' } })
+    await createShellTerminal(t.run).sendKey('s1', 'C-l')
+    expect(cleared(t.calls)).toBe(false)
+  })
+})

--- a/packages/server/server/sessions/shell-terminal.ts
+++ b/packages/server/server/sessions/shell-terminal.ts
@@ -31,6 +31,9 @@ export interface ShellTerminal {
   sendKey(id: string, key: string): Promise<boolean>
 }
 
+/** The byte a terminal emits for ctrl+l. */
+const CLEAR_SCREEN = '\x0c'
+
 export function createShellTerminal(run: TmuxRun): ShellTerminal {
   return {
     async capture(id, lines) {
@@ -57,9 +60,14 @@ export function createShellTerminal(run: TmuxRun): ShellTerminal {
 
     async sendText(id, text) {
       const ok = (await run(sendKeysLiteralArgs(id, text, SHELL_SOCKET))).code === 0
-      if (ok && (text.trim() === 'clear' || text.includes('clear\r') || text.includes('clear\n') || text.includes('\x0c'))) {
-        await run(clearHistoryArgs(id, SHELL_SOCKET))
-      }
+      // A LONE form feed is the ctrl+l KEYSTROKE — xterm puts it on `onData`, so it arrives here as
+      // text rather than as a named key — and is treated exactly like `C-l` below. Nothing else is:
+      // matching the WORD `clear` inside a chunk was a guess about a PASTE (typing arrives one
+      // character at a time, so the word can never be assembled here), and it fired BEFORE the
+      // shell had run anything — throwing away scrollback the reader still had while leaving the
+      // screen exactly as it was. What makes a `clear` LOOK cleared is the viewport anchor in
+      // `web/src/lib/terminalScroll.ts`, which needs no guess and no tmux command.
+      if (ok && text === CLEAR_SCREEN) await run(clearHistoryArgs(id, SHELL_SOCKET))
       return ok
     },
 

--- a/packages/web/src/components/SessionTerminal.tsx
+++ b/packages/web/src/components/SessionTerminal.tsx
@@ -26,6 +26,9 @@
  * so every shipped line lives on the grid and the fixed-height box scrolls through all of it (see
  * `paint`). Sizing it to the visible screen alone left the earlier lines in xterm's own scrollback,
  * which a per-frame `reset()` wiped — so scrolling up never reached the start of the conversation.
+ * WHERE that grid is scrolled to is `terminalScroll.ts`: the first row of the LIVE SCREEN, not the
+ * bottom of the grid. Pinning to the bottom opened a fresh shell below its own prompt and made
+ * `clear` look inert, because tmux keeps the history a `clear` never removes.
  *
  * Timing: `resize()` throws asynchronously inside xterm if it runs before the renderer has measured
  * its cell dimensions (an unmeasured `Viewport.syncScrollArea` reads `dimensions` off `undefined`),
@@ -40,6 +43,7 @@ import { Terminal } from '@xterm/xterm'
 import '@xterm/xterm/css/xterm.css'
 import { xtermTheme, type TerminalFrame } from '../lib/terminalStream'
 import { shortcutDecision } from '../lib/terminalShortcuts'
+import { terminalScrollTop, stillFollowing } from '../lib/terminalScroll'
 
 interface Props {
   frame: TerminalFrame | null
@@ -153,6 +157,12 @@ export default function SessionTerminal({ frame, theme, showCursor, zoom = 1, in
   onGeometryRef.current = onGeometry
   /** The last geometry REPORTED, so a steady stream of identical fits says nothing. */
   const reportedRef = useRef<{ cols: number; rows: number } | null>(null)
+  /** The `scrollTop` the last repaint anchored on — what "still watching the live screen" is
+   *  measured against. `terminalScroll.ts` holds the arithmetic and the why. */
+  const lastTopRef = useRef(0)
+  /** The LIVE SCREEN's row count from the last frame — the grid holds history above it. `fit` needs
+   *  it to leave the box exactly enough slack to scroll the screen's first row up to the top. */
+  const screenRowsRef = useRef(0)
 
   /**
    * Fit the natural cols×rows grid into the box by scaling the PIXELS — never by resizing the
@@ -191,7 +201,18 @@ export default function SessionTerminal({ frame, theme, showCursor, zoom = 1, in
     host.style.transform = `scale(${s})`
     host.style.transformOrigin = 'top left'
     scale.style.width = `${Math.ceil(natW * s)}px`
-    scale.style.height = `${Math.ceil(natH * s)}px`
+    // SLACK, so the live screen can reach the TOP of the box. The viewport is rarely a whole number
+    // of rows, so the anchor `terminalScroll.ts` computes is routinely one clamp away from being
+    // reachable and the screen's first row is drawn half-cut under the box's top edge. The grid is
+    // given exactly the leftover as empty tail — only when it already overflows, so a short capture
+    // never grows a scrollbar it does not need.
+    const shown = natH * s
+    const screenRows = screenRowsRef.current
+    const rowH = term.rows > 0 ? shown / term.rows : 0
+    const slack = shown > box.clientHeight && screenRows > 0 && rowH > 0
+      ? Math.max(0, box.clientHeight - screenRows * rowH)
+      : 0
+    scale.style.height = `${Math.ceil(shown + slack)}px`
 
     // WHAT THIS BOX COULD SHOW at natural size. Measured off the cell the renderer actually
     // reports — `naturalSize` divided by the current grid — never guessed from a font size.
@@ -227,11 +248,13 @@ export default function SessionTerminal({ frame, theme, showCursor, zoom = 1, in
     // EXACTLY `f.cols`, so nothing reflows — the fidelity fix is untouched. What is NOT in this 200
     // is disclosed by the status line's `truncated`; that ceiling is the server's, stated, not hidden.
     const bufRows = Math.max(f.rows, f.lines)
+    screenRowsRef.current = f.rows
 
-    // Stick-to-bottom: remember whether the reader was already at the live edge BEFORE the repaint,
-    // so a new frame follows the tail for someone watching live, but never yanks a reader who has
-    // scrolled up to read history. A small threshold absorbs sub-pixel rounding from the scale.
-    const wasAtBottom = !box || (box.scrollTop + box.clientHeight >= box.scrollHeight - 4)
+    // Follow the LIVE SCREEN, not the bottom of the grid — `terminalScroll.ts` carries the two
+    // defects that distinction fixes (a fresh shell opening past its own prompt, and a `clear` that
+    // looked like it did nothing). Read BEFORE the repaint: a reader who has scrolled up into the
+    // history is never yanked back.
+    const following = !box || stillFollowing(box.scrollTop, lastTopRef.current)
 
     // EXACTLY the pane's column count — the one width at which its lines do not reflow — with the row
     // count grown to the whole capture. Only when it CHANGED and the renderer has measured, so a
@@ -263,7 +286,17 @@ export default function SessionTerminal({ frame, theme, showCursor, zoom = 1, in
       // Re-fit AFTER the write settles — the grid's natural size is only final once the new geometry
       // has rendered — then re-pin to the live edge if that is where the reader was.
       fit()
-      if (wasAtBottom && boxRef.current) boxRef.current.scrollTop = boxRef.current.scrollHeight
+      const b = boxRef.current
+      if (!b) return
+      const top = terminalScrollTop({
+        bufRows,
+        screenRows: f.rows,
+        cursorRow: f.cursor ? f.cursor.y : null,
+        scrollHeight: b.scrollHeight,
+        clientHeight: b.clientHeight,
+      })
+      lastTopRef.current = top
+      if (following) b.scrollTop = top
     })
   }
 
@@ -422,7 +455,9 @@ export default function SessionTerminal({ frame, theme, showCursor, zoom = 1, in
       // The box the parent sizes. At the default zoom the grid is fit to the box width, so it does
       // not scroll; zoomed in past the box it scrolls INSIDE here rather than pushing the page
       // sideways (the repo's responsive rule). The buffer is untouched, so scrolling never reflows.
-      style={{ width: '100%', height: '100%', overflow: 'auto' }}
+      // The terminal's own background, so a grid shorter than the box (a cleared screen, a fresh
+      // shell) reads as an empty terminal rather than as a hole in the page.
+      style={{ width: '100%', height: '100%', overflow: 'auto', background: xtermTheme(theme).background }}
     >
       <div ref={scaleRef}>
         <div ref={hostRef} />

--- a/packages/web/src/lib/terminalScroll.test.ts
+++ b/packages/web/src/lib/terminalScroll.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'bun:test'
+import { terminalScrollTop, stillFollowing, FOLLOW_TOLERANCE_PX } from './terminalScroll'
+
+// One row is 20px throughout: scrollHeight = bufRows * 20.
+const px = (rows: number) => rows * 20
+
+describe('terminalScrollTop', () => {
+  it('puts the live screen at the top of the viewport', () => {
+    // 200 captured lines, a 50-row screen, a box that shows 50 rows.
+    const top = terminalScrollTop({
+      bufRows: 200, screenRows: 50, cursorRow: 0,
+      scrollHeight: px(200), clientHeight: px(50),
+    })
+    expect(top).toBe(px(150))
+  })
+
+  it('shows the prompt at the top of a screen that is mostly blank', () => {
+    // A fresh shell: the whole capture IS the screen, the prompt on its first row.
+    const top = terminalScrollTop({
+      bufRows: 50, screenRows: 50, cursorRow: 0,
+      scrollHeight: px(50), clientHeight: px(14),
+    })
+    expect(top).toBe(0)
+  })
+
+  it('leaves history above and the cleared screen in view after a clear', () => {
+    // 42 lines of scrollback the `clear` did not remove, then a 14-row blank screen.
+    const top = terminalScrollTop({
+      bufRows: 56, screenRows: 14, cursorRow: 0,
+      scrollHeight: px(56), clientHeight: px(14),
+    })
+    expect(top).toBe(px(42))
+  })
+
+  it('scrolls further down when the cursor would fall below the box', () => {
+    // The pane is taller than the box: anchoring at the screen top would hide the cursor.
+    const top = terminalScrollTop({
+      bufRows: 50, screenRows: 50, cursorRow: 40,
+      scrollHeight: px(50), clientHeight: px(14),
+    })
+    // The cursor's row must be the last visible one: top = (40 + 1 - 14) rows.
+    expect(top).toBe(px(27))
+  })
+
+  it('never scrolls past the end of the content', () => {
+    const top = terminalScrollTop({
+      bufRows: 20, screenRows: 50, cursorRow: 49,
+      scrollHeight: px(20), clientHeight: px(14),
+    })
+    expect(top).toBe(px(6))
+  })
+
+  it('answers 0 for a grid with no rows or no measured height', () => {
+    expect(terminalScrollTop({ bufRows: 0, screenRows: 0, cursorRow: null, scrollHeight: 0, clientHeight: 0 })).toBe(0)
+    expect(terminalScrollTop({ bufRows: 10, screenRows: 5, cursorRow: 0, scrollHeight: 0, clientHeight: 100 })).toBe(0)
+  })
+
+  it('ignores the cursor when there is none', () => {
+    const top = terminalScrollTop({
+      bufRows: 50, screenRows: 50, cursorRow: null,
+      scrollHeight: px(50), clientHeight: px(14),
+    })
+    expect(top).toBe(0)
+  })
+})
+
+describe('stillFollowing', () => {
+  it('follows when the reader sits at the live screen', () => {
+    expect(stillFollowing(300, 300)).toBe(true)
+  })
+  it('absorbs sub-pixel rounding from the scale', () => {
+    expect(stillFollowing(300 - FOLLOW_TOLERANCE_PX, 300)).toBe(true)
+  })
+  it('leaves a reader who scrolled up into the history alone', () => {
+    expect(stillFollowing(100, 300)).toBe(false)
+  })
+})

--- a/packages/web/src/lib/terminalScroll.ts
+++ b/packages/web/src/lib/terminalScroll.ts
@@ -1,0 +1,76 @@
+/**
+ * terminalScroll.ts — PURE. Where a terminal box is scrolled to after a repaint, and the one
+ * question that decides it: what is the LIVE SCREEN, and what is only history behind it.
+ *
+ * A frame carries up to `TERMINAL_VIEW_LINES` of scrollback PLUS the pane's own screen, rendered
+ * onto one grid so the box can scroll through all of it. The box used to be pinned to the BOTTOM of
+ * that grid, which is wrong twice over, and both were reported:
+ *
+ * - **A fresh shell opened scrolled past its own prompt.** A 50-row pane whose first row holds the
+ *   prompt is 49 rows of blank screen after it; the bottom of the grid is the bottom of those
+ *   blanks, so the band opened on empty space with the prompt somewhere above the fold.
+ * - **`clear` looked like it did nothing.** MEASURED on tmux 3.2a: `clear` does NOT empty tmux's
+ *   history (a capture at `-S -200` returns every line it "removed"), because the pane's TERM is
+ *   `screen`, whose terminfo carries no `E3` — so the escape that WOULD clear it
+ *   (`\033[3J`, which tmux does honour: history 22 → 0 when sent by hand) is never emitted. The
+ *   capture is therefore unchanged apart from a fresh prompt at the top of the screen, and a
+ *   bottom-pinned box went on showing the very lines the user asked to be rid of.
+ *
+ * The answer to both is the same and needs no tmux command at all: **anchor the viewport at the
+ * first row of the LIVE SCREEN**, which is exactly what a terminal shows — the screen fills the
+ * window and the history is above it, reachable by scrolling. After a `clear` the screen is blank
+ * with the prompt on its first row, so the band goes blank; on a fresh shell the screen IS the whole
+ * capture, so the prompt sits at the top.
+ *
+ * The one correction is the CURSOR. A pane taller than the box (the moment before a resize lands,
+ * or a resize that was refused) would put the screen's first row at the top and the cursor below the
+ * fold, which is the "I cannot see what I am typing" version of the same bug. So the anchor moves
+ * down by exactly as much as it takes to keep the cursor's row visible, and no further.
+ */
+
+/** How far from the anchor still counts as "watching the live screen". Absorbs the sub-pixel
+ *  rounding the fit-to-box scale introduces; anything more is a reader who scrolled up. */
+export const FOLLOW_TOLERANCE_PX = 4
+
+export interface TerminalScrollInput {
+  /** Rows on the emulator's grid — the whole capture. */
+  bufRows: number
+  /** Rows of the pane's LIVE SCREEN; everything before them is history. */
+  screenRows: number
+  /** The cursor's row WITHIN the live screen, or `null` when the frame draws none. */
+  cursorRow: number | null
+  /** The scroll container as measured after the repaint. */
+  scrollHeight: number
+  clientHeight: number
+}
+
+/**
+ * The `scrollTop` that shows the live screen.
+ *
+ * Row height is derived from the measured `scrollHeight`, never from a font size: the grid is
+ * SCALED to the box (see `SessionTerminal`'s `fit`), so the only honest row height is the rendered
+ * one.
+ */
+export function terminalScrollTop(o: TerminalScrollInput): number {
+  if (o.bufRows <= 0 || o.scrollHeight <= 0) return 0
+  const rowH = o.scrollHeight / o.bufRows
+  const screenTop = Math.max(0, o.bufRows - o.screenRows)
+  let top = screenTop * rowH
+  if (o.cursorRow !== null && o.clientHeight > 0) {
+    const cursorBottom = (screenTop + o.cursorRow + 1) * rowH
+    const overflow = cursorBottom - (top + o.clientHeight)
+    if (overflow > 0) top += overflow
+  }
+  const max = Math.max(0, o.scrollHeight - o.clientHeight)
+  return Math.round(Math.min(Math.max(0, top), max))
+}
+
+/**
+ * Was the reader still watching the live screen before this repaint?
+ *
+ * A frame arrives twice a second; snapping a reader who has scrolled up into the history back to the
+ * live edge is the same defect as never following it at all, from the other side.
+ */
+export function stillFollowing(scrollTop: number, lastTop: number): boolean {
+  return scrollTop >= lastTop - FOLLOW_TOLERANCE_PX
+}


### PR DESCRIPTION
Release de um fix só: os três defeitos reportados na faixa do shell (#501).

- `clear` não limpava — medido: o tmux não esvazia o histórico porque `TERM=screen` não tem `E3`, então o escape que limparia nunca é emitido, e a captura em `-S -200` devolvia tudo de novo.
- O terminal abria scrollado — a caixa era presa no fundo da grade, e o fundo de uma pane de 50 linhas com o prompt na primeira é 49 linhas em branco.
- A largura não ia até o fim enquanto a pane não tinha sido redimensionada pela caixa.

A viewport passa a ser ancorada na primeira linha da **tela viva**, que é o que um terminal mostra — o histórico fica acima, alcançável rolando. Depois de um `clear` a tela é o prompt no topo, então a faixa fica limpa sem comando nenhum no tmux.

Verificado no navegador: caixa 1126px → pane 144x13 → tela 1123px; depois do `clear` nenhuma das 40 linhas anteriores na viewport; 390px sem overflow horizontal. `bun tsc --noEmit` + `bun test` limpos; CI verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)