### PR TITLE
release: musl binary for Alpine + sessions aside grouping

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -210,6 +210,16 @@ jobs:
           mkdir -p release
           bun build --compile packages/server/bin/cli.ts --outfile ./release/agentop
 
+      # Alpine and other musl-based distros have no glibc dynamic linker at all — the glibc binary
+      # above fails there with a bare "not found" that names no missing library (the kernel is
+      # looking for /lib64/ld-linux-x86-64.so.2, which does not exist, and the shell reports that
+      # ENOENT as though the file itself were missing). install.sh picks between the two by
+      # checking `ldd --version` for "musl". Cross-compiled from this same glibc runner — Bun
+      # downloads the musl runtime for the target rather than needing one installed here.
+      - name: Compile musl binary (cross-compile)
+        if: steps.skip_check.outputs.skip != 'true' && steps.version.outputs.skip != 'true'
+        run: bun build --compile --target=bun-linux-x64-musl packages/server/bin/cli.ts --outfile ./release/agentop-musl
+
       - name: Compile Windows binary (cross-compile)
         if: steps.skip_check.outputs.skip != 'true' && steps.version.outputs.skip != 'true'
         run: bun build --compile --target=bun-windows-x64 packages/server/bin/cli.ts --outfile ./release/agentop.exe
@@ -225,6 +235,21 @@ jobs:
       - name: Smoke test
         if: steps.skip_check.outputs.skip != 'true' && steps.version.outputs.skip != 'true'
         run: ./release/agentop --help
+
+      # The runner itself is glibc, so the musl binary cannot be exec'd directly here — it needs an
+      # actual musl system. Alpine via Docker is the cheapest one, and it is also where the binary
+      # needs libstdc++/libgcc (verified by hand: Bun's own runtime links them even in its musl
+      # build, and Alpine's base image ships neither) — installing them here doubles as a check
+      # that install.sh's own musl branch names the right packages.
+      - name: Smoke test (musl)
+        if: steps.skip_check.outputs.skip != 'true' && steps.version.outputs.skip != 'true'
+        run: |
+          docker run --rm -v "$(pwd)/release:/release:ro" alpine:latest sh -c '
+            apk add --no-cache libstdc++ libgcc >/dev/null &&
+            cp /release/agentop-musl /tmp/agentop-musl &&
+            chmod +x /tmp/agentop-musl &&
+            /tmp/agentop-musl --help
+          '
 
       - name: Generate changelog
         if: github.ref == 'refs/heads/main' && steps.skip_check.outputs.skip != 'true' && steps.version.outputs.skip != 'true'
@@ -318,12 +343,13 @@ jobs:
           # failure at the first step. Upload into it instead when it is already there.
           if gh release view "$TAG" >/dev/null 2>&1; then
             echo "release $TAG already exists — uploading the binaries into it"
-            gh release upload "$TAG" ./release/agentop ./release/agentop.exe $VSIX --clobber
+            gh release upload "$TAG" ./release/agentop ./release/agentop-musl ./release/agentop.exe $VSIX --clobber
           else
             gh release create "$TAG" \
               --title "v${VERSION}" \
               --notes-file /tmp/release-notes.md \
               ./release/agentop \
+              ./release/agentop-musl \
               ./release/agentop.exe \
               $VSIX
           fi
@@ -347,6 +373,7 @@ jobs:
             --title "Latest build ($(date -u +'%Y-%m-%d %H:%M UTC'))" \
             --notes-file /tmp/release-notes.md \
             ./release/agentop \
+            ./release/agentop-musl \
             ./release/agentop.exe \
             $VSIX
 

--- a/install.sh
+++ b/install.sh
@@ -7,7 +7,6 @@ set -euo pipefail
 
 REPO="blpsoares/agentistics"
 BINARY="agentop"
-RELEASE_URL="https://github.com/${REPO}/releases/latest/download/${BINARY}"
 
 # ── Determine install directory ────────────────────────────────────────────
 if [[ "${EUID:-$(id -u)}" -eq 0 ]]; then
@@ -30,11 +29,47 @@ if [[ "$ARCH" != "x86_64" ]]; then
   exit 1
 fi
 
+# ── libc: glibc vs musl ─────────────────────────────────────────────────────
+#
+# Two binaries are published: `agentop` (glibc) and `agentop-musl` (Alpine and other musl-based
+# distros — glibc's dynamic linker does not exist there, so the glibc binary fails with a bare
+# "not found" that names no missing library). `ldd --version` prints "musl libc" on a musl system
+# regardless of its own exit code (busybox's `ldd` does not fully support `--version`) — and this
+# script runs under `set -o pipefail`, under which the PIPELINE fails if ANY stage does, not only
+# the last, so ldd's own non-zero exit would sink the `if` even when grep matches. The `|| true`
+# neutralises that: only grep's result decides.
+IS_MUSL=0
+if (ldd --version 2>&1 || true) | grep -qi musl; then
+  IS_MUSL=1
+fi
+
+BINARY_ASSET="$BINARY"
+if [[ "$IS_MUSL" -eq 1 ]]; then
+  BINARY_ASSET="${BINARY}-musl"
+
+  # Bun's own runtime links libstdc++/libgcc even in its musl build, and Alpine's base image ships
+  # neither — without them the binary fails with "Error relocating ...: symbol not found" instead
+  # of running. `apk` is the only musl-distro package manager worth targeting here.
+  if command -v apk >/dev/null 2>&1; then
+    echo "musl libc detected — ensuring libstdc++/libgcc are present…"
+    if [[ "${EUID:-$(id -u)}" -eq 0 ]]; then
+      apk add --no-cache libstdc++ libgcc >/dev/null 2>&1 || true
+    elif command -v sudo >/dev/null 2>&1; then
+      sudo apk add --no-cache libstdc++ libgcc >/dev/null 2>&1 || true
+    else
+      echo "  Not root and no sudo on PATH — if the binary fails to start, run:"
+      echo "    apk add libstdc++ libgcc"
+    fi
+  fi
+fi
+
+RELEASE_URL="https://github.com/${REPO}/releases/latest/download/${BINARY_ASSET}"
+
 # ── Runtime dependency: tmux ────────────────────────────────────────────────
 #
-# agentop's session manager (`agentop session`, the cockpit's Sessions tab) is built on tmux —
-# there is no other backend (see packages/server/server/sessions/dependency-plan.ts, which the
-# already-installed binary uses to explain a MISSING tmux to someone who skipped this script or
+# agentop's session manager (`agentop session`, the cockpit's Sessions tab) is built entirely on
+# tmux — there is no other backend (see packages/server/server/sessions/dependency-plan.ts, which
+# the already-installed binary uses to explain a MISSING tmux to someone who skipped this script or
 # removed the package afterwards). Without it every session-related feature fails the moment it is
 # used, well after the install already reported success — a confusing place to first learn about a
 # missing dependency. So it is installed HERE, proactively, the same way any competent install
@@ -90,7 +125,7 @@ if ! command -v tmux >/dev/null 2>&1; then
 fi
 
 # ── Download ───────────────────────────────────────────────────────────────
-echo "Downloading ${BINARY} from ${RELEASE_URL} …"
+echo "Downloading ${BINARY_ASSET} from ${RELEASE_URL} …"
 mkdir -p "$INSTALL_DIR"
 curl -fsSL "$RELEASE_URL" -o "${INSTALL_DIR}/${BINARY}"
 chmod +x "${INSTALL_DIR}/${BINARY}"

--- a/packages/web/src/components/nav/SessionsAside.tsx
+++ b/packages/web/src/components/nav/SessionsAside.tsx
@@ -15,13 +15,19 @@
 import { useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react'
 import { useIsMobile } from '../../hooks/useIsMobile'
 import { useNavigate, useParams } from 'react-router-dom'
-import { Clock, Pin, PinOff, Plus, RotateCcw, Search, Send, X } from 'lucide-react'
+import { ChevronDown, ChevronRight, Clock, Pin, PinOff, Plus, RotateCcw, Search, Send, X } from 'lucide-react'
 import type { Filters } from '@agentistics/core'
 import {
   ACTIVE_STATES, filterSessions, sessionNotify,
-  type ControlSession, type SessionGroup,
+  type ControlSession, type SessionGroup, type SessionState,
 } from '@agentistics/tui/control/session-fleet'
-import { projectGroups, showsProjectHeadings } from '../../lib/fleetGroups'
+import { asideGroups, showsGroupHeadings } from '../../lib/fleetGroups'
+import {
+  collapseKey, readAsideGroupPrefs, writeAsideGroupPrefs,
+  type AsideBandId, type AsideCardColor, type AsideGroupBy,
+} from '../../lib/sessionsAsidePrefs'
+import { sessionCardStyle, STATE_COLOR } from '../../lib/sessionCardStyle'
+import { SessionsGroupMenu } from './SessionsGroupMenu'
 import { rowSelected } from '../../lib/fleetSelection'
 import { filterFleet, ignoredDimensions } from '../../lib/fleetFilter'
 import { NewSessionModal } from '../sessions/NewSessionModal'
@@ -112,32 +118,6 @@ export interface SessionsAsideProps {
   }) => Promise<{ ok: boolean; message: string; id?: string }>
 }
 
