### PR TITLE
feat(web): custo/tokens por subtask na SubtaskTable

### DIFF
--- a/packages/web/src/components/tasks/DeliveryDetail.tsx
+++ b/packages/web/src/components/tasks/DeliveryDetail.tsx
@@ -1250,6 +1250,7 @@ export function DeliveryDetail({ id, detail, lang, reload, dense, onDeleted }: D
             <SubtaskTable
               subtasks={detail.subtasks}
               sessions={detail.sessions}
+              subtaskRollups={detail.subtaskRollups}
               lang={lang}
               onAdd={title => run(() => addSubtask(id, title))}
               onPatch={(sid, patch) => run(() => patchSubtask(id, sid, patch))}

--- a/packages/web/src/components/tasks/SubtaskTable.tsx
+++ b/packages/web/src/components/tasks/SubtaskTable.tsx
@@ -3,7 +3,9 @@
  *
  * One component drawn in two places, deliberately: a subtask that shows five columns on the board
  * and a checkbox on the detail page is two different records as far as the reader is concerned, and
- * the one with fewer columns teaches people the fields do not exist.
+ * the one with fewer columns teaches people the fields do not exist. (`TaskTable.tsx`'s inline
+ * subitem rows mirror the base columns but do NOT yet draw the two below — a gap worth closing
+ * there too, tracked separately rather than done as a side effect of this file.)
  *
  * A subtask carries a SESSION — which piece of work is being done where — and now a ROLLUP of its
  * own: cost, rounds and tokens are still measured per SESSION, never stored on the subtask itself,
@@ -11,19 +13,29 @@
  * `attemptViews()` sums an attempt's, as a partition of the task's rows rather than a second count
  * of them — nothing here double-counts a session or invents a split the data does not record. See
  * docs/superpowers/specs/2026-09-10-task-session-hierarchy-design.md §4.2.
+ *
+ * The Cost/Tokens columns below read `p.subtaskRollups`, keyed by subtask id, and render them with
+ * the exact same formatters `TaskTable.tsx`'s own cost/tokens cells use (`useMoney()`, `fmtTokens`,
+ * `NA`) — a second formatting rule here would be a second answer for the same figure. A subtask
+ * with no session filed yet still gets a bucket from the server (`sessionsUsed: 0`, every metric
+ * `null`), and `null` renders as `NA` — never a `0` pretending to be a measurement. The `id: null`
+ * direct-branch bucket (sessions filed straight on the delivery) is deliberately NOT drawn as a row
+ * here — that footer is `s-2cb8108f97`'s job, once this lands.
  */
 
 import { useState } from 'react'
 import { Plus, Trash2 } from 'lucide-react'
 import { useIsMobile } from '../../hooks/useIsMobile'
-import { COLUMN_ORDER, STATUS, microLabel, surface, type BoardStatus } from './board'
+import { COLUMN_ORDER, STATUS, fmtTokens, microLabel, numeric, surface, type BoardStatus } from './board'
 import { SessionPicker } from './SessionPicker'
 import { DatePicker } from '../DatePicker'
 import { TaskProgressBar } from './TaskProgressBar'
 import { subtaskSessions } from './SubtaskSessions'
 import { SubtaskBlockedBy } from './SubtaskBlockedBy'
 import { boardCopy, statusLabel, type Lang } from './copy'
