### PR TITLE
feat(server): detect live sessions on macOS via ps/lsof, not just Linux /proc

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2719,10 +2719,19 @@ harness must not break.
 - **Binary mode**: `agentop server` sets `SERVE_STATIC=1`; `index.ts` then binds **two ports with one shared request handler** — `PORT` (47291) is the api + mcp endpoint, `WEB_PORT` (47292) serves the web dashboard (the URL you open). Same handler → the SPA on 47292 makes same-origin `/api/*` calls that resolve locally, so 91 stays api+mcp and 92 is the dashboard. The startup log lists `web` (92) above `api` (91)
 - **Machine in Docker**: `docker/machine.yml` runs a solo/member machine in a container — reuses the central image (minus Mongo/central mode), mounts the host harness dirs read-only + `~/.agentistics` read-write, host networking. Offered as the `docker` option in the control center's Services tab. Run the machine in Docker **or** natively, never both
 - **Live sessions are host-process detection, and every layer must stay honest about it.**
-  `live-sessions.ts` reads `/proc` on the machine serving the request; a central never does this
-  for members (it has no visibility into them) — members report their own snapshot over the
-  reverse-channel WebSocket, filtered by that connection's sharing rules exactly like their
-  metrics, so **a repository a member withholds does not appear on the central either**. Rules:
+  `live-sessions.ts` reads the machine's own process list on Linux (`/proc`) and macOS (`ps` +
+  `lsof`, via `macos-processes.ts` pure parsers + `macos-processes-io.ts` IO — no `/proc`
+  equivalent exists there); a central never does this for members (it has no visibility into
+  them) — members report their own snapshot over the reverse-channel WebSocket, filtered by that
+  connection's sharing rules exactly like their metrics, so **a repository a member withholds
+  does not appear on the central either**. Rules:
+  - **The macOS reader has a STATED LIMIT this repo's other readers don't carry: it was written
+    against `ps`/`lsof`'s documented output shapes, never measured against a live Mac** (no macOS
+    machine was available when it was built). Its own header names the two consequences —
+    `command=`'s space-joined argv cannot distinguish an argument containing a space from two
+    arguments, and `comm=` is assumed to print the full executable path the way it does for an
+    ordinary (non-app) process there, unlike Linux's kernel-truncated 15-character `comm`. Verify
+    against a real Mac before trusting it the way the Linux path is trusted.
   - **A process cwd is matched against `sessionAtCwd`, which accepts EITHER `current_cwd` or
     `project_path` — never `sessionCwd()`.** The two disagree precisely in the worktree case this
     repo mandates: `claude` is launched at the repo root and its kernel cwd stays there, while the
@@ -2730,7 +2739,8 @@ harness must not break.
     NEITHER end and reported every session closed. It stays EXACT on both paths — a prefix test
     would let a process in `$HOME` claim every session on the machine.
   - **An empty list is never rendered as a zero when detection is impossible.** `scanProcesses`
-    returns a `LiveUnavailableReason` (not Linux, no `/proc`, a container that cannot see the host,
+    returns a `LiveUnavailableReason` (an unsupported platform — neither Linux nor macOS, so
+    Windows — an unreadable `/proc` or a failed `ps`/`lsof`, a container that cannot see the host,
     one whose uid cannot read a host cwd, or the capability being off) and `liveEmptyNotice`
     (`web/src/lib/sessionLive.ts`, pure, EN+PT) is the ONE place that turns it into a sentence —
     the same N/A-versus-a-confident-0 rule `HARNESS_CAPABILITIES` applies to metrics.
@@ -2739,12 +2749,19 @@ harness must not break.
     assistants run as the host user. `docker/machine.yml` sets `pid: host` and documents
     the `user:` line as a deliberate opt-in that trades the hardening for the feature.
     `docker/central.yml` (the central) deliberately has NO `pid: host` — its own processes are not
-    what anyone is asking about.
-  - **The /proc read is gated by `CAPS.localProcesses` inside the handler** (`readLocalLiveSnapshot`
-    in `index.ts`), NOT by registering the path in `capability-guard.ts`: `/api/live-sessions` also
-    carries the members' self-reported snapshots on a central, and a blanket 403 would take the
-    central's "Open now" down with the host read. `capability-guard.test.ts` pins that exemption
-    and asserts the module has exactly one import site.
+    what anyone is asking about. (Docker on macOS runs a Linux VM, so this container path is
+    Linux-only regardless of the host OS — it is not how the native macOS reader is exercised.)
+  - **The process read is gated by `CAPS.localProcesses` inside the handler**
+    (`readLocalLiveSnapshot` in `index.ts`), NOT by registering the path in `capability-guard.ts`:
+    `/api/live-sessions` also carries the members' self-reported snapshots on a central, and a
+    blanket 403 would take the central's "Open now" down with the host read.
+    `capability-guard.test.ts` pins that exemption and asserts the module has exactly one import
+    site.
+  - **`mcp-admin.ts`'s separate `/proc` reader (for MCP server processes, matched on argv rather
+    than being a harness) stays Linux-only on purpose** — it answers `'unsupported-platform'`
+    directly on macOS rather than through `detectionUnavailable`'s darwin branch, which now
+    describes `live-sessions.ts`'s own `ps`/`lsof` reader and would otherwise claim a tool this
+    reader never runs failed.
 - **`packages/server/server/embedded-dist.generated.ts`** is in `.gitignore` — auto-generated, never commit it
 - **`packages/server/` modules** are server-only — never import them from `packages/web/src/` (Vite would try to bundle them and fail on Node/Bun APIs)
 - **`@agentistics/core`** is the shared package — import types, pricing, and formatters from there; never duplicate them inline

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -636,10 +636,15 @@ export interface AppData {
 
 /** Why live-session detection cannot work in this configuration. */
 export type LiveUnavailableReason =
-  /** Not a Linux host — /proc is the only process source this reads. */
-  | 'not-linux'
-  /** /proc is absent or unreadable. */
+  /** Neither Linux (/proc) nor macOS (ps + lsof) — no process source is implemented for this
+   *  platform at all (e.g. Windows; use WSL). */
+  | 'unsupported-platform'
+  /** Linux: /proc is absent or unreadable. */
   | 'no-proc'
+  /** macOS: `ps` or `lsof` could not be run (missing from PATH, or exited non-zero). Extremely
+   *  rare — both ship with the OS — but a reader that could not run its own tool must say so
+   *  rather than report a confident empty list. */
+  | 'no-ps'
   /** A container that cannot see the host's processes (no `pid: host`). */
   | 'container-isolated'
   /** The host's processes are visible but their cwd may not be read (uid mismatch). */

--- a/packages/server/server/index.ts
+++ b/packages/server/server/index.ts
@@ -52,7 +52,10 @@ async function readLocalLiveSnapshot(sessions: SessionMeta[]): Promise<{
     const { getLiveSnapshot } = await import('./live-sessions')
     return await getLiveSnapshot(sessions)
   } catch {
-    return { liveSessionIds: [], liveProcesses: [], liveUnavailable: 'no-proc' }
+    // getLiveSnapshot/scanProcesses are designed never to throw — this is a defensive backstop,
+    // and its reason should still name the platform's own mechanism rather than assume Linux.
+    const reason = process.platform === 'darwin' ? 'no-ps' : 'no-proc'
+    return { liveSessionIds: [], liveProcesses: [], liveUnavailable: reason }
   }
 }
 import { AUTH_PUBLIC, isAdminPath, MFA_EXEMPT } from './index-routes'

--- a/packages/server/server/live-sessions.test.ts
+++ b/packages/server/server/live-sessions.test.ts
@@ -419,12 +419,26 @@ test('an ordinary node process is not mistaken for a harness', () => {
 test('an empty scan is reported as impossible only when it genuinely is', () => {
   const base = { platform: 'linux', procReadable: true, foreignPids: 40, cwdDenied: false }
   expect(detectionUnavailable(base)).toBeNull()
-  expect(detectionUnavailable({ ...base, platform: 'darwin' })).toBe('not-linux')
+  // macOS is a supported platform now (ps + lsof) — a genuinely unreadable /proc is 'no-proc'.
   expect(detectionUnavailable({ ...base, procReadable: false })).toBe('no-proc')
   // A container without `pid: host` sees only its own processes.
   expect(detectionUnavailable({ ...base, foreignPids: 0 })).toBe('container-isolated')
   // pid: host, but the container's uid cannot ptrace the host user's processes.
   expect(detectionUnavailable({ ...base, cwdDenied: true })).toBe('permission-denied')
+})
+
+test('macOS is a supported platform, with its own reason codes', () => {
+  const mac = { platform: 'darwin', procReadable: true, foreignPids: 40, cwdDenied: false }
+  expect(detectionUnavailable(mac)).toBeNull()
+  // ps/lsof could not be run at all — the macOS equivalent of an unreadable /proc.
+  expect(detectionUnavailable({ ...mac, procReadable: false })).toBe('no-ps')
+  expect(detectionUnavailable({ ...mac, foreignPids: 0 })).toBe('container-isolated')
+  expect(detectionUnavailable({ ...mac, cwdDenied: true })).toBe('permission-denied')
+})
+
+test('a genuinely unsupported platform (Windows) says so', () => {
+  const base = { platform: 'win32', procReadable: false, foreignPids: 0, cwdDenied: false }
+  expect(detectionUnavailable(base)).toBe('unsupported-platform')
 })
 
 describe('management subcommands are not sessions', () => {

--- a/packages/server/server/live-sessions.ts
+++ b/packages/server/server/live-sessions.ts
@@ -315,18 +315,21 @@ export function harnessOfProcess(
  */
 export function detectionUnavailable(o: {
   platform: string
+  /** Whether this platform's own process source could be read at all: Linux's /proc, or macOS's
+   *  `ps`/`lsof` pair. */
   procReadable: boolean
   /** Processes visible besides this one's own. A container without `pid: host` sees only itself. */
   foreignPids: number
-  /** A process was identified as a harness but its cwd link could not be read. */
+  /** A process was identified as a harness but its cwd could not be read. */
   cwdDenied: boolean
 }): LiveUnavailableReason | null {
-  if (o.platform !== 'linux') return 'not-linux'
-  if (!o.procReadable) return 'no-proc'
+  if (o.platform !== 'linux' && o.platform !== 'darwin') return 'unsupported-platform'
+  if (!o.procReadable) return o.platform === 'darwin' ? 'no-ps' : 'no-proc'
   if (o.foreignPids === 0) return 'container-isolated'
-  // Reading `/proc/<pid>/cwd` of another user's process needs a matching uid or CAP_SYS_PTRACE.
-  // The container image runs as uid 10001 while the host user is typically 1000, so `pid: host`
-  // on its own yields a full process list whose cwds are all unreadable.
+  // Reading another user's process cwd needs a matching uid (Linux: or CAP_SYS_PTRACE; macOS:
+  // `lsof` refuses another user's open files outright without root). The container image runs as
+  // uid 10001 while the host user is typically 1000, so `pid: host` on its own yields a full
+  // process list whose cwds are all unreadable.
   if (o.cwdDenied) return 'permission-denied'
   return null
 }
@@ -440,12 +443,53 @@ export function sessionIdFromArgv(argv: string[]): string | undefined {
   return undefined
 }
 
-/** Read every running harness process (Linux /proc only): which harness it is, its cwd, the session
- *  it resumed when argv says so, and when it started. [] on non-Linux hosts or unreadable /proc. */
+/**
+ * The macOS scan, overlaid with the same `harness-sessions.ts` index the Linux path reads —
+ * Claude Code's own `~/.claude/sessions/<pid>.json` is a plain file, not a `/proc` read, so it is
+ * exactly as available here. It is the STRONGEST identity signal (the harness's own record for
+ * this pid), so it OVERWRITES the argv/fd-derived id `scanMacProcesses` already filled in, never
+ * only patching a gap — matching the `??` chain's priority order in the Linux branch below.
+ *
+ * A dynamic import, not a static one: `macos-processes-io.ts` imports several pure helpers back
+ * out of THIS module (`harnessOfProcess`, `sessionIdFromArgv`, `sessionIdFromFdPaths`), and a
+ * static two-way import between the files is the shape of bug a build tool resolves inconsistently
+ * depending on which side loads first — the same reason `harness-sessions` is imported this way
+ * a few lines below.
+ */
+async function scanMacProcessesWithHarnessIndex(): Promise<{
+  procs: HarnessProcess[]
+  unavailable: LiveUnavailableReason | null
+}> {
+  const { scanMacProcesses } = await import('./macos-processes-io')
+  const result = scanMacProcesses()
+  if (result.psFailed) return { procs: [], unavailable: 'no-ps' }
+
+  try {
+    const { loadHarnessSessions } = await import('./sessions/harness-sessions')
+    const harnessIndex = await loadHarnessSessions()
+    for (const p of result.procs) {
+      if (p.pid === undefined) continue
+      const rec = harnessIndex.byPid.get(p.pid)
+      if (rec?.sessionId) p.sessionId = rec.sessionId
+    }
+  } catch { /* best-effort, same as the Linux path */ }
+
+  const unavailable = result.procs.length > 0
+    ? null
+    : detectionUnavailable({
+      platform: 'darwin', procReadable: true, foreignPids: result.foreignPids, cwdDenied: result.cwdDenied,
+    })
+  return { procs: result.procs, unavailable }
+}
+
+/** Read every running harness process (Linux /proc, macOS `ps`+`lsof`): which harness it is, its
+ *  cwd, the session it resumed when argv says so, and when it started. [] on any other platform,
+ *  or when this platform's own process source could not be read. */
 export async function scanProcesses(): Promise<{
   procs: HarnessProcess[]
   unavailable: LiveUnavailableReason | null
 }> {
+  if (process.platform === 'darwin') return scanMacProcessesWithHarnessIndex()
   if (process.platform !== 'linux') {
     return { procs: [], unavailable: detectionUnavailable({ platform: process.platform, procReadable: false, foreignPids: 0, cwdDenied: false }) }
   }

--- a/packages/server/server/macos-processes-io.ts
+++ b/packages/server/server/macos-processes-io.ts
@@ -1,0 +1,131 @@
+/**
+ * macos-processes-io.ts — the IO half of macOS process detection: shells out to `ps` and `lsof`,
+ * hands the raw text to the PURE parsers in `macos-processes.ts`, and assembles the same
+ * `HarnessProcess[]` shape the Linux `/proc` reader produces so `live-sessions.ts` never has to
+ * know which platform it is running on past this one call.
+ *
+ * See `macos-processes.ts`'s header for the STATED LIMIT — this was written against documented
+ * `ps`/`lsof` behaviour, not measured on a live Mac.
+ *
+ * Two calls per scan, not one per process: a bulk `ps -axwwo pid=,etime=,comm=` identifies every
+ * HARNESS candidate cheaply (comm/runtime match, same rule the Linux reader applies), and only
+ * THOSE pids pay for the expensive per-pid follow-ups (`ps … command=` for full argv, `lsof` for
+ * cwd and open files) — the same shape as `/proc`, where reading every pid's `cmdline` is cheap
+ * but a harness match is confirmed before anything else is read.
+ */
+
+import type { HarnessId } from '@agentistics/core'
+import {
+  harnessOfProcess, sessionIdFromArgv, sessionIdFromFdPaths, type HarnessProcess,
+} from './live-sessions'
+import {
+  cwdFromLsof, parseLsofFields, parsePsList, processStartFromEtime, splitPsCommand,
+} from './macos-processes'
+
+const JS_RUNTIME_COMMS = new Set(['node', 'bun', 'deno'])
+
+function run(argv: string[], timeoutMs = 4000): { ok: boolean; stdout: string } {
+  try {
+    const proc = Bun.spawnSync(argv, { stdout: 'pipe', stderr: 'pipe', timeout: timeoutMs })
+    return { ok: proc.exitCode === 0, stdout: proc.stdout.toString('utf-8') }
+  } catch {
+    return { ok: false, stdout: '' }
+  }
+}
+
+/** The full argv for one pid, via a per-pid `ps -o command=` (the bulk scan's `comm` alone is not
+ *  enough to identify a script-installed harness or read a `--resume` flag). `undefined` when the
+ *  process already exited between the bulk scan and this call. */
+function fullArgv(pid: number): string[] | undefined {
+  const { ok, stdout } = run(['ps', '-p', String(pid), '-o', 'command='])
+  const line = stdout.trim()
+  if (!ok || !line) return undefined
+  return splitPsCommand(line)
+}
+
+/** Every open file `lsof` names for a set of pids, in ONE call — `-Fpn` gives the parseable field
+ *  form and no per-pid round trip. `-a -p <list>` intersects "these pids" with the default filter
+ *  (every open file), which is what makes a single call answer for every candidate at once. */
+function openFilesFor(pids: number[]): Map<number, string[]> {
+  if (pids.length === 0) return new Map()
+  const { ok, stdout } = run(['lsof', '-a', '-p', pids.join(','), '-Fpn'])
+  return ok ? parseLsofFields(stdout) : new Map()
+}
+
+/** The cwd for a set of pids, in ONE call — `-d cwd` narrows lsof to just that file descriptor,
+ *  so this is cheap even for a large candidate list. */
+function cwdsFor(pids: number[]): Map<number, string[]> {
+  if (pids.length === 0) return new Map()
+  const { ok, stdout } = run(['lsof', '-a', '-d', 'cwd', '-p', pids.join(','), '-Fpn'])
+  return ok ? parseLsofFields(stdout) : new Map()
+}
+
+export interface MacScanResult {
+  procs: HarnessProcess[]
+  /** `ps` itself could not be run at all (missing from PATH, or exited non-zero) — the bulk scan
+   *  never happened, so this is distinct from "ran, found nothing". */
+  psFailed: boolean
+  /** How many OTHER processes `ps` reported, for the same "is this configuration isolated"
+   *  question `detectionUnavailable` asks on Linux. */
+  foreignPids: number
+  /** A harness candidate was identified but `lsof` could not resolve its cwd. */
+  cwdDenied: boolean
+}
+
+/** Read every running harness process via `ps` + `lsof`. Bun's own pid is excluded from
+ *  `foreignPids`, matching the Linux reader's own-pid exclusion. */
+export function scanMacProcesses(nowMs: number = Date.now()): MacScanResult {
+  const bulk = run(['ps', '-axwwo', 'pid=,etime=,comm='])
+  if (!bulk.ok) return { procs: [], psFailed: true, foreignPids: 0, cwdDenied: false }
+
+  const entries = parsePsList(bulk.stdout)
+  const ownPid = process.pid
+  const foreignPids = entries.filter(e => e.pid !== ownPid).length
+
+  // First pass: which pids are even worth the expensive follow-ups. `harnessOfProcess` needs argv
+  // for a JS-runtime comm, so a runtime candidate is provisionally kept and resolved below; a comm
+  // matching neither a known harness NOR a runtime is dropped here, before any lsof/ps call spends
+  // a process on it.
+  const candidates = entries.filter(e => {
+    const base = e.comm.slice(e.comm.lastIndexOf('/') + 1)
+    return JS_RUNTIME_COMMS.has(base) || harnessOfProcess(base, e.comm, [e.comm]) !== undefined
+  })
+  if (candidates.length === 0) return { procs: [], psFailed: false, foreignPids, cwdDenied: false }
+
+  const pids = candidates.map(c => c.pid)
+  const cwds = cwdsFor(pids)
+  let cwdDenied = false
+  const procs: HarnessProcess[] = []
+
+  for (const entry of candidates) {
+    const argv = fullArgv(entry.pid)
+    if (!argv || argv.length === 0) continue // exited between the two reads
+    const comm = entry.comm.slice(entry.comm.lastIndexOf('/') + 1)
+    const harness: HarnessId | undefined = harnessOfProcess(comm, entry.comm, argv)
+    if (!harness) continue
+    const cwd = cwdFromLsof(cwds, entry.pid)
+    if (cwd === undefined) { cwdDenied = true; continue }
+    const startedMs = processStartFromEtime(entry.etime, nowMs)
+    // argv is the WEAKEST identity signal (see `harness-sessions.ts`'s file-based record and the
+    // fd-derived id below, both stronger) — kept as the fallback here, overwritten below in that
+    // priority order, matching the `??` chain the Linux reader uses.
+    const sessionId = sessionIdFromArgv(argv)
+    procs.push({ harness, cwd, startedMs, pid: entry.pid, ...(sessionId ? { sessionId } : {}) })
+  }
+
+  // Session ids from open files (the macOS equivalent of reading /proc/<pid>/fd/* symlinks) —
+  // one more lsof call, scoped to the pids that actually became rows, never the whole candidate
+  // list. This OUTRANKS the argv-derived id above (the kernel's own open-file record beats a
+  // guess read off the command line), so it overwrites rather than only filling gaps.
+  if (procs.length > 0) {
+    const openFiles = openFilesFor(procs.map(p => p.pid!))
+    for (const p of procs) {
+      const paths = openFiles.get(p.pid!)
+      if (!paths) continue
+      const sid = sessionIdFromFdPaths(paths, p.harness)
+      if (sid) p.sessionId = sid
+    }
+  }
+
+  return { procs, psFailed: false, foreignPids, cwdDenied }
+}

--- a/packages/server/server/macos-processes.test.ts
+++ b/packages/server/server/macos-processes.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  cwdFromLsof, etimeToMs, parseLsofFields, parsePsList, processStartFromEtime, splitPsCommand,
+} from './macos-processes'
+
+describe('parsePsList', () => {
+  test('parses pid, etime, comm from ps -axwwo pid=,etime=,comm=', () => {
+    const raw = [
+      '  1234 03:12 /usr/local/bin/claude',
+      ' 56789 1-04:03:12 node',
+      '    42 00:05 bun',
+    ].join('\n')
+    expect(parsePsList(raw)).toEqual([
+      { pid: 1234, etime: '03:12', comm: '/usr/local/bin/claude' },
+      { pid: 56789, etime: '1-04:03:12', comm: 'node' },
+      { pid: 42, etime: '00:05', comm: 'bun' },
+    ])
+  })
+
+  test('a comm containing spaces is kept whole, not split', () => {
+    const raw = ' 100 00:01 /Applications/Some App.app/Contents/MacOS/binary'
+    expect(parsePsList(raw)).toEqual([
+      { pid: 100, etime: '00:01', comm: '/Applications/Some App.app/Contents/MacOS/binary' },
+    ])
+  })
+
+  test('blank lines and unparseable lines are skipped', () => {
+    const raw = '\n  not a pid line\n 5 00:01 sh\n'
+    expect(parsePsList(raw)).toEqual([{ pid: 5, etime: '00:01', comm: 'sh' }])
+  })
+
+  test('empty input yields an empty list', () => {
+    expect(parsePsList('')).toEqual([])
+  })
+})
+
+describe('etimeToMs', () => {
+  test('mm:ss', () => {
+    expect(etimeToMs('03:12')).toBe((3 * 60 + 12) * 1000)
+  })
+
+  test('hh:mm:ss', () => {
+    expect(etimeToMs('04:03:12')).toBe(((4 * 60 + 3) * 60 + 12) * 1000)
+  })
+
+  test('dd-hh:mm:ss', () => {
+    expect(etimeToMs('1-04:03:12')).toBe((((24 + 4) * 60 + 3) * 60 + 12) * 1000)
+  })
+
+  test('an unrecognised shape is undefined, never a guessed number', () => {
+    expect(etimeToMs('')).toBeUndefined()
+    expect(etimeToMs('garbage')).toBeUndefined()
+  })
+})
+
+describe('processStartFromEtime', () => {
+  test('subtracts elapsed time from now', () => {
+    const now = 1_000_000
+    expect(processStartFromEtime('00:01', now)).toBe(now - 1000)
+  })
+
+  test('undefined when etime cannot be parsed, never a zero start time', () => {
+    expect(processStartFromEtime('???', 1_000_000)).toBeUndefined()
+  })
+})
+
+describe('splitPsCommand', () => {
+  test('splits a joined argv string on whitespace', () => {
+    expect(splitPsCommand('claude --resume abc-123')).toEqual(['claude', '--resume', 'abc-123'])
+  })
+
+  test('collapses doubled spaces instead of producing empty tokens', () => {
+    expect(splitPsCommand('claude  --resume  abc-123')).toEqual(['claude', '--resume', 'abc-123'])
+  })
+
+  test('trims leading and trailing whitespace', () => {
+    expect(splitPsCommand('  node script.js  ')).toEqual(['node', 'script.js'])
+  })
+})
+
+describe('parseLsofFields', () => {
+  test('parses one process block with its cwd (lsof -a -d cwd -Fpn)', () => {
+    const raw = ['p1234', 'fcwd', 'n/Users/dev/project'].join('\n')
+    const byPid = parseLsofFields(raw)
+    expect(byPid.get(1234)).toEqual(['/Users/dev/project'])
+  })
+
+  test('parses several process blocks with several open files each', () => {
+    const raw = [
+      'p1234',
+      'f10',
+      'n/Users/dev/project',
+      'f11',
+      'n/Users/dev/project/.claude/sessions/1234.json',
+      'p5678',
+      'f9',
+      'n/Users/dev/other',
+    ].join('\n')
+    const byPid = parseLsofFields(raw)
+    expect(byPid.get(1234)).toEqual([
+      '/Users/dev/project',
+      '/Users/dev/project/.claude/sessions/1234.json',
+    ])
+    expect(byPid.get(5678)).toEqual(['/Users/dev/other'])
+  })
+
+  test('a pid with no open files reported is present with an empty list, not absent', () => {
+    const raw = 'p999'
+    expect(parseLsofFields(raw).get(999)).toEqual([])
+  })
+
+  test('empty input yields an empty map', () => {
+    expect(parseLsofFields('').size).toBe(0)
+  })
+})
+
+describe('cwdFromLsof', () => {
+  test('returns the single path lsof named for that pid', () => {
+    const byPid = new Map([[1234, ['/Users/dev/project']]])
+    expect(cwdFromLsof(byPid, 1234)).toBe('/Users/dev/project')
+  })
+
+  test('undefined when the pid is absent or named nothing', () => {
+    const byPid = new Map([[1234, [] as string[]]])
+    expect(cwdFromLsof(byPid, 1234)).toBeUndefined()
+    expect(cwdFromLsof(byPid, 9999)).toBeUndefined()
+  })
+})

--- a/packages/server/server/macos-processes.ts
+++ b/packages/server/server/macos-processes.ts
@@ -1,0 +1,137 @@
+/**
+ * macos-processes.ts — PURE parsers for macOS's process sources.
+ *
+ * macOS has no `/proc`: `live-sessions.ts`'s Linux reader has nothing to fall back to, so this
+ * reads the same facts (pid, comm, argv, cwd, start time, open files) from the two tools every
+ * macOS ships with — `ps` and `lsof` — through the IO layer in `macos-processes-io.ts`.
+ *
+ * STATED LIMIT, matching this repo's own rule for an unverified reading: every parser below is
+ * written against the DOCUMENTED output shapes of `ps -o etime,command` and `lsof -F` (both
+ * stable, long-standing BSD/macOS interfaces), not against a capture from a running Mac — this
+ * environment has no macOS machine to drive one on. Unlike every other "measured on <date>"
+ * comment in this codebase, this one cannot make that claim. Treat it as a first cut that wants
+ * verification against a real Mac before being trusted the way the Linux reader is.
+ *
+ * Two consequences of that limit, both leaning toward under-reporting rather than a wrong answer:
+ *   - `ps`'s `command=` field joins argv with plain spaces and carries no quoting, so an argument
+ *     that itself contains a space (a path, a prompt) cannot be told apart from two arguments.
+ *     Splitting on whitespace is the same imperfect approach the Linux reader already applies to
+ *     a pty host's rewritten `argv[0]` (see `isHarnessInfrastructure`'s header) — not a new risk,
+ *     but a real one, and worth remembering if a macOS session's argv-derived id ever looks wrong.
+ *   - `ps -o comm=` is assumed to print the full executable PATH on macOS, the way it does for a
+ *     non-app process there — unlike Linux, where `comm` is the kernel's 15-character-truncated
+ *     process name (see `harnessOf`'s header) and the reader turns to `/proc/<pid>/exe` instead.
+ *     If that assumption is wrong for some processes, `comm` alone still carries the identical
+ *     information `harnessOf` already uses for its exact matches (`PROCESS_HARNESS`), so the
+ *     worst case is losing the version-install and script-runtime fallbacks, not the direct one.
+ */
+
+/** One process from a bulk `ps -axwwo pid=,etime=,comm=` scan. */
+export interface PsListEntry {
+  pid: number
+  /** `ps`'s own elapsed-time token, e.g. `03:12`, `1-04:03:12`. Kept raw; `etimeToMs` converts it. */
+  etime: string
+  /** The executable — assumed to be the full path (see header). May itself be `node`/`bun`/etc. */
+  comm: string
+}
+
+/**
+ * Parse a bulk `ps -axwwo pid=,etime=,comm=` listing.
+ *
+ * `pid` and `etime` are single tokens with no internal whitespace (verified against `ps(1)`'s own
+ * documented `etime` format, `[[dd-]hh:]mm:ss`), so splitting the line on the first TWO runs of
+ * whitespace and keeping everything after as `comm` is exact even when `comm` itself is a path
+ * containing spaces — which `command=` (used for the per-pid follow-up) cannot promise once argv
+ * joins it. A line that does not start with a pid is skipped rather than guessed at.
+ */
+export function parsePsList(raw: string): PsListEntry[] {
+  const out: PsListEntry[] = []
+  for (const line of raw.split('\n')) {
+    const trimmed = line.trim()
+    if (!trimmed) continue
+    const m = /^(\d+)\s+(\S+)\s+(.+)$/.exec(trimmed)
+    if (!m) continue
+    const pid = Number(m[1])
+    if (!Number.isFinite(pid)) continue
+    out.push({ pid, etime: m[2]!, comm: m[3]! })
+  }
+  return out
+}
+
+/**
+ * `ps`'s `etime` token → elapsed milliseconds. Formats, per `ps(1)`: `mm:ss`, `hh:mm:ss`,
+ * `dd-hh:mm:ss`. Returns `undefined` for anything that does not match one of the three — a
+ * process whose start time cannot be read should bound nothing rather than be assigned `0`
+ * (which would make it look like it started at the epoch and satisfy every "started before X"
+ * check it should not).
+ */
+export function etimeToMs(etime: string): number | undefined {
+  const dayMatch = /^(\d+)-(\d{1,2}):(\d{2}):(\d{2})$/.exec(etime)
+  const hourMatch = /^(\d{1,2}):(\d{2}):(\d{2})$/.exec(etime)
+  const minMatch = /^(\d{1,2}):(\d{2})$/.exec(etime)
+  let days = 0, hours = 0, mins = 0, secs = 0
+  if (dayMatch) {
+    days = Number(dayMatch[1]); hours = Number(dayMatch[2]); mins = Number(dayMatch[3]); secs = Number(dayMatch[4])
+  } else if (hourMatch) {
+    hours = Number(hourMatch[1]); mins = Number(hourMatch[2]); secs = Number(hourMatch[3])
+  } else if (minMatch) {
+    mins = Number(minMatch[1]); secs = Number(minMatch[2])
+  } else {
+    return undefined
+  }
+  return ((days * 24 + hours) * 60 + mins) * 60_000 + secs * 1000
+}
+
+/** `nowMs - elapsed` — the process's start time. `undefined` when `etime` could not be parsed. */
+export function processStartFromEtime(etime: string, nowMs: number): number | undefined {
+  const elapsed = etimeToMs(etime)
+  return elapsed === undefined ? undefined : nowMs - elapsed
+}
+
+/**
+ * Split a `ps -o command=` joined argv string into tokens.
+ *
+ * Naive whitespace splitting — see the header's stated limit. Collapses runs of spaces so a
+ * double space (which `ps` sometimes pads with) does not produce an empty argv element the way
+ * `String.split(' ')` would.
+ */
+export function splitPsCommand(command: string): string[] {
+  return command.trim().split(/\s+/).filter(Boolean)
+}
+
+/**
+ * Parse `lsof -F pfn` "field output" — one attribute per line, first letter is the field id.
+ * Stable, documented format (`lsof(1)`, "OUTPUT FOR OTHER PROGRAMS"): a `p<pid>` line opens a
+ * process block, and every `n<path>` line until the next `p` line names one of ITS open files.
+ *
+ * Returns every pid lsof reported, each with the full list of paths its open files resolve to
+ * (the `cwd` fd's target included, indistinguishable here from any other open file — the caller
+ * selects it by having asked `lsof` to list only `-d cwd`, or filters by descriptor separately).
+ */
+export function parseLsofFields(raw: string): Map<number, string[]> {
+  const byPid = new Map<number, string[]>()
+  let currentPid: number | null = null
+  for (const line of raw.split('\n')) {
+    if (line.length === 0) continue
+    const tag = line[0]
+    const value = line.slice(1)
+    if (tag === 'p') {
+      const pid = Number(value)
+      currentPid = Number.isFinite(pid) ? pid : null
+      if (currentPid !== null && !byPid.has(currentPid)) byPid.set(currentPid, [])
+      continue
+    }
+    if (tag === 'n' && currentPid !== null) {
+      byPid.get(currentPid)!.push(value)
+    }
+  }
+  return byPid
+}
+
+/** The single cwd path for a pid, from a `lsof -a -d cwd -Fpn` listing — `undefined` when lsof
+ *  named no cwd file for it (the process exited between the `ps` scan and this call, or its cwd
+ *  could not be read). */
+export function cwdFromLsof(byPid: Map<number, string[]>, pid: number): string | undefined {
+  const paths = byPid.get(pid)
+  return paths && paths.length > 0 ? paths[0] : undefined
+}

--- a/packages/server/server/mcp-admin.ts
+++ b/packages/server/server/mcp-admin.ts
@@ -45,7 +45,10 @@ async function readJson(file: string): Promise<unknown> {
 async function readProcArgv(): Promise<{ procs: ProcArgv[]; unavailable: LiveUnavailableReason | null }> {
   if (!CAPS.localProcesses) return { procs: [], unavailable: 'capability-off' }
   if (process.platform !== 'linux') {
-    return { procs: [], unavailable: detectionUnavailable({ platform: process.platform, procReadable: false, foreignPids: 0, cwdDenied: false }) }
+    // Only Linux is implemented HERE — unlike `live-sessions.ts`, which also reads macOS via
+    // `ps`/`lsof`. Reported directly as unsupported rather than through `detectionUnavailable`,
+    // whose darwin branch now describes THAT reader's own tool, not this argv-only one.
+    return { procs: [], unavailable: 'unsupported-platform' }
   }
   let pids: string[]
   try { pids = await readdir('/proc') } catch { return { procs: [], unavailable: 'no-proc' } }

--- a/packages/server/server/mcp-status.test.ts
+++ b/packages/server/server/mcp-status.test.ts
@@ -32,7 +32,7 @@ describe('mcpRunState — measured, and never a confident "offline"', () => {
   })
 
   it('says UNKNOWN, with the reason, when it could not look at all', () => {
-    expect(mcpRunState(stdio(), [], 'not-linux')).toEqual({ state: 'unknown', reason: 'not-linux' })
+    expect(mcpRunState(stdio(), [], 'unsupported-platform')).toEqual({ state: 'unknown', reason: 'unsupported-platform' })
     expect(mcpRunState(stdio(), [], 'container-isolated').state).toBe('unknown')
   })
 

--- a/packages/web/src/lib/mcpPanel.test.ts
+++ b/packages/web/src/lib/mcpPanel.test.ts
@@ -26,7 +26,7 @@ describe('runText — the word "offline" is never used', () => {
   })
 
   it('turns every unavailability code into a sentence, and passes an unknown one through', () => {
-    for (const reason of ['not-linux', 'no-proc', 'container-isolated', 'permission-denied', 'capability-off']) {
+    for (const reason of ['unsupported-platform', 'no-proc', 'no-ps', 'container-isolated', 'permission-denied', 'capability-off']) {
       const d = runText({ state: 'unknown', reason }, false).detail!
       expect(d).not.toBe(reason)
       expect(d.length).toBeGreaterThan(10)

--- a/packages/web/src/lib/mcpPanel.ts
+++ b/packages/web/src/lib/mcpPanel.ts
@@ -98,8 +98,9 @@ export function runText(run: McpRunState, pt: boolean): { text: string; color: s
 /** The `LiveUnavailableReason` codes, in words — the same sentences the live-sessions panel uses. */
 function unknownReason(reason: string, pt: boolean): string {
   switch (reason) {
-    case 'not-linux': return pt ? 'esta máquina não é Linux, e /proc é a única fonte de processos aqui' : 'this machine is not Linux, and /proc is the only process source here'
+    case 'unsupported-platform': return pt ? 'esta máquina não é Linux nem macOS, e nenhuma outra fonte de processos existe aqui' : 'this machine is neither Linux nor macOS, and no other process source exists here'
     case 'no-proc': return pt ? '/proc não está acessível' : '/proc is not readable'
+    case 'no-ps': return pt ? 'não foi possível executar ps/lsof nesta máquina' : 'ps/lsof could not be run on this machine'
     case 'container-isolated': return pt ? 'este container não enxerga os processos do host' : 'this container cannot see the host’s processes'
     case 'permission-denied': return pt ? 'os processos do host não podem ser lidos por este usuário' : 'the host’s processes cannot be read by this user'
     case 'capability-off': return pt ? 'este perfil de exposição não permite ler processos' : 'this exposure profile does not allow reading processes'

--- a/packages/web/src/lib/sessionLive.test.ts
+++ b/packages/web/src/lib/sessionLive.test.ts
@@ -39,7 +39,7 @@ test('isLive true within threshold, false outside', () => {
 // --- what an empty "Open now" is allowed to claim ------------------------------------------------
 
 const ALL_REASONS: LiveUnavailableReason[] =
-  ['not-linux', 'no-proc', 'container-isolated', 'permission-denied', 'capability-off']
+  ['unsupported-platform', 'no-proc', 'no-ps', 'container-isolated', 'permission-denied', 'capability-off']
 
 test('a non-empty panel says nothing', () => {
   expect(liveEmptyNotice({ count: 1, lang: 'en' })).toBeNull()
@@ -70,7 +70,7 @@ test('every impossible configuration explains itself in both languages, and none
   }
   // Guards the loop: a reason added to the union without copy must fail here, not pass silently.
   expect(checked).toBe(ALL_REASONS.length)
-  expect(checked).toBe(5)
+  expect(checked).toBe(6)
 })
 
 test('a central explains the member channel instead of its own host', () => {

--- a/packages/web/src/lib/sessionLive.ts
+++ b/packages/web/src/lib/sessionLive.ts
@@ -83,13 +83,17 @@ export function liveEmptyNotice(o: {
 
 /** Why each configuration cannot see the host's assistants, and what to change. EN + PT. */
 const LIVE_UNAVAILABLE_DETAIL: Record<LiveUnavailableReason, { en: string; pt: string }> = {
-  'not-linux': {
-    en: 'Open assistants are detected by reading /proc, which only exists on Linux. Everything else on this page is unaffected.',
-    pt: 'Assistentes abertos são detectados lendo /proc, que só existe no Linux. O resto desta página não é afetado.',
+  'unsupported-platform': {
+    en: 'Open assistants are detected by reading Linux’s /proc or macOS’s process list. Neither exists here (Windows). Everything else on this page is unaffected — WSL on this same machine can run agentop with live detection.',
+    pt: 'Assistentes abertos são detectados lendo o /proc do Linux ou a lista de processos do macOS. Nenhum dos dois existe aqui (Windows). O resto desta página não é afetado — o WSL nesta mesma máquina roda o agentop com detecção ao vivo.',
   },
   'no-proc': {
     en: '/proc could not be read, so no running assistant can be observed.',
     pt: 'Não foi possível ler /proc, então nenhum assistente em execução pode ser observado.',
+  },
+  'no-ps': {
+    en: 'This machine’s `ps`/`lsof` could not be run, so no running assistant can be observed.',
+    pt: 'Não foi possível executar `ps`/`lsof` nesta máquina, então nenhum assistente em execução pode ser observado.',
   },
   'container-isolated': {
     en: 'This machine runs in a container with its own process namespace, so assistants running on the host are invisible to it. Add `pid: host` to docker/machine.yml, or run the machine natively.',


### PR DESCRIPTION
## Summary
- `live-sessions.ts`'s `scanProcesses()` only read Linux's `/proc`, so a macOS machine always reported `not-linux` and the "Open now" panel there was permanently empty regardless of what was actually running.
- Adds a second reader (`macos-processes.ts` pure parsers + `macos-processes-io.ts` IO) built on `ps` and `lsof` — the two tools every macOS ships with, since there is no `/proc` equivalent there: a cheap bulk `ps -axwwo pid=,etime=,comm=` scan first, then per-candidate `ps -o command=` (full argv) and `lsof` (cwd + open-file session ids — the macOS analog of reading `/proc/<pid>/fd/*` symlinks) only for processes that already matched a known harness. Produces the exact same `HarnessProcess[]` shape the Linux reader does, so `resolveOpenSessionIds`/`resolveLiveSnapshot` needed no changes at all.
- `LiveUnavailableReason` gains `'no-ps'` (ps/lsof could not be run) and renames `'not-linux'` → `'unsupported-platform'` (now genuinely meaning "neither Linux nor macOS" — Windows) across its call sites, including `mcp-admin.ts`'s separate, still-Linux-only `/proc` argv reader (kept honest: it now answers `'unsupported-platform'` directly rather than through `detectionUnavailable`'s new darwin branch, which would otherwise claim a tool that reader never runs had failed).

## Important — a stated limit unlike this codebase's usual "measured on `<date>`" readers
`macos-processes.ts`'s header says this explicitly: it was written against `ps`/`lsof`'s **documented** output formats, not against a capture from a real Mac — there is no macOS machine in this environment to test on. Two concrete consequences are named in the comment:
- `ps -o command=` joins argv with plain spaces and no quoting, so an argument containing a space cannot be told apart from two arguments (same imperfect approach the Linux reader already applies to a pty host's rewritten `argv[0]`).
- `ps -o comm=` is *assumed* to print the full executable path for an ordinary process on macOS (unlike Linux, where `comm` is kernel-truncated to 15 characters and the reader falls back to `/proc/<pid>/exe`). If that assumption is wrong for some processes, the worst case is losing the version-install/script-runtime fallbacks, not the direct match.

**This should be verified against a real Mac before being trusted the way the Linux path is** — it degrades honestly (reports `unavailable` rather than guessing) whenever `ps`/`lsof` fail outright, but a live-Mac check would confirm or correct the two assumptions above.

## Scope note
This is the `live-sessions.ts` gap flagged as out-of-scope in the earlier macOS binary-distribution PR (#526) — the install/release pipeline already ships macOS binaries; this closes the process-detection gap on that platform.

## Test plan
- [x] `bun tsc --noEmit` — clean
- [x] `bun test` — 8004 pass, 0 fail (19 new pure-parser tests against documented `ps`/`lsof` field-output formats, plus updated `detectionUnavailable`/`liveEmptyNotice` coverage for the new reason codes)
- [ ] A real macOS run of `agentop` with a live Claude/Codex/etc. session open, to confirm the "Open now" panel populates correctly — not possible from this environment; flagged above for whoever can run it next

🤖 Generated with [Claude Code](https://claude.com/claude-code)