### PR TITLE
fix(web): show delivery name above session title, not folded into meta

### DIFF
--- a/packages/web/src/components/sessions/SessionFacts.tsx
+++ b/packages/web/src/components/sessions/SessionFacts.tsx
@@ -49,9 +49,21 @@ export interface SessionFactsProps {
 export function SessionFacts({ session, selected = false, onFile, lang = 'en', metaColor }: SessionFactsProps) {
   const wants = sessionNotify(session)
   return (
-    <span style={{ minWidth: 0, flex: 1, display: 'flex', flexDirection: 'column', gap: 3 }}>
+    <span style={{ minWidth: 0, flex: 1, display: 'flex', flexDirection: 'column', gap: 2 }}>
+      {/* The DELIVERY's name, read above the title rather than folded into the meta line below —
+          the meta line's Bookmark segment (onFile) still does the filing gesture; this is purely
+          about where the name is READ. */}
+      {session.task && (
+        <span style={{
+          fontSize: 9.5, color: 'var(--text-tertiary)', fontWeight: 600,
+          overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+        }}>
+          {session.task}
+        </span>
+      )}
       <span style={{
-        fontSize: 12.5, fontWeight: selected || wants ? 650 : 500,
+        fontSize: session.task ? 13.5 : 12.5,
+        fontWeight: (selected || wants ? 650 : 500) + (session.task ? 50 : 0),
         overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
       }}>
         {session.title}


### PR DESCRIPTION
## Summary
- `SessionFacts.tsx`: when `session.task` is set, render the delivery name on its own muted line above the session title, and bump the title's `fontSize`/`fontWeight` slightly in that case.
- The meta line's `Bookmark`/`onFile` segment (the filing control) is unchanged — this is purely about where the delivery's name is read.
- `SessionFacts` is shared by the open sessions list and the collapsed rail's tooltip, and by desktop and mobile, so this single-file change covers all four surfaces.

Implements subtask `s-011e5cbd97` of task `t-918cc82233`, per `docs/superpowers/specs/2026-09-11-alm-session-linking-ux.md` §C.3.

## Test plan
- [x] `bun tsc --noEmit` clean
- [x] `bun test packages/web` clean (2214 pass)
- [x] Full pre-commit suite clean (7934 pass via husky hook)
- [x] Visual check with an isolated preview server (scratch `AGENTISTICS_DIR`, ports 47391/47392, never the user's live instance) + Playwright at 1440px and 390px: filed vs. unfiled session rows compared, no horizontal overflow at 390px

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)