### PR TITLE
feat(terminal): o shell tem tela própria, e a pane já nasce do tamanho da caixa

### DIFF
--- a/packages/server/server/sessions/pane-resize.test.ts
+++ b/packages/server/server/sessions/pane-resize.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 import { PANE_COLS, PANE_ROWS } from './tmux-cli'
-import { resizePlan } from './pane-resize'
+import { readWantedGeometry, resizePlan } from './pane-resize'
 
 describe('a SHELL pane follows the box it is drawn in', () => {
   test('it takes the geometry asked for', () => {
@@ -54,5 +54,35 @@ describe('a geometry that is not one is refused rather than resolved', () => {
     for (const want of [{ cols: 0, rows: 50 }, { cols: 120, rows: 0 }, { cols: -5, rows: 50 }, { cols: 5000, rows: 50 }]) {
       expect(resizePlan({ scope: 'shell', want, current: { cols: 120, rows: 50 } })).toBeNull()
     }
+  })
+})
+
+describe('the geometry a stream may be OPENED with', () => {
+  const q = (s: string) => readWantedGeometry(new URLSearchParams(s))
+
+  test('a pair of positive whole numbers is read', () => {
+    expect(q('id=s1&cols=144&rows=13')).toEqual({ cols: 144, rows: 13 })
+  })
+
+  test('saying nothing is not an error — it is the ordinary case', () => {
+    expect(q('id=s1')).toBeNull()
+    expect(q('id=s1&cols=144')).toBeNull()
+    expect(q('id=s1&rows=13')).toBeNull()
+  })
+
+  // A query string is untrusted input and this one arrives BEFORE the stream exists, so a value it
+  // cannot read must cost the caller the resize and never the stream.
+  test('anything that is not a pair of positive whole numbers is refused, never clamped', () => {
+    for (const s of [
+      'cols=0&rows=13', 'cols=144&rows=0', 'cols=-5&rows=13', 'cols=1.5&rows=13',
+      'cols=abc&rows=13', 'cols=144&rows=NaN', 'cols=&rows=13', 'cols=1e400&rows=13',
+    ]) {
+      expect(q(s), s).toBeNull()
+    }
+  })
+
+  test('a geometry past the ceiling is refused here too, so the plan is never asked a silly question', () => {
+    expect(q('cols=100000&rows=13')).toBeNull()
+    expect(q('cols=144&rows=100000')).toBeNull()
   })
 })

--- a/packages/server/server/sessions/pane-resize.ts
+++ b/packages/server/server/sessions/pane-resize.ts
@@ -41,6 +41,34 @@ function sane(g: PaneGeometry): boolean {
 }
 
 /**
+ * The geometry a READER stated when it opened the stream, or `null` for "it said nothing".
+ *
+ * A pane has one size and the last viewer to ask wins, so a shell last read on a phone hands a
+ * desktop its first frames hard-broken at 52 columns and the band snaps a quarter-second later,
+ * once the emulator has measured itself and the debounced resize lands. Letting the reader state
+ * the size on the way in closes that window — the pane is resized BEFORE the first capture.
+ *
+ * It is untrusted input arriving before the stream exists, so it is REFUSED rather than clamped:
+ * a value nobody can read costs the caller its resize, never its stream. The ceiling is the same
+ * one `resizePlan` holds, applied here so the plan is never asked a question it would only reject.
+ */
+export function readWantedGeometry(params: URLSearchParams): PaneGeometry | null {
+  const read = (name: string): number | null => {
+    const raw = params.get(name)
+    if (!raw) return null
+    // `Number` so `1.5` and `1e400` are read as themselves and then refused — `parseInt` would
+    // truncate both into perfectly usable numbers nobody asked for.
+    const n = Number(raw)
+    return Number.isInteger(n) && n > 0 ? n : null
+  }
+  const cols = read('cols')
+  const rows = read('rows')
+  if (cols === null || rows === null) return null
+  const want = { cols, rows }
+  return sane(want) ? want : null
+}
+
+/**
  * The geometry to apply, or `null` for "do nothing".
  *
  * `null` covers three different situations on purpose — the numbers are unusable, the clamp landed

--- a/packages/server/server/sessions/shell-web.ts
+++ b/packages/server/server/sessions/shell-web.ts
@@ -13,6 +13,7 @@ import type { CliLang } from '../cli-lang'
 import { closeShells, listShells, openShell } from './shell-backend'
 import { openShellStream, shellStreamAtCapacity, shellStreamExists } from './shell-stream-web'
 import { createPaneResizer } from './pane-resize-web'
+import { readWantedGeometry } from './pane-resize'
 import { SHELL_CAP, type ShellRefusal } from './shell-spec'
 
 /** One sentence per refusal code. The module that decides never writes prose; this one never decides. */
@@ -68,6 +69,13 @@ export async function handleShellRoute(
     if (!id) return json({ error: 'bad_request' }, 400)
     if (!(await shellStreamExists(id))) return json({ error: 'not_found' }, 404)
     if (shellStreamAtCapacity()) return json({ error: 'too_many_streams' }, 503)
+    // BEFORE the first capture. A pane has one size and the last viewer to ask wins, so without
+    // this a shell last read on a phone hands a desktop frames hard-broken at 52 columns until the
+    // emulator has measured itself and the debounced resize lands. The reader states what its box
+    // holds on the way in and the first frame is already right. A resize that fails costs the
+    // width for a quarter-second and never the stream — the measurement corrects it either way.
+    const want = readWantedGeometry(url.searchParams)
+    if (want) await resizeShellPane('shell', id, want)
     return new Response(await openShellStream(id, req.signal), {
       status: 200,
       headers: {

--- a/packages/web/src/components/sessions/SessionPanel.tsx
+++ b/packages/web/src/components/sessions/SessionPanel.tsx
@@ -69,6 +69,8 @@ export interface SessionPanelProps {
    * then the enlarge control is ABSENT too rather than inert.
    */
   onOpenTerminal?: () => void
+  /** Take the SHELL to its own screen. Absent where there is no route to take it to. */
+  onOpenShellFullscreen?: () => void
   /**
    * May this machine serve a per-session utility SHELL right now — `CAPS.localShell` AND the
    * user's own switch, as `/api/team/session` reports it.
@@ -81,7 +83,7 @@ export interface SessionPanelProps {
   shellEnabled?: boolean
 }
 
-export function SessionPanel({ session, row, lang, theme, act, authorName, onGone, onOpened, view: viewProp, onViewChange, onArtifacts, shellEnabled, onOpenTerminal }: SessionPanelProps) {
+export function SessionPanel({ session, row, lang, theme, act, authorName, onGone, onOpened, view: viewProp, onViewChange, onArtifacts, shellEnabled, onOpenTerminal, onOpenShellFullscreen }: SessionPanelProps) {
   /**
    * Is this a session of ANOTHER machine, reached through the relay?
    *
@@ -243,6 +245,7 @@ export function SessionPanel({ session, row, lang, theme, act, authorName, onGon
           key={session.id}
           sessionId={session.id}
           {...(session.cwd ? { cwd: session.cwd } : {})}
+          {...(onOpenShellFullscreen ? { onOpenFullscreen: onOpenShellFullscreen } : {})}
           lang={lang}
           theme={theme}
         />

--- a/packages/web/src/components/sessions/ShellBand.tsx
+++ b/packages/web/src/components/sessions/ShellBand.tsx
@@ -41,15 +41,16 @@
 
 import { Suspense, lazy, useCallback, useEffect, useMemo, useReducer, useRef, useState } from 'react'
 import {
-  ChevronDown, ChevronUp, ChevronLeft, Loader2, RotateCcw, TerminalSquare, Trash2,
+  ChevronDown, ChevronUp, ChevronLeft, Loader2, Maximize2, RotateCcw, TerminalSquare, Trash2,
 } from 'lucide-react'
 import { useDocumentVisible } from '../../hooks/useDocumentVisible'
+import { keyStripShown } from '../../lib/terminalSurface'
 import { useIsMobile } from '../../hooks/useIsMobile'
 import { useTerminalStream } from '../../hooks/useTerminalStream'
 import { useTerminalWrite } from '../../hooks/useTerminalWrite'
 import {
   BAND_MIN_PX, clampBandHeight, readBandPrefs, shellApiUrl, shellErrorText, shellWatching,
-  shellWhere, writeBandPrefs,
+  bandGeometry, shellWhere, writeBandGeometry, writeBandPrefs,
 } from '../../lib/shellBand'
 import {
   INITIAL_SHELL_BAND, shellBandReducer, shellResolveWanted, type OpenShell,
@@ -73,6 +74,7 @@ interface T {
   ctrlRefused: (c: string) => string
   resize: string
   retry: string
+  fullscreen: string
 }
 
 const TXT: Record<'pt' | 'en', T> = {
@@ -89,6 +91,7 @@ const TXT: Record<'pt' | 'en', T> = {
     ctrlRefused: c => `ctrl+${c} is not one of the keys this channel sends.`,
     resize: 'Drag to resize the shell',
     retry: 'Try again',
+    fullscreen: 'Open the shell full screen',
   },
   pt: {
     title: 'Shell',
@@ -103,6 +106,7 @@ const TXT: Record<'pt' | 'en', T> = {
     ctrlRefused: c => `ctrl+${c} não é uma das teclas que este canal envia.`,
     resize: 'Arraste para redimensionar o shell',
     retry: 'Tentar de novo',
+    fullscreen: 'Abrir o shell em tela cheia',
   },
 }
 
@@ -113,17 +117,34 @@ export interface ShellBandProps {
   cwd?: string
   lang: 'pt' | 'en'
   theme: 'dark' | 'light'
+  /**
+   * WHERE this shell is drawn. `docked` is the band under the composer — the placement whose whole
+   * point is SIMULTANEITY, reading the conversation while a build runs beside it. `dedicated` is
+   * the shell filling its own screen: no bar, no drag handle, no collapsed state, because you got
+   * here by asking for it and the way back is the screen's own control.
+   *
+   * The two share every rule that matters — one stream, one write channel, one emulator, the same
+   * unwatch discipline — which is the entire reason this is a prop and not a second component.
+   */
+  placement?: 'docked' | 'dedicated'
+  /** Offered only when there is somewhere to go: the band's "take the whole screen" control. */
+  onOpenFullscreen?: () => void
 }
 
-export function ShellBand({ sessionId, cwd, lang, theme }: ShellBandProps) {
+export function ShellBand({ sessionId, cwd, lang, theme, placement = 'docked', onOpenFullscreen }: ShellBandProps) {
   const t = TXT[lang]
   const isMobile = useIsMobile()
   const documentVisible = useDocumentVisible()
 
+  const dedicated = placement === 'dedicated'
   const [prefs, setPrefs] = useState(() => readBandPrefs())
+  // A DEDICATED shell is open by definition — you navigated to a screen that is nothing else. The
+  // stored `open` is the DOCKED band's state and must not decide it, or arriving here with the band
+  // collapsed would show an empty screen with no way to fill it.
+  const bandOpen = dedicated || prefs.open
   // THE MACHINE, not a pile of flags. See `shellBandState.ts` for the rule it enforces.
   const [band, dispatch] = useReducer(shellBandReducer, INITIAL_SHELL_BAND, init =>
-    readBandPrefs().open ? shellBandReducer(init, { type: 'openBand' }) : init)
+    dedicated || readBandPrefs().open ? shellBandReducer(init, { type: 'openBand' }) : init)
   const shell = band.shell
   const [ctrlArmed, setCtrlArmed] = useState(false)
   const [ctrlNote, setCtrlNote] = useState<string | null>(null)
@@ -194,12 +215,14 @@ export function ShellBand({ sessionId, cwd, lang, theme }: ShellBandProps) {
   }, [band.attempt, sessionId, lang])
 
   const watching = shellWatching({
-    bandOpen: prefs.open,
+    bandOpen,
     sessionSelected: Boolean(sessionId),
     documentVisible,
   })
   // `null` is what DROPS the subscription — the client half of the unwatch discipline.
-  const { state } = useTerminalStream(watching && shell ? shell.id : null, 'shell')
+  // The remembered geometry rides the OPEN, so the pane is already this box's size on the first
+  // frame instead of arriving at whatever width the last viewer left it — see `shellBand.ts`.
+  const { state } = useTerminalStream(watching && shell ? shell.id : null, 'shell', bandGeometry(placement))
   const write = useTerminalWrite(shell?.id ?? '', watching && Boolean(shell), lang, 'shell')
   // `'shell'`: the honesty line must say whose screen this is. The default subject calls it "the
   // agent's current screen", which over a shell the person opened themselves is simply false.
@@ -210,6 +233,16 @@ export function ShellBand({ sessionId, cwd, lang, theme }: ShellBandProps) {
     [shell?.id],
   )
   useEffect(() => () => resizer.cancel(), [resizer])
+  /**
+   * One measurement, two consumers: the pane is resized NOW (debounced) and the number is kept for
+   * the NEXT open. Written straight to storage rather than through React state — the emulator
+   * reports on every layout change, and a re-render of the whole panel for a number nothing on
+   * screen shows would be a cost with no reader.
+   */
+  const onGeometry = useCallback((g: { cols: number; rows: number }) => {
+    writeBandGeometry(placement, g)
+    resizer.request(g)
+  }, [resizer, placement])
 
   /**
    * One send path for everything.
@@ -296,7 +329,7 @@ export function ShellBand({ sessionId, cwd, lang, theme }: ShellBandProps) {
           showCursor={status.showCursor}
           interactive={write.ready}
           onInput={send}
-          onGeometry={shell ? resizer.request : undefined}
+          onGeometry={shell ? onGeometry : undefined}
         />
       </Suspense>
     </div>
@@ -364,6 +397,22 @@ export function ShellBand({ sessionId, cwd, lang, theme }: ShellBandProps) {
       })}
     </div>
   )
+
+  // ---- dedicated: the shell IS the screen ------------------------------------------------------
+  // No bar, no drag handle, no collapsed state: you navigated here, and the way back belongs to the
+  // screen around it. The key strip follows `keyStripShown` — a phone has no ctrl key, and this is
+  // the placement a phone always gets.
+  if (dedicated) {
+    return (
+      <div style={{
+        flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column', gap: 8,
+      }}>
+        {shell ? screen : <div style={{ flex: 1 }} />}
+        {notice}
+        {keyStripShown('dedicated', isMobile) && strip}
+      </div>
+    )
+  }
 
   // ---- mobile: a full-screen sheet over the session --------------------------------------------
   if (isMobile) {
@@ -496,6 +545,20 @@ export function ShellBand({ sessionId, cwd, lang, theme }: ShellBandProps) {
         }}>{where}</span>}
         {!where && <span style={{ flex: 1 }} />}
         {busy && <Loader2 size={13} className="ag-spin" style={{ color: 'var(--text-tertiary)' }} />}
+        {/* TAKE THE WHOLE SCREEN. Offered only with a shell open and somewhere to go, so the bar of
+            a band nobody has opened carries nothing that cannot act. It is the only way to the
+            shell's own screen — the route has accepted `?pane=shell` since phase 3b and nothing
+            linked there. */}
+        {prefs.open && shell && onOpenFullscreen && (
+          <button className="ag-tap-icon"
+            onClick={e => { e.stopPropagation(); onOpenFullscreen() }}
+            title={t.fullscreen}
+            aria-label={t.fullscreen}
+            style={iconBtn}
+          >
+            <Maximize2 size={13} />
+          </button>
+        )}
         {prefs.open && shell && (
           <button className="ag-tap-icon"
             /* A TRASH CAN, not an ✕. The ✕ read as "close this panel" next to a chevron that

--- a/packages/web/src/hooks/useTerminalStream.ts
+++ b/packages/web/src/hooks/useTerminalStream.ts
@@ -49,8 +49,21 @@ export interface TerminalStream {
   reconnect: () => void
 }
 
-export function useTerminalStream(id: string | null, scope: TerminalScope = 'fleet'): TerminalStream {
+/**
+ * @param want the geometry this reader's box holds, stated ONCE when the stream opens so the pane is
+ *   already the right size on the first frame (`terminalEndpoint.ts` carries the why). It is read
+ *   through a ref and is deliberately NOT a dependency: it changes on every layout tick, and
+ *   re-opening an SSE stream for it would trade a quarter-second of wrong width for a reconnect per
+ *   animation frame. The steady-state answer is the debounced `POST .../resize`.
+ */
+export function useTerminalStream(
+  id: string | null,
+  scope: TerminalScope = 'fleet',
+  want?: { cols: number; rows: number },
+): TerminalStream {
   const [state, dispatch] = useReducer(terminalReducer, INITIAL_TERMINAL_STATE)
+  const wantRef = useRef(want)
+  wantRef.current = want
   // Bumped by reconnect() to force the effect to tear down and re-open, even for the same id.
   const [nonce, setNonce] = useState(0)
   const reconnect = useCallback(() => setNonce(n => n + 1), [])
@@ -64,7 +77,7 @@ export function useTerminalStream(id: string | null, scope: TerminalScope = 'fle
     // Fresh id → clear any previous session's frame before a single byte of the new one arrives.
     dispatch({ type: 'connecting' })
 
-    const es = new EventSource(streamUrl(scope, id))
+    const es = new EventSource(streamUrl(scope, id, wantRef.current))
 
     // Has this connection drawn anything yet? While false, a timeout or an error means the channel
     // never established — worth saying so. Once true, a drop is a transient blip: keep the screen and

--- a/packages/web/src/lib/shellBand.test.ts
+++ b/packages/web/src/lib/shellBand.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, test } from 'bun:test'
 import {
   BAND_MAX_FRACTION, BAND_MIN_PX, DEFAULT_BAND_PREFS, clampBandHeight, readBandPrefs, shellErrorText,
-  shellApiUrl, shellWatching, shellWhere, writeBandPrefs, type BandPrefs,
+  bandGeometry, shellApiUrl, shellWatching, shellWhere, writeBandGeometry, writeBandPrefs, type BandPrefs,
 } from './shellBand'
 
 describe('the unwatch discipline', () => {
@@ -139,5 +139,80 @@ describe('the band prefs are a per-viewer convenience and never a hard dependenc
     expect(readBandPrefs(s).open).toBe(false)
     s.setItem('agentistics-shell-band', '{"open":"yes","height":"tall"}')
     expect(readBandPrefs(s)).toEqual({ open: false, height: DEFAULT_BAND_PREFS.height })
+  })
+})
+
+describe('the geometry the band remembers', () => {
+  const fake = (): Storage => {
+    const m = new Map<string, string>()
+    return {
+      getItem: (k: string) => m.get(k) ?? null,
+      setItem: (k: string, v: string) => { m.set(k, v) },
+      removeItem: (k: string) => { m.delete(k) },
+      clear: () => m.clear(),
+      key: () => null,
+      get length() { return m.size },
+    } as unknown as Storage
+  }
+
+  test('a band that has never been measured remembers nothing', () => {
+    expect(bandGeometry('docked', fake())).toBeUndefined()
+    expect(bandGeometry('dedicated', fake())).toBeUndefined()
+  })
+
+  test('the last measurement survives a reload, so the next open starts at the right size', () => {
+    const s = fake()
+    writeBandGeometry('docked', { cols: 144, rows: 13 }, s)
+    expect(bandGeometry('docked', s)).toEqual({ cols: 144, rows: 13 })
+  })
+
+  // THE PLACEMENTS ARE DIFFERENT BOXES. A band under the composer is ~13 rows and the shell's own
+  // screen is ~48; one shared memory means every arrival on the dedicated screen opens at the
+  // band's height and jumps — the exact snap this memory exists to remove, from the other side.
+  test('each placement remembers its OWN box', () => {
+    const s = fake()
+    writeBandGeometry('docked', { cols: 144, rows: 13 }, s)
+    writeBandGeometry('dedicated', { cols: 144, rows: 48 }, s)
+    expect(bandGeometry('docked', s)).toEqual({ cols: 144, rows: 13 })
+    expect(bandGeometry('dedicated', s)).toEqual({ cols: 144, rows: 48 })
+  })
+
+  test('writing a geometry keeps everything else the record already held', () => {
+    const s = fake()
+    writeBandPrefs({ open: true, height: 320 }, s)
+    writeBandGeometry('docked', { cols: 200, rows: 40 }, s)
+    const back = readBandPrefs(s)
+    expect(back.open).toBe(true)
+    expect(back.height).toBe(320)
+    expect(bandGeometry('docked', s)).toEqual({ cols: 200, rows: 40 })
+  })
+
+  test('a stored geometry that does not read as one is DROPPED, never half-used', () => {
+    for (const bad of [
+      { cols: 0, rows: 13 }, { cols: 144 }, { rows: 13 }, { cols: '144', rows: 13 },
+      { cols: 1.5, rows: 13 }, { cols: 144, rows: -2 }, 'nope', null, 7,
+    ]) {
+      const s = fake()
+      s.setItem('agentistics-shell-band', JSON.stringify({ open: true, height: 240, geometry: { docked: bad } }))
+      expect(bandGeometry('docked', s), JSON.stringify(bad)).toBeUndefined()
+      // The rest of the record still reads — one unreadable field is not an unreadable record.
+      expect(readBandPrefs(s).open).toBe(true)
+    }
+  })
+
+  test('one unreadable placement never costs the other', () => {
+    const s = fake()
+    s.setItem('agentistics-shell-band', JSON.stringify({
+      open: true, height: 240, geometry: { docked: { cols: 0, rows: 0 }, dedicated: { cols: 144, rows: 48 } },
+    }))
+    expect(bandGeometry('docked', s)).toBeUndefined()
+    expect(bandGeometry('dedicated', s)).toEqual({ cols: 144, rows: 48 })
+  })
+
+  test('a storage that throws costs the memory and never the band', () => {
+    const hostile = { getItem: () => { throw new Error('blocked') }, setItem: () => { throw new Error('blocked') } } as unknown as Storage
+    expect(() => writeBandGeometry('docked', { cols: 144, rows: 13 }, hostile)).not.toThrow()
+    expect(bandGeometry('docked', hostile)).toBeUndefined()
+    expect(readBandPrefs(hostile)).toEqual(DEFAULT_BAND_PREFS)
   })
 })

--- a/packages/web/src/lib/shellBand.ts
+++ b/packages/web/src/lib/shellBand.ts
@@ -129,7 +129,27 @@ export function shellWhere(cwd: string | undefined): string {
 export interface BandPrefs {
   open: boolean
   height: number
+  /**
+   * The last geometry each PLACEMENT measured for its terminal, so the next open can state it
+   * before the first capture instead of snapping a quarter-second later.
+   *
+   * It is a memory of THIS browser's box, not a fact about the pane — a pane has one size and the
+   * last viewer to ask wins, which is exactly why a shell last read on a phone opens 52 columns
+   * wide on a desktop. Absent, stale and unreadable all mean the same thing here: say nothing and
+   * let the measurement that lands moments later decide.
+   *
+   * KEYED BY PLACEMENT, because they are different boxes: the band under the composer is about 13
+   * rows and the shell's own screen about 48. Measured on a real layout — one shared number made
+   * every arrival on the dedicated screen open at the band's height and jump, which is the same
+   * snap this memory exists to remove, from the other side.
+   */
+  geometry?: Partial<Record<ShellPlacement, PaneGeometry>>
 }
+
+/** Where a shell is drawn. `docked` is the band under the composer; `dedicated` is its own screen. */
+export type ShellPlacement = 'docked' | 'dedicated'
+
+export interface PaneGeometry { cols: number; rows: number }
 
 /** ABSENT READS AS CLOSED. Nobody acquires an open shell band by having reloaded the page. */
 export const DEFAULT_BAND_PREFS: BandPrefs = { open: false, height: 240 }
@@ -148,10 +168,55 @@ export function readBandPrefs(storage?: Storage): BandPrefs {
       height: typeof r.height === 'number' && Number.isFinite(r.height)
         ? Math.max(BAND_MIN_PX, r.height)
         : DEFAULT_BAND_PREFS.height,
+      // DROPPED PER PLACEMENT when it does not read as a pair of positive whole numbers. Half a
+      // geometry is worse than none — it would be sent, refused, and the reader would never learn
+      // why — and one unreadable placement must not cost the other.
+      ...(readGeometries(r.geometry) ? { geometry: readGeometries(r.geometry)! } : {}),
     }
   } catch {
     return DEFAULT_BAND_PREFS
   }
+}
+
+function readGeometry(v: unknown): PaneGeometry | null {
+  if (typeof v !== 'object' || v === null) return null
+  const g = v as Record<string, unknown>
+  const ok = (n: unknown): n is number => typeof n === 'number' && Number.isInteger(n) && n > 0
+  return ok(g.cols) && ok(g.rows) ? { cols: g.cols, rows: g.rows } : null
+}
+
+function readGeometries(v: unknown): Partial<Record<ShellPlacement, PaneGeometry>> | null {
+  if (typeof v !== 'object' || v === null) return null
+  const r = v as Record<string, unknown>
+  const out: Partial<Record<ShellPlacement, PaneGeometry>> = {}
+  for (const key of ['docked', 'dedicated'] as const) {
+    const g = readGeometry(r[key])
+    if (g) out[key] = g
+  }
+  return Object.keys(out).length > 0 ? out : null
+}
+
+/** What this placement's box measured last time, or `undefined` for "it has never said". */
+export function bandGeometry(placement: ShellPlacement, storage?: Storage): PaneGeometry | undefined {
+  return readBandPrefs(storage).geometry?.[placement]
+}
+
+/**
+ * Record the measurement without disturbing the rest of the record.
+ *
+ * A read-modify-write rather than a field on the band's React state: the emulator reports a
+ * geometry on every layout change, and routing that through a `setState` would re-render the whole
+ * panel for a number nothing on screen shows.
+ */
+export function writeBandGeometry(
+  placement: ShellPlacement,
+  geometry: PaneGeometry,
+  storage?: Storage,
+): void {
+  try {
+    const prefs = readBandPrefs(storage)
+    writeBandPrefs({ ...prefs, geometry: { ...prefs.geometry, [placement]: geometry } }, storage)
+  } catch { /* the memory is a convenience; the band works without it */ }
 }
 
 export function writeBandPrefs(prefs: BandPrefs, storage?: Storage): void {

--- a/packages/web/src/lib/terminalEndpoint.test.ts
+++ b/packages/web/src/lib/terminalEndpoint.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'bun:test'
+import { describe, expect, it, test } from 'bun:test'
 import { inputWsUrl, streamUrl, type TerminalScope } from './terminalEndpoint'
 
 describe('a scope decides which route a terminal talks to', () => {
@@ -31,6 +31,29 @@ describe('a scope decides which route a terminal talks to', () => {
     for (const s of scopes) {
       expect(streamUrl(s, 'i')).toStartWith('/api/')
       expect(inputWsUrl(s, 'i', 'http:', 'h')).toStartWith('ws://')
+    }
+  })
+})
+
+describe('the geometry a stream may open with', () => {
+  test('is absent unless the caller has one', () => {
+    expect(streamUrl('shell', 's1')).toBe('/api/shell/stream?id=s1')
+  })
+
+  test('rides the stream URL, so the pane is already the right size on the FIRST frame', () => {
+    // Without it the first capture is whatever width the pane was left at by the last viewer, and
+    // the band visibly snaps a moment later. The numbers are the box's own last measurement.
+    expect(streamUrl('shell', 's1', { cols: 144, rows: 13 }))
+      .toBe('/api/shell/stream?id=s1&cols=144&rows=13')
+  })
+
+  test('a geometry that is not a pair of positive whole numbers is left off entirely', () => {
+    for (const g of [
+      { cols: 0, rows: 13 }, { cols: 144, rows: 0 },
+      { cols: -1, rows: 13 }, { cols: 1.5, rows: 13 },
+      { cols: Number.NaN, rows: 13 }, { cols: 144, rows: Number.POSITIVE_INFINITY },
+    ]) {
+      expect(streamUrl('shell', 's1', g), JSON.stringify(g)).toBe('/api/shell/stream?id=s1')
     }
   })
 })

--- a/packages/web/src/lib/terminalEndpoint.ts
+++ b/packages/web/src/lib/terminalEndpoint.ts
@@ -22,9 +22,32 @@ const BASE: Record<TerminalScope, string> = {
   shell: '/api/shell',
 }
 
-/** The SSE read channel for one pane. */
-export function streamUrl(scope: TerminalScope, id: string): string {
-  return `${BASE[scope]}/stream?id=${encodeURIComponent(id)}`
+/** What a box can show at natural size — the pane's target geometry. */
+export interface PaneGeometry { cols: number; rows: number }
+
+function usable(g: PaneGeometry | undefined): g is PaneGeometry {
+  return Boolean(g)
+    && Number.isInteger(g!.cols) && Number.isInteger(g!.rows)
+    && g!.cols > 0 && g!.rows > 0
+}
+
+/**
+ * The SSE read channel for one pane, optionally stating the geometry the reader's box wants.
+ *
+ * A pane has ONE size and the last viewer to ask wins, so a shell opened on a phone and then on a
+ * desktop starts at the phone's width: the first frames arrive hard-broken at 52 columns and the
+ * band visibly snaps a quarter-second later, when the emulator has measured itself and the
+ * debounced `POST /api/shell/resize` lands. Saying the size UP FRONT closes that window — the
+ * server resizes before the first capture, so frame one is already right. It is a REQUEST, not a
+ * promise: an assistant's pane may refuse to shrink below its floor, and the measured geometry
+ * corrects a stale one moments later either way.
+ *
+ * A geometry that is not a pair of positive whole numbers is left off rather than sent and refused
+ * — a browser mid-layout reports anything, and a query string is not the place to argue about it.
+ */
+export function streamUrl(scope: TerminalScope, id: string, want?: PaneGeometry): string {
+  const base = `${BASE[scope]}/stream?id=${encodeURIComponent(id)}`
+  return usable(want) ? `${base}&cols=${want.cols}&rows=${want.rows}` : base
 }
 
 /**

--- a/packages/web/src/pages/SessionsPage.tsx
+++ b/packages/web/src/pages/SessionsPage.tsx
@@ -52,6 +52,7 @@ import {
   arrivalFor, reopenedSessionRoute, sessionPath, stillArriving, type SessionArrival,
 } from '../lib/sessionRoute'
 import { dedicatedTerminalPath, readTerminalPane } from '../lib/terminalSurface'
+import { ShellBand } from '../components/sessions/ShellBand'
 import { TerminalRegion } from '../components/RecentSessions'
 import { sessionPlanFactor } from '../lib/costBasis'
 
@@ -124,6 +125,7 @@ export default function SessionsPage() {
    */
   const dedicatedTerminal = useLocation().pathname.endsWith('/terminal')
   const dedicatedPane = readTerminalPane(useSearchParams()[0].get('pane'))
+  const shellEnabled = ctx.shellEnabled === true
 
   /**
    * WHERE A REOPEN LANDS — one place, for all three controls on this page that can perform one.
@@ -550,9 +552,10 @@ export default function SessionsPage() {
       onViewChange={setSessionView}
       onArtifacts={onArtifacts}
       // The capability AND the user's switch, as the server reports them. Absent reads as OFF.
-      shellEnabled={ctx.shellEnabled === true}
+      shellEnabled={shellEnabled}
       // The terminal's own screen. A route, so it survives a reload and can be sent to somebody.
       onOpenTerminal={() => navigate(dedicatedTerminalPath(selected.id))}
+      onOpenShellFullscreen={() => navigate(dedicatedTerminalPath(selected.id, 'shell'))}
     />
   )
 
@@ -715,28 +718,79 @@ export default function SessionsPage() {
             </div>
           </div>
         </div>
-        <div style={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column', padding: 10 }}>
-          {/* The SHELL's own dedicated screen is not built yet, and this says so rather than
-              drawing the assistant's pane under a shell's name. Nothing links here today — the
-              selector is what will make it reachable. */}
-          {dedicatedPane === 'shell' && (
-            <div role="status" style={{ fontSize: 11, color: 'var(--accent-red)', marginBottom: 8 }}>
-              {pt
-                ? 'A tela dedicada do shell ainda não existe — abaixo está o terminal do assistente.'
-                : 'The shell’s own dedicated screen does not exist yet — below is the assistant’s terminal.'}
+        <div style={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column', gap: 8, padding: 10 }}>
+          {/* THE TARGET SELECTOR. One screen, two panes, and neither segment may be called
+              "Terminal" — that ambiguity is exactly what phase 1 avoided by naming the shell a
+              shell. It is a ROUTE and not a state, so a reload and a shared link land on the pane
+              you were looking at. Withheld when this machine serves no shell: a segment whose only
+              outcome is a refusal is worse than no segment. */}
+          {shellEnabled && (
+            <div role="tablist" aria-label={pt ? 'Qual terminal' : 'Which terminal'} style={{
+              display: 'flex', gap: 4, flexShrink: 0, alignSelf: 'flex-start',
+              padding: 3, borderRadius: 8, background: 'var(--bg-elevated)',
+              border: '1px solid var(--border-subtle)',
+            }}>
+              {(['assistant', 'shell'] as const).map(target => {
+                const on = dedicatedPane === target
+                const label = target === 'assistant'
+                  ? (pt ? 'Assistente' : 'Assistant')
+                  : 'Shell'
+                return (
+                  <button
+                    key={target}
+                    role="tab"
+                    aria-selected={on}
+                    onClick={() => navigate(dedicatedTerminalPath(selected.id, target), { replace: true })}
+                    style={{
+                      // 44px is the MOBILE figure; on a desktop it would turn a segmented control
+                      // into a row of buttons.
+                      minHeight: isMobile ? 44 : 26, padding: isMobile ? '0 16px' : '0 12px',
+                      borderRadius: 6, cursor: 'pointer', fontFamily: 'inherit',
+                      fontSize: 12, fontWeight: 650, border: 'none',
+                      background: on ? 'var(--bg-surface)' : 'transparent',
+                      color: on ? 'var(--text-primary)' : 'var(--text-tertiary)',
+                      boxShadow: on ? '0 1px 2px rgba(0,0,0,0.18)' : 'none',
+                    }}
+                  >
+                    {label}
+                  </button>
+                )
+              })}
             </div>
           )}
-          <TerminalRegion
-            /* DEDICATED: you asked for this screen, so focus is the consent and there is no arm
-               button; on a phone it carries the key strip. */
-            placement="dedicated"
-            id={selected.id}
-            theme={theme === 'light' ? 'light' : 'dark'}
-            lang={pt ? 'pt' : 'en'}
-            fill
-            {...(rowIndex.get(selected.id) ? { row: rowIndex.get(selected.id)! } : {})}
-            act={act}
-          />
+          {/* A link to `?pane=shell` on a machine that serves no shell must not quietly draw the
+              ASSISTANT's pane under a shell's name. The selector is absent there — a segment whose
+              only outcome is a refusal is worse than none — so the sentence is the only thing that
+              can say what happened. */}
+          {dedicatedPane === 'shell' && !shellEnabled && (
+            <div role="status" style={{ fontSize: 11, color: 'var(--accent-red)', flexShrink: 0 }}>
+              {pt
+                ? 'Esta máquina não está servindo shell — abaixo está o terminal do assistente.'
+                : 'This machine is not serving a shell — below is the assistant’s terminal.'}
+            </div>
+          )}
+          {dedicatedPane === 'shell' && shellEnabled ? (
+            <ShellBand
+              key={`shell-${selected.id}`}
+              placement="dedicated"
+              sessionId={selected.id}
+              {...(selected.cwd ? { cwd: selected.cwd } : {})}
+              lang={pt ? 'pt' : 'en'}
+              theme={theme === 'light' ? 'light' : 'dark'}
+            />
+          ) : (
+            <TerminalRegion
+              /* DEDICATED: you asked for this screen, so focus is the consent and there is no arm
+                 button; on a phone it carries the key strip. */
+              placement="dedicated"
+              id={selected.id}
+              theme={theme === 'light' ? 'light' : 'dark'}
+              lang={pt ? 'pt' : 'en'}
+              fill
+              {...(rowIndex.get(selected.id) ? { row: rowIndex.get(selected.id)! } : {})}
+              act={act}
+            />
+          )}
         </div>
       </div>
     )


### PR DESCRIPTION
Duas coisas. A segunda é a que incomodava.

## 1. O seletor `Assistente | Shell` (fase 3c), na tela dedicada

A rota aceita `?pane=shell` desde a fase 3b e **nada linkava para lá**: a tela desenhava a pane do ASSISTENTE com uma frase dizendo que a do shell não existia. Agora existe.

`ShellBand` ganha uma **colocação**:
- `docked` — a faixa sob o compositor, cujo ponto inteiro é a **simultaneidade** (ler a conversa enquanto o build roda ao lado);
- `dedicated` — o shell ocupando a tela: sem barra, sem alça de arraste, sem estado recolhido, porque você navegou até aqui e a volta é o controle da própria tela.

As duas dividem stream, canal de escrita, emulador e a disciplina de unwatch — que é exatamente por que isto é uma **prop** e não um segundo componente.

O seletor é **rota, não estado**, então recarregar e mandar o link caem na pane que você estava vendo. Nenhum dos dois segmentos se chama "Terminal" — a ambiguidade que a fase 1 evitou de propósito. É **ausente** quando a máquina não serve shell (um segmento cujo único desfecho é uma recusa é pior que nenhum), e aí uma **frase** é a única coisa que pode dizer o que aconteceu a quem abriu o link mesmo assim. A faixa ganha o botão que leva até lá.

**Deliberadamente fora**: "assistente na faixa". A aba `replacing` já está a um clique, e o segmento dobraria a superfície por quase nada.

## 2. A pane já nasce do tamanho da caixa

Uma pane tmux tem **um** tamanho e o último espectador a pedir ganha — o limite que já estava declarado e continua sendo verdade. O que não precisava continuar assim é a **janela**: um shell lido por último num celular entregava ao desktop os primeiros frames quebrados em 52 colunas, e a faixa saltava um quarto de segundo depois, quando o emulador tinha se medido e o `POST /api/shell/resize` debounçado chegava.

Agora a caixa **diz o tamanho na abertura do stream** (`GET /api/shell/stream?id=…&cols=…&rows=…`) e o servidor redimensiona **antes da primeira captura**. É um pedido, não uma promessa: a pane do assistente pode recusar encolher abaixo do piso que `readDialog`/`approvalTail` dependem, e a medição real corrige uma memória velha logo em seguida de qualquer jeito. Uma geometria que não lê como um par de inteiros positivos é **recusada, nunca clampada** — é query string, chega antes do stream existir, e custa ao chamador o resize e nunca o stream.

A memória é **por colocação**. A faixa tem ~13 linhas e a tela do shell ~48; um número só fazia toda chegada na tela dedicada abrir na altura da faixa e saltar — o mesmo salto, pelo outro lado. Isso foi encontrado medindo, não pensando.

## Verificação no navegador

Preview isolado (47492, `AGENTISTICS_DIR` próprio), Chromium, um contexto só:

| | stream aberto com |
|---|---|
| 1ª abertura da faixa (nada lembrado) | sem geometria |
| 1ª visita à tela dedicada | sem geometria |
| 2ª abertura da faixa | `&cols=144&rows=13` |
| 2ª visita à tela dedicada | `&cols=144&rows=48` |

Tela dedicada do shell: caixa 1130×723, `.xterm-screen` 1123px, pane em `144x48`, `scrollTop` 0. Alternar para `Assistente` navega para `/terminal` e desenha a pane do assistente (50 linhas, ancorada no cursor).

A 390px: `document.documentElement.scrollWidth === window.innerWidth`, segmentos e tira de teclas (`esc tab ctrl ↑ ↓ ← →`) a 44px, nenhum `<input>` abaixo de 16px, pane em `47x38`.

`bun tsc --noEmit` + `bun test` (7908 passando, 0 falhas).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lr8C4E9sJWirekwVfSr3UN