### PR TITLE
release: o teto do shell deixa de ser um beco sem saída

### DIFF
--- a/packages/server/server/sessions/shell-web.ts
+++ b/packages/server/server/sessions/shell-web.ts
@@ -100,7 +100,27 @@ export async function handleShellRoute(
   }
 
   if (url.pathname === '/api/shell/list' && req.method === 'GET') {
-    return json({ shells: await listShells(), cap: SHELL_CAP })
+    const shells = await listShells()
+    // `?titles=1` is OPT-IN because naming the sessions costs a fleet walk (~200 ms of pane reads),
+    // and the band asks this route on EVERY open. Only the CEILING list needs the names — and it
+    // needs them badly: a per-session shell in one repository puts every row in the same directory,
+    // so without them the picker's rows all read alike. The names come from the injected HOST, the
+    // same way `/api/shell/open` resolves the row it takes a directory from; nothing here imports
+    // the registry, which is what `shell-isolation.test.ts` asserts over this source.
+    if (url.searchParams.get('titles') !== '1' || !host.sessions) {
+      return json({ shells, cap: SHELL_CAP })
+    }
+    const fleet = await host.sessions().catch(() => null)
+    const byId = new Map((fleet?.sessions ?? []).map(r => [r.id, r.title]))
+    return json({
+      shells: shells.map(sh => {
+        const title = byId.get(sh.sessionId)
+        // A session nobody could name is left WITHOUT the field rather than given a blank one:
+        // `ceilingRows` falls back to where the shell is, which is a real answer.
+        return title ? { ...sh, sessionTitle: title } : sh
+      }),
+      cap: SHELL_CAP,
+    })
   }
 
   if (url.pathname === '/api/shell/open' && req.method === 'POST') {

--- a/packages/server/server/sessions/task-done-needs-session.test.ts
+++ b/packages/server/server/sessions/task-done-needs-session.test.ts
@@ -1,0 +1,166 @@
+import { expect, test } from 'bun:test'
+import { mkdtemp } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+/**
+ * `done` requires a session filed under the task/subtask — see
+ * docs/superpowers/specs/2026-09-11-alm-session-linking-ux.md §A.2/§A.3.
+ *
+ * `patchSubtask`/`setSubtaskDone`/`markTask` all call `loadTaskWorld()`, which is hardcoded to the
+ * module-level `TASKS_FILE`/`MANAGED_SESSIONS_FILE` in `config.ts` — values computed once at module
+ * load from `process.env` (see `config-datadir.test.ts`'s own docstring: they cannot be re-derived
+ * by mutating `process.env` inside THIS process, because `config.ts` has almost certainly already
+ * been imported by an earlier test file in the same `bun test` run). So each scenario runs in its
+ * OWN process, pointed at its own `AGENTISTICS_DIR`, the same shape `registry-concurrency.test.ts`
+ * and `config-datadir.test.ts` use.
+ */
+
+const SESSIONS_DIR = import.meta.dir
+
+async function run(body: string): Promise<unknown> {
+  const dir = await mkdtemp(join(tmpdir(), 'agentop-done-needs-session-'))
+  const script = `
+    const cfg = await import(${JSON.stringify(join(SESSIONS_DIR, '..', 'config.ts'))})
+    const { createTaskStore } = await import(${JSON.stringify(join(SESSIONS_DIR, 'task-store.ts'))})
+    const { createSessionRegistry } = await import(${JSON.stringify(join(SESSIONS_DIR, 'registry.ts'))})
+    const web = await import(${JSON.stringify(join(SESSIONS_DIR, 'task-web.ts'))})
+    const store = createTaskStore(cfg.TASKS_FILE)
+    const registry = createSessionRegistry(cfg.MANAGED_SESSIONS_FILE)
+    ${body}
+  `
+  const proc = Bun.spawn([process.execPath, '-e', script], {
+    env: { ...process.env, AGENTISTICS_DIR: dir },
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+  const out = await new Response(proc.stdout).text()
+  const err = await new Response(proc.stderr).text()
+  const code = await proc.exited
+  if (code !== 0) {
+    throw new Error(`script failed (${code}): ${err.trim().split('\n').slice(-8).join(' | ')}`)
+  }
+  const line = out.trim().split('\n').filter(Boolean).at(-1) ?? '{}'
+  return JSON.parse(line)
+}
+
+const task = (id: string, over = '') => `
+  await store.upsertTask({
+    id: '${id}', title: '${id}', status: 'todo',
+    createdAt: '2026-09-11T10:00:00.000Z', updatedAt: '2026-09-11T10:00:00.000Z',
+    ${over}
+  })
+`
+const subtask = (id: string, taskId: string, over = '') => `
+  await store.upsertSubtask({
+    id: '${id}', taskId: '${taskId}', title: '${id}', status: 'todo', done: false,
+    createdAt: '2026-09-11T10:00:00.000Z', updatedAt: '2026-09-11T10:00:00.000Z',
+    ${over}
+  })
+`
+const session = (id: string, over = '') => `
+  await registry.add({
+    id: '${id}', harness: 'claude', cwd: '/tmp/x',
+    createdAt: '2026-09-11T10:00:00.000Z',
+    ${over}
+  })
+`
+
+test('setSubtaskDone refuses a subtask with NO session filed under it', async () => {
+  const out = await run(`
+    ${task('t1')}
+    ${subtask('s1', 't1')}
+    const result = await web.setSubtaskDone('s1', true)
+    const after = await store.read()
+    console.log(JSON.stringify({ result, status: after.subtasks[0].status, done: after.subtasks[0].done }))
+  `)
+  expect(out).toEqual({ result: { ok: false, message: 'done_needs_session' }, status: 'todo', done: false })
+})
+
+test('setSubtaskDone succeeds once a session is filed under THAT subtask', async () => {
+  const out = await run(`
+    ${task('t1')}
+    ${subtask('s1', 't1')}
+    ${session('sess1', "taskId: 't1', subtaskId: 's1',")}
+    const result = await web.setSubtaskDone('s1', true)
+    const after = await store.read()
+    console.log(JSON.stringify({ result, status: after.subtasks[0].status, done: after.subtasks[0].done }))
+  `)
+  expect(out).toEqual({ result: { ok: true }, status: 'done', done: true })
+})
+
+test('patchSubtask refuses an unknown subtask id', async () => {
+  const out = await run(`
+    const result = await web.patchSubtask('nope', { status: 'done' })
+    console.log(JSON.stringify({ result }))
+  `)
+  expect(out).toEqual({ result: { ok: false, message: 'no_such_subtask' } })
+})
+
+test('patchSubtask does not re-trigger the check on a patch that is not a move INTO done', async () => {
+  // The subtask is already `done`, with no session — seeded directly, bypassing the check, the way
+  // a record from before this rule existed would read. Editing its due date must still succeed: the
+  // guard is `found.status !== 'done'`, so a patch that is not actually a transition into `done`
+  // (this one leaves status alone) must never re-run it.
+  const out = await run(`
+    ${task('t1')}
+    ${subtask('s1', 't1', "status: 'done', done: true,")}
+    const result = await web.patchSubtask('s1', { dueDate: '2026-09-20' })
+    const after = await store.read()
+    console.log(JSON.stringify({ result, dueDate: after.subtasks[0].dueDate }))
+  `)
+  expect(out).toEqual({ result: { ok: true }, dueDate: '2026-09-20' })
+})
+
+test('patchSubtask allows moving to a non-done status with no session at all', async () => {
+  const out = await run(`
+    ${task('t1')}
+    ${subtask('s1', 't1')}
+    const result = await web.patchSubtask('s1', { status: 'in_progress' })
+    const after = await store.read()
+    console.log(JSON.stringify({ result, status: after.subtasks[0].status }))
+  `)
+  expect(out).toEqual({ result: { ok: true }, status: 'in_progress' })
+})
+
+test('markTask refuses `done` on a task with zero sessions anywhere under it — and writes nothing', async () => {
+  const out = await run(`
+    ${task('t1')}
+    const result = await web.markTask('t1', 'done')
+    const after = await store.read()
+    console.log(JSON.stringify({ result, status: after.tasks[0].status }))
+  `)
+  expect(out).toEqual({ result: { ok: false, message: 'done_needs_session' }, status: 'todo' })
+})
+
+test('markTask allows `done` on a task with a session filed DIRECTLY under it', async () => {
+  const out = await run(`
+    ${task('t1')}
+    ${session('sess1', "taskId: 't1',")}
+    const result = await web.markTask('t1', 'done')
+    const after = await store.read()
+    console.log(JSON.stringify({ ok: result.ok, status: after.tasks[0].status }))
+  `)
+  expect(out).toEqual({ ok: true, status: 'done' })
+})
+
+test('markTask allows `done` when the only session is filed under one of its SUBTASKS — no extra logic needed (§A.3)', async () => {
+  const out = await run(`
+    ${task('t1')}
+    ${subtask('s1', 't1')}
+    ${session('sess1', "taskId: 't1', subtaskId: 's1',")}
+    const result = await web.markTask('t1', 'done')
+    const after = await store.read()
+    console.log(JSON.stringify({ ok: result.ok, status: after.tasks[0].status }))
+  `)
+  expect(out).toEqual({ ok: true, status: 'done' })
+})
+
+test('markTask does not re-trigger the check on an already-done task, even once its sessions are gone', async () => {
+  const out = await run(`
+    ${task('t1', "status: 'done',")}
+    const result = await web.markTask('t1', 'done')
+    console.log(JSON.stringify({ ok: result.ok }))
+  `)
+  expect(out).toEqual({ ok: true })
+})

--- a/packages/server/server/sessions/task-stats.test.ts
+++ b/packages/server/server/sessions/task-stats.test.ts
@@ -1,0 +1,149 @@
+/**
+ * `subtaskStats` — the same evidence numbers `taskStats` computes for a whole delivery, re-partitioned
+ * per subtask (or the "direct" branch). See docs/superpowers/specs/2026-09-11-alm-session-linking-ux.md
+ * §C.5, and the doc comment on `subtaskStats` itself for the full design.
+ */
+
+import { describe, expect, it } from 'bun:test'
+import type { SessionMeta } from '@agentistics/core'
+import { subtaskStats, taskStats } from './task-stats'
+import type { ManagedSession } from './types'
+
+const row = (over: Partial<ManagedSession> = {}): ManagedSession => ({
+  id: 'r1', harness: 'claude', cwd: '/repo', createdAt: '2026-09-05T10:00:00.000Z',
+  taskId: 't1', conversationId: 'c1',
+  ...over,
+} as ManagedSession)
+
+const meta = (over: Partial<SessionMeta> = {}): SessionMeta => ({
+  session_id: 'c1', project_path: '/repo', start_time: '2026-09-05T10:00:00.000Z',
+  harness: 'claude', model: 'claude-sonnet-5',
+  input_tokens: 100, output_tokens: 50, cache_read_input_tokens: 800, cache_creation_input_tokens: 50,
+  files_modified: 3, lines_added: 20, lines_removed: 5, git_commits: 1, tool_errors: 0,
+  ...over,
+} as SessionMeta)
+
+const metasOf = (...ms: SessionMeta[]) =>
+  new Map(ms.map(m => [m.session_id, m] as [string, SessionMeta]))
+
+describe('subtaskStats', () => {
+  it('returns null when nothing is filed under this subtask — never a stats block of empty fields', () => {
+    // The subtask exists (it could be `todo`, freshly created), but no row names it: there is no
+    // evidence block to draw at all, which is a different claim from "sessions are filed here but
+    // reported nothing" (covered below).
+    const rows = [row({ id: 'r1', conversationId: 'c1', subtaskId: 'other' })]
+    const result = subtaskStats({
+      subtaskId: 's1', rows, metas: metasOf(meta()), createdAt: '2026-09-05T10:00:00.000Z',
+    })
+    expect(result).toBeNull()
+  })
+
+  it('returns null for the direct branch too, when every row is filed under some subtask', () => {
+    const rows = [row({ id: 'r1', conversationId: 'c1', subtaskId: 's1' })]
+    const result = subtaskStats({
+      subtaskId: null, rows, metas: metasOf(meta()), createdAt: '2026-09-05T10:00:00.000Z',
+    })
+    expect(result).toBeNull()
+  })
+
+  it('is a real, honest empty block (not null) when rows are filed but none resolve to a meta', () => {
+    // "Filed but unmeasured" and "nothing filed" are different facts — only the second returns null.
+    const rows = [row({ id: 'r1', conversationId: 'gone', subtaskId: 's1' })]
+    const result = subtaskStats({
+      subtaskId: 's1', rows, metas: metasOf(), createdAt: '2026-09-05T10:00:00.000Z',
+    })
+    expect(result).not.toBeNull()
+    expect(result!.models).toEqual([])
+    expect(result!.tokens).toBeNull()
+    expect(result!.filesModified).toBeNull()
+  })
+
+  it('counts only the sessions filed under THIS subtask, never the whole task\'s rows', () => {
+    const rows = [
+      row({ id: 'r1', conversationId: 'c1', subtaskId: 's1' }),
+      row({ id: 'r2', conversationId: 'c2', subtaskId: 's2' }),
+    ]
+    const metas = metasOf(
+      meta({ session_id: 'c1', files_modified: 3, lines_added: 20, lines_removed: 5 }),
+      meta({ session_id: 'c2', files_modified: 99, lines_added: 999, lines_removed: 999 }),
+    )
+    const result = subtaskStats({ subtaskId: 's1', rows, metas, createdAt: '2026-09-05T10:00:00.000Z' })
+    expect(result).not.toBeNull()
+    expect(result!.filesModified).toBe(3)
+    expect(result!.linesAdded).toBe(20)
+    expect(result!.linesRemoved).toBe(5)
+  })
+
+  it('the direct branch holds exactly the rows filed on the task itself, under no subtask', () => {
+    const rows = [
+      row({ id: 'r1', conversationId: 'c1' }), // direct
+      row({ id: 'r2', conversationId: 'c2', subtaskId: 's1' }),
+    ]
+    const metas = metasOf(
+      meta({ session_id: 'c1', files_modified: 3 }),
+      meta({ session_id: 'c2', files_modified: 99 }),
+    )
+    const direct = subtaskStats({ subtaskId: null, rows, metas, createdAt: '2026-09-05T10:00:00.000Z' })
+    expect(direct).not.toBeNull()
+    expect(direct!.filesModified).toBe(3)
+  })
+
+  it('sums (subtasks + the direct branch) back to the task-wide taskStats total, no session in two buckets', () => {
+    // The identical check `subtaskViews`'s three-shapes test already applies to the cost/session
+    // rollup, applied here to the evidence numbers: every row falls into exactly one bucket, so
+    // adding every bucket's numeric fields must reproduce the whole task's own `taskStats`.
+    const rows = [
+      row({ id: 'r1', conversationId: 'c1' }), // direct
+      row({ id: 'r2', conversationId: 'c2' }), // direct
+      row({ id: 'r3', conversationId: 'c3', subtaskId: 's1' }),
+      row({ id: 'r4', conversationId: 'c4', subtaskId: 's2' }),
+      row({ id: 'r5', conversationId: 'c5', subtaskId: 's2' }),
+    ]
+    const metas = metasOf(
+      meta({ session_id: 'c1', files_modified: 5, lines_added: 10, lines_removed: 1, git_commits: 1 }),
+      meta({ session_id: 'c2', files_modified: 2, lines_added: 3, lines_removed: 0, git_commits: 0 }),
+      meta({ session_id: 'c3', files_modified: 7, lines_added: 40, lines_removed: 6, git_commits: 2 }),
+      meta({ session_id: 'c4', files_modified: 11, lines_added: 1, lines_removed: 1, git_commits: 0 }),
+      meta({ session_id: 'c5', files_modified: 1, lines_added: 1, lines_removed: 1, git_commits: 1 }),
+    )
+    const createdAt = '2026-09-05T10:00:00.000Z'
+
+    const buckets = [
+      subtaskStats({ subtaskId: null, rows, metas, createdAt }),
+      subtaskStats({ subtaskId: 's1', rows, metas, createdAt }),
+      subtaskStats({ subtaskId: 's2', rows, metas, createdAt }),
+    ].filter((b): b is NonNullable<typeof b> => b !== null)
+
+    // No bucket dropped and no session counted twice: three real buckets (direct, s1, s2).
+    expect(buckets).toHaveLength(3)
+
+    const sum = (field: 'filesModified' | 'linesAdded' | 'linesRemoved' | 'commits') =>
+      buckets.reduce((a, b) => a + (b[field] ?? 0), 0)
+
+    const whole = taskStats({
+      metas: rows.map(r => metas.get(r.conversationId!)!),
+      createdAt,
+    })
+
+    expect(sum('filesModified')).toBe(whole.filesModified ?? 0)
+    expect(sum('linesAdded')).toBe(whole.linesAdded ?? 0)
+    expect(sum('linesRemoved')).toBe(whole.linesRemoved ?? 0)
+    expect(sum('commits')).toBe(whole.commits ?? 0)
+    expect(whole.filesModified).toBe(26) // 5+2+7+11+1
+  })
+
+  it('a subtask with a subset of models/harnesses only ranks what its own rows reported', () => {
+    const rows = [
+      row({ id: 'r1', conversationId: 'c1', subtaskId: 's1' }),
+      row({ id: 'r2', conversationId: 'c2', subtaskId: 's1' }),
+    ]
+    const metas = metasOf(
+      meta({ session_id: 'c1', model: 'claude-sonnet-5', harness: 'claude' }),
+      meta({ session_id: 'c2', model: 'gpt-5', harness: 'codex' }),
+    )
+    const result = subtaskStats({ subtaskId: 's1', rows, metas, createdAt: '2026-09-05T10:00:00.000Z' })
+    expect(result).not.toBeNull()
+    expect(result!.models.map(b => b.key).sort()).toEqual(['claude-sonnet-5', 'gpt-5'])
+    expect(result!.harnesses.map(b => b.key).sort()).toEqual(['claude', 'codex'])
+  })
+})

--- a/packages/server/server/sessions/task-stats.ts
+++ b/packages/server/server/sessions/task-stats.ts
@@ -13,6 +13,7 @@
 
 import type { SessionMeta } from '@agentistics/core'
 import { sessionTokens, type TokenBreakdown } from '@agentistics/core'
+import type { ManagedSession } from './types'
 
 export interface Bucket {
   key: string
@@ -126,4 +127,56 @@ export function taskStats(o: {
     firstSessionAt: starts[0] ?? null,
     lastSessionAt: ends.at(-1) ?? null,
   }
+}
+
+/**
+ * `taskStats`, scoped to ONE piece of the delivery — a subtask, or the "direct" branch
+ * (`subtaskId: null`, the rows filed on the task itself, under no subtask). This is the same
+ * partition `subtaskViews` (`task-report.ts`) already applies to the ROLLUP, extended to this
+ * block: files/errors/lines/tokens/commits/models/harnesses computed over only the rows filed
+ * under this one piece, never over the whole task's rows.
+ *
+ * `rows` is expected already scoped to the task (`rowsOfTask(task, allRows)`), exactly like
+ * `subtaskViews`'s own `rows` parameter — this never re-derives that scope. Every row of a task
+ * falls into EXACTLY one bucket across the full set of calls (one per subtask, plus `null` for the
+ * direct branch), so summing every bucket's numeric fields reproduces `taskStats` computed once
+ * over the task's whole row set — the same guarantee `subtaskViews`'s three-shapes test pins for
+ * the cost/session rollup, checked here for the evidence numbers instead.
+ *
+ * **Returns `null` when NOTHING is filed under this piece** (`rows.filter(...)` is empty) — never a
+ * `TaskStats` whose every field happens to be `null`/`[]`. Those two situations are different
+ * claims: "there is no evidence block for this piece at all" (nothing was ever filed here) versus
+ * "N sessions are filed here but none of them reported files/tokens/etc" (a real, if uninformative,
+ * measurement — `taskStats` already renders that case honestly on its own, since every one of its
+ * fields is already null-safe over an empty `metas` array). A caller — e.g. `SessionTasksTab.tsx`'s
+ * subtask-scoped panel — uses the `null` return to render "nothing filed here yet" instead of a
+ * stats block full of dashes. Same rule as `HARNESS_CAPABILITIES`'s N/A-vs-real-0, applied to a
+ * whole block instead of one metric.
+ *
+ * `createdAt`/`deliveredAt` are passed straight through to `taskStats` and are NOT re-derived from
+ * the subtask's own dates — `Subtask` carries no `deliveredAt` field today, so what a subtask's own
+ * "delivery" wall time should mean is left to the caller to decide (and is out of scope for this
+ * function, which only re-partitions the evidence numbers `taskStats` already computes).
+ */
+export function subtaskStats(o: {
+  subtaskId: string | null
+  rows: readonly ManagedSession[]
+  metas: ReadonlyMap<string, SessionMeta>
+  createdAt: string
+  deliveredAt?: string
+}): TaskStats | null {
+  const mine = o.subtaskId === null
+    ? o.rows.filter(r => !r.subtaskId)
+    : o.rows.filter(r => r.subtaskId === o.subtaskId)
+  if (mine.length === 0) return null
+
+  const resolved = mine
+    .map(r => (r.conversationId ? o.metas.get(r.conversationId) : undefined))
+    .filter((m): m is SessionMeta => m !== undefined)
+
+  return taskStats({
+    metas: resolved,
+    createdAt: o.createdAt,
+    ...(o.deliveredAt !== undefined ? { deliveredAt: o.deliveredAt } : {}),
+  })
 }

--- a/packages/server/server/sessions/task-web.ts
+++ b/packages/server/server/sessions/task-web.ts
@@ -384,6 +384,11 @@ export async function addSubtask(ref: string, title: string): Promise<boolean> {
  * `done` is never taken from the caller — it is derived from `status`, because two fields for one
  * fact drift and a row reading `done: false, status: 'done'` has no correct interpretation. A
  * caller that ticks the box sends `status: 'done'`; one that moves the status gets the tick free.
+ *
+ * A move INTO `done` requires a session filed under this specific subtask — see
+ * docs/superpowers/specs/2026-09-11-alm-session-linking-ux.md §A.2. The guard is
+ * `found.status !== 'done'`: a patch that is not actually a transition into `done` (editing the due
+ * date of an already-done subtask) must not re-trigger it.
  */
 export async function patchSubtask(subtaskId: string, patch: {
   title?: string
@@ -395,11 +400,15 @@ export async function patchSubtask(subtaskId: string, patch: {
   notes?: string
   /** Sanitized against this subtask's OWN siblings — see `sanitizeSubtaskBlockedBy`. */
   blockedBy?: string[]
-}): Promise<boolean> {
+}): Promise<{ ok: true } | { ok: false; message: 'no_such_subtask' | 'done_needs_session' }> {
   const w = await loadTaskWorld()
   const found = w.book.subtasks.find(t => t.id === subtaskId)
-  if (!found) return false
+  if (!found) return { ok: false, message: 'no_such_subtask' }
   const status = patch.status ?? found.status
+  if (status === 'done' && found.status !== 'done') {
+    const hasSession = w.rows.some(r => r.subtaskId === subtaskId)
+    if (!hasSession) return { ok: false, message: 'done_needs_session' }
+  }
   await w.store.upsertSubtask({
     ...found,
     ...(patch.title?.trim() ? { title: patch.title.trim() } : {}),
@@ -419,7 +428,7 @@ export async function patchSubtask(subtaskId: string, patch: {
     } : {}),
     updatedAt: new Date().toISOString(),
   })
-  return true
+  return { ok: true }
 }
 
 export async function removeSubtask(subtaskId: string): Promise<boolean> {
@@ -431,7 +440,9 @@ export async function removeSubtask(subtaskId: string): Promise<boolean> {
 }
 
 /** The tick, expressed as what it means: a move to `done`, or back to `todo`. */
-export async function setSubtaskDone(subtaskId: string, done: boolean): Promise<boolean> {
+export async function setSubtaskDone(subtaskId: string, done: boolean): Promise<
+  { ok: true } | { ok: false; message: 'no_such_subtask' | 'done_needs_session' }
+> {
   return await patchSubtask(subtaskId, { status: done ? 'done' : 'todo' })
 }
 
@@ -701,6 +712,20 @@ export async function markTask(
       })
     }
   }
+  /*
+   * `done` requires a session filed under the task — same shape as `blocked_needs_reason` above,
+   * checked BEFORE the write so it binds the browser, the CLI and the MCP alike. `rowsOfTask`
+   * counts a session ANYWHERE under the task — filed directly, or under any of its subtasks,
+   * regardless of `subtaskId` — so this one check is correct for a task with subtasks, without
+   * subtasks, or a mix, with no new counting logic (see
+   * docs/superpowers/specs/2026-09-11-alm-session-linking-ux.md §A.3). The guard is
+   * `task.status !== 'done'`: a move that is not actually a transition into `done` (re-marking an
+   * already-done task) must not re-trigger it. Computed once and reused below for the
+   * delivery-evidence block, rather than calling `rowsOfTask` a second time.
+   */
+  const mine = to === 'done' && task.status !== 'done' ? rowsOfTask(task, w.rows) : undefined
+  if (mine && mine.length === 0) return { ok: false, message: 'done_needs_session' }
+
   // `done` is the ONE status that stamps a delivery. Every other move is a change of where the work
   // stands, and stamping one of those would close rounds-to-delivery on work that is not delivered.
   const done = to === 'done'
@@ -743,8 +768,8 @@ export async function markTask(
 
   if (!done) return { ok: true }
 
-  const mine = rowsOfTask(task, w.rows)
-  const dirs = [...new Set(mine.map(r => r.cwd).filter(Boolean))]
+  const rows = mine ?? rowsOfTask(task, w.rows)
+  const dirs = [...new Set(rows.map(r => r.cwd).filter(Boolean))]
   const bySha = new Map<string, { sha: string; message: string; atMs: number }>()
   for (const dir of dirs) {
     // Deduped by sha: two sessions of one task routinely share a checkout, and the same commit read

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -103,6 +103,7 @@ import { PAGE_INSET, PAGE_MAX_WIDTH } from './components/sessions/FleetOverview'
 import { setFleetSourceCentral } from './lib/fleet'
 import { reopenedSessionRoute, sessionPath } from './lib/sessionRoute'
 import { SessionStatsMenu } from './components/sessions/SessionStatsMenu'
+import { SessionTitleFlag } from './components/sessions/SessionTitleFlag'
 
 /**
  * What the SESSIONS filter bar may filter by — narrower than the dashboard's on purpose: a fleet
@@ -1899,7 +1900,7 @@ export default function AppLayout() {
   // A CENTRAL's fleet is the RELAY's, for the machine the aside's picker chose. Set once, here,
   // because the poller is module-scoped and every surface reads the same snapshot.
   useEffect(() => { setFleetSourceCentral(isCentral) }, [isCentral])
-  const { fleet: headerFleet, act: headerFleetAct, unsupported: headerFleetUnsupported } = useFleet(lang === 'pt' ? 'pt' : 'en')
+  const { fleet: headerFleet, act: headerFleetAct, unsupported: headerFleetUnsupported, refresh: headerFleetRefresh } = useFleet(lang === 'pt' ? 'pt' : 'en')
   /**
    * "Active only" needs a fleet to intersect against, on EITHER page. An exposed profile with no
    * host power, or a central with no machine chosen, both report `unsupported` here — offering the
@@ -3060,6 +3061,15 @@ export default function AppLayout() {
           }}>
             {selectedFleetSession.title}
           </span>
+          <SessionTitleFlag
+            session={{
+              id: selectedFleetSession.id, title: selectedFleetSession.title,
+              ...(selectedFleetSession.harness ? { harness: selectedFleetSession.harness } : {}),
+              ...(selectedFleetSession.task ? { task: selectedFleetSession.task } : {}),
+            }}
+            lang={lang === 'pt' ? 'pt' : 'en'}
+            onLinked={headerFleetRefresh}
+          />
           {/* Gives up before the title does: the name is what identifies the session, and the state
               is repeated on its own row in the aside two centimetres away. */}
           <span style={{

--- a/packages/web/src/components/sessions/NewSessionModal.tsx
+++ b/packages/web/src/components/sessions/NewSessionModal.tsx
@@ -97,9 +97,19 @@ export interface NewSessionModalProps {
    * field gets left blank.
    */
   initialTask?: string
+  /**
+   * The real task this session is being started FOR, once one already exists.
+   *
+   * `initialTask` alone only ever fills the free-text label sent to `/api/fleet/new` — it never
+   * files the session under the task, because a display string carries no id. When the caller
+   * already has a real `Task`, it passes this too, so the wizard seeds `subtaskTarget` with a bare
+   * task-level attach (no subtask — the caller never asked for one) and the session that comes out
+   * the other end is actually filed, not just labeled. See spec 2026-09-11 §C.2.
+   */
+  initialTaskId?: string
 }
 
-export function NewSessionModal({ lang, onClose, onStarted, initialTask }: NewSessionModalProps) {
+export function NewSessionModal({ lang, onClose, onStarted, initialTask, initialTaskId }: NewSessionModalProps) {
   const pt = lang === 'pt'
   const [harnesses, setHarnesses] = useState<HarnessOption[] | null>(null)
   const [projects, setProjects] = useState<ProjectOption[]>([])
@@ -132,13 +142,17 @@ export function NewSessionModal({ lang, onClose, onStarted, initialTask }: NewSe
   const [cwd, setCwd] = useState('')
   const [task, setTask] = useState(initialTask ?? '')
   /**
-   * The exact SUBTASK this session will be filed under, once it exists — set only by the picker,
-   * never by the folder suggestion below (which only ever proposes a delivery TITLE, and asking a
-   * suggestion to also pick a subtask would be asking it to answer a question it never asked).
-   * `task` stays the free-text label sent at spawn either way — this is the extra, exact half that
-   * lets the attach happen automatically once the session is created.
+   * The exact TASK (and, when the picker was used, SUBTASK) this session will be filed under, once
+   * it exists. `subtaskId` is absent for a bare task-level attach — set either by `initialTaskId`
+   * (the caller already has a real task and never asked for a subtask) or by the folder suggestion
+   * resolving its guessed title against a real task (same reason, see the effect below); it is set
+   * WITH a subtask only by the picker. `task` stays the free-text label sent at spawn either way —
+   * this is the extra, exact half that lets the attach happen automatically once the session is
+   * created. See spec 2026-09-11 §C.2.
    */
-  const [subtaskTarget, setSubtaskTarget] = useState<{ taskId: string; subtaskId: string } | null>(null)
+  const [subtaskTarget, setSubtaskTarget] = useState<{ taskId: string; subtaskId?: string } | null>(
+    initialTaskId ? { taskId: initialTaskId } : null,
+  )
   /** Set when that automatic attach comes back refused because the subtask is still blocked. */
   const [subtaskBlocked, setSubtaskBlocked] = useState<
     { taskId: string; subtaskId: string; blockedBy: string[]; sessionId: string } | null
@@ -195,6 +209,11 @@ export function NewSessionModal({ lang, onClose, onStarted, initialTask }: NewSe
   /**
    * Fill the field FROM the suggestion — never over a person's own choice, and never again once
    * they have cleared it for this folder.
+   *
+   * A suggestion is only ever a TITLE guess, but when it happens to name a real, already-created
+   * task, resolving that id and seeding `subtaskTarget` (no subtask) is what turns "looks filed"
+   * into actually filed — the same root cause and the same fix as `initialTaskId` above. See spec
+   * 2026-09-11 §C.2.
    */
   useEffect(() => {
     if (suggestionDismissed) return
@@ -203,7 +222,9 @@ export function NewSessionModal({ lang, onClose, onStarted, initialTask }: NewSe
     if (next === task) return
     setTask(next)
     setTaskWasSuggested(next !== '')
-  }, [suggestion, suggestionDismissed, task, taskWasSuggested])
+    const matchedId = next ? taskRows?.find(r => r.task.title === next)?.task.id : undefined
+    setSubtaskTarget(matchedId ? { taskId: matchedId } : null)
+  }, [suggestion, suggestionDismissed, task, taskWasSuggested, taskRows])
 
   const [busy, setBusy] = useState(false)
   const [notice, setNotice] = useState<string | null>(null)
@@ -589,7 +610,9 @@ export function NewSessionModal({ lang, onClose, onStarted, initialTask }: NewSe
         if (subtaskTarget && json.id) {
           const { taskId, subtaskId } = subtaskTarget
           const result = await attachSession(taskId, json.id, subtaskId)
-          if (!result.ok && result.reason === 'blocked') {
+          // `blocked` is a SUBTASK concept — a bare task-level attach (no `subtaskId`) can never
+          // come back refused this way, so the branch below only ever runs with a real subtask id.
+          if (!result.ok && result.reason === 'blocked' && subtaskId) {
             const detailRes = await fetch(`/api/tasks/${encodeURIComponent(taskId)}`).catch(() => null)
             const body = detailRes?.ok ? await detailRes.json() as { task: TaskDetail } : null
             setBlockedDetail(body?.task ?? null)

--- a/packages/web/src/components/sessions/SessionFacts.tsx
+++ b/packages/web/src/components/sessions/SessionFacts.tsx
@@ -49,9 +49,21 @@ export interface SessionFactsProps {
 export function SessionFacts({ session, selected = false, onFile, lang = 'en', metaColor }: SessionFactsProps) {
   const wants = sessionNotify(session)
   return (
-    <span style={{ minWidth: 0, flex: 1, display: 'flex', flexDirection: 'column', gap: 3 }}>
+    <span style={{ minWidth: 0, flex: 1, display: 'flex', flexDirection: 'column', gap: 2 }}>
+      {/* The DELIVERY's name, read above the title rather than folded into the meta line below —
+          the meta line's Bookmark segment (onFile) still does the filing gesture; this is purely
+          about where the name is READ. */}
+      {session.task && (
+        <span style={{
+          fontSize: 9.5, color: 'var(--text-tertiary)', fontWeight: 600,
+          overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+        }}>
+          {session.task}
+        </span>
+      )}
       <span style={{
-        fontSize: 12.5, fontWeight: selected || wants ? 650 : 500,
+        fontSize: session.task ? 13.5 : 12.5,
+        fontWeight: (selected || wants ? 650 : 500) + (session.task ? 50 : 0),
         overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
       }}>
         {session.title}

--- a/packages/web/src/components/sessions/SessionTitleFlag.tsx
+++ b/packages/web/src/components/sessions/SessionTitleFlag.tsx
@@ -1,0 +1,82 @@
+/**
+ * SessionTitleFlag — the OPEN session's own delivery flag, beside its title.
+ *
+ * Three headers currently draw an open session's title inline — the desktop shared header
+ * (`App.tsx`), the mobile panel header and the mobile dedicated-terminal header (both in
+ * `SessionsPage.tsx`) — and each used to be a candidate for pasting the same "flag icon, filled
+ * orange when `task` is set, dotted outline otherwise" markup a fourth time. One gesture
+ * implemented three times is the bug `task-reopen.ts` exists to have fixed once, so it lives here
+ * instead and every header imports it.
+ *
+ * Unlinked: an outlined, dashed flag. Clicking it opens `NewTaskWizard` pre-linked to this
+ * session — the same dialog `SessionTasksTab`'s own "New task for this session" composer opens,
+ * so there is no second creation flow, only a new entry point into the existing one.
+ *
+ * Linked: a filled orange flag. Clicking it opens this session's own aside on the Deliveries tab
+ * (`openArtifacts('tasks')`) — the pattern `chatNote.ts`'s `systemRef` navigation already uses for
+ * "open this tab of the aside," rather than navigating away from the conversation.
+ */
+
+import { useState } from 'react'
+import { Flag } from 'lucide-react'
+import { openArtifacts } from '../../lib/artifactsStore'
+import { NewTaskWizard } from '../tasks/NewTaskWizard'
+
+export interface SessionTitleFlagProps {
+  session: { id: string; title: string; harness?: string; task?: string }
+  lang: 'pt' | 'en'
+  /**
+   * A task was just created and this session linked to it.
+   *
+   * The fleet poll would pick this up within a few seconds regardless, but calling it lets the
+   * caller refresh right away so the flag fills in the same moment the dialog closes.
+   */
+  onLinked?: () => void
+}
+
+export function SessionTitleFlag({ session, lang, onLinked }: SessionTitleFlagProps) {
+  const pt = lang === 'pt'
+  const [creating, setCreating] = useState(false)
+  const linked = Boolean(session.task)
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => { if (linked) openArtifacts('tasks'); else setCreating(true) }}
+        title={linked
+          ? (pt ? `Entrega: ${session.task} — abrir` : `Delivery: ${session.task} — open`)
+          : (pt ? 'Sem entrega — criar uma para esta sessão' : 'No delivery — create one for this session')}
+        aria-label={linked
+          ? (pt ? 'Abrir a entrega desta sessão' : "Open this session's delivery")
+          : (pt ? 'Criar uma entrega para esta sessão' : 'Create a delivery for this session')}
+        style={{
+          display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+          width: 22, height: 22, flexShrink: 0, padding: 0,
+          border: 'none', borderRadius: 6, background: 'transparent', cursor: 'pointer',
+          color: linked ? 'var(--anthropic-orange)' : 'var(--text-tertiary)',
+        }}
+      >
+        <Flag
+          size={13}
+          {...(linked
+            ? { fill: 'currentColor' }
+            // Unlinked reads as an outline the reader can fill in, never a solid mark that looks
+            // like a fact already recorded.
+            : { strokeDasharray: '2,1.6' })}
+        />
+      </button>
+
+      {creating && (
+        <NewTaskWizard
+          session={{
+            id: session.id, title: session.title,
+            ...(session.harness ? { harness: session.harness } : {}),
+          }}
+          onClose={() => setCreating(false)}
+          onDone={() => { setCreating(false); onLinked?.() }}
+        />
+      )}
+    </>
+  )
+}

--- a/packages/web/src/components/sessions/ShellBand.tsx
+++ b/packages/web/src/components/sessions/ShellBand.tsx
@@ -45,6 +45,9 @@ import {
 } from 'lucide-react'
 import { useDocumentVisible } from '../../hooks/useDocumentVisible'
 import { keyStripShown } from '../../lib/terminalSurface'
+import {
+  atCap, ceilingRows, ceilingTitle, type CeilingRow, type CeilingShell,
+} from '../../lib/shellCeiling'
 import { useIsMobile } from '../../hooks/useIsMobile'
 import { useTerminalStream } from '../../hooks/useTerminalStream'
 import { useTerminalWrite } from '../../hooks/useTerminalWrite'
@@ -75,6 +78,7 @@ interface T {
   resize: string
   retry: string
   fullscreen: string
+  endThis: string
 }
 
 const TXT: Record<'pt' | 'en', T> = {
@@ -92,6 +96,7 @@ const TXT: Record<'pt' | 'en', T> = {
     resize: 'Drag to resize the shell',
     retry: 'Try again',
     fullscreen: 'Open the shell full screen',
+    endThis: 'End this terminal',
   },
   pt: {
     title: 'Shell',
@@ -107,6 +112,7 @@ const TXT: Record<'pt' | 'en', T> = {
     resize: 'Arraste para redimensionar o shell',
     retry: 'Tentar de novo',
     fullscreen: 'Abrir o shell em tela cheia',
+    endThis: 'Encerrar este terminal',
   },
 }
 
@@ -147,6 +153,8 @@ export function ShellBand({ sessionId, cwd, lang, theme, placement = 'docked', o
     dedicated || readBandPrefs().open ? shellBandReducer(init, { type: 'openBand' }) : init)
   const shell = band.shell
   const [ctrlArmed, setCtrlArmed] = useState(false)
+  /** The open shells, fetched ONLY when the ceiling refuses — see `shellCeiling.ts`. */
+  const [ceiling, setCeiling] = useState<{ rows: CeilingRow[]; cap: number } | null>(null)
   const [ctrlNote, setCtrlNote] = useState<string | null>(null)
 
   const setBand = useCallback((next: Partial<{ open: boolean; height: number }>) => {
@@ -197,13 +205,15 @@ export function ShellBand({ sessionId, cwd, lang, theme, placement = 'docked', o
           body: JSON.stringify({ sessionId }),
         })
         const body = await res.json().catch(() => ({})) as {
-          ok?: boolean; shell?: OpenShell; message?: string; error?: string
+          ok?: boolean; shell?: OpenShell; message?: string; error?: string; reason?: string
         }
         if (cancelled) return
         // A REFUSAL arrives as a sentence the server composed; it is shown verbatim. A route-level
         // error carries only a code, and `shellErrorText` is the one place that words those.
         if (body.ok && body.shell) dispatch({ type: 'resolved', shell: body.shell })
-        else if (body.message) dispatch({ type: 'refused', message: body.message })
+        // The CODE travels with the sentence: only `at-cap` has anything to offer, and matching on
+        // a localized sentence would stop working the day somebody rewords it.
+        else if (body.message) dispatch({ type: 'refused', message: body.message, ...(body.reason ? { reason: body.reason } : {}) })
         else dispatch({ type: 'refused', message: shellErrorText(body.error ?? 'network', lang) })
       } catch {
         if (!cancelled) dispatch({ type: 'refused', message: shellErrorText('network', lang) })
@@ -213,6 +223,37 @@ export function ShellBand({ sessionId, cwd, lang, theme, placement = 'docked', o
     // render asks again instead of leaving a spinner over nothing.
     return () => { cancelled = true; dispatch({ type: 'cancelled' }) }
   }, [band.attempt, sessionId, lang])
+
+  /**
+   * THE CEILING IS THE ONE REFUSAL A PERSON CAN ACT ON, and until now it was the one with no
+   * action: nothing in this product listed or closed a shell, so "close one to open another" sent
+   * you looking through eight other sessions. The list is fetched only on that refusal — `?titles=1`
+   * costs a fleet walk, and the names are what make the rows distinguishable when every shell of a
+   * repository sits in the same directory.
+   */
+  useEffect(() => {
+    if (!atCap(band.reason)) { setCeiling(null); return }
+    let gone = false
+    void (async () => {
+      const body = await fetch(shellApiUrl('/api/shell/list', lang) + '&titles=1')
+        .then(r => r.ok ? r.json() as Promise<{ shells?: CeilingShell[]; cap?: number }> : null)
+        .catch(() => null)
+      if (gone || !body) return
+      setCeiling({ rows: ceilingRows(body.shells ?? []), cap: body.cap ?? 0 })
+    })()
+    return () => { gone = true }
+  }, [band.reason, band.attempt, lang])
+
+  /** End one of the OTHER shells, then ask again — the retry is the whole point of the list. */
+  const closeOther = useCallback(async (id: string) => {
+    setCeiling(c => (c ? { ...c, rows: c.rows.filter(r => r.id !== id) } : c))
+    await fetch(shellApiUrl('/api/shell/close', lang), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ids: [id] }),
+    }).catch(() => {})
+    dispatch({ type: 'retry' })
+  }, [lang])
 
   const watching = shellWatching({
     bandOpen,
@@ -351,7 +392,7 @@ export function ShellBand({ sessionId, cwd, lang, theme, placement = 'docked', o
       {ctrlArmed ? t.ctrlHint : ctrlNote ?? line}
       {/* A refusal is a DEAD STOP by design — the band never retries a "no" on its own — so the way
           forward has to be on screen. Without it a refused band is a sentence and nothing else. */}
-      {band.phase === 'refused' && (
+      {band.phase === 'refused' && !atCap(band.reason) && (
         <button
           onClick={() => dispatch({ type: 'retry' })}
           style={{
@@ -368,6 +409,56 @@ export function ShellBand({ sessionId, cwd, lang, theme, placement = 'docked', o
       )}
     </div>
   )
+
+  /**
+   * THE WAY OUT OF THE CEILING. `at-cap` used to be a sentence and nothing else; this is the list
+   * the sentence was telling you to go and find. Each row NAMES its session (the directory alone
+   * does not separate them — a repository's shells all sit in the same one) and carries the handle,
+   * so two rows that still read alike are told apart by something.
+   */
+  const ceilingList = ceiling && atCap(band.reason) ? (
+    <div style={{
+      flexShrink: 0, display: 'flex', flexDirection: 'column', gap: 6,
+      maxHeight: isMobile ? 260 : 180, overflowY: 'auto',
+      padding: 8, borderRadius: 8,
+      border: '1px solid var(--border-subtle)', background: 'var(--bg-elevated)',
+    }}>
+      <div style={{ fontSize: 11, fontWeight: 700, color: 'var(--text-secondary)' }}>
+        {ceilingTitle(ceiling.cap, lang)}
+      </div>
+      {ceiling.rows.map(row => (
+        <div key={row.id} style={{ display: 'flex', alignItems: 'center', gap: 8, minWidth: 0 }}>
+          <div style={{ minWidth: 0, flex: 1 }}>
+            <div style={{
+              fontSize: 12, fontWeight: 600, color: 'var(--text-primary)',
+              overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+            }}>{row.title}</div>
+            <div style={{
+              fontSize: 10.5, color: 'var(--text-tertiary)', fontFamily: 'monospace',
+              overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+            }}>{row.short}{row.where ? ` · ${row.where}` : ''}</div>
+          </div>
+          <button className="ag-tap-icon"
+            onClick={() => { void closeOther(row.id) }}
+            title={t.endThis}
+            aria-label={`${t.endThis} — ${row.title}`}
+            style={{
+              // PAINTED small, TARGETED at 44px by `.ag-tap-icon` — the repo's rule, and the one
+              // this list must not break: a row of 44px squares turns a compact list into a column
+              // of boxes, while the finger still needs the 44.
+              display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0,
+              width: 26, height: 26,
+              borderRadius: 6, cursor: 'pointer',
+              border: '1px solid var(--border-subtle)', background: 'transparent',
+              color: 'var(--text-tertiary)',
+            }}
+          >
+            <Trash2 size={13} />
+          </button>
+        </div>
+      ))}
+    </div>
+  ) : null
 
   const strip = (
     <div style={{
@@ -409,6 +500,7 @@ export function ShellBand({ sessionId, cwd, lang, theme, placement = 'docked', o
       }}>
         {shell ? screen : <div style={{ flex: 1 }} />}
         {notice}
+        {ceilingList}
         {keyStripShown('dedicated', isMobile) && strip}
       </div>
     )
@@ -420,6 +512,10 @@ export function ShellBand({ sessionId, cwd, lang, theme, placement = 'docked', o
       return (
         <button
           onClick={() => setBand({ open: true })}
+          aria-expanded={false}
+          // The desktop bar has carried this since phase 2 and the phone's had nothing: a screen
+          // reader met a button whose whole content was an icon, the word "Shell" and a path.
+          aria-label={t.toggleBar}
           style={{
             display: 'flex', alignItems: 'center', gap: 8, width: '100%',
             minHeight: 44, padding: '0 12px', flexShrink: 0,
@@ -485,6 +581,7 @@ export function ShellBand({ sessionId, cwd, lang, theme, placement = 'docked', o
         }}>
           {shell ? screen : <div style={{ flex: 1 }} />}
           {notice}
+          {ceilingList}
           {strip}
         </div>
       </div>
@@ -588,6 +685,7 @@ export function ShellBand({ sessionId, cwd, lang, theme, placement = 'docked', o
         }}>
           {shell ? screen : <div style={{ flex: 1 }} />}
           {notice}
+          {ceilingList}
         </div>
       )}
     </div>

--- a/packages/web/src/components/tasks/DeliveryDetail.tsx
+++ b/packages/web/src/components/tasks/DeliveryDetail.tsx
@@ -824,15 +824,99 @@ function isDescriptionFile(f: File): boolean {
 }
 
 /**
+ * Splits a description on its own markdown headings — never on prose structure this file has to
+ * guess at (bold lead-ins, paragraph breaks). `null` means the text has no heading at all, which is
+ * the common case: this task's own description is four paragraphs of **bold** lead-ins and no `#`.
+ *
+ * Content before the first heading (if any) is the LEAD — read unfolded, because it is usually one
+ * or two sentences of framing rather than a section of its own.
+ */
+const DESCRIPTION_HEADING_RE = /^(#{1,6})\s+(.+)$/
+
+function splitDescriptionHeadings(
+  text: string,
+): { lead: string; sections: Array<{ title: string; body: string }> } | null {
+  const lines = text.split('\n')
+  const lead: string[] = []
+  const sections: Array<{ title: string; body: string[] }> = []
+  let current: { title: string; body: string[] } | null = null
+  for (const line of lines) {
+    const m = line.match(DESCRIPTION_HEADING_RE)
+    if (m) {
+      if (current) sections.push(current)
+      current = { title: m[2]!.trim(), body: [] }
+    } else if (current) {
+      current.body.push(line)
+    } else {
+      lead.push(line)
+    }
+  }
+  if (current) sections.push(current)
+  if (sections.length === 0) return null
+  return {
+    lead: lead.join('\n').trim(),
+    sections: sections.map(s => ({ title: s.title, body: s.body.join('\n').trim() })),
+  }
+}
+
+/** How much of an un-headinged description shows before the reader has to ask for more. */
+const DESCRIPTION_PREVIEW_LINES = 3
+
+/**
+ * A description with no heading to fold by — the common case — becomes ONE collapsed block: a
+ * short preview plus a single toggle, never N sections invented from prose structure.
+ */
+function CollapsedDescription({ body, files, lang }: { body: string; files: TaskFile[]; lang: Lang }) {
+  const copy = boardCopy(lang)
+  const [expanded, setExpanded] = useState(false)
+  const lines = body.split('\n')
+  const hasMore = lines.length > DESCRIPTION_PREVIEW_LINES
+  if (!hasMore) return <CommentBody body={body} files={files} />
+  const shown = expanded ? body : lines.slice(0, DESCRIPTION_PREVIEW_LINES).join('\n')
+  return (
+    <div style={{ display: 'grid', gap: 8 }}>
+      <CommentBody body={shown} files={files} />
+      <button
+        onClick={() => setExpanded(v => !v)}
+        style={{
+          justifySelf: 'start', background: 'none', border: 'none', cursor: 'pointer', padding: 0,
+          fontSize: 11.5, fontWeight: 600, color: 'var(--anthropic-orange)',
+        }}
+      >{expanded ? copy.showLessDescription : copy.showAllDescription}</button>
+    </div>
+  )
+}
+
+/**
+ * The description's READ-ONLY presentation. Editing (below) always works on the whole string as
+ * one textarea — folding is how the same text is DISPLAYED, never a second data model.
+ */
+function DescriptionView({ body, files, lang }: { body: string; files: TaskFile[]; lang: Lang }) {
+  const split = useMemo(() => splitDescriptionHeadings(body), [body])
+  if (!split) return <CollapsedDescription body={body} files={files} lang={lang} />
+  return (
+    <div style={{ display: 'grid', gap: 10 }}>
+      {split.lead && <CommentBody body={split.lead} files={files} />}
+      {split.sections.map((s, i) => (
+        <RailSection key={i} id={`description-section-${i}`} title={s.title} defaultOpen={i === 0}>
+          <CommentBody body={s.body} files={files} />
+        </RailSection>
+      ))}
+    </div>
+  )
+}
+
+/**
  * The delivery's DESCRIPTION — what the whole thing is for, editable the same way a comment is
  * written: plain text plus files pasted, dropped or attached into it. `Task.detail` already carried
  * this shape (see `commentBody.ts`); it just had no editor, so the field could be set once at
  * creation and never touched again.
  */
-function DescriptionEditor({ id, task, files, onSaved }: {
+function DescriptionEditor({ id, task, files, lang, onSaved }: {
   id: string
   task: TaskListRow['task']
   files: TaskFile[]
+  lang: Lang
   onSaved: (detail: string) => void | Promise<void>
 }) {
   const isMobile = useIsMobile()
@@ -871,7 +955,7 @@ function DescriptionEditor({ id, task, files, onSaved }: {
       ? (
         <div style={{ ...surface, padding: 14, display: 'flex', alignItems: 'flex-start', gap: 8 }}>
           <div style={{ flex: 1, minWidth: 0 }}>
-            <CommentBody body={task.detail} files={files} />
+            <DescriptionView body={task.detail} files={files} lang={lang} />
           </div>
           <button
             onClick={() => { setText(task.detail ?? ''); setAttached([]); setEditing(true) }}
@@ -1170,6 +1254,7 @@ export function DeliveryDetail({ id, detail, lang, reload, dense, onDeleted }: D
             id={id}
             task={detail.task}
             files={detail.files}
+            lang={lang}
             onSaved={next => run(() => editTask(id, { detail: next }))}
           />
 

--- a/packages/web/src/components/tasks/NewTaskWizard.tsx
+++ b/packages/web/src/components/tasks/NewTaskWizard.tsx
@@ -22,8 +22,14 @@ import { BetaTag } from '../BetaTag'
 export interface NewTaskWizardProps {
   onDone: (taskId: string) => void | Promise<void>
   onClose: () => void
-  /** Opens the existing session wizard. The task is created first and handed over. */
-  onCreateSession: (taskId: string, title: string) => void
+  /**
+   * Opens the existing session wizard. The task is created first and handed over.
+   *
+   * Absent where a session already exists to file under it — opened from that session's own title
+   * flag, say, there is nothing for "start a new one" to mean, and `TaskComposer` already renders
+   * no such button when it gets none.
+   */
+  onCreateSession?: (taskId: string, title: string) => void
   /** Opened FROM a session — it arrives pre-linked. See `TaskComposer`. */
   session?: { id: string; title: string; harness?: string }
 }
@@ -75,7 +81,7 @@ export function NewTaskWizard({ onDone, onClose, onCreateSession, session }: New
           {...(session ? { session } : {})}
           onDone={taskId => onDone(taskId)}
           onCancel={onClose}
-          onCreateSession={onCreateSession}
+          {...(onCreateSession ? { onCreateSession } : {})}
         />
       </div>
     </div>,

--- a/packages/web/src/components/tasks/copy.ts
+++ b/packages/web/src/components/tasks/copy.ts
@@ -126,6 +126,9 @@ export interface BoardCopy {
   tokenCacheWrite: string
   links: string
   blockedBy: string
+  /** The description's own collapse/expand, when it has no markdown headings to fold by. */
+  showAllDescription: string
+  showLessDescription: string
 }
 
 const EN: BoardCopy = {
@@ -220,6 +223,8 @@ const EN: BoardCopy = {
   tokenCacheWrite: 'Cache write',
   links: 'Links',
   blockedBy: 'Blocked by',
+  showAllDescription: 'Show all',
+  showLessDescription: 'Show less',
 }
 
 const PT: BoardCopy = {
@@ -316,6 +321,8 @@ const PT: BoardCopy = {
   tokenCacheWrite: 'Escrita de cache',
   links: 'Links',
   blockedBy: 'Bloqueada por',
+  showAllDescription: 'Mostrar tudo',
+  showLessDescription: 'Mostrar menos',
 }
 
 export function boardCopy(lang: Lang): BoardCopy {

--- a/packages/web/src/lib/shellBandState.test.ts
+++ b/packages/web/src/lib/shellBandState.test.ts
@@ -110,3 +110,32 @@ describe('the band never claims to be opening with nothing in flight', () => {
     expect(shellResolveWanted(shellBandReducer(INITIAL_SHELL_BAND, { type: 'openBand' }))).toBe(true)
   })
 })
+
+describe('the refusal keeps its CODE, not only its sentence', () => {
+  const refuse = (message: string, reason?: string) =>
+    shellBandReducer(INITIAL_SHELL_BAND, { type: 'refused', message, ...(reason ? { reason } : {}) })
+
+  // The sentence is what a person reads; the CODE is what the band acts on. Only the ceiling
+  // refusal has anything to offer — a list of the open shells — and without the code the band
+  // would have to match on the sentence, which is localized and would break on a rewording.
+  test('a ceiling refusal is recognisable afterwards', () => {
+    const s = refuse('All 8 terminals are open.', 'at-cap')
+    expect(s.phase).toBe('refused')
+    expect(s.reason).toBe('at-cap')
+  })
+
+  test('a refusal with no code carries none rather than inventing one', () => {
+    expect(refuse('the network went away').reason).toBeNull()
+  })
+
+  test('retrying clears the code with the sentence — both describe an attempt that is over', () => {
+    const s = shellBandReducer(refuse('All 8 terminals are open.', 'at-cap'), { type: 'retry' })
+    expect(s.reason).toBeNull()
+    expect(s.message).toBeNull()
+  })
+
+  test('a resolved shell clears it too', () => {
+    const s = shellBandReducer(refuse('x', 'at-cap'), { type: 'resolved', shell: { id: 'a', cwd: '/x' } })
+    expect(s.reason).toBeNull()
+  })
+})

--- a/packages/web/src/lib/shellBandState.ts
+++ b/packages/web/src/lib/shellBandState.ts
@@ -41,6 +41,15 @@ export interface ShellBandState {
   /** The refusal's own sentence, verbatim from the server. Null unless `phase === 'refused'`. */
   message: string | null
   /**
+   * The refusal's CODE, kept beside its sentence. Null when the server named none.
+   *
+   * The sentence is what a person reads; the code is what the BAND acts on, and exactly one
+   * refusal has anything to offer — the ceiling, whose answer is a list of the open shells. Without
+   * the code the band would have to match on the sentence, which is localized and would stop
+   * matching the day somebody rewords it.
+   */
+  reason: string | null
+  /**
    * How many times a person has ASKED for a shell here. `0` = never.
    *
    * It is the caller's effect dependency, and that is its whole job: an effect that resolves the
@@ -53,7 +62,7 @@ export interface ShellBandState {
 }
 
 export const INITIAL_SHELL_BAND: ShellBandState = {
-  phase: 'closed', shell: null, message: null, attempt: 0,
+  phase: 'closed', shell: null, message: null, reason: null, attempt: 0,
 }
 
 export type ShellBandAction =
@@ -65,7 +74,7 @@ export type ShellBandAction =
   | { type: 'resolving' }
   | { type: 'resolved'; shell: OpenShell }
   /** The server refused, or the request failed — the sentence is the caller's to compose. */
-  | { type: 'refused'; message: string }
+  | { type: 'refused'; message: string; reason?: string }
   /** The attempt was abandoned (the component re-ran, the session changed). NOT a failure. */
   | { type: 'cancelled' }
   /** The person asked again after a refusal. */
@@ -90,20 +99,20 @@ export function shellBandReducer(state: ShellBandState, action: ShellBandAction)
       return state.phase === 'wanted' ? { ...state, phase: 'opening' } : state
 
     case 'resolved':
-      return { ...state, phase: 'ready', shell: action.shell, message: null }
+      return { ...state, phase: 'ready', shell: action.shell, message: null, reason: null }
 
     case 'refused':
-      return { ...state, phase: 'refused', message: action.message }
+      return { ...state, phase: 'refused', message: action.message, reason: action.reason ?? null }
 
     case 'cancelled':
       // Back to WANTED, never left in `opening`: the band must not claim work nobody is doing.
       return state.phase === 'opening' ? { ...state, phase: 'wanted' } : state
 
     case 'retry':
-      return { ...state, phase: 'wanted', message: null, attempt: state.attempt + 1 }
+      return { ...state, phase: 'wanted', message: null, reason: null, attempt: state.attempt + 1 }
 
     case 'ended':
-      return { ...state, phase: 'closed', shell: null, message: null }
+      return { ...state, phase: 'closed', shell: null, message: null, reason: null }
 
     default:
       return state

--- a/packages/web/src/lib/shellCeiling.test.ts
+++ b/packages/web/src/lib/shellCeiling.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from 'bun:test'
+import { atCap, ceilingRows, ceilingTitle } from './shellCeiling'
+
+const sh = (id: string, cwd: string, createdMs: number, sessionTitle?: string) =>
+  ({ id, sessionId: `s-${id}`, cwd, createdMs, ...(sessionTitle ? { sessionTitle } : {}) })
+
+describe('when the list is shown at all', () => {
+  test('only the ceiling refusal opens it — the other three are impossible, not full', () => {
+    expect(atCap('at-cap')).toBe(true)
+    for (const r of ['no-tmux', 'no-cwd', 'cwd-missing', undefined, null, 'network']) {
+      expect(atCap(r), String(r)).toBe(false)
+    }
+  })
+})
+
+describe('the rows a person has to choose between', () => {
+  // THE DIRECTORY IS NOT ENOUGH. On the machine this was written for, all three open shells sat in
+  // `/home/mithrandir/agentistics` — a picker whose rows all read the same is not a picker.
+  test('the session’s own name leads, because several shells share one directory', () => {
+    const rows = ceilingRows([
+      sh('aaaaaaaa-1', '/home/u/proj', 3, 'Bug Fixer'),
+      sh('bbbbbbbb-2', '/home/u/proj', 1, 'ALM: rollup'),
+    ])
+    expect(rows.map(r => r.title)).toEqual(['ALM: rollup', 'Bug Fixer'])
+  })
+
+  test('oldest first — the one most likely to be finished with', () => {
+    const rows = ceilingRows([sh('c', '/a', 30), sh('a', '/a', 10), sh('b', '/a', 20)])
+    expect(rows.map(r => r.id)).toEqual(['a', 'b', 'c'])
+  })
+
+  // A shell whose session nobody could name still has to be closable, and a blank row is not one.
+  test('a shell with no session name falls back to WHERE it is, never to nothing', () => {
+    const [row] = ceilingRows([sh('deadbeef-x', '/home/u/deep/er/proj', 1)])
+    expect(row!.title).not.toBe('')
+    expect(row!.title).toContain('proj')
+  })
+
+  test('the handle is always there, so two rows that read alike are still told apart', () => {
+    const rows = ceilingRows([
+      sh('aaaaaaaa-1111', '/home/u/proj', 1, 'same'),
+      sh('bbbbbbbb-2222', '/home/u/proj', 2, 'same'),
+    ])
+    expect(rows[0]!.short).toBe('aaaaaaaa')
+    expect(rows[1]!.short).toBe('bbbbbbbb')
+    expect(rows[0]!.short).not.toBe(rows[1]!.short)
+  })
+
+  test('the home directory is shortened the way the band’s own title is', () => {
+    const [row] = ceilingRows([sh('a', '/home/u/proj', 1, 'x')])
+    expect(row!.where.startsWith('~')).toBe(true)
+  })
+
+  test('a list with nothing in it yields no rows rather than a row saying nothing', () => {
+    expect(ceilingRows([])).toEqual([])
+  })
+})
+
+describe('the sentence over the list', () => {
+  test('names the ceiling and what to do, in both languages', () => {
+    expect(ceilingTitle(8, 'pt')).toContain('8')
+    expect(ceilingTitle(8, 'en')).toContain('8')
+    expect(ceilingTitle(8, 'pt')).not.toBe(ceilingTitle(8, 'en'))
+  })
+})

--- a/packages/web/src/lib/shellCeiling.ts
+++ b/packages/web/src/lib/shellCeiling.ts
@@ -1,0 +1,76 @@
+/**
+ * shellCeiling.ts — PURE. What the band shows when the shell ceiling refuses an open.
+ *
+ * `SHELL_CAP` is 8 and the refusal has always been a SENTENCE — "Já há 8 terminais abertos. Feche
+ * um para abrir outro." It is a correct sentence and it was a DEAD END: nothing in this product
+ * listed or closed a shell. The only close was the trash can on a band you already had open, so if
+ * the eight were spread across eight other sessions, you were told to close one with no way to find
+ * them. That is the one refusal in this feature a person can actually act on, and it was the one
+ * with no action.
+ *
+ * The ceiling itself is deliberately a CEILING and not a timer (`shell-spec.ts` records why: a TTL
+ * kills the `bun test` that finished at minute 61). So the answer is not to raise it — it is to
+ * make the moment it fires the moment you can do something.
+ *
+ * **THE DIRECTORY IS NOT ENOUGH TO TELL THEM APART.** Measured on the machine this was written for:
+ * all three open shells sat in `/home/mithrandir/agentistics`, because that is what a per-session
+ * shell in a repository looks like. A picker whose rows all read the same is not a picker, so the
+ * SESSION's own name leads, the directory is beside it, and the HANDLE — the eight characters
+ * `agentop session attach` resolves — is always drawn, so two rows that still read alike are told
+ * apart by something.
+ */
+
+import { shellWhere } from './shellBand'
+
+/** One open shell as the list receives it. `sessionTitle` is what `?titles=1` adds. */
+export interface CeilingShell {
+  id: string
+  sessionId?: string
+  cwd?: string
+  createdMs?: number
+  sessionTitle?: string
+}
+
+export interface CeilingRow {
+  id: string
+  /** What the row is CALLED: the session's own name, or where the shell is when nobody could name it. */
+  title: string
+  /** The trimmed directory, in the same form the band's own title row uses. */
+  where: string
+  /** The handle, so two rows that read alike are still distinguishable. */
+  short: string
+}
+
+/** Only the FULL refusal opens the list. The other three are impossible rather than full — there is
+ *  no tmux, the row records no directory, the directory is gone — and offering to close somebody
+ *  else's shell would not help any of them. */
+export function atCap(reason: string | null | undefined): boolean {
+  return reason === 'at-cap'
+}
+
+/**
+ * The rows, OLDEST FIRST — the one a person is most likely finished with, and the only ordering
+ * that does not change under them while they read it.
+ */
+export function ceilingRows(shells: readonly CeilingShell[]): CeilingRow[] {
+  return [...shells]
+    .sort((a, b) => (a.createdMs ?? 0) - (b.createdMs ?? 0))
+    .map(s => {
+      const where = shellWhere(s.cwd)
+      return {
+        id: s.id,
+        // A blank row is not a closable row: with no name, WHERE it is has to serve as the name.
+        title: s.sessionTitle?.trim() || where || s.id.slice(0, 8),
+        where,
+        short: s.id.slice(0, 8),
+      }
+    })
+}
+
+/** The sentence over the list. It names the ceiling, because "close one" without "of eight" reads
+ *  as an arbitrary refusal. */
+export function ceilingTitle(cap: number, lang: 'pt' | 'en'): string {
+  return lang === 'pt'
+    ? `Os ${cap} terminais possíveis estão abertos. Encerre um para abrir este.`
+    : `All ${cap} terminals are open. End one to open this.`
+}

--- a/packages/web/src/pages/SessionsPage.tsx
+++ b/packages/web/src/pages/SessionsPage.tsx
@@ -31,6 +31,7 @@ import { SessionCreating } from '../components/sessions/SessionCreating'
 // while creating was the only thing that could announce a session; a reopen announces one too, and
 // two constants for one budget is two answers.
 import { SessionStatsMenu } from '../components/sessions/SessionStatsMenu'
+import { SessionTitleFlag } from '../components/sessions/SessionTitleFlag'
 import { MagnifierButton } from '../components/a11y/MagnifierButton'
 import { HideLensesButton } from '../components/a11y/HideLensesButton'
 import { ArtifactsAside } from '../components/sessions/ArtifactsAside'
@@ -705,10 +706,21 @@ export default function SessionsPage() {
             <ChevronLeft size={20} />
           </button>
           <div style={{ minWidth: 0, flex: 1 }}>
-            <div style={{
-              fontSize: 13, fontWeight: 650, color: 'var(--text-primary)',
-              overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
-            }}>{selected.title}</div>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 6, minWidth: 0 }}>
+              <div style={{
+                fontSize: 13, fontWeight: 650, color: 'var(--text-primary)', minWidth: 0,
+                overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+              }}>{selected.title}</div>
+              <SessionTitleFlag
+                session={{
+                  id: selected.id, title: selected.title,
+                  ...(selected.harness ? { harness: selected.harness } : {}),
+                  ...(selected.task ? { task: selected.task } : {}),
+                }}
+                lang={pt ? 'pt' : 'en'}
+                onLinked={refresh}
+              />
+            </div>
             <div style={{
               fontSize: 10.5, color: 'var(--text-tertiary)',
               overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
@@ -848,11 +860,22 @@ export default function SessionsPage() {
             </button>
 
             <div style={{ minWidth: 0, flex: 1, display: 'flex', flexDirection: 'column' }}>
-              <span style={{
-                fontSize: 13, fontWeight: 650, color: 'var(--text-primary)',
-                overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
-              }}>
-                {selected.title}
+              <span style={{ display: 'flex', alignItems: 'center', gap: 6, minWidth: 0 }}>
+                <span style={{
+                  fontSize: 13, fontWeight: 650, color: 'var(--text-primary)', minWidth: 0,
+                  overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+                }}>
+                  {selected.title}
+                </span>
+                <SessionTitleFlag
+                  session={{
+                    id: selected.id, title: selected.title,
+                    ...(selected.harness ? { harness: selected.harness } : {}),
+                    ...(selected.task ? { task: selected.task } : {}),
+                  }}
+                  lang={pt ? 'pt' : 'en'}
+                  onLinked={refresh}
+                />
               </span>
               {/* The state stays, on its own line: it is the one fact that changes while you read,
                   and the row below is a conversation that does not repeat it. */}

--- a/packages/web/src/pages/TasksPage.tsx
+++ b/packages/web/src/pages/TasksPage.tsx
@@ -274,6 +274,7 @@ function TaskList() {
         <NewSessionModal
           lang={lang}
           initialTask={starting.title}
+          initialTaskId={starting.taskId}
           onClose={() => setStarting(null)}
           onStarted={async () => {
             const to = starting.taskId


### PR DESCRIPTION
## Shell (#523)

`SHELL_CAP` é 8 e a recusa sempre foi uma frase correta e sem saída: nada no produto listava ou encerrava um shell, então "feche um para abrir outro" mandava você procurar por oito outras sessões. Agora a recusa **abre a lista**, com um encerrar por linha, e encerrar um já tenta abrir o seu.

A linha é nomeada pela **sessão**, porque o diretório não separa nada — medido: com oito abertos, oito linhas diziam `~/agentistics`. Os nomes vêm de `?titles=1`, opt-in, porque custam uma caminhada pela frota e só esta lista precisa deles. E a recusa passa a guardar o **código** junto com a frase, para a faixa não ter que casar em texto localizado.

De quebra, a barra do shell no mobile ganhou o `aria-label` que a do desktop tem desde a fase 2.

## Também em dev (outra sessão, ALM)

#517 #518 #519 #520 #521 #522 — descrição em accordion, recusa de `done` sem sessão filiada, filiação correta ao criar, bandeirola de vínculo, nome da entrega acima do título, e `subtaskStats`.

`bun tsc --noEmit` + `bun test` (7966 passando); CI verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lr8C4E9sJWirekwVfSr3UN