### PR TITLE
feat(alm): add Subtask.groupId + newGroupId() for subtask rollup grouping

### DIFF
--- a/packages/server/server/sessions/task-model.ts
+++ b/packages/server/server/sessions/task-model.ts
@@ -312,6 +312,14 @@ export interface Subtask {
    * cross-task version lives.
    */
   blockedBy?: string[]
+  /**
+   * Subtasks that share a `groupId` are read as ONE bucket for rollup: a session filed under any
+   * member counts for all of them, and their `subtaskViews` rollup is the SAME object, keyed by
+   * the group id rather than by each subtask's own id — never summed per member, which is what
+   * would multiply a shared session's cost by the group's size. Absent = today's behaviour
+   * unchanged: every existing subtask, with no `groupId`, is its own group of one.
+   */
+  groupId?: string
 }
 
 /**
@@ -394,6 +402,10 @@ export function newCommentId(): string {
 
 export function newSubtaskId(): string {
   return mint('s')
+}
+
+export function newGroupId(): string {
+  return mint('g')
 }
 
 export function newFileId(): string {


### PR DESCRIPTION
## Summary
- Adds optional `Subtask.groupId?: string` to `task-model.ts` per spec `2026-09-11-alm-session-linking-ux.md` §B.2: subtasks sharing a `groupId` are read as one rollup bucket, never summed per member.
- Adds `newGroupId()` (mint('g')), same pattern as `newSubtaskId()`/`newTaskId()`.
- No migration needed: absent `groupId` = today's behaviour, unchanged.
- Scope intentionally limited to `task-model.ts` — `task-report.ts` (bucketing logic), `task-web.ts`/`index.ts` (write path), and the web UI are separate subtasks of t-918cc82233, blocked by this one.

## Test plan
- [x] `bun tsc --noEmit` clean
- [x] `bun test packages/server` clean (0 fail)

Closes subtask s-820b526baa of task t-918cc82233.

🤖 Generated with [Claude Code](https://claude.com/claude-code)