### PR TITLE
fix(tasks): chips de sessão respeitam o grupo da subtask

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,15 @@
+# These are supported funding model platforms
+
+github: blpsoares
+# patreon: # Replace with a single Patreon username
+# open_collective: # Replace with a single Open Collective username
+# ko_fi: # Replace with a single Ko-fi username
+# tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
+# community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
+# liberapay: # Replace with a single Liberapay username
+# issuehunt: # Replace with a single IssueHunt username
+# lfx_crowdfunding: # Replace with a single LFX Crowdfunding project-name e.g., cloud-foundry
+# polar: # Replace with a single Polar username
+# buy_me_a_coffee: # Replace with a single Buy Me a Coffee username
+# thanks_dev: # Replace with a single thanks.dev username
+# custom: # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']

--- a/bun.lock
+++ b/bun.lock
@@ -46,14 +46,14 @@
     },
     "packages/agentop": {
       "name": "@agentistics/agentop",
-      "version": "2.21.0",
+      "version": "2.35.1",
       "bin": {
         "agentop": "bin/agentop.js",
       },
     },
     "packages/core": {
       "name": "@agentistics/core",
-      "version": "2.21.0",
+      "version": "2.35.1",
       "dependencies": {
         "@opentelemetry/api": "^1.9.1",
         "date-fns": "^4.1.0",
@@ -71,7 +71,7 @@
     },
     "packages/mcp": {
       "name": "@agentistics/mcp",
-      "version": "2.21.0",
+      "version": "2.35.1",
       "bin": {
         "agentistics-mcp": "dist/agentistics-mcp.js",
       },
@@ -81,7 +81,7 @@
     },
     "packages/server": {
       "name": "@agentistics/server",
-      "version": "2.21.0",
+      "version": "2.35.1",
       "dependencies": {
         "@agentistics/core": "workspace:*",
         "@agentistics/tui": "workspace:*",
@@ -91,7 +91,7 @@
     },
     "packages/tui": {
       "name": "@agentistics/tui",
-      "version": "2.21.0",
+      "version": "2.35.1",
       "dependencies": {
         "@agentistics/core": "workspace:*",
         "es-toolkit": "^1.50.0",
@@ -116,7 +116,7 @@
     },
     "packages/web": {
       "name": "@agentistics/web",
-      "version": "2.21.0",
+      "version": "2.35.1",
       "dependencies": {
         "@agentistics/core": "workspace:*",
         "@agentistics/tui": "workspace:*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentistics",
-  "version": "2.35.0",
+  "version": "2.35.1",
   "description": "Local analytics dashboard for AI coding assistants — tracks tokens, cost, sessions, and activity from ~/.claude/",
   "keywords": [
     "claude",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentistics",
-  "version": "2.34.0",
+  "version": "2.35.0",
   "description": "Local analytics dashboard for AI coding assistants — tracks tokens, cost, sessions, and activity from ~/.claude/",
   "keywords": [
     "claude",

--- a/packages/agentop/package.json
+++ b/packages/agentop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentistics/agentop",
-  "version": "2.34.0",
+  "version": "2.35.0",
   "description": "agentop CLI — npm install for the same native binary distributed via install.sh (Linux x86_64 only)",
   "type": "commonjs",
   "bin": {

--- a/packages/agentop/package.json
+++ b/packages/agentop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentistics/agentop",
-  "version": "2.35.0",
+  "version": "2.35.1",
   "description": "agentop CLI — npm install for the same native binary distributed via install.sh (Linux x86_64 only)",
   "type": "commonjs",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentistics/core",
-  "version": "2.34.0",
+  "version": "2.35.0",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentistics/core",
-  "version": "2.35.0",
+  "version": "2.35.1",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentistics/mcp",
-  "version": "2.35.0",
+  "version": "2.35.1",
   "description": "Agentistics MCP server — Claude Code analytics for Claude Desktop and Claude Code",
   "type": "module",
   "main": "./dist/agentistics-mcp.js",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentistics/mcp",
-  "version": "2.34.0",
+  "version": "2.35.0",
   "description": "Agentistics MCP server — Claude Code analytics for Claude Desktop and Claude Code",
   "type": "module",
   "main": "./dist/agentistics-mcp.js",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentistics/server",
-  "version": "2.34.0",
+  "version": "2.35.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentistics/server",
-  "version": "2.35.0",
+  "version": "2.35.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentistics/tui",
-  "version": "2.35.0",
+  "version": "2.35.1",
   "private": true,
   "type": "module",
   "main": "src/control/index.ts",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentistics/tui",
-  "version": "2.34.0",
+  "version": "2.35.0",
   "private": true,
   "type": "module",
   "main": "src/control/index.ts",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentistics/web",
-  "version": "2.34.0",
+  "version": "2.35.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentistics/web",
-  "version": "2.35.0",
+  "version": "2.35.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/web/src/components/tasks/SubtaskSessions.test.ts
+++ b/packages/web/src/components/tasks/SubtaskSessions.test.ts
@@ -1,0 +1,71 @@
+import { test, expect } from 'bun:test'
+import { subtaskSessions } from './SubtaskSessions'
+import type { TaskSessionRow } from '../../lib/tasks'
+
+function session(over: Partial<TaskSessionRow> = {}): TaskSessionRow {
+  return {
+    id: 's1', harness: 'claude', cwd: '/repo', attemptId: null, subtaskId: 'sub-a',
+    createdAt: '2026-09-11T00:00:00.000Z', tokens: 1000, costUSD: 1, rounds: 1,
+    ...over,
+  }
+}
+
+/** `subtaskSessions` returns a React element tree without touching the DOM, so its `props.children`
+ *  can be inspected directly — same approach `subtaskRollup.test.ts` takes with plain data instead
+ *  of rendering. */
+function chipIds(node: React.ReactNode): string[] {
+  const el = node as { props: { children: React.ReactNode[] } }
+  const flat = el.props.children.flat(Infinity as 1)
+  return flat
+    .filter((c): c is React.ReactElement<{ id: string }> =>
+      !!c && typeof c === 'object' && 'props' in c && 'id' in (c as any).props)
+    .map(c => c.props.id)
+}
+
+const noop = () => {}
+
+test('subtaskSessions: ungrouped — subtaskIds of just its own id filters exactly like the old subtaskId did', () => {
+  const sessions = [
+    session({ id: 's1', subtaskId: 'sub-a' }),
+    session({ id: 's2', subtaskId: 'sub-b' }),
+  ]
+  const el = subtaskSessions({
+    subtaskId: 'sub-a', subtaskIds: ['sub-a'], sessions, lang: 'en',
+    onLink: noop, onUnfile: noop,
+  })
+  expect(chipIds(el)).toEqual(['s1'])
+})
+
+test('subtaskSessions: grouped — a session filed under a SIBLING member shows on this row too', () => {
+  const sessions = [
+    session({ id: 's1', subtaskId: 'sub-a' }),
+    session({ id: 's2', subtaskId: 'sub-b' }),
+    session({ id: 's3', subtaskId: 'sub-c' }),
+  ]
+  // sub-a and sub-b share a groupId; sub-c does not.
+  const el = subtaskSessions({
+    subtaskId: 'sub-a', subtaskIds: ['sub-a', 'sub-b'], sessions, lang: 'en',
+    onLink: noop, onUnfile: noop,
+  })
+  expect(chipIds(el)).toEqual(['s1', 's2'])
+})
+
+test('subtaskSessions: a session filed directly on the delivery (subtaskId null) never shows on any subtask row', () => {
+  const sessions = [session({ id: 's1', subtaskId: null })]
+  const el = subtaskSessions({
+    subtaskId: 'sub-a', subtaskIds: ['sub-a'], sessions, lang: 'en',
+    onLink: noop, onUnfile: noop,
+  })
+  expect(chipIds(el)).toEqual([])
+})
+
+test('subtaskSessions: linking a new session always targets this row\'s own subtaskId, never a group sibling', () => {
+  const linked: { id: string | null } = { id: null }
+  const el = subtaskSessions({
+    subtaskId: 'sub-a', subtaskIds: ['sub-a', 'sub-b'], sessions: [], lang: 'en',
+    onLink: id => { linked.id = id }, onUnfile: noop,
+  })
+  const button = (el as any).props.children.flat(Infinity).find((c: any) => c?.type === 'button')
+  button.props.onClick()
+  expect(linked.id).toBe('sub-a')
+})

--- a/packages/web/src/components/tasks/SubtaskSessions.tsx
+++ b/packages/web/src/components/tasks/SubtaskSessions.tsx
@@ -26,6 +26,11 @@ import type { Lang } from './copy'
 import type { TaskSessionRow } from '../../lib/tasks'
 
 export interface SubtaskSessionsProps {
+  /** This subtask's own id, plus every sibling sharing its `groupId` — the id alone when
+   *  ungrouped. A session filed under ANY member shows here, so every member of a group
+   *  renders the identical chip list — see docs/superpowers/specs/2026-09-11-alm-session-linking-ux.md §B.4. */
+  subtaskIds: readonly string[]
+  /** Where a NEW session gets filed — this row's own id, never a sibling's. */
   subtaskId: string
   /** The DELIVERY's sessions — every one of them. This filters to the ones filed here. */
   sessions: readonly TaskSessionRow[]
@@ -40,7 +45,7 @@ export interface SubtaskSessionsProps {
 }
 
 export function subtaskSessions(p: SubtaskSessionsProps): React.ReactNode {
-  const mine = p.sessions.filter(s => s.subtaskId === p.subtaskId)
+  const mine = p.sessions.filter(s => s.subtaskId && p.subtaskIds.includes(s.subtaskId))
   const pt = p.lang === 'pt'
   return (
     <span style={{ display: 'inline-flex', alignItems: 'center', gap: 5, flexWrap: 'wrap', minWidth: 0 }}>

--- a/packages/web/src/components/tasks/SubtaskTable.tsx
+++ b/packages/web/src/components/tasks/SubtaskTable.tsx
@@ -221,6 +221,11 @@ export function SubtaskTable(p: SubtaskTableProps) {
               <td style={{ ...cell, minWidth: 190 }}>
                 {subtaskSessions({
                   subtaskId: t.id,
+                  // The row's group siblings show the identical chip list — see
+                  // docs/superpowers/specs/2026-09-11-alm-session-linking-ux.md §B.4.
+                  subtaskIds: t.groupId
+                    ? p.subtasks.filter(s => s.groupId === t.groupId).map(s => s.id)
+                    : [t.id],
                   sessions: p.sessions,
                   lang: p.lang,
                   mobile: isMobile,

--- a/packages/web/src/components/tasks/TaskTable.tsx
+++ b/packages/web/src/components/tasks/TaskTable.tsx
@@ -346,6 +346,11 @@ function SubtaskRows({
           <td style={{ padding: cellPad }}>
             {subtaskSessions({
               subtaskId: t.id,
+              // The row's group siblings show the identical chip list — see
+              // docs/superpowers/specs/2026-09-11-alm-session-linking-ux.md §B.4.
+              subtaskIds: t.groupId
+                ? subtasks.filter(s => s.groupId === t.groupId).map(s => s.id)
+                : [t.id],
               sessions,
               lang,
               mobile: isMobile,

--- a/packages/web/src/lib/tasks.ts
+++ b/packages/web/src/lib/tasks.ts
@@ -201,6 +201,12 @@ export interface Subtask {
    * this one. See `task-attach.ts`'s `planAttach` — the rule lives on the server; this is the fact.
    */
   blockedBy?: string[]
+  /**
+   * Subtasks that share a `groupId` are read as ONE bucket: a session filed under any member
+   * counts for all of them. Absent = not grouped — every subtask is its own group of one. See
+   * docs/superpowers/specs/2026-09-11-alm-session-linking-ux.md §B.2.
+   */
+  groupId?: string
 }
 export interface TaskFile {
   id: string; taskId: string; name: string; size: number


### PR DESCRIPTION
## Summary
- `SubtaskSessions.tsx` filtra chips de sessão pelo conjunto `subtaskIds` (a subtask + irmãos do mesmo `groupId`) em vez de só o `subtaskId` próprio.
- `SubtaskTable.tsx`/`TaskTable.tsx` computam esse conjunto via `subtask.groupId`.
- Efeito: toda subtask de um grupo mostra os mesmos chips de sessão, coerente com o rollup unificado de `subtaskViews`.

## Test plan
- [x] `bun tsc --noEmit`
- [x] `bun test packages/web` (2250/2250) + suíte completa via pre-commit hook (8019 pass)
- [x] Novo `SubtaskSessions.test.ts`

Parte da task ALM `t-918cc82233`, subtask `s-bf6cf5b807`, seguindo `docs/superpowers/specs/2026-09-11-alm-session-linking-ux.md` §B.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)