### PR TITLE
feat(release): publish a musl binary for Alpine and other musl distros

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -210,6 +210,16 @@ jobs:
           mkdir -p release
           bun build --compile packages/server/bin/cli.ts --outfile ./release/agentop
 
+      # Alpine and other musl-based distros have no glibc dynamic linker at all — the glibc binary
+      # above fails there with a bare "not found" that names no missing library (the kernel is
+      # looking for /lib64/ld-linux-x86-64.so.2, which does not exist, and the shell reports that
+      # ENOENT as though the file itself were missing). install.sh picks between the two by
+      # checking `ldd --version` for "musl". Cross-compiled from this same glibc runner — Bun
+      # downloads the musl runtime for the target rather than needing one installed here.
+      - name: Compile musl binary (cross-compile)
+        if: steps.skip_check.outputs.skip != 'true' && steps.version.outputs.skip != 'true'
+        run: bun build --compile --target=bun-linux-x64-musl packages/server/bin/cli.ts --outfile ./release/agentop-musl
+
       - name: Compile Windows binary (cross-compile)
         if: steps.skip_check.outputs.skip != 'true' && steps.version.outputs.skip != 'true'
         run: bun build --compile --target=bun-windows-x64 packages/server/bin/cli.ts --outfile ./release/agentop.exe
@@ -225,6 +235,21 @@ jobs:
       - name: Smoke test
         if: steps.skip_check.outputs.skip != 'true' && steps.version.outputs.skip != 'true'
         run: ./release/agentop --help
+
+      # The runner itself is glibc, so the musl binary cannot be exec'd directly here — it needs an
+      # actual musl system. Alpine via Docker is the cheapest one, and it is also where the binary
+      # needs libstdc++/libgcc (verified by hand: Bun's own runtime links them even in its musl
+      # build, and Alpine's base image ships neither) — installing them here doubles as a check
+      # that install.sh's own musl branch names the right packages.
+      - name: Smoke test (musl)
+        if: steps.skip_check.outputs.skip != 'true' && steps.version.outputs.skip != 'true'
+        run: |
+          docker run --rm -v "$(pwd)/release:/release:ro" alpine:latest sh -c '
+            apk add --no-cache libstdc++ libgcc >/dev/null &&
+            cp /release/agentop-musl /tmp/agentop-musl &&
+            chmod +x /tmp/agentop-musl &&
+            /tmp/agentop-musl --help
+          '
 
       - name: Generate changelog
         if: github.ref == 'refs/heads/main' && steps.skip_check.outputs.skip != 'true' && steps.version.outputs.skip != 'true'
@@ -318,12 +343,13 @@ jobs:
           # failure at the first step. Upload into it instead when it is already there.
           if gh release view "$TAG" >/dev/null 2>&1; then
             echo "release $TAG already exists — uploading the binaries into it"
-            gh release upload "$TAG" ./release/agentop ./release/agentop.exe $VSIX --clobber
+            gh release upload "$TAG" ./release/agentop ./release/agentop-musl ./release/agentop.exe $VSIX --clobber
           else
             gh release create "$TAG" \
               --title "v${VERSION}" \
               --notes-file /tmp/release-notes.md \
               ./release/agentop \
+              ./release/agentop-musl \
               ./release/agentop.exe \
               $VSIX
           fi
@@ -347,6 +373,7 @@ jobs:
             --title "Latest build ($(date -u +'%Y-%m-%d %H:%M UTC'))" \
             --notes-file /tmp/release-notes.md \
             ./release/agentop \
+            ./release/agentop-musl \
             ./release/agentop.exe \
             $VSIX
 

--- a/install.sh
+++ b/install.sh
@@ -7,7 +7,6 @@ set -euo pipefail
 
 REPO="blpsoares/agentistics"
 BINARY="agentop"
-RELEASE_URL="https://github.com/${REPO}/releases/latest/download/${BINARY}"
 
 # ── Determine install directory ────────────────────────────────────────────
 if [[ "${EUID:-$(id -u)}" -eq 0 ]]; then
@@ -30,11 +29,47 @@ if [[ "$ARCH" != "x86_64" ]]; then
   exit 1
 fi
 
