### PR TITLE
release: install.sh auto-installs tmux + subtask cost/tokens

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -46,14 +46,14 @@
     },
     "packages/agentop": {
       "name": "@agentistics/agentop",
-      "version": "2.15.0",
+      "version": "2.21.0",
       "bin": {
         "agentop": "bin/agentop.js",
       },
     },
     "packages/core": {
       "name": "@agentistics/core",
-      "version": "2.15.0",
+      "version": "2.21.0",
       "dependencies": {
         "@opentelemetry/api": "^1.9.1",
         "date-fns": "^4.1.0",
@@ -71,7 +71,7 @@
     },
     "packages/mcp": {
       "name": "@agentistics/mcp",
-      "version": "2.15.0",
+      "version": "2.21.0",
       "bin": {
         "agentistics-mcp": "dist/agentistics-mcp.js",
       },
@@ -81,7 +81,7 @@
     },
     "packages/server": {
       "name": "@agentistics/server",
-      "version": "2.15.0",
+      "version": "2.21.0",
       "dependencies": {
         "@agentistics/core": "workspace:*",
         "@agentistics/tui": "workspace:*",
@@ -91,7 +91,7 @@
     },
     "packages/tui": {
       "name": "@agentistics/tui",
-      "version": "2.15.0",
+      "version": "2.21.0",
       "dependencies": {
         "@agentistics/core": "workspace:*",
         "es-toolkit": "^1.50.0",
@@ -116,7 +116,7 @@
     },
     "packages/web": {
       "name": "@agentistics/web",
-      "version": "2.15.0",
+      "version": "2.21.0",
       "dependencies": {
         "@agentistics/core": "workspace:*",
         "@agentistics/tui": "workspace:*",

--- a/docs/superpowers/specs/2026-09-10-sessions-aside-grouping-design.md
+++ b/docs/superpowers/specs/2026-09-10-sessions-aside-grouping-design.md
@@ -1,0 +1,241 @@
+# Sessions aside — grouping, collapsing, reordering and card color
+
+## Problem
+
+The Sessions workspace's aside (`SessionsAside.tsx`) sub-groups the fleet by **project only**,
+hardcoded. There is no way to see "which sessions are filed under which delivery" or "which
+sessions are working vs. waiting" as a grouping — only as a flat rank inside the Active/Inactive
+bands. There is also no way to collapse a group, reorder groups, or change how a session's status
+color renders on its own card (today it is an all-or-nothing wash, applied only to `working` and
+`waiting`/`waiting-approval`).
+
+## What this covers
+
+A discreet control in the aside that lets a person:
+1. Choose the sub-grouping: **Project** (current, default) / **Task** / **Status**.
+2. Reorder the groups of whichever dimension is active.
+3. Collapse a group by clicking its own heading.
+4. Choose how a session's card shows its status color: **wash** (current, extended to all
+   states) / **neutral background + colored text** / **colored left stripe**.
+
+Everything is a per-viewer screen arrangement, saved in `localStorage` — never lost across
+reloads, never shared across a central's several signed-in users.
+
+## Out of scope
+
+- The terminal cockpit (`packages/tui`) is untouched. Its own `status` dimension deliberately
+  collapses `exited`/`lost`/`closed` into one `Off` bucket (the "3 desligadas, wtf" fix) — a
+  decision this feature does not reopen. The web aside's Status grouping is a **separate,
+  web-only** implementation that shows all 7 raw states, because that is what was asked here.
+- The fixed **Ativas / Inativas** bands are untouched — they keep following the header's
+  filters exactly as today. The new grouping controls apply **inside** each band.
+- No change to which sessions are shown, only to how they are arranged and colored.
+
+## Data model — `sessionsAsidePrefs.ts` (new, `localStorage`)
+
+Mirrors `boardPrefs.ts`'s own pattern and its stated reason: on a central, `/api/preferences` is
+shared by every signed-in user, so an arrangement of a list (as opposed to a fact about the work,
+like a pin) must not live there — one person's collapsed groups must not collapse them for the
+whole team viewing that central's relayed fleet.
+
+```ts
+export type AsideGroupBy = 'project' | 'task' | 'status'
+export type AsideCardColor = 'wash' | 'neutral' | 'stripe'
+
+export interface AsideGroupPrefs {
+  groupBy: AsideGroupBy
+  /** Manual order of group KEYS, per dimension. Absent = automatic (most-urgent-first). */
+  order: Partial<Record<AsideGroupBy, string[]>>
+  /** Collapsed groups, keyed `${bandId}:${groupBy}:${key}` — see "Collapsing" below. */
+  collapsed: string[]
+  cardColor: AsideCardColor
+}
+
+export const DEFAULT_ASIDE_GROUP_PREFS: AsideGroupPrefs = {
+  groupBy: 'project', order: {}, collapsed: [], cardColor: 'wash',
+}
+
+export function readAsideGroupPrefs(): AsideGroupPrefs
+export function writeAsideGroupPrefs(patch: Partial<AsideGroupPrefs>): void
+```
+
+Storage key: `agentistics-sessions-aside-v1`. Read/write guarded exactly like `boardPrefs.ts` —
+a private window or blocked storage falls back to defaults rather than throwing.
+
+An unrecognised `groupBy`/`cardColor` value (an older build, a hand-edited value) falls back to
+its default rather than being rendered as-is — the same rule `boardPrefs.ts`'s `isView`/`isLane`
+guards apply.
+
+## Grouping — `fleetGroups.ts` (extended)
+
+Replaces the current hardcoded `projectGroups`/`showsProjectHeadings` pair with a dimension-aware
+version. The one existing caller (`SessionsAside.tsx`) is updated; nothing else imports these
+today.
+
+```ts
+export function asideGroups(
+  rows: readonly ControlSession[],
+  by: AsideGroupBy,
+  lang: Lang,
+  order: readonly string[],
+): SessionGroup[]
+
+/** Same rule as before, generalized: a band holding ONE group draws no heading. */
+export function showsGroupHeadings(groups: readonly SessionGroup[]): boolean
+```
+
+- `by === 'project'` — unchanged: `groupSessions(rows, 'project', wordBook(lang), [], DEFAULT_ORDER)`.
+- `by === 'task'` — `groupSessions(rows, 'task', wordBook(lang), [], DEFAULT_ORDER)`. Reuses the
+  existing `task` dimension verbatim (its `UNFILED` bucket already reads "no delivery"/"sem
+  entrega", matching `SessionFacts`'s own wording for an unfiled row).
+- `by === 'status'` — **new, web-only**. Buckets by the raw `session.state` (all 7 values:
+  `working`, `waiting`, `waiting-approval`, `exited`, `lost`, `closed`, `unknown`), each its own
+  group. Ordered by `sessionRank` of each group's first (already-sorted) member, same rule
+  `groupSessions` applies elsewhere. Labels and colors come from a small local EN/PT table
+  (below) rather than the shared `session-dimensions.ts` word book, because that module's
+  `status` dimension is deliberately collapsed and reusing its `values` map would either mislabel
+  a merged bucket or require changing a shared, tested dimension for a web-only requirement.
+
+Both branches finish through the same pure step:
+
+```ts
+/** Manually-ordered keys first (in that order), then every other group in its existing order. */
+export function applyManualOrder(groups: SessionGroup[], order: readonly string[]): SessionGroup[]
+```
+
+A key in `order` that no longer exists is simply absent from `groups` and drops out on its own —
+nothing to reconcile. A group not yet in `order` (a brand new task, a status nobody has seen
+before) is appended after every manually-placed group, in whatever order the automatic
+urgency-first sort already gave it — so a new group is never lost, only unpositioned until moved.
+
+The manual order is **not** banded — one order per dimension, shared between the Active and
+Inactive sub-lists. A task's relative position is a statement about that task, not about which
+band it currently happens to render in.
+
+## Status word/color table (new, in `fleetGroups.ts`)
+
+```ts
+const STATUS_GROUP_WORDS: Record<SessionState, { en: string; pt: string }> = {
+  working: { en: 'Working', pt: 'Trabalhando' },
+  waiting: { en: 'Needs you', pt: 'Precisa de você' },
+  'waiting-approval': { en: 'Needs approval', pt: 'Precisa de aprovação' },
+  exited: { en: 'Finished', pt: 'Encerradas' },
+  lost: { en: 'Lost', pt: 'Desconectadas' },
+  closed: { en: 'Closed', pt: 'Fechadas' },
+  unknown: { en: 'External', pt: 'Externas' },
+}
+```
+
+Mirrors the vocabulary already used elsewhere (`board.ts`'s `SESSION_STATE` for EN, `cli-i18n.ts`'s
+per-row PT words) rather than inventing new terms.
+
+The group heading gets a small color dot (reusing the row's own state-dot convention) when
+`groupBy === 'status'` — free, consistent, and not part of the card-color preference below (that
+one is about the row cards, per your screenshot).
+
+## Card color — `sessionCardStyle.ts` (new, pure)
+
+Centralizes what is today inlined as `STATE_COLOR`/`STATE_WASH` in `SessionsAside.tsx`, so the
+group-heading dot and every row (including the pinned band) read the same colors, and so the
+three modes are one tested function:
+
+```ts
+export interface CardStyle {
+  background: string
+  /** The left-edge indicator (inset box-shadow), or undefined for none. */
+  edge?: string
+  /** Only set in `neutral` mode — the meta line's state-word color. */
+  stateTextColor?: string
+}
+
+export function sessionCardStyle(
+  state: SessionState,
+  mode: AsideCardColor,
+  selected: boolean,
+): CardStyle
+```
+
+Rules, all three modes:
+- **`selected` always wins** — the existing neutral selection style (lifted background, full
+  white/text-primary edge) is untouched in every mode; status color never competes with "this is
+  the row you're on".
+- **`wash`** (default, current behavior extended): background is a 10–12% color-mix of the
+  state's color for **all seven states** (today only `working`/`waiting`/`waiting-approval` get
+  one; `exited`/`lost`/`closed`/`unknown` will now get their own, mostly-gray tint too — a real
+  color always means the same thing).
+- **`neutral`**: background stays the row's plain hover/transparent background; no wash. The meta
+  line's state word (already rendered by `SessionFacts`, currently tertiary-or-orange-if-wants)
+  takes the state's color instead.
+- **`stripe`**: background stays plain like `neutral`, plus a colored left edge
+  (`inset 3px 0 0 <state color>`) — the same visual language `TaskBoard`'s cards already use for
+  their status stripe.
+
+`STATE_COLOR` gains an explicit `lost: 'var(--accent-red)'` entry (today it falls through to
+tertiary) so a Status group and a `stripe`/`wash` row can tell "lost" apart from "exited"/"closed",
+matching `board.ts`'s own `SESSION_STATE.lost` color.
+
+## Collapsing groups
+
+Clicking a group's own heading (the sub-heading line under a band, e.g. "agentistics · 3")
+toggles it collapsed — chevron flips (`ChevronRight`/`ChevronDown`, same icons `TaskTable` already
+uses for its own fold), sessions hide, the count stays. The **band** headings (Ativas/Inativas)
+are not affected — only the dimension sub-group is clickable, per your instruction.
+
+Persisted key: `${bandId}:${groupBy}:${key}` (`bandId` is `'active' | 'inactive'`, not the
+localized label, so PT/EN never split one preference in two). A band holding exactly one group
+draws no heading at all (existing rule, `showsGroupHeadings`) — such a group is therefore never
+collapsible, same as it is never headed today.
+
+## The discreet control — `SessionsGroupMenu.tsx` (new)
+
+One icon-only trigger (`SlidersHorizontal`, 13px) in the aside's existing top icon row, beside
+search / new / send — always visible (unlike "send to several", which only appears when it would
+do something). `title`/`aria-label`: "Arrange list" / "Organizar lista".
+
+Its popover — `position: fixed` in a portal, clamped to viewport, closes on scroll, same contract
+`PickerMenu`/`BoardArrange`'s panels already follow — carries three sections:
+
+1. **GROUP BY** — three rows, single-select: Project · Task · Status.
+2. **GROUP ORDER** — shown only when the current dimension has 2+ groups. A draggable list
+   (drag handle + ▲▼, no checkboxes — nothing here is hidden, only reordered) of that dimension's
+   current groups, by label. Dragging or pressing an arrow writes the new key order to
+   `order[groupBy]` immediately.
+3. **CARD COLOR** — three rows, single-select: "Background follows status" / "Neutral background,
+   colored text" / "Colored left stripe".
+
+Every change writes through `writeAsideGroupPrefs` immediately (no separate "save").
+
+## `SessionsAside.tsx` changes
+
+- Seed `groupBy` / `order` / `cardColor` from `readAsideGroupPrefs()` once (`useMemo`), same
+  pattern `TaskList` uses for `readBoardPrefs()`.
+- The `bands` memo's two `projectGroups(...)` calls become
+  `asideGroups(rest, groupBy, lang, order[groupBy] ?? [])`.
+- `SessionBand` gains `collapsed: ReadonlySet<string>` and `onToggleCollapse(key: string)`; its
+  per-group heading becomes a button with a chevron, matching `TaskTable`'s fold row.
+- `SessionRow` (and the pinned band, which renders the same component) takes a `cardColor` prop
+  and calls `sessionCardStyle(session.state, cardColor, selected)` instead of inlining
+  `STATE_COLOR`/`STATE_WASH` lookups.
+- `SessionsGroupMenu` is rendered once, near the search/new/send row.
+
+## Testing
+
+- `fleetGroups.test.ts` (new): `applyManualOrder` (known keys ordered, unknown keys appended
+  preserving relative order, empty order is a no-op), `asideGroups('status', …)` produces exactly
+  the 7-state buckets with the right labels/counts and no `session-dimensions.ts` collapsing,
+  `asideGroups('task'|'project', …)` unchanged from today's behavior, `showsGroupHeadings`
+  unchanged rule.
+- `sessionCardStyle.test.ts` (new): all three modes × all seven states × selected/not — a pure
+  table, easy to pin exactly.
+- `sessionsAsidePrefs.test.ts` (new): read/write round-trip, corrupt JSON falls back to defaults,
+  an unrecognised `groupBy`/`cardColor` value falls back rather than rendering as-is.
+
+## Files touched
+
+- `packages/web/src/lib/sessionsAsidePrefs.ts` — new
+- `packages/web/src/lib/sessionCardStyle.ts` — new
+- `packages/web/src/lib/fleetGroups.ts` — extended (drops `projectGroups`/`showsProjectHeadings`
+  in favor of `asideGroups`/`showsGroupHeadings`, adds `applyManualOrder` and the status word
+  table)
+- `packages/web/src/components/nav/SessionsGroupMenu.tsx` — new
+- `packages/web/src/components/nav/SessionsAside.tsx` — wires all of the above in

--- a/install.sh
+++ b/install.sh
@@ -30,6 +30,65 @@ if [[ "$ARCH" != "x86_64" ]]; then
   exit 1
 fi
 
+# ── Runtime dependency: tmux ────────────────────────────────────────────────
+#
+# agentop's session manager (`agentop session`, the cockpit's Sessions tab) is built on tmux —
+# there is no other backend (see packages/server/server/sessions/dependency-plan.ts, which the
+# already-installed binary uses to explain a MISSING tmux to someone who skipped this script or
+# removed the package afterwards). Without it every session-related feature fails the moment it is
+# used, well after the install already reported success — a confusing place to first learn about a
+# missing dependency. So it is installed HERE, proactively, the same way any competent install
+# script pulls in what it needs — never silently, and never left to fail on first use.
+#
+# `apt` is checked before `apt-get` (Debian/Ubuntu ship both; a machine with both gets the modern
+# one) and `apt-get update` runs first because a freshly booted cloud VM or container image
+# routinely has an empty or stale package index — `apt-get install` alone fails on exactly the
+# machines this script most often runs on. `pacman -Sy` syncs the database for the same reason.
+if ! command -v tmux >/dev/null 2>&1; then
+  echo "tmux not found — agentop's session manager needs it. Installing…"
+
+  TMUX_SUDO=()
+  if [[ "${EUID:-$(id -u)}" -ne 0 ]]; then
+    if command -v sudo >/dev/null 2>&1; then
+      TMUX_SUDO=(sudo)
+    else
+      echo "  Not root and no sudo on PATH — install tmux yourself, e.g.: apt install tmux"
+    fi
+  fi
+
+  if [[ "${EUID:-$(id -u)}" -eq 0 || ${#TMUX_SUDO[@]} -gt 0 ]]; then
+    if command -v apt >/dev/null 2>&1; then
+      "${TMUX_SUDO[@]}" apt-get update -qq 2>/dev/null || true
+      "${TMUX_SUDO[@]}" apt install -y tmux
+    elif command -v apt-get >/dev/null 2>&1; then
+      "${TMUX_SUDO[@]}" apt-get update -qq 2>/dev/null || true
+      "${TMUX_SUDO[@]}" apt-get install -y tmux
+    elif command -v dnf >/dev/null 2>&1; then
+      "${TMUX_SUDO[@]}" dnf install -y tmux
+    elif command -v yum >/dev/null 2>&1; then
+      "${TMUX_SUDO[@]}" yum install -y tmux
+    elif command -v pacman >/dev/null 2>&1; then
+      "${TMUX_SUDO[@]}" pacman -Sy --noconfirm tmux
+    elif command -v zypper >/dev/null 2>&1; then
+      "${TMUX_SUDO[@]}" zypper install -y tmux
+    elif command -v apk >/dev/null 2>&1; then
+      "${TMUX_SUDO[@]}" apk add tmux
+    elif command -v brew >/dev/null 2>&1; then
+      brew install tmux
+    else
+      echo "  No supported package manager found — install tmux manually."
+    fi
+  fi
+
+  if command -v tmux >/dev/null 2>&1; then
+    echo "  tmux installed ($(tmux -V))."
+  else
+    echo "  tmux is still missing — agentop will run, but session features (agentop session," \
+         "the cockpit's Sessions tab) will not work until it is installed."
+  fi
+  echo ""
+fi
+
 # ── Download ───────────────────────────────────────────────────────────────
 echo "Downloading ${BINARY} from ${RELEASE_URL} …"
 mkdir -p "$INSTALL_DIR"

--- a/packages/web/src/components/tasks/DeliveryDetail.tsx
+++ b/packages/web/src/components/tasks/DeliveryDetail.tsx
@@ -1250,6 +1250,7 @@ export function DeliveryDetail({ id, detail, lang, reload, dense, onDeleted }: D
             <SubtaskTable
               subtasks={detail.subtasks}
               sessions={detail.sessions}
+              subtaskRollups={detail.subtaskRollups}
               lang={lang}
               onAdd={title => run(() => addSubtask(id, title))}
               onPatch={(sid, patch) => run(() => patchSubtask(id, sid, patch))}

--- a/packages/web/src/components/tasks/SessionFiling.tsx
+++ b/packages/web/src/components/tasks/SessionFiling.tsx
@@ -77,7 +77,11 @@ export function SessionFiling(p: SessionFilingProps) {
 
   const refresh = async () => { await reload(); await reloadDetail(); await p.onChanged() }
 
-  const here = detail?.sessions.find(s => s.id === p.session.id)?.subtaskId ?? null
+  const filedRow = detail?.sessions.find(s => s.id === p.session.id)
+  const here = filedRow?.subtaskId ?? null
+  /** True only when the session is actually filed on THIS delivery directly — not merely absent
+   *  from it, which also reads `subtaskId` as `null` via the fallback above. */
+  const directOn = filedRow != null && filedRow.subtaskId == null
 
   const shown = useMemo(() => {
     const needle = q.trim().toLowerCase()
@@ -85,13 +89,15 @@ export function SessionFiling(p: SessionFilingProps) {
     return needle ? all.filter(r => r.task.title.toLowerCase().includes(needle)) : all
   }, [rows, q])
 
-  const fileInto = async (taskId: string, subtaskId: string) => {
+  /** `subtaskId` omitted files the session directly on the delivery — see spec §4.1/§4.4. */
+  const fileInto = async (taskId: string, subtaskId?: string) => {
     setBusy(true)
     const result = await attachSession(taskId, p.session.id, subtaskId)
     setBusy(false)
-    if (!result.ok && result.reason === 'blocked') {
+    if (!result.ok && result.reason === 'blocked' && subtaskId) {
       // The dialog it opens is HANDED the answer, never asked to guess it — the ids `planAttach`
-      // named are exactly what it needs.
+      // named are exactly what it needs. A direct-on-the-delivery file can never come back
+      // `blocked` — only a subtask carries `blockedBy` — so this branch only ever fires with one.
       setBlocked({ taskId, subtaskId, blockedBy: result.blockedBy ?? [] })
       return
     }
@@ -193,6 +199,40 @@ export function SessionFiling(p: SessionFilingProps) {
     )
   }
 
+  /**
+   * The "no breakdown" option — file straight on the delivery, no subtask. Drawn like a subtask
+   * row (same radio, same icon, same list) because it is one more place the session can sit, not
+   * a lesser control — it leads the list because it is the simplest of the three shapes a task can
+   * take (spec §4.4, diagram #1).
+   */
+  const directRow = () => (
+    <button
+      key="__direct__"
+      onClick={() => void fileInto(target!.task.id)}
+      disabled={busy || directOn}
+      aria-pressed={directOn}
+      style={{
+        display: 'flex', alignItems: 'center', gap: 8, width: '100%', textAlign: 'left',
+        minHeight: isMobile ? 44 : 32, padding: isMobile ? '8px 10px' : '6px 9px',
+        borderRadius: 7, font: 'inherit', fontSize: 12.5, fontStyle: 'italic',
+        border: `1px solid ${directOn ? 'var(--anthropic-orange)' : 'transparent'}`,
+        background: directOn ? 'var(--anthropic-orange-dim)' : 'transparent',
+        color: directOn ? 'var(--anthropic-orange)' : 'var(--text-secondary)',
+        cursor: directOn || busy ? 'default' : 'pointer',
+      }}
+    >
+      <span style={{
+        width: 12, height: 12, borderRadius: 6, flexShrink: 0,
+        border: `1px solid ${directOn ? 'var(--anthropic-orange)' : 'var(--border)'}`,
+        background: directOn ? 'radial-gradient(circle, var(--anthropic-orange) 0 3px, transparent 4px)' : 'transparent',
+      }} />
+      <CornerDownRight size={11} style={{ opacity: 0.6, flexShrink: 0 }} />
+      <span style={{ minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+        {pt ? '— direto na entrega —' : '— directly on the delivery —'}
+      </span>
+    </button>
+  )
+
   const body = target
     ? (
       // ── THE DELIVERY ITSELF ────────────────────────────────────────────────────────────────
@@ -210,20 +250,23 @@ export function SessionFiling(p: SessionFilingProps) {
         </div>
 
         <span style={{ ...microLabel, fontSize: 9 }}>
-          {pt ? 'Subtarefas — a sessão fica em UMA delas' : 'Subtasks — the session sits in ONE of them'}
+          {pt
+            ? 'Onde a sessão fica — direto na entrega, ou em UMA subtarefa'
+            : 'Where the session sits — directly on the delivery, or under ONE subtask'}
         </span>
+
+        <div style={{ display: 'grid', gap: 2, maxHeight: 260, overflowY: 'auto' }}>
+          {directRow()}
+          {(detail?.subtasks ?? []).map(subtaskRow)}
+        </div>
 
         {(detail?.subtasks.length ?? 0) === 0 && !adding && (
           <p style={{ margin: 0, fontSize: 11.5, lineHeight: 1.5, color: 'var(--text-tertiary)' }}>
             {pt
-              ? 'Esta entrega ainda não tem subtarefas, e uma sessão só se filia a uma subtarefa — o custo da entrega é o das partes dela. Crie a primeira aqui.'
-              : 'This delivery has no subtasks yet, and a session is only ever filed under one — a delivery’s cost is the cost of its parts. Create the first one here.'}
+              ? 'Esta entrega ainda não tem subtarefas. Filie aqui direto, ou quebre a entrega em subtarefas abaixo.'
+              : 'This delivery has no subtasks yet. File it here directly, or break the delivery into subtasks below.'}
           </p>
         )}
-
-        <div style={{ display: 'grid', gap: 2, maxHeight: 260, overflowY: 'auto' }}>
-          {(detail?.subtasks ?? []).map(subtaskRow)}
-        </div>
 
         {adding
           ? (

--- a/packages/web/src/components/tasks/SubtaskTable.tsx
+++ b/packages/web/src/components/tasks/SubtaskTable.tsx
@@ -3,7 +3,9 @@
  *
  * One component drawn in two places, deliberately: a subtask that shows five columns on the board
  * and a checkbox on the detail page is two different records as far as the reader is concerned, and
- * the one with fewer columns teaches people the fields do not exist.
+ * the one with fewer columns teaches people the fields do not exist. (`TaskTable.tsx`'s inline
+ * subitem rows mirror the base columns but do NOT yet draw the two below — a gap worth closing
+ * there too, tracked separately rather than done as a side effect of this file.)
  *
  * A subtask carries a SESSION — which piece of work is being done where — and now a ROLLUP of its
  * own: cost, rounds and tokens are still measured per SESSION, never stored on the subtask itself,
@@ -11,19 +13,29 @@
  * `attemptViews()` sums an attempt's, as a partition of the task's rows rather than a second count
  * of them — nothing here double-counts a session or invents a split the data does not record. See
  * docs/superpowers/specs/2026-09-10-task-session-hierarchy-design.md §4.2.
+ *
+ * The Cost/Tokens columns below read `p.subtaskRollups`, keyed by subtask id, and render them with
+ * the exact same formatters `TaskTable.tsx`'s own cost/tokens cells use (`useMoney()`, `fmtTokens`,
+ * `NA`) — a second formatting rule here would be a second answer for the same figure. A subtask
+ * with no session filed yet still gets a bucket from the server (`sessionsUsed: 0`, every metric
+ * `null`), and `null` renders as `NA` — never a `0` pretending to be a measurement. The `id: null`
+ * direct-branch bucket (sessions filed straight on the delivery) is deliberately NOT drawn as a row
+ * here — that footer is `s-2cb8108f97`'s job, once this lands.
  */
 
 import { useState } from 'react'
 import { Plus, Trash2 } from 'lucide-react'
 import { useIsMobile } from '../../hooks/useIsMobile'
-import { COLUMN_ORDER, STATUS, microLabel, surface, type BoardStatus } from './board'
+import { COLUMN_ORDER, STATUS, fmtTokens, microLabel, numeric, surface, type BoardStatus } from './board'
 import { SessionPicker } from './SessionPicker'
 import { DatePicker } from '../DatePicker'
 import { TaskProgressBar } from './TaskProgressBar'
 import { subtaskSessions } from './SubtaskSessions'
 import { SubtaskBlockedBy } from './SubtaskBlockedBy'
 import { boardCopy, statusLabel, type Lang } from './copy'
-import type { Subtask, TaskSessionRow, TaskStatus } from '../../lib/tasks'
+import { useMoney } from './money'
+import { costCaveat, costCellFor, subtaskRollupOf } from './subtaskRollup'
+import type { Subtask, SubtaskView, TaskSessionRow, TaskStatus } from '../../lib/tasks'
 
 function StatusPick({ value, lang, onPick }: {
   value: TaskStatus
@@ -83,6 +95,9 @@ export interface SubtaskTableProps {
   subtasks: Subtask[]
   /** The DELIVERY's sessions. Each row shows the ones filed under it — see `SubtaskSessions`. */
   sessions: readonly TaskSessionRow[]
+  /** One rollup per subtask (and the `id: null` direct-branch bucket this table does not draw
+   *  yet) — `TaskDetail.subtaskRollups`, straight off the server's `subtaskViews()`. */
+  subtaskRollups: readonly SubtaskView[]
   lang: Lang
   onAdd: (title: string) => void | Promise<void>
   onPatch: (id: string, patch: Partial<Subtask>) => void | Promise<void>
@@ -98,6 +113,7 @@ export interface SubtaskTableProps {
 export function SubtaskTable(p: SubtaskTableProps) {
   const isMobile = useIsMobile()
   const copy = boardCopy(p.lang)
+  const money = useMoney()
   const [draft, setDraft] = useState('')
   const [linking, setLinking] = useState<string | null>(null)
 
@@ -117,11 +133,17 @@ export function SubtaskTable(p: SubtaskTableProps) {
         </div>
       </div>
 
-      <table style={{ width: '100%', borderCollapse: 'collapse', minWidth: 620 }}>
+      <table style={{ width: '100%', borderCollapse: 'collapse', minWidth: 760 }}>
         <thead>
           <tr>
-            {[copy.subtasks, 'Status', copy.owner, copy.start, copy.due, copy.sessions, ''].map((h, i) => (
-              <th key={i} style={{ ...microLabel, textAlign: 'left', padding: '6px 9px', fontWeight: 600 }}>
+            {[copy.subtasks, 'Status', copy.owner, copy.start, copy.due, copy.sessions, copy.cost, copy.tokens, ''].map((h, i) => (
+              <th
+                key={i}
+                style={{
+                  ...microLabel, padding: '6px 9px', fontWeight: 600,
+                  textAlign: h === copy.cost || h === copy.tokens ? 'right' : 'left',
+                }}
+              >
                 {h}
               </th>
             ))}
@@ -130,12 +152,15 @@ export function SubtaskTable(p: SubtaskTableProps) {
         <tbody>
           {p.subtasks.length === 0 && (
             <tr>
-              <td colSpan={7} style={{ ...cell, fontSize: 12, color: 'var(--text-tertiary)', lineHeight: 1.55 }}>
+              <td colSpan={9} style={{ ...cell, fontSize: 12, color: 'var(--text-tertiary)', lineHeight: 1.55 }}>
                 {copy.nothingBrokenOut}
               </td>
             </tr>
           )}
-          {p.subtasks.map(t => (
+          {p.subtasks.map(t => {
+            const r = subtaskRollupOf(p.subtaskRollups, t.id)
+            const cost = costCellFor(r)
+            return (
             <tr key={t.id}>
               <td style={{ ...cell, minWidth: 180 }}>
                 <input
@@ -205,15 +230,36 @@ export function SubtaskTable(p: SubtaskTableProps) {
                 })}
               </td>
               <td style={{ ...cell, textAlign: 'right' }}>
+                {/* `r` absent (no bucket at all) reads exactly like an empty one — the "not
+                    measured yet" answer for a subtask nobody has filed a session under. */}
+                {cost.kind === 'credits' ? (
+                  <span style={{ ...numeric, fontSize: 12 }}>{cost.premiumRequests} req</span>
+                ) : (
+                  <span
+                    style={{
+                      ...numeric, fontSize: 12,
+                      color: cost.kind === 'na' || cost.usd === null ? 'var(--text-tertiary)' : 'var(--anthropic-orange)',
+                    }}
+                    title={costCaveat(r)}
+                  >{money(cost.kind === 'money' ? cost.usd : null)}</span>
+                )}
+              </td>
+              <td style={{ ...cell, textAlign: 'right' }}>
+                <span style={{ ...numeric, fontSize: 12, color: !r || r.tokens === null ? 'var(--text-tertiary)' : undefined }}>
+                  {fmtTokens(r?.tokens ?? null)}
+                </span>
+              </td>
+              <td style={{ ...cell, textAlign: 'right' }}>
                 <button
                   onClick={() => void p.onRemove(t.id)} title={copy.remove}
                   style={{ background: 'none', border: 'none', color: 'var(--text-tertiary)', cursor: 'pointer', display: 'inline-flex' }}
                 ><Trash2 size={12} /></button>
               </td>
             </tr>
-          ))}
+            )
+          })}
           <tr>
-            <td colSpan={7} style={{ ...cell }}>
+            <td colSpan={9} style={{ ...cell }}>
               <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6, width: '100%' }}>
                 <Plus size={12} style={{ color: 'var(--text-tertiary)', flexShrink: 0 }} />
                 <input

--- a/packages/web/src/components/tasks/subtaskRollup.test.ts
+++ b/packages/web/src/components/tasks/subtaskRollup.test.ts
@@ -1,0 +1,69 @@
+import { test, expect } from 'bun:test'
+import { costCaveat, costCellFor, subtaskRollupOf } from './subtaskRollup'
+import type { AttemptRollup, SubtaskView } from '../../lib/tasks'
+
+function rollup(over: Partial<AttemptRollup> = {}): AttemptRollup {
+  return {
+    sessionsUsed: 1, sessionsLinked: 1, provenance: { assigned: 1, observed: 0, none: 0 },
+    rounds: 3, activeMinutes: 10, tokens: 1000, costUSD: 1.5,
+    costMeasuredSessions: 0, costEstimatedSessions: 1, credits: null, mixedCurrency: false,
+    ...over,
+  }
+}
+
+// --- subtaskRollupOf -----------------------------------------------------------------------------
+
+test('subtaskRollupOf: finds the bucket by subtask id', () => {
+  const r = rollup({ costUSD: 7 })
+  const views: SubtaskView[] = [{ id: 's1', rollup: r }, { id: 's2', rollup: rollup({ costUSD: 3 }) }]
+  expect(subtaskRollupOf(views, 's1')).toBe(r)
+})
+
+test('subtaskRollupOf: undefined when the server has no bucket for this subtask', () => {
+  const views: SubtaskView[] = [{ id: 's1', rollup: rollup() }]
+  expect(subtaskRollupOf(views, 'unknown')).toBeUndefined()
+})
+
+test('subtaskRollupOf: the id:null direct-branch bucket is not confused with a real subtask', () => {
+  const views: SubtaskView[] = [{ id: null, rollup: rollup({ costUSD: 99 }) }]
+  expect(subtaskRollupOf(views, 's1')).toBeUndefined()
+})
+
+// --- costCellFor -----------------------------------------------------------------------------
+
+test('costCellFor: no bucket at all renders N/A, never a 0', () => {
+  expect(costCellFor(undefined)).toEqual({ kind: 'na' })
+})
+
+test('costCellFor: a subtask with no session filed yet — sessionsUsed 0, costUSD null — is honest N/A, not a fake 0', () => {
+  const r = rollup({ sessionsUsed: 0, sessionsLinked: 0, rounds: null, activeMinutes: null, tokens: null, costUSD: null })
+  expect(costCellFor(r)).toEqual({ kind: 'money', usd: null })
+})
+
+test('costCellFor: an ordinary priced subtask renders its dollar figure', () => {
+  expect(costCellFor(rollup({ costUSD: 12.34 }))).toEqual({ kind: 'money', usd: 12.34 })
+})
+
+test('costCellFor: mixed currency takes the credits branch even if costUSD is set', () => {
+  const r = rollup({ mixedCurrency: true, costUSD: 5, credits: { nanoAiu: 0, premiumRequests: 4 } })
+  expect(costCellFor(r)).toEqual({ kind: 'credits', premiumRequests: 4 })
+})
+
+test('costCellFor: Copilot-only credits with no USD figure takes the credits branch', () => {
+  const r = rollup({ mixedCurrency: false, costUSD: null, credits: { nanoAiu: 0, premiumRequests: 2 } })
+  expect(costCellFor(r)).toEqual({ kind: 'credits', premiumRequests: 2 })
+})
+
+// --- costCaveat ------------------------------------------------------------------------------
+
+test('costCaveat: absent when every linked session is priced', () => {
+  expect(costCaveat(rollup({ sessionsUsed: 2, sessionsLinked: 2 }))).toBeUndefined()
+})
+
+test('costCaveat: names the split when some sessions have no conversation link', () => {
+  expect(costCaveat(rollup({ sessionsUsed: 3, sessionsLinked: 2 }))).toBe('cost covers 2 of 3 sessions')
+})
+
+test('costCaveat: absent when there is no bucket to speak of', () => {
+  expect(costCaveat(undefined)).toBeUndefined()
+})

--- a/packages/web/src/components/tasks/subtaskRollup.ts
+++ b/packages/web/src/components/tasks/subtaskRollup.ts
@@ -1,0 +1,38 @@
+/**
+ * subtaskRollup.ts — pure reads over `TaskDetail.subtaskRollups`, pulled out of `SubtaskTable.tsx`
+ * so the N/A-vs-zero decision has something testable to assert against.
+ *
+ * This project has no React-rendering test infrastructure (see `ConnectionCard.test.tsx`), so the
+ * one thing worth getting wrong here — whether a subtask with no session yet renders as an honest
+ * "not measured" rather than a `0` — is asserted directly against these functions, not through DOM.
+ */
+
+import type { AttemptRollup, SubtaskView } from '../../lib/tasks'
+
+/** The rollup for one subtask, or `undefined` when the server has no bucket for it at all — which
+ *  reads exactly like an empty one: nothing measured, never a `0` standing in for it. */
+export function subtaskRollupOf(views: readonly SubtaskView[], id: string): AttemptRollup | undefined {
+  return views.find(v => v.id === id)?.rollup
+}
+
+export type CostCell =
+  | { kind: 'na' }
+  | { kind: 'credits'; premiumRequests: number }
+  /** `usd: null` still renders as N/A — `useMoney()` already refuses to turn `null` into `$0.00`. */
+  | { kind: 'money'; usd: number | null }
+
+/** Same branch `TaskTable.tsx`'s own cost cell takes, over one subtask's rollup instead of a
+ *  task's — a second formatting rule here would be a second answer for the same figure. */
+export function costCellFor(r: AttemptRollup | undefined): CostCell {
+  if (!r) return { kind: 'na' }
+  if (r.mixedCurrency || (r.credits !== null && r.costUSD === null)) {
+    return { kind: 'credits', premiumRequests: r.credits!.premiumRequests }
+  }
+  return { kind: 'money', usd: r.costUSD }
+}
+
+/** Whether the cost cell should carry the "N of M sessions priced" caveat as a tooltip. */
+export function costCaveat(r: AttemptRollup | undefined): string | undefined {
+  if (!r || r.sessionsLinked >= r.sessionsUsed) return undefined
+  return `cost covers ${r.sessionsLinked} of ${r.sessionsUsed} sessions`
+}


### PR DESCRIPTION
Promotes \`dev\` to \`main\`.

Includes since the last release:
- feat(install): auto-install tmux when missing (#506)
- feat(web): custo/tokens por subtask na SubtaskTable (#505)
- feat(web): opção de filiar sessão direto na entrega (SessionFiling) (#504)
- docs: spec para agrupamento, ordenação e cor dos cards no aside de sessões

🤖 Generated with [Claude Code](https://claude.com/claude-code)