-/** The colour a state is said in. `running` is its own token, not `success`, which reads teal. */
-const STATE_COLOR: Record<string, string> = {
-  working: 'var(--accent-green)',
-  waiting: 'var(--anthropic-orange)',
-  'waiting-approval': 'var(--anthropic-orange)',
-  exited: 'var(--text-tertiary)',
-  lost: 'var(--text-tertiary)',
-  closed: 'var(--text-tertiary)',
-  unknown: 'var(--text-tertiary)',
-}
-
-/**
- * The wash behind a LIVE row, so its state is readable without reading the word.
- *
- * Only the two active states get one. A tint on every row is a list with no contrast left, and the
- * point of the wash is that the handful of rows doing something stand out from the history under
- * them. It is a WASH, never the row's whole background: the selected row's own highlight has to
- * stay distinguishable from it, or selection stops being visible on exactly the rows you select
- * most.
- */
-const STATE_WASH: Record<string, string> = {
-  working: 'color-mix(in srgb, #22c55e 10%, transparent)',
-  waiting: 'color-mix(in srgb, var(--anthropic-orange) 12%, transparent)',
-  'waiting-approval': 'color-mix(in srgb, var(--anthropic-orange) 12%, transparent)',
-}
-
 /**
  * What a pin is stored under.
  *
@@ -162,6 +142,31 @@ export function SessionsAside({
   const { sessionId } = useParams()
   const [query, setQuery] = useState('')
   const [creating, setCreating] = useState(false)
+  /**
+   * The aside's own arrangement — which dimension it sub-groups by, the manual order per
+   * dimension, which groups are folded, and how a card shows its status. Read once on mount, like
+   * `TaskList` seeds `readBoardPrefs()` — see `sessionsAsidePrefs.ts` for why this is
+   * `localStorage` and not `/api/preferences`.
+   */
+  const storedGroupPrefs = useMemo(readAsideGroupPrefs, [])
+  const [groupBy, setGroupByState] = useState<AsideGroupBy>(storedGroupPrefs.groupBy)
+  const setGroupBy = (v: AsideGroupBy) => { setGroupByState(v); writeAsideGroupPrefs({ groupBy: v }) }
+  const [groupOrder, setGroupOrderState] =
+    useState<Partial<Record<AsideGroupBy, string[]>>>(storedGroupPrefs.order)
+  const setGroupOrder = (by: AsideGroupBy, keys: string[]) => {
+    const next = { ...groupOrder, [by]: keys }
+    setGroupOrderState(next)
+    writeAsideGroupPrefs({ order: next })
+  }
+  const [foldedGroups, setFoldedGroupsState] = useState<Set<string>>(new Set(storedGroupPrefs.collapsed))
+  const toggleGroupFold = (key: string) => {
+    const next = new Set(foldedGroups)
+    next.has(key) ? next.delete(key) : next.add(key)
+    setFoldedGroupsState(next)
+    writeAsideGroupPrefs({ collapsed: [...next] })
+  }
+  const [cardColor, setCardColorState] = useState<AsideCardColor>(storedGroupPrefs.cardColor)
+  const setCardColor = (v: AsideCardColor) => { setCardColorState(v); writeAsideGroupPrefs({ cardColor: v }) }
   /** Which GROUP modal is open, if any. Both are the one picker — see `SessionPickModal`. */
   const [picking, setPicking] = useState<'reopen' | 'send' | null>(null)
   const [groupBusy, setGroupBusy] = useState(false)
