### PR TITLE
release: tela própria para o shell, seletor de alvo e a pane no tamanho da caixa

### DIFF
--- a/docs/superpowers/specs/2026-09-11-alm-session-linking-ux.md
+++ b/docs/superpowers/specs/2026-09-11-alm-session-linking-ux.md
@@ -1,0 +1,541 @@
+# ALM session linking — the `done` rule, subtask groups, and the UX outside `/tasks`
+
+Extends `docs/superpowers/specs/2026-09-10-task-session-hierarchy-design.md` (the three filing
+shapes and per-subtask rollup). That spec is unchanged by this one — read it first for the
+vocabulary (`rowsOfTask`, `subtaskViews`, the `id: null` direct bucket) this document builds on.
+
+This is task `t-918cc82233`'s third round: two pieces of user feedback (A, B) plus six UX reports
+about task/subtask management **outside** the `/tasks` board (C), catalogued in comment
+`c-8140507765`. Every file named below was opened and read in this worktree before it is named —
+no filename is guessed.
+
+## 0. What is already on `origin/dev` vs. still in a worktree
+
+Checked directly rather than assumed, because three parallel sessions have been landing pieces of
+the 2026-09-10 spec all at once:
+
+- **On `origin/dev` already**: `task-attach.ts`'s reopened `{kind: 'task'}` branch (§4.1),
+  `task-report.ts`'s `subtaskViews`/`SubtaskView` (§4.2), the `web/src/lib/tasks.ts` mirror, and
+  `agentistics_task_session`'s MCP description. `agentistics_task_subtask`'s description still
+  says "no cost of its own" — stale, not yet corrected (see §3's note).
+- **Not yet on `origin/dev`**, still in their own worktrees: `SubtaskTable.tsx`'s cost/tokens
+  columns (`s-2ed5531c53`, worktree `subtable-cost-ui`), and `SessionFiling.tsx`'s "direto na
+  entrega" row (`s-eda72d6def`, worktree `session-filing-ui`, session `2c853d1993` — **running right
+  now**). Every subtask below that touches `SessionFiling.tsx` is `blockedBy: ["s-eda72d6def"]`.
+
+## A. `done` requires a linked session
+
+### A.1 What happened
+
+Four subtasks of this very task (`s-843b0dd3cb`, `s-b7392c752d`, `s-af6c8722f3`, `s-f61f59be4f`)
+were marked `done` with no session filed under them — the work happened, but as a side effect of a
+sibling subtask's session, or as a docblock-only commit, so the subtask record itself carries no
+link. `SubtaskTable.tsx` renders these rows with a bare "filiar" control, same as a subtask nobody
+has started (screenshot `698b9e38-image.png`).
+
+### A.2 Where the rule binds
+
+Two independent entry points move a task or subtask to `done`, and both must refuse — this is the
+same shape as `blocked_needs_reason` (`task-web.ts`'s `markTask`, §"Important rules" in CLAUDE.md),
+checked server-side so it binds the browser, the CLI and the MCP alike, never only the button.
+
+**Subtask**: `task-web.ts`'s `patchSubtask` (line 388) and `setSubtaskDone` (line 434). Today both
+return a bare `Promise<boolean>` — no refusal reason travels at all. This has to become a typed
+result, the same shape `markTask` already returns (`{ok: boolean; message?: string}`), because a
+route that can refuse and a function that can only report `false` cannot tell "no such subtask"
+from "needs a session" from "wrote fine."
+
+```ts
+export async function patchSubtask(subtaskId: string, patch: {...}): Promise<
+  { ok: true } | { ok: false; message: 'no_such_subtask' | 'done_needs_session' }
+> {
+  const w = await loadTaskWorld()
+  const found = w.book.subtasks.find(t => t.id === subtaskId)
+  if (!found) return { ok: false, message: 'no_such_subtask' }
+  const status = patch.status ?? found.status
+  if (status === 'done' && found.status !== 'done') {
+    const hasSession = w.rows.some(r => r.subtaskId === subtaskId)
+    if (!hasSession) return { ok: false, message: 'done_needs_session' }
+  }
+  ...
+}
+```
+
+The guard is `found.status !== 'done' →` (a status PATCH that is not actually changing to `done` —
+editing the due date of an already-done subtask — must not re-trigger the check) and it only looks
+at `w.rows.some(r => r.subtaskId === subtaskId)` — the exact same predicate `subtaskViews` already
+filters on (`task-report.ts` line ~224), so this is not a second definition of "has a session," it
+is the same one read at write time.
+
+**Task**: `markTask` (`task-web.ts` line 663) already has `w.rows` in scope at the point it decides
+`done` (it computes `rowsOfTask(task, w.rows)` right after, for the delivery-evidence block at line
+746 — the check can sit immediately before that, reusing the same call rather than adding a second
+one):
+
+```ts
+if (to === 'done') {
+  const mine = rowsOfTask(task, w.rows)
+  if (mine.length === 0) return { ok: false, message: 'done_needs_session' }
+}
+```
+
+`rowsOfTask` counts a session **anywhere** under the task — filed directly, or under any of its
+subtasks — so this one check is correct for a task with subtasks, without subtasks, or a mix, with
+no new counting logic.
+
+### A.3 The two open questions from the task detail — decided
+
+**"A task with no subtasks and no direct session — refused on `done`?"** Yes, by the same rule
+above: `rowsOfTask` returns nothing either way, and there is no special case for "this task never
+had any subtasks." A task that was never worked cannot be delivered.
+
+**"A task with every subtask `done` but no session of its own — does it count as having a
+session?"** Yes — and this needs no extra logic to make true. `rowsOfTask(task, rows)` matches
+every row whose `taskId` equals the task's id, **regardless of `subtaskId`** (§4.2 of the
+2026-09-10 spec: this was already true before this change, it is what makes the task total sum
+both branches). A task whose subtasks each have a session already has sessions under it by this
+same test — "the task has a session of its own" was never the right question to ask; "does
+`rowsOfTask` return anything" is, and it already answers both cases identically. This is also why
+the task-level check must be `rowsOfTask`, never `w.rows.filter(r => r.taskId === task.id &&
+!r.subtaskId)` (sessions filed *directly*) — that narrower test would refuse a task whose delivery
+is entirely accounted for by its subtasks, which is the ordinary, common shape (§2 of the
+2026-09-10 spec, shape #2).
+
+### A.4 Wire and surfaces
+
+- `index.ts`'s `subtasks` verb (lines 1701–1727) currently does `json({ ok: await
+  mod.patchSubtask(...) })` / `json({ ok: await mod.setSubtaskDone(...) })` with no status code
+  branch. Once `patchSubtask`/`setSubtaskDone` return the typed result, this becomes the same
+  422-on-refusal shape the `sessions` verb already uses two blocks above it (line 1685-1688):
+  `json(result, result.ok ? 200 : (result.message === 'done_needs_session' ? 422 : 404))`.
+- `markTask`'s `done_needs_session` rides the exact channel `blocked_needs_reason` already uses —
+  `web/src/lib/tasks.ts`'s `markTask()` (line 354) returns `boolean` today from `res.ok`; nothing
+  there needs to change shape, only the caller reads the same 422 it already has to plan for.
+- **UI**: wherever a "done" tick or status move can be pressed without a session yet —
+  `SubtaskTable.tsx`'s status pill, `DeliveryDetail.tsx`'s status dropdown — the refusal has to
+  surface as a sentence, not a silently-failed request. The natural spot is the same one
+  `BlockedDialog.tsx` already exists for `blocked_needs_reason`: a small dialog naming the rule
+  ("esta subtarefa/entrega precisa de uma sessão filiada antes de ser marcada como entregue") with
+  the filing control (`SessionFiling`/`SubtaskSessions`' "filiar") one click away, not a toast that
+  disappears.
+- **MCP**: `agentistics_task_status` and `agentistics_task_subtask`'s descriptions gain one
+  sentence each, matching how `blocked`'s requirement is already documented in both — "**`done`
+  REQUIRES the task/subtask to have at least one session filed under it** and is refused (422,
+  `done_needs_session`) without one." While in that file, fix `agentistics_task_subtask`'s stale
+  "no cost of its own" line (packages/mcp/agentistics-mcp.ts line 246) — the rollup work already
+  shipped and this sentence was never updated; it is the same kind of drift `s-843b0dd3cb` already
+  fixed in `task-model.ts`/`SubtaskTable.tsx`, just missed in this one file. Also fix
+  `task-web.ts`'s own stale comment at line 594 ("A DELIVERY DOES NOT TAKE SESSIONS: without a
+  subtask this refuses") — `attachSession` no longer refuses a bare task target; the comment
+  describes the pre-§4.1 behaviour.
+
+## B. Subtask groups — one session, several subtasks, no double counting
+
+### B.1 The feature
+
+A session can be assigned to a **group** of subtasks instead of one, and every subtask in the
+group automatically counts that session as its own. The open question the user flagged and asked
+to be resolved: if every subtask in the group showed the session's full cost, summing the group's
+N subtasks would multiply the cost by N.
+
+### B.2 Decision: `Subtask.groupId`, not a new entity
+
+Rejected: a `SubtaskGroup` record of its own (id, title, its own rollup, its own store). It would
+duplicate exactly the shape `Subtask` already has, need its own CRUD surface, and buy nothing a
+plain field does not already buy — a group here is not a piece of work with its own status or due
+date, it is a **label two or more subtasks share**.
+
+Adopted: one new optional field on `Subtask` (`task-model.ts` line 289), alongside the existing
+optional columns:
+
+```ts
+export interface Subtask {
+  ...
+  /**
+   * Subtasks that share a `groupId` are read as ONE bucket for rollup: a session filed under any
+   * member counts for all of them, and their `subtaskViews` rollup is the SAME object, keyed by
+   * the group id rather than by each subtask's own id — never summed per member, which is what
+   * would multiply a shared session's cost by the group's size. Absent = today's behaviour
+   * unchanged: every existing subtask, with no `groupId`, is its own group of one.
+   */
+  groupId?: string
+}
+```
+
+No migration: absent reads as "not grouped," exactly the same rule `Subtask.blockedBy`,
+`Task.shared` and every other optional column in this codebase already follow. Minted the same way
+subtask/task ids are (`mint('g')` in `task-model.ts`, beside `newSubtaskId`).
+
+### B.3 The rollup: one bucket per group, never per member
+
+This is route (1) from the task comment — **the group's rollup is the source of truth; a member
+subtask's own row is a reference to it, never a second sum.**
+
+`subtaskViews` (`task-report.ts` line 216) buckets by **effective key**: a subtask's own id when it
+has no `groupId`, or the `groupId` when it does. Two or more subtasks sharing a `groupId` therefore
+collapse into **one** `SubtaskView` in the returned list — not one per member — which is what keeps
+the existing guarantee intact ("every row of a task falls into exactly one bucket," stated in the
+current docblock at line ~190 of `task-report.ts`): a session filed under any group member's
+`subtaskId` is counted in that ONE bucket, once, regardless of which specific member the session's
+`subtaskId` happens to name.
+
+```ts
+export function subtaskViews(task, subtasks, rows, metas, costOf): SubtaskView[] {
+  const mine = subtasks.filter(s => s.taskId === task.id)
+  // Effective bucket key: the group id when grouped, the subtask's own id otherwise.
+  const keyOf = (s: Subtask) => s.groupId ?? s.id
+  const groups = new Map<string, Subtask[]>()
+  for (const s of mine) {
+    const k = keyOf(s)
+    groups.set(k, [...(groups.get(k) ?? []), s])
+  }
+  const views: SubtaskView[] = [...groups.entries()].map(([key, members]) => ({
+    id: key,
+    // A session's subtaskId can name ANY member — the union is the group's rows.
+    rollup: rollupAttempt({
+      sessions: rollupSessionsFor(
+        rows.filter(r => members.some(m => m.id === r.subtaskId)), metas, costOf,
+      ),
+    }),
+  }))
+  const direct = rows.filter(r => !r.subtaskId)
+  if (direct.length > 0) views.push({ id: null, rollup: rollupAttempt({ sessions: rollupSessionsFor(direct, metas, costOf) }) })
+  return views
+}
+```
+
+`SubtaskView.id` was already `string | null`; a group's id is just another string in that same
+slot, so `TaskDetail.subtaskRollups`'s shape (and its wire mirror in `web/src/lib/tasks.ts`) needs
+no change at all — only the function that builds it.
+
+**A reader resolves "my rollup" by the same effective key**: `SubtaskTable.tsx` (once
+`s-2ed5531c53`'s cost columns land) looks up a row's rollup via `subtaskRollups.find(v => v.id ===
+(subtask.groupId ?? subtask.id))`, never via `v.id === subtask.id` alone — the same one-line change
+in the one place that reads the list, rather than a second copy of the bucketing rule.
+
+### B.4 The session-chip list also needs group-awareness
+
+`SubtaskSessions.tsx` (line 43: `mine = p.sessions.filter(s => s.subtaskId === p.subtaskId)`)
+filters by the exact subtask id — so today, a session filed under group member A would show only
+on A's row, not on sibling B's, even though B's cost column (per §B.3) would already include it.
+That mismatch — a number that counts a session no chip on the row names — is exactly the kind of
+inconsistency this codebase's N/A-vs-confident-number rule exists to prevent.
+
+So `subtaskSessions` needs the **member set**, not a bare id, to filter by:
+
+```ts
+export interface SubtaskSessionsProps {
+  /** This subtask's own id, plus every sibling sharing its `groupId` — the id alone when ungrouped. */
+  subtaskIds: readonly string[]
+  ...
+}
+export function subtaskSessions(p: SubtaskSessionsProps) {
+  const mine = p.sessions.filter(s => s.subtaskId && p.subtaskIds.includes(s.subtaskId))
+  ...
+}
+```
+
+`SubtaskTable.tsx`/`TaskTable.tsx` (both callers) compute the member set once per row: `subtask.groupId
+? subtasks.filter(s => s.groupId === subtask.groupId).map(s => s.id) : [subtask.id]`. This makes
+every member of a group show the identical chip list and the identical cost — the same session,
+named the same number of times as subtasks it belongs to, which is the feature as described ("todas
+as subtasks do grupo passam a contar essa sessão").
+
+### B.5 Forming a group — the write side
+
+`patchSubtask` gains `groupId?: string | null` (`null` clears it — the same "empty string clears a
+column" convention `dueDate`/`assignee` already use, except `groupId` is not free text so `null` is
+the honest "remove" rather than an empty string). `index.ts`'s `subtasks` verb passes it through
+like every other optional column.
+
+The **UI gesture** — "put this subtask in the same group as that one" — is a picker inside
+`SubtaskTable.tsx`'s row menu (wherever "Filiar"/session actions already live): pick a sibling
+subtask, and the two of them are stamped with the same freshly-minted `groupId` (if neither already
+has one) or the target's existing `groupId` (if it does — joining an existing group). This is new
+UI surface, not covered by any subtask already filed; §5 below files it.
+
+**Out of scope for this round**: a human-readable group name. The group is identified by which
+subtasks share the badge (`SubtaskTable.tsx` shows a small "grupo" chip on every member row,
+listing the sibling titles on hover) — the same "no invented state beyond what is needed" reasoning
+that kept `Task.hierarchyMode` out of the 2026-09-10 spec applies here: a name is a field that can
+drift from what the group actually contains, and nothing asked for one yet.
+
+## C. UX outside `/tasks` — six points
+
+### C.1 The filing modal (`SessionFiling.tsx`) is hard to use
+
+Confirmed component from screenshot `7f06ed4a-image.png`: the "SUBTAREFAS — A SESSÃO FICA EM UMA
+DELAS" dialog is `SessionFiling.tsx`'s "delivery itself" face (line ~196 in this worktree's
+pre-`s-eda72d6def` version). **This file is being edited right now** by session `2c853d1993`
+(`s-eda72d6def`, adding the "— direto na entrega —" row above the subtask list) — every subtask
+below that touches it is `blockedBy: ["s-eda72d6def"]`.
+
+What is concretely wrong, read against the component as it stands (plus the pending direct-row
+change):
+
+- **No distinction for a grouped subtask.** Once §B ships, a subtask row here needs to say it is
+  part of a group (so choosing it is understood to also affect its siblings) — otherwise filing a
+  session "into one subtask" silently changes N rows' totals with nothing on screen saying so.
+- **No search inside a long subtask list.** The list scrolls (`maxHeight: 260`) but has no filter —
+  fine for the six subtasks in this very task, not fine for a task broken into thirty.
+- **"Trocar de entrega" is a full re-pick, with no fast path back to the CURRENT delivery's other
+  subtask.** Moving between two subtasks of the SAME delivery already works (click the other row);
+  the friction is specifically leaving-and-returning to a different delivery, which requires the
+  search-and-pick flow every time even for a delivery visited a minute ago (no "recent" list).
+
+**Recommendation**: the group badge (concrete, blocked on B) and a search field over the subtask
+list (concrete, useful today) are the two changes worth making now; "recent deliveries" is a
+smaller, separable convenience that can wait — flagged here rather than speced in full, since it
+touches the same file as the group badge and should not be a third overlapping PR on it.
+
+### C.2 Creating a task together with a new session — confirmed root cause
+
+This is a real, reproducible defect, traced to a specific gap rather than "something in
+`fleet-spawn.ts`."
+
+**The flow**: `TasksPage.tsx` → `NewTaskWizard` → `TaskComposer`'s "create, then start a session"
+button (line 405, `onCreateSession`) → `TasksPage.tsx` line 264's handler, which does:
+
+```ts
+onCreateSession={(taskId, taskTitle) => {
+  setOpen(false)
+  setStarting({ taskId, title: taskTitle })
+}}
+```
+
+→ opens `NewSessionModal` with `initialTask={starting.title}` (line 276) — **a bare string, the
+task's TITLE, never its `taskId`**.
+
+`NewSessionModal` only ever attaches a spawned session to a real task record through its
+`subtaskTarget` state (`{taskId, subtaskId}`, both required — set exclusively by `TaskPicker`'s
+`onPick`, line 1063). `initialTask` feeds only the free-text `task` field (line 133:
+`useState(initialTask ?? '')`), which becomes the `task` string sent to `POST /api/fleet/new` — a
+**display label** on the spawned session, nothing more (`fleet-spawn.ts` line 137-146 just carries
+it through as `plan.task`). Since `subtaskTarget` is never set on this path, `start()`'s attach
+block (line 589: `if (subtaskTarget && json.id) { attachSession(...) }`) never runs. **The session
+is created, but never actually filed under the task the wizard just made.**
+
+Why this reads as invisible on the surface but real underneath: `rowsOfTask` (`task-report.ts` line
+102-106) matches a session either by `taskId` (the real link, never set here) OR by
+`legacyTaskId(r.task) === task.id` — a fallback for sessions filed before real task ids existed.
+`legacyTaskId(name)` (`task-model.ts` line 422) is `` `legacy-${sha256(name).slice(0,10)}` ``, a
+**different id format** from a real task's `` `t-${uuid}` `` (`newTaskId`, line 383-385). A task
+just created via `createTask()` always has a `t-` id, so `legacyTaskId(title)` can never equal it —
+the fallback exists only for tasks that were themselves migrated from free-text names, never for a
+freshly-created real `Task`. **The session's `task` label matches the new task's title in every UI
+that joins by string (`SessionFiling`'s `filed`, `SessionTasksTab`'s `current`), so it LOOKS filed
+in the aside and the delivery panel — but `rowsOfTask` never finds it, so the task's rollup, its
+`sessionsUsed` count, and `agentistics_task`'s `sessions` list are permanently silent about a
+session that was created specifically for it.**
+
+**The same root cause also affects `suggestDelivery`'s auto-fill** (`NewSessionModal.tsx` lines
+199-206): accepting a suggested task title (never dismissed, never routed through `TaskPicker`)
+sets `task` without ever setting `subtaskTarget`, for any REAL (non-legacy) task the suggestion
+names. This is pre-existing, silent, and shares the identical fix.
+
+**The fix** (implementation, not this round's work, but specified so a subtask can be filed
+precisely):
+
+1. `NewTaskWizard`'s `onCreateSession` and `TasksPage.tsx`'s handler already have `taskId` — thread
+   it through as a new `initialTaskId?: string` prop on `NewSessionModal`, alongside the existing
+   `initialTask` (kept as the label pre-fill, unchanged).
+2. Generalize `subtaskTarget: {taskId, subtaskId}` to allow `subtaskId` to be **absent** — `{taskId,
+   subtaskId?: string}` — since §4.1 of the 2026-09-10 spec makes a bare task-level attach valid.
+   On mount, if `initialTaskId` is given and no `TaskPicker` selection has overridden it, seed this
+   state with `{taskId: initialTaskId}` (no subtask — the wizard from `/tasks` never asked for one).
+3. `start()`'s attach block (line 589) already gates on `subtaskTarget && json.id` — with the type
+   widened, it becomes `attachSession(taskId, json.id, subtaskId)` (subtaskId possibly `undefined`,
+   which the existing client (`web/src/lib/tasks.ts` line 513) already sends as a bare
+   `{sessionId}` body when absent — no change needed there).
+4. The suggestion-acceptance path (§199-206) gets the same treatment: when the suggested title
+   matches an existing task row in `taskRows`, resolve its real id and set the SAME state
+   (`{taskId}`, no subtask) instead of only writing the free-text label.
+
+This turns `task` (the free-text field sent to `/api/fleet/new`) into what its own name always
+implied but never guaranteed: a **display label**, always backed by a real `attachSession` call
+when the label was chosen from something real — never the only record of the intent.
+
+### C.3 Task name above the session title, in the list
+
+Confirmed component: `SessionFacts.tsx` — the row shared by the open aside list (`SessionsAside.tsx`
+line 938) and the collapsed rail's tooltip (per its own docblock). Today the delivery is a small
+`Bookmark`-prefixed segment on the META line, below and same-size as the title (lines 44-116).
+
+**Change**: when `session.task` is set, render it as its own line **above** the title —
+small/muted, matching the visual weight `microLabel` already gives other row-level context — and
+bump the title's `fontWeight`/`fontSize` slightly (the request: "título um pouco maior"). The
+existing `Bookmark` segment on the meta line, and its `onFile` click target, are UNCHANGED — that
+one already does its job (open the filing picker) and stays where a reader expects a click-to-file
+control; this is purely about WHERE the delivery's NAME is read, not about adding a second control
+for the same gesture.
+
+```tsx
+<span style={{ minWidth: 0, flex: 1, display: 'flex', flexDirection: 'column', gap: 2 }}>
+  {session.task && (
+    <span style={{
+      fontSize: 9.5, color: 'var(--text-tertiary)', fontWeight: 600,
+      overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+    }}>{session.task}</span>
+  )}
+  <span style={{ fontSize: session.task ? 13.5 : 12.5, fontWeight: ... /* unchanged rule */ }}>
+    {session.title}
+  </span>
+  {/* meta line: unchanged */}
+</span>
+```
+
+Because `SessionFacts` is the ONE component behind both the open list and the rail tooltip, this
+one change covers desktop and mobile — `SessionsAside.tsx` renders the same rows on both layouts
+(the mobile branch of `SessionsPage.tsx` mounts `SessionsAside` directly, line 1036). No separate
+mobile version to write.
+
+### C.4 The "Entregas" panel dumps raw markdown
+
+Confirmed: `SessionTasksTab.tsx` renders `DeliveryDetail` in `dense` mode (line 138-144) — the
+exact component `/tasks/:id` renders — and `DeliveryDetail.tsx`'s description block (the
+`!editing` branch, line 869-888) shows `task.detail` through `CommentBody`/`ReactMarkdown` with no
+folding at all. The 974-character description on this very task (`e66414ca-image.png`, matching
+the char counter in the SAME component's edit view, line 930) renders as one unbroken scroll —
+confirmed directly against `t-918cc82233`'s own `detail` field, which is exactly the four
+paragraphs shown unfolded in screenshot `263c7eef-image.png`.
+
+**Design decision: fold by markdown heading when the text has any, otherwise a single
+expand/collapse — never invent section boundaries prose does not have.** This task's own
+description uses **bold inline lead-ins** ("**Possibilidade nº1 (mais simples)**: ..."), not `#`
+headings — splitting on bold spans would be guessing at structure the author did not declare. So:
+
+- If `task.detail` contains one or more markdown heading lines (`/^#{1,6}\s+.+$/m`), split on them
+  and render each section as a `RailSection` (`packages/web/src/components/tasks/RailSection.tsx`
+  — already the primitive `DeliveryDetail`'s own rail uses for Tokens/Links/Bloqueada por, per
+  screenshot `3895ea5b-image.png`; `id`/`title`/`badge`/`defaultOpen`/`children`, already
+  remembers its open state per browser). Content before the first heading (if any) renders
+  un-folded, as a lead paragraph.
+- If it contains none — this task's own case — the WHOLE description becomes one collapsed block: a
+  short preview (first ~2-3 lines) plus "mostrar tudo / show all," expanding in place. This is a
+  single `RailSection`-shaped disclosure, not N invented sections.
+- Either way, this is **read-only presentation**. The edit view (`editing` branch, unchanged) keeps
+  editing the whole string as one textarea — folding is not a second data model, it is how the
+  same string is DISPLAYED.
+
+This lives entirely in `DeliveryDetail.tsx`'s non-editing branch (a new small helper, e.g.
+`DescriptionView`, replacing the bare `<CommentBody>` call at line 874) — and because
+`SessionTasksTab` renders the identical component, this fixes the aside panel and the `/tasks/:id`
+page's own description at once, on both desktop and mobile (`dense`/non-`dense` is layout-only per
+the component's own docblock, line 16-19).
+
+### C.5 The panel shows TASK-wide fields when filed under a SUBTASK
+
+This is the clearest, most concrete of the six reports, and it is exactly what `SessionTasksTab.tsx`
+already has the pieces to fix — it just does not use them yet.
+
+**What's wrong today**: `SessionTasksTab.tsx` (line 64) fetches the WHOLE `TaskDetail` via
+`useTaskDetail(current?.task.id)` and passes it straight to `DeliveryDetail` unfiltered (line 138).
+`DeliveryDetail` then renders the TASK's own status/priority/assignee/dates (screenshot
+`3895ea5b-image.png`) and the TASK's own delivery-evidence numbers (files 123, errors 22, lines
++7922/-771, tokens 153.9M — matching `t-918cc82233`'s own `stats` block exactly, confirmed against
+the task's real numbers read via `agentistics_task` above) — **even when the session is filed under
+one specific subtask**, where the honest numbers are that subtask's own `subtaskRollups` entry, not
+the task's.
+
+**The component already computes the right answer and throws it away.** `here` (line 75-78) already
+resolves the exact subtask title the session sits in — it is used only for the small "na parte X"
+pill (line 104-108) beside the filing buttons, and nowhere else.
+
+**The fix**: when `here` resolves to a subtask (not the direct branch), the panel needs a
+subtask-scoped view, not the full `DeliveryDetail`:
+
+- **Status/priority/assignee/dates**: the SUBTASK already carries its own `status`, `assignee`,
+  `dueDate`, `startDate` (`task-model.ts`'s `Subtask`, line 289-315) — a subtask-scoped header shows
+  THESE, not the task's `TaskFieldPatch`-driven status dropdown. (There is no subtask `priority`
+  field today — that column is task-only, so a subtask-scoped view either omits the priority row
+  entirely or states in words that priority is set at the delivery level; omitting is the honest
+  choice, matching the same "N/A over a confident but wrong number" rule this codebase applies
+  everywhere else, rather than showing the task's priority as if it belonged to the subtask.)
+- **Delivery-evidence numbers (files/errors/lines/tokens/commits)**: these come from
+  `TaskStats`/`DeliveryEvidence`, computed over `rowsOfTask(task, rows)` — the WHOLE task's rows.
+  There is no subtask-scoped equivalent of `taskStats` today; one is needed
+  (`packages/server/server/sessions/task-stats.ts`), filtering the same computation to
+  `rows.filter(r => r.subtaskId === thisSubtaskId)` (or the group's member set, once §B ships) —
+  the identical partition `subtaskViews` already applies to the ROLLUP, extended to the other stats
+  block. **This is new server-side work**, not a client-side re-filter — the underlying commit/file
+  scan (`getCommitsInWindow`, git stats) has no per-session granularity to filter after the fact
+  client-side; it has to be recomputed over the narrower row set.
+- **Comments**: `TaskComment` (`task-model.ts`) carries no `subtaskId` today — comments are task-wide
+  by design (they are the delivery's log, not a per-piece one). **This part of the request is
+  therefore out of scope as stated** — scoping comments to a subtask would need a new field on
+  every comment and a decision about where a comment made "about the subtask" should show when read
+  from the task's own page, which the six existing subtasks and this task's own comments never
+  needed to answer. Flagged rather than silently dropped: the panel should keep showing every
+  comment (task-wide), and a future request to scope comments is its own, separate piece of work.
+
+**Component shape**: rather than teaching `DeliveryDetail` a `scopeToSubtask` prop (which would
+mean every one of its many internal reads — status, dates, the rail sections, the table rows —
+individually branching on it, spreading the concept through a 1420-line component that today never
+needs to know about a single subtask), `SessionTasksTab.tsx` should render a **new, smaller,
+subtask-scoped view** when `here` names a subtask — reusing pieces of `DeliveryDetail` where they
+already work unmodified (e.g. `SubtaskSessions` for the chip list, `RailSection` for the stats),
+rather than teaching the big component two contradictory modes at once. This is the shape
+`SessionTasksTab`'s own docblock already half-describes ("what stays local is the FILING... the one
+thing this tab answers that the page does not") — this extends that same local half rather than
+threading a new mode through the shared page component. Naming and exact composition are an
+implementation decision; this spec commits to the DATA answer (subtask-scoped status/dates/stats,
+task-wide comments) and the STRUCTURAL one (a sibling view, not a mode flag on `DeliveryDetail`).
+
+**Mobile**: `SessionTasksTab` already renders inside the mobile aside exactly as it does on
+desktop (it is the tab content, not a layout branch) — no separate mobile version needed beyond
+whatever `RailSection`/`SubtaskSessions` already handle (both already `isMobile`-aware).
+
+### C.6 A flag icon near the session title — linked / unlinked
+
+**Placement, decided**: the OPEN session's own title bar, not the aside list row. Point C.3 already
+covers the LIST ("na lista/cards de sessões... mostrar o nome da task"); this point names "perto do
+título da sessão" without "lista," and its behaviour — "clique sem task → abre modal de criar task;
+clique com task → abre o aside da entrega" — is a per-open-session action, which only the header of
+an OPEN session has room to mean unambiguously. Putting a second delivery-control on the already
+dense aside-row meta line (which already has the `Bookmark` control from C.3) would be two icons
+doing adjacent things on one crowded row.
+
+**Three places currently render an open session's title**, confirmed by reading each:
+
+- Desktop shared header: `App.tsx`, lines 3055-3073 (`selectedFleetSession.title`).
+- Mobile panel header: `SessionsPage.tsx`, lines 796-812 (the `panel && selected` branch).
+- Mobile dedicated-terminal header: `SessionsPage.tsx`, lines 704-716 (the `dedicatedTerminal &&
+  selected` branch).
+
+All three currently duplicate the same title+state markup inline. Rather than pasting a fourth copy
+of "flag icon, filled orange when `task` is set, dotted outline otherwise, opens `NewTaskWizard`
+or `SessionTasksTab`'s panel depending on state" into three places (which is exactly the kind of
+duplication CLAUDE.md calls out for `task-reopen.ts`/`session-table.ts` elsewhere — "one gesture
+implemented twice is the bug this exists to have fixed once"), extract a small shared
+`SessionTitleFlag` component (or fold the flag into a slightly generalized version of
+`SessionFacts`'s title rendering, since that already has the exact `session.task` check needed) and
+use it in all three headers.
+
+- **No task** (`session.task` unset): outlined/dotted flag. Click → opens `NewTaskWizard` (already
+  exists, already supports a `session` pre-link prop per its own signature at line 28) — this is
+  the SAME dialog `SessionTasksTab`'s own "Nova tarefa para esta sessão" button opens (line 177),
+  so no new creation flow, only a new entry point into the existing one.
+- **Has task** (`session.task` set): filled orange flag. Click → opens the session's own aside on
+  the Deliveries tab — on desktop this is `openArtifacts('tasks')`-shaped (matching the pattern
+  `chatNote.ts`'s `systemRef` navigation already uses for "open this tab of the aside," per
+  CLAUDE.md's "A SYSTEM NOTE... GOES WHERE ITS ACTION IS" section); on mobile, wherever the
+  Deliveries tab is already reached from (the artifacts pane/tab bar for that session).
+
+This needs no server change — `session.task` is already on the wire (`ControlSession.task`,
+`session-fleet.ts` line 596) and is exactly the fact the icon's two states are keyed on.
+
+## D. What this spec does NOT decide
+
+- **C.1's "recent deliveries" list** — named as a smaller follow-up, not speced in full (§C.1).
+- **Comment scoping to a subtask** (part of C.5's original ask) — out of scope, reasoned in §C.5.
+- **A human name for a subtask group** — deliberately absent, reasoned in §B.5.
+- **The preset/wake session idea** (`s-d85c7d9d9d`) — untouched, a different topic per the task's
+  own history.
+- **Sending group rollups or subtask-scoped stats to a central** — neither travels today (the
+  2026-09-10 spec's §4.3 already draws this line for the plain per-subtask rollup); extending
+  central sync for either is separate work if wanted later.
+
+## E. Subtasks filed from this spec
+
+Each is independent where the dependency graph allows, and named for the one file/behaviour it
+changes — see the board (`t-918cc82233`) for exact ids and `blockedBy` wiring.

--- a/packages/server/server/sessions/pane-resize.test.ts
+++ b/packages/server/server/sessions/pane-resize.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 import { PANE_COLS, PANE_ROWS } from './tmux-cli'
-import { resizePlan } from './pane-resize'
+import { readWantedGeometry, resizePlan } from './pane-resize'
 
 describe('a SHELL pane follows the box it is drawn in', () => {
   test('it takes the geometry asked for', () => {
@@ -54,5 +54,35 @@ describe('a geometry that is not one is refused rather than resolved', () => {
     for (const want of [{ cols: 0, rows: 50 }, { cols: 120, rows: 0 }, { cols: -5, rows: 50 }, { cols: 5000, rows: 50 }]) {
       expect(resizePlan({ scope: 'shell', want, current: { cols: 120, rows: 50 } })).toBeNull()
     }
+  })
+})
+
+describe('the geometry a stream may be OPENED with', () => {
+  const q = (s: string) => readWantedGeometry(new URLSearchParams(s))
+
+  test('a pair of positive whole numbers is read', () => {
+    expect(q('id=s1&cols=144&rows=13')).toEqual({ cols: 144, rows: 13 })
+  })
+
+  test('saying nothing is not an error — it is the ordinary case', () => {
+    expect(q('id=s1')).toBeNull()
+    expect(q('id=s1&cols=144')).toBeNull()
+    expect(q('id=s1&rows=13')).toBeNull()
+  })
+
+  // A query string is untrusted input and this one arrives BEFORE the stream exists, so a value it
+  // cannot read must cost the caller the resize and never the stream.
+  test('anything that is not a pair of positive whole numbers is refused, never clamped', () => {
+    for (const s of [
+      'cols=0&rows=13', 'cols=144&rows=0', 'cols=-5&rows=13', 'cols=1.5&rows=13',
+      'cols=abc&rows=13', 'cols=144&rows=NaN', 'cols=&rows=13', 'cols=1e400&rows=13',
+    ]) {
+      expect(q(s), s).toBeNull()
+    }
+  })
+
+  test('a geometry past the ceiling is refused here too, so the plan is never asked a silly question', () => {
+    expect(q('cols=100000&rows=13')).toBeNull()
+    expect(q('cols=144&rows=100000')).toBeNull()
   })
 })

--- a/packages/server/server/sessions/pane-resize.ts
+++ b/packages/server/server/sessions/pane-resize.ts
@@ -41,6 +41,34 @@ function sane(g: PaneGeometry): boolean {
 }
 
 /**
+ * The geometry a READER stated when it opened the stream, or `null` for "it said nothing".
+ *
+ * A pane has one size and the last viewer to ask wins, so a shell last read on a phone hands a
+ * desktop its first frames hard-broken at 52 columns and the band snaps a quarter-second later,
+ * once the emulator has measured itself and the debounced resize lands. Letting the reader state
+ * the size on the way in closes that window — the pane is resized BEFORE the first capture.
+ *
+ * It is untrusted input arriving before the stream exists, so it is REFUSED rather than clamped:
+ * a value nobody can read costs the caller its resize, never its stream. The ceiling is the same
+ * one `resizePlan` holds, applied here so the plan is never asked a question it would only reject.
+ */
+export function readWantedGeometry(params: URLSearchParams): PaneGeometry | null {
+  const read = (name: string): number | null => {
+    const raw = params.get(name)
+    if (!raw) return null
+    // `Number` so `1.5` and `1e400` are read as themselves and then refused — `parseInt` would
+    // truncate both into perfectly usable numbers nobody asked for.
+    const n = Number(raw)
+    return Number.isInteger(n) && n > 0 ? n : null
+  }
+  const cols = read('cols')
+  const rows = read('rows')
+  if (cols === null || rows === null) return null
+  const want = { cols, rows }
+  return sane(want) ? want : null
+}
+
+/**
  * The geometry to apply, or `null` for "do nothing".
  *
  * `null` covers three different situations on purpose — the numbers are unusable, the clamp landed

--- a/packages/server/server/sessions/shell-web.ts
+++ b/packages/server/server/sessions/shell-web.ts
@@ -13,6 +13,7 @@ import type { CliLang } from '../cli-lang'
 import { closeShells, listShells, openShell } from './shell-backend'
 import { openShellStream, shellStreamAtCapacity, shellStreamExists } from './shell-stream-web'
 import { createPaneResizer } from './pane-resize-web'
+import { readWantedGeometry } from './pane-resize'
 import { SHELL_CAP, type ShellRefusal } from './shell-spec'
 
 /** One sentence per refusal code. The module that decides never writes prose; this one never decides. */
@@ -68,6 +69,13 @@ export async function handleShellRoute(
     if (!id) return json({ error: 'bad_request' }, 400)
     if (!(await shellStreamExists(id))) return json({ error: 'not_found' }, 404)
     if (shellStreamAtCapacity()) return json({ error: 'too_many_streams' }, 503)
+    // BEFORE the first capture. A pane has one size and the last viewer to ask wins, so without
+    // this a shell last read on a phone hands a desktop frames hard-broken at 52 columns until the
+    // emulator has measured itself and the debounced resize lands. The reader states what its box
+    // holds on the way in and the first frame is already right. A resize that fails costs the
+    // width for a quarter-second and never the stream — the measurement corrects it either way.
+    const want = readWantedGeometry(url.searchParams)
+    if (want) await resizeShellPane('shell', id, want)
     return new Response(await openShellStream(id, req.signal), {
       status: 200,
       headers: {

--- a/packages/web/src/components/sessions/SessionPanel.tsx
+++ b/packages/web/src/components/sessions/SessionPanel.tsx
@@ -69,6 +69,8 @@ export interface SessionPanelProps {
    * then the enlarge control is ABSENT too rather than inert.
    */
   onOpenTerminal?: () => void
+  /** Take the SHELL to its own screen. Absent where there is no route to take it to. */
+  onOpenShellFullscreen?: () => void
   /**
    * May this machine serve a per-session utility SHELL right now — `CAPS.localShell` AND the
    * user's own switch, as `/api/team/session` reports it.
@@ -81,7 +83,7 @@ export interface SessionPanelProps {
   shellEnabled?: boolean
 }
 
-export function SessionPanel({ session, row, lang, theme, act, authorName, onGone, onOpened, view: viewProp, onViewChange, onArtifacts, shellEnabled, onOpenTerminal }: SessionPanelProps) {
+export function SessionPanel({ session, row, lang, theme, act, authorName, onGone, onOpened, view: viewProp, onViewChange, onArtifacts, shellEnabled, onOpenTerminal, onOpenShellFullscreen }: SessionPanelProps) {
   /**
    * Is this a session of ANOTHER machine, reached through the relay?
    *
@@ -243,6 +245,7 @@ export function SessionPanel({ session, row, lang, theme, act, authorName, onGon
           key={session.id}
           sessionId={session.id}
           {...(session.cwd ? { cwd: session.cwd } : {})}
+          {...(onOpenShellFullscreen ? { onOpenFullscreen: onOpenShellFullscreen } : {})}
           lang={lang}
           theme={theme}
         />

--- a/packages/web/src/components/sessions/ShellBand.tsx
+++ b/packages/web/src/components/sessions/ShellBand.tsx
@@ -41,15 +41,16 @@
 
 import { Suspense, lazy, useCallback, useEffect, useMemo, useReducer, useRef, useState } from 'react'
 import {
-  ChevronDown, ChevronUp, ChevronLeft, Loader2, RotateCcw, TerminalSquare, Trash2,
+  ChevronDown, ChevronUp, ChevronLeft, Loader2, Maximize2, RotateCcw, TerminalSquare, Trash2,
 } from 'lucide-react'
 import { useDocumentVisible } from '../../hooks/useDocumentVisible'
+import { keyStripShown } from '../../lib/terminalSurface'
 import { useIsMobile } from '../../hooks/useIsMobile'
 import { useTerminalStream } from '../../hooks/useTerminalStream'
 import { useTerminalWrite } from '../../hooks/useTerminalWrite'
 import {
   BAND_MIN_PX, clampBandHeight, readBandPrefs, shellApiUrl, shellErrorText, shellWatching,
-  shellWhere, writeBandPrefs,
+  bandGeometry, shellWhere, writeBandGeometry, writeBandPrefs,
 } from '../../lib/shellBand'
 import {
   INITIAL_SHELL_BAND, shellBandReducer, shellResolveWanted, type OpenShell,
@@ -73,6 +74,7 @@ interface T {
   ctrlRefused: (c: string) => string
   resize: string
   retry: string
+  fullscreen: string
 }
 
 const TXT: Record<'pt' | 'en', T> = {
@@ -89,6 +91,7 @@ const TXT: Record<'pt' | 'en', T> = {
     ctrlRefused: c => `ctrl+${c} is not one of the keys this channel sends.`,
     resize: 'Drag to resize the shell',
     retry: 'Try again',
+    fullscreen: 'Open the shell full screen',
   },
   pt: {
     title: 'Shell',
@@ -103,6 +106,7 @@ const TXT: Record<'pt' | 'en', T> = {
     ctrlRefused: c => `ctrl+${c} não é uma das teclas que este canal envia.`,
     resize: 'Arraste para redimensionar o shell',
     retry: 'Tentar de novo',
+    fullscreen: 'Abrir o shell em tela cheia',
   },
 }
 
@@ -113,17 +117,34 @@ export interface ShellBandProps {
   cwd?: string
   lang: 'pt' | 'en'
   theme: 'dark' | 'light'
+  /**
+   * WHERE this shell is drawn. `docked` is the band under the composer — the placement whose whole
+   * point is SIMULTANEITY, reading the conversation while a build runs beside it. `dedicated` is
+   * the shell filling its own screen: no bar, no drag handle, no collapsed state, because you got
+   * here by asking for it and the way back is the screen's own control.
+   *
+   * The two share every rule that matters — one stream, one write channel, one emulator, the same
+   * unwatch discipline — which is the entire reason this is a prop and not a second component.
+   */
+  placement?: 'docked' | 'dedicated'
+  /** Offered only when there is somewhere to go: the band's "take the whole screen" control. */
+  onOpenFullscreen?: () => void
 }
 
-export function ShellBand({ sessionId, cwd, lang, theme }: ShellBandProps) {
+export function ShellBand({ sessionId, cwd, lang, theme, placement = 'docked', onOpenFullscreen }: ShellBandProps) {
   const t = TXT[lang]
   const isMobile = useIsMobile()
   const documentVisible = useDocumentVisible()
 
+  const dedicated = placement === 'dedicated'
   const [prefs, setPrefs] = useState(() => readBandPrefs())
+  // A DEDICATED shell is open by definition — you navigated to a screen that is nothing else. The
+  // stored `open` is the DOCKED band's state and must not decide it, or arriving here with the band
+  // collapsed would show an empty screen with no way to fill it.
+  const bandOpen = dedicated || prefs.open
   // THE MACHINE, not a pile of flags. See `shellBandState.ts` for the rule it enforces.
   const [band, dispatch] = useReducer(shellBandReducer, INITIAL_SHELL_BAND, init =>
-    readBandPrefs().open ? shellBandReducer(init, { type: 'openBand' }) : init)
+    dedicated || readBandPrefs().open ? shellBandReducer(init, { type: 'openBand' }) : init)
   const shell = band.shell
   const [ctrlArmed, setCtrlArmed] = useState(false)
   const [ctrlNote, setCtrlNote] = useState<string | null>(null)
@@ -194,12 +215,14 @@ export function ShellBand({ sessionId, cwd, lang, theme }: ShellBandProps) {
   }, [band.attempt, sessionId, lang])
 
   const watching = shellWatching({
-    bandOpen: prefs.open,
+    bandOpen,
     sessionSelected: Boolean(sessionId),
     documentVisible,
   })
   // `null` is what DROPS the subscription — the client half of the unwatch discipline.
-  const { state } = useTerminalStream(watching && shell ? shell.id : null, 'shell')
+  // The remembered geometry rides the OPEN, so the pane is already this box's size on the first
+  // frame instead of arriving at whatever width the last viewer left it — see `shellBand.ts`.
+  const { state } = useTerminalStream(watching && shell ? shell.id : null, 'shell', bandGeometry(placement))
   const write = useTerminalWrite(shell?.id ?? '', watching && Boolean(shell), lang, 'shell')
   // `'shell'`: the honesty line must say whose screen this is. The default subject calls it "the
   // agent's current screen", which over a shell the person opened themselves is simply false.
@@ -210,6 +233,16 @@ export function ShellBand({ sessionId, cwd, lang, theme }: ShellBandProps) {
     [shell?.id],
   )
   useEffect(() => () => resizer.cancel(), [resizer])
+  /**
+   * One measurement, two consumers: the pane is resized NOW (debounced) and the number is kept for
+   * the NEXT open. Written straight to storage rather than through React state — the emulator
+   * reports on every layout change, and a re-render of the whole panel for a number nothing on
+   * screen shows would be a cost with no reader.
+   */
+  const onGeometry = useCallback((g: { cols: number; rows: number }) => {
+    writeBandGeometry(placement, g)
+    resizer.request(g)
+  }, [resizer, placement])
 
   /**
    * One send path for everything.
@@ -296,7 +329,7 @@ export function ShellBand({ sessionId, cwd, lang, theme }: ShellBandProps) {
           showCursor={status.showCursor}
           interactive={write.ready}
           onInput={send}
-          onGeometry={shell ? resizer.request : undefined}
+          onGeometry={shell ? onGeometry : undefined}
         />
       </Suspense>
     </div>
@@ -364,6 +397,22 @@ export function ShellBand({ sessionId, cwd, lang, theme }: ShellBandProps) {
       })}
     </div>
   )
+
+  // ---- dedicated: the shell IS the screen ------------------------------------------------------
+  // No bar, no drag handle, no collapsed state: you navigated here, and the way back belongs to the
+  // screen around it. The key strip follows `keyStripShown` — a phone has no ctrl key, and this is
+  // the placement a phone always gets.
+  if (dedicated) {
+    return (
+      <div style={{
+        flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column', gap: 8,
+      }}>
+        {shell ? screen : <div style={{ flex: 1 }} />}
+        {notice}
+        {keyStripShown('dedicated', isMobile) && strip}
+      </div>
+    )
+  }
 
   // ---- mobile: a full-screen sheet over the session --------------------------------------------
   if (isMobile) {
@@ -496,6 +545,20 @@ export function ShellBand({ sessionId, cwd, lang, theme }: ShellBandProps) {
         }}>{where}</span>}
         {!where && <span style={{ flex: 1 }} />}
         {busy && <Loader2 size={13} className="ag-spin" style={{ color: 'var(--text-tertiary)' }} />}
+        {/* TAKE THE WHOLE SCREEN. Offered only with a shell open and somewhere to go, so the bar of
+            a band nobody has opened carries nothing that cannot act. It is the only way to the
+            shell's own screen — the route has accepted `?pane=shell` since phase 3b and nothing
+            linked there. */}
+        {prefs.open && shell && onOpenFullscreen && (
+          <button className="ag-tap-icon"
+            onClick={e => { e.stopPropagation(); onOpenFullscreen() }}
+            title={t.fullscreen}
+            aria-label={t.fullscreen}
+            style={iconBtn}
+          >
+            <Maximize2 size={13} />
+          </button>
+        )}
         {prefs.open && shell && (
           <button className="ag-tap-icon"
             /* A TRASH CAN, not an ✕. The ✕ read as "close this panel" next to a chevron that

--- a/packages/web/src/hooks/useTerminalStream.ts
+++ b/packages/web/src/hooks/useTerminalStream.ts
@@ -49,8 +49,21 @@ export interface TerminalStream {
   reconnect: () => void
 }
 
-export function useTerminalStream(id: string | null, scope: TerminalScope = 'fleet'): TerminalStream {
+/**
+ * @param want the geometry this reader's box holds, stated ONCE when the stream opens so the pane is
+ *   already the right size on the first frame (`terminalEndpoint.ts` carries the why). It is read
+ *   through a ref and is deliberately NOT a dependency: it changes on every layout tick, and
+ *   re-opening an SSE stream for it would trade a quarter-second of wrong width for a reconnect per
+ *   animation frame. The steady-state answer is the debounced `POST .../resize`.
+ */
+export function useTerminalStream(
+  id: string | null,
+  scope: TerminalScope = 'fleet',
+  want?: { cols: number; rows: number },
+): TerminalStream {
   const [state, dispatch] = useReducer(terminalReducer, INITIAL_TERMINAL_STATE)
+  const wantRef = useRef(want)
+  wantRef.current = want
   // Bumped by reconnect() to force the effect to tear down and re-open, even for the same id.
   const [nonce, setNonce] = useState(0)
   const reconnect = useCallback(() => setNonce(n => n + 1), [])
@@ -64,7 +77,7 @@ export function useTerminalStream(id: string | null, scope: TerminalScope = 'fle
     // Fresh id → clear any previous session's frame before a single byte of the new one arrives.
     dispatch({ type: 'connecting' })
 
-    const es = new EventSource(streamUrl(scope, id))
+    const es = new EventSource(streamUrl(scope, id, wantRef.current))
 
     // Has this connection drawn anything yet? While false, a timeout or an error means the channel
     // never established — worth saying so. Once true, a drop is a transient blip: keep the screen and

--- a/packages/web/src/lib/shellBand.test.ts
+++ b/packages/web/src/lib/shellBand.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, test } from 'bun:test'
 import {
   BAND_MAX_FRACTION, BAND_MIN_PX, DEFAULT_BAND_PREFS, clampBandHeight, readBandPrefs, shellErrorText,
-  shellApiUrl, shellWatching, shellWhere, writeBandPrefs, type BandPrefs,
+  bandGeometry, shellApiUrl, shellWatching, shellWhere, writeBandGeometry, writeBandPrefs, type BandPrefs,
 } from './shellBand'
 
 describe('the unwatch discipline', () => {
@@ -139,5 +139,80 @@ describe('the band prefs are a per-viewer convenience and never a hard dependenc
     expect(readBandPrefs(s).open).toBe(false)
     s.setItem('agentistics-shell-band', '{"open":"yes","height":"tall"}')
     expect(readBandPrefs(s)).toEqual({ open: false, height: DEFAULT_BAND_PREFS.height })
+  })
+})
+
+describe('the geometry the band remembers', () => {
+  const fake = (): Storage => {
+    const m = new Map<string, string>()
+    return {
+      getItem: (k: string) => m.get(k) ?? null,
+      setItem: (k: string, v: string) => { m.set(k, v) },
+      removeItem: (k: string) => { m.delete(k) },
+      clear: () => m.clear(),
+      key: () => null,
+      get length() { return m.size },
+    } as unknown as Storage
+  }
+
+  test('a band that has never been measured remembers nothing', () => {
+    expect(bandGeometry('docked', fake())).toBeUndefined()
+    expect(bandGeometry('dedicated', fake())).toBeUndefined()
+  })
+
+  test('the last measurement survives a reload, so the next open starts at the right size', () => {
+    const s = fake()
+    writeBandGeometry('docked', { cols: 144, rows: 13 }, s)
+    expect(bandGeometry('docked', s)).toEqual({ cols: 144, rows: 13 })
+  })
+
+  // THE PLACEMENTS ARE DIFFERENT BOXES. A band under the composer is ~13 rows and the shell's own
+  // screen is ~48; one shared memory means every arrival on the dedicated screen opens at the
+  // band's height and jumps — the exact snap this memory exists to remove, from the other side.
+  test('each placement remembers its OWN box', () => {
+    const s = fake()
+    writeBandGeometry('docked', { cols: 144, rows: 13 }, s)
+    writeBandGeometry('dedicated', { cols: 144, rows: 48 }, s)
+    expect(bandGeometry('docked', s)).toEqual({ cols: 144, rows: 13 })
+    expect(bandGeometry('dedicated', s)).toEqual({ cols: 144, rows: 48 })
+  })
+
+  test('writing a geometry keeps everything else the record already held', () => {
+    const s = fake()
+    writeBandPrefs({ open: true, height: 320 }, s)
+    writeBandGeometry('docked', { cols: 200, rows: 40 }, s)
+    const back = readBandPrefs(s)
+    expect(back.open).toBe(true)
+    expect(back.height).toBe(320)
+    expect(bandGeometry('docked', s)).toEqual({ cols: 200, rows: 40 })
+  })
+
+  test('a stored geometry that does not read as one is DROPPED, never half-used', () => {
+    for (const bad of [
+      { cols: 0, rows: 13 }, { cols: 144 }, { rows: 13 }, { cols: '144', rows: 13 },
+      { cols: 1.5, rows: 13 }, { cols: 144, rows: -2 }, 'nope', null, 7,
+    ]) {
+      const s = fake()
+      s.setItem('agentistics-shell-band', JSON.stringify({ open: true, height: 240, geometry: { docked: bad } }))
+      expect(bandGeometry('docked', s), JSON.stringify(bad)).toBeUndefined()
+      // The rest of the record still reads — one unreadable field is not an unreadable record.
+      expect(readBandPrefs(s).open).toBe(true)
+    }
+  })
+
+  test('one unreadable placement never costs the other', () => {
+    const s = fake()
+    s.setItem('agentistics-shell-band', JSON.stringify({
+      open: true, height: 240, geometry: { docked: { cols: 0, rows: 0 }, dedicated: { cols: 144, rows: 48 } },
+    }))
+    expect(bandGeometry('docked', s)).toBeUndefined()
+    expect(bandGeometry('dedicated', s)).toEqual({ cols: 144, rows: 48 })
+  })
+
+  test('a storage that throws costs the memory and never the band', () => {
+    const hostile = { getItem: () => { throw new Error('blocked') }, setItem: () => { throw new Error('blocked') } } as unknown as Storage
+    expect(() => writeBandGeometry('docked', { cols: 144, rows: 13 }, hostile)).not.toThrow()
+    expect(bandGeometry('docked', hostile)).toBeUndefined()
+    expect(readBandPrefs(hostile)).toEqual(DEFAULT_BAND_PREFS)
   })
 })

--- a/packages/web/src/lib/shellBand.ts
+++ b/packages/web/src/lib/shellBand.ts
@@ -129,7 +129,27 @@ export function shellWhere(cwd: string | undefined): string {
 export interface BandPrefs {
   open: boolean
   height: number
+  /**
+   * The last geometry each PLACEMENT measured for its terminal, so the next open can state it
+   * before the first capture instead of snapping a quarter-second later.
+   *
+   * It is a memory of THIS browser's box, not a fact about the pane — a pane has one size and the
+   * last viewer to ask wins, which is exactly why a shell last read on a phone opens 52 columns
+   * wide on a desktop. Absent, stale and unreadable all mean the same thing here: say nothing and
+   * let the measurement that lands moments later decide.
+   *
+   * KEYED BY PLACEMENT, because they are different boxes: the band under the composer is about 13
+   * rows and the shell's own screen about 48. Measured on a real layout — one shared number made
+   * every arrival on the dedicated screen open at the band's height and jump, which is the same
+   * snap this memory exists to remove, from the other side.
+   */
+  geometry?: Partial<Record<ShellPlacement, PaneGeometry>>
 }
+
+/** Where a shell is drawn. `docked` is the band under the composer; `dedicated` is its own screen. */
+export type ShellPlacement = 'docked' | 'dedicated'
+
+export interface PaneGeometry { cols: number; rows: number }
 
 /** ABSENT READS AS CLOSED. Nobody acquires an open shell band by having reloaded the page. */
 export const DEFAULT_BAND_PREFS: BandPrefs = { open: false, height: 240 }
@@ -148,10 +168,55 @@ export function readBandPrefs(storage?: Storage): BandPrefs {
       height: typeof r.height === 'number' && Number.isFinite(r.height)
         ? Math.max(BAND_MIN_PX, r.height)
         : DEFAULT_BAND_PREFS.height,
+      // DROPPED PER PLACEMENT when it does not read as a pair of positive whole numbers. Half a
+      // geometry is worse than none — it would be sent, refused, and the reader would never learn
+      // why — and one unreadable placement must not cost the other.
+      ...(readGeometries(r.geometry) ? { geometry: readGeometries(r.geometry)! } : {}),
     }
   } catch {
     return DEFAULT_BAND_PREFS
   }
+}
+
+function readGeometry(v: unknown): PaneGeometry | null {
+  if (typeof v !== 'object' || v === null) return null
+  const g = v as Record<string, unknown>
+  const ok = (n: unknown): n is number => typeof n === 'number' && Number.isInteger(n) && n > 0
+  return ok(g.cols) && ok(g.rows) ? { cols: g.cols, rows: g.rows } : null
+}
+
+function readGeometries(v: unknown): Partial<Record<ShellPlacement, PaneGeometry>> | null {
+  if (typeof v !== 'object' || v === null) return null
+  const r = v as Record<string, unknown>
+  const out: Partial<Record<ShellPlacement, PaneGeometry>> = {}
+  for (const key of ['docked', 'dedicated'] as const) {
+    const g = readGeometry(r[key])
+    if (g) out[key] = g
+  }
+  return Object.keys(out).length > 0 ? out : null
+}
+
+/** What this placement's box measured last time, or `undefined` for "it has never said". */
+export function bandGeometry(placement: ShellPlacement, storage?: Storage): PaneGeometry | undefined {
+  return readBandPrefs(storage).geometry?.[placement]
+}
+
+/**
+ * Record the measurement without disturbing the rest of the record.
+ *
+ * A read-modify-write rather than a field on the band's React state: the emulator reports a
+ * geometry on every layout change, and routing that through a `setState` would re-render the whole
+ * panel for a number nothing on screen shows.
+ */
+export function writeBandGeometry(
+  placement: ShellPlacement,
+  geometry: PaneGeometry,
+  storage?: Storage,
+): void {
+  try {
+    const prefs = readBandPrefs(storage)
+    writeBandPrefs({ ...prefs, geometry: { ...prefs.geometry, [placement]: geometry } }, storage)
+  } catch { /* the memory is a convenience; the band works without it */ }
 }
 
 export function writeBandPrefs(prefs: BandPrefs, storage?: Storage): void {

--- a/packages/web/src/lib/terminalEndpoint.test.ts
+++ b/packages/web/src/lib/terminalEndpoint.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'bun:test'
+import { describe, expect, it, test } from 'bun:test'
 import { inputWsUrl, streamUrl, type TerminalScope } from './terminalEndpoint'
 
 describe('a scope decides which route a terminal talks to', () => {
@@ -31,6 +31,29 @@ describe('a scope decides which route a terminal talks to', () => {
     for (const s of scopes) {
       expect(streamUrl(s, 'i')).toStartWith('/api/')
       expect(inputWsUrl(s, 'i', 'http:', 'h')).toStartWith('ws://')
+    }
+  })
+})
+
+describe('the geometry a stream may open with', () => {
+  test('is absent unless the caller has one', () => {
+    expect(streamUrl('shell', 's1')).toBe('/api/shell/stream?id=s1')
+  })
+
+  test('rides the stream URL, so the pane is already the right size on the FIRST frame', () => {
+    // Without it the first capture is whatever width the pane was left at by the last viewer, and
+    // the band visibly snaps a moment later. The numbers are the box's own last measurement.
+    expect(streamUrl('shell', 's1', { cols: 144, rows: 13 }))
+      .toBe('/api/shell/stream?id=s1&cols=144&rows=13')
+  })
+
+  test('a geometry that is not a pair of positive whole numbers is left off entirely', () => {
+    for (const g of [
+      { cols: 0, rows: 13 }, { cols: 144, rows: 0 },
+      { cols: -1, rows: 13 }, { cols: 1.5, rows: 13 },
+      { cols: Number.NaN, rows: 13 }, { cols: 144, rows: Number.POSITIVE_INFINITY },
+    ]) {
+      expect(streamUrl('shell', 's1', g), JSON.stringify(g)).toBe('/api/shell/stream?id=s1')
     }
   })
 })

--- a/packages/web/src/lib/terminalEndpoint.ts
+++ b/packages/web/src/lib/terminalEndpoint.ts
@@ -22,9 +22,32 @@ const BASE: Record<TerminalScope, string> = {
   shell: '/api/shell',
 }
 
-/** The SSE read channel for one pane. */
-export function streamUrl(scope: TerminalScope, id: string): string {
-  return `${BASE[scope]}/stream?id=${encodeURIComponent(id)}`
+/** What a box can show at natural size — the pane's target geometry. */
+export interface PaneGeometry { cols: number; rows: number }
+
+function usable(g: PaneGeometry | undefined): g is PaneGeometry {
+  return Boolean(g)
+    && Number.isInteger(g!.cols) && Number.isInteger(g!.rows)
+    && g!.cols > 0 && g!.rows > 0
+}
+
+/**
+ * The SSE read channel for one pane, optionally stating the geometry the reader's box wants.
+ *
+ * A pane has ONE size and the last viewer to ask wins, so a shell opened on a phone and then on a
+ * desktop starts at the phone's width: the first frames arrive hard-broken at 52 columns and the
+ * band visibly snaps a quarter-second later, when the emulator has measured itself and the
+ * debounced `POST /api/shell/resize` lands. Saying the size UP FRONT closes that window — the
+ * server resizes before the first capture, so frame one is already right. It is a REQUEST, not a
+ * promise: an assistant's pane may refuse to shrink below its floor, and the measured geometry
+ * corrects a stale one moments later either way.
+ *
+ * A geometry that is not a pair of positive whole numbers is left off rather than sent and refused
+ * — a browser mid-layout reports anything, and a query string is not the place to argue about it.
+ */
+export function streamUrl(scope: TerminalScope, id: string, want?: PaneGeometry): string {
+  const base = `${BASE[scope]}/stream?id=${encodeURIComponent(id)}`
+  return usable(want) ? `${base}&cols=${want.cols}&rows=${want.rows}` : base
 }
 
 /**

--- a/packages/web/src/pages/SessionsPage.tsx
+++ b/packages/web/src/pages/SessionsPage.tsx
@@ -52,6 +52,7 @@ import {
   arrivalFor, reopenedSessionRoute, sessionPath, stillArriving, type SessionArrival,
 } from '../lib/sessionRoute'
 import { dedicatedTerminalPath, readTerminalPane } from '../lib/terminalSurface'
+import { ShellBand } from '../components/sessions/ShellBand'
 import { TerminalRegion } from '../components/RecentSessions'
 import { sessionPlanFactor } from '../lib/costBasis'
 
@@ -124,6 +125,7 @@ export default function SessionsPage() {
    */
   const dedicatedTerminal = useLocation().pathname.endsWith('/terminal')
   const dedicatedPane = readTerminalPane(useSearchParams()[0].get('pane'))
+  const shellEnabled = ctx.shellEnabled === true
 
   /**
    * WHERE A REOPEN LANDS — one place, for all three controls on this page that can perform one.
@@ -550,9 +552,10 @@ export default function SessionsPage() {
       onViewChange={setSessionView}
       onArtifacts={onArtifacts}
       // The capability AND the user's switch, as the server reports them. Absent reads as OFF.
-      shellEnabled={ctx.shellEnabled === true}
+      shellEnabled={shellEnabled}
       // The terminal's own screen. A route, so it survives a reload and can be sent to somebody.
       onOpenTerminal={() => navigate(dedicatedTerminalPath(selected.id))}
+      onOpenShellFullscreen={() => navigate(dedicatedTerminalPath(selected.id, 'shell'))}
     />
   )
 
@@ -715,28 +718,79 @@ export default function SessionsPage() {
             </div>
           </div>
         </div>
-        <div style={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column', padding: 10 }}>
-          {/* The SHELL's own dedicated screen is not built yet, and this says so rather than
-              drawing the assistant's pane under a shell's name. Nothing links here today — the
-              selector is what will make it reachable. */}
-          {dedicatedPane === 'shell' && (
-            <div role="status" style={{ fontSize: 11, color: 'var(--accent-red)', marginBottom: 8 }}>
-              {pt
-                ? 'A tela dedicada do shell ainda não existe — abaixo está o terminal do assistente.'
-                : 'The shell’s own dedicated screen does not exist yet — below is the assistant’s terminal.'}
+        <div style={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column', gap: 8, padding: 10 }}>
+          {/* THE TARGET SELECTOR. One screen, two panes, and neither segment may be called
+              "Terminal" — that ambiguity is exactly what phase 1 avoided by naming the shell a
+              shell. It is a ROUTE and not a state, so a reload and a shared link land on the pane
+              you were looking at. Withheld when this machine serves no shell: a segment whose only
+              outcome is a refusal is worse than no segment. */}
+          {shellEnabled && (
+            <div role="tablist" aria-label={pt ? 'Qual terminal' : 'Which terminal'} style={{
+              display: 'flex', gap: 4, flexShrink: 0, alignSelf: 'flex-start',
+              padding: 3, borderRadius: 8, background: 'var(--bg-elevated)',
+              border: '1px solid var(--border-subtle)',
+            }}>
+              {(['assistant', 'shell'] as const).map(target => {
+                const on = dedicatedPane === target
+                const label = target === 'assistant'
+                  ? (pt ? 'Assistente' : 'Assistant')
+                  : 'Shell'
+                return (
+                  <button
+                    key={target}
+                    role="tab"
+                    aria-selected={on}
+                    onClick={() => navigate(dedicatedTerminalPath(selected.id, target), { replace: true })}
+                    style={{
+                      // 44px is the MOBILE figure; on a desktop it would turn a segmented control
+                      // into a row of buttons.
+                      minHeight: isMobile ? 44 : 26, padding: isMobile ? '0 16px' : '0 12px',
+                      borderRadius: 6, cursor: 'pointer', fontFamily: 'inherit',
+                      fontSize: 12, fontWeight: 650, border: 'none',
+                      background: on ? 'var(--bg-surface)' : 'transparent',
+                      color: on ? 'var(--text-primary)' : 'var(--text-tertiary)',
+                      boxShadow: on ? '0 1px 2px rgba(0,0,0,0.18)' : 'none',
+                    }}
+                  >
+                    {label}
+                  </button>
+                )
+              })}
             </div>
           )}
-          <TerminalRegion
-            /* DEDICATED: you asked for this screen, so focus is the consent and there is no arm
-               button; on a phone it carries the key strip. */
-            placement="dedicated"
-            id={selected.id}
-            theme={theme === 'light' ? 'light' : 'dark'}
-            lang={pt ? 'pt' : 'en'}
-            fill
-            {...(rowIndex.get(selected.id) ? { row: rowIndex.get(selected.id)! } : {})}
-            act={act}
-          />
+          {/* A link to `?pane=shell` on a machine that serves no shell must not quietly draw the
+              ASSISTANT's pane under a shell's name. The selector is absent there — a segment whose
+              only outcome is a refusal is worse than none — so the sentence is the only thing that
+              can say what happened. */}
+          {dedicatedPane === 'shell' && !shellEnabled && (
+            <div role="status" style={{ fontSize: 11, color: 'var(--accent-red)', flexShrink: 0 }}>
+              {pt
+                ? 'Esta máquina não está servindo shell — abaixo está o terminal do assistente.'
+                : 'This machine is not serving a shell — below is the assistant’s terminal.'}
+            </div>
+          )}
+          {dedicatedPane === 'shell' && shellEnabled ? (
+            <ShellBand
+              key={`shell-${selected.id}`}
+              placement="dedicated"
+              sessionId={selected.id}
+              {...(selected.cwd ? { cwd: selected.cwd } : {})}
+              lang={pt ? 'pt' : 'en'}
+              theme={theme === 'light' ? 'light' : 'dark'}
+            />
+          ) : (
+            <TerminalRegion
+              /* DEDICATED: you asked for this screen, so focus is the consent and there is no arm
+                 button; on a phone it carries the key strip. */
+              placement="dedicated"
+              id={selected.id}
+              theme={theme === 'light' ? 'light' : 'dark'}
+              lang={pt ? 'pt' : 'en'}
+              fill
+              {...(rowIndex.get(selected.id) ? { row: rowIndex.get(selected.id)! } : {})}
+              act={act}
+            />
+          )}
         </div>
       </div>
     )


### PR DESCRIPTION
## O terminal (#509)

- **Fase 3c — o seletor `Assistente | Shell` na tela dedicada.** A rota aceitava `?pane=shell` desde a fase 3b e nada linkava para lá. Agora o shell tem tela própria: `ShellBand` ganha uma colocação (`docked`, a faixa sob o compositor; `dedicated`, o shell ocupando a tela), as duas dividindo stream, canal de escrita, emulador e disciplina de unwatch. O seletor é rota e não estado, então o link é compartilhável e sobrevive ao reload; é ausente onde a máquina não serve shell, com uma frase para quem abrir o link mesmo assim.
- **A pane já nasce do tamanho da caixa.** A caixa diz a geometria na abertura do stream e o servidor redimensiona antes da primeira captura — fim da janela em que um shell lido por último num celular entregava ao desktop frames quebrados em 52 colunas. A memória é por colocação (a faixa tem ~13 linhas, a tela do shell ~48).

Verificado no navegador: `&cols=144&rows=13` na faixa e `&cols=144&rows=48` na tela dedicada na segunda visita; pane em `144x48`, `.xterm-screen` 1123px numa caixa de 1130px. A 390px sem overflow horizontal, alvos a 44px, pane em `47x38`.

## Também em dev

- #508 — spec de ALM (regra done-exige-sessão, grupos de subtask, UX fora do board). Documentação.

`bun tsc --noEmit` + `bun test` (7908 passando, 0 falhas); CI verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lr8C4E9sJWirekwVfSr3UN