### PR TITLE
feat(install): auto-install tmux when missing

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -30,6 +30,65 @@ if [[ "$ARCH" != "x86_64" ]]; then
   exit 1
 fi
 
+# ── Runtime dependency: tmux ────────────────────────────────────────────────
+#
+# agentop's session manager (`agentop session`, the cockpit's Sessions tab) is built on tmux —
+# there is no other backend (see packages/server/server/sessions/dependency-plan.ts, which the
+# already-installed binary uses to explain a MISSING tmux to someone who skipped this script or
+# removed the package afterwards). Without it every session-related feature fails the moment it is
+# used, well after the install already reported success — a confusing place to first learn about a
+# missing dependency. So it is installed HERE, proactively, the same way any competent install
+# script pulls in what it needs — never silently, and never left to fail on first use.
+#
+# `apt` is checked before `apt-get` (Debian/Ubuntu ship both; a machine with both gets the modern
+# one) and `apt-get update` runs first because a freshly booted cloud VM or container image
+# routinely has an empty or stale package index — `apt-get install` alone fails on exactly the
+# machines this script most often runs on. `pacman -Sy` syncs the database for the same reason.
+if ! command -v tmux >/dev/null 2>&1; then
+  echo "tmux not found — agentop's session manager needs it. Installing…"
+
+  TMUX_SUDO=()
+  if [[ "${EUID:-$(id -u)}" -ne 0 ]]; then
+    if command -v sudo >/dev/null 2>&1; then
+      TMUX_SUDO=(sudo)
+    else
+      echo "  Not root and no sudo on PATH — install tmux yourself, e.g.: apt install tmux"
+    fi
+  fi
+
+  if [[ "${EUID:-$(id -u)}" -eq 0 || ${#TMUX_SUDO[@]} -gt 0 ]]; then
+    if command -v apt >/dev/null 2>&1; then
+      "${TMUX_SUDO[@]}" apt-get update -qq 2>/dev/null || true
+      "${TMUX_SUDO[@]}" apt install -y tmux
+    elif command -v apt-get >/dev/null 2>&1; then
+      "${TMUX_SUDO[@]}" apt-get update -qq 2>/dev/null || true
+      "${TMUX_SUDO[@]}" apt-get install -y tmux
+    elif command -v dnf >/dev/null 2>&1; then
+      "${TMUX_SUDO[@]}" dnf install -y tmux
+    elif command -v yum >/dev/null 2>&1; then
+      "${TMUX_SUDO[@]}" yum install -y tmux
+    elif command -v pacman >/dev/null 2>&1; then
+      "${TMUX_SUDO[@]}" pacman -Sy --noconfirm tmux
+    elif command -v zypper >/dev/null 2>&1; then
+      "${TMUX_SUDO[@]}" zypper install -y tmux
+    elif command -v apk >/dev/null 2>&1; then
+      "${TMUX_SUDO[@]}" apk add tmux
+    elif command -v brew >/dev/null 2>&1; then
+      brew install tmux
+    else
+      echo "  No supported package manager found — install tmux manually."
+    fi
+  fi
+
+  if command -v tmux >/dev/null 2>&1; then
+    echo "  tmux installed ($(tmux -V))."
+  else
+    echo "  tmux is still missing — agentop will run, but session features (agentop session," \
+         "the cockpit's Sessions tab) will not work until it is installed."
+  fi
+  echo ""
+fi
+
 # ── Download ───────────────────────────────────────────────────────────────
 echo "Downloading ${BINARY} from ${RELEASE_URL} …"
 mkdir -p "$INSTALL_DIR"


### PR DESCRIPTION
## What

`install.sh` (the `curl -fsSL ... | bash` installer) now detects and installs `tmux` before downloading the `agentop` binary, instead of only downloading the binary and leaving tmux to be discovered missing on first use.

## Why

agentop's session manager (`agentop session`, the cockpit's Sessions tab) is built entirely on tmux — there is no other backend. Without it, everything session-related fails, but that failure only surfaced *after* install already reported success, on the first attempt to use a session. A curl-installed machine had no warning at all until that moment.

## How

Covers `apt` (checked before `apt-get` — a machine with both gets the modern one), `apt-get`, `dnf`, `yum`, `pacman`, `zypper`, `apk`, `brew`. `apt`/`apt-get` run `update -qq` first since a freshly booted cloud VM or container image routinely has an empty package index — installing straight away is exactly where this most commonly fails. Root installs directly; a non-root user with `sudo` on `PATH` gets it via `sudo`; when neither is available, the script prints the manual command and continues (never blocks the rest of the install on this).

## Testing

Verified in isolated, throwaway Docker containers — actually run, not simulated:

| Scenario | Result |
|---|---|
| Debian, root, apt, no tmux | ✅ installs tmux, binary runs |
| Debian, non-root + sudo, apt | ✅ sudo install, binary runs |
| Alpine, root, apk | ✅ tmux installs correctly (the binary itself hits a **pre-existing, unrelated** glibc/musl incompatibility on Alpine — confirmed present even without this script, by downloading the release binary directly) |
| tmux already installed | ✅ the whole block is skipped silently |
| non-root, no sudo | ✅ prints the manual command, install still completes |

🤖 Generated with [Claude Code](https://claude.com/claude-code)