@@ -307,22 +312,40 @@ export function SessionsAside({
    * is running, ranked by what needs you most, and everything else beneath it.
    *
    * `DEFAULT_ORDER` (`state`, via `sessionRank`) is the SAME ranking the terminal cockpit breaks
-   * ties on, so "sorted by status" means one thing in both places — `projectGroups` applies it
-   * inside each project band and orders the bands themselves by their most urgent member.
+   * ties on, so "sorted by status" means one thing in both places — `asideGroups` applies it
+   * inside each sub-group and orders the groups themselves by their most urgent member.
    *
-   * Inside a band the rows are grouped BY PROJECT (`lib/fleetGroups.ts`), and a band holding one
-   * project draws no heading at all — see that module's header. On a machine whose whole fleet sits
-   * in one checkout this therefore looks exactly as it did.
+   * Inside a band the rows are grouped by the reader's chosen dimension — project by default —
+   * via `lib/fleetGroups.ts`'s `asideGroups`, and a band holding one group draws no heading at
+   * all (see that module's header). On a machine whose whole fleet sits in one checkout this
+   * therefore looks exactly as it did.
    */
-  const bands = useMemo((): { label: string; groups: SessionGroup[] }[] => {
+  const bands = useMemo((): { id: AsideBandId; label: string; groups: SessionGroup[] }[] => {
     const rest = matched.filter(r => !pinned.has(pinKeyOf(r)))
+    const order = groupOrder[groupBy] ?? []
     return [
-      { label: pt ? 'Ativas' : 'Active', groups: projectGroups(rest.filter(r => active.has(r.state)), lang) },
+      {
+        id: 'active',
+        label: pt ? 'Ativas' : 'Active',
+        groups: asideGroups(rest.filter(r => active.has(r.state)), groupBy, lang, order),
+      },
       // Never computed while activeOnly is on — those rows are the ones the switch is withholding,
       // not a second list to render beside it.
-      { label: pt ? 'Inativas' : 'Inactive', groups: activeOnly ? [] : projectGroups(rest.filter(r => !active.has(r.state)), lang) },
+      {
+        id: 'inactive',
+        label: pt ? 'Inativas' : 'Inactive',
+        groups: activeOnly ? [] : asideGroups(rest.filter(r => !active.has(r.state)), groupBy, lang, order),
+      },
     ]
-  }, [matched, pinned, active, activeOnly, pt, lang])
+  }, [matched, pinned, active, activeOnly, pt, lang, groupBy, groupOrder])
+
+  /** The current dimension's groups, across both bands, deduped by key, in their effective
+   *  order — what the popover's reorder list edits. */
+  const groupOrderCandidates = useMemo(() => {
+    const seen = new Map<string, string>()
+    for (const b of bands) for (const g of b.groups) if (!seen.has(g.key)) seen.set(g.key, g.label)
+    return [...seen.entries()].map(([key, label]) => ({ key, label }))
+  }, [bands])
 
   const total = bands.reduce(
     (n, b) => n + b.groups.reduce((m, g) => m + g.sessions.length, 0),
@@ -422,6 +445,15 @@ export function SessionsAside({
             <Send size={14} />
           </button>
         )}
+        <SessionsGroupMenu
+          lang={lang}
+          groupBy={groupBy}
+          onGroupBy={setGroupBy}
+          groups={groupOrderCandidates}
+          onReorder={keys => setGroupOrder(groupBy, keys)}
+          cardColor={cardColor}
+          onCardColor={setCardColor}
+        />
       </div>
 
       {/*
@@ -586,6 +618,7 @@ export function SessionsAside({
                     onOpenMenu={(x, y, verbs) => openMenu(s, x, y, verbs)}
                     onFile={(x, y) => setLinking({ id: s.id, x, y })}
                     lang={lang}
+                    cardColor={cardColor}
                   />
                 </div>
               ))}
@@ -606,13 +639,17 @@ export function SessionsAside({
                 // The label is not unique — two dimensions can legitimately produce one word, and
                 // an empty band still holds its place in the order.
                 key={`${i}-${b.label}`}
-                label={b.label} groups={b.groups} pinned={pinned}
+                bandId={b.id}
+                label={b.label} groups={b.groups} groupBy={groupBy} pinned={pinned}
                 sessionId={sessionId} tap={tap} onPin={flip}
                 onOpen={s => (onOpenRow ? onOpenRow(s) : navigate(sessionPath(s.id)))}
                 {...(rowsById ? { rowsById } : {})}
                 onOpenMenu={openMenu}
                 onFile={(s, x, y) => setLinking({ id: s.id, x, y })}
                 lang={lang}
+                foldedGroups={foldedGroups}
+                onToggleGroupFold={toggleGroupFold}
+                cardColor={cardColor}
               />
             ))}
           </>
@@ -725,10 +762,16 @@ export function SessionsAside({
 
 /** One band of the two-way (active/inactive) split. Absent when it would be empty — an empty
  *  band with a heading and no rows under it is a label pretending to be information. */
-function SessionBand({ label, groups, pinned, sessionId, tap, onPin, onOpen, rowsById, onOpenMenu, onFile, lang }: {
+function SessionBand({
+  bandId, label, groups, groupBy, pinned, sessionId, tap, onPin, onOpen, rowsById, onOpenMenu,
+  onFile, lang, foldedGroups, onToggleGroupFold, cardColor,
+}: {
+  bandId: AsideBandId
   label: string
-  /** The band's rows, already grouped by project and ordered — see `lib/fleetGroups.ts`. */
+  /** The band's rows, already grouped by the chosen dimension and ordered — see
+   *  `lib/fleetGroups.ts`. */
   groups: readonly SessionGroup[]
+  groupBy: AsideGroupBy
   pinned: ReadonlySet<string>
   sessionId?: string
   tap?: number
@@ -739,12 +782,16 @@ function SessionBand({ label, groups, pinned, sessionId, tap, onPin, onOpen, row
   /** File a row under a delivery — the visible half of the gesture the menu also offers. */
   onFile: (session: ControlSession, x: number, y: number) => void
   lang: 'pt' | 'en'
+  /** Collapse keys already toggled shut — see `collapseKey` in `sessionsAsidePrefs.ts`. */
+  foldedGroups: ReadonlySet<string>
+  onToggleGroupFold: (key: string) => void
+  cardColor: AsideCardColor
 }) {
   const count = groups.reduce((n, g) => n + g.sessions.length, 0)
   if (count === 0) return null
-  // One project under this band names it twice — the band heading is directly above. See the rule
+  // One group under this band names it twice — the band heading is directly above. See the rule
   // in `fleetGroups.ts`; it is the same one the cockpit's cascade applies to its own root.
-  const headings = showsProjectHeadings(groups)
+  const headings = showsGroupHeadings(groups)
   return (
     <div style={{ marginBottom: 16 }}>
       <div style={{
@@ -755,36 +802,59 @@ function SessionBand({ label, groups, pinned, sessionId, tap, onPin, onOpen, row
         <span style={{ minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis' }}>{label}</span>
         <span style={{ marginLeft: 'auto', fontWeight: 600, opacity: 0.75 }}>{count}</span>
       </div>
-      {groups.map(g => (
-        <div key={g.key} style={{ display: 'flex', flexDirection: 'column', gap: 4, marginBottom: headings ? 10 : 0 }}>
-          {headings && (
-            // Deliberately quieter than the band above it — lowercase, no letter-spacing — so the
-            // two headings read as a hierarchy rather than as two lists.
-            <div style={{
-              display: 'flex', alignItems: 'baseline', gap: 6, padding: '4px 9px 2px',
-              fontSize: 11, fontWeight: 600, color: 'var(--text-tertiary)',
-            }}>
-              <span style={{ minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{g.label}</span>
-              <span style={{ marginLeft: 'auto', opacity: 0.7 }}>{g.sessions.length}</span>
-            </div>
-          )}
-          {g.sessions.map(s => (
-            <SessionRow
-              key={s.id}
-              session={s}
-              selected={rowSelected(s, sessionId)}
-              pinned={pinned.has(pinKeyOf(s))}
-              {...(tap ? { tap } : {})}
-              onPin={() => onPin(s)}
-              onOpen={() => onOpen(s)}
-              {...(rowsById?.get(s.id) ? { verbs: rowsById.get(s.id)!.verbs } : {})}
-              onOpenMenu={(x, y, verbs) => onOpenMenu(s, x, y, verbs)}
-              onFile={(x, y) => onFile(s, x, y)}
-              lang={lang}
-            />
-          ))}
-        </div>
-      ))}
+      {groups.map(g => {
+        const ck = collapseKey(bandId, groupBy, g.key)
+        const folded = foldedGroups.has(ck)
+        // A small dot naming the state's own color, ONLY when grouping by status — free, and
+        // consistent with the dot every row already wears. Not part of the card-color preference
+        // below, which is about the ROW cards, not this heading.
+        const dotColor = groupBy === 'status' ? STATE_COLOR[g.key as SessionState] : undefined
+        return (
+          <div key={g.key} style={{ display: 'flex', flexDirection: 'column', gap: 4, marginBottom: headings ? 10 : 0 }}>
+            {headings && (
+              // Deliberately quieter than the band above it — lowercase, no letter-spacing — so
+              // the two headings read as a hierarchy rather than as two lists. Clicking it folds
+              // this group, per your instruction — the click target is the heading itself.
+              <button
+                onClick={() => onToggleGroupFold(ck)}
+                style={{
+                  display: 'flex', alignItems: 'center', gap: 6, width: '100%', textAlign: 'left',
+                  background: 'none', border: 'none', cursor: 'pointer', fontFamily: 'inherit',
+                  padding: '4px 9px 2px', fontSize: 11, fontWeight: 600, color: 'var(--text-tertiary)',
+                  minHeight: tap,
+                }}
+              >
+                {folded ? <ChevronRight size={11} /> : <ChevronDown size={11} />}
+                {dotColor && (
+                  <span aria-hidden style={{
+                    width: 6, height: 6, borderRadius: 3, flexShrink: 0, background: dotColor,
+                  }} />
+                )}
+                <span style={{ minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                  {g.label}
+                </span>
+                <span style={{ marginLeft: 'auto', opacity: 0.7 }}>{g.sessions.length}</span>
+              </button>
+            )}
+            {(!headings || !folded) && g.sessions.map(s => (
+              <SessionRow
+                key={s.id}
+                session={s}
+                selected={rowSelected(s, sessionId)}
+                pinned={pinned.has(pinKeyOf(s))}
+                {...(tap ? { tap } : {})}
+                onPin={() => onPin(s)}
+                onOpen={() => onOpen(s)}
+                {...(rowsById?.get(s.id) ? { verbs: rowsById.get(s.id)!.verbs } : {})}
+                onOpenMenu={(x, y, verbs) => onOpenMenu(s, x, y, verbs)}
+                onFile={(x, y) => onFile(s, x, y)}
+                lang={lang}
+                cardColor={cardColor}
+              />
+            ))}
+          </div>
+        )
+      })}
     </div>
   )
 }
@@ -840,7 +910,7 @@ function EmptyReason({
 }
 
 
-function SessionRow({ session, selected, pinned, tap, onPin, onOpen, onMoveBy, verbs, onOpenMenu, onFile, lang }: {
+function SessionRow({ session, selected, pinned, tap, onPin, onOpen, onMoveBy, verbs, onOpenMenu, onFile, lang, cardColor }: {
   session: ControlSession; selected: boolean
   /** Minimum row height on mobile — 44px, and undefined on desktop. */
   tap?: number
@@ -856,8 +926,11 @@ function SessionRow({ session, selected, pinned, tap, onPin, onOpen, onMoveBy, v
   /** File this row under a delivery — the visible half of the gesture the menu also offers. */
   onFile?: (x: number, y: number) => void
   lang?: 'pt' | 'en'
+  /** How this card shows its state — see `sessionCardStyle.ts`. */
+  cardColor: AsideCardColor
 }) {
   const wants = sessionNotify(session)
+  const cardStyle = sessionCardStyle(session.state, cardColor, selected)
   const color = STATE_COLOR[session.state] ?? 'var(--text-tertiary)'
   const longPress = useRef<ReturnType<typeof setTimeout> | null>(null)
   /** Where the last pointer event landed, so a picker opened from inside the row is anchored. */
@@ -877,16 +950,11 @@ function SessionRow({ session, selected, pinned, tap, onPin, onOpen, onMoveBy, v
         // Selection is a fact about where the READER is, so it uses the neutral surface tokens —
         // a lifted background and a full-height accent-free edge — and leaves every colour on this
         // list to mean exactly one thing about the SESSION.
-        background: selected ? 'var(--bg-elevated)' : (STATE_WASH[session.state] ?? 'transparent'),
+        background: cardStyle.background,
         // Two different edges, and they never collide: the STATE edge is the left rule a live row
-        // carries, and SELECTION replaces it with a brighter, full one plus an outline. The wash
-        // alone is faint by design, and an edge survives a light theme and a colour-blind reader
-        // where a 10% tint does not.
-        boxShadow: selected
-          ? 'inset 3px 0 0 var(--text-primary), inset 0 0 0 1px var(--border)'
-          : (STATE_WASH[session.state]
-            ? `inset 2px 0 0 ${STATE_COLOR[session.state] ?? 'transparent'}`
-            : undefined),
+        // carries in `wash`/`stripe` mode, and SELECTION replaces it with a brighter, full one
+        // plus an outline — `sessionCardStyle` already resolves that precedence.
+        boxShadow: cardStyle.edge,
         color: selected ? 'var(--text-primary)' : 'var(--text-secondary)',
         cursor: 'pointer', fontFamily: 'inherit', minWidth: 0,
         transition: 'background 0.15s',
@@ -894,7 +962,7 @@ function SessionRow({ session, selected, pinned, tap, onPin, onOpen, onMoveBy, v
       onPointerDown={e => { lastPoint.current = { x: e.clientX, y: e.clientY } }}
       onMouseEnter={e => { if (!selected) e.currentTarget.style.background = 'var(--bg-elevated)' }}
       onMouseLeave={e => {
-        if (!selected) e.currentTarget.style.background = STATE_WASH[session.state] ?? 'transparent'
+        if (!selected) e.currentTarget.style.background = cardStyle.background
       }}
       onKeyDown={e => {
         // alt+arrows, so the plain arrows keep whatever the browser and the list do with them. A
@@ -939,6 +1007,7 @@ function SessionRow({ session, selected, pinned, tap, onPin, onOpen, onMoveBy, v
         session={session}
         selected={selected}
         {...(lang ? { lang } : {})}
+        {...(cardStyle.stateTextColor ? { metaColor: cardStyle.stateTextColor } : {})}
         {...(onFile
           // Anchored where the click landed, like the menu's own picker — the gesture stays where
           // the reader's eye already is.

--- a/packages/web/src/components/nav/SessionsGroupMenu.tsx
+++ b/packages/web/src/components/nav/SessionsGroupMenu.tsx
@@ -1,0 +1,222 @@
+/**
+ * SessionsGroupMenu — the aside's one discreet control for how its list is arranged.
+ *
+ * Three questions, one popover, because they are all "how does this list organize and look":
+ * which dimension the sessions are sub-grouped by, in what order those groups appear, and how a
+ * session's own card shows its status color. Reordering lives inside the SAME item that picks the
+ * grouping — the reorder list only makes sense once a dimension is chosen, and it always shows
+ * exactly what THAT dimension is currently drawing.
+ *
+ * Follows the settings screens' popover contract — `position: fixed` in a portal, measured from
+ * the trigger, clamped to the viewport, closing on scroll — the same contract `PickerMenu` and
+ * `BoardArrange`'s panels already keep, because a menu that opens inside a scrolling list gets
+ * clipped by it.
+ */
+
+import { useEffect, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
+import { ChevronDown, ChevronUp, GripVertical, SlidersHorizontal } from 'lucide-react'
+import { useIsMobile } from '../../hooks/useIsMobile'
+import {
+  ASIDE_CARD_COLOR_VALUES, ASIDE_GROUP_BY_VALUES,
+  type AsideCardColor, type AsideGroupBy,
+} from '../../lib/sessionsAsidePrefs'
+
+const GROUP_BY_LABEL: Record<AsideGroupBy, { en: string; pt: string }> = {
+  project: { en: 'Project', pt: 'Projeto' },
+  task: { en: 'Task', pt: 'Tarefa' },
+  status: { en: 'Status', pt: 'Status' },
+}
+
+const CARD_COLOR_LABEL: Record<AsideCardColor, { en: string; pt: string }> = {
+  wash: { en: 'Background follows status', pt: 'Fundo acompanha o status' },
+  neutral: { en: 'Neutral background, colored text', pt: 'Fundo neutro, texto colorido' },
+  stripe: { en: 'Colored left stripe', pt: 'Barra lateral colorida' },
+}
+
+export interface SessionsGroupMenuProps {
+  lang: 'pt' | 'en'
+  groupBy: AsideGroupBy
+  onGroupBy: (v: AsideGroupBy) => void
+  /** The current dimension's groups, across both bands, deduped by key, in their EFFECTIVE order
+   *  (manual order already applied) — what the reorder list edits and shows. */
+  groups: readonly { key: string; label: string }[]
+  /** The full new key order, every time a drag or a step button moves one. */
+  onReorder: (next: string[]) => void
+  cardColor: AsideCardColor
+  onCardColor: (v: AsideCardColor) => void
+}
+
+export function SessionsGroupMenu(p: SessionsGroupMenuProps) {
+  const pt = p.lang === 'pt'
+  const isMobile = useIsMobile()
+  const tap = isMobile ? 44 : undefined
+  const [open, setOpen] = useState(false)
+  const [at, setAt] = useState<{ left: number; top: number } | null>(null)
+  const [drag, setDrag] = useState<string | null>(null)
+  const trigger = useRef<HTMLButtonElement>(null)
+  const panel = useRef<HTMLDivElement>(null)
+  const width = 240
+
+  useEffect(() => {
+    if (!open) return
+    // Capture-phase on `window` so scrolling the PAGE (or any ancestor) closes a panel that can no
+    // longer follow its trigger — but that also fires when the panel's OWN option list scrolls
+    // (e.g. reaching the Card Color section past the fold on a fleet with many groups), which
+    // closed the menu before that scroll could ever land. Only close for a scroll whose target is
+    // outside this panel's own DOM subtree — same fix as PickerMenu's, in settings/primitives.tsx.
+    const onScroll = (e: Event) => {
+      if (panel.current && !panel.current.contains(e.target as Node)) setOpen(false)
+    }
+    const close = () => setOpen(false)
+    window.addEventListener('scroll', onScroll, true)
+    window.addEventListener('resize', close)
+    return () => {
+      window.removeEventListener('scroll', onScroll, true)
+      window.removeEventListener('resize', close)
+    }
+  }, [open])
+
+  const move = (from: string, to: string) => {
+    if (from === to) return
+    const keys = p.groups.map(g => g.key)
+    const without = keys.filter(k => k !== from)
+    const at_ = without.indexOf(to)
+    if (at_ === -1) return
+    without.splice(at_, 0, from)
+    p.onReorder(without)
+  }
+
+  const step = (key: string, by: 1 | -1) => {
+    const keys = p.groups.map(g => g.key)
+    const from = keys.indexOf(key)
+    const to = from + by
+    if (from === -1 || to < 0 || to >= keys.length) return
+    const next = [...keys]
+    next.splice(to, 0, ...next.splice(from, 1))
+    p.onReorder(next)
+  }
+
+  const rowStyle = (on: boolean): React.CSSProperties => ({
+    display: 'flex', alignItems: 'center', gap: 8, cursor: 'pointer', textAlign: 'left',
+    width: '100%', padding: '6px 8px', borderRadius: 6, fontSize: 12, fontFamily: 'inherit',
+    minHeight: tap,
+    background: on ? 'var(--anthropic-orange-dim)' : 'transparent',
+    color: on ? 'var(--text-primary)' : 'var(--text-secondary)',
+    border: `1px solid ${on ? 'var(--anthropic-orange)' : 'transparent'}`,
+  })
+
+  const sectionLabel: React.CSSProperties = {
+    fontSize: 10.5, fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.05em',
+    color: 'var(--text-tertiary)', padding: '6px 8px 3px',
+  }
+
+  return (
+    <>
+      <button
+        ref={trigger}
+        onClick={() => {
+          if (open) { setOpen(false); return }
+          const r = trigger.current?.getBoundingClientRect()
+          if (!r) return
+          setAt({ left: Math.min(r.left, window.innerWidth - width - 12), top: r.bottom + 6 })
+          setOpen(true)
+        }}
+        aria-label={pt ? 'Organizar lista' : 'Arrange list'}
+        title={pt ? 'Organizar lista' : 'Arrange list'}
+        style={{
+          display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0,
+          width: tap ?? 34, padding: 0, borderRadius: 9, cursor: 'pointer',
+          border: '1px solid var(--border-subtle)', background: 'var(--bg-elevated)',
+          color: open ? 'var(--anthropic-orange)' : 'var(--text-tertiary)', fontFamily: 'inherit',
+        }}
+      >
+        <SlidersHorizontal size={14} />
+      </button>
+
+      {open && at && createPortal(
+        <>
+          <div onClick={() => setOpen(false)} style={{ position: 'fixed', inset: 0, zIndex: 1199 }} />
+          <div ref={panel} style={{
+            position: 'fixed', left: at.left, top: at.top, width, zIndex: 1200,
+            borderRadius: 12, border: '1px solid var(--border-subtle)',
+            background: 'var(--bg-elevated)', padding: 8, display: 'grid', gap: 2,
+            boxShadow: 'var(--ag-shadow-menu)', maxHeight: 420, overflowY: 'auto',
+          }}>
+            <div style={sectionLabel}>{pt ? 'Agrupamento por' : 'Group by'}</div>
+            {ASIDE_GROUP_BY_VALUES.map(v => (
+              <button key={v} onClick={() => p.onGroupBy(v)} style={rowStyle(p.groupBy === v)}>
+                {GROUP_BY_LABEL[v][p.lang]}
+              </button>
+            ))}
+
+            {p.groups.length > 1 && (
+              <>
+                <div style={sectionLabel}>{pt ? 'Ordem dos grupos' : 'Group order'}</div>
+                {p.groups.map((g, i) => (
+                  <div
+                    key={g.key}
+                    draggable
+                    onDragStart={() => setDrag(g.key)}
+                    onDragEnd={() => setDrag(null)}
+                    onDragOver={e => e.preventDefault()}
+                    onDrop={e => { e.preventDefault(); if (drag) move(drag, g.key); setDrag(null) }}
+                    style={{
+                      display: 'flex', alignItems: 'center', gap: 8, padding: '5px 8px',
+                      borderRadius: 6, fontSize: 12, color: 'var(--text-secondary)',
+                      minHeight: tap,
+                      opacity: drag === g.key ? 0.45 : 1,
+                    }}
+                  >
+                    <GripVertical
+                      size={12}
+                      style={{ flexShrink: 0, color: 'var(--text-tertiary)', cursor: 'grab' }}
+                    />
+                    <span style={{
+                      flex: 1, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis',
+                      whiteSpace: 'nowrap',
+                    }}>{g.label}</span>
+                    <button
+                      onClick={() => step(g.key, -1)} disabled={i === 0}
+                      aria-label={pt ? 'Mover para cima' : 'Move up'}
+                      style={{
+                        background: 'none', border: 'none', padding: 0, width: tap ?? 18, height: tap ?? 18,
+                        display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0,
+                        color: i === 0 ? 'var(--border)' : 'var(--text-tertiary)',
+                        cursor: i === 0 ? 'default' : 'pointer',
+                      }}
+                    ><ChevronUp size={13} /></button>
+                    <button
+                      onClick={() => step(g.key, 1)} disabled={i === p.groups.length - 1}
+                      aria-label={pt ? 'Mover para baixo' : 'Move down'}
+                      style={{
+                        background: 'none', border: 'none', padding: 0, width: tap ?? 18, height: tap ?? 18,
+                        display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0,
+                        color: i === p.groups.length - 1 ? 'var(--border)' : 'var(--text-tertiary)',
+                        cursor: i === p.groups.length - 1 ? 'default' : 'pointer',
+                      }}
+                    ><ChevronDown size={13} /></button>
+                  </div>
+                ))}
+                <button
+                  onClick={() => p.onReorder([])}
+                  style={rowStyle(false)}
+                >
+                  {pt ? 'Automático' : 'Automatic'}
+                </button>
+              </>
+            )}
+
+            <div style={sectionLabel}>{pt ? 'Cor dos cards' : 'Card color'}</div>
+            {ASIDE_CARD_COLOR_VALUES.map(v => (
+              <button key={v} onClick={() => p.onCardColor(v)} style={rowStyle(p.cardColor === v)}>
+                {CARD_COLOR_LABEL[v][p.lang]}
+              </button>
+            ))}
+          </div>
+        </>,
+        document.body,
+      )}
+    </>
+  )
+}

--- a/packages/web/src/components/nav/SessionsRail.tsx
+++ b/packages/web/src/components/nav/SessionsRail.tsx
@@ -28,7 +28,7 @@ import { sessionPath } from '../../lib/sessionRoute'
  *
  * Only the ACTIVE states are marked. A dot on every row is a rail with no contrast left, and the
  * point of the marker is that the handful of sessions doing something stand out from the history
- * under them — the same reasoning `STATE_WASH` records for the open list.
+ * under them — the same reasoning `sessionCardStyle.ts` records for the open list.
  */
 function stateDot(state: string): string | null {
   if (state === 'waiting' || state === 'waiting-approval') return 'var(--anthropic-orange)'

--- a/packages/web/src/components/sessions/SessionFacts.tsx
+++ b/packages/web/src/components/sessions/SessionFacts.tsx
@@ -36,9 +36,17 @@ export interface SessionFactsProps {
    */
   onFile?: () => void
   lang?: 'pt' | 'en'
+  /**
+   * Overrides the meta line's state-word color only — set by the Sessions aside's "neutral
+   * background" card-color mode. The rest of the meta line (harness, model, delivery chip) keeps
+   * its own colors regardless. Absent keeps the current wants-driven color on the state word
+   * (orange when the session wants a person, tertiary otherwise), which is what the collapsed
+   * rail's tooltip still gets: this is a Sessions-aside preference, not a fact about the row itself.
+   */
+  metaColor?: string
 }
 
-export function SessionFacts({ session, selected = false, onFile, lang = 'en' }: SessionFactsProps) {
+export function SessionFacts({ session, selected = false, onFile, lang = 'en', metaColor }: SessionFactsProps) {
   const wants = sessionNotify(session)
   return (
     <span style={{ minWidth: 0, flex: 1, display: 'flex', flexDirection: 'column', gap: 3 }}>
@@ -52,7 +60,7 @@ export function SessionFacts({ session, selected = false, onFile, lang = 'en' }:
         display: 'flex', alignItems: 'center', gap: 5, minWidth: 0,
         fontSize: 10.5, color: wants ? 'var(--anthropic-orange)' : 'var(--text-tertiary)',
       }}>
-        <span style={{ flexShrink: 0 }}>{session.stateLabel}</span>
+        <span style={{ flexShrink: 0, color: metaColor }}>{session.stateLabel}</span>
         <span style={{ opacity: 0.4, flexShrink: 0 }}>·</span>
         <span style={{
           color: (HARNESS_COLORS as Record<string, string>)[session.harness] ?? 'var(--text-tertiary)',

--- a/packages/web/src/lib/fleetGroups.test.ts
+++ b/packages/web/src/lib/fleetGroups.test.ts
@@ -1,6 +1,6 @@
 import { expect, test, describe } from 'bun:test'
 import { GONE_PROJECT_KEY, type ControlSession } from '@agentistics/tui/control/session-fleet'
-import { projectGroups, showsProjectHeadings } from './fleetGroups'
+import { applyManualOrder, asideGroups, showsGroupHeadings } from './fleetGroups'
 
 function row(o: Partial<ControlSession> & { id: string }): ControlSession {
   return {
@@ -11,37 +11,37 @@ function row(o: Partial<ControlSession> & { id: string }): ControlSession {
   } as ControlSession
 }
 
-describe('projectGroups', () => {
+describe('asideGroups — project', () => {
   test('one band per project, named by the project', () => {
-    const out = projectGroups([
+    const out = asideGroups([
       row({ id: 'a', project: 'agentistics' }),
       row({ id: 'b', project: 'aipe' }),
       row({ id: 'c', project: 'agentistics' }),
-    ], 'en')
+    ], 'project', 'en')
     expect(out.map(g => g.label).sort()).toEqual(['agentistics', 'aipe'])
     expect(out.find(g => g.label === 'agentistics')!.sessions).toHaveLength(2)
   })
 
   test('the band holding the most urgent session comes first', () => {
-    const out = projectGroups([
+    const out = asideGroups([
       row({ id: 'a', project: 'quiet', state: 'working' }),
       row({ id: 'b', project: 'blocked', state: 'waiting-approval' }),
-    ], 'en')
+    ], 'project', 'en')
     expect(out[0]!.label).toBe('blocked')
   })
 
   test('a session with no project gets a band said in WORDS, never a blank heading', () => {
-    const en = projectGroups([row({ id: 'a', project: '' })], 'en')
-    const pt = projectGroups([row({ id: 'a', project: '' })], 'pt')
+    const en = asideGroups([row({ id: 'a', project: '' })], 'project', 'en')
+    const pt = asideGroups([row({ id: 'a', project: '' })], 'project', 'pt')
     expect(en[0]!.label).toBe('No project')
     expect(pt[0]!.label).toBe('Sem projeto')
   })
 
   test('a directory that is GONE is its own band, not the no-project one', () => {
-    const out = projectGroups([
+    const out = asideGroups([
       row({ id: 'a', project: 'x', dirGone: 'the folder is gone' }),
       row({ id: 'b', project: '' }),
-    ], 'en')
+    ], 'project', 'en')
     const labels = out.map(g => g.label)
     expect(labels).toContain('Folder is gone')
     expect(labels).toContain('No project')
@@ -49,41 +49,125 @@ describe('projectGroups', () => {
   })
 
   test('an empty fleet yields no bands', () => {
-    expect(projectGroups([], 'en')).toEqual([])
-  })
-})
-
-describe('showsProjectHeadings', () => {
-  // The rule the whole feature turns on: a heading naming the ONLY project in the band repeats what
-  // the band above it already said and costs a row — the same reason the cascade drops its root when
-  // the grouping is already the project.
-  test('one project draws no heading', () => {
-    expect(showsProjectHeadings(projectGroups([
-      row({ id: 'a', project: 'agentistics' }),
-      row({ id: 'b', project: 'agentistics' }),
-    ], 'en'))).toBe(false)
+    expect(asideGroups([], 'project', 'en')).toEqual([])
   })
 
-  test('two projects draw headings', () => {
-    expect(showsProjectHeadings(projectGroups([
-      row({ id: 'a', project: 'agentistics' }),
-      row({ id: 'b', project: 'aipe' }),
-    ], 'en'))).toBe(true)
-  })
-
-  test('nothing at all draws no heading', () => {
-    expect(showsProjectHeadings([])).toBe(false)
-  })
-})
-
-describe("the grouping key is the TUI's own", () => {
   test('projectGroup outranks the directory name, and GONE has its own key', () => {
-    const out = projectGroups([
+    const out = asideGroups([
       row({ id: 'a', project: 'worktree-x', projectGroup: 'agentistics' }),
       row({ id: 'b', project: 'worktree-y', projectGroup: 'agentistics' }),
-    ], 'en')
+    ], 'project', 'en')
     expect(out).toHaveLength(1)
     expect(out[0]!.label).toBe('agentistics')
     expect(out[0]!.key).not.toBe(GONE_PROJECT_KEY)
+  })
+})
+
+describe('asideGroups — task', () => {
+  test('one band per delivery, and an unfiled session gets the same word the row chip uses', () => {
+    const out = asideGroups([
+      row({ id: 'a', task: 'ALM board' }),
+      row({ id: 'b' }),
+    ], 'task', 'en')
+    expect(out.map(g => g.label).sort()).toEqual(['ALM board', 'No delivery'])
+  })
+
+  test('PT names the same unfiled bucket "sem entrega"', () => {
+    const out = asideGroups([row({ id: 'a' })], 'task', 'pt')
+    expect(out[0]!.label).toBe('Sem entrega')
+  })
+})
+
+describe('asideGroups — status', () => {
+  test('seven raw states are seven distinct groups, never collapsed', () => {
+    const out = asideGroups([
+      row({ id: 'a', state: 'exited' }),
+      row({ id: 'b', state: 'lost' }),
+      row({ id: 'c', state: 'closed' }),
+    ], 'status', 'en')
+    expect(out).toHaveLength(3)
+    expect(out.map(g => g.label).sort()).toEqual(['Closed', 'Finished', 'Lost'])
+  })
+
+  test('the most urgent state leads', () => {
+    const out = asideGroups([
+      row({ id: 'a', state: 'working' }),
+      row({ id: 'b', state: 'waiting-approval' }),
+    ], 'status', 'en')
+    expect(out[0]!.label).toBe('Needs approval')
+  })
+
+  test('PT labels match the vocabulary used elsewhere in the product', () => {
+    const out = asideGroups([row({ id: 'a', state: 'waiting' })], 'status', 'pt')
+    expect(out[0]!.label).toBe('Precisa de você')
+  })
+
+  test('a session is counted once, under its OWN state — no state absorbs another', () => {
+    const out = asideGroups([
+      row({ id: 'a', state: 'exited' }),
+      row({ id: 'b', state: 'exited' }),
+      row({ id: 'c', state: 'lost' }),
+    ], 'status', 'en')
+    expect(out.find(g => g.label === 'Finished')!.sessions).toHaveLength(2)
+    expect(out.find(g => g.label === 'Lost')!.sessions).toHaveLength(1)
+  })
+})
+
+describe('showsGroupHeadings', () => {
+  test('one group draws no heading', () => {
+    expect(showsGroupHeadings(asideGroups([
+      row({ id: 'a', project: 'agentistics' }),
+      row({ id: 'b', project: 'agentistics' }),
+    ], 'project', 'en'))).toBe(false)
+  })
+
+  test('two groups draw headings', () => {
+    expect(showsGroupHeadings(asideGroups([
+      row({ id: 'a', project: 'agentistics' }),
+      row({ id: 'b', project: 'aipe' }),
+    ], 'project', 'en'))).toBe(true)
+  })
+
+  test('nothing at all draws no heading', () => {
+    expect(showsGroupHeadings([])).toBe(false)
+  })
+})
+
+describe('applyManualOrder', () => {
+  test('empty order leaves the automatic order untouched', () => {
+    const groups = asideGroups([
+      row({ id: 'a', project: 'quiet', state: 'working' }),
+      row({ id: 'b', project: 'blocked', state: 'waiting-approval' }),
+    ], 'project', 'en')
+    expect(applyManualOrder(groups, [])).toEqual(groups)
+  })
+
+  test('known keys come first, in the given order, overriding the automatic one', () => {
+    const groups = asideGroups([
+      row({ id: 'a', project: 'quiet', state: 'working' }),
+      row({ id: 'b', project: 'blocked', state: 'waiting-approval' }),
+    ], 'project', 'en')
+    // Automatic order puts "blocked" first (waiting-approval outranks working) — manual order
+    // overrides it.
+    const out = applyManualOrder(groups, ['quiet', 'blocked'])
+    expect(out.map(g => g.key)).toEqual(['quiet', 'blocked'])
+  })
+
+  test('a key with no group is simply absent — nothing to reconcile', () => {
+    const groups = asideGroups([row({ id: 'a', project: 'quiet' })], 'project', 'en')
+    const out = applyManualOrder(groups, ['gone-project', 'quiet'])
+    expect(out.map(g => g.key)).toEqual(['quiet'])
+  })
+
+  test('a group not yet in the manual order is appended after every placed one', () => {
+    const groups = asideGroups([
+      row({ id: 'a', project: 'x' }),
+      row({ id: 'b', project: 'y' }),
+      row({ id: 'c', project: 'z' }),
+    ], 'project', 'en')
+    // Only "z" has been manually placed — "x" and "y" fall in after it.
+    const out = applyManualOrder(groups, ['z'])
+    expect(out[0]!.key).toBe('z')
+    expect(new Set(out.map(g => g.key))).toEqual(new Set(['x', 'y', 'z']))
   })
 })

--- a/packages/web/src/lib/fleetGroups.ts
+++ b/packages/web/src/lib/fleetGroups.ts
@@ -1,39 +1,40 @@
 /**
- * fleetGroups.ts — which PROJECT band a fleet row belongs to, for the sidebar — PURE.
+ * fleetGroups.ts — which sub-group a fleet row belongs to, for the sessions aside — PURE.
  *
- * It arranges nothing itself. The bucketing, the band ordering and the ordering inside each band
- * all come from `groupSessions` in `@agentistics/tui/control/session-fleet` — the very function the
- * terminal cockpit and `agentop session ls` resolve their bands with. A second implementation of
- * "which band does this row belong to" is exactly the defect that module exists to remove, and the
- * project key is the one most worth not re-deriving: it is `projectGroup || (dirGone ? gone :
- * project)`, so a worktree files under its main checkout and a directory that no longer exists gets
- * its own bucket instead of being named after a path that resolves to nothing.
+ * Project and Task reuse `groupSessions` in `@agentistics/tui/control/session-fleet` — the very
+ * function the terminal cockpit and `agentop session ls` resolve their bands with. A second
+ * implementation of "which band does this row belong to" is exactly the defect that module exists
+ * to remove.
  *
- * What lives here is the WORDS, which that module deliberately owns none of, and one rule.
+ * Status is the one exception, and it is web-only on purpose. The shared `status` dimension in
+ * `session-dimensions.ts` deliberately collapses `exited`/`lost`/`closed` into one `Off` bucket —
+ * the "3 desligadas, wtf" fix, a decision made for the terminal's filter menu and tested there.
+ * This aside groups by the raw `session.state` instead (seven distinct buckets), because that is
+ * a different, purely visual arrangement question, and reusing the collapsed dimension would
+ * either mislabel a merged bucket or reopen a decision this feature has no reason to touch.
  *
- * The rule: a band holding ONE project draws no heading (`showsProjectHeadings`). A heading naming
- * the only project under it repeats what the band above already said and costs a row — the same
- * reason the cockpit's cascade drops its root when the grouping is already the project. On a
- * machine whose whole fleet sits in one checkout this feature is therefore INVISIBLE, and that is
- * the correct amount of screen for it to take.
+ * What lives here besides the grouping itself: the WORDS (this module deliberately owns none of
+ * `groupSessions`'s own vocabulary, but Status needs its own, since it does not go through that
+ * function), the rule that a band holding one group draws no heading, and the manual reordering a
+ * person can apply on top of the automatic (most-urgent-first) order.
  */
 
 import {
-  DEFAULT_ORDER, dimensionWordBook, groupSessions,
-  type ControlSession, type DimensionWordBook, type SessionGroup,
+  DEFAULT_ORDER, dimensionWordBook, groupSessions, sessionRank, sortSessions,
+  type ControlSession, type DimensionWordBook, type SessionGroup, type SessionState,
 } from '@agentistics/tui/control/session-fleet'
+import type { AsideGroupBy } from './sessionsAsidePrefs'
 
 type Lang = 'pt' | 'en'
 
 /**
- * The word book, built for the PROJECT dimension only.
+ * The word book, built for Project and Task — the two dimensions that still go through
+ * `groupSessions`. Status never reads this: see `STATUS_GROUP_WORDS` below.
  *
  * `DimensionWordBook` is a `Record` over every dimension because `groupSessions` takes the whole
- * book, and the sidebar groups by exactly one of them. The other entries carry their real names so
- * nothing reads as a placeholder, but they have no `values` map: a `status` band drawn from this
- * book would be headed by the raw state key. That is a limit, not an oversight — a surface that
- * groups this fleet by another dimension has to supply that dimension's words, exactly as the
- * cockpit's `sessionWordBook` does, and must not reach for this one.
+ * book; this aside only ever asks for one of them at a time. The other entries carry their real
+ * names so nothing reads as a placeholder, but only `project` needs a `values` map — a project,
+ * repo, model or task key IS its name.
  */
 function wordBook(lang: Lang): DimensionWordBook {
   const pt = lang === 'pt'
@@ -48,8 +49,8 @@ function wordBook(lang: Lang): DimensionWordBook {
       task: pt ? 'Tarefa' : 'Task',
       marked: pt ? 'Marcadas' : 'Marked',
     },
-    // Each absence is its OWN sentence: "the folder was never recorded" and "no model recorded" are
-    // different facts, and one blank heading shared between them is how a list starts lying.
+    // Each absence is its OWN sentence: "the folder was never recorded" and "no delivery filed"
+    // are different facts, and one blank heading shared between them is how a list starts lying.
     unfiled: {
       day: pt ? 'Sem data' : 'No date',
       status: pt ? 'Sem estado' : 'No status',
@@ -57,7 +58,10 @@ function wordBook(lang: Lang): DimensionWordBook {
       model: pt ? 'Sem modelo' : 'No model',
       project: pt ? 'Sem projeto' : 'No project',
       repo: pt ? 'Fora de um repositório' : 'Outside a repository',
-      task: pt ? 'Sem tarefa' : 'No task',
+      // The same word `SessionFacts.tsx` already prints on a row's own delivery chip — a group
+      // heading calling this "no task" while the row underneath it says "no delivery" is one
+      // feature disagreeing with itself about its own vocabulary.
+      task: pt ? 'Sem entrega' : 'No delivery',
       marked: pt ? 'Não marcadas' : 'Not marked',
     },
     states: {},
@@ -66,18 +70,81 @@ function wordBook(lang: Lang): DimensionWordBook {
   })
 }
 
-/**
- * The fleet as project bands — most urgent band first, and the rows inside each in `DEFAULT_ORDER`.
- *
- * `DEFAULT_ORDER` is the same ranking the cockpit breaks ties on, so a session that needs a person
- * is at the top of its band here for the same reason it is there in the terminal.
- */
-export function projectGroups(rows: readonly ControlSession[], lang: Lang): SessionGroup[] {
-  if (rows.length === 0) return []
-  return groupSessions(rows, 'project', wordBook(lang), [], DEFAULT_ORDER)
+/** The seven raw states, in the words this aside heads a Status group with. */
+const STATUS_GROUP_WORDS: Record<SessionState, { en: string; pt: string }> = {
+  working: { en: 'Working', pt: 'Trabalhando' },
+  waiting: { en: 'Needs you', pt: 'Precisa de você' },
+  'waiting-approval': { en: 'Needs approval', pt: 'Precisa de aprovação' },
+  exited: { en: 'Finished', pt: 'Encerradas' },
+  lost: { en: 'Lost', pt: 'Desconectadas' },
+  closed: { en: 'Closed', pt: 'Fechadas' },
+  unknown: { en: 'External', pt: 'Externas' },
 }
 
-/** Whether these bands are worth heading at all — see the module header for the rule. */
-export function showsProjectHeadings(groups: readonly SessionGroup[]): boolean {
+/**
+ * One group per raw state — never through `bucketKey`/`groupSessions`, and never collapsed.
+ *
+ * Ordered the same way `groupSessions` orders every other dimension: by each group's most urgent
+ * member, ties broken by label.
+ */
+function statusGroups(rows: readonly ControlSession[], lang: Lang): SessionGroup[] {
+  const groups = new Map<SessionState, SessionGroup>()
+  for (const s of rows) {
+    const found = groups.get(s.state)
+    if (found) found.sessions.push(s)
+    else groups.set(s.state, { key: s.state, label: STATUS_GROUP_WORDS[s.state][lang], sessions: [s] })
+  }
+  return [...groups.values()]
+    .map(g => ({ ...g, sessions: sortSessions(g.sessions, DEFAULT_ORDER) }))
+    .sort((a, b) => {
+      const byRank = sessionRank(a.sessions[0]!) - sessionRank(b.sessions[0]!)
+      return byRank !== 0 ? byRank : a.label.localeCompare(b.label)
+    })
+}
+
+/**
+ * Reorder groups by a person's manual choice — PURE.
+ *
+ * A key in `order` that no longer has a group (a deleted task, a status nobody has right now)
+ * simply is not in `groups` and drops out on its own — nothing to reconcile. A group not yet in
+ * `order` (a brand new task, a status nobody has seen before) is appended after every
+ * manually-placed group, in whatever order the automatic urgency-first sort already gave it — so
+ * a new group is never lost, only unpositioned until somebody moves it.
+ */
+export function applyManualOrder(
+  groups: readonly SessionGroup[],
+  order: readonly string[],
+): SessionGroup[] {
+  if (order.length === 0) return [...groups]
+  const byKey = new Map(groups.map(g => [g.key, g]))
+  const known = order
+    .map(k => byKey.get(k))
+    .filter((g): g is SessionGroup => g !== undefined)
+  const knownKeys = new Set(known.map(g => g.key))
+  const rest = groups.filter(g => !knownKeys.has(g.key))
+  return [...known, ...rest]
+}
+
+/**
+ * The fleet as groups of the chosen dimension — most urgent group first, and the rows inside each
+ * in `DEFAULT_ORDER` — with the person's manual order applied on top.
+ */
+export function asideGroups(
+  rows: readonly ControlSession[],
+  by: AsideGroupBy,
+  lang: Lang,
+  order: readonly string[] = [],
+): SessionGroup[] {
+  if (rows.length === 0) return []
+  const raw = by === 'status'
+    ? statusGroups(rows, lang)
+    : groupSessions(rows, by, wordBook(lang), [], DEFAULT_ORDER)
+  return applyManualOrder(raw, order)
+}
+
+/** Whether these bands are worth heading at all — a band holding ONE group repeats what the band
+ *  above it already said and costs a row, the same reason the cockpit's cascade drops its root
+ *  when the grouping is already the project. */
+export function showsGroupHeadings(groups: readonly SessionGroup[]): boolean {
   return groups.length > 1
 }

--- a/packages/web/src/lib/sessionCardStyle.test.ts
+++ b/packages/web/src/lib/sessionCardStyle.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from 'bun:test'
+import type { SessionState } from '@agentistics/tui/control/session-fleet'
+import { STATE_COLOR, sessionCardStyle } from './sessionCardStyle'
+
+const STATES: SessionState[] =
+  ['working', 'waiting', 'waiting-approval', 'exited', 'lost', 'closed', 'unknown']
+
+describe('sessionCardStyle — selected always wins', () => {
+  test('every state, every mode, selected renders the same neutral style', () => {
+    for (const state of STATES) {
+      for (const mode of ['wash', 'neutral', 'stripe'] as const) {
+        const out = sessionCardStyle(state, mode, true)
+        expect(out.background).toBe('var(--bg-elevated)')
+        expect(out.edge).toContain('var(--text-primary)')
+        expect(out.stateTextColor).toBeUndefined()
+      }
+    }
+  })
+})
+
+describe('sessionCardStyle — wash', () => {
+  test('every one of the seven states gets its own tint and edge', () => {
+    for (const state of STATES) {
+      const out = sessionCardStyle(state, 'wash', false)
+      expect(out.background).toContain(STATE_COLOR[state])
+      expect(out.edge).toBe(`inset 2px 0 0 ${STATE_COLOR[state]}`)
+      expect(out.stateTextColor).toBeUndefined()
+    }
+  })
+
+  test('the two states that need a person keep their existing 12% figure', () => {
+    expect(sessionCardStyle('waiting', 'wash', false).background).toContain('12%')
+    expect(sessionCardStyle('waiting-approval', 'wash', false).background).toContain('12%')
+    expect(sessionCardStyle('working', 'wash', false).background).toContain('10%')
+  })
+})
+
+describe('sessionCardStyle — neutral', () => {
+  test('no background tint and no edge — the state word carries the color instead', () => {
+    for (const state of STATES) {
+      const out = sessionCardStyle(state, 'neutral', false)
+      expect(out.background).toBe('transparent')
+      expect(out.edge).toBeUndefined()
+      expect(out.stateTextColor).toBe(STATE_COLOR[state])
+    }
+  })
+})
+
+describe('sessionCardStyle — stripe', () => {
+  test('no background tint, a colored left edge, no text override', () => {
+    for (const state of STATES) {
+      const out = sessionCardStyle(state, 'stripe', false)
+      expect(out.background).toBe('transparent')
+      expect(out.edge).toBe(`inset 3px 0 0 ${STATE_COLOR[state]}`)
+      expect(out.stateTextColor).toBeUndefined()
+    }
+  })
+})
+
+describe('STATE_COLOR', () => {
+  test('lost is its own color, no longer sharing the tertiary fallback with exited/closed', () => {
+    expect(STATE_COLOR.lost).toBe('var(--accent-red)')
+    expect(STATE_COLOR.lost).not.toBe(STATE_COLOR.exited)
+  })
+})

--- a/packages/web/src/lib/sessionCardStyle.ts
+++ b/packages/web/src/lib/sessionCardStyle.ts
@@ -1,0 +1,73 @@
+/**
+ * sessionCardStyle.ts — how ONE session's card shows its state — PURE.
+ *
+ * Three modes, chosen by the person and stored in `sessionsAsidePrefs.ts`:
+ *  - `wash`    — the card's whole background is tinted by the state's color, for all seven
+ *    states. Before this module existed only `working`/`waiting`/`waiting-approval` got a tint
+ *    and everything else read as plain, which made "the background follows the status" describe
+ *    two different things depending on which status a row happened to be in.
+ *  - `neutral` — the background stays plain; the state WORD (in the row's meta line) takes the
+ *    state's color instead.
+ *  - `stripe`  — the background stays plain, plus a colored left edge — the same visual language
+ *    `TaskBoard`'s cards already use for their own status stripe.
+ *
+ * `selected` always wins, in every mode: a selected row's neutral, full-height edge is a fact
+ * about where the READER is, and it must never compete with a fact about the SESSION — the same
+ * rule `SessionsAside.tsx` states for why selection is not colored orange.
+ */
+
+import type { SessionState } from '@agentistics/tui/control/session-fleet'
+import type { AsideCardColor } from './sessionsAsidePrefs'
+
+/** The color a state is said in, everywhere this feature draws one. `working` is its own token,
+ *  never `success` (which reads teal on a terminal and sits within a hair of a harness color). */
+export const STATE_COLOR: Record<SessionState, string> = {
+  working: '#22c55e',
+  waiting: 'var(--anthropic-orange)',
+  'waiting-approval': 'var(--anthropic-orange)',
+  exited: 'var(--text-tertiary)',
+  lost: 'var(--accent-red)',
+  closed: 'var(--text-tertiary)',
+  unknown: 'var(--text-tertiary)',
+}
+
+/** How much of the state's color the `wash` background carries, in percent. The three states
+ *  that already had a wash keep their exact figures; the four newly-covered ones take the same
+ *  figure `working` always used. */
+const WASH_PCT: Record<SessionState, number> = {
+  working: 10, waiting: 12, 'waiting-approval': 12,
+  exited: 10, lost: 10, closed: 10, unknown: 10,
+}
+
+export interface CardStyle {
+  background: string
+  /** The left-edge indicator (an inset box-shadow), or undefined for none. */
+  edge?: string
+  /** Set only in `neutral` mode — the meta line's state-word color. */
+  stateTextColor?: string
+}
+
+const SELECTED: CardStyle = {
+  background: 'var(--bg-elevated)',
+  edge: 'inset 3px 0 0 var(--text-primary), inset 0 0 0 1px var(--border)',
+}
+
+export function sessionCardStyle(
+  state: SessionState,
+  mode: AsideCardColor,
+  selected: boolean,
+): CardStyle {
+  if (selected) return SELECTED
+  const color = STATE_COLOR[state]
+  switch (mode) {
+    case 'wash':
+      return {
+        background: `color-mix(in srgb, ${color} ${WASH_PCT[state]}%, transparent)`,
+        edge: `inset 2px 0 0 ${color}`,
+      }
+    case 'stripe':
+      return { background: 'transparent', edge: `inset 3px 0 0 ${color}` }
+    case 'neutral':
+      return { background: 'transparent', stateTextColor: color }
+  }
+}

--- a/packages/web/src/lib/sessionsAsidePrefs.test.ts
+++ b/packages/web/src/lib/sessionsAsidePrefs.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import {
+  DEFAULT_ASIDE_GROUP_PREFS, collapseKey, readAsideGroupPrefs, writeAsideGroupPrefs,
+} from './sessionsAsidePrefs'
+
+/** A minimal localStorage, so the module runs outside a browser — same pattern
+ *  `sessionNotifications.test.ts` uses. */
+function installStorage(): void {
+  const store = new Map<string, string>()
+  const g = globalThis as Record<string, unknown>
+  g.localStorage = {
+    getItem: (k: string) => store.get(k) ?? null,
+    setItem: (k: string, v: string) => { store.set(k, v) },
+    removeItem: (k: string) => { store.delete(k) },
+  }
+}
+
+beforeEach(installStorage)
+afterEach(() => { delete (globalThis as Record<string, unknown>).localStorage })
+
+describe('readAsideGroupPrefs', () => {
+  test('nothing stored yields the defaults', () => {
+    expect(readAsideGroupPrefs()).toEqual(DEFAULT_ASIDE_GROUP_PREFS)
+  })
+
+  test('corrupt JSON falls back to the defaults rather than throwing', () => {
+    localStorage.setItem('agentistics-sessions-aside-v1', '{not json')
+    expect(readAsideGroupPrefs()).toEqual(DEFAULT_ASIDE_GROUP_PREFS)
+  })
+
+  test('an unrecognised groupBy falls back rather than rendering as-is', () => {
+    localStorage.setItem('agentistics-sessions-aside-v1', JSON.stringify({ groupBy: 'repo' }))
+    expect(readAsideGroupPrefs().groupBy).toBe('project')
+  })
+
+  test('an unrecognised cardColor falls back rather than rendering as-is', () => {
+    localStorage.setItem('agentistics-sessions-aside-v1', JSON.stringify({ cardColor: 'rainbow' }))
+    expect(readAsideGroupPrefs().cardColor).toBe('wash')
+  })
+
+  test('order keeps only known dimensions and string arrays', () => {
+    localStorage.setItem('agentistics-sessions-aside-v1', JSON.stringify({
+      order: { status: ['working', 'lost'], repo: ['x'], task: 'not-an-array' },
+    }))
+    expect(readAsideGroupPrefs().order).toEqual({ status: ['working', 'lost'] })
+  })
+
+  test('collapsed drops non-string entries', () => {
+    localStorage.setItem('agentistics-sessions-aside-v1', JSON.stringify({
+      collapsed: ['active:project:agentistics', 42, null],
+    }))
+    expect(readAsideGroupPrefs().collapsed).toEqual(['active:project:agentistics'])
+  })
+})
+
+describe('writeAsideGroupPrefs', () => {
+  test('round-trips a full write', () => {
+    writeAsideGroupPrefs({
+      groupBy: 'status',
+      order: { status: ['working', 'waiting'] },
+      collapsed: ['active:status:working'],
+      cardColor: 'neutral',
+    })
+    expect(readAsideGroupPrefs()).toEqual({
+      groupBy: 'status',
+      order: { status: ['working', 'waiting'] },
+      collapsed: ['active:status:working'],
+      cardColor: 'neutral',
+    })
+  })
+
+  test('a partial write merges over what is already stored', () => {
+    writeAsideGroupPrefs({ groupBy: 'task' })
+    writeAsideGroupPrefs({ cardColor: 'stripe' })
+    const out = readAsideGroupPrefs()
+    expect(out.groupBy).toBe('task')
+    expect(out.cardColor).toBe('stripe')
+  })
+})
+
+describe('collapseKey', () => {
+  test('bands the same key/dimension apart, so one band folding never folds the other', () => {
+    expect(collapseKey('active', 'project', 'agentistics'))
+      .not.toBe(collapseKey('inactive', 'project', 'agentistics'))
+  })
+
+  test('is stable and readable', () => {
+    expect(collapseKey('active', 'status', 'working')).toBe('active:status:working')
+  })
+})

--- a/packages/web/src/lib/sessionsAsidePrefs.ts
+++ b/packages/web/src/lib/sessionsAsidePrefs.ts
@@ -1,0 +1,86 @@
+/**
+ * sessionsAsidePrefs.ts — how the Sessions workspace's aside arranges its own list.
+ *
+ * `localStorage`, deliberately not `/api/preferences` — the same rule and the same reason
+ * `boardPrefs.ts` states: on a central, `preferences.json` is shared by every signed-in user, and
+ * this is a per-viewer arrangement of a list (which grouping, in what order, which groups are
+ * folded, how a card shows its status), not a fact about the work like a pin. One person's
+ * collapsed groups must not collapse them for the whole team looking at that central's relayed
+ * fleet.
+ *
+ * Every read and write is guarded: a private window, cleared site data, or blocked storage makes
+ * the accessor throw, and an aside that will not render because it could not remember its
+ * arrangement is worse than one that opens on the defaults.
+ */
+
+const KEY = 'agentistics-sessions-aside-v1'
+
+/** The sub-grouping inside each Active/Inactive band. */
+export type AsideGroupBy = 'project' | 'task' | 'status'
+
+export const ASIDE_GROUP_BY_VALUES: readonly AsideGroupBy[] = ['project', 'task', 'status']
+
+/** How a session's card shows its state — see `sessionCardStyle.ts`. */
+export type AsideCardColor = 'wash' | 'neutral' | 'stripe'
+
+export const ASIDE_CARD_COLOR_VALUES: readonly AsideCardColor[] = ['wash', 'neutral', 'stripe']
+
+/** The band a group lives under — never the localized label, or PT/EN would split one
+ *  preference in two. */
+export type AsideBandId = 'active' | 'inactive'
+
+export interface AsideGroupPrefs {
+  groupBy: AsideGroupBy
+  /** Manual order of group KEYS, per dimension. An absent dimension is fully automatic. */
+  order: Partial<Record<AsideGroupBy, string[]>>
+  /** Collapsed groups, keyed `${band}:${groupBy}:${key}` — see `collapseKey`. */
+  collapsed: string[]
+  cardColor: AsideCardColor
+}
+
+export const DEFAULT_ASIDE_GROUP_PREFS: AsideGroupPrefs = {
+  groupBy: 'project', order: {}, collapsed: [], cardColor: 'wash',
+}
+
+/** The stable key one group's collapsed state is stored under. */
+export function collapseKey(band: AsideBandId, groupBy: AsideGroupBy, key: string): string {
+  return `${band}:${groupBy}:${key}`
+}
+
+const isGroupBy = (v: unknown): v is AsideGroupBy =>
+  typeof v === 'string' && (ASIDE_GROUP_BY_VALUES as readonly string[]).includes(v)
+
+const isCardColor = (v: unknown): v is AsideCardColor =>
+  typeof v === 'string' && (ASIDE_CARD_COLOR_VALUES as readonly string[]).includes(v)
+
+function readOrder(v: unknown): Partial<Record<AsideGroupBy, string[]>> {
+  if (!v || typeof v !== 'object') return {}
+  const out: Partial<Record<AsideGroupBy, string[]>> = {}
+  for (const by of ASIDE_GROUP_BY_VALUES) {
+    const list = (v as Record<string, unknown>)[by]
+    if (Array.isArray(list)) out[by] = list.filter((x): x is string => typeof x === 'string')
+  }
+  return out
+}
+
+export function readAsideGroupPrefs(): AsideGroupPrefs {
+  try {
+    const raw = localStorage.getItem(KEY)
+    if (!raw) return DEFAULT_ASIDE_GROUP_PREFS
+    const p = JSON.parse(raw) as Record<string, unknown>
+    return {
+      groupBy: isGroupBy(p.groupBy) ? p.groupBy : DEFAULT_ASIDE_GROUP_PREFS.groupBy,
+      order: readOrder(p.order),
+      collapsed: Array.isArray(p.collapsed)
+        ? p.collapsed.filter((x): x is string => typeof x === 'string')
+        : [],
+      cardColor: isCardColor(p.cardColor) ? p.cardColor : DEFAULT_ASIDE_GROUP_PREFS.cardColor,
+    }
+  } catch { return DEFAULT_ASIDE_GROUP_PREFS }
+}
+
+export function writeAsideGroupPrefs(patch: Partial<AsideGroupPrefs>): void {
+  try {
+    localStorage.setItem(KEY, JSON.stringify({ ...readAsideGroupPrefs(), ...patch }))
+  } catch { /* storage unavailable — the arrangement lasts this visit and no longer */ }
+}


### PR DESCRIPTION
Promotes \`dev\` to \`main\`.

Includes since the last release:
- feat(release): publish a musl binary for Alpine and other musl distros (#512)
- feat(web): agrupamento por Tarefa/Status, reordenar, minimizar e cor do card no aside de sessões (#511)

🤖 Generated with [Claude Code](https://claude.com/claude-code)