-import type { Subtask, TaskSessionRow, TaskStatus } from '../../lib/tasks'
+import { useMoney } from './money'
+import { costCaveat, costCellFor, subtaskRollupOf } from './subtaskRollup'
+import type { Subtask, SubtaskView, TaskSessionRow, TaskStatus } from '../../lib/tasks'
 
 function StatusPick({ value, lang, onPick }: {
   value: TaskStatus
@@ -83,6 +95,9 @@ export interface SubtaskTableProps {
   subtasks: Subtask[]
   /** The DELIVERY's sessions. Each row shows the ones filed under it — see `SubtaskSessions`. */
   sessions: readonly TaskSessionRow[]
+  /** One rollup per subtask (and the `id: null` direct-branch bucket this table does not draw
+   *  yet) — `TaskDetail.subtaskRollups`, straight off the server's `subtaskViews()`. */
+  subtaskRollups: readonly SubtaskView[]
   lang: Lang
   onAdd: (title: string) => void | Promise<void>
   onPatch: (id: string, patch: Partial<Subtask>) => void | Promise<void>
@@ -98,6 +113,7 @@ export interface SubtaskTableProps {
 export function SubtaskTable(p: SubtaskTableProps) {
   const isMobile = useIsMobile()
   const copy = boardCopy(p.lang)
+  const money = useMoney()
   const [draft, setDraft] = useState('')
   const [linking, setLinking] = useState<string | null>(null)
 
@@ -117,11 +133,17 @@ export function SubtaskTable(p: SubtaskTableProps) {
         </div>
       </div>
 
-      <table style={{ width: '100%', borderCollapse: 'collapse', minWidth: 620 }}>
+      <table style={{ width: '100%', borderCollapse: 'collapse', minWidth: 760 }}>
         <thead>
           <tr>
-            {[copy.subtasks, 'Status', copy.owner, copy.start, copy.due, copy.sessions, ''].map((h, i) => (
-              <th key={i} style={{ ...microLabel, textAlign: 'left', padding: '6px 9px', fontWeight: 600 }}>
+            {[copy.subtasks, 'Status', copy.owner, copy.start, copy.due, copy.sessions, copy.cost, copy.tokens, ''].map((h, i) => (
+              <th
+                key={i}
+                style={{
+                  ...microLabel, padding: '6px 9px', fontWeight: 600,
+                  textAlign: h === copy.cost || h === copy.tokens ? 'right' : 'left',
+                }}
+              >
                 {h}
               </th>
             ))}
@@ -130,12 +152,15 @@ export function SubtaskTable(p: SubtaskTableProps) {
         <tbody>
           {p.subtasks.length === 0 && (
             <tr>
-              <td colSpan={7} style={{ ...cell, fontSize: 12, color: 'var(--text-tertiary)', lineHeight: 1.55 }}>
+              <td colSpan={9} style={{ ...cell, fontSize: 12, color: 'var(--text-tertiary)', lineHeight: 1.55 }}>
                 {copy.nothingBrokenOut}
               </td>
             </tr>
           )}
-          {p.subtasks.map(t => (
+          {p.subtasks.map(t => {
+            const r = subtaskRollupOf(p.subtaskRollups, t.id)
+            const cost = costCellFor(r)
+            return (
             <tr key={t.id}>
               <td style={{ ...cell, minWidth: 180 }}>
                 <input
@@ -205,15 +230,36 @@ export function SubtaskTable(p: SubtaskTableProps) {
                 })}
               </td>
               <td style={{ ...cell, textAlign: 'right' }}>
+                {/* `r` absent (no bucket at all) reads exactly like an empty one — the "not
+                    measured yet" answer for a subtask nobody has filed a session under. */}
+                {cost.kind === 'credits' ? (
+                  <span style={{ ...numeric, fontSize: 12 }}>{cost.premiumRequests} req</span>
+                ) : (
+                  <span
+                    style={{
+                      ...numeric, fontSize: 12,
+                      color: cost.kind === 'na' || cost.usd === null ? 'var(--text-tertiary)' : 'var(--anthropic-orange)',
+                    }}
+                    title={costCaveat(r)}
+                  >{money(cost.kind === 'money' ? cost.usd : null)}</span>
+                )}
+              </td>
+              <td style={{ ...cell, textAlign: 'right' }}>
+                <span style={{ ...numeric, fontSize: 12, color: !r || r.tokens === null ? 'var(--text-tertiary)' : undefined }}>
+                  {fmtTokens(r?.tokens ?? null)}
+                </span>
+              </td>
+              <td style={{ ...cell, textAlign: 'right' }}>
                 <button
                   onClick={() => void p.onRemove(t.id)} title={copy.remove}
                   style={{ background: 'none', border: 'none', color: 'var(--text-tertiary)', cursor: 'pointer', display: 'inline-flex' }}
                 ><Trash2 size={12} /></button>
               </td>
             </tr>
-          ))}
+            )
+          })}
           <tr>
-            <td colSpan={7} style={{ ...cell }}>
+            <td colSpan={9} style={{ ...cell }}>
               <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6, width: '100%' }}>
                 <Plus size={12} style={{ color: 'var(--text-tertiary)', flexShrink: 0 }} />
                 <input

--- a/packages/web/src/components/tasks/subtaskRollup.test.ts
+++ b/packages/web/src/components/tasks/subtaskRollup.test.ts
@@ -1,0 +1,69 @@
+import { test, expect } from 'bun:test'
+import { costCaveat, costCellFor, subtaskRollupOf } from './subtaskRollup'
+import type { AttemptRollup, SubtaskView } from '../../lib/tasks'
+
+function rollup(over: Partial<AttemptRollup> = {}): AttemptRollup {
+  return {
+    sessionsUsed: 1, sessionsLinked: 1, provenance: { assigned: 1, observed: 0, none: 0 },
+    rounds: 3, activeMinutes: 10, tokens: 1000, costUSD: 1.5,
+    costMeasuredSessions: 0, costEstimatedSessions: 1, credits: null, mixedCurrency: false,
+    ...over,
+  }
+}
+
+// --- subtaskRollupOf -----------------------------------------------------------------------------
+
+test('subtaskRollupOf: finds the bucket by subtask id', () => {
+  const r = rollup({ costUSD: 7 })
+  const views: SubtaskView[] = [{ id: 's1', rollup: r }, { id: 's2', rollup: rollup({ costUSD: 3 }) }]
+  expect(subtaskRollupOf(views, 's1')).toBe(r)
+})
+
+test('subtaskRollupOf: undefined when the server has no bucket for this subtask', () => {
+  const views: SubtaskView[] = [{ id: 's1', rollup: rollup() }]
+  expect(subtaskRollupOf(views, 'unknown')).toBeUndefined()
+})
+
+test('subtaskRollupOf: the id:null direct-branch bucket is not confused with a real subtask', () => {
+  const views: SubtaskView[] = [{ id: null, rollup: rollup({ costUSD: 99 }) }]
+  expect(subtaskRollupOf(views, 's1')).toBeUndefined()
+})
+
+// --- costCellFor -----------------------------------------------------------------------------
+
+test('costCellFor: no bucket at all renders N/A, never a 0', () => {
+  expect(costCellFor(undefined)).toEqual({ kind: 'na' })
+})
+
+test('costCellFor: a subtask with no session filed yet — sessionsUsed 0, costUSD null — is honest N/A, not a fake 0', () => {
+  const r = rollup({ sessionsUsed: 0, sessionsLinked: 0, rounds: null, activeMinutes: null, tokens: null, costUSD: null })
+  expect(costCellFor(r)).toEqual({ kind: 'money', usd: null })
+})
+
+test('costCellFor: an ordinary priced subtask renders its dollar figure', () => {
+  expect(costCellFor(rollup({ costUSD: 12.34 }))).toEqual({ kind: 'money', usd: 12.34 })
+})
+
+test('costCellFor: mixed currency takes the credits branch even if costUSD is set', () => {
+  const r = rollup({ mixedCurrency: true, costUSD: 5, credits: { nanoAiu: 0, premiumRequests: 4 } })
+  expect(costCellFor(r)).toEqual({ kind: 'credits', premiumRequests: 4 })
+})
+
+test('costCellFor: Copilot-only credits with no USD figure takes the credits branch', () => {
+  const r = rollup({ mixedCurrency: false, costUSD: null, credits: { nanoAiu: 0, premiumRequests: 2 } })
+  expect(costCellFor(r)).toEqual({ kind: 'credits', premiumRequests: 2 })
+})
+
+// --- costCaveat ------------------------------------------------------------------------------
+
+test('costCaveat: absent when every linked session is priced', () => {
+  expect(costCaveat(rollup({ sessionsUsed: 2, sessionsLinked: 2 }))).toBeUndefined()
+})
+
+test('costCaveat: names the split when some sessions have no conversation link', () => {
+  expect(costCaveat(rollup({ sessionsUsed: 3, sessionsLinked: 2 }))).toBe('cost covers 2 of 3 sessions')
+})
+
+test('costCaveat: absent when there is no bucket to speak of', () => {
+  expect(costCaveat(undefined)).toBeUndefined()
+})

--- a/packages/web/src/components/tasks/subtaskRollup.ts
+++ b/packages/web/src/components/tasks/subtaskRollup.ts
@@ -1,0 +1,38 @@
+/**
+ * subtaskRollup.ts — pure reads over `TaskDetail.subtaskRollups`, pulled out of `SubtaskTable.tsx`
+ * so the N/A-vs-zero decision has something testable to assert against.
+ *
+ * This project has no React-rendering test infrastructure (see `ConnectionCard.test.tsx`), so the
+ * one thing worth getting wrong here — whether a subtask with no session yet renders as an honest
+ * "not measured" rather than a `0` — is asserted directly against these functions, not through DOM.
+ */
+
+import type { AttemptRollup, SubtaskView } from '../../lib/tasks'
+
+/** The rollup for one subtask, or `undefined` when the server has no bucket for it at all — which
+ *  reads exactly like an empty one: nothing measured, never a `0` standing in for it. */
+export function subtaskRollupOf(views: readonly SubtaskView[], id: string): AttemptRollup | undefined {
+  return views.find(v => v.id === id)?.rollup
+}
+
+export type CostCell =
+  | { kind: 'na' }
+  | { kind: 'credits'; premiumRequests: number }
+  /** `usd: null` still renders as N/A — `useMoney()` already refuses to turn `null` into `$0.00`. */
+  | { kind: 'money'; usd: number | null }
+
+/** Same branch `TaskTable.tsx`'s own cost cell takes, over one subtask's rollup instead of a
+ *  task's — a second formatting rule here would be a second answer for the same figure. */
+export function costCellFor(r: AttemptRollup | undefined): CostCell {
+  if (!r) return { kind: 'na' }
+  if (r.mixedCurrency || (r.credits !== null && r.costUSD === null)) {
+    return { kind: 'credits', premiumRequests: r.credits!.premiumRequests }
+  }
+  return { kind: 'money', usd: r.costUSD }
+}
+
+/** Whether the cost cell should carry the "N of M sessions priced" caveat as a tooltip. */
+export function costCaveat(r: AttemptRollup | undefined): string | undefined {
+  if (!r || r.sessionsLinked >= r.sessionsUsed) return undefined
+  return `cost covers ${r.sessionsLinked} of ${r.sessionsUsed} sessions`
+}


### PR DESCRIPTION
## Summary
- Cada linha da `SubtaskTable` passa a mostrar **custo** e **tokens**, lidos de `TaskDetail.subtaskRollups` (o `subtaskViews()` do servidor, já em `dev` via #494) — reaproveitando os mesmos formatters que `TaskTable.tsx` usa para o total da task (`useMoney()`, `fmtTokens`), nunca uma segunda regra de formatação.
- Uma subtask sem sessão filiada ainda (`sessionsUsed: 0`, métricas `null`) renderiza **N/A**, nunca um `0` fingindo medição — a mesma regra N/A-vs-zero do resto do produto (`HARNESS_CAPABILITIES`).
- A decisão de qual variante de custo desenhar (dólares / créditos Copilot / N/A) foi extraída para `subtaskRollup.ts`, pura, com 11 testes unitários (`subtaskRollup.test.ts`) — este projeto não tem infraestrutura de teste de renderização React (ver `ConnectionCard.test.tsx`), então segui o mesmo padrão já usado ali.
- Mobile: mantido o padrão já existente da tabela (scroll horizontal contido no próprio container via `overflowX: auto` + `minWidth` no `<table>`, com `minWidth: 0` no grid ancestral em `DeliveryDetail.tsx`) — só ampliei a largura mínima para as duas colunas novas.

Board: `t-918cc82233`, subtask `s-2ed5531c53`.

Fora de escopo (bloqueado por `s-2cb8108f97`): a linha-rodapé mostrando o bucket `id: null` (sessões filiadas direto na entrega).

## Test plan
- [x] `bun tsc --noEmit` limpo (raiz cobre todo o monorepo)
- [x] `bun test` completo: 7894 pass / 0 fail / 1 skip, incluindo os 11 casos novos de `subtaskRollup.test.ts`
- [x] Revisão manual dos valores reais desta task (`t-918cc82233`) contra a lógica de formatação (ex.: subtask com 2 sessões → US$20,45/61,0M tokens; subtask sem sessão → N/A/N/A)

🤖 Generated with [Claude Code](https://claude.com/claude-code)