### PR TITLE
fix(web): file a session under its real task when created together

### DIFF
--- a/packages/web/src/components/sessions/NewSessionModal.tsx
+++ b/packages/web/src/components/sessions/NewSessionModal.tsx
@@ -97,9 +97,19 @@ export interface NewSessionModalProps {
    * field gets left blank.
    */
   initialTask?: string
+  /**
+   * The real task this session is being started FOR, once one already exists.
+   *
+   * `initialTask` alone only ever fills the free-text label sent to `/api/fleet/new` — it never
+   * files the session under the task, because a display string carries no id. When the caller
+   * already has a real `Task`, it passes this too, so the wizard seeds `subtaskTarget` with a bare
+   * task-level attach (no subtask — the caller never asked for one) and the session that comes out
+   * the other end is actually filed, not just labeled. See spec 2026-09-11 §C.2.
+   */
+  initialTaskId?: string
 }
 
-export function NewSessionModal({ lang, onClose, onStarted, initialTask }: NewSessionModalProps) {
+export function NewSessionModal({ lang, onClose, onStarted, initialTask, initialTaskId }: NewSessionModalProps) {
   const pt = lang === 'pt'
   const [harnesses, setHarnesses] = useState<HarnessOption[] | null>(null)
   const [projects, setProjects] = useState<ProjectOption[]>([])
@@ -132,13 +142,17 @@ export function NewSessionModal({ lang, onClose, onStarted, initialTask }: NewSe
   const [cwd, setCwd] = useState('')
   const [task, setTask] = useState(initialTask ?? '')
   /**
-   * The exact SUBTASK this session will be filed under, once it exists — set only by the picker,
-   * never by the folder suggestion below (which only ever proposes a delivery TITLE, and asking a
-   * suggestion to also pick a subtask would be asking it to answer a question it never asked).
-   * `task` stays the free-text label sent at spawn either way — this is the extra, exact half that
-   * lets the attach happen automatically once the session is created.
+   * The exact TASK (and, when the picker was used, SUBTASK) this session will be filed under, once
+   * it exists. `subtaskId` is absent for a bare task-level attach — set either by `initialTaskId`
+   * (the caller already has a real task and never asked for a subtask) or by the folder suggestion
+   * resolving its guessed title against a real task (same reason, see the effect below); it is set
+   * WITH a subtask only by the picker. `task` stays the free-text label sent at spawn either way —
+   * this is the extra, exact half that lets the attach happen automatically once the session is
+   * created. See spec 2026-09-11 §C.2.
    */
-  const [subtaskTarget, setSubtaskTarget] = useState<{ taskId: string; subtaskId: string } | null>(null)
+  const [subtaskTarget, setSubtaskTarget] = useState<{ taskId: string; subtaskId?: string } | null>(
+    initialTaskId ? { taskId: initialTaskId } : null,
+  )
   /** Set when that automatic attach comes back refused because the subtask is still blocked. */
   const [subtaskBlocked, setSubtaskBlocked] = useState<
     { taskId: string; subtaskId: string; blockedBy: string[]; sessionId: string } | null
@@ -195,6 +209,11 @@ export function NewSessionModal({ lang, onClose, onStarted, initialTask }: NewSe
   /**
    * Fill the field FROM the suggestion — never over a person's own choice, and never again once
    * they have cleared it for this folder.
+   *
+   * A suggestion is only ever a TITLE guess, but when it happens to name a real, already-created
+   * task, resolving that id and seeding `subtaskTarget` (no subtask) is what turns "looks filed"
+   * into actually filed — the same root cause and the same fix as `initialTaskId` above. See spec
+   * 2026-09-11 §C.2.
    */
   useEffect(() => {
     if (suggestionDismissed) return
@@ -203,7 +222,9 @@ export function NewSessionModal({ lang, onClose, onStarted, initialTask }: NewSe
     if (next === task) return
     setTask(next)
     setTaskWasSuggested(next !== '')
-  }, [suggestion, suggestionDismissed, task, taskWasSuggested])
+    const matchedId = next ? taskRows?.find(r => r.task.title === next)?.task.id : undefined
+    setSubtaskTarget(matchedId ? { taskId: matchedId } : null)
+  }, [suggestion, suggestionDismissed, task, taskWasSuggested, taskRows])
 
   const [busy, setBusy] = useState(false)
   const [notice, setNotice] = useState<string | null>(null)
@@ -589,7 +610,9 @@ export function NewSessionModal({ lang, onClose, onStarted, initialTask }: NewSe
         if (subtaskTarget && json.id) {
           const { taskId, subtaskId } = subtaskTarget
           const result = await attachSession(taskId, json.id, subtaskId)
-          if (!result.ok && result.reason === 'blocked') {
+          // `blocked` is a SUBTASK concept — a bare task-level attach (no `subtaskId`) can never
+          // come back refused this way, so the branch below only ever runs with a real subtask id.
+          if (!result.ok && result.reason === 'blocked' && subtaskId) {
             const detailRes = await fetch(`/api/tasks/${encodeURIComponent(taskId)}`).catch(() => null)
             const body = detailRes?.ok ? await detailRes.json() as { task: TaskDetail } : null
             setBlockedDetail(body?.task ?? null)

--- a/packages/web/src/pages/TasksPage.tsx
+++ b/packages/web/src/pages/TasksPage.tsx
@@ -274,6 +274,7 @@ function TaskList() {
         <NewSessionModal
           lang={lang}
           initialTask={starting.title}
+          initialTaskId={starting.taskId}
           onClose={() => setStarting(null)}
           onStarted={async () => {
             const to = starting.taskId


### PR DESCRIPTION
## Summary
- `NewSessionModal` only ever filed a spawned session under a task through `subtaskTarget`, set exclusively by `TaskPicker`. The task wizard's "create, then start a session" flow and the folder-suggestion auto-fill both set only the free-text task label — so a session created for a brand-new task *looked* filed everywhere that joins by string, while `rowsOfTask` (which matches by real `taskId` or a legacy hash) never found it. The task's rollup and sessions list stayed permanently empty for a session created specifically for it.
- `NewSessionModal` now takes an `initialTaskId` prop and seeds `subtaskTarget` with a bare task-level attach (no subtask) when set; `subtaskTarget` widens to `{taskId, subtaskId?}`.
- The suggestion-acceptance effect resolves its guessed title against `taskRows` and seeds the same bare attach when it names a real task.
- `TasksPage` passes the real `taskId` it already has through to the modal.

See `docs/superpowers/specs/2026-09-11-alm-session-linking-ux.md` §C.2 for the confirmed root cause and the spec this follows exactly.

## Test plan
- [x] `bun tsc --noEmit` clean
- [x] `bun test` (repo-wide) clean — 7934 pass / 0 fail
- [x] Manual end-to-end check on an isolated preview server (isolated port + `AGENTISTICS_DIR`, never the live instance): created a real task, spawned a probe session, performed the bare task-level attach exactly as the fixed code does, confirmed via `GET /api/tasks/:id` that `sessionsUsed: 1` and `provenance.assigned: 1` — the session was actually linked, not just labeled. Probe session and task discarded afterward.
- [x] Mobile: no JSX/layout touched — wizard was already `isMobile`-aware and did not regress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)