### PR TITLE
feat(server): accept groupId on the subtask PATCH (set, join, clear)

### DIFF
--- a/packages/server/server/index.ts
+++ b/packages/server/server/index.ts
@@ -1734,6 +1734,12 @@ async function handleRequestInner(req: Request, server: Server<WSData>): Promise
             ...(Array.isArray(body.blockedBy)
               ? { blockedBy: body.blockedBy.filter((x): x is string => typeof x === 'string') }
               : {}),
+            // The rollup group (spec §B.5). `null` is the CLEAR and is therefore matched
+            // explicitly: it is a value the caller sent, not an absent field, and the two must not
+            // collapse — an omitted `groupId` leaves the column alone, a null removes it.
+            ...(typeof body.groupId === 'string'
+              ? { groupId: body.groupId }
+              : body.groupId === null ? { groupId: null } : {}),
           })
           return json(result, result.ok ? 200 : (result.message === 'done_needs_session' ? 422 : 404))
         }

--- a/packages/server/server/sessions/subtask-groupid-patch.test.ts
+++ b/packages/server/server/sessions/subtask-groupid-patch.test.ts
@@ -1,0 +1,130 @@
+import { expect, test } from 'bun:test'
+import { mkdtemp } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+/**
+ * The WRITE side of the subtask rollup group — `patchSubtask`'s `groupId`, spec
+ * docs/superpowers/specs/2026-09-11-alm-session-linking-ux.md §B.5. The READ side (`subtaskViews`
+ * bucketing by `groupId ?? id`) is `task-report.test.ts`'s; this file only asserts that the column
+ * can be set, joined, left alone and CLEARED.
+ *
+ * Out-of-process for the same reason `task-done-needs-session.test.ts` is: `loadTaskWorld()` reads
+ * the module-level `TASKS_FILE` computed once at `config.ts` load, so each scenario needs its own
+ * `AGENTISTICS_DIR` in its own process.
+ */
+
+const SESSIONS_DIR = import.meta.dir
+
+async function run(body: string): Promise<unknown> {
+  const dir = await mkdtemp(join(tmpdir(), 'agentop-subtask-groupid-'))
+  const script = `
+    const cfg = await import(${JSON.stringify(join(SESSIONS_DIR, '..', 'config.ts'))})
+    const { createTaskStore } = await import(${JSON.stringify(join(SESSIONS_DIR, 'task-store.ts'))})
+    const web = await import(${JSON.stringify(join(SESSIONS_DIR, 'task-web.ts'))})
+    const store = createTaskStore(cfg.TASKS_FILE)
+    ${body}
+  `
+  const proc = Bun.spawn([process.execPath, '-e', script], {
+    env: { ...process.env, AGENTISTICS_DIR: dir },
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+  const out = await new Response(proc.stdout).text()
+  const err = await new Response(proc.stderr).text()
+  const code = await proc.exited
+  if (code !== 0) {
+    throw new Error(`script failed (${code}): ${err.trim().split('\n').slice(-8).join(' | ')}`)
+  }
+  const line = out.trim().split('\n').filter(Boolean).at(-1) ?? '{}'
+  return JSON.parse(line)
+}
+
+const task = (id: string) => `
+  await store.upsertTask({
+    id: '${id}', title: '${id}', status: 'todo',
+    createdAt: '2026-09-11T10:00:00.000Z', updatedAt: '2026-09-11T10:00:00.000Z',
+  })
+`
+const subtask = (id: string, taskId: string, over = '') => `
+  await store.upsertSubtask({
+    id: '${id}', taskId: '${taskId}', title: '${id}', status: 'todo', done: false,
+    createdAt: '2026-09-11T10:00:00.000Z', updatedAt: '2026-09-11T10:00:00.000Z',
+    ${over}
+  })
+`
+const groupOf = (id: string) => `(after.subtasks.find(s => s.id === '${id}').groupId ?? null)`
+
+test('patchSubtask stamps a groupId on a subtask that had none', async () => {
+  const out = await run(`
+    ${task('t1')}
+    ${subtask('s1', 't1')}
+    const result = await web.patchSubtask('s1', { groupId: 'g-abc' })
+    const after = await store.read()
+    console.log(JSON.stringify({ result, groupId: ${groupOf('s1')} }))
+  `)
+  expect(out).toEqual({ result: { ok: true }, groupId: 'g-abc' })
+})
+
+test('two subtasks stamped with the same groupId end up in one group', async () => {
+  const out = await run(`
+    ${task('t1')}
+    ${subtask('s1', 't1')}
+    ${subtask('s2', 't1')}
+    await web.patchSubtask('s1', { groupId: 'g-abc' })
+    await web.patchSubtask('s2', { groupId: 'g-abc' })
+    const after = await store.read()
+    console.log(JSON.stringify({ one: ${groupOf('s1')}, two: ${groupOf('s2')} }))
+  `)
+  expect(out).toEqual({ one: 'g-abc', two: 'g-abc' })
+})
+
+test('`null` CLEARS the group — the key is gone from the record, not written as null', async () => {
+  const out = await run(`
+    ${task('t1')}
+    ${subtask('s1', 't1', "groupId: 'g-abc',")}
+    const result = await web.patchSubtask('s1', { groupId: null })
+    const after = await store.read()
+    const row = after.subtasks.find(s => s.id === 's1')
+    console.log(JSON.stringify({ result, hasKey: 'groupId' in row, groupId: row.groupId ?? null }))
+  `)
+  expect(out).toEqual({ result: { ok: true }, hasKey: false, groupId: null })
+})
+
+test('an empty or whitespace-only string clears too — a blank key would pass `groupId ?? id` and merge unrelated subtasks', async () => {
+  const out = await run(`
+    ${task('t1')}
+    ${subtask('s1', 't1', "groupId: 'g-abc',")}
+    ${subtask('s2', 't1', "groupId: 'g-xyz',")}
+    await web.patchSubtask('s1', { groupId: '' })
+    await web.patchSubtask('s2', { groupId: '   ' })
+    const after = await store.read()
+    console.log(JSON.stringify({ one: ${groupOf('s1')}, two: ${groupOf('s2')} }))
+  `)
+  expect(out).toEqual({ one: null, two: null })
+})
+
+test('a groupId is trimmed, so the same group typed with stray spaces is the same bucket', async () => {
+  const out = await run(`
+    ${task('t1')}
+    ${subtask('s1', 't1')}
+    ${subtask('s2', 't1')}
+    await web.patchSubtask('s1', { groupId: 'g-abc' })
+    await web.patchSubtask('s2', { groupId: '  g-abc  ' })
+    const after = await store.read()
+    console.log(JSON.stringify({ same: ${groupOf('s1')} === ${groupOf('s2')}, key: ${groupOf('s2')} }))
+  `)
+  expect(out).toEqual({ same: true, key: 'g-abc' })
+})
+
+test('a patch that does not mention groupId leaves it alone', async () => {
+  const out = await run(`
+    ${task('t1')}
+    ${subtask('s1', 't1', "groupId: 'g-abc',")}
+    const result = await web.patchSubtask('s1', { assignee: 'alguem' })
+    const after = await store.read()
+    const row = after.subtasks.find(s => s.id === 's1')
+    console.log(JSON.stringify({ result, groupId: row.groupId ?? null, assignee: row.assignee }))
+  `)
+  expect(out).toEqual({ result: { ok: true }, groupId: 'g-abc', assignee: 'alguem' })
+})

--- a/packages/server/server/sessions/task-store.ts
+++ b/packages/server/server/sessions/task-store.ts
@@ -300,6 +300,12 @@ function sanitizeSubtask(raw: unknown): Subtask | null {
     ...(str(t.startDate) ? { startDate: str(t.startDate)! } : {}),
     ...(str(t.sessionId) ? { sessionId: str(t.sessionId)! } : {}),
     ...(str(t.notes) ? { notes: str(t.notes)! } : {}),
+    // The rollup group (spec 2026-09-11-alm-session-linking-ux.md §B.5). It has to be carried here
+    // or the write is a no-op: `patchSubtask` stamps it, the next `read()` drops it, and the group
+    // that `subtaskViews` buckets on never exists. A blank one is read as ABSENT rather than kept,
+    // for the same reason `patchSubtask` refuses to write one — `groupId ?? id` lets `''` through,
+    // and every subtask carrying it would collapse into one bucket.
+    ...(str(t.groupId) ? { groupId: str(t.groupId)! } : {}),
   }
 }
 

--- a/packages/server/server/sessions/task-web.ts
+++ b/packages/server/server/sessions/task-web.ts
@@ -400,6 +400,16 @@ export async function patchSubtask(subtaskId: string, patch: {
   notes?: string
   /** Sanitized against this subtask's OWN siblings — see `sanitizeSubtaskBlockedBy`. */
   blockedBy?: string[]
+  /**
+   * The group this subtask shares its rollup bucket with (`Subtask.groupId`, spec
+   * 2026-09-11-alm-session-linking-ux.md §B.5). **`null` CLEARS it** — deliberately not the empty
+   * string the free-text columns above use: a group id is an identity, not prose, so removing it
+   * is a distinct act rather than "set it to nothing". An empty or whitespace-only string is read
+   * as the same clear rather than written through, because `subtaskViews`'s bucket key is
+   * `groupId ?? id` — `''` passes that `??` and would silently merge every subtask carrying it
+   * into one bucket, which is the cost-multiplying bug the group key exists to avoid.
+   */
+  groupId?: string | null
 }): Promise<{ ok: true } | { ok: false; message: 'no_such_subtask' | 'done_needs_session' }> {
   const w = await loadTaskWorld()
   const found = w.book.subtasks.find(t => t.id === subtaskId)
@@ -426,6 +436,11 @@ export async function patchSubtask(subtaskId: string, patch: {
         subtaskId: found.id, taskId: found.taskId, ids: patch.blockedBy, siblings: w.book.subtasks,
       }),
     } : {}),
+    // `undefined` is what the store writes as "absent": `JSON.stringify` drops the key, so the
+    // subtask reads back as its own group of one — the pre-group behaviour, exactly.
+    ...(patch.groupId !== undefined
+      ? { groupId: patch.groupId?.trim() ? patch.groupId.trim() : undefined }
+      : {}),
     updatedAt: new Date().toISOString(),
   })
   return { ok: true }


### PR DESCRIPTION
## Summary
- `task-web.ts`'s `patchSubtask` accepts `groupId?: string|null` in the patch (`null` clears the column, same convention as `dueDate`/`assignee`).
- `index.ts`'s `verb === 'subtasks'` block passes the field through when present in the body.

## Test plan
- [x] `bun tsc --noEmit`
- [x] `bun test`

Parte da task ALM `t-918cc82233`, subtask `s-1d64b99943`, seguindo `docs/superpowers/specs/2026-09-11-alm-session-linking-ux.md` §B.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)