+# ── libc: glibc vs musl ─────────────────────────────────────────────────────
+#
+# Two binaries are published: `agentop` (glibc) and `agentop-musl` (Alpine and other musl-based
+# distros — glibc's dynamic linker does not exist there, so the glibc binary fails with a bare
+# "not found" that names no missing library). `ldd --version` prints "musl libc" on a musl system
+# regardless of its own exit code (busybox's `ldd` does not fully support `--version`) — and this
+# script runs under `set -o pipefail`, under which the PIPELINE fails if ANY stage does, not only
+# the last, so ldd's own non-zero exit would sink the `if` even when grep matches. The `|| true`
+# neutralises that: only grep's result decides.
+IS_MUSL=0
+if (ldd --version 2>&1 || true) | grep -qi musl; then
+  IS_MUSL=1
+fi
+
+BINARY_ASSET="$BINARY"
+if [[ "$IS_MUSL" -eq 1 ]]; then
+  BINARY_ASSET="${BINARY}-musl"
+
+  # Bun's own runtime links libstdc++/libgcc even in its musl build, and Alpine's base image ships
+  # neither — without them the binary fails with "Error relocating ...: symbol not found" instead
+  # of running. `apk` is the only musl-distro package manager worth targeting here.
+  if command -v apk >/dev/null 2>&1; then
+    echo "musl libc detected — ensuring libstdc++/libgcc are present…"
+    if [[ "${EUID:-$(id -u)}" -eq 0 ]]; then
+      apk add --no-cache libstdc++ libgcc >/dev/null 2>&1 || true
+    elif command -v sudo >/dev/null 2>&1; then
+      sudo apk add --no-cache libstdc++ libgcc >/dev/null 2>&1 || true
+    else
+      echo "  Not root and no sudo on PATH — if the binary fails to start, run:"
+      echo "    apk add libstdc++ libgcc"
+    fi
+  fi
+fi
+
+RELEASE_URL="https://github.com/${REPO}/releases/latest/download/${BINARY_ASSET}"
+
 # ── Runtime dependency: tmux ────────────────────────────────────────────────
 #
-# agentop's session manager (`agentop session`, the cockpit's Sessions tab) is built on tmux —
-# there is no other backend (see packages/server/server/sessions/dependency-plan.ts, which the
-# already-installed binary uses to explain a MISSING tmux to someone who skipped this script or
+# agentop's session manager (`agentop session`, the cockpit's Sessions tab) is built entirely on
+# tmux — there is no other backend (see packages/server/server/sessions/dependency-plan.ts, which
+# the already-installed binary uses to explain a MISSING tmux to someone who skipped this script or
 # removed the package afterwards). Without it every session-related feature fails the moment it is
 # used, well after the install already reported success — a confusing place to first learn about a
 # missing dependency. So it is installed HERE, proactively, the same way any competent install
@@ -90,7 +125,7 @@ if ! command -v tmux >/dev/null 2>&1; then
 fi
 
 # ── Download ───────────────────────────────────────────────────────────────
-echo "Downloading ${BINARY} from ${RELEASE_URL} …"
+echo "Downloading ${BINARY_ASSET} from ${RELEASE_URL} …"
 mkdir -p "$INSTALL_DIR"
 curl -fsSL "$RELEASE_URL" -o "${INSTALL_DIR}/${BINARY}"
 chmod +x "${INSTALL_DIR}/${BINARY}"


### PR DESCRIPTION
## What

Publishes a second binary, \`agentop-musl\`, for Alpine and other musl-based distros, and teaches \`install.sh\` to pick the right one.

## Why

The published \`agentop\` binary links against glibc, whose dynamic linker (\`/lib64/ld-linux-x86-64.so.2\`) does not exist on Alpine — it fails there with a bare "not found" that names no missing library. Confirmed by downloading the release binary directly, outside \`install.sh\`: the same failure, unrelated to the installer. Found while testing the previous tmux auto-install PR (#506).

## How

- \`release.yml\` cross-compiles with \`--target=bun-linux-x64-musl\` (Bun downloads the musl runtime for the target; nothing extra needed on the glibc runner) and publishes \`agentop-musl\` alongside \`agentop\`, on both the versioned release and the rolling \`latest\` one.
- A dedicated smoke test runs the musl binary inside a throwaway Alpine container in CI (the runner itself is glibc and cannot exec it directly) — this doubles as verification that \`install.sh\`'s own musl branch names the right runtime packages.
- \`install.sh\` detects musl via \`ldd --version\` (prints "musl libc" regardless of its own exit code — busybox's \`ldd\` doesn't fully support \`--version\`) and downloads \`agentop-musl\` instead. It also installs \`libstdc++\`/\`libgcc\` via \`apk\` when needed: Bun's own runtime links them even in its musl build, and Alpine's base image ships neither — verified by hand, the musl binary fails with \`Error relocating ...: symbol not found\` without them.

## A real bug found and fixed while testing

\`install.sh\` runs under \`set -o pipefail\`, under which a pipeline fails if **any** stage does, not only the last — so \`ldd --version | grep -qi musl\` never set \`IS_MUSL\`, because \`ldd\`'s own non-zero exit sank the whole pipeline even when \`grep\` matched. Fixed with \`(ldd --version 2>&1 || true) | grep -qi musl\`, so only \`grep\`'s result decides. Caught by testing end-to-end rather than trusting the logic on paper.

## Testing

Verified end to end in throwaway Docker containers, both before and after the pipefail fix (RED then GREEN):
- **Alpine**: musl detected, \`libstdc++\`/\`libgcc\` installed, \`tmux\` installed, \`agentop-musl\` downloaded (served locally, standing in for the not-yet-published release asset) and its \`--help\` runs.
- **Debian**: unaffected — glibc detected, plain \`agentop\` downloaded and runs, \`tmux\` installs via \`apt\` as before.

Full suite: 7908 pass, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)