### PR TITLE
fix(server): codex session stuck needs-approval forever after its trust dialog was answered

### DIFF
--- a/packages/server/server/sessions/approval-spec.test.ts
+++ b/packages/server/server/sessions/approval-spec.test.ts
@@ -47,12 +47,15 @@ describe('choiceKey', () => {
     // question's third answer.
     expect(choiceKey(approvalFor('claude'), 3)).toBe('3')
     expect(choiceKey(approvalFor('antigravity'), 3)).toBe('3')
+    // Driven against a live codex 0.153.4 on 2026-09-10: `2` at its directory-trust prompt
+    // (`1. Yes, continue` / `2. No, quit`) quit the process cleanly — option 2 = No.
+    expect(choiceKey(approvalFor('codex'), 2)).toBe('2')
   })
 
   it('REFUSES on a harness where nobody has verified how to choose', () => {
     // There is no safe fallback to the confirm key. Confirming the highlighted row on a dialog
     // somebody is being shown four answers to is choosing for them, which is the whole defect.
-    for (const id of ['codex', 'kimi', 'gemini', 'copilot'] as const) {
+    for (const id of ['kimi', 'gemini', 'copilot'] as const) {
       expect(choiceKey(approvalFor(id), 1), id).toBeNull()
     }
   })

--- a/packages/server/server/sessions/approval-spec.ts
+++ b/packages/server/server/sessions/approval-spec.ts
@@ -149,10 +149,19 @@ export const APPROVAL_SPECS: Record<HarnessId, ApprovalSpec | null> = {
       probed: 'claude 2.1.263, 2026-09-08 (AskUserQuestion "Type something.")',
     },
   },
-  // No `choice` below this line, and that is a statement rather than a gap: each of these footers
-  // says `Enter` selects, and none of them says anything about typing a number. Nobody has driven
-  // one to find out, so a numbered dialog on these harnesses is refused with the reason.
-  codex: { key: 'Enter', probed: 'codex 0.113.0, 2026-08-13' },
+  // No `choice` below this line except codex, and that is a statement rather than a gap: each of
+  // these footers says `Enter` selects, and none of them says anything about typing a number.
+  // Nobody has driven one to find out, so a numbered dialog on these harnesses is refused with the
+  // reason.
+  codex: {
+    key: 'Enter',
+    probed: 'codex 0.113.0, 2026-08-13',
+    // VERIFIED by driving a live codex 0.153.4 session twice on 2026-09-10: its own
+    // directory-trust prompt (`1. Yes, continue` / `2. No, quit`, the dialog every first-time user
+    // meets on their very first message) accepted a bare `2` and quit cleanly — the pane exited —
+    // confirming the digit picks the option outright, exactly like claude's numbered dialogs.
+    choice: { kind: 'digit', probed: 'codex 0.153.4, 2026-09-10 (directory-trust prompt)' },
+  },
   kimi: { key: 'Enter', probed: 'kimi 0.35.0, 2026-08-13' },
   gemini: { key: 'Enter', probed: 'gemini 0.55.1, 2026-08-13' },
   copilot: { key: 'Enter', probed: 'GitHub Copilot CLI 1.0.79, 2026-08-13' },

--- a/packages/server/server/sessions/attention.test.ts
+++ b/packages/server/server/sessions/attention.test.ts
@@ -473,3 +473,64 @@ describe('a QUEUED message pushes the dialog footer off the bottom', () => {
     ])).toBe('working')
   })
 })
