### PR TITLE
fix(server): refuse done on a task/subtask with no session filed under it

### DIFF
--- a/packages/server/server/sessions/task-done-needs-session.test.ts
+++ b/packages/server/server/sessions/task-done-needs-session.test.ts
@@ -1,0 +1,166 @@
+import { expect, test } from 'bun:test'
+import { mkdtemp } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+/**
+ * `done` requires a session filed under the task/subtask — see
+ * docs/superpowers/specs/2026-09-11-alm-session-linking-ux.md §A.2/§A.3.
+ *
+ * `patchSubtask`/`setSubtaskDone`/`markTask` all call `loadTaskWorld()`, which is hardcoded to the
+ * module-level `TASKS_FILE`/`MANAGED_SESSIONS_FILE` in `config.ts` — values computed once at module
+ * load from `process.env` (see `config-datadir.test.ts`'s own docstring: they cannot be re-derived
+ * by mutating `process.env` inside THIS process, because `config.ts` has almost certainly already
+ * been imported by an earlier test file in the same `bun test` run). So each scenario runs in its
+ * OWN process, pointed at its own `AGENTISTICS_DIR`, the same shape `registry-concurrency.test.ts`
+ * and `config-datadir.test.ts` use.
+ */
+
+const SESSIONS_DIR = import.meta.dir
+
+async function run(body: string): Promise<unknown> {
+  const dir = await mkdtemp(join(tmpdir(), 'agentop-done-needs-session-'))
+  const script = `
+    const cfg = await import(${JSON.stringify(join(SESSIONS_DIR, '..', 'config.ts'))})
+    const { createTaskStore } = await import(${JSON.stringify(join(SESSIONS_DIR, 'task-store.ts'))})
+    const { createSessionRegistry } = await import(${JSON.stringify(join(SESSIONS_DIR, 'registry.ts'))})
+    const web = await import(${JSON.stringify(join(SESSIONS_DIR, 'task-web.ts'))})
+    const store = createTaskStore(cfg.TASKS_FILE)
+    const registry = createSessionRegistry(cfg.MANAGED_SESSIONS_FILE)
+    ${body}
+  `
+  const proc = Bun.spawn([process.execPath, '-e', script], {
+    env: { ...process.env, AGENTISTICS_DIR: dir },
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+  const out = await new Response(proc.stdout).text()
+  const err = await new Response(proc.stderr).text()
+  const code = await proc.exited
+  if (code !== 0) {
+    throw new Error(`script failed (${code}): ${err.trim().split('\n').slice(-8).join(' | ')}`)
+  }
+  const line = out.trim().split('\n').filter(Boolean).at(-1) ?? '{}'
+  return JSON.parse(line)
+}
+
+const task = (id: string, over = '') => `
+  await store.upsertTask({
+    id: '${id}', title: '${id}', status: 'todo',
+    createdAt: '2026-09-11T10:00:00.000Z', updatedAt: '2026-09-11T10:00:00.000Z',
+    ${over}
+  })
+`
+const subtask = (id: string, taskId: string, over = '') => `
+  await store.upsertSubtask({
+    id: '${id}', taskId: '${taskId}', title: '${id}', status: 'todo', done: false,
+    createdAt: '2026-09-11T10:00:00.000Z', updatedAt: '2026-09-11T10:00:00.000Z',
+    ${over}
+  })
+`
+const session = (id: string, over = '') => `
+  await registry.add({
+    id: '${id}', harness: 'claude', cwd: '/tmp/x',
+    createdAt: '2026-09-11T10:00:00.000Z',
+    ${over}
+  })
+`
+
+test('setSubtaskDone refuses a subtask with NO session filed under it', async () => {
+  const out = await run(`
+    ${task('t1')}
+    ${subtask('s1', 't1')}
+    const result = await web.setSubtaskDone('s1', true)
+    const after = await store.read()
+    console.log(JSON.stringify({ result, status: after.subtasks[0].status, done: after.subtasks[0].done }))
+  `)
+  expect(out).toEqual({ result: { ok: false, message: 'done_needs_session' }, status: 'todo', done: false })
+})
+
+test('setSubtaskDone succeeds once a session is filed under THAT subtask', async () => {
+  const out = await run(`
+    ${task('t1')}
+    ${subtask('s1', 't1')}
+    ${session('sess1', "taskId: 't1', subtaskId: 's1',")}
+    const result = await web.setSubtaskDone('s1', true)
+    const after = await store.read()
+    console.log(JSON.stringify({ result, status: after.subtasks[0].status, done: after.subtasks[0].done }))
+  `)
+  expect(out).toEqual({ result: { ok: true }, status: 'done', done: true })
+})
+
+test('patchSubtask refuses an unknown subtask id', async () => {
+  const out = await run(`
+    const result = await web.patchSubtask('nope', { status: 'done' })
+    console.log(JSON.stringify({ result }))
+  `)
+  expect(out).toEqual({ result: { ok: false, message: 'no_such_subtask' } })
+})
+
+test('patchSubtask does not re-trigger the check on a patch that is not a move INTO done', async () => {
+  // The subtask is already `done`, with no session — seeded directly, bypassing the check, the way
+  // a record from before this rule existed would read. Editing its due date must still succeed: the
+  // guard is `found.status !== 'done'`, so a patch that is not actually a transition into `done`
+  // (this one leaves status alone) must never re-run it.
+  const out = await run(`
+    ${task('t1')}
+    ${subtask('s1', 't1', "status: 'done', done: true,")}
+    const result = await web.patchSubtask('s1', { dueDate: '2026-09-20' })
+    const after = await store.read()
+    console.log(JSON.stringify({ result, dueDate: after.subtasks[0].dueDate }))
+  `)
+  expect(out).toEqual({ result: { ok: true }, dueDate: '2026-09-20' })
+})
+
+test('patchSubtask allows moving to a non-done status with no session at all', async () => {
+  const out = await run(`
+    ${task('t1')}
+    ${subtask('s1', 't1')}
+    const result = await web.patchSubtask('s1', { status: 'in_progress' })
+    const after = await store.read()
+    console.log(JSON.stringify({ result, status: after.subtasks[0].status }))
+  `)
+  expect(out).toEqual({ result: { ok: true }, status: 'in_progress' })
+})
+
+test('markTask refuses `done` on a task with zero sessions anywhere under it — and writes nothing', async () => {
+  const out = await run(`
+    ${task('t1')}
+    const result = await web.markTask('t1', 'done')
+    const after = await store.read()
+    console.log(JSON.stringify({ result, status: after.tasks[0].status }))
+  `)
+  expect(out).toEqual({ result: { ok: false, message: 'done_needs_session' }, status: 'todo' })
+})
+
+test('markTask allows `done` on a task with a session filed DIRECTLY under it', async () => {
+  const out = await run(`
+    ${task('t1')}
+    ${session('sess1', "taskId: 't1',")}
+    const result = await web.markTask('t1', 'done')
+    const after = await store.read()
+    console.log(JSON.stringify({ ok: result.ok, status: after.tasks[0].status }))
+  `)
+  expect(out).toEqual({ ok: true, status: 'done' })
+})
+
+test('markTask allows `done` when the only session is filed under one of its SUBTASKS — no extra logic needed (§A.3)', async () => {
+  const out = await run(`
+    ${task('t1')}
+    ${subtask('s1', 't1')}
+    ${session('sess1', "taskId: 't1', subtaskId: 's1',")}
+    const result = await web.markTask('t1', 'done')
+    const after = await store.read()
+    console.log(JSON.stringify({ ok: result.ok, status: after.tasks[0].status }))
+  `)
+  expect(out).toEqual({ ok: true, status: 'done' })
+})
+
+test('markTask does not re-trigger the check on an already-done task, even once its sessions are gone', async () => {
+  const out = await run(`
+    ${task('t1', "status: 'done',")}
+    const result = await web.markTask('t1', 'done')
+    console.log(JSON.stringify({ ok: result.ok }))
+  `)
+  expect(out).toEqual({ ok: true })
+})

--- a/packages/server/server/sessions/task-web.ts
+++ b/packages/server/server/sessions/task-web.ts
@@ -384,6 +384,11 @@ export async function addSubtask(ref: string, title: string): Promise<boolean> {
  * `done` is never taken from the caller — it is derived from `status`, because two fields for one
  * fact drift and a row reading `done: false, status: 'done'` has no correct interpretation. A
  * caller that ticks the box sends `status: 'done'`; one that moves the status gets the tick free.
+ *
+ * A move INTO `done` requires a session filed under this specific subtask — see
+ * docs/superpowers/specs/2026-09-11-alm-session-linking-ux.md §A.2. The guard is
+ * `found.status !== 'done'`: a patch that is not actually a transition into `done` (editing the due
+ * date of an already-done subtask) must not re-trigger it.
  */
 export async function patchSubtask(subtaskId: string, patch: {
   title?: string
@@ -395,11 +400,15 @@ export async function patchSubtask(subtaskId: string, patch: {
   notes?: string
   /** Sanitized against this subtask's OWN siblings — see `sanitizeSubtaskBlockedBy`. */
   blockedBy?: string[]
-}): Promise<boolean> {
+}): Promise<{ ok: true } | { ok: false; message: 'no_such_subtask' | 'done_needs_session' }> {
   const w = await loadTaskWorld()
   const found = w.book.subtasks.find(t => t.id === subtaskId)
-  if (!found) return false
+  if (!found) return { ok: false, message: 'no_such_subtask' }
   const status = patch.status ?? found.status
+  if (status === 'done' && found.status !== 'done') {
+    const hasSession = w.rows.some(r => r.subtaskId === subtaskId)
+    if (!hasSession) return { ok: false, message: 'done_needs_session' }
+  }
   await w.store.upsertSubtask({
     ...found,
     ...(patch.title?.trim() ? { title: patch.title.trim() } : {}),
@@ -419,7 +428,7 @@ export async function patchSubtask(subtaskId: string, patch: {
     } : {}),
     updatedAt: new Date().toISOString(),
   })
-  return true
+  return { ok: true }
 }
 
 export async function removeSubtask(subtaskId: string): Promise<boolean> {
@@ -431,7 +440,9 @@ export async function removeSubtask(subtaskId: string): Promise<boolean> {
 }
 
 /** The tick, expressed as what it means: a move to `done`, or back to `todo`. */
-export async function setSubtaskDone(subtaskId: string, done: boolean): Promise<boolean> {
+export async function setSubtaskDone(subtaskId: string, done: boolean): Promise<
+  { ok: true } | { ok: false; message: 'no_such_subtask' | 'done_needs_session' }
+> {
   return await patchSubtask(subtaskId, { status: done ? 'done' : 'todo' })
 }
 
@@ -701,6 +712,20 @@ export async function markTask(
       })
     }
   }
+  /*
+   * `done` requires a session filed under the task — same shape as `blocked_needs_reason` above,
+   * checked BEFORE the write so it binds the browser, the CLI and the MCP alike. `rowsOfTask`
+   * counts a session ANYWHERE under the task — filed directly, or under any of its subtasks,
+   * regardless of `subtaskId` — so this one check is correct for a task with subtasks, without
+   * subtasks, or a mix, with no new counting logic (see
+   * docs/superpowers/specs/2026-09-11-alm-session-linking-ux.md §A.3). The guard is
+   * `task.status !== 'done'`: a move that is not actually a transition into `done` (re-marking an
+   * already-done task) must not re-trigger it. Computed once and reused below for the
+   * delivery-evidence block, rather than calling `rowsOfTask` a second time.
+   */
+  const mine = to === 'done' && task.status !== 'done' ? rowsOfTask(task, w.rows) : undefined
+  if (mine && mine.length === 0) return { ok: false, message: 'done_needs_session' }
+
   // `done` is the ONE status that stamps a delivery. Every other move is a change of where the work
   // stands, and stamping one of those would close rounds-to-delivery on work that is not delivered.
   const done = to === 'done'
@@ -743,8 +768,8 @@ export async function markTask(
 
   if (!done) return { ok: true }
 
-  const mine = rowsOfTask(task, w.rows)
-  const dirs = [...new Set(mine.map(r => r.cwd).filter(Boolean))]
+  const rows = mine ?? rowsOfTask(task, w.rows)
+  const dirs = [...new Set(rows.map(r => r.cwd).filter(Boolean))]
   const bySha = new Map<string, { sha: string; message: string; atMs: number }>()
   for (const dir of dirs) {
     // Deduped by sha: two sessions of one task routinely share a checkout, and the same commit read


### PR DESCRIPTION
## Summary
- `patchSubtask`/`setSubtaskDone` now return `{ok:true} | {ok:false, message:'no_such_subtask'|'done_needs_session'}` instead of a bare boolean, and refuse a move into `done` when no session is filed under that specific subtask.
- `markTask` gains the same `done_needs_session` guard, checked **before** any write (same shape as `blocked_needs_reason`), reusing the existing `rowsOfTask(task, w.rows)` call already made for the delivery-evidence block — no second call added.
- Both guards fire only on an actual transition into `done` (`status !== 'done'` before the patch), so re-marking an already-done record, or editing an unrelated column, never re-triggers them.
- Out of scope by design (separate subtasks of t-918cc82233): `index.ts`'s HTTP wiring (422 propagation) and the UI refusal dialog.

See `docs/superpowers/specs/2026-09-11-alm-session-linking-ux.md` §A.2/§A.3.

## Test plan
- [x] New `task-done-needs-session.test.ts` (9 cases) — each spawns an isolated subprocess with its own `AGENTISTICS_DIR`, since `loadTaskWorld()` resolves paths from `config.ts` at module load (same pattern as `registry-concurrency.test.ts`/`config-datadir.test.ts`).
- [x] TDD: tests written and run red against the old implementation first, then green after.
- [x] `bun tsc --noEmit` clean.
- [x] `bun test packages/server` clean (4129 tests; full suite 7944 tests green via the pre-commit hook).