### PR TITLE
fix(server): propagate done_needs_session (422) through the subtasks/task HTTP routes

### DIFF
--- a/packages/server/server/index.ts
+++ b/packages/server/server/index.ts
@@ -1713,10 +1713,14 @@ async function handleRequestInner(req: Request, server: Server<WSData>): Promise
           if (body.remove === true) return json({ ok: await mod.removeSubtask(body.id) })
           // A bare `{id, done}` is the tick; anything else is a column edit. Both land on
           // `patchSubtask`, which derives `done` from `status` so the two cannot disagree.
+          // `done_needs_session` is a 422, the same shape `sessions`'s `blocked` answers with above
+          // — both name a piece of work this request cannot do YET, not a resource that is missing.
+          // `no_such_subtask` stays 404: the id named nothing.
           if (typeof body.done === 'boolean' && Object.keys(body).length === 2) {
-            return json({ ok: await mod.setSubtaskDone(body.id, body.done) })
+            const result = await mod.setSubtaskDone(body.id, body.done)
+            return json(result, result.ok ? 200 : (result.message === 'done_needs_session' ? 422 : 404))
           }
-          return json({ ok: await mod.patchSubtask(body.id, {
+          const result = await mod.patchSubtask(body.id, {
             ...(typeof body.title === 'string' ? { title: body.title } : {}),
             ...(typeof body.status === 'string' ? { status: body.status as never } : {}),
             ...(typeof body.assignee === 'string' ? { assignee: body.assignee } : {}),
@@ -1730,7 +1734,8 @@ async function handleRequestInner(req: Request, server: Server<WSData>): Promise
             ...(Array.isArray(body.blockedBy)
               ? { blockedBy: body.blockedBy.filter((x): x is string => typeof x === 'string') }
               : {}),
-          }) })
+          })
+          return json(result, result.ok ? 200 : (result.message === 'done_needs_session' ? 422 : 404))
         }
         const ok = await mod.addSubtask(ref, String(body.title ?? ''))
         return json({ ok }, ok ? 200 : 400)
@@ -1805,8 +1810,11 @@ async function handleRequestInner(req: Request, server: Server<WSData>): Promise
         },
       )
       // 422, not 404: the task exists and the move is understood — it is missing the one thing
-      // `blocked` cannot be recorded without. A 4xx a caller can act on, with a code that says so.
-      return json(out, out.ok ? 200 : out.message === 'blocked_needs_reason' ? 422 : 404)
+      // `blocked`/`done` cannot be recorded without. A 4xx a caller can act on, with a code that
+      // says so. `done_needs_session` rides the exact same channel `blocked_needs_reason` does
+      // (spec 2026-09-11 §A.4).
+      return json(out, out.ok ? 200
+        : (out.message === 'blocked_needs_reason' || out.message === 'done_needs_session') ? 422 : 404)
     }
 
     /**


### PR DESCRIPTION
## Summary
- Propaga a recusa `done_needs_session` (já implementada em `task-web.ts`'s `patchSubtask`/`setSubtaskDone`/`markTask`) pro HTTP: `index.ts`'s bloco `verb === 'subtasks'` agora responde 422 no lugar de engolir a recusa como `{ok:false}` genérico.
- Client (`web/lib/tasks.ts`) atualizado para o novo formato de retorno.

## Test plan
- [x] `bun tsc --noEmit`
- [x] `bun test`

Parte da task ALM `t-918cc82233`, subtask `s-8617946452`, seguindo `docs/superpowers/specs/2026-09-11-alm-session-linking-ux.md` §A.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)