### PR TITLE
fix(web): read a subtask's rollup by its effective group key

### DIFF
--- a/packages/web/src/components/tasks/SubtaskTable.tsx
+++ b/packages/web/src/components/tasks/SubtaskTable.tsx
@@ -14,7 +14,9 @@
  * of them — nothing here double-counts a session or invents a split the data does not record. See
  * docs/superpowers/specs/2026-09-10-task-session-hierarchy-design.md §4.2.
  *
- * The Cost/Tokens columns below read `p.subtaskRollups`, keyed by subtask id, and render them with
+ * The Cost/Tokens columns below read `p.subtaskRollups` through `subtaskRollupOf`, which resolves
+ * the EFFECTIVE key — a subtask's own id, or its `groupId` when it is one of a group, since the
+ * server files a whole group under ONE bucket (see `rollupKeyOf`) — and render them with
  * the exact same formatters `TaskTable.tsx`'s own cost/tokens cells use (`useMoney()`, `fmtTokens`,
  * `NA`) — a second formatting rule here would be a second answer for the same figure. A subtask
  * with no session filed yet still gets a bucket from the server (`sessionsUsed: 0`, every metric
@@ -158,7 +160,7 @@ export function SubtaskTable(p: SubtaskTableProps) {
             </tr>
           )}
           {p.subtasks.map(t => {
-            const r = subtaskRollupOf(p.subtaskRollups, t.id)
+            const r = subtaskRollupOf(p.subtaskRollups, t)
             const cost = costCellFor(r)
             return (
             <tr key={t.id}>

--- a/packages/web/src/components/tasks/subtaskRollup.test.ts
+++ b/packages/web/src/components/tasks/subtaskRollup.test.ts
@@ -1,6 +1,6 @@
 import { test, expect } from 'bun:test'
-import { costCaveat, costCellFor, subtaskRollupOf } from './subtaskRollup'
-import type { AttemptRollup, SubtaskView } from '../../lib/tasks'
+import { costCaveat, costCellFor, rollupKeyOf, subtaskRollupOf } from './subtaskRollup'
+import type { AttemptRollup, Subtask, SubtaskView } from '../../lib/tasks'
 
 function rollup(over: Partial<AttemptRollup> = {}): AttemptRollup {
   return {
@@ -11,22 +11,65 @@ function rollup(over: Partial<AttemptRollup> = {}): AttemptRollup {
   }
 }
 
+function sub(id: string, groupId?: string): Pick<Subtask, 'id' | 'groupId'> {
+  return groupId === undefined ? { id } : { id, groupId }
+}
+
+// --- rollupKeyOf -----------------------------------------------------------------------------
+
+test('rollupKeyOf: an ungrouped subtask is bucketed under its own id', () => {
+  expect(rollupKeyOf(sub('s1'))).toBe('s1')
+})
+
+test('rollupKeyOf: a grouped subtask is bucketed under the group id, never its own', () => {
+  expect(rollupKeyOf(sub('s1', 'g1'))).toBe('g1')
+})
+
 // --- subtaskRollupOf -----------------------------------------------------------------------------
 
 test('subtaskRollupOf: finds the bucket by subtask id', () => {
   const r = rollup({ costUSD: 7 })
   const views: SubtaskView[] = [{ id: 's1', rollup: r }, { id: 's2', rollup: rollup({ costUSD: 3 }) }]
-  expect(subtaskRollupOf(views, 's1')).toBe(r)
+  expect(subtaskRollupOf(views, sub('s1'))).toBe(r)
 })
 
 test('subtaskRollupOf: undefined when the server has no bucket for this subtask', () => {
   const views: SubtaskView[] = [{ id: 's1', rollup: rollup() }]
-  expect(subtaskRollupOf(views, 'unknown')).toBeUndefined()
+  expect(subtaskRollupOf(views, sub('unknown'))).toBeUndefined()
 })
 
 test('subtaskRollupOf: the id:null direct-branch bucket is not confused with a real subtask', () => {
   const views: SubtaskView[] = [{ id: null, rollup: rollup({ costUSD: 99 }) }]
-  expect(subtaskRollupOf(views, 's1')).toBeUndefined()
+  expect(subtaskRollupOf(views, sub('s1'))).toBeUndefined()
+})
+
+test('subtaskRollupOf: two subtasks sharing a groupId read the SAME bucket, keyed by the group', () => {
+  // The server collapses a group into ONE view keyed by the group id (task-report.ts's `keyOf`),
+  // so neither member's own id appears in the list at all.
+  const shared = rollup({ costUSD: 8, sessionsUsed: 2, sessionsLinked: 2 })
+  const views: SubtaskView[] = [{ id: 'g1', rollup: shared }, { id: 's3', rollup: rollup({ costUSD: 1 }) }]
+  const a = subtaskRollupOf(views, sub('s1', 'g1'))
+  const b = subtaskRollupOf(views, sub('s2', 'g1'))
+  expect(a).toBe(shared)
+  expect(b).toBe(shared)
+  // The SAME object, never two sums: reading it per member is what would multiply the cost by the
+  // group's size.
+  expect(a).toBe(b!)
+})
+
+test('subtaskRollupOf: a grouped subtask never falls back to a bucket under its own id', () => {
+  // If the list somehow still carried a per-member bucket, the group's key must win — the member
+  // id is not the effective key and reading it would be a second, smaller sum.
+  const own = rollup({ costUSD: 1 })
+  const group = rollup({ costUSD: 9 })
+  const views: SubtaskView[] = [{ id: 's1', rollup: own }, { id: 'g1', rollup: group }]
+  expect(subtaskRollupOf(views, sub('s1', 'g1'))).toBe(group)
+})
+
+test('subtaskRollupOf: an ungrouped subtask beside a group is unaffected', () => {
+  const mine = rollup({ costUSD: 4 })
+  const views: SubtaskView[] = [{ id: 'g1', rollup: rollup({ costUSD: 8 }) }, { id: 's3', rollup: mine }]
+  expect(subtaskRollupOf(views, sub('s3'))).toBe(mine)
 })
 
 // --- costCellFor -----------------------------------------------------------------------------

--- a/packages/web/src/components/tasks/subtaskRollup.ts
+++ b/packages/web/src/components/tasks/subtaskRollup.ts
@@ -7,12 +7,33 @@
  * "not measured" rather than a `0` — is asserted directly against these functions, not through DOM.
  */
 
-import type { AttemptRollup, SubtaskView } from '../../lib/tasks'
+import type { AttemptRollup, Subtask, SubtaskView } from '../../lib/tasks'
+
+/**
+ * The EFFECTIVE bucket key of a subtask — the same one the server bucketed by.
+ *
+ * `subtaskViews()` (`task-report.ts`) keys a bucket by `s.groupId ?? s.id`, so a group of subtasks
+ * collapses into ONE view filed under the group id and NEITHER member's own id appears in the list.
+ * Reading a grouped subtask by its own id therefore finds nothing — or, worse, a stale per-member
+ * bucket — and a member would show N/A (or a second, smaller sum) beside siblings showing the
+ * group's real figure. See docs/superpowers/specs/2026-09-11-alm-session-linking-ux.md §B.3.
+ */
+export function rollupKeyOf(subtask: Pick<Subtask, 'id' | 'groupId'>): string {
+  return subtask.groupId ?? subtask.id
+}
 
 /** The rollup for one subtask, or `undefined` when the server has no bucket for it at all — which
- *  reads exactly like an empty one: nothing measured, never a `0` standing in for it. */
-export function subtaskRollupOf(views: readonly SubtaskView[], id: string): AttemptRollup | undefined {
-  return views.find(v => v.id === id)?.rollup
+ *  reads exactly like an empty one: nothing measured, never a `0` standing in for it.
+ *
+ *  It takes the SUBTASK and not a bare id on purpose: the effective key is the group's whenever
+ *  there is one, and a signature accepting a plain string is one a caller can satisfy with
+ *  `t.id` — silently reading the wrong bucket for every grouped row. */
+export function subtaskRollupOf(
+  views: readonly SubtaskView[],
+  subtask: Pick<Subtask, 'id' | 'groupId'>,
+): AttemptRollup | undefined {
+  const key = rollupKeyOf(subtask)
+  return views.find(v => v.id === key)?.rollup
 }
 
 export type CostCell =


### PR DESCRIPTION
## Summary
- `SubtaskTable.tsx` reads a subtask's cost/tokens rollup via the same effective key the server uses (`subtask.groupId ?? subtask.id`), matching `task-report.ts`'s `subtaskViews` grouping (already in dev).
- Two or more subtasks sharing a `groupId` now show the same, correctly shared rollup instead of one of them missing its number.

## Test plan
- [x] `bun tsc --noEmit`
- [x] `bun test`

Parte da task ALM `t-918cc82233`, subtask `s-c7692d31c1`, seguindo `docs/superpowers/specs/2026-09-11-alm-session-linking-ux.md` §B.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)