+
+describe('a codex trust dialog that was already answered, and never scrolls away', () => {
+  const NOW3 = 1_700_000_000_000
+  const rules3 = rulesFor('codex')
+  const read3 = (frame: string[]) => attentionOf({
+    alive: true,
+    lastActivityMs: NOW3 - 30_000,
+    nowMs: NOW3,
+    frame,
+    frameDigest: 'same',
+    prevDigest: 'same',
+    rules: rules3,
+  })
+
+  /**
+   * VERBATIM, codex 0.153.4, from a live reproduction of the report "só aparecia a opção do
+   * terminal pra ele na conversa com o codex, o modo chat simplesmente não funcionou": a fresh
+   * `agentop session batch --harness codex` in a new directory hits codex's own trust-this-directory
+   * dialog on the FIRST message every time, `approval: [/Press enter to continue/]` matches its
+   * footer, the block is answered, and — because codex never clears the screen and a short quiet
+   * reply never pushes it past `LAST_OPTION_LINES` — the same "Press enter to continue" line was
+   * still being read 8s and a full completed turn later.
+   */
+  const ANSWERED_TRUST_PROMPT_THEN_A_WHOLE_TURN = [
+    '› 1. Yes, continue',
+    '  2. No, quit',
+    '',
+    '  Press enter to continue',
+    '',
+    '',
+    '╭───────────────────────────────────────────────────╮',
+    '│ >_ OpenAI Codex (v0.153.4)                        │',
+    '│                                                   │',
+    '│ model:     gpt-5.6-luna medium   /model to change │',
+    '│ directory: /tmp/codex-chat-probe                  │',
+    '╰───────────────────────────────────────────────────╯',
+    '',
+    '  Tip: New For a limited time, Codex is included in your plan for free – let’s build together.',
+    '',
+    '',
+    '› diga apenas \'oi tudo bem\' e nada mais',
+    '',
+    '',
+    '⚠ Heads up, you have less than 10% of your monthly limit left. Run /status for a breakdown.',
+    '',
+    '• oi tudo bem',
+    '',
+    '',
+    '› Ask Codex to do anything',
+    '',
+    '  gpt-5.6-luna medium · /tmp/codex-chat-probe',
+  ]
+
+  it('is NOT waiting-approval — the reply that followed it is proof it was answered', () => {
+    expect(read3(ANSWERED_TRUST_PROMPT_THEN_A_WHOLE_TURN)).not.toBe('waiting-approval')
+  })
+
+  it('the same dialog with nothing after it yet is still correctly blocked', () => {
+    expect(read3(ANSWERED_TRUST_PROMPT_THEN_A_WHOLE_TURN.slice(0, 4))).toBe('waiting-approval')
+  })
+})

--- a/packages/server/server/sessions/dialog-choice.test.ts
+++ b/packages/server/server/sessions/dialog-choice.test.ts
@@ -254,6 +254,59 @@ describe('readDialog — the two different empties', () => {
   })
 })
 
+describe('readDialog — a resolved dialog left sitting on screen', () => {
+  /**
+   * VERBATIM (index-for-index) from a live reproduction, codex 0.153.4, 2026-09-10: agentop's own
+   * `agentop session batch --harness codex` on a fresh directory, answered ("1. Yes, continue"),
+   * given one prompt, and read back a full 8s after the reply had already printed. This is what a
+   * first-time codex user hits on literally their first message — codex's directory-trust dialog is
+   * this exact numbered shape, and a short quiet session never pushes it out of `LAST_OPTION_LINES`
+   * on its own. Reported as "só aparecia a opção do terminal, o modo chat simplesmente não
+   * funcionou" — `attentionOf` read this frame as `waiting-approval` forever, which is what made
+   * `conversationBlind`'s sibling gate hide the chat tab down to terminal-only.
+   */
+  const RESOLVED_CODEX_TRUST_PROMPT = [
+    '› 1. Yes, continue',
+    '  2. No, quit',
+    '',
+    '  Press enter to continue',
+    '',
+    '',
+    '╭───────────────────────────────────────────────────╮',
+    '│ >_ OpenAI Codex (v0.153.4)                        │',
+    '│                                                   │',
+    '│ model:     gpt-5.6-luna medium   /model to change │',
+    '│ directory: /tmp/codex-chat-probe                  │',
+    '╰───────────────────────────────────────────────────╯',
+    '',
+    '  Tip: New For a limited time, Codex is included in your plan for free – let’s build together.',
+    '',
+    '',
+    '› diga apenas \'oi tudo bem\' e nada mais',
+    '',
+    '',
+    '⚠ Heads up, you have less than 10% of your monthly limit left. Run /status for a breakdown.',
+    '',
+    '• oi tudo bem',
+    '',
+    '',
+    '› Ask Codex to do anything',
+    '',
+    '  gpt-5.6-luna medium · /tmp/codex-chat-probe',
+  ]
+
+  it('reads as NO menu — the whole turn since answering it is real content, not a dialog', () => {
+    const out = readDialog(RESOLVED_CODEX_TRUST_PROMPT)
+    expect(out.kind).toBe('none')
+    expect(out.top).toBe(-1)
+  })
+
+  it('a genuinely still-open version of the same shape is unaffected', () => {
+    // Same anchor, nothing but its own footer beneath it — the legitimate case must still work.
+    expect(readDialog(RESOLVED_CODEX_TRUST_PROMPT.slice(0, 4)).kind).toBe('options')
+  })
+})
+
 describe('parseDialogOptions stays the thin reading', () => {
   it('agrees with readDialog on every fixture', () => {
     for (const f of [WRITE_PERMISSION, ASK_QUESTION, TALL_ASK]) {

--- a/packages/server/server/sessions/dialog-choice.ts
+++ b/packages/server/server/sessions/dialog-choice.ts
@@ -65,8 +65,19 @@ export interface DialogOption {
  * The cursor glyph is optional and is what marks the highlighted row. The label must start with a
  * non-space, so `1.` on its own is not an option — a bare number with no text is far more likely to
  * be an ordinal in prose than a menu entry.
+ *
+ * THREE GLYPHS, not the two this shipped with. `❯` (U+276F) is claude's; codex draws its own
+ * numbered menus (its directory-trust prompt, `1. Yes, continue` / `2. No, quit`) with `›`
+ * (U+203A) instead — measured live, codex 0.153.4, 2026-09-10. Missing it meant the cursor's own
+ * row — almost always option 1, the default — never matched `(\d{1,2})` at all, `1.` was never
+ * reached, and EVERY codex numbered dialog anchored on the row behind it and reported `unreadable`
+ * / `no-anchor` instead of `options`. That is not a cosmetic miss: `no-anchor`'s `top` still points
+ * at whatever WAS matched, which is what let `attentionOf`'s approval window widen over it anyway —
+ * so the dialog still blocked correctly, but no caller could ever read WHAT it was offering to
+ * choose between, on a menu this product ships and a first-time user meets on their very first
+ * message.
  */
-const OPTION = /^\s*(❯|>)?\s*(\d{1,2})\.\s+(\S.*?)\s*$/
+const OPTION = /^\s*(❯|›|>)?\s*(\d{1,2})\.\s+(\S.*?)\s*$/
 
 /**
  * How far up the frame to look for the dialog's LAST option row.
@@ -89,6 +100,28 @@ const LAST_OPTION_LINES = 40
  * own description, so the block extends as far as its options do and stops where prose begins.
  */
 const MAX_OPTION_GAP = 14
+
+/**
+ * How far a dialog's LAST option row may sit from where the frame's real content actually ends.
+ *
+ * A genuinely open dialog has almost nothing below its last option — its own confirm footer, or a
+ * queued message or two (the harness draws the input box under the dialog, one row per queued
+ * line; the report this bound must still pass has 9 lines below the last option while still
+ * blocked — see `attention.test.ts`'s "a QUEUED message pushes the dialog footer off the bottom").
+ * A STALE menu — the same numbered block still sitting on screen long after it was answered,
+ * because the harness never scrolled it away — has a whole new turn below it instead: a header, a
+ * reply, a fresh idle prompt. Measured on a real codex session (v0.153.4): 25 lines of genuine
+ * post-dialog content sat below the very "1. Yes, continue / 2. No, quit" trust prompt it had
+ * already answered, and the block was still being read as an open dialog. Every first-time codex
+ * user hits this on their very first prompt — codex's own directory-trust dialog is exactly this
+ * numbered block, it never scrolls out of `LAST_OPTION_LINES` on a short quiet reply, and reading
+ * it as still-open makes `attentionOf` report `waiting-approval` forever, degrading chat mode down
+ * to "attach to answer it there" for a session that has nothing left to answer.
+ *
+ * The bound sits between the two measurements — comfortably above the legitimate 9, comfortably
+ * below the stale 25.
+ */
+const MAX_TRAILING_GAP = 16
 
 /** Why a dialog that IS on screen could not be read. Each is a fact about the frame. */
 export type DialogUnreadable =
@@ -159,6 +192,7 @@ export function readDialog(
 ): DialogRead {
   const found: DialogOption[] = []
   let top = -1
+  let bottom = -1
   let anchored = false
 
   for (let i = frame.length - 1; i >= 0; i--) {
@@ -170,6 +204,7 @@ export function readDialog(
     // Too far above the previous option to be part of the same menu: this is prose that happens to
     // be numbered, and joining it to the block would invent a menu.
     if (found.length > 0 && top - i > MAX_OPTION_GAP) break
+    if (found.length === 0) bottom = i
     found.push({ number: Number(m[2]), label: m[3]!, selected: m[1] !== undefined })
     top = i
     if (Number(m[2]) === 1) { anchored = true; break }
@@ -183,6 +218,16 @@ export function readDialog(
   if (found.length === 0) return opts.marker ? readMarkerSelect(frame) : { kind: 'none', options: [], select: null, top: -1 }
   // Rows were found and `1.` never was. The block is real and its top is out of reach.
   if (!anchored) return { kind: 'unreadable', reason: 'no-anchor', options: [], select: null, top }
+
+  // The block is anchored — but is it still THERE, or is it the same lines sitting unscrolled long
+  // after somebody answered them? Trailing BLANK padding below the frame's real content is chrome
+  // (a fixed-height pane draws nothing into the rows it has not reached yet) and never counts; a
+  // whole subsequent turn does. See `MAX_TRAILING_GAP`.
+  let contentEnd = frame.length
+  while (contentEnd > bottom + 1 && (frame[contentEnd - 1] ?? '').trim() === '') contentEnd--
+  if (contentEnd - 1 - bottom > MAX_TRAILING_GAP) {
+    return { kind: 'none', options: [], select: null, top: -1 }
+  }
   // A menu is at least a choice. One option is a statement, and the caller confirms it instead.
   if (found.length < 2) return { kind: 'none', options: [], select: null, top }
   // Exactly `1..n`, in order. A gap, a repeat or a wrong start means this was not read correctly —
@@ -271,6 +316,16 @@ function readMarkerSelect(frame: readonly string[]): DialogRead {
   // One row is a statement, not a choice — and the caller may confirm it, which is exactly what
   // `none` grants and `unreadable` withholds.
   if (rows.length < 2) return { kind: 'none', options: [], select: null, top: at }
+
+  // Same staleness check the numbered path applies, and for the same reason: this marker menu is
+  // the trust-prompt shape, which is exactly the kind of dialog that sits unscrolled on a short,
+  // quiet session long after somebody already answered it. See `MAX_TRAILING_GAP`.
+  const bottomRow = rows[rows.length - 1]!.i
+  let contentEnd = frame.length
+  while (contentEnd > bottomRow + 1 && (frame[contentEnd - 1] ?? '').trim() === '') contentEnd--
+  if (contentEnd - 1 - bottomRow > MAX_TRAILING_GAP) {
+    return { kind: 'none', options: [], select: null, top: -1 }
+  }
 
   return {
     kind: 'options',


### PR DESCRIPTION
## Bug

"hoje meu pai instalou o codex e comecou a usar do zero, so tava aparecendo a opcao do terminal pra ele na conversa com o codex, simplesmente NAO FUNCIONOU o modo chat"

Codex draws its own directory-trust prompt ("1. Yes, continue" / "2. No, quit") on literally the first message in any new directory — every first-time codex user hits this. Reproduced live (codex 0.153.4) and found two independent bugs in the same dialog:

1. **The cursor glyph wasn't recognized.** `readDialog`'s numbered-option regex only matched `❯`/`>`; codex draws its cursor with `›` (U+203A), a different character. The "1." row — almost always the cursor row, since it's the default — never matched, so `1.` was never reached and the dialog read as `unreadable`/`no-anchor` instead of a real 2-option menu.
2. **The resolved dialog never scrolled away and got permanently re-read as still-open.** Codex doesn't clear its screen, so on a short quiet session the same "Press enter to continue" text sits comfortably inside `readDialog`'s 40-line search window long after a whole new turn completed underneath it. `attentionOf` kept matching it and reporting `waiting-approval` forever, which degraded the session down to "attach to answer it there" — Terminal-only, permanently — even though there was nothing left to answer. That's `conversationBlind`'s sibling gate hiding the chat tab down to terminal-only, matching the report exactly.

## Fix

- `dialog-choice.ts`: OPTION regex now also recognizes `›`. `readDialog` refuses an anchored menu whose last option sits more than `MAX_TRAILING_GAP` (16) real lines above the frame's actual end — bound picked from two live measurements (9 lines below a genuinely-still-open dialog with messages queued under it, which must keep reading as blocked; 25 lines below this stale one, which must not). Applied to both the numbered and marker-select paths.
- `approval-spec.ts`: verified live that sending a bare `2` at codex's trust prompt quits the process cleanly (option 2 = "No, quit"), so codex now carries `choice: {kind: 'digit'}` — the trust dialog can be answered directly from the web UI, no Terminal needed at all.

## Tests

- New regression tests in `dialog-choice.test.ts` and `attention.test.ts` using the exact, verbatim frame from the live reproduction.
- Updated `approval-spec.test.ts` for codex's new verified `choice`.
- `bunx tsc --noEmit` clean.
- Full suite: 7868 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)