### PR TITLE
release: o botão de atualizar checa a versão ao vivo

### DIFF
--- a/packages/server/server/upgrade-web.test.ts
+++ b/packages/server/server/upgrade-web.test.ts
@@ -39,3 +39,21 @@ describe('the upgrade must not be this process’s child', () => {
     expect(src).not.toContain("stdio: 'inherit'")
   })
 })
+
+/**
+ * The version the route judges must be read LIVE, not from the cache.
+ *
+ * MEASURED on a real machine: v2.32.0 was published, the machine was on v2.31.0, and the route
+ * answered `up-to-date` — `getVersionInfo` caches for hours and its entry had been minted before
+ * the release existed. Somebody pressing this button is acting on an update they are looking at
+ * right now; refusing them with a sentence that contradicts the modal above it is the worst answer
+ * available. `agentop upgrade` already forces the same check for the same reason.
+ */
+describe('the version the press is judged against', () => {
+  const src = readFileSync(new URL('./upgrade-web.ts', import.meta.url), 'utf8')
+
+  test('is fetched with force, never off the cache', () => {
+    expect(src).toContain('getVersionInfo({ force: true })')
+    expect(src).not.toContain('getVersionInfo()')
+  })
+})

--- a/packages/server/server/upgrade-web.ts
+++ b/packages/server/server/upgrade-web.ts
@@ -77,7 +77,13 @@ export async function handleUpgradeRoute(
 ): Promise<Response | null> {
   if (url.pathname !== '/api/upgrade' || req.method !== 'POST') return null
 
-  const info = await getVersionInfo().catch(() => null)
+  // FORCE. `getVersionInfo` caches for hours, and somebody pressing this button is acting on an
+  // update they are looking at RIGHT NOW — a cached "you are up to date" refuses the press with a
+  // sentence that contradicts the modal above it. Measured: a machine on 2.31.0 with 2.32.0
+  // published answered `up-to-date` from a cache minted before the release existed. It is one
+  // round trip per press, on a press, which is exactly what `agentop upgrade` already does for the
+  // same reason (`force live GitHub release check during manual upgrade`).
+  const info = await getVersionInfo({ force: true }).catch(() => null)
   const decision = upgradeFromUiDecision({
     capable: CAPS.localShell,
     central: TEAM_CENTRAL,


### PR DESCRIPTION
#528 — medido em produção logo depois de publicar a v2.32.0: a máquina estava na v2.31.0, o botão foi apertado, e a rota respondeu *"já está na versão mais recente"*, porque `getVersionInfo` guarda a resposta por horas e a entrada era anterior à release. Quem aperta o botão está agindo sobre uma atualização que está olhando; a recusa contradizia o modal logo acima dela. Agora a checagem é forçada, como `agentop upgrade` já fazia.

Mais o que dev tiver acumulado de outras sessões.

CI verde; `bun tsc --noEmit` + `bun test` (7983 passando).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lr8C4E9sJWirekwVfSr3UN