### PR TITLE
feat(sessions): a conversa é a sessão, e a faixa é a porta dos dois terminais

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -3170,29 +3170,14 @@ export default function AppLayout() {
         }} />
       )}
 
-      {/* NOT ON A CENTRAL. The conversation is not relayed — the reverse channel's chat route
-          answers 410 — so a Chat tab there is a control that cannot do what it says, and choosing
-          it drops the reader back onto the same relayed screen with a sentence explaining that the
-          screen is all there is. The release note for this claimed the toggle was already withheld;
-          it was not, because the gate keys on `conversationBlind`, a MACHINE-LOCAL sentence that
-          `reduceMachineFleetRow` deliberately strips from the wire — so on a relayed row it is
-          always `undefined` and the tab was always offered. `isCentral` is the fact that decides
-          this, and it is the one the relay cannot lose. */}
-      {selectedFleetSession && !isCentral && selectedFleetSession.conversationBlind === undefined && (
-        <div role="tablist" style={{
-          display: 'flex', gap: 3, padding: 2, borderRadius: 9, flexShrink: 0,
-          background: 'var(--bg-elevated)', border: '1px solid var(--border-subtle)',
-        }}>
-          <Segment
-            on={sessionView === 'chat'} onClick={() => setSessionView('chat')}
-            icon={<MessagesSquare size={13} />} label={lang === 'pt' ? 'Conversa' : 'Chat'}
-          />
-          <Segment
-            on={sessionView === 'terminal'} onClick={() => setSessionView('terminal')}
-            icon={<TerminalSquare size={13} />} label="Terminal"
-          />
-        </div>
-      )}
+      {/* THE `Conversa | Terminal` TOGGLE IS GONE FROM THE HEADER, and its absence is the design.
+          A SESSION OPENS ON ITS CONVERSATION — that is what a session is — and the terminals are
+          reached from the BAND at the foot of the panel, which offers both of them BY NAME
+          (`Claude Code` and `Shell`). What this toggle did was ask "which view" in a second place
+          and a second vocabulary, while the band underneath asked "which terminal" in a third; a
+          reader had to hold all of it to answer one question. The band is now the one door, and the
+          dedicated screen the one full-page view. `sessionView` survives for the routes that still
+          name a view (a deep link, the reopen flow); nothing on screen sets it any more. */}
 
       {/* THE ARTIFACTS BUTTON, beside the view tabs — the panel is a view OF this session, so it
           belongs with the two that already are.

--- a/packages/web/src/components/sessions/SessionPanel.tsx
+++ b/packages/web/src/components/sessions/SessionPanel.tsx
@@ -152,23 +152,11 @@ export function SessionPanel({ session, row, lang, theme, act, authorName, onGon
           </p>
         </div>
 
-        {/* The toggle. Only rendered when there are two views to choose between — a segmented
-            control with one segment is a label pretending to be a control. */}
-        {chattable && (
-          <div role="tablist" style={{
-            display: 'flex', gap: 3, padding: 3, borderRadius: 10, flexShrink: 0,
-            background: 'var(--bg-elevated)', border: '1px solid var(--border-subtle)',
-          }}>
-            <Segment
-              on={active === 'chat'} onClick={() => setView('chat')}
-              icon={<MessagesSquare size={14} />} label={pt ? 'Conversa' : 'Chat'}
-            />
-            <Segment
-              on={active === 'terminal'} onClick={() => setView('terminal')}
-              icon={<TerminalSquare size={14} />} label={pt ? 'Terminal' : 'Terminal'}
-            />
-          </div>
-        )}
+        {/* THE `Conversa | Terminal` TOGGLE IS GONE, and its absence is the design.
+            A session opens on its CONVERSATION — that is what a session is — and the terminals are
+            reached from the BAND at the foot of the panel, which names both of them. Two controls
+            for one decision, in two places, with different words ("Terminal" here, "Assistente"
+            there) was the ambiguity phase 1 set out to avoid and this header reintroduced. */}
 
         {/* The row's verbs. Every one of them, its label and whether it is enabled arrive already
             decided by `sessionActions` — the same answer the terminal cockpit resolves against. */}
