### PR TITLE
fix(alm): subtaskViews agrupa por groupId, sem contar sessão duas vezes

### DIFF
--- a/packages/server/server/sessions/task-report.test.ts
+++ b/packages/server/server/sessions/task-report.test.ts
@@ -339,4 +339,103 @@ describe('subtaskViews — the three shapes, no session counted twice', () => {
     expect(views[0]).toEqual({ id: 's1', rollup: expect.objectContaining({ sessionsUsed: 1 }) })
     expect(views[1]!.id).toBeNull()
   })
+
+  describe('grouped subtasks — one bucket per group, never per member', () => {
+    // docs/superpowers/specs/2026-09-11-alm-session-linking-ux.md §B.3: two or more subtasks
+    // sharing a `groupId` must collapse into ONE SubtaskView, keyed by the group id, whose rollup
+    // is the union of rows filed under ANY member — never one bucket per member, which would
+    // multiply a shared session's cost by the group's size.
+
+    it('two subtasks sharing a groupId collapse into one bucket, summing sessions filed under either member exactly once', () => {
+      const subs = [
+        subtask({ id: 's1', groupId: 'g1' }),
+        subtask({ id: 's2', groupId: 'g1' }),
+      ]
+      const rows = [
+        row({ id: 'r1', conversationId: 'c1', subtaskId: 's1' }),
+        row({ id: 'r2', conversationId: 'c2', subtaskId: 's2' }),
+      ]
+      const views = subtaskViews(task(), subs, rows, metasAll, costOf)
+
+      // ONE view for the group, never two.
+      expect(views).toHaveLength(1)
+      expect(views[0]!.id).toBe('g1')
+      // Both sessions counted, once each — not doubled by appearing under two subtasks' totals.
+      expect(views[0]!.rollup.sessionsUsed).toBe(2)
+      expect(views[0]!.rollup.costUSD).toBe(8) // c1 (5) + c2 (3), summed once
+
+      // Same session set read through buildTaskDetail agrees with the task's own total — the
+      // group's bucket is a breakdown of the total, never a second, inflated sum beside it.
+      const detail = detailOf(rows, subs)
+      expect(detail.subtaskRollups).toHaveLength(1)
+      expect(detail.rollup.costUSD).toBe(8)
+    })
+
+    it('a session filed under either group member is counted in the SAME bucket, not duplicated across it', () => {
+      const subs = [
+        subtask({ id: 's1', groupId: 'g1' }),
+        subtask({ id: 's2', groupId: 'g1' }),
+        subtask({ id: 's3', groupId: 'g1' }),
+      ]
+      const rows = [
+        row({ id: 'r1', conversationId: 'c1', subtaskId: 's1' }),
+        row({ id: 'r2', conversationId: 'c2', subtaskId: 's1' }), // second session, same member
+        row({ id: 'r3', conversationId: 'c3', subtaskId: 's3' }), // a different member
+      ]
+      const detail = detailOf(rows, subs)
+
+      expect(detail.subtaskRollups).toHaveLength(1)
+      expect(detail.subtaskRollups[0]!.id).toBe('g1')
+      expect(detail.subtaskRollups[0]!.rollup.sessionsUsed).toBe(3)
+      // The group's total matches the task's own total exactly — no inflation from the group
+      // spanning three members while only two of them carry a session.
+      expect(detail.subtaskRollups[0]!.rollup.costUSD).toBe(detail.rollup.costUSD)
+      expect(detail.rollup.costUSD).toBe(10) // c1 (5) + c2 (3) + c3 (2)
+    })
+
+    it('subtasks with no groupId keep exactly today\'s behaviour — one bucket each, unaffected by a grouped sibling', () => {
+      const subs = [
+        subtask({ id: 's1' }), // ungrouped
+        subtask({ id: 's2' }), // ungrouped
+        subtask({ id: 's3', groupId: 'g1' }),
+        subtask({ id: 's4', groupId: 'g1' }),
+      ]
+      const rows = [
+        row({ id: 'r1', conversationId: 'c1', subtaskId: 's1' }),
+        row({ id: 'r2', conversationId: 'c2', subtaskId: 's2' }),
+        row({ id: 'r3', conversationId: 'c3', subtaskId: 's3' }),
+        row({ id: 'r4', conversationId: 'c4', subtaskId: 's4' }),
+      ]
+      const views = subtaskViews(task(), subs, rows, metasAll, costOf)
+
+      // Four subtasks, but only three buckets: s1 and s2 stay independent (a group of one each),
+      // s3+s4 collapse into a single 'g1' bucket.
+      expect(views).toHaveLength(3)
+      const byId = new Map(views.map(v => [v.id, v]))
+      expect([...byId.keys()].sort()).toEqual(['g1', 's1', 's2'].sort())
+
+      expect(byId.get('s1')!.rollup.sessionsUsed).toBe(1)
+      expect(byId.get('s1')!.rollup.costUSD).toBe(5) // c1
+      expect(byId.get('s2')!.rollup.sessionsUsed).toBe(1)
+      expect(byId.get('s2')!.rollup.costUSD).toBe(3) // c2
+      expect(byId.get('g1')!.rollup.sessionsUsed).toBe(2)
+      expect(byId.get('g1')!.rollup.costUSD).toBe(9) // c3 (2) + c4 (7)
+    })
+
+    it('a grouped subtask with no sessions of its own still contributes zero, not a missing bucket, when a sibling has sessions', () => {
+      // The group as a whole is measured, not each member separately — a member with nothing
+      // filed under it directly must not create a second, empty view beside the group's own.
+      const subs = [
+        subtask({ id: 's1', groupId: 'g1' }),
+        subtask({ id: 's2', groupId: 'g1' }),
+      ]
+      const rows = [row({ id: 'r1', conversationId: 'c1', subtaskId: 's1' })]
+      const views = subtaskViews(task(), subs, rows, metasAll, costOf)
+
+      expect(views).toHaveLength(1)
+      expect(views[0]!.id).toBe('g1')
+      expect(views[0]!.rollup.sessionsUsed).toBe(1)
+      expect(views[0]!.rollup.costUSD).toBe(5)
+    })
+  })
 })

--- a/packages/server/server/sessions/task-report.ts
+++ b/packages/server/server/sessions/task-report.ts
@@ -194,11 +194,15 @@ export function attemptViews(
   return views
 }
 
-/** One rollup for a subtask, or for the direct branch (`id: null`) — sessions filed on the task
- *  itself, under no subtask. Every row of a task falls into EXACTLY one of these buckets, because
- *  `subtaskId` and "no subtaskId" partition `rowsOfTask(task, rows)` completely — the same
- *  guarantee `filedUnder` already gives every session a single owner. */
+/** One rollup for a subtask (or a group of subtasks sharing a `groupId` — see below), or for the
+ *  direct branch (`id: null`) — sessions filed on the task itself, under no subtask. Every row of a
+ *  task falls into EXACTLY one of these buckets, because `subtaskId` and "no subtaskId" partition
+ *  `rowsOfTask(task, rows)` completely — the same guarantee `filedUnder` already gives every
+ *  session a single owner. */
 export interface SubtaskView {
+  /** A plain subtask's own id, or the shared `groupId` when it is one of a group — never a
+   *  per-member id in that case, which is what stops a shared session's cost being summed once per
+   *  member. */
   id: string | null
   rollup: AttemptRollup
 }
@@ -212,6 +216,15 @@ export interface SubtaskView {
  * partitions back into a total: `TaskDetail.rollup` is computed once, over the whole set, and this
  * is only ever a breakdown of it. A subtask with no sessions filed under it yet still gets a row —
  * "nothing filed here" is a real, empty measurement, not an omission.
+ *
+ * **Grouped subtasks collapse into ONE bucket, never one per member.** Two or more subtasks sharing
+ * a `groupId` (`Subtask.groupId`, docs/superpowers/specs/2026-09-11-alm-session-linking-ux.md §B)
+ * are bucketed by that group id rather than by each subtask's own id — a session filed under ANY
+ * member's `subtaskId` is counted in that one bucket, once, regardless of which specific member the
+ * session names. Summing per member would multiply a shared session's cost by the group's size,
+ * which is exactly the double-count this function exists to rule out for every other shape. A
+ * subtask with no `groupId` is unaffected — it is its own group of one, bucketed by its own id
+ * exactly as before.
  */
 export function subtaskViews(
   task: Task,
@@ -221,10 +234,23 @@ export function subtaskViews(
   costOf: (m: SessionMeta) => number,
 ): SubtaskView[] {
   const mine = subtasks.filter(s => s.taskId === task.id)
-  const views: SubtaskView[] = mine.map(s => ({
-    id: s.id,
+  // Effective bucket key: a subtask's own id, or the group id it shares with its siblings.
+  const keyOf = (s: Subtask) => s.groupId ?? s.id
+  const groups = new Map<string, Subtask[]>()
+  for (const s of mine) {
+    const key = keyOf(s)
+    const members = groups.get(key)
+    if (members) members.push(s)
+    else groups.set(key, [s])
+  }
+  const views: SubtaskView[] = [...groups.entries()].map(([key, members]) => ({
+    id: key,
+    // A session's `subtaskId` can name ANY member of the group — the union of their rows is what
+    // the group's bucket rolls up, so the same session is never counted once per member.
     rollup: rollupAttempt({
-      sessions: rollupSessionsFor(rows.filter(r => r.subtaskId === s.id), metas, costOf),
+      sessions: rollupSessionsFor(
+        rows.filter(r => members.some(m => m.id === r.subtaskId)), metas, costOf,
+      ),
     }),
   }))
   const direct = rows.filter(r => !r.subtaskId)


### PR DESCRIPTION
## Summary
- `subtaskViews` (task-report.ts) agora bucketiza pela chave efetiva (`groupId ?? id`) — subtasks que compartilham um `groupId` colapsam em UM `SubtaskView` só, cuja soma cobre sessões filiadas em QUALQUER membro do grupo.
- Subtasks sem `groupId` continuam exatamente como hoje (grupo de 1, sem regressão).

## Test plan
- [x] `bun tsc --noEmit`
- [x] `bun test` (task-report.test.ts estendido: dois cenários — colapso de grupo e regressão sem grupo)

Parte da task ALM `t-918cc82233`, subtask `s-e73097e19f`, seguindo `docs/superpowers/specs/2026-09-11-alm-session-linking-ux.md` §B.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)