### PR TITLE
feat(web): flag icon near an open session's title — linked/unlinked to a delivery

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -103,6 +103,7 @@ import { PAGE_INSET, PAGE_MAX_WIDTH } from './components/sessions/FleetOverview'
 import { setFleetSourceCentral } from './lib/fleet'
 import { reopenedSessionRoute, sessionPath } from './lib/sessionRoute'
 import { SessionStatsMenu } from './components/sessions/SessionStatsMenu'
+import { SessionTitleFlag } from './components/sessions/SessionTitleFlag'
 
 /**
  * What the SESSIONS filter bar may filter by — narrower than the dashboard's on purpose: a fleet
@@ -1899,7 +1900,7 @@ export default function AppLayout() {
   // A CENTRAL's fleet is the RELAY's, for the machine the aside's picker chose. Set once, here,
   // because the poller is module-scoped and every surface reads the same snapshot.
   useEffect(() => { setFleetSourceCentral(isCentral) }, [isCentral])
-  const { fleet: headerFleet, act: headerFleetAct, unsupported: headerFleetUnsupported } = useFleet(lang === 'pt' ? 'pt' : 'en')
+  const { fleet: headerFleet, act: headerFleetAct, unsupported: headerFleetUnsupported, refresh: headerFleetRefresh } = useFleet(lang === 'pt' ? 'pt' : 'en')
   /**
    * "Active only" needs a fleet to intersect against, on EITHER page. An exposed profile with no
    * host power, or a central with no machine chosen, both report `unsupported` here — offering the
@@ -3060,6 +3061,15 @@ export default function AppLayout() {
           }}>
             {selectedFleetSession.title}
           </span>
+          <SessionTitleFlag
+            session={{
+              id: selectedFleetSession.id, title: selectedFleetSession.title,
+              ...(selectedFleetSession.harness ? { harness: selectedFleetSession.harness } : {}),
+              ...(selectedFleetSession.task ? { task: selectedFleetSession.task } : {}),
+            }}
+            lang={lang === 'pt' ? 'pt' : 'en'}
+            onLinked={headerFleetRefresh}
+          />
           {/* Gives up before the title does: the name is what identifies the session, and the state
               is repeated on its own row in the aside two centimetres away. */}
           <span style={{

--- a/packages/web/src/components/sessions/SessionTitleFlag.tsx
+++ b/packages/web/src/components/sessions/SessionTitleFlag.tsx
@@ -1,0 +1,82 @@
+/**
+ * SessionTitleFlag — the OPEN session's own delivery flag, beside its title.
+ *
+ * Three headers currently draw an open session's title inline — the desktop shared header
+ * (`App.tsx`), the mobile panel header and the mobile dedicated-terminal header (both in
+ * `SessionsPage.tsx`) — and each used to be a candidate for pasting the same "flag icon, filled
+ * orange when `task` is set, dotted outline otherwise" markup a fourth time. One gesture
+ * implemented three times is the bug `task-reopen.ts` exists to have fixed once, so it lives here
+ * instead and every header imports it.
+ *
+ * Unlinked: an outlined, dashed flag. Clicking it opens `NewTaskWizard` pre-linked to this
+ * session — the same dialog `SessionTasksTab`'s own "New task for this session" composer opens,
+ * so there is no second creation flow, only a new entry point into the existing one.
+ *
+ * Linked: a filled orange flag. Clicking it opens this session's own aside on the Deliveries tab
+ * (`openArtifacts('tasks')`) — the pattern `chatNote.ts`'s `systemRef` navigation already uses for
+ * "open this tab of the aside," rather than navigating away from the conversation.
+ */
+
+import { useState } from 'react'
+import { Flag } from 'lucide-react'
+import { openArtifacts } from '../../lib/artifactsStore'
+import { NewTaskWizard } from '../tasks/NewTaskWizard'
+
+export interface SessionTitleFlagProps {
+  session: { id: string; title: string; harness?: string; task?: string }
+  lang: 'pt' | 'en'
+  /**
+   * A task was just created and this session linked to it.
+   *
+   * The fleet poll would pick this up within a few seconds regardless, but calling it lets the
+   * caller refresh right away so the flag fills in the same moment the dialog closes.
+   */
+  onLinked?: () => void
+}
+
+export function SessionTitleFlag({ session, lang, onLinked }: SessionTitleFlagProps) {
+  const pt = lang === 'pt'
+  const [creating, setCreating] = useState(false)
+  const linked = Boolean(session.task)
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => { if (linked) openArtifacts('tasks'); else setCreating(true) }}
+        title={linked
+          ? (pt ? `Entrega: ${session.task} — abrir` : `Delivery: ${session.task} — open`)
+          : (pt ? 'Sem entrega — criar uma para esta sessão' : 'No delivery — create one for this session')}
+        aria-label={linked
+          ? (pt ? 'Abrir a entrega desta sessão' : "Open this session's delivery")
+          : (pt ? 'Criar uma entrega para esta sessão' : 'Create a delivery for this session')}
+        style={{
+          display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+          width: 22, height: 22, flexShrink: 0, padding: 0,
+          border: 'none', borderRadius: 6, background: 'transparent', cursor: 'pointer',
+          color: linked ? 'var(--anthropic-orange)' : 'var(--text-tertiary)',
+        }}
+      >
+        <Flag
+          size={13}
+          {...(linked
+            ? { fill: 'currentColor' }
+            // Unlinked reads as an outline the reader can fill in, never a solid mark that looks
+            // like a fact already recorded.
+            : { strokeDasharray: '2,1.6' })}
+        />
+      </button>
+
+      {creating && (
+        <NewTaskWizard
+          session={{
+            id: session.id, title: session.title,
+            ...(session.harness ? { harness: session.harness } : {}),
+          }}
+          onClose={() => setCreating(false)}
+          onDone={() => { setCreating(false); onLinked?.() }}
+        />
+      )}
+    </>
+  )
+}

--- a/packages/web/src/components/tasks/NewTaskWizard.tsx
+++ b/packages/web/src/components/tasks/NewTaskWizard.tsx
@@ -22,8 +22,14 @@ import { BetaTag } from '../BetaTag'
 export interface NewTaskWizardProps {
   onDone: (taskId: string) => void | Promise<void>
   onClose: () => void
-  /** Opens the existing session wizard. The task is created first and handed over. */
-  onCreateSession: (taskId: string, title: string) => void
+  /**
+   * Opens the existing session wizard. The task is created first and handed over.
+   *
+   * Absent where a session already exists to file under it — opened from that session's own title
+   * flag, say, there is nothing for "start a new one" to mean, and `TaskComposer` already renders
+   * no such button when it gets none.
+   */
+  onCreateSession?: (taskId: string, title: string) => void
   /** Opened FROM a session — it arrives pre-linked. See `TaskComposer`. */
   session?: { id: string; title: string; harness?: string }
 }
@@ -75,7 +81,7 @@ export function NewTaskWizard({ onDone, onClose, onCreateSession, session }: New
           {...(session ? { session } : {})}
           onDone={taskId => onDone(taskId)}
           onCancel={onClose}
-          onCreateSession={onCreateSession}
+          {...(onCreateSession ? { onCreateSession } : {})}
         />
       </div>
     </div>,

--- a/packages/web/src/pages/SessionsPage.tsx
+++ b/packages/web/src/pages/SessionsPage.tsx
@@ -31,6 +31,7 @@ import { SessionCreating } from '../components/sessions/SessionCreating'
 // while creating was the only thing that could announce a session; a reopen announces one too, and
 // two constants for one budget is two answers.
 import { SessionStatsMenu } from '../components/sessions/SessionStatsMenu'
+import { SessionTitleFlag } from '../components/sessions/SessionTitleFlag'
 import { MagnifierButton } from '../components/a11y/MagnifierButton'
 import { HideLensesButton } from '../components/a11y/HideLensesButton'
 import { ArtifactsAside } from '../components/sessions/ArtifactsAside'
@@ -705,10 +706,21 @@ export default function SessionsPage() {
             <ChevronLeft size={20} />
           </button>
           <div style={{ minWidth: 0, flex: 1 }}>
-            <div style={{
-              fontSize: 13, fontWeight: 650, color: 'var(--text-primary)',
-              overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
-            }}>{selected.title}</div>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 6, minWidth: 0 }}>
+              <div style={{
+                fontSize: 13, fontWeight: 650, color: 'var(--text-primary)', minWidth: 0,
+                overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+              }}>{selected.title}</div>
+              <SessionTitleFlag
+                session={{
+                  id: selected.id, title: selected.title,
+                  ...(selected.harness ? { harness: selected.harness } : {}),
+                  ...(selected.task ? { task: selected.task } : {}),
+                }}
+                lang={pt ? 'pt' : 'en'}
+                onLinked={refresh}
+              />
+            </div>
             <div style={{
               fontSize: 10.5, color: 'var(--text-tertiary)',
               overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
@@ -848,11 +860,22 @@ export default function SessionsPage() {
             </button>
 
             <div style={{ minWidth: 0, flex: 1, display: 'flex', flexDirection: 'column' }}>
-              <span style={{
-                fontSize: 13, fontWeight: 650, color: 'var(--text-primary)',
-                overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
-              }}>
-                {selected.title}
+              <span style={{ display: 'flex', alignItems: 'center', gap: 6, minWidth: 0 }}>
+                <span style={{
+                  fontSize: 13, fontWeight: 650, color: 'var(--text-primary)', minWidth: 0,
+                  overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+                }}>
+                  {selected.title}
+                </span>
+                <SessionTitleFlag
+                  session={{
+                    id: selected.id, title: selected.title,
+                    ...(selected.harness ? { harness: selected.harness } : {}),
+                    ...(selected.task ? { task: selected.task } : {}),
+                  }}
+                  lang={pt ? 'pt' : 'en'}
+                  onLinked={refresh}
+                />
               </span>
               {/* The state stays, on its own line: it is the one fact that changes while you read,
                   and the row below is a conversation that does not repeat it. */}


### PR DESCRIPTION
## Summary
- Adds `SessionTitleFlag`, a shared component drawn beside an open session's own title in the three headers that render it (`App.tsx`'s desktop strip, `SessionsPage.tsx`'s mobile panel and dedicated-terminal headers): an outlined/dashed flag when the session has no delivery (click opens `NewTaskWizard` pre-linked to it — same dialog `SessionTasksTab`'s own composer opens), filled orange when it does (click opens the session's own aside on the Deliveries tab).
- `NewTaskWizard.onCreateSession` is now optional (matching `TaskComposer`'s own prop), since a session opened from its own title flag already exists and "start a new one" has nothing to mean there.

Implements §C.6 of `docs/superpowers/specs/2026-09-11-alm-session-linking-ux.md` (subtask s-16817126b7 of the internal ALM task board, t-918cc82233).

## Test plan
- [x] `bun tsc --noEmit` clean
- [x] `bun test` clean (full monorepo, 7934 pass / 0 fail via the pre-commit hook)
- [x] Verified in an isolated preview instance (own `AGENTISTICS_DIR`/ports, no production data touched) against a real live session: empty flag → `NewTaskWizard` pre-linked → create-and-link → flag fills in immediately (no poll wait) → click opens the aside's Deliveries tab showing "This session is filed under Parte 1"
- [x] Confirmed the real production fleet's session (`localhost:47291/api/fleet`) still reports `task: null` — the test task only lived in the isolated preview store
- [x] Mobile (390×844, Playwright) confirmed on both mobile headers via accessibility snapshot

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TvLqkzjWg6BQR2K554jGMK