### PR TITLE
feat(shell): o teto deixa de ser um beco sem saída

### DIFF
--- a/packages/server/server/sessions/shell-web.ts
+++ b/packages/server/server/sessions/shell-web.ts
@@ -100,7 +100,27 @@ export async function handleShellRoute(
   }
 
   if (url.pathname === '/api/shell/list' && req.method === 'GET') {
-    return json({ shells: await listShells(), cap: SHELL_CAP })
+    const shells = await listShells()
+    // `?titles=1` is OPT-IN because naming the sessions costs a fleet walk (~200 ms of pane reads),
+    // and the band asks this route on EVERY open. Only the CEILING list needs the names — and it
+    // needs them badly: a per-session shell in one repository puts every row in the same directory,
+    // so without them the picker's rows all read alike. The names come from the injected HOST, the
+    // same way `/api/shell/open` resolves the row it takes a directory from; nothing here imports
+    // the registry, which is what `shell-isolation.test.ts` asserts over this source.
+    if (url.searchParams.get('titles') !== '1' || !host.sessions) {
+      return json({ shells, cap: SHELL_CAP })
+    }
+    const fleet = await host.sessions().catch(() => null)
+    const byId = new Map((fleet?.sessions ?? []).map(r => [r.id, r.title]))
+    return json({
+      shells: shells.map(sh => {
+        const title = byId.get(sh.sessionId)
+        // A session nobody could name is left WITHOUT the field rather than given a blank one:
+        // `ceilingRows` falls back to where the shell is, which is a real answer.
+        return title ? { ...sh, sessionTitle: title } : sh
+      }),
+      cap: SHELL_CAP,
+    })
   }
 
   if (url.pathname === '/api/shell/open' && req.method === 'POST') {

--- a/packages/web/src/components/sessions/ShellBand.tsx
+++ b/packages/web/src/components/sessions/ShellBand.tsx
@@ -45,6 +45,9 @@ import {
 } from 'lucide-react'
 import { useDocumentVisible } from '../../hooks/useDocumentVisible'
 import { keyStripShown } from '../../lib/terminalSurface'
+import {
+  atCap, ceilingRows, ceilingTitle, type CeilingRow, type CeilingShell,
+} from '../../lib/shellCeiling'
 import { useIsMobile } from '../../hooks/useIsMobile'
 import { useTerminalStream } from '../../hooks/useTerminalStream'
 import { useTerminalWrite } from '../../hooks/useTerminalWrite'
@@ -75,6 +78,7 @@ interface T {
   resize: string
   retry: string
   fullscreen: string
+  endThis: string
 }
 
 const TXT: Record<'pt' | 'en', T> = {
@@ -92,6 +96,7 @@ const TXT: Record<'pt' | 'en', T> = {
     resize: 'Drag to resize the shell',
     retry: 'Try again',
     fullscreen: 'Open the shell full screen',
+    endThis: 'End this terminal',
   },
   pt: {
     title: 'Shell',
@@ -107,6 +112,7 @@ const TXT: Record<'pt' | 'en', T> = {
     resize: 'Arraste para redimensionar o shell',
     retry: 'Tentar de novo',
     fullscreen: 'Abrir o shell em tela cheia',
+    endThis: 'Encerrar este terminal',
   },
 }
 
@@ -147,6 +153,8 @@ export function ShellBand({ sessionId, cwd, lang, theme, placement = 'docked', o
     dedicated || readBandPrefs().open ? shellBandReducer(init, { type: 'openBand' }) : init)
   const shell = band.shell
   const [ctrlArmed, setCtrlArmed] = useState(false)
+  /** The open shells, fetched ONLY when the ceiling refuses — see `shellCeiling.ts`. */
+  const [ceiling, setCeiling] = useState<{ rows: CeilingRow[]; cap: number } | null>(null)
   const [ctrlNote, setCtrlNote] = useState<string | null>(null)
 
   const setBand = useCallback((next: Partial<{ open: boolean; height: number }>) => {
@@ -197,13 +205,15 @@ export function ShellBand({ sessionId, cwd, lang, theme, placement = 'docked', o
           body: JSON.stringify({ sessionId }),
         })
         const body = await res.json().catch(() => ({})) as {
-          ok?: boolean; shell?: OpenShell; message?: string; error?: string
+          ok?: boolean; shell?: OpenShell; message?: string; error?: string; reason?: string
         }
         if (cancelled) return
         // A REFUSAL arrives as a sentence the server composed; it is shown verbatim. A route-level
         // error carries only a code, and `shellErrorText` is the one place that words those.
         if (body.ok && body.shell) dispatch({ type: 'resolved', shell: body.shell })
-        else if (body.message) dispatch({ type: 'refused', message: body.message })
+        // The CODE travels with the sentence: only `at-cap` has anything to offer, and matching on
+        // a localized sentence would stop working the day somebody rewords it.
+        else if (body.message) dispatch({ type: 'refused', message: body.message, ...(body.reason ? { reason: body.reason } : {}) })
         else dispatch({ type: 'refused', message: shellErrorText(body.error ?? 'network', lang) })
       } catch {
         if (!cancelled) dispatch({ type: 'refused', message: shellErrorText('network', lang) })
@@ -213,6 +223,37 @@ export function ShellBand({ sessionId, cwd, lang, theme, placement = 'docked', o
     // render asks again instead of leaving a spinner over nothing.
     return () => { cancelled = true; dispatch({ type: 'cancelled' }) }
   }, [band.attempt, sessionId, lang])
+
+  /**
+   * THE CEILING IS THE ONE REFUSAL A PERSON CAN ACT ON, and until now it was the one with no
+   * action: nothing in this product listed or closed a shell, so "close one to open another" sent
+   * you looking through eight other sessions. The list is fetched only on that refusal — `?titles=1`
+   * costs a fleet walk, and the names are what make the rows distinguishable when every shell of a
+   * repository sits in the same directory.
+   */
+  useEffect(() => {
+    if (!atCap(band.reason)) { setCeiling(null); return }
+    let gone = false
+    void (async () => {
+      const body = await fetch(shellApiUrl('/api/shell/list', lang) + '&titles=1')
+        .then(r => r.ok ? r.json() as Promise<{ shells?: CeilingShell[]; cap?: number }> : null)
+        .catch(() => null)
+      if (gone || !body) return
+      setCeiling({ rows: ceilingRows(body.shells ?? []), cap: body.cap ?? 0 })
+    })()
+    return () => { gone = true }
+  }, [band.reason, band.attempt, lang])
+
+  /** End one of the OTHER shells, then ask again — the retry is the whole point of the list. */
+  const closeOther = useCallback(async (id: string) => {
+    setCeiling(c => (c ? { ...c, rows: c.rows.filter(r => r.id !== id) } : c))
+    await fetch(shellApiUrl('/api/shell/close', lang), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ids: [id] }),
+    }).catch(() => {})
+    dispatch({ type: 'retry' })
+  }, [lang])
 
   const watching = shellWatching({
     bandOpen,
@@ -351,7 +392,7 @@ export function ShellBand({ sessionId, cwd, lang, theme, placement = 'docked', o
       {ctrlArmed ? t.ctrlHint : ctrlNote ?? line}
       {/* A refusal is a DEAD STOP by design — the band never retries a "no" on its own — so the way
           forward has to be on screen. Without it a refused band is a sentence and nothing else. */}
-      {band.phase === 'refused' && (
+      {band.phase === 'refused' && !atCap(band.reason) && (
         <button
           onClick={() => dispatch({ type: 'retry' })}
           style={{
@@ -368,6 +409,56 @@ export function ShellBand({ sessionId, cwd, lang, theme, placement = 'docked', o
       )}
     </div>
   )
+
+  /**
+   * THE WAY OUT OF THE CEILING. `at-cap` used to be a sentence and nothing else; this is the list
+   * the sentence was telling you to go and find. Each row NAMES its session (the directory alone
+   * does not separate them — a repository's shells all sit in the same one) and carries the handle,
+   * so two rows that still read alike are told apart by something.
+   */
+  const ceilingList = ceiling && atCap(band.reason) ? (
+    <div style={{
+      flexShrink: 0, display: 'flex', flexDirection: 'column', gap: 6,
+      maxHeight: isMobile ? 260 : 180, overflowY: 'auto',
+      padding: 8, borderRadius: 8,
+      border: '1px solid var(--border-subtle)', background: 'var(--bg-elevated)',
+    }}>
+      <div style={{ fontSize: 11, fontWeight: 700, color: 'var(--text-secondary)' }}>
+        {ceilingTitle(ceiling.cap, lang)}
+      </div>
+      {ceiling.rows.map(row => (
+        <div key={row.id} style={{ display: 'flex', alignItems: 'center', gap: 8, minWidth: 0 }}>
+          <div style={{ minWidth: 0, flex: 1 }}>
+            <div style={{
+              fontSize: 12, fontWeight: 600, color: 'var(--text-primary)',
+              overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+            }}>{row.title}</div>
+            <div style={{
+              fontSize: 10.5, color: 'var(--text-tertiary)', fontFamily: 'monospace',
+              overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+            }}>{row.short}{row.where ? ` · ${row.where}` : ''}</div>
+          </div>
+          <button className="ag-tap-icon"
+            onClick={() => { void closeOther(row.id) }}
+            title={t.endThis}
+            aria-label={`${t.endThis} — ${row.title}`}
+            style={{
+              // PAINTED small, TARGETED at 44px by `.ag-tap-icon` — the repo's rule, and the one
+              // this list must not break: a row of 44px squares turns a compact list into a column
+              // of boxes, while the finger still needs the 44.
+              display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0,
+              width: 26, height: 26,
+              borderRadius: 6, cursor: 'pointer',
+              border: '1px solid var(--border-subtle)', background: 'transparent',
+              color: 'var(--text-tertiary)',
+            }}
+          >
+            <Trash2 size={13} />
+          </button>
+        </div>
+      ))}
+    </div>
+  ) : null
 
   const strip = (
     <div style={{
@@ -409,6 +500,7 @@ export function ShellBand({ sessionId, cwd, lang, theme, placement = 'docked', o
       }}>
         {shell ? screen : <div style={{ flex: 1 }} />}
         {notice}
+        {ceilingList}
         {keyStripShown('dedicated', isMobile) && strip}
       </div>
     )
@@ -420,6 +512,10 @@ export function ShellBand({ sessionId, cwd, lang, theme, placement = 'docked', o
       return (
         <button
           onClick={() => setBand({ open: true })}
+          aria-expanded={false}
+          // The desktop bar has carried this since phase 2 and the phone's had nothing: a screen
+          // reader met a button whose whole content was an icon, the word "Shell" and a path.
+          aria-label={t.toggleBar}
           style={{
             display: 'flex', alignItems: 'center', gap: 8, width: '100%',
             minHeight: 44, padding: '0 12px', flexShrink: 0,
@@ -485,6 +581,7 @@ export function ShellBand({ sessionId, cwd, lang, theme, placement = 'docked', o
         }}>
           {shell ? screen : <div style={{ flex: 1 }} />}
           {notice}
+          {ceilingList}
           {strip}
         </div>
       </div>
@@ -588,6 +685,7 @@ export function ShellBand({ sessionId, cwd, lang, theme, placement = 'docked', o
         }}>
           {shell ? screen : <div style={{ flex: 1 }} />}
           {notice}
+          {ceilingList}
         </div>
       )}
     </div>

--- a/packages/web/src/lib/shellBandState.test.ts
+++ b/packages/web/src/lib/shellBandState.test.ts
@@ -110,3 +110,32 @@ describe('the band never claims to be opening with nothing in flight', () => {
     expect(shellResolveWanted(shellBandReducer(INITIAL_SHELL_BAND, { type: 'openBand' }))).toBe(true)
   })
 })
+
+describe('the refusal keeps its CODE, not only its sentence', () => {
+  const refuse = (message: string, reason?: string) =>
+    shellBandReducer(INITIAL_SHELL_BAND, { type: 'refused', message, ...(reason ? { reason } : {}) })
+
+  // The sentence is what a person reads; the CODE is what the band acts on. Only the ceiling
+  // refusal has anything to offer — a list of the open shells — and without the code the band
+  // would have to match on the sentence, which is localized and would break on a rewording.
+  test('a ceiling refusal is recognisable afterwards', () => {
+    const s = refuse('All 8 terminals are open.', 'at-cap')
+    expect(s.phase).toBe('refused')
+    expect(s.reason).toBe('at-cap')
+  })
+
+  test('a refusal with no code carries none rather than inventing one', () => {
+    expect(refuse('the network went away').reason).toBeNull()
+  })
+
+  test('retrying clears the code with the sentence — both describe an attempt that is over', () => {
+    const s = shellBandReducer(refuse('All 8 terminals are open.', 'at-cap'), { type: 'retry' })
+    expect(s.reason).toBeNull()
+    expect(s.message).toBeNull()
+  })
+
+  test('a resolved shell clears it too', () => {
+    const s = shellBandReducer(refuse('x', 'at-cap'), { type: 'resolved', shell: { id: 'a', cwd: '/x' } })
+    expect(s.reason).toBeNull()
+  })
+})

--- a/packages/web/src/lib/shellBandState.ts
+++ b/packages/web/src/lib/shellBandState.ts
@@ -41,6 +41,15 @@ export interface ShellBandState {
   /** The refusal's own sentence, verbatim from the server. Null unless `phase === 'refused'`. */
   message: string | null
   /**
+   * The refusal's CODE, kept beside its sentence. Null when the server named none.
+   *
+   * The sentence is what a person reads; the code is what the BAND acts on, and exactly one
+   * refusal has anything to offer — the ceiling, whose answer is a list of the open shells. Without
+   * the code the band would have to match on the sentence, which is localized and would stop
+   * matching the day somebody rewords it.
+   */
+  reason: string | null
+  /**
    * How many times a person has ASKED for a shell here. `0` = never.
    *
    * It is the caller's effect dependency, and that is its whole job: an effect that resolves the
@@ -53,7 +62,7 @@ export interface ShellBandState {
 }
 
 export const INITIAL_SHELL_BAND: ShellBandState = {
-  phase: 'closed', shell: null, message: null, attempt: 0,
+  phase: 'closed', shell: null, message: null, reason: null, attempt: 0,
 }
 
 export type ShellBandAction =
@@ -65,7 +74,7 @@ export type ShellBandAction =
   | { type: 'resolving' }
   | { type: 'resolved'; shell: OpenShell }
   /** The server refused, or the request failed — the sentence is the caller's to compose. */
-  | { type: 'refused'; message: string }
+  | { type: 'refused'; message: string; reason?: string }
   /** The attempt was abandoned (the component re-ran, the session changed). NOT a failure. */
   | { type: 'cancelled' }
   /** The person asked again after a refusal. */
@@ -90,20 +99,20 @@ export function shellBandReducer(state: ShellBandState, action: ShellBandAction)
       return state.phase === 'wanted' ? { ...state, phase: 'opening' } : state
 
     case 'resolved':
-      return { ...state, phase: 'ready', shell: action.shell, message: null }
+      return { ...state, phase: 'ready', shell: action.shell, message: null, reason: null }
 
     case 'refused':
-      return { ...state, phase: 'refused', message: action.message }
+      return { ...state, phase: 'refused', message: action.message, reason: action.reason ?? null }
 
     case 'cancelled':
       // Back to WANTED, never left in `opening`: the band must not claim work nobody is doing.
       return state.phase === 'opening' ? { ...state, phase: 'wanted' } : state
 
     case 'retry':
-      return { ...state, phase: 'wanted', message: null, attempt: state.attempt + 1 }
+      return { ...state, phase: 'wanted', message: null, reason: null, attempt: state.attempt + 1 }
 
     case 'ended':
-      return { ...state, phase: 'closed', shell: null, message: null }
+      return { ...state, phase: 'closed', shell: null, message: null, reason: null }
 
     default:
       return state

--- a/packages/web/src/lib/shellCeiling.test.ts
+++ b/packages/web/src/lib/shellCeiling.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from 'bun:test'
+import { atCap, ceilingRows, ceilingTitle } from './shellCeiling'
+
+const sh = (id: string, cwd: string, createdMs: number, sessionTitle?: string) =>
+  ({ id, sessionId: `s-${id}`, cwd, createdMs, ...(sessionTitle ? { sessionTitle } : {}) })
+
+describe('when the list is shown at all', () => {
+  test('only the ceiling refusal opens it — the other three are impossible, not full', () => {
+    expect(atCap('at-cap')).toBe(true)
+    for (const r of ['no-tmux', 'no-cwd', 'cwd-missing', undefined, null, 'network']) {
+      expect(atCap(r), String(r)).toBe(false)
+    }
+  })
+})
+
+describe('the rows a person has to choose between', () => {
+  // THE DIRECTORY IS NOT ENOUGH. On the machine this was written for, all three open shells sat in
+  // `/home/mithrandir/agentistics` — a picker whose rows all read the same is not a picker.
+  test('the session’s own name leads, because several shells share one directory', () => {
+    const rows = ceilingRows([
+      sh('aaaaaaaa-1', '/home/u/proj', 3, 'Bug Fixer'),
+      sh('bbbbbbbb-2', '/home/u/proj', 1, 'ALM: rollup'),
+    ])
+    expect(rows.map(r => r.title)).toEqual(['ALM: rollup', 'Bug Fixer'])
+  })
+
+  test('oldest first — the one most likely to be finished with', () => {
+    const rows = ceilingRows([sh('c', '/a', 30), sh('a', '/a', 10), sh('b', '/a', 20)])
+    expect(rows.map(r => r.id)).toEqual(['a', 'b', 'c'])
+  })
+
+  // A shell whose session nobody could name still has to be closable, and a blank row is not one.
+  test('a shell with no session name falls back to WHERE it is, never to nothing', () => {
+    const [row] = ceilingRows([sh('deadbeef-x', '/home/u/deep/er/proj', 1)])
+    expect(row!.title).not.toBe('')
+    expect(row!.title).toContain('proj')
+  })
+
+  test('the handle is always there, so two rows that read alike are still told apart', () => {
+    const rows = ceilingRows([
+      sh('aaaaaaaa-1111', '/home/u/proj', 1, 'same'),
+      sh('bbbbbbbb-2222', '/home/u/proj', 2, 'same'),
+    ])
+    expect(rows[0]!.short).toBe('aaaaaaaa')
+    expect(rows[1]!.short).toBe('bbbbbbbb')
+    expect(rows[0]!.short).not.toBe(rows[1]!.short)
+  })
+
+  test('the home directory is shortened the way the band’s own title is', () => {
+    const [row] = ceilingRows([sh('a', '/home/u/proj', 1, 'x')])
+    expect(row!.where.startsWith('~')).toBe(true)
+  })
+
+  test('a list with nothing in it yields no rows rather than a row saying nothing', () => {
+    expect(ceilingRows([])).toEqual([])
+  })
+})
+
+describe('the sentence over the list', () => {
+  test('names the ceiling and what to do, in both languages', () => {
+    expect(ceilingTitle(8, 'pt')).toContain('8')
+    expect(ceilingTitle(8, 'en')).toContain('8')
+    expect(ceilingTitle(8, 'pt')).not.toBe(ceilingTitle(8, 'en'))
+  })
+})

--- a/packages/web/src/lib/shellCeiling.ts
+++ b/packages/web/src/lib/shellCeiling.ts
@@ -1,0 +1,76 @@
+/**
+ * shellCeiling.ts — PURE. What the band shows when the shell ceiling refuses an open.
+ *
+ * `SHELL_CAP` is 8 and the refusal has always been a SENTENCE — "Já há 8 terminais abertos. Feche
+ * um para abrir outro." It is a correct sentence and it was a DEAD END: nothing in this product
+ * listed or closed a shell. The only close was the trash can on a band you already had open, so if
+ * the eight were spread across eight other sessions, you were told to close one with no way to find
+ * them. That is the one refusal in this feature a person can actually act on, and it was the one
+ * with no action.
+ *
+ * The ceiling itself is deliberately a CEILING and not a timer (`shell-spec.ts` records why: a TTL
+ * kills the `bun test` that finished at minute 61). So the answer is not to raise it — it is to
+ * make the moment it fires the moment you can do something.
+ *
+ * **THE DIRECTORY IS NOT ENOUGH TO TELL THEM APART.** Measured on the machine this was written for:
+ * all three open shells sat in `/home/mithrandir/agentistics`, because that is what a per-session
+ * shell in a repository looks like. A picker whose rows all read the same is not a picker, so the
+ * SESSION's own name leads, the directory is beside it, and the HANDLE — the eight characters
+ * `agentop session attach` resolves — is always drawn, so two rows that still read alike are told
+ * apart by something.
+ */
+
+import { shellWhere } from './shellBand'
+
+/** One open shell as the list receives it. `sessionTitle` is what `?titles=1` adds. */
+export interface CeilingShell {
+  id: string
+  sessionId?: string
+  cwd?: string
+  createdMs?: number
+  sessionTitle?: string
+}
+
+export interface CeilingRow {
+  id: string
+  /** What the row is CALLED: the session's own name, or where the shell is when nobody could name it. */
+  title: string
+  /** The trimmed directory, in the same form the band's own title row uses. */
+  where: string
+  /** The handle, so two rows that read alike are still distinguishable. */
+  short: string
+}
+
+/** Only the FULL refusal opens the list. The other three are impossible rather than full — there is
+ *  no tmux, the row records no directory, the directory is gone — and offering to close somebody
+ *  else's shell would not help any of them. */
+export function atCap(reason: string | null | undefined): boolean {
+  return reason === 'at-cap'
+}
+
+/**
+ * The rows, OLDEST FIRST — the one a person is most likely finished with, and the only ordering
+ * that does not change under them while they read it.
+ */
+export function ceilingRows(shells: readonly CeilingShell[]): CeilingRow[] {
+  return [...shells]
+    .sort((a, b) => (a.createdMs ?? 0) - (b.createdMs ?? 0))
+    .map(s => {
+      const where = shellWhere(s.cwd)
+      return {
+        id: s.id,
+        // A blank row is not a closable row: with no name, WHERE it is has to serve as the name.
+        title: s.sessionTitle?.trim() || where || s.id.slice(0, 8),
+        where,
+        short: s.id.slice(0, 8),
+      }
+    })
+}
+
+/** The sentence over the list. It names the ceiling, because "close one" without "of eight" reads
+ *  as an arbitrary refusal. */
+export function ceilingTitle(cap: number, lang: 'pt' | 'en'): string {
+  return lang === 'pt'
+    ? `Os ${cap} terminais possíveis estão abertos. Encerre um para abrir este.`
+    : `All ${cap} terminals are open. End one to open this.`
+}


### PR DESCRIPTION
`SHELL_CAP` é 8 e a recusa sempre foi uma frase — *"Já há 8 terminais abertos. Feche um para abrir outro."* A frase está certa e era **um beco sem saída**: nada neste produto listava ou encerrava um shell. O único encerrar era a lixeira de uma faixa que você já tinha aberta, então com os oito espalhados por oito outras sessões, você era mandado fechar um **sem ter como achá-los**. Era a única recusa da funcionalidade em que uma pessoa pode fazer algo, e a única sem ação.

O teto continua um **teto** e não um timer (`shell-spec.ts` registra por quê: um TTL mata o `bun test` que terminou no minuto 61), e **não sobe**. O que muda é que o instante em que ele dispara passa a ser o instante em que dá para agir: a recusa abre a lista dos shells abertos, um encerrar por linha, e encerrar um já tenta abrir o seu.

## A linha precisa do nome da sessão

Medido na máquina em que isto foi escrito: com oito abertos, **oito linhas diziam `~/agentistics`** — é assim que um shell por sessão num repositório se parece. Um seletor cujas linhas são todas iguais não é um seletor.

Então o **nome da sessão** lidera, o diretório fica ao lado, e o **handle** (os oito caracteres que `agentop session attach` resolve) é sempre desenhado, para que duas linhas que ainda assim se pareçam sejam distinguidas por algo.

Os nomes vêm de `GET /api/shell/list?titles=1`, **opt-in** porque custam uma caminhada pela frota (~200 ms de leituras de pane) e a faixa chama essa rota em toda abertura — só a lista do teto precisa deles. Vêm do **host injetado**, do mesmo jeito que `/api/shell/open` resolve a linha de onde tira o diretório; nada aqui importa o registry, que é o que `shell-isolation.test.ts` prende sobre esta fonte.

## A recusa guarda o código, não só a frase

A frase é o que a pessoa lê; o **código** é o que a faixa usa. Casar na frase seria casar em texto localizado, que para de casar no dia em que alguém reescreve. Exatamente uma recusa tem o que oferecer.

## De quebra

A barra do shell **no mobile** ganhou o `aria-label` que a do desktop tem desde a fase 2 — um leitor de tela encontrava um botão cujo conteúdo inteiro era um ícone, a palavra "Shell" e um caminho.

## Verificação

Enchendo o teto de verdade no preview isolado: 8 shells abertos, a recusa aparece, e as **8 linhas nomeadas pelas sessões** ("Repo view no aside da direita", "ALM: bandeirola de vínculo no título da sessão", …). Encerrar uma linha abriu o shell desta sessão sozinho (`xterm` presente, recusa sumiu).

A 390px: 8 linhas, alvo de 44px, `scrollWidth === innerWidth`. O alvo é **projetado e não pintado** — `touchTarget.lint.test.ts` pegou a primeira versão, que teria virado uma coluna de caixas de 44px.

`bun tsc --noEmit` + `bun test` (7966 passando, 0 falhas).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lr8C4E9sJWirekwVfSr3UN