### PR TITLE
fix(update): o botão checa a versão ao vivo, não pelo cache

### DIFF
--- a/packages/server/server/upgrade-web.test.ts
+++ b/packages/server/server/upgrade-web.test.ts
@@ -39,3 +39,21 @@ describe('the upgrade must not be this process’s child', () => {
     expect(src).not.toContain("stdio: 'inherit'")
   })
 })
+
+/**
+ * The version the route judges must be read LIVE, not from the cache.
+ *
+ * MEASURED on a real machine: v2.32.0 was published, the machine was on v2.31.0, and the route
+ * answered `up-to-date` — `getVersionInfo` caches for hours and its entry had been minted before
+ * the release existed. Somebody pressing this button is acting on an update they are looking at
+ * right now; refusing them with a sentence that contradicts the modal above it is the worst answer
+ * available. `agentop upgrade` already forces the same check for the same reason.
+ */
+describe('the version the press is judged against', () => {
+  const src = readFileSync(new URL('./upgrade-web.ts', import.meta.url), 'utf8')
+
+  test('is fetched with force, never off the cache', () => {
+    expect(src).toContain('getVersionInfo({ force: true })')
+    expect(src).not.toContain('getVersionInfo()')
+  })
+})

--- a/packages/server/server/upgrade-web.ts
+++ b/packages/server/server/upgrade-web.ts
@@ -77,7 +77,13 @@ export async function handleUpgradeRoute(
 ): Promise<Response | null> {
   if (url.pathname !== '/api/upgrade' || req.method !== 'POST') return null
 
-  const info = await getVersionInfo().catch(() => null)
+  // FORCE. `getVersionInfo` caches for hours, and somebody pressing this button is acting on an
+  // update they are looking at RIGHT NOW — a cached "you are up to date" refuses the press with a
+  // sentence that contradicts the modal above it. Measured: a machine on 2.31.0 with 2.32.0
+  // published answered `up-to-date` from a cache minted before the release existed. It is one
+  // round trip per press, on a press, which is exactly what `agentop upgrade` already does for the
+  // same reason (`force live GitHub release check during manual upgrade`).
+  const info = await getVersionInfo({ force: true }).catch(() => null)
   const decision = upgradeFromUiDecision({
     capable: CAPS.localShell,
     central: TEAM_CENTRAL,


### PR DESCRIPTION
Medido em produção logo depois de publicar a **v2.32.0**: a máquina estava na **v2.31.0**, o botão foi apertado, e a rota respondeu *"Esta máquina já está na versão mais recente"*. `getVersionInfo` guarda a resposta por horas e a entrada tinha sido cunhada antes de a release existir.

Quem aperta este botão está agindo sobre uma atualização que está **olhando**. Uma recusa vinda do cache contradiz o modal logo acima dela — a pior resposta disponível, porque a pessoa não tem como saber qual dos dois está certo.

É uma ida ao GitHub **por pressão, numa pressão**, que é exatamente o que `agentop upgrade` já faz pelo mesmo motivo (`force live GitHub release check during manual upgrade`).

Preso por um lint sobre a fonte do módulo, junto dos outros dois invariantes que já estavam lá.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lr8C4E9sJWirekwVfSr3UN