### PR TITLE
release: atualizar pela página

### DIFF
--- a/packages/server/server/audit.ts
+++ b/packages/server/server/audit.ts
@@ -42,6 +42,7 @@ export type AuditAction =
   // reuse of the fleet's: a shell is a raw PTY on this host and a session is a named assistant CLI,
   // so a reader of the log must be able to tell which of the two a keyboard was attached to.
   | 'shell.input.open' | 'shell.input.denied'
+  | 'upgrade.started' | 'upgrade.denied'
 
 export interface AuditEvent {
   action: AuditAction

--- a/packages/server/server/capability-guard.test.ts
+++ b/packages/server/server/capability-guard.test.ts
@@ -23,6 +23,9 @@ const localCaps = capabilitiesFor('local', {
 describe('routeCapability', () => {
   it('maps the shell route', () => {
     expect(routeCapability('/api/exec')).toBe('localShell')
+    // It downloads a release binary, EXECUTES it and restarts the service serving the page. If
+    // this ever stops resolving, a published profile gains a remote code-execution button.
+    expect(routeCapability('/api/upgrade')).toBe('localShell')
   })
 
   it('maps the session fleet routes to localShell', () => {

--- a/packages/server/server/capability-guard.ts
+++ b/packages/server/server/capability-guard.ts
@@ -16,6 +16,10 @@ import { CAPS, type Capabilities } from './exposure'
 /** Exact path → capability. Detail sub-paths are handled by the prefix table below. */
 const EXACT: ReadonlyMap<string, keyof Capabilities> = new Map<string, keyof Capabilities>([
   ['/api/exec', 'localShell'],
+  // It DOWNLOADS a release binary, EXECUTES it and restarts the service serving this page — the
+  // most powerful thing this product does from a browser, so it rides the gate the shell rides.
+  // `upgrade-gate.ts` refuses a central on top of this, and says so in words.
+  ['/api/upgrade', 'localShell'],
   // It SPAWNS `tailscale` to read what this machine is already serving — a process, so it is host
   // power and belongs here. It configures nothing; see `secure-origin.ts`.
   ['/api/secure-origin', 'localShell'],

--- a/packages/server/server/index.ts
+++ b/packages/server/server/index.ts
@@ -6,6 +6,7 @@ import type { Server, ServerWebSocket } from 'bun'
 import type { LiveProcess, LiveUnavailableReason, SessionMeta } from '@agentistics/core'
 import { getRates } from './rates'
 import { getVersionInfo, startVersionRecheck } from './version'
+import { handleUpgradeRoute } from './upgrade-web'
 import { buildApiResponse, buildApiResponseStream, invalidateCache } from './data'
 import { readPreferences, writePreferences, redactPreferences, guardTeamConnectionsWipe, PreferencesLockTimeoutError, type Preferences } from './preferences'
 import {
@@ -637,6 +638,12 @@ async function handleRequestInner(req: Request, server: Server<WSData>): Promise
         status: 200,
         headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
       })
+    }
+
+    // "Update now" — see `upgrade-web.ts` for why the child must NOT be this process's child.
+    {
+      const res = await handleUpgradeRoute(req, url, url.searchParams.get('lang') === 'pt' ? 'pt' : 'en', clientIp)
+      if (res) return res
     }
 
     if (url.pathname === '/api/version' && req.method === 'GET') {

--- a/packages/server/server/sessions/task-model.ts
+++ b/packages/server/server/sessions/task-model.ts
@@ -312,6 +312,14 @@ export interface Subtask {
    * cross-task version lives.
    */
   blockedBy?: string[]
+  /**
+   * Subtasks that share a `groupId` are read as ONE bucket for rollup: a session filed under any
+   * member counts for all of them, and their `subtaskViews` rollup is the SAME object, keyed by
+   * the group id rather than by each subtask's own id — never summed per member, which is what
+   * would multiply a shared session's cost by the group's size. Absent = today's behaviour
+   * unchanged: every existing subtask, with no `groupId`, is its own group of one.
+   */
+  groupId?: string
 }
 
 /**
@@ -394,6 +402,10 @@ export function newCommentId(): string {
 
 export function newSubtaskId(): string {
   return mint('s')
+}
+
+export function newGroupId(): string {
+  return mint('g')
 }
 
 export function newFileId(): string {

--- a/packages/server/server/upgrade-gate.test.ts
+++ b/packages/server/server/upgrade-gate.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from 'bun:test'
+import { upgradeFromUiDecision, UPGRADE_REFUSALS } from './upgrade-gate'
+
+const base = { capable: true, central: false, hasUpdate: true, latest: '2.30.0' }
+
+describe('who may press "update now"', () => {
+  test('a local machine with an update waiting may', () => {
+    expect(upgradeFromUiDecision(base)).toEqual({ ok: true, version: '2.30.0' })
+  })
+
+  // It downloads a binary and EXECUTES it, then restarts the service serving this page. There is
+  // nothing more powerful in this product, so it rides the gate the shell and the fleet ride.
+  test('a profile without host power may not, and the answer names the capability', () => {
+    expect(upgradeFromUiDecision({ ...base, capable: false }))
+      .toEqual({ ok: false, reason: 'no-capability' })
+  })
+
+  // A central is reachable from the internet and its upgrade is a compose rebuild of minutes, not
+  // a binary swap — a button here would be a remote rebuild trigger on a published host.
+  test('a central may not, whatever its profile says', () => {
+    expect(upgradeFromUiDecision({ ...base, central: true }))
+      .toEqual({ ok: false, reason: 'central' })
+    expect(upgradeFromUiDecision({ ...base, central: true, capable: true }))
+      .toEqual({ ok: false, reason: 'central' })
+  })
+
+  // Without this the button is a free "download a release again" trigger, repeatable at will.
+  test('a machine already on the latest version has nothing to run', () => {
+    expect(upgradeFromUiDecision({ ...base, hasUpdate: false }))
+      .toEqual({ ok: false, reason: 'up-to-date' })
+  })
+
+  test('an update with no version to name is refused rather than run blind', () => {
+    expect(upgradeFromUiDecision({ ...base, latest: '' })).toEqual({ ok: false, reason: 'up-to-date' })
+    expect(upgradeFromUiDecision({ ...base, latest: null })).toEqual({ ok: false, reason: 'up-to-date' })
+  })
+
+  test('the capability is checked BEFORE the central, so a published central never reports its profile', () => {
+    // Both wrong at once: the answer must be the one that discloses least.
+    expect(upgradeFromUiDecision({ ...base, capable: false, central: true }))
+      .toEqual({ ok: false, reason: 'no-capability' })
+  })
+
+  // "não é um binário" NÃO pode reusar a frase de "perfil sem permissão": num checkout de
+  // desenvolvimento o perfil permite perfeitamente, e a frase mandaria a pessoa mexer na exposição
+  // por um motivo que não existe.
+  test('every refusal has a sentence in both languages, and none is reused for another reason', () => {
+    const seen = new Set<string>()
+    for (const reason of ['no-capability', 'central', 'up-to-date', 'busy', 'not-a-binary'] as const) {
+      expect(seen.has(UPGRADE_REFUSALS[reason].pt), reason).toBe(false)
+      seen.add(UPGRADE_REFUSALS[reason].pt)
+    }
+    for (const reason of ['no-capability', 'central', 'up-to-date', 'busy', 'not-a-binary'] as const) {
+      expect(UPGRADE_REFUSALS[reason].pt.length, reason).toBeGreaterThan(10)
+      expect(UPGRADE_REFUSALS[reason].en.length, reason).toBeGreaterThan(10)
+    }
+  })
+})

--- a/packages/server/server/upgrade-gate.ts
+++ b/packages/server/server/upgrade-gate.ts
@@ -1,0 +1,71 @@
+/**
+ * upgrade-gate.ts — PURE. Who may press "update now" in the dashboard, and the sentence each
+ * refusal gets.
+ *
+ * The modal has always PRINTED the command and left the person to open a terminal. Running it from
+ * the page is a different kind of act: it downloads a release binary, EXECUTES it, and restarts the
+ * service serving the very page that asked. There is nothing more powerful in this product, so the
+ * decision is its own module with its own test rather than three conditions inside a route.
+ *
+ * THE ORDER MATTERS. The capability is checked before anything else, so a central published on the
+ * internet answers "this profile has no host power" and never "I am a central" — the refusal that
+ * discloses least is the one that goes out first, the same rule `machineOwnedBy` follows when it
+ * answers `not-owner` for a machine that does not exist.
+ *
+ * A CENTRAL IS REFUSED OUTRIGHT, whatever its profile. Its upgrade is a compose rebuild of several
+ * minutes against an image, not a binary swap; a button for it on a reachable host is a remote
+ * rebuild trigger. The modal keeps printing `bun run up:central` there, which is the honest answer.
+ *
+ * And a machine already on the latest version has NOTHING TO RUN. Without that, the button is a
+ * "download a release again" trigger anybody can hold down.
+ */
+
+export type UpgradeRefusal = 'no-capability' | 'central' | 'up-to-date' | 'busy' | 'not-a-binary'
+
+export type UpgradeDecision =
+  | { ok: true; version: string }
+  | { ok: false; reason: UpgradeRefusal }
+
+/** Every refusal, in words, in both languages. A code the UI would have to word itself is a code
+ *  two surfaces will word differently. */
+export const UPGRADE_REFUSALS: Record<UpgradeRefusal, { pt: string; en: string }> = {
+  'no-capability': {
+    pt: 'Este perfil de exposição não permite rodar comandos nesta máquina, então a atualização tem que ser feita no terminal.',
+    en: 'This exposure profile does not allow running commands on this machine, so the upgrade has to be done in a terminal.',
+  },
+  central: {
+    pt: 'Um central se atualiza reconstruindo a imagem, não trocando um binário — rode o comando abaixo no host dele.',
+    en: 'A central upgrades by rebuilding its image rather than swapping a binary — run the command below on its host.',
+  },
+  'up-to-date': {
+    pt: 'Esta máquina já está na versão mais recente; não há nada para atualizar.',
+    en: 'This machine is already on the latest version; there is nothing to upgrade.',
+  },
+  busy: {
+    pt: 'Já existe uma atualização em andamento nesta máquina. Espere ela terminar.',
+    en: 'An upgrade is already running on this machine. Wait for it to finish.',
+  },
+  // DELIBERADAMENTE separada de `no-capability`: num checkout de desenvolvimento o perfil permite
+  // rodar comandos, e reusar aquela frase mandaria a pessoa mexer na exposição por um motivo que
+  // não existe. Aqui a atualização é `git pull`, não a troca de um binário.
+  'not-a-binary': {
+    pt: 'Este servidor está rodando a partir do código-fonte, não de um binário instalado — aqui a atualização é um `git pull`.',
+    en: 'This server is running from source rather than from an installed binary — here the update is a `git pull`.',
+  },
+}
+
+export function upgradeFromUiDecision(o: {
+  /** `CAPS.localShell` — the same gate the shell and the fleet ride. */
+  capable: boolean
+  central: boolean
+  hasUpdate: boolean
+  /** The version `getVersionInfo` named. Blank or absent means nobody could say. */
+  latest: string | null | undefined
+}): UpgradeDecision {
+  if (!o.capable) return { ok: false, reason: 'no-capability' }
+  if (o.central) return { ok: false, reason: 'central' }
+  // A version nobody could name is not an update: running the CLI blind would re-download whatever
+  // GitHub calls latest at that instant, which is not what the person read on screen.
+  if (!o.hasUpdate || !o.latest) return { ok: false, reason: 'up-to-date' }
+  return { ok: true, version: o.latest }
+}

--- a/packages/server/server/upgrade-web.test.ts
+++ b/packages/server/server/upgrade-web.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { upgradeBinary } from './upgrade-web'
+
+describe('which binary an in-page upgrade would run', () => {
+  test('a compiled agentop runs itself — the exact binary the upgrade replaces', () => {
+    expect(upgradeBinary('/home/u/.local/bin/agentop')).toBe('/home/u/.local/bin/agentop')
+    expect(upgradeBinary('/usr/local/bin/agentop-linux-x64')).toBe('/usr/local/bin/agentop-linux-x64')
+  })
+
+  // Under `bun server/index.ts` the execPath is bun. Spawning `upgrade` there would ask BUN to
+  // upgrade itself, and a development checkout updates with git anyway.
+  test('a source checkout runs nothing', () => {
+    expect(upgradeBinary('/home/u/.bun/bin/bun')).toBeNull()
+    expect(upgradeBinary('/usr/bin/node')).toBeNull()
+    expect(upgradeBinary('')).toBeNull()
+  })
+})
+
+/**
+ * A LINT OVER THIS MODULE'S OWN SOURCE, in the shape `shell-isolation.test.ts` uses.
+ *
+ * `upgrade.ts` finds the servers to restart with `pgrep -f 'agentop.*(server|start)'` and EXCLUDES
+ * its own pid and its PPID. Spawned as a child of this server, the server is the ppid: it would be
+ * skipped, the upgrade would report success, and the machine would keep serving the old bundle off
+ * a new binary. Nothing about that is visible from inside — which is why it is asserted here rather
+ * than trusted to survive a refactor.
+ */
+describe('the upgrade must not be this process’s child', () => {
+  const src = readFileSync(new URL('./upgrade-web.ts', import.meta.url), 'utf8')
+
+  test('the spawn is detached and unref’d', () => {
+    expect(src).toContain('detached: true')
+    expect(src).toContain('.unref()')
+  })
+
+  test('it never inherits this server’s stdio, which would outlive the restart', () => {
+    expect(src).toContain("stdio: 'ignore'")
+    expect(src).not.toContain("stdio: 'inherit'")
+  })
+})

--- a/packages/server/server/upgrade-web.ts
+++ b/packages/server/server/upgrade-web.ts
@@ -1,0 +1,112 @@
+/**
+ * upgrade-web.ts — `POST /api/upgrade`: the dashboard's own "update now".
+ *
+ * The modal has always printed `agentop upgrade` and left the person to find a terminal. The whole
+ * point of this route is that they do not have to — and the whole reason it is its own module is
+ * that running it correctly is NOT "spawn the command".
+ *
+ * **THE UPGRADE MUST NOT BE THIS PROCESS'S CHILD.** `upgrade.ts` restarts whatever `agentop server`
+ * it can find, and it finds them with `pgrep -f 'agentop.*(server|start)'` while excluding its own
+ * `pid` and its `ppid` — the exclusion that makes running it from a terminal safe. Spawned as a
+ * child of the server, the server IS the `ppid`: it would be skipped, the upgrade would report
+ * success, and the machine would go on serving the old bundle with a new binary on disk. So the
+ * child is DETACHED and `unref`'d — its parent becomes init, nothing is excluded, and the server it
+ * restarts is the one that started it.
+ *
+ * That restart is also why there is no "and then tell the browser it worked": the process answering
+ * would be killed mid-sentence. The route answers `started` and the PAGE watches `/api/version`
+ * until the machine comes back on the new version — an honest poll rather than a promise made by
+ * something about to be replaced.
+ *
+ * ONE AT A TIME. A second press while one runs is refused in words rather than starting a second
+ * download over the same binary path.
+ */
+
+import { basename } from 'node:path'
+import { spawn } from 'node:child_process'
+import { CAPS } from './exposure'
+import { TEAM_CENTRAL } from './config'
+import { getVersionInfo } from './version'
+import { upgradeFromUiDecision, UPGRADE_REFUSALS, type UpgradeRefusal } from './upgrade-gate'
+import { writeAudit } from './audit'
+import type { CliLang } from './cli-lang'
+
+/** Set while a detached upgrade is in flight, so a second press is refused rather than racing. */
+let running: { version: string; startedMs: number } | null = null
+
+/** How long a start is believed before the flag is let go. The child is detached and its exit is
+ *  not observable here; without a ceiling a failed upgrade would lock the button until a restart —
+ *  and the restart is exactly what a SUCCESSFUL one causes. */
+const RUN_TTL_MS = 10 * 60_000
+
+function inFlight(now: number): boolean {
+  if (!running) return false
+  if (now - running.startedMs > RUN_TTL_MS) { running = null; return false }
+  return true
+}
+
+/**
+ * The binary to run, or `null` when this process is not one.
+ *
+ * A compiled `agentop` has itself as `execPath`, which is the exact binary the user is running and
+ * the one `upgrade.ts` replaces. Under `bun server/index.ts` the `execPath` is bun — that is a
+ * development checkout, where an upgrade means `git pull`, so the button is absent rather than
+ * running something that would replace a binary nobody is using.
+ */
+export function upgradeBinary(execPath: string): string | null {
+  return basename(execPath).startsWith('agentop') ? execPath : null
+}
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+function refuse(reason: UpgradeRefusal, lang: CliLang, ip: string): Response {
+  void writeAudit({ action: 'upgrade.denied', ip, meta: { reason } })
+  return json({ ok: false, reason, message: UPGRADE_REFUSALS[reason][lang === 'pt' ? 'pt' : 'en'] }, 409)
+}
+
+export async function handleUpgradeRoute(
+  req: Request,
+  url: URL,
+  lang: CliLang,
+  ip: string,
+): Promise<Response | null> {
+  if (url.pathname !== '/api/upgrade' || req.method !== 'POST') return null
+
+  const info = await getVersionInfo().catch(() => null)
+  const decision = upgradeFromUiDecision({
+    capable: CAPS.localShell,
+    central: TEAM_CENTRAL,
+    hasUpdate: info?.hasUpdate === true,
+    latest: info?.latest ?? null,
+  })
+  if (!decision.ok) return refuse(decision.reason, lang, ip)
+
+  const bin = upgradeBinary(process.execPath)
+  // Not a compiled binary: a development checkout upgrades with `git pull`, and spawning
+  // `bun upgrade` here would upgrade BUN. It gets its OWN sentence — reusing `no-capability` would
+  // tell somebody their exposure profile is locked down when it is not.
+  if (!bin) return refuse('not-a-binary', lang, ip)
+
+  const now = Date.now()
+  if (inFlight(now)) return refuse('busy', lang, ip)
+  running = { version: decision.version, startedMs: now }
+
+  try {
+    // DETACHED — see this module's header. `setsid` is not enough on its own: the handles must go
+    // too, or the child holds this server's stdio open across its own restart.
+    const child = spawn(bin, ['upgrade'], { detached: true, stdio: 'ignore' })
+    child.unref()
+  } catch {
+    running = null
+    return json({ ok: false, reason: 'spawn-failed' }, 500)
+  }
+
+  void writeAudit({ action: 'upgrade.started', ip, targetId: decision.version })
+  // `started`, never `done`: the process that would say "done" is the one this upgrade restarts.
+  return json({ ok: true, started: true, version: decision.version })
+}

--- a/packages/web/src/components/UpdateModal.tsx
+++ b/packages/web/src/components/UpdateModal.tsx
@@ -1,7 +1,10 @@
 import React, { useEffect, useCallback, useState } from 'react'
-import { X, ArrowUpCircle, Terminal, Download, Copy, Check } from 'lucide-react'
+import { X, ArrowUpCircle, Terminal, Download, Copy, Check, Loader2 } from 'lucide-react'
 import type { Lang } from '@agentistics/core'
 import { copyText } from '../lib/clipboard'
+import {
+  UPGRADE_POLL_MS, UPGRADE_WAIT_MS, browserReloadEnv, clearAppCaches, upgradeArrived,
+} from '../lib/appReload'
 
 interface Props {
   current: string
@@ -15,6 +18,20 @@ interface Props {
 }
 
 export function UpdateModal({ current, latest, lang, isCentral, isMember, onClose }: Props) {
+  /**
+   * `idle → confirm → running → (reload | timeout | refused)`.
+   *
+   * There is no `done`: the machine coming back IS the end, and what announces it is the page
+   * reloading. A modal that said "updated" and left the old bundle on screen would be the exact
+   * lie this control exists to remove.
+   */
+  const [phase, setPhase] = useState<'idle' | 'confirm' | 'running' | 'refused' | 'timeout'>('idle')
+  const [note, setNote] = useState('')
+  // Set when the modal closes mid-flight, so the poll stops rather than reloading a page the
+  // reader has moved on from.
+  const goneRef = React.useRef(false)
+  useEffect(() => () => { goneRef.current = true }, [])
+
   const handleKey = useCallback(
     (e: KeyboardEvent) => { if (e.key === 'Escape') onClose() },
     [onClose],
@@ -43,6 +60,17 @@ export function UpdateModal({ current, latest, lang, isCentral, isMember, onClos
         close: 'Fechar',
         copy: 'Copiar',
         copied: 'Copiado',
+        now: 'Atualizar agora',
+        confirmTitle: 'Atualizar agora?',
+        confirmBody: (v: string) =>
+          `Isto baixa a versão ${v} nesta máquina, substitui o binário e reinicia o serviço. A página recarrega sozinha quando ele voltar. As sessões em tmux não são afetadas.`,
+        confirmYes: 'Sim, atualizar',
+        confirmNo: 'Cancelar',
+        working: 'Atualizando — o servidor vai reiniciar…',
+        waiting: 'Esperando a máquina voltar…',
+        reloading: 'Recarregando com a versão nova…',
+        timedOut: 'A máquina não voltou a tempo. Ela pode ainda estar atualizando — recarregue em um minuto, ou use o comando abaixo.',
+        orByHand: 'Ou faça no terminal',
       }
     : {
         title: 'New version available',
@@ -61,7 +89,64 @@ export function UpdateModal({ current, latest, lang, isCentral, isMember, onClos
         close: 'Close',
         copy: 'Copy',
         copied: 'Copied',
+        now: 'Update now',
+        confirmTitle: 'Update now?',
+        confirmBody: (v: string) =>
+          `This downloads version ${v} on this machine, replaces the binary and restarts the service. The page reloads itself once it is back. Your tmux sessions are not affected.`,
+        confirmYes: 'Yes, update',
+        confirmNo: 'Cancel',
+        working: 'Updating — the server is about to restart…',
+        waiting: 'Waiting for the machine to come back…',
+        reloading: 'Reloading on the new version…',
+        timedOut: 'The machine did not come back in time. It may still be upgrading — reload in a minute, or use the command below.',
+        orByHand: 'Or do it in a terminal',
       }
+
+  /**
+   * Ask the machine to upgrade itself, then WATCH for it to come back.
+   *
+   * The route answers `started` and nothing else, because the process that would say "done" is the
+   * one the upgrade restarts — so every failed poll from here is the ordinary case and is ignored
+   * until the ceiling. When the version it names is the one we asked for, the service worker and
+   * its caches are emptied and the page reloads: the programmatic form of the ctrl+shift+R this
+   * release flow has needed every single time.
+   */
+  const start = useCallback(async () => {
+    setPhase('running')
+    setNote(t.working)
+    try {
+      const res = await fetch(`/api/upgrade?lang=${lang === 'pt' ? 'pt' : 'en'}`, { method: 'POST' })
+      const body = await res.json().catch(() => ({})) as { ok?: boolean; message?: string }
+      if (!res.ok || !body.ok) {
+        // The server's OWN sentence: it knows which of the four refusals this is.
+        setPhase('refused')
+        setNote(body.message ?? t.timedOut)
+        return
+      }
+    } catch {
+      setPhase('refused')
+      setNote(t.timedOut)
+      return
+    }
+
+    setNote(t.waiting)
+    const until = Date.now() + UPGRADE_WAIT_MS
+    while (Date.now() < until) {
+      await new Promise(r => setTimeout(r, UPGRADE_POLL_MS))
+      if (goneRef.current) return
+      // `no-store`: the one request that must not be answered by the very cache being replaced.
+      const info = await fetch('/api/version', { cache: 'no-store' })
+        .then(r => r.ok ? r.json() as Promise<{ current?: string }> : null)
+        .catch(() => null)
+      if (!upgradeArrived(info, latest)) continue
+      setNote(t.reloading)
+      await clearAppCaches(browserReloadEnv())
+      window.location.reload()
+      return
+    }
+    setPhase('timeout')
+    setNote(t.timedOut)
+  }, [lang, latest, t])
 
   return (
     <div
@@ -130,13 +215,90 @@ export function UpdateModal({ current, latest, lang, isCentral, isMember, onClos
           <VersionPill label={t.latest} version={latest} accent="var(--accent-green)" />
         </div>
 
+        {/* UPDATE NOW — the whole point is that nobody has to open a terminal for this. It is
+            ABSENT on a central (its upgrade is a compose rebuild, and `upgrade-gate.ts` refuses the
+            route there anyway) and it ASKS before running: this downloads and executes a binary and
+            restarts the service serving the page. */}
+        {!isCentral && (
+          <div style={{ padding: '0 24px 16px' }}>
+            {phase === 'idle' && (
+              <button
+                onClick={() => setPhase('confirm')}
+                style={{
+                  display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 8,
+                  width: '100%', minHeight: 44, borderRadius: 10, border: 'none', cursor: 'pointer',
+                  fontFamily: 'inherit', fontSize: 13.5, fontWeight: 700,
+                  background: 'var(--anthropic-orange)', color: '#fff',
+                }}
+              >
+                <ArrowUpCircle size={16} />
+                {t.now}
+              </button>
+            )}
+
+            {phase === 'confirm' && (
+              <div style={{
+                background: 'var(--bg-card)', border: '1px solid var(--border)',
+                borderRadius: 10, padding: '14px 16px',
+              }}>
+                <div style={{ fontSize: 13, fontWeight: 700, color: 'var(--text-primary)', marginBottom: 6 }}>
+                  {t.confirmTitle}
+                </div>
+                <p style={{ fontSize: 12, color: 'var(--text-secondary)', margin: '0 0 12px', lineHeight: 1.6 }}>
+                  {t.confirmBody(latest)}
+                </p>
+                <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+                  <button
+                    onClick={start}
+                    style={{
+                      minHeight: 44, padding: '0 16px', borderRadius: 8, border: 'none', cursor: 'pointer',
+                      fontFamily: 'inherit', fontSize: 13, fontWeight: 700,
+                      background: 'var(--anthropic-orange)', color: '#fff',
+                    }}
+                  >
+                    {t.confirmYes}
+                  </button>
+                  <button
+                    onClick={() => setPhase('idle')}
+                    style={{
+                      minHeight: 44, padding: '0 16px', borderRadius: 8, cursor: 'pointer',
+                      fontFamily: 'inherit', fontSize: 13, fontWeight: 600,
+                      border: '1px solid var(--border)', background: 'transparent',
+                      color: 'var(--text-secondary)',
+                    }}
+                  >
+                    {t.confirmNo}
+                  </button>
+                </div>
+              </div>
+            )}
+
+            {/* A REFUSAL IS THE SERVER'S OWN SENTENCE, shown verbatim — the route knows whether this
+                profile has host power, whether this is a central and whether one is already
+                running, and a generic "could not update" would name none of them. */}
+            {(phase === 'running' || phase === 'refused' || phase === 'timeout') && (
+              <div
+                role="status"
+                style={{
+                  display: 'flex', alignItems: 'center', gap: 8,
+                  fontSize: 12, lineHeight: 1.6,
+                  color: phase === 'running' ? 'var(--text-secondary)' : 'var(--accent-red)',
+                }}
+              >
+                {phase === 'running' && <Loader2 size={14} className="ag-spin" />}
+                <span>{note}</span>
+              </div>
+            )}
+          </div>
+        )}
+
         {/* How to update */}
         <div style={{ padding: '0 24px 24px' }}>
           <div style={{
             fontSize: 11, fontWeight: 700, color: 'var(--text-tertiary)',
             letterSpacing: '0.07em', textTransform: 'uppercase', marginBottom: 14,
           }}>
-            {t.howTo}
+            {isCentral ? t.howTo : t.orByHand}
           </div>
 
           {isCentral ? (

--- a/packages/web/src/lib/appReload.test.ts
+++ b/packages/web/src/lib/appReload.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from 'bun:test'
+import { upgradeArrived, clearAppCaches, UPGRADE_WAIT_MS } from './appReload'
+
+describe('when has the machine come back on the new version', () => {
+  test('the version it reports IS the one we asked for', () => {
+    expect(upgradeArrived({ current: '2.30.0' }, '2.30.0')).toBe(true)
+  })
+
+  test('a `v` prefix on either side is the same version', () => {
+    expect(upgradeArrived({ current: 'v2.30.0' }, '2.30.0')).toBe(true)
+    expect(upgradeArrived({ current: '2.30.0' }, 'v2.30.0')).toBe(true)
+  })
+
+  // The server is restarted mid-upgrade, so a poll that cannot reach it is the ORDINARY case and
+  // must never be read as "done" — reloading then would put the OLD bundle back on screen.
+  test('a poll that answered nothing is not an arrival', () => {
+    expect(upgradeArrived(null, '2.30.0')).toBe(false)
+    expect(upgradeArrived({ current: '' }, '2.30.0')).toBe(false)
+  })
+
+  test('the version still on the old number is not an arrival', () => {
+    expect(upgradeArrived({ current: '2.29.0' }, '2.30.0')).toBe(false)
+  })
+
+  // A machine that jumped PAST the version we asked for still arrived: another upgrade could have
+  // landed in between, and refusing to reload would strand the reader on an older bundle.
+  test('a version newer than the one asked for counts as arrived', () => {
+    expect(upgradeArrived({ current: '2.31.0' }, '2.30.0')).toBe(true)
+  })
+
+  test('the wait has a ceiling, so a failed upgrade stops spinning', () => {
+    expect(UPGRADE_WAIT_MS).toBeGreaterThan(60_000)
+    expect(UPGRADE_WAIT_MS).toBeLessThanOrEqual(10 * 60_000)
+  })
+})
+
+describe('the hard reload, done by the page', () => {
+  const spy = () => {
+    const calls: string[] = []
+    return {
+      calls,
+      caches: {
+        keys: async () => ['assets-v1', 'html-v1'],
+        delete: async (k: string) => { calls.push(`cache:${k}`); return true },
+      },
+      sw: {
+        getRegistrations: async () => [
+          { unregister: async () => { calls.push('sw:a'); return true } },
+          { unregister: async () => { calls.push('sw:b'); return true } },
+        ],
+      },
+    }
+  }
+
+  // `location.reload()` alone hands the reader the SERVICE WORKER's copy of the old bundle — the
+  // reason a person has had to press ctrl+shift+R after every release. Unregistering and emptying
+  // the caches first is what the keystroke actually does.
+  test('unregisters every worker and empties every cache', async () => {
+    const s = spy()
+    await clearAppCaches({ caches: s.caches, serviceWorker: s.sw })
+    expect(s.calls.sort()).toEqual(['cache:assets-v1', 'cache:html-v1', 'sw:a', 'sw:b'].sort())
+  })
+
+  // A browser with no service worker, a private window, an accessor that throws: none of them may
+  // stop the reload that follows.
+  test('a browser that offers neither is not an error', async () => {
+    await expect(clearAppCaches({})).resolves.toBeUndefined()
+  })
+
+  test('an accessor that throws is swallowed, because the reload still has to happen', async () => {
+    const hostile = {
+      caches: { keys: async () => { throw new Error('blocked') }, delete: async () => true },
+      serviceWorker: { getRegistrations: async () => { throw new Error('blocked') } },
+    }
+    await expect(clearAppCaches(hostile)).resolves.toBeUndefined()
+  })
+})

--- a/packages/web/src/lib/appReload.ts
+++ b/packages/web/src/lib/appReload.ts
@@ -1,0 +1,87 @@
+/**
+ * appReload.ts — PURE (the decision) plus one total, guarded side effect: bringing the page back on
+ * a bundle that was just published, without asking a person to press ctrl+shift+R.
+ *
+ * This app is a PWA, so a plain `location.reload()` is served by the SERVICE WORKER, which hands
+ * back its cached copy of the bundle that was current when it last updated. That is why every
+ * release so far has ended with "give it a hard reload first" — and why a reader who forgot tested
+ * yesterday's code believing it was today's, which is the worst shape a verification can take.
+ * `clearAppCaches` is what the keystroke actually does: unregister every worker, empty every cache,
+ * and only then reload.
+ *
+ * The WAIT is the other half. `POST /api/upgrade` answers `started` and nothing more, because the
+ * process that would say "done" is the one the upgrade restarts. So the page WATCHES: it polls
+ * `/api/version` and reloads when the machine comes back naming the version it asked for. Every
+ * failed poll in between is the ordinary case — the server really is down for a moment — and must
+ * never be mistaken for an answer.
+ */
+
+/** How long to keep watching before saying so. An upgrade is a download plus a service restart;
+ *  past this, something went wrong and a spinner that never ends is not an answer. */
+export const UPGRADE_WAIT_MS = 4 * 60_000
+
+/** How often to ask. Short enough to feel immediate, long enough that a restarting server is not
+ *  hammered by a page that cannot help it. */
+export const UPGRADE_POLL_MS = 1500
+
+function numbers(v: string): number[] {
+  return v.replace(/^v/, '').split('.').map(n => parseInt(n, 10))
+}
+
+/**
+ * Has the machine come back on (at least) the version we asked for?
+ *
+ * `null` and a blank version are the SERVER BEING DOWN, which is what an upgrade looks like from
+ * here — never an arrival. A version PAST the target counts: another release can land in between,
+ * and refusing to reload would leave the reader on an older bundle for no reason.
+ */
+export function upgradeArrived(info: { current?: string } | null, target: string): boolean {
+  const current = info?.current?.trim()
+  if (!current || !target) return false
+  const a = numbers(current)
+  const b = numbers(target)
+  if (a.some(Number.isNaN) || b.some(Number.isNaN)) return current.replace(/^v/, '') === target.replace(/^v/, '')
+  for (let i = 0; i < Math.max(a.length, b.length); i++) {
+    const x = a[i] ?? 0
+    const y = b[i] ?? 0
+    if (x !== y) return x > y
+  }
+  return true
+}
+
+/** The two accessors, injected so this is testable without a browser — and so a context that has
+ *  neither (an older browser, a private window, a preview frame) is a supported case and not a
+ *  throw. */
+export interface ReloadEnv {
+  caches?: { keys(): Promise<string[]>; delete(key: string): Promise<boolean> }
+  serviceWorker?: { getRegistrations(): Promise<readonly { unregister(): Promise<boolean> }[]> }
+}
+
+/**
+ * Empty everything a reload would otherwise be served from.
+ *
+ * EVERY step is swallowed on purpose. This runs immediately before a reload the reader asked for:
+ * a browser that blocks site data, a worker that is already gone, a cache API that throws on
+ * access — none of them is a reason to leave the person looking at the old bundle with an error
+ * where their new version should be.
+ */
+export async function clearAppCaches(env: ReloadEnv): Promise<void> {
+  try {
+    const regs = await env.serviceWorker?.getRegistrations()
+    await Promise.all((regs ?? []).map(r => r.unregister().catch(() => false)))
+  } catch { /* no worker, or the accessor itself threw */ }
+  try {
+    const keys = await env.caches?.keys()
+    await Promise.all((keys ?? []).map(k => env.caches!.delete(k).catch(() => false)))
+  } catch { /* no cache storage, or site data is blocked */ }
+}
+
+/** The browser's own accessors, read defensively — `caches` is absent over plain HTTP on a LAN. */
+export function browserReloadEnv(): ReloadEnv {
+  const env: ReloadEnv = {}
+  try { if (typeof caches !== 'undefined') env.caches = caches } catch { /* blocked */ }
+  try {
+    if (typeof navigator !== 'undefined' && navigator.serviceWorker) env.serviceWorker = navigator.serviceWorker
+  } catch { /* blocked */ }
+  return env
+}


### PR DESCRIPTION
## O modal de atualização vira um botão (#515)

Antes: `agentop upgrade`, copiado do modal e colado num terminal, seguido de `ctrl+shift+R` porque o service worker do PWA continua servindo o bundle antigo. Agora: **Atualizar agora** → uma confirmação que diz o que vai acontecer → a página volta sozinha na versão nova.

Três coisas que não são óbvias e estão no código:

- **O filho tem que ser destacado.** `upgrade.ts` reinicia os servidores que acha com `pgrep` excluindo o próprio pid e o PPID; como filho do servidor, o servidor seria pulado e a máquina seguiria servindo o bundle velho com um binário novo no disco. Preso por um lint sobre a fonte.
- **Não existe "pronto".** O processo que diria isso é o que a atualização reinicia — a rota responde `started` e a página observa `/api/version` até a máquina voltar.
- **O hard reload é feito pela página**: desregistra os workers, esvazia os caches, recarrega.

Portões: `localShell` no `capability-guard` (a rota baixa e executa um binário), central recusado à parte, capacidade checada antes do central, nada a fazer numa máquina já atualizada, e uma frase própria por recusa nos dois idiomas.

## Também em dev

- #514 — `Subtask.groupId` + `newGroupId()` para o agrupamento de rollup (outra sessão).

`bun tsc --noEmit` + `bun test` (7954 passando); CI verde.

**Limite declarado:** o spawn só é exercitável a partir de um binário compilado, então o primeiro teste ponta a ponta é a release SEGUINTE a esta — é ela que vai ter o botão para valer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lr8C4E9sJWirekwVfSr3UN