### PR TITLE
feat(install): publish and detect macOS (Darwin) binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -224,6 +224,19 @@ jobs:
         if: steps.skip_check.outputs.skip != 'true' && steps.version.outputs.skip != 'true'
         run: bun build --compile --target=bun-windows-x64 packages/server/bin/cli.ts --outfile ./release/agentop.exe
 
+      # Same cross-compile pattern as the musl and Windows binaries above — Bun downloads the
+      # macOS runtime for each target rather than needing a macOS machine to build on. TWO
+      # binaries because Apple Silicon and Intel Macs are different architectures with no
+      # universal fallback the way glibc/musl share one ISA; install.sh picks between them off
+      # `uname -m`.
+      - name: Compile macOS binary (Intel, cross-compile)
+        if: steps.skip_check.outputs.skip != 'true' && steps.version.outputs.skip != 'true'
+        run: bun build --compile --target=bun-darwin-x64 packages/server/bin/cli.ts --outfile ./release/agentop-darwin-x64
+
+      - name: Compile macOS binary (Apple Silicon, cross-compile)
+        if: steps.skip_check.outputs.skip != 'true' && steps.version.outputs.skip != 'true'
+        run: bun build --compile --target=bun-darwin-arm64 packages/server/bin/cli.ts --outfile ./release/agentop-darwin-arm64
+
       - name: Upload Windows binary artifact
         if: steps.skip_check.outputs.skip != 'true' && steps.version.outputs.skip != 'true'
         uses: actions/upload-artifact@v4
@@ -250,6 +263,26 @@ jobs:
             chmod +x /tmp/agentop-musl &&
             /tmp/agentop-musl --help
           '
+
+      # This runner is glibc/x86_64 Linux and can execute neither macOS binary — there is no
+      # emulator here the way Docker gave the musl binary a real place to run. What CAN be
+      # verified without a macOS machine is that Bun actually produced two DIFFERENT, genuine
+      # Mach-O executables rather than, say, two copies of the same file or a truncated download:
+      # `file` reads the Mach-O magic bytes and reports the architecture it finds. This is a
+      # header check, not a functional smoke test — it would not catch a binary that starts and
+      # then crashes. A real run needs a `runs-on: macos-latest` job, which this repo does not
+      # have yet.
+      - name: Verify macOS binaries (Mach-O header check — not a functional test)
+        if: steps.skip_check.outputs.skip != 'true' && steps.version.outputs.skip != 'true'
+        run: |
+          for f in ./release/agentop-darwin-x64 ./release/agentop-darwin-arm64; do
+            echo "== $f =="
+            file "$f"
+          done
+          file ./release/agentop-darwin-x64   | grep -qi 'Mach-O' || { echo "::error::agentop-darwin-x64 is not a Mach-O binary"; exit 1; }
+          file ./release/agentop-darwin-arm64 | grep -qi 'Mach-O' || { echo "::error::agentop-darwin-arm64 is not a Mach-O binary"; exit 1; }
+          file ./release/agentop-darwin-x64   | grep -qi 'x86_64' || { echo "::error::agentop-darwin-x64 is not x86_64"; exit 1; }
+          file ./release/agentop-darwin-arm64 | grep -qi 'arm64'  || { echo "::error::agentop-darwin-arm64 is not arm64"; exit 1; }
 
       - name: Generate changelog
         if: github.ref == 'refs/heads/main' && steps.skip_check.outputs.skip != 'true' && steps.version.outputs.skip != 'true'
@@ -343,13 +376,15 @@ jobs:
           # failure at the first step. Upload into it instead when it is already there.
           if gh release view "$TAG" >/dev/null 2>&1; then
             echo "release $TAG already exists — uploading the binaries into it"
-            gh release upload "$TAG" ./release/agentop ./release/agentop-musl ./release/agentop.exe $VSIX --clobber
+            gh release upload "$TAG" ./release/agentop ./release/agentop-musl ./release/agentop-darwin-x64 ./release/agentop-darwin-arm64 ./release/agentop.exe $VSIX --clobber
           else
             gh release create "$TAG" \
               --title "v${VERSION}" \
               --notes-file /tmp/release-notes.md \
               ./release/agentop \
               ./release/agentop-musl \
+              ./release/agentop-darwin-x64 \
+              ./release/agentop-darwin-arm64 \
               ./release/agentop.exe \
               $VSIX
           fi
@@ -374,6 +409,8 @@ jobs:
             --notes-file /tmp/release-notes.md \
             ./release/agentop \
             ./release/agentop-musl \
+            ./release/agentop-darwin-x64 \
+            ./release/agentop-darwin-arm64 \
             ./release/agentop.exe \
             $VSIX
 

--- a/install.sh
+++ b/install.sh
@@ -19,32 +19,50 @@ fi
 OS="$(uname -s)"
 ARCH="$(uname -m)"
 
-if [[ "$OS" != "Linux" ]]; then
-  echo "Error: only Linux binaries are published at the moment (detected: $OS)."
-  exit 1
-fi
+case "$OS" in
+  Linux)
+    if [[ "$ARCH" != "x86_64" ]]; then
+      echo "Error: only x86_64 Linux binaries are published at the moment (detected: $ARCH)."
+      exit 1
+    fi
+    ;;
+  Darwin)
+    case "$ARCH" in
+      x86_64|arm64) ;;
+      *)
+        echo "Error: only x86_64 and arm64 macOS binaries are published at the moment (detected: $ARCH)."
+        exit 1
+        ;;
+    esac
+    ;;
+  *)
+    echo "Error: only Linux and macOS binaries are published at the moment (detected: $OS)."
+    exit 1
+    ;;
+esac
 
-if [[ "$ARCH" != "x86_64" ]]; then
-  echo "Error: only x86_64 binaries are published at the moment (detected: $ARCH)."
-  exit 1
-fi
-
-# ── libc: glibc vs musl ─────────────────────────────────────────────────────
+# ── libc: glibc vs musl (Linux only — macOS has no equivalent split) ────────
 #
-# Two binaries are published: `agentop` (glibc) and `agentop-musl` (Alpine and other musl-based
-# distros — glibc's dynamic linker does not exist there, so the glibc binary fails with a bare
-# "not found" that names no missing library). `ldd --version` prints "musl libc" on a musl system
-# regardless of its own exit code (busybox's `ldd` does not fully support `--version`) — and this
-# script runs under `set -o pipefail`, under which the PIPELINE fails if ANY stage does, not only
-# the last, so ldd's own non-zero exit would sink the `if` even when grep matches. The `|| true`
-# neutralises that: only grep's result decides.
+# Two Linux binaries are published: `agentop` (glibc) and `agentop-musl` (Alpine and other
+# musl-based distros — glibc's dynamic linker does not exist there, so the glibc binary fails with
+# a bare "not found" that names no missing library). `ldd --version` prints "musl libc" on a musl
+# system regardless of its own exit code (busybox's `ldd` does not fully support `--version`) —
+# and this script runs under `set -o pipefail`, under which the PIPELINE fails if ANY stage does,
+# not only the last, so ldd's own non-zero exit would sink the `if` even when grep matches. The
+# `|| true` neutralises that: only grep's result decides.
 IS_MUSL=0
-if (ldd --version 2>&1 || true) | grep -qi musl; then
+if [[ "$OS" == "Linux" ]] && (ldd --version 2>&1 || true) | grep -qi musl; then
   IS_MUSL=1
 fi
 
 BINARY_ASSET="$BINARY"
-if [[ "$IS_MUSL" -eq 1 ]]; then
+if [[ "$OS" == "Darwin" ]]; then
+  if [[ "$ARCH" == "arm64" ]]; then
+    BINARY_ASSET="${BINARY}-darwin-arm64"
+  else
+    BINARY_ASSET="${BINARY}-darwin-x64"
+  fi
+elif [[ "$IS_MUSL" -eq 1 ]]; then
   BINARY_ASSET="${BINARY}-musl"
 
   # Bun's own runtime links libstdc++/libgcc even in its musl build, and Alpine's base image ships


### PR DESCRIPTION
## Summary
- `install.sh` only accepted Linux binaries — this is the same install/distribution gap the recent musl work closed for Alpine, applied to macOS.
- `.github/workflows/release.yml` now cross-compiles `agentop-darwin-x64` and `agentop-darwin-arm64` from the existing Linux runner (same pattern as the Windows and musl binaries), verifies both are genuine Mach-O binaries of the right architecture, and publishes them alongside the existing assets on both the versioned release and the rolling `latest` release.
- `install.sh` now detects `Darwin` via `uname -s`/`uname -m` and picks the right asset (`agentop-darwin-x64` or `agentop-darwin-arm64`); the existing Linux/musl logic is untouched (verified via simulated `uname` shims for Linux-glibc, Darwin-x64, Darwin-arm64, and two rejected/unsupported combos).

## Scope note
This covers the install/binary-distribution gap only — the direct macOS counterpart to the musl fix just shipped. The service/autostart layer (`service-manager.ts`, launchd) and the dependency-proposal layer (`dependency-plan.ts`, brew) already had real macOS support before this PR. `live-sessions.ts`'s `/proc`-based process detection remains Linux-only; it already degrades honestly (`'not-linux'`, never a false zero) rather than being broken, and is a materially larger feature (a macOS-native process scanner) left out of this PR's scope.

## Test plan
- [x] `bun tsc --noEmit` — clean
- [x] `bun test` — 7970 pass, 0 fail
- [x] `packages/core/src/releaseWorkflow.lint.test.ts` — pass
- [x] YAML syntax validated (`yaml.safe_load`)
- [x] Simulated `uname` shims confirm: Darwin/x86_64 → `agentop-darwin-x64`, Darwin/arm64 → `agentop-darwin-arm64`, Linux/x86_64 → `agentop` (unchanged regression check), FreeBSD → refused, Darwin/i386 → refused
- [ ] Real end-to-end run of the compiled macOS binaries on actual hardware — not possible from this environment (no macOS machine); the CI header check confirms genuine Mach-O output for the right architecture but is explicitly not a functional smoke test, stated as such in the workflow's own comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FbrNA7mQjd3jLq7faygZo9