@@ -246,6 +234,7 @@ export function SessionPanel({ session, row, lang, theme, act, authorName, onGon
           sessionId={session.id}
           {...(session.cwd ? { cwd: session.cwd } : {})}
           {...(onOpenShellFullscreen ? { onOpenFullscreen: onOpenShellFullscreen } : {})}
+          {...(session.harness ? { harness: session.harness } : {})}
           lang={lang}
           theme={theme}
         />

--- a/packages/web/src/components/sessions/ShellBand.tsx
+++ b/packages/web/src/components/sessions/ShellBand.tsx
@@ -46,6 +46,9 @@ import {
 import { useDocumentVisible } from '../../hooks/useDocumentVisible'
 import { keyStripShown } from '../../lib/terminalSurface'
 import {
+  TERMINAL_TARGETS, readTarget, targetLabel, targetScope, targetStreamId, type TerminalTarget,
+} from '../../lib/terminalTarget'
+import {
   atCap, ceilingRows, ceilingTitle, type CeilingRow, type CeilingShell,
 } from '../../lib/shellCeiling'
 import { useIsMobile } from '../../hooks/useIsMobile'
@@ -79,6 +82,8 @@ interface T {
   retry: string
   fullscreen: string
   endThis: string
+  whichTerminal: string
+  openTerminal: string
 }
 
 const TXT: Record<'pt' | 'en', T> = {
@@ -97,6 +102,8 @@ const TXT: Record<'pt' | 'en', T> = {
     retry: 'Try again',
     fullscreen: 'Open the shell full screen',
     endThis: 'End this terminal',
+    whichTerminal: 'Which terminal',
+    openTerminal: 'Open a terminal',
   },
   pt: {
     title: 'Shell',
@@ -113,6 +120,8 @@ const TXT: Record<'pt' | 'en', T> = {
     retry: 'Tentar de novo',
     fullscreen: 'Abrir o shell em tela cheia',
     endThis: 'Encerrar este terminal',
+    whichTerminal: 'Qual terminal',
+    openTerminal: 'Abrir um terminal',
   },
 }
 
@@ -123,6 +132,10 @@ export interface ShellBandProps {
   cwd?: string
   lang: 'pt' | 'en'
   theme: 'dark' | 'light'
+  /** The harness running in this session, so the CLI target is named after what is on its screen
+   *  (`Claude Code`) rather than after a concept ("Assistente"). Absent, or one this build has no
+   *  label for, falls back to words — never to a blank segment. */
+  harness?: string
   /**
    * WHERE this shell is drawn. `docked` is the band under the composer — the placement whose whole
    * point is SIMULTANEITY, reading the conversation while a build runs beside it. `dedicated` is
@@ -137,13 +150,20 @@ export interface ShellBandProps {
   onOpenFullscreen?: () => void
 }
 
-export function ShellBand({ sessionId, cwd, lang, theme, placement = 'docked', onOpenFullscreen }: ShellBandProps) {
+export function ShellBand({ sessionId, cwd, lang, theme, harness, placement = 'docked', onOpenFullscreen }: ShellBandProps) {
   const t = TXT[lang]
   const isMobile = useIsMobile()
   const documentVisible = useDocumentVisible()
 
   const dedicated = placement === 'dedicated'
   const [prefs, setPrefs] = useState(() => readBandPrefs())
+  /**
+   * WHICH terminal this band is showing. It is the band's own state and not the session's, because
+   * the band is now the door to BOTH panes: the header's `Conversa | Terminal` toggle is gone, a
+   * session opens on its conversation, and choosing a terminal is choosing which one.
+   */
+  const [target, setTarget] = useState<TerminalTarget>(() => readTarget(readBandPrefs().target))
+  const scope = targetScope(target)
   // A DEDICATED shell is open by definition — you navigated to a screen that is nothing else. The
   // stored `open` is the DOCKED band's state and must not decide it, or arriving here with the band
   // collapsed would show an empty screen with no way to fill it.
@@ -156,6 +176,12 @@ export function ShellBand({ sessionId, cwd, lang, theme, placement = 'docked', o
   /** The open shells, fetched ONLY when the ceiling refuses — see `shellCeiling.ts`. */
   const [ceiling, setCeiling] = useState<{ rows: CeilingRow[]; cap: number } | null>(null)
   const [ctrlNote, setCtrlNote] = useState<string | null>(null)
+
+  /** Choosing a terminal is remembered, so the band comes back on the one you were using. */
+  const chooseTarget = useCallback((next: TerminalTarget) => {
+    setTarget(next)
+    try { writeBandPrefs({ ...readBandPrefs(), target: next }) } catch { /* storage blocked */ }
+  }, [])
 
   const setBand = useCallback((next: Partial<{ open: boolean; height: number }>) => {
     setPrefs(p => {
@@ -181,7 +207,9 @@ export function ShellBand({ sessionId, cwd, lang, theme, placement = 'docked', o
   // DEPENDS ON `band.attempt` AND NOT ON `band`. The effect dispatches, and an effect that depends
   // on what it dispatches cancels its own request on the very next render — the loop that made this
   // band spin on "Abrindo…". `attempt` moves only when a PERSON opens or retries.
-  const wanted = shellResolveWanted(band)
+  // Only the SHELL has to be resolved: the CLI pane IS the session and is already there. Asking
+  // for one while the band is showing the other would mint a shell nobody opened.
+  const wanted = shellResolveWanted(band) && target === 'shell'
   const wantedRef = useRef(wanted)
   wantedRef.current = wanted
   useEffect(() => {
@@ -222,7 +250,11 @@ export function ShellBand({ sessionId, cwd, lang, theme, placement = 'docked', o
     // An abandoned attempt is NOT a failure and NOT a silence: it returns to `wanted`, so the next
     // render asks again instead of leaving a spinner over nothing.
     return () => { cancelled = true; dispatch({ type: 'cancelled' }) }
-  }, [band.attempt, sessionId, lang])
+    // `target` IS a dependency, and leaving it out was a measured bug: a band opened on the CLI
+    // pane skips the resolve, and switching to the shell moved nothing the effect watches — so the
+    // request that had been skipped was never made and the shell never appeared. It is safe to
+    // depend on because a PERSON moves it, unlike the dispatches this effect makes itself.
+  }, [band.attempt, sessionId, lang, target])
 
   /**
    * THE CEILING IS THE ONE REFUSAL A PERSON CAN ACT ON, and until now it was the one with no
@@ -260,18 +292,21 @@ export function ShellBand({ sessionId, cwd, lang, theme, placement = 'docked', o
     sessionSelected: Boolean(sessionId),
     documentVisible,
   })
+  /** The pane this band is watching: the session itself, or the shell it opened. `null` while a
+   *  shell has not been resolved yet, which is what keeps the stream from asking for a blank. */
+  const streamId = targetStreamId(target, { sessionId, shellId: shell?.id ?? null })
   // `null` is what DROPS the subscription — the client half of the unwatch discipline.
   // The remembered geometry rides the OPEN, so the pane is already this box's size on the first
   // frame instead of arriving at whatever width the last viewer left it — see `shellBand.ts`.
-  const { state } = useTerminalStream(watching && shell ? shell.id : null, 'shell', bandGeometry(placement))
-  const write = useTerminalWrite(shell?.id ?? '', watching && Boolean(shell), lang, 'shell')
-  // `'shell'`: the honesty line must say whose screen this is. The default subject calls it "the
-  // agent's current screen", which over a shell the person opened themselves is simply false.
-  const status = terminalStatus(state, lang, 'shell')
+  const { state } = useTerminalStream(watching ? streamId : null, scope, bandGeometry(placement))
+  const write = useTerminalWrite(streamId ?? '', watching && Boolean(streamId), lang, scope)
+  // The honesty line must say WHOSE screen this is: "the agent's current screen" over a shell the
+  // person opened themselves is simply false, and the reverse is just as wrong.
+  const status = terminalStatus(state, lang, target === 'shell' ? 'shell' : 'session')
   /** A shell follows its box in BOTH directions — nothing in this product reads its screen. */
   const resizer = useMemo(
-    () => createPaneResizer({ scope: 'shell', id: shell?.id ?? '' }),
-    [shell?.id],
+    () => createPaneResizer({ scope, id: streamId ?? '' }),
+    [scope, streamId],
   )
   useEffect(() => () => resizer.cancel(), [resizer])
   /**
@@ -351,6 +386,41 @@ export function ShellBand({ sessionId, cwd, lang, theme, placement = 'docked', o
     }
   }, [isMobile, setBand])
 
+  /**
+   * THE ONE CONTROL THAT PICKS A TERMINAL. It replaced the header's `Conversa | Terminal` toggle —
+   * a session opens on its conversation, and this band is the door to both panes. The CLI segment
+   * is named after the HARNESS, so it names what is on the screen instead of a concept.
+   */
+  const targetSwitch = (
+    <div role="tablist" aria-label={t.whichTerminal} style={{
+      display: 'flex', gap: 3, padding: 3, borderRadius: 8, flexShrink: 0,
+      background: 'var(--bg-elevated)', border: '1px solid var(--border-subtle)',
+    }}>
+      {TERMINAL_TARGETS.map(id => {
+        const on = target === id
+        return (
+          <button
+            key={id}
+            role="tab"
+            aria-selected={on}
+            onClick={e => { e.stopPropagation(); chooseTarget(id) }}
+            style={{
+              // 44px is the MOBILE figure; on a pointer it would turn a segmented control into a
+              // row of buttons.
+              minHeight: isMobile ? 44 : 22, padding: isMobile ? '0 14px' : '0 9px',
+              borderRadius: 6, cursor: 'pointer', fontFamily: 'inherit',
+              fontSize: 11, fontWeight: 650, border: 'none', whiteSpace: 'nowrap',
+              background: on ? 'var(--bg-surface)' : 'transparent',
+              color: on ? 'var(--text-primary)' : 'var(--text-tertiary)',
+            }}
+          >
+            {targetLabel(id, harness, lang)}
+          </button>
+        )
+      })}
+    </div>
+  )
+
   const where = shellWhere(cwd)
 
   const screen = (
@@ -364,13 +434,13 @@ export function ShellBand({ sessionId, cwd, lang, theme, placement = 'docked', o
       </div>}>
         {/* key={shell.id}: a new shell gets a brand-new emulator, so no content leaks across. */}
         <SessionTerminal
-          key={shell?.id ?? 'none'}
+          key={streamId ?? 'none'}
           frame={state.frame}
           theme={theme}
           showCursor={status.showCursor}
           interactive={write.ready}
           onInput={send}
-          onGeometry={shell ? onGeometry : undefined}
+          onGeometry={streamId ? onGeometry : undefined}
         />
       </Suspense>
     </div>
@@ -416,7 +486,7 @@ export function ShellBand({ sessionId, cwd, lang, theme, placement = 'docked', o
    * does not separate them — a repository's shells all sit in the same one) and carries the handle,
    * so two rows that still read alike are told apart by something.
    */
-  const ceilingList = ceiling && atCap(band.reason) ? (
+  const ceilingList = ceiling && atCap(band.reason) && target === 'shell' ? (
     <div style={{
       flexShrink: 0, display: 'flex', flexDirection: 'column', gap: 6,
       maxHeight: isMobile ? 260 : 180, overflowY: 'auto',
@@ -498,7 +568,7 @@ export function ShellBand({ sessionId, cwd, lang, theme, placement = 'docked', o
       <div style={{
         flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column', gap: 8,
       }}>
-        {shell ? screen : <div style={{ flex: 1 }} />}
+        {streamId ? screen : <div style={{ flex: 1 }} />}
         {notice}
         {ceilingList}
         {keyStripShown('dedicated', isMobile) && strip}
@@ -509,28 +579,33 @@ export function ShellBand({ sessionId, cwd, lang, theme, placement = 'docked', o
   // ---- mobile: a full-screen sheet over the session --------------------------------------------
   if (isMobile) {
     if (!prefs.open) {
+      // The door to BOTH terminals, named. It is two buttons and not one bar plus a hidden state:
+      // on a phone the band IS the only way to a terminal now that the header toggle is gone.
       return (
-        <button
-          onClick={() => setBand({ open: true })}
-          aria-expanded={false}
-          // The desktop bar has carried this since phase 2 and the phone's had nothing: a screen
-          // reader met a button whose whole content was an icon, the word "Shell" and a path.
-          aria-label={t.toggleBar}
-          style={{
-            display: 'flex', alignItems: 'center', gap: 8, width: '100%',
-            minHeight: 44, padding: '0 12px', flexShrink: 0,
-            borderTop: '1px solid var(--border)', border: 'none',
-            background: 'var(--bg-surface)', color: 'var(--text-secondary)',
-            fontFamily: 'inherit', fontSize: 13, fontWeight: 600, cursor: 'pointer',
-          }}
-        >
-          <TerminalSquare size={16} />
-          <span>{t.title}</span>
-          {where && <span style={{
-            minWidth: 0, flex: 1, textAlign: 'right', fontSize: 11, color: 'var(--text-tertiary)',
-            overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
-          }}>{where}</span>}
-        </button>
+        <div style={{
+          display: 'flex', alignItems: 'center', gap: 8, width: '100%',
+          minHeight: 44, padding: '0 12px', flexShrink: 0,
+          borderTop: '1px solid var(--border)', background: 'var(--bg-surface)',
+        }}>
+          <span style={{ color: 'var(--anthropic-orange)', display: 'inline-flex', flexShrink: 0 }}>
+            <TerminalSquare size={16} />
+          </span>
+          {TERMINAL_TARGETS.map(id => (
+            <button
+              key={id}
+              onClick={() => { chooseTarget(id); setBand({ open: true }) }}
+              aria-label={`${t.openTerminal} — ${targetLabel(id, harness, lang)}`}
+              style={{
+                minHeight: 44, padding: '0 14px', borderRadius: 8, cursor: 'pointer',
+                fontFamily: 'inherit', fontSize: 13, fontWeight: 650, whiteSpace: 'nowrap',
+                border: '1px solid var(--border-subtle)', background: 'var(--bg-elevated)',
+                color: 'var(--text-secondary)',
+              }}
+            >
+              {targetLabel(id, harness, lang)}
+            </button>
+          ))}
+        </div>
       )
     }
     return (
@@ -556,13 +631,15 @@ export function ShellBand({ sessionId, cwd, lang, theme, placement = 'docked', o
             <ChevronLeft size={20} />
           </button>
           <div style={{ minWidth: 0, flex: 1 }}>
-            <div style={{ fontSize: 13, fontWeight: 650, color: 'var(--text-primary)' }}>{t.title}</div>
+            <div style={{ fontSize: 13, fontWeight: 650, color: 'var(--text-primary)' }}>
+              {targetLabel(target, harness, lang)}
+            </div>
             {where && <div style={{
               fontSize: 10.5, color: 'var(--text-tertiary)',
               overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
             }}>{where}</div>}
           </div>
-          {shell && (
+          {shell && target === 'shell' && (
             <button
               onClick={() => { void close() }}
               aria-label={t.close}
@@ -579,7 +656,8 @@ export function ShellBand({ sessionId, cwd, lang, theme, placement = 'docked', o
         <div style={{
           flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column', gap: 8, padding: 10,
         }}>
-          {shell ? screen : <div style={{ flex: 1 }} />}
+          {targetSwitch}
+          {streamId ? screen : <div style={{ flex: 1 }} />}
           {notice}
           {ceilingList}
           {strip}
@@ -633,20 +711,45 @@ export function ShellBand({ sessionId, cwd, lang, theme, placement = 'docked', o
         }}
       >
         <span style={{ color: 'var(--anthropic-orange)', display: 'inline-flex' }}><TerminalSquare size={14} /></span>
-        <span style={{ fontSize: 11.5, fontWeight: 700, letterSpacing: 0.4, color: 'var(--text-secondary)' }}>
-          {t.title.toUpperCase()}
-        </span>
+        {/* COLLAPSED, the bar is the door to BOTH terminals, so it offers both by name rather than
+            calling itself "SHELL" and hiding the other one behind a state nobody can see. Open, the
+            switch above says which you are in. */}
+        {prefs.open ? (
+          <span style={{ fontSize: 11.5, fontWeight: 700, letterSpacing: 0.4, color: 'var(--text-secondary)' }}>
+            {targetLabel(target, harness, lang).toUpperCase()}
+          </span>
+        ) : (
+          <span style={{ display: 'flex', gap: 6, alignItems: 'center', flexShrink: 0 }}>
+            {TERMINAL_TARGETS.map(id => (
+              <button
+                key={id}
+                onClick={e => { e.stopPropagation(); chooseTarget(id); setBand({ open: true }) }}
+                aria-label={`${t.openTerminal} — ${targetLabel(id, harness, lang)}`}
+                style={{
+                  minHeight: isMobile ? 44 : 22, padding: isMobile ? '0 14px' : '0 9px',
+                  borderRadius: 6, cursor: 'pointer', fontFamily: 'inherit',
+                  fontSize: 11, fontWeight: 650, whiteSpace: 'nowrap',
+                  border: '1px solid var(--border-subtle)', background: 'var(--bg-elevated)',
+                  color: 'var(--text-secondary)',
+                }}
+              >
+                {targetLabel(id, harness, lang)}
+              </button>
+            ))}
+          </span>
+        )}
         {where && <span style={{
           minWidth: 0, flex: 1, fontSize: 11, color: 'var(--text-tertiary)',
           overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
         }}>{where}</span>}
         {!where && <span style={{ flex: 1 }} />}
+        {prefs.open && targetSwitch}
         {busy && <Loader2 size={13} className="ag-spin" style={{ color: 'var(--text-tertiary)' }} />}
         {/* TAKE THE WHOLE SCREEN. Offered only with a shell open and somewhere to go, so the bar of
             a band nobody has opened carries nothing that cannot act. It is the only way to the
             shell's own screen — the route has accepted `?pane=shell` since phase 3b and nothing
             linked there. */}
-        {prefs.open && shell && onOpenFullscreen && (
+        {prefs.open && streamId && onOpenFullscreen && (
           <button className="ag-tap-icon"
             onClick={e => { e.stopPropagation(); onOpenFullscreen() }}
             title={t.fullscreen}
@@ -656,7 +759,9 @@ export function ShellBand({ sessionId, cwd, lang, theme, placement = 'docked', o
             <Maximize2 size={13} />
           </button>
         )}
-        {prefs.open && shell && (
+        {/* A shell is something the person OPENED and can end; the CLI pane is the session itself
+            and ending it here would be a kill button wearing a wastebasket. */}
+        {prefs.open && shell && target === 'shell' && (
           <button className="ag-tap-icon"
             /* A TRASH CAN, not an ✕. The ✕ read as "close this panel" next to a chevron that
                actually closes the panel, and this one KILLS the shell — a different, irreversible
@@ -683,7 +788,7 @@ export function ShellBand({ sessionId, cwd, lang, theme, placement = 'docked', o
           height: Math.max(BAND_MIN_PX, prefs.height),
           display: 'flex', flexDirection: 'column', gap: 6, padding: '0 12px 10px',
         }}>
-          {shell ? screen : <div style={{ flex: 1 }} />}
+          {streamId ? screen : <div style={{ flex: 1 }} />}
           {notice}
           {ceilingList}
         </div>

--- a/packages/web/src/lib/shellBand.ts
+++ b/packages/web/src/lib/shellBand.ts
@@ -144,6 +144,15 @@ export interface BandPrefs {
    * snap this memory exists to remove, from the other side.
    */
   geometry?: Partial<Record<ShellPlacement, PaneGeometry>>
+  /**
+   * WHICH terminal the band was last showing — the session's CLI pane or its shell.
+   *
+   * It is a preference and not a route because the band is a place you glance at while reading the
+   * conversation beside it; the ROUTE belongs to the dedicated screen, where the target is the
+   * whole page and a shared link must open on the right one. Read through `readTarget`, which
+   * treats absent and unreadable alike as the shell — what this band has been since phase 2.
+   */
+  target?: string
 }
 
 /** Where a shell is drawn. `docked` is the band under the composer; `dedicated` is its own screen. */
@@ -172,6 +181,9 @@ export function readBandPrefs(storage?: Storage): BandPrefs {
       // geometry is worse than none — it would be sent, refused, and the reader would never learn
       // why — and one unreadable placement must not cost the other.
       ...(readGeometries(r.geometry) ? { geometry: readGeometries(r.geometry)! } : {}),
+      // Kept as the RAW string: `readTarget` is the one place that decides what an unreadable
+      // value means, and duplicating that rule here would be a second answer to one question.
+      ...(typeof r.target === 'string' ? { target: r.target } : {}),
     }
   } catch {
     return DEFAULT_BAND_PREFS

--- a/packages/web/src/lib/shellBandState.test.ts
+++ b/packages/web/src/lib/shellBandState.test.ts
@@ -139,3 +139,21 @@ describe('the refusal keeps its CODE, not only its sentence', () => {
     expect(s.reason).toBeNull()
   })
 })
+
+describe('switching target asks for what the new target needs', () => {
+  // MEASURED in the browser: the band was opened on the CLI pane (which needs no resolving), then
+  // switched to the shell — and nothing happened. The resolve effect keys on `attempt`, which a
+  // target switch does not move, so the request that had been skipped while the CLI was showing was
+  // never made. `retry` is the action that says "ask again", and the switch is a person asking.
+  test('a band left WANTING is still wanting after the switch', () => {
+    const opened = shellBandReducer(INITIAL_SHELL_BAND, { type: 'openBand' })
+    expect(shellResolveWanted(opened)).toBe(true)
+  })
+
+  test('and a retry advances the attempt, which is what re-runs the effect', () => {
+    const opened = shellBandReducer(INITIAL_SHELL_BAND, { type: 'openBand' })
+    const again = shellBandReducer(opened, { type: 'retry' })
+    expect(again.attempt).toBe(opened.attempt + 1)
+    expect(shellResolveWanted(again)).toBe(true)
+  })
+})

--- a/packages/web/src/lib/terminalTarget.test.ts
+++ b/packages/web/src/lib/terminalTarget.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  TERMINAL_TARGETS, readTarget, targetLabel, targetScope, targetStreamId,
+} from './terminalTarget'
+
+describe('the two things a terminal band can show', () => {
+  test('there are exactly two, and shell is not one of the assistants', () => {
+    expect(TERMINAL_TARGETS).toEqual(['cli', 'shell'])
+  })
+
+  // The two channels are resolved against DIFFERENT stores — the fleet's registry and
+  // `shells.json` — so handing one the other's id is the mistake the whole scope split exists to
+  // make impossible. The target decides both halves together, in one place.
+  test('each target names its own channel AND its own id', () => {
+    expect(targetScope('cli')).toBe('fleet')
+    expect(targetScope('shell')).toBe('shell')
+    expect(targetStreamId('cli', { sessionId: 's1', shellId: 'sh1' })).toBe('s1')
+    expect(targetStreamId('shell', { sessionId: 's1', shellId: 'sh1' })).toBe('sh1')
+  })
+
+  test('a shell that has not been opened yet has no id to stream', () => {
+    expect(targetStreamId('shell', { sessionId: 's1', shellId: null })).toBeNull()
+  })
+
+  test('the CLI pane is always streamable — it IS the session', () => {
+    expect(targetStreamId('cli', { sessionId: 's1', shellId: null })).toBe('s1')
+  })
+})
+
+describe('what each target is CALLED', () => {
+  // "Assistente" named a concept; the harness names the thing that is actually on the screen, and
+  // needs no explanation. Reported as "invés de assistant coloca algo que dê a entender mais fácil".
+  test('the CLI pane is named after the harness running in it', () => {
+    expect(targetLabel('cli', 'claude', 'pt')).toBe('Claude Code')
+    expect(targetLabel('cli', 'codex', 'en')).toBe('Codex CLI')
+  })
+
+  test('a harness nobody can name falls back to words, never to a blank segment', () => {
+    expect(targetLabel('cli', undefined, 'pt')).toBe('Sessão CLI')
+    expect(targetLabel('cli', undefined, 'en')).toBe('CLI session')
+    expect(targetLabel('cli', 'nope' as never, 'pt')).toBe('Sessão CLI')
+  })
+
+  test('the shell is called Shell in both languages — it is the word the product already uses', () => {
+    expect(targetLabel('shell', 'claude', 'pt')).toBe('Shell')
+    expect(targetLabel('shell', 'claude', 'en')).toBe('Shell')
+  })
+})
+
+describe('the stored target', () => {
+  test('absent or unreadable reads as the SHELL, which is what the band has always been', () => {
+    for (const raw of [undefined, null, '', 'nope', 7]) {
+      expect(readTarget(raw), String(raw)).toBe('shell')
+    }
+  })
+
+  test('a stored target is honoured', () => {
+    expect(readTarget('cli')).toBe('cli')
+    expect(readTarget('shell')).toBe('shell')
+  })
+})

--- a/packages/web/src/lib/terminalTarget.ts
+++ b/packages/web/src/lib/terminalTarget.ts
@@ -1,0 +1,68 @@
+/**
+ * terminalTarget.ts — PURE. WHICH terminal a surface is showing, and everything that follows from
+ * the answer.
+ *
+ * There are two panes behind one session and they are not interchangeable: the CLI's own screen
+ * (an assistant running under tmux, resolved against `managed-sessions.json`) and the utility SHELL
+ * the person opened themselves (its own tmux socket, resolved against `shells.json`). Handing one
+ * channel the other's id is precisely the mistake `terminalEndpoint.ts` splits the scopes to make
+ * impossible — so the target decides the SCOPE and the ID together, here, rather than at each of
+ * the three surfaces that draw a terminal.
+ *
+ * **Why this module exists at all.** The header used to carry a `Conversa | Terminal` toggle and the
+ * dedicated screen a second `Assistente | Shell` one: two controls for one decision, in two places,
+ * with different words. The toggle is gone — the conversation is what a session opens on, and the
+ * BAND at the foot of the panel is the door to both terminals — so there is now exactly one
+ * question ("which terminal") asked in exactly one vocabulary.
+ *
+ * **The CLI pane is named after its HARNESS.** "Assistente" named a concept the reader has to
+ * translate; `Claude Code` names the thing that is on the screen. Reported as "invés de assistant
+ * coloca algo que dê a entender mais fácil". Where the harness cannot be named the label falls back
+ * to words rather than to a blank segment — the same rule every N/A in this product follows.
+ */
+
+import { HARNESS_LABELS } from './harness'
+import type { TerminalScope } from './terminalEndpoint'
+
+/** `cli` first: it is the session's own screen, and the shell is the thing you add beside it. */
+export const TERMINAL_TARGETS = ['cli', 'shell'] as const
+export type TerminalTarget = (typeof TERMINAL_TARGETS)[number]
+
+/** ABSENT READS AS `shell`: the band has been the shell's since phase 2, and a stored preference
+ *  that cannot be read must not silently move somebody to the other pane. */
+export function readTarget(raw: unknown): TerminalTarget {
+  return raw === 'cli' ? 'cli' : 'shell'
+}
+
+/** Which of the two channels this target speaks. Never inferred from an id — an id is opaque. */
+export function targetScope(target: TerminalTarget): TerminalScope {
+  return target === 'cli' ? 'fleet' : 'shell'
+}
+
+/**
+ * The id to stream, or `null` when there is nothing to stream yet.
+ *
+ * A CLI pane always has one — it IS the session. A shell has one only once it has been opened, and
+ * `null` is what makes the band ask for it rather than streaming a blank.
+ */
+export function targetStreamId(
+  target: TerminalTarget,
+  ids: { sessionId: string; shellId: string | null },
+): string | null {
+  return target === 'cli' ? ids.sessionId : ids.shellId
+}
+
+/**
+ * `harness` is a plain STRING on purpose: it arrives from `ControlSession.harness`, which is what a
+ * row reports, and a harness this build has no label for must fall back to words rather than fail
+ * to type-check into a blank segment.
+ */
+export function targetLabel(
+  target: TerminalTarget,
+  harness: string | undefined,
+  lang: 'pt' | 'en',
+): string {
+  if (target === 'shell') return 'Shell'
+  const named = harness ? (HARNESS_LABELS as Record<string, string | undefined>)[harness] : undefined
+  return named ?? (lang === 'pt' ? 'Sessão CLI' : 'CLI session')
+}

--- a/packages/web/src/pages/SessionsPage.tsx
+++ b/packages/web/src/pages/SessionsPage.tsx
@@ -54,6 +54,7 @@ import {
 } from '../lib/sessionRoute'
 import { dedicatedTerminalPath, readTerminalPane } from '../lib/terminalSurface'
 import { ShellBand } from '../components/sessions/ShellBand'
+import { targetLabel } from '../lib/terminalTarget'
 import { TerminalRegion } from '../components/RecentSessions'
 import { sessionPlanFactor } from '../lib/costBasis'
 
@@ -744,9 +745,14 @@ export default function SessionsPage() {
             }}>
               {(['assistant', 'shell'] as const).map(target => {
                 const on = dedicatedPane === target
-                const label = target === 'assistant'
-                  ? (pt ? 'Assistente' : 'Assistant')
-                  : 'Shell'
+                // ONE VOCABULARY. The band and this screen ask the same question, so they may not
+                // word it differently — and the CLI segment is named after the harness on the
+                // screen rather than after a concept.
+                const label = targetLabel(
+                  target === 'assistant' ? 'cli' : 'shell',
+                  selected.harness,
+                  pt ? 'pt' : 'en',
+                )
                 return (
                   <button
                     key={target}
@@ -789,6 +795,7 @@ export default function SessionsPage() {
               {...(selected.cwd ? { cwd: selected.cwd } : {})}
               lang={pt ? 'pt' : 'en'}
               theme={theme === 'light' ? 'light' : 'dark'}
+              {...(selected.harness ? { harness: selected.harness } : {})}
             />
           ) : (
             <TerminalRegion


### PR DESCRIPTION
O toggle `Conversa | Terminal` **sai do cabeçalho**. Uma sessão abre na **conversa** — é o que uma sessão é — e os terminais são alcançados pela **faixa no pé do painel**, que agora oferece os dois **pelo nome**.

## O que estava errado

Havia **dois controles para uma decisão só**, em dois lugares, com vocabulários diferentes: `Conversa | Terminal` no topo e `Assistente | Shell` na tela dedicada — e a faixa, embaixo, era uma terceira coisa que só sabia do shell. Para responder *"quero o terminal do CLI"* a pessoa tinha que segurar os três na cabeça.

Agora a pergunta é **uma** ("qual terminal") e o vocabulário é **um**.

## O nome do alvo é o harness

"Assistente" nomeava um conceito que o leitor tem que traduzir; **`Claude Code`** nomeia o que está na tela. Vem da própria linha da sessão e cai para "Sessão CLI" quando este build não sabe nomear o harness — palavras, nunca um segmento em branco.

## A faixa deixa de ser só do shell

`terminalTarget.ts` (puro, testado) decide o **canal** e o **id** juntos, porque são resolvidos contra stores diferentes — o registry do fleet e `shells.json` — e entregar a um o id do outro é exatamente o engano que a separação de escopos existe para tornar impossível.

- **Colapsada**, a barra mostra os dois alvos como botões nomeados.
- **Aberta**, o switch diz em qual você está, e o título da faixa vira o nome do alvo.
- Só o shell tem **lixeira** (é algo que a pessoa abriu e pode encerrar; a pane do CLI é a sessão, e uma lixeira ali seria um botão de matar vestido de cesto) e só o shell tem a **lista do teto**.

**Isto reverte um corte meu.** Eu tinha decidido não fazer "assistente na faixa" porque a aba `replacing` já dava essa pane a um clique. Com a aba fora, a faixa passa a ser o único caminho até ela — o corte deixou de fazer sentido.

## Um bug pego medindo, não lendo

Trocar de alvo **não abria nada**. O efeito que resolve o shell depende de `attempt`, que uma troca de alvo não move — então o pedido que tinha sido pulado enquanto o CLI estava na tela nunca era feito. `target` entrou nas dependências; é seguro porque quem o move é uma **pessoa**, diferente dos dispatches que o próprio efeito faz.

## Verificação

No navegador, digitando de verdade nos dois alvos:

| alvo | canal aberto | teclas |
|---|---|---|
| `Claude Code` | `/api/fleet/input?id=<sessão>` | todas `ok:true` |
| `Shell` | `/api/shell/input?id=<shell>` | todas `ok:true` |

Topo sem o toggle (`[role=tablist]` não tem mais "ChatTerminal"). A 390px: os dois botões da barra e o switch a **44px**, tira de teclas completa (`esc tab ctrl ↑ ↓ ← →`), `scrollWidth === innerWidth`. Zero erro de console.

`bun tsc --noEmit` + `bun test` (7994 passando, 0 falhas).

🤖 Generated with [Claude Code](https://claude.com